### PR TITLE
Increase font weight for session title label

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -61,6 +61,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	font-weight: 500;
 }
 
 /* Repository/folder label */


### PR DESCRIPTION
Enhance the visibility of the session title label by increasing its font weight. This change improves the overall readability of the title in the user interface.

