### PR TITLE
fix: do not refocus webview when find widget is hidden programmatically

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -66,7 +66,9 @@ export class WebviewFindWidget extends SimpleFindWidget {
 	public override hide(animated = true) {
 		super.hide(animated);
 		this._delegate.stopFind(true);
-		this._delegate.focus();
+		if (animated) {
+			this._delegate.focus();
+		}
 	}
 
 	protected _onInputChanged(): boolean {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When trying to maximize the bottom panel while a webview editor (e.g., PR overview, extension editor) is open, the panel cannot be maximized. The webview editor keeps re-activating itself.

The root cause (identified by @benibenj in the issue) is:
1. `WebviewEditor.setEditorVisible(false)` is called
2. `OverlayWebview.release()` calls `hideFind(false)`
3. `WebviewFindWidget.hide()` calls `this._delegate.focus()`
4. This focuses the webview element, which propagates to `EditorPart.doSetGroupActive()`, re-showing the editor

Closes #248324

## What is the new behavior?

`WebviewFindWidget.hide()` now only calls `this._delegate.focus()` when `animated` is `true` (user-initiated close via Escape key or close button). When `animated` is `false` (programmatic hide during `OverlayWebview.release()`), the focus call is skipped, preventing the webview from stealing focus back.

## Additional context

The `animated` parameter already serves as the semantic indicator for whether the hide is user-initiated (`true`, the default) or programmatic (`false`, passed explicitly by `OverlayWebview.release()` at line 184 of `overlayWebview.ts`). This makes it a natural guard for the focus behavior without needing to introduce new state.