### PR TITLE
Fix customization file resolution errors for remote agent host sessions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -19,6 +19,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { localize } from '../../../../nls.js';
+import { AGENT_HOST_SCHEME } from '../../../../platform/agentHost/common/agentHostUri.js';
 
 /**
  * Agent Sessions override of IAICustomizationWorkspaceService.
@@ -61,7 +62,11 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 			}
 			const session = this.sessionsService.activeSession.read(reader);
 			const repo = session?.workspace.read(reader)?.repositories[0];
-			return repo?.workingDirectory ?? repo?.uri;
+			const root = repo?.workingDirectory ?? repo?.uri;
+			if (root?.scheme === AGENT_HOST_SCHEME) {
+				return undefined;
+			}
+			return root;
 		});
 
 		this.hasOverrideProjectRoot = derived(reader => {
@@ -76,7 +81,11 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 		}
 		const session = this.sessionsService.activeSession.get();
 		const repo = session?.workspace.get()?.repositories[0];
-		return repo?.workingDirectory ?? repo?.uri;
+		const root = repo?.workingDirectory ?? repo?.uri;
+		if (root?.scheme === AGENT_HOST_SCHEME) {
+			return undefined;
+		}
+		return root;
 	}
 
 	setOverrideProjectRoot(root: URI): void {


### PR DESCRIPTION
When a remote agent host session is active, `SessionsAICustomizationWorkspaceService.getActiveProjectRoot()` returns the session's repository URI, which is a `vscode-agent-host://` URI. The `AgenticPromptFilesLocator` then uses this as a workspace folder root and tries to resolve `.github/prompts` and `.github/hooks` against it, causing errors like:\n\n```\nFailed to resolve files at location: vscode-agent-host://localhost__8080/file/-/datadrive2/debugtest/.github/prompts No connection for authority: localhost__8080\n```\n\nThe fix filters out `AGENT_HOST_SCHEME` URIs in both the `activeProjectRoot` derived observable and the `getActiveProjectRoot()` getter, so the project root returns `undefined` for remote sessions — consistent with the existing guard in `WorkspaceFolderManagementContribution`.\n\n(Written by Copilot)"