### PR TITLE
feat: show 'Commit Staged' label when staged and unstaged changes coexist

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -163,10 +163,16 @@ export class ActionButton {
 
 		// Not a branch (tag, detached)
 		if (this.state.HEAD?.type === RefType.Tag || !this.state.HEAD?.name) {
+			const hasStagedChanges = this.repository.indexGroup.resourceStates.length > 0;
+			const hasUnstagedChanges = this.repository.workingTreeGroup.resourceStates.length > 0;
+			const isStagedCommit = hasStagedChanges && hasUnstagedChanges;
+
 			return {
 				command: 'git.commit',
-				title: l10n.t('{0} Commit', '$(check)'),
-				tooltip: this.state.isCommitInProgress ? l10n.t('Committing Changes...') : l10n.t('Commit Changes'),
+				title: isStagedCommit ? l10n.t('{0} Commit Staged', '$(check)') : l10n.t('{0} Commit', '$(check)'),
+				tooltip: this.state.isCommitInProgress
+					? isStagedCommit ? l10n.t('Committing Staged Changes...') : l10n.t('Committing Changes...')
+					: isStagedCommit ? l10n.t('Commit Staged Changes') : l10n.t('Commit Changes'),
 				arguments: [this.repository.sourceControl, null]
 			};
 		}

--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -189,22 +189,34 @@ export class CommitCommandsCenter {
 
 		// Tooltip (default)
 		const branch = this.repository.HEAD?.name;
+		const hasStagedChanges = this.repository.indexGroup.resourceStates.length > 0;
+		const hasUnstagedChanges = this.repository.workingTreeGroup.resourceStates.length > 0;
+		const isStagedCommit = hasStagedChanges && hasUnstagedChanges;
 		let tooltip = alwaysCommitToNewBranch ?
 			l10n.t('Commit Changes to New Branch') :
 			branch ?
-				l10n.t('Commit Changes on "{0}"', branch) :
-				l10n.t('Commit Changes');
+				isStagedCommit ?
+					l10n.t('Commit Staged Changes on "{0}"', branch) :
+					l10n.t('Commit Changes on "{0}"', branch) :
+				isStagedCommit ?
+					l10n.t('Commit Staged Changes') :
+					l10n.t('Commit Changes');
 
 		// Tooltip (in progress)
 		if (this.repository.operations.isRunning(OperationKind.Commit)) {
-			tooltip = !alwaysCommitToNewBranch ?
-				l10n.t('Committing Changes...') :
-				l10n.t('Committing Changes to New Branch...');
+			tooltip = alwaysCommitToNewBranch ?
+				l10n.t('Committing Changes to New Branch...') :
+				isStagedCommit ?
+					l10n.t('Committing Staged Changes...') :
+					l10n.t('Committing Changes...');
 		}
 
+		const commitTitle = isStagedCommit ? l10n.t('{0} Commit Staged', icon ?? '$(check)') : l10n.t('{0} Commit', icon ?? '$(check)');
+		const commitAmendTitle = isStagedCommit ? l10n.t('{0} Commit Staged (Amend)', icon ?? '$(check)') : l10n.t('{0} Commit (Amend)', icon ?? '$(check)');
+
 		return [
-			{ command: 'git.commit', title: l10n.t('{0} Commit', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
-			{ command: 'git.commitAmend', title: l10n.t('{0} Commit (Amend)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
+			{ command: 'git.commit', title: commitTitle, tooltip, arguments: [this.repository.sourceControl, null] },
+			{ command: 'git.commitAmend', title: commitAmendTitle, tooltip, arguments: [this.repository.sourceControl, null] },
 		];
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / UX improvement

## What is the current behavior?

When a repository has both staged changes and unstaged changes, the commit button shows "Commit" with a tooltip like "Commit Changes on main". This makes it unclear whether only the staged changes will be committed or all changes.

Closes #243419

## What is the new behavior?

When both staged and unstaged changes exist, the commit button text and tooltip now distinguish between the two states:

- **Button text**: "Commit Staged" instead of "Commit"
- **Tooltip**: "Commit Staged Changes on {branch}" instead of "Commit Changes on {branch}"
- **In-progress tooltip**: "Committing Staged Changes..." instead of "Committing Changes..."
- **Amend variant**: "Commit Staged (Amend)" instead of "Commit (Amend)"

When only staged changes exist (no unstaged changes), or when smart commit handles all changes, the button continues to show "Commit" as before.

This applies to:
- Normal branch commit flow (via `postCommitCommands.ts`)
- Detached HEAD / tag commit flow (via `actionButton.ts`)

## Additional context

The `isStagedCommit` condition is `hasStagedChanges && hasUnstagedChanges` -- it only activates when both are present, which is the scenario where the user needs clarity about what will be committed. The button re-evaluates on every git status update, so it responds immediately when files are staged or unstaged.