### PR TITLE
Increase minimum width of AuxiliaryBarPart

### DIFF
--- a/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
@@ -61,7 +61,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	private readonly _runScriptMenu = this._register(new MutableDisposable<IMenu>());
 	private readonly _runScriptMenuListener = this._register(new MutableDisposable<IDisposable>());
 
-	// Use the side bar dimensions
+	// Sessions-specific auxiliary bar dimensions (intentionally not tied to the sessions SidebarPart values)
 	override readonly minimumWidth: number = 270;
 	override readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	override readonly minimumHeight: number = 0;

--- a/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
@@ -62,7 +62,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	private readonly _runScriptMenuListener = this._register(new MutableDisposable<IDisposable>());
 
 	// Use the side bar dimensions
-	override readonly minimumWidth: number = 170;
+	override readonly minimumWidth: number = 270;
 	override readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	override readonly minimumHeight: number = 0;
 	override readonly maximumHeight: number = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
Adjust the minimum width of the AuxiliaryBarPart to enhance layout and usability. This change improves the overall appearance and functionality of the interface.

