### PR TITLE
fix: show error message when JSON sort command fails

### DIFF
--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -255,15 +255,20 @@ async function startClientWithParticipants(_context: ExtensionContext, languageP
 		if (isClientReady) {
 			const textEditor = window.activeTextEditor;
 			if (textEditor) {
-				const documentOptions = textEditor.options;
-				const textEdits = await getSortTextEdits(textEditor.document, documentOptions.tabSize, documentOptions.insertSpaces);
-				const success = await textEditor.edit(mutator => {
-					for (const edit of textEdits) {
-						mutator.replace(client.protocol2CodeConverter.asRange(edit.range), edit.newText);
+				try {
+					const documentOptions = textEditor.options;
+					const textEdits = await getSortTextEdits(textEditor.document, documentOptions.tabSize, documentOptions.insertSpaces);
+					const success = await textEditor.edit(mutator => {
+						for (const edit of textEdits) {
+							mutator.replace(client.protocol2CodeConverter.asRange(edit.range), edit.newText);
+						}
+					});
+					if (!success) {
+						window.showErrorMessage(l10n.t('Failed to sort the JSONC document, please consider opening an issue.'));
 					}
-				});
-				if (!success) {
-					window.showErrorMessage(l10n.t('Failed to sort the JSONC document, please consider opening an issue.'));
+				} catch (e) {
+					const message = e instanceof Error ? e.message : String(e);
+					window.showErrorMessage(l10n.t('Failed to sort the JSON document: {0}', message));
 				}
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (improved error handling)

## What is the current behavior?

When the "JSON: Sort Document" command fails (e.g. due to trailing commas inside nested objects), the error is silently swallowed and only appears in the developer console as an unhandled rejection:

```
Request json/sort failed with message: Cannot read properties of undefined (reading 'addChildProperty')
```

Users see no feedback about what went wrong, or in some cases the document gets corrupted.

Closes #208763

## What is the new behavior?

The sort command now wraps the language server request in a try/catch and shows a user-friendly error notification with the error message. This makes it clear that the sort failed and provides diagnostic information.

Note: The root cause of the sorting failure (trailing commas in nested objects causing the JSON language service to crash) is in the upstream `vscode-json-languageservice` package. This PR addresses the immediate user experience issue by surfacing the error rather than silently failing.

## Additional context

The error is most commonly triggered by JSON/JSONC files with trailing commas inside nested objects (e.g. `"[python]": { ... , }`). Users report that repeated sorting can even corrupt the document structure. Showing the error message prevents users from unknowingly continuing to sort a document that the parser cannot handle correctly.