### PR TITLE
feat: make find widget match count clickable to trigger Go to Match

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.css
+++ b/src/vs/editor/contrib/find/browser/findWidget.css
@@ -122,6 +122,7 @@
 	box-sizing: border-box;
 	text-align: center;
 	line-height: 23px;
+	cursor: pointer;
 }
 
 .monaco-editor .find-widget .button {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -76,6 +76,7 @@ const NLS_TOGGLE_REPLACE_MODE_BTN_LABEL = nls.localize('label.toggleReplaceButto
 const NLS_MATCHES_COUNT_LIMIT_TITLE = nls.localize('title.matchesCountLimit', "Only the first {0} results are highlighted, but all find operations work on the entire text.", MATCHES_LIMIT);
 export const NLS_MATCHES_LOCATION = nls.localize('label.matchesLocation', "{0} of {1}");
 export const NLS_NO_RESULTS = nls.localize('label.noResults', "No results");
+const NLS_MATCHES_COUNT_TITLE = nls.localize('title.matchesCount', "Click to go to a specific match");
 
 const FIND_WIDGET_INITIAL_WIDTH = 419;
 const PART_WIDTH = 275;
@@ -460,6 +461,11 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			this._matchesCount.title = NLS_MATCHES_COUNT_LIMIT_TITLE;
 		} else {
 			this._matchesCount.title = '';
+		}
+
+		if (this._state.matchesCount > 0) {
+			const goToMatchLabel = this._keybindingLabelFor(FIND_IDS.GoToMatchFindAction);
+			this._matchesCount.title = NLS_MATCHES_COUNT_TITLE + (goToMatchLabel ? ` (${goToMatchLabel})` : '');
 		}
 
 		// remove previous content
@@ -1065,6 +1071,11 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._matchesCount = document.createElement('div');
 		this._matchesCount.className = 'matchesCount';
 		this._updateMatchesCount();
+		this._register(dom.addDisposableListener(this._matchesCount, dom.EventType.CLICK, () => {
+			if (this._state.matchesCount > 0) {
+				assertReturnsDefined(this._codeEditor.getAction(FIND_IDS.GoToMatchFindAction)).run().then(undefined, onUnexpectedError);
+			}
+		}));
 
 		const hoverLifecycleOptions: IHoverLifecycleOptions = { groupId: 'find-widget' };
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (polish)

## What is the current behavior?

The match count indicator in the find widget ("1 of 5") is purely informational. The "Go to Match..." feature is only accessible via the command palette, which is not very discoverable.

Closes #172127

## What is the new behavior?

Clicking the match count indicator ("1 of 5") in the find widget now opens the "Go to Match..." input picker, allowing users to quickly jump to a specific match by number.

- The cursor changes to a pointer when hovering over the match count
- A tooltip shows "Click to go to a specific match" along with the keybinding (if any)
- Clicking only triggers the picker when there are matches (not when it shows "No results")

## Additional context

This follows the suggestion from @bpasero in the issue: "One idea would be to allow to click on this [match count] to bring up the picker." The approach was endorsed by @rebornix.

The implementation uses the same `assertReturnsDefined(this._codeEditor.getAction(FIND_IDS.GoToMatchFindAction)).run()` pattern used by the Previous/Next match buttons.