### PR TITLE
Adjust padding for secondary action buttons in changes view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -179,7 +179,7 @@
 }
 
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button.secondary.monaco-text-button.codicon {
-	padding: 4px 8px;
+	padding: 4px 6px;
 	font-size: 16px !important;
 }
 


### PR DESCRIPTION
Reduce the horizontal padding of secondary action buttons in the changes view to enhance the visual layout. This change improves the overall user interface consistency.

