### PR TITLE
Add `chat.tools.terminal.forceBackgroundMode` setting

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -526,7 +526,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			const truncatedCommand = normalizedCommand.length > 80
 				? normalizedCommand.substring(0, 77) + '...'
 				: normalizedCommand;
-			const invocationMessage = partialInput.isBackground
+			const isBackground = partialInput.isBackground || this._configurationService.getValue(TerminalChatAgentToolsSettingId.ForceBackgroundMode) === true;
+			const invocationMessage = isBackground
 				? new MarkdownString(localize('runInTerminal.streaming.background', "Running `{0}` in background", truncatedCommand))
 				: new MarkdownString(localize('runInTerminal.streaming', "Running `{0}`", truncatedCommand));
 			return { invocationMessage };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -536,6 +536,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		const args = context.parameters as IRunInTerminalInputParams;
+		if (this._configurationService.getValue(TerminalChatAgentToolsSettingId.ForceBackgroundMode) === true) {
+			args.isBackground = true;
+		}
 
 		const chatSessionResource = context.chatSessionResource;
 		let instance: ITerminalInstance | undefined;
@@ -866,6 +869,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		const args = invocation.parameters as IRunInTerminalInputParams;
+		if (this._configurationService.getValue(TerminalChatAgentToolsSettingId.ForceBackgroundMode) === true) {
+			args.isBackground = true;
+		}
 		this._logService.debug(`RunInTerminalTool: Invoking with options ${JSON.stringify(args)}`);
 		let toolResultMessage: string | IMarkdownString | undefined;
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -28,6 +28,7 @@ export const enum TerminalChatAgentToolsSettingId {
 	TerminalSandboxMacFileSystem = 'chat.tools.terminal.sandbox.macFileSystem',
 	PreventShellHistory = 'chat.tools.terminal.preventShellHistory',
 	EnforceTimeoutFromModel = 'chat.tools.terminal.enforceTimeoutFromModel',
+	ForceBackgroundMode = 'chat.tools.terminal.forceBackgroundMode',
 	IdlePollInterval = 'chat.tools.terminal.idlePollInterval',
 
 	TerminalProfileLinux = 'chat.tools.terminal.terminalProfile.linux',
@@ -639,6 +640,13 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			mode: 'auto'
 		},
 		markdownDescription: localize('enforceTimeoutFromModel.description', "Whether to enforce the timeout value provided by the model in the run in terminal tool. When enabled, if the model provides a timeout parameter, the tool will stop tracking the command after that duration and return the output collected so far."),
+	},
+	[TerminalChatAgentToolsSettingId.ForceBackgroundMode]: {
+		restricted: true,
+		type: 'boolean',
+		default: false,
+		tags: ['experimental'],
+		markdownDescription: localize('forceBackgroundMode.description', "When enabled, all commands executed by the run in terminal tool are forced to run in background mode regardless of the model's `isBackground` parameter. This prevents the agent from blocking on long-running foreground commands. Each command will run in its own terminal and the agent must use `get_terminal_output` to check on progress."),
 	}
 };
 


### PR DESCRIPTION
EDIT: I actually think to keep VS Code and Evals aligned, what we want is to implement https://github.com/microsoft/vscode/issues/288566, which should also fix this kind of issue.

Related https://github.com/microsoft/vscode-copilot-evaluation/issues/3103#issuecomment-4144415564, will adopt in evals and maybe also VS Code as an experiment https://github.com/microsoft/vscode-copilot-evaluation/issues/3105

Adds an experimental `chat.tools.terminal.forceBackgroundMode` setting that, when enabled, forces all `run_in_terminal` tool invocations to execute in background mode regardless of what the model requests.

### Problem

In eval runs, we observed that ~30% of VS Code agent regressions (vs GitHub CLI) were caused by the agent running long-lived or blocking commands (e.g. `sleep 300`, `make`, server processes) in foreground mode. This leads to:

- **Agent timeouts**: The agent blocks waiting for a foreground command to finish, hitting the 3600s `X_AGENT_STILL_RESPONDING` limit (6 tests affected)
- **Servers not surviving**: Foreground processes started by the agent die when the tool call completes, causing eval assertions to fail because the server isn't running at evaluation time (4 tests affected)

The CLI agent doesn't have this problem because all its terminal commands are inherently non-blocking.

### Fix

- New restricted, experimental boolean setting `chat.tools.terminal.forceBackgroundMode` (default: `false`)
- When enabled, overrides `args.isBackground` to `true` early in both `prepareToolInvocation` and `invoke`, before any downstream logic branches on it
- This affects terminal reuse, confirmation titles, terminal creation, timeout handling, and result formatting — all consistently treating the command as background
- The `handleToolStream` method now also applies the same override when computing the streamed invocation message, so the UI correctly shows "Running `{command}` in background" when the setting is enabled, keeping the streamed message consistent with actual execution behavior

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.