### PR TITLE
feat: add sort by extension option to SCM changes view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -291,11 +291,12 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.defaultViewSortKey': {
 			type: 'string',
-			enum: ['name', 'path', 'status'],
+			enum: ['name', 'path', 'status', 'extension'],
 			enumDescriptions: [
 				localize('scm.defaultViewSortKey.name', "Sort the repository changes by file name."),
 				localize('scm.defaultViewSortKey.path', "Sort the repository changes by path."),
-				localize('scm.defaultViewSortKey.status', "Sort the repository changes by Source Control status.")
+				localize('scm.defaultViewSortKey.status', "Sort the repository changes by Source Control status."),
+				localize('scm.defaultViewSortKey.extension', "Sort the repository changes by file extension.")
 			],
 			description: localize('scm.defaultViewSortKey', "Controls the default Source Control repository changes sort order when viewed as a list."),
 			default: 'path'

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -35,7 +35,7 @@ import { Iterable } from '../../../../base/common/iterator.js';
 import { ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
 import { URI } from '../../../../base/common/uri.js';
 import { FileKind } from '../../../../platform/files/common/files.js';
-import { compareFileNames, comparePaths } from '../../../../base/common/comparers.js';
+import { compareFileExtensions, compareFileNames, comparePaths } from '../../../../base/common/comparers.js';
 import { FuzzyScore, createMatches, IMatch } from '../../../../base/common/filters.js';
 import { IViewDescriptorService } from '../../../common/views.js';
 import { localize } from '../../../../nls.js';
@@ -764,6 +764,14 @@ export class SCMTreeSorter implements ITreeSorter<TreeElement> {
 				return compareFileNames(oneName, otherName);
 			}
 
+			// Extension
+			if (this.viewSortKey() === ViewSortKey.Extension) {
+				const oneName = basename((one as ISCMResource).sourceUri);
+				const otherName = basename((other as ISCMResource).sourceUri);
+
+				return compareFileExtensions(oneName, otherName);
+			}
+
 			// Status
 			if (this.viewSortKey() === ViewSortKey.Status) {
 				const oneTooltip = (one as ISCMResource).decorations.tooltip ?? '';
@@ -921,7 +929,8 @@ export class SCMAccessibilityProvider implements IListAccessibilityProvider<Tree
 const enum ViewSortKey {
 	Path = 'path',
 	Name = 'name',
-	Status = 'status'
+	Status = 'status',
+	Extension = 'extension'
 }
 
 const Menus = {
@@ -1281,9 +1290,16 @@ class SetSortByStatusAction extends SetSortKeyAction {
 	}
 }
 
+class SetSortByExtensionAction extends SetSortKeyAction {
+	constructor() {
+		super(ViewSortKey.Extension, localize('sortChangesByExtension', "Sort Changes by Extension"));
+	}
+}
+
 registerAction2(SetSortByNameAction);
 registerAction2(SetSortByPathAction);
 registerAction2(SetSortByStatusAction);
+registerAction2(SetSortByExtensionAction);
 
 class CollapseAllRepositoriesAction extends ViewAction<SCMViewPane> {
 
@@ -1936,13 +1952,16 @@ export class SCMViewPane extends ViewPane {
 
 		// List
 		let viewSortKey: ViewSortKey;
-		const viewSortKeyString = this.configurationService.getValue<'path' | 'name' | 'status'>('scm.defaultViewSortKey');
+		const viewSortKeyString = this.configurationService.getValue<'path' | 'name' | 'status' | 'extension'>('scm.defaultViewSortKey');
 		switch (viewSortKeyString) {
 			case 'name':
 				viewSortKey = ViewSortKey.Name;
 				break;
 			case 'status':
 				viewSortKey = ViewSortKey.Status;
+				break;
+			case 'extension':
+				viewSortKey = ViewSortKey.Extension;
 				break;
 			default:
 				viewSortKey = ViewSortKey.Path;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The SCM changes list view supports sorting by Name, Path, and Status only. There is no option to sort by file extension/type.

Closes #163849

## What is the new behavior?

A new "Sort Changes by Extension" option is added to the SCM changes list view sort menu. This groups files by their file extension (e.g., all `.ts` files together, all `.json` files together), making it easier to review changes by file type.

Changes:
- Added `Extension = 'extension'` to the `ViewSortKey` enum
- Added extension sort comparison using the existing `compareFileExtensions` comparator
- Added `SetSortByExtensionAction` class and registered it
- Added `'extension'` to the `scm.defaultViewSortKey` configuration enum
- Added `'extension'` case to the `getViewSortKey` switch statement

## Additional context

The implementation follows the exact same pattern as the existing sort options (Name, Path, Status) and uses the existing `compareFileExtensions` function from `base/common/comparers.ts`, which handles extension comparison with proper locale-aware sorting.