### PR TITLE
sessions: adjust workspace picker empty state text segmentation

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -443,7 +443,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		const pickersLabel = dom.append(pickersRow, dom.$('.chat-full-welcome-pickers-label'));
 		pickersLabel.textContent = this._workspacePicker.selectedProject
 			? localize('newSessionIn', "New session in")
-			: localize('newSessionChooseWorkspace', "Start by picking");
+			: localize('newSessionChooseWorkspace', "Start by picking a");
 
 		// Project picker (unified folder + repo picker)
 		this._workspacePicker.render(pickersRow);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -381,7 +381,7 @@ export class WorkspacePicker extends Disposable {
 
 		dom.clearNode(this._triggerElement);
 		const workspace = this._selectedWorkspace?.workspace;
-		const label = workspace ? workspace.label : localize('pickWorkspace', "a workspace");
+		const label = workspace ? workspace.label : localize('pickWorkspace', "workspace");
 		const icon = workspace ? workspace.icon : Codicon.project;
 
 		dom.append(this._triggerElement, renderIcon(icon));


### PR DESCRIPTION
## Summary

Adjusts the text segmentation in the new chat empty state (when no workspace is selected) so the dropdown only contains the word "workspace" instead of "a workspace".

**Before:** `"Start by picking"` + `[a workspace ▾]`
**After:** `"Start by picking a"` + `[workspace ▾]`

Related: https://github.com/microsoft/vscode/pull/304529

## Changes

- `newChatViewPane.ts`: Updated localized string from `"Start by picking"` to `"Start by picking a"`
- `sessionWorkspacePicker.ts`: Updated the picker's empty label from `"a workspace"` to `"workspace"`