### PR TITLE
fix: standalone color picker inserts color at all cursor positions

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPicker/standaloneColorPickerParticipant.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPicker/standaloneColorPickerParticipant.ts
@@ -17,6 +17,7 @@ import { ColorPickerModel } from '../colorPickerModel.js';
 import { BaseColor, ColorPickerWidgetType, createColorHover, updateColorPresentations, updateEditorModel } from '../colorPickerParticipantUtils.js';
 import { ColorPickerWidget } from '../colorPickerWidget.js';
 import { Range } from '../../../../common/core/range.js';
+import { ISingleEditOperation } from '../../../../common/core/editOperation.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { Dimension } from '../../../../../base/browser/dom.js';
 
@@ -115,7 +116,20 @@ export class StandaloneColorPickerParticipant {
 		let range = new Range(colorHoverData.range.startLineNumber, colorHoverData.range.startColumn, colorHoverData.range.endLineNumber, colorHoverData.range.endColumn);
 		if (this._color) {
 			await updateColorPresentations(this._editor.getModel(), colorPickerModel, this._color, range, colorHoverData);
-			range = updateEditorModel(this._editor, range, colorPickerModel);
+			const colorText = colorPickerModel.presentation.label;
+			const selections = this._editor.getSelections();
+			if (selections && selections.length > 1) {
+				// Multi-cursor: insert color at all cursor positions
+				const edits: ISingleEditOperation[] = selections.map(selection => ({
+					range: selection.isEmpty() ? Range.fromPositions(selection.getStartPosition()) : selection,
+					text: colorText,
+					forceMoveMarkers: true
+				}));
+				this._editor.executeEdits('colorpicker', edits);
+				this._editor.pushUndoStop();
+			} else {
+				range = updateEditorModel(this._editor, range, colorPickerModel);
+			}
 		}
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using multi-cursor and invoking "Show or Focus Standalone Color Picker", selecting a color and clicking "Insert" only inserts the color at one cursor position. The other cursors are ignored.

Closes #180918

## What is the new behavior?

When multiple cursors are active, the selected color text is inserted at all cursor positions. If cursors have selections, the selections are replaced with the color text. For single-cursor usage, the existing behavior is preserved (using `updateEditorModel` which handles color presentation text edits and tracked ranges).

## Additional context

The fix is in `StandaloneColorPickerParticipant.updateEditorModel()`. When `editor.getSelections()` returns more than one selection, the color text is applied at all positions using `editor.executeEdits()` with edits for each selection. This follows the same multi-cursor edit pattern used elsewhere in the codebase.