### PR TITLE
feat: add history to Emmet wrap with abbreviation

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -29,6 +29,9 @@ interface PreviewRangesWithContent {
 	baseIndent: string;
 }
 
+const wrapAbbreviationHistory: string[] = [];
+const MAX_HISTORY_LENGTH = 20;
+
 export async function wrapWithAbbreviation(args: any): Promise<boolean> {
 	if (!validate(false)) {
 		return false;
@@ -249,11 +252,42 @@ export async function wrapWithAbbreviation(args: any): Promise<boolean> {
 	}
 
 	const prompt = vscode.l10n.t("Enter Abbreviation");
-	const inputAbbreviation = (args && args['abbreviation'])
-		? (args['abbreviation'] as string)
-		: await vscode.window.showInputBox({ prompt, validateInput: inputChanged });
+	let inputAbbreviation: string | undefined;
+	if (args && args['abbreviation']) {
+		inputAbbreviation = args['abbreviation'] as string;
+	} else {
+		inputAbbreviation = await new Promise<string | undefined>(resolve => {
+			const quickPick = vscode.window.createQuickPick();
+			quickPick.placeholder = prompt;
+			quickPick.items = wrapAbbreviationHistory.map(abbr => ({ label: abbr }));
+			quickPick.onDidChangeValue(value => {
+				inputChanged(value);
+			});
+			quickPick.onDidAccept(() => {
+				const value = quickPick.selectedItems[0]?.label ?? quickPick.value;
+				quickPick.dispose();
+				resolve(value || undefined);
+			});
+			quickPick.onDidHide(() => {
+				quickPick.dispose();
+				resolve(undefined);
+			});
+			quickPick.show();
+		});
+	}
 
 	const changesWereMade = await makeChanges(inputAbbreviation, false);
+	if (changesWereMade && inputAbbreviation) {
+		// Add to history, moving to front if already present
+		const existingIndex = wrapAbbreviationHistory.indexOf(inputAbbreviation);
+		if (existingIndex !== -1) {
+			wrapAbbreviationHistory.splice(existingIndex, 1);
+		}
+		wrapAbbreviationHistory.unshift(inputAbbreviation);
+		if (wrapAbbreviationHistory.length > MAX_HISTORY_LENGTH) {
+			wrapAbbreviationHistory.pop();
+		}
+	}
 	if (!changesWereMade) {
 		editor.selections = oldSelections;
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature enhancement

## What is the current behavior?

The "Wrap with Abbreviation" command (`editor.emmet.action.wrapWithAbbreviation`) shows a plain input box with no memory of previous abbreviations. Users must re-type long or complex abbreviations from scratch each time.

Closes #40096

## What is the new behavior?

The input box is replaced with a QuickPick that displays previously used wrap abbreviations. Users can:
- Type a new abbreviation (with live preview, same as before)
- Use arrow keys to select a previously used abbreviation
- See up to 20 most recently used abbreviations in MRU order

The live preview behavior is preserved through the QuickPick's `onDidChangeValue` event, matching the existing experience when typing.

## Implementation details

- History is stored in a module-level array (in-memory, per session)
- MRU ordering: most recently used abbreviations appear first
- Maximum 20 entries to keep the list manageable
- When an abbreviation is successfully applied, it's moved to the front of the history
- When called with `args.abbreviation` (programmatic invocation), the QuickPick is bypassed

## Additional context

Previous PRs (#46006, #114170) were closed. The maintainer suggested "implementing a history feature into the inputbox would be a better solution." Since VS Code's `showInputBox` doesn't support history natively, this implementation uses `createQuickPick` which provides both a text input and a selectable list of history items, achieving the same goal.