### PR TITLE
sessions: add sync-upstream built-in skill

### DIFF
--- a/src/vs/sessions/skills/sync-upstream/SKILL.md
+++ b/src/vs/sessions/skills/sync-upstream/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update-branch
+name: sync-upstream
 description: Update a stale session branch by rebasing onto the latest origin. Use when the upstream has moved significantly and the session needs to catch up, resolving conflicts by preserving upstream changes and adapting session work to fit.
 ---
 <!-- Customize this skill and select save to override its behavior. Delete that copy to restore the built-in behavior. -->

--- a/src/vs/sessions/skills/update-branch/SKILL.md
+++ b/src/vs/sessions/skills/update-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-branch
-description: Rebase the current session branch onto the latest origin, resolving conflicts by preserving upstream changes and adapting session work to fit.
+description: Update a stale session branch by rebasing onto the latest origin. Use when the upstream has moved significantly and the session needs to catch up, resolving conflicts by preserving upstream changes and adapting session work to fit.
 ---
 <!-- Customize this skill and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
 

--- a/src/vs/sessions/skills/update-branch/SKILL.md
+++ b/src/vs/sessions/skills/update-branch/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: update-branch
+description: Rebase the current session branch onto the latest origin, resolving conflicts by preserving upstream changes and adapting session work to fit.
+---
+<!-- Customize this skill and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
+
+# Update Branch
+
+Rebase the current session branch onto the latest upstream so the work stays grounded in origin.
+
+## Workflow
+
+1. If there are uncommitted changes, use the `/commit` skill to commit them first.
+2. Fetch the latest upstream and rebase onto it:
+   ```
+   git fetch origin
+   git rebase origin/main
+   ```
+   Use the appropriate base branch if it is not `main`.
+
+## Conflict Resolution
+
+When conflicts arise, **upstream always wins**:
+
+- **Never alter upstream logic, APIs, or patterns** to accommodate session changes.
+- **Adapt session work** to fit the new upstream — rename, restructure, or rewrite as needed while preserving the session's goals.
+- After resolving each conflict, `git add` the files and `git rebase --continue`.
+
+## Validation
+
+After the rebase completes, verify the result still compiles and meets the session's objectives. If session changes no longer make sense against the updated upstream, explain what changed and propose a revised approach.


### PR DESCRIPTION
Adds a new built-in skill `sync-upstream` for the sessions app that rebases a stale session branch onto the latest origin.

### What
New skill at `src/vs/sessions/skills/sync-upstream/SKILL.md` — auto-discovered by `AgenticPromptsService`.

### Why
Sessions can go stale when the upstream moves significantly. This skill provides a structured workflow for catching up, with a clear conflict resolution policy: **upstream always wins**, and session work is adapted to fit.

### Conflict resolution guidance
- Never alter upstream logic, APIs, or patterns to accommodate session changes
- Rework session changes to achieve the same goals on top of the new upstream
- Validate the result still compiles and meets session objectives