### PR TITLE
Fix #305742: restore agent loop request limit in sessions

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -16,7 +16,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 			'.claude/settings.json': false,
 			'~/.claude/settings.json': false,
 		},
-		'chat.agent.maxRequests': 1000,
 		'chat.customizationsMenu.userStoragePath': '~/.copilot',
 		'chat.viewSessions.enabled': false,
 		'chat.implicitContext.suggestedContext': false,


### PR DESCRIPTION
## Problem

Issue #305742 reports agent mode getting stuck in a loop and consuming excessive RAM.

Sessions defaults were forcing `chat.agent.maxRequests` to `1000`, which effectively weakens per-turn loop protection and allows runaway request chains to continue much longer before any stop/confirm behavior can intervene.

## Fix

Removed the sessions-specific override for `chat.agent.maxRequests` from sessions default configuration.

This restores the normal platform default/experiment-driven limit behavior intended for loop protection in agent turns.

## Why this helps

- Removes an outlier high limit in sessions mode
- Allows standard max-request safety behavior to apply consistently
- Reduces likelihood and severity of runaway loop memory growth

## Validation

- npm run compile passes with 0 errors
- npm run test-node -- --grep "chatService" passes

Fixes #305742
