### PR TITLE
Enable log rotation on Agent Sessions output channel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -293,7 +293,7 @@ class AgentSessionsLogger extends Disposable {
 			Registry.as<IOutputChannelRegistry>(Extensions.OutputChannels).registerChannel({
 				id: agentSessionsOutputChannelId,
 				label: agentSessionsOutputChannelLabel,
-				log: false
+				log: true
 			});
 			this.isChannelRegistered = true;
 		}


### PR DESCRIPTION
## Problem

Under `--log trace`, the Agent Sessions output channel grows without bound because it is registered with `log: false`. This uses `FileOutputChannelModel` backed by a logger with `donotRotate: true`, so the backing file never rotates.

`logAllStatsIfTrace()` dumps **all** sessions on every resolution cycle (throttled to 500ms via `resolveProvider`). With 55+ sessions over hours of uptime, this produces 30+ MB log files. When the output channel is visible, the entire file is loaded into a text model in the renderer, amplifying the memory impact.

### Observed incidents (3 total)

| Incident | Version | Sessions | Renderer memory | Output log size |
|----------|---------|----------|-----------------|-----------------|
| 1 | 1.112.0 (6da8508c16) | 72 | ~15.7 GB (V8 limit) | 30,684 KB |
| 2 | 1.112.0 (adbfed6309) | 55+20 | ~15.7 GB (V8 limit) | 30,712 KB (different window) |
| 3 | current | multiple | 15.1 GB (plateaued) | 30,718 KB |

All three incidents had `--log trace` active. Memory growth rate in incident 2 was ~250 MB/3sec before hitting the V8 heap limit.

### Event chain under `--log trace`

```
autorun (per model change)
  → tryUpdateLiveSessionItem() [cheap, with isEqual dedup — fixed recently]
    → _onDidChangeChatSessionItems.fire()
      → AgentSessionsModel.resolveProvider() [throttled 500ms]
        → updateItems()
          → logAllStatsIfTrace() → dumps ALL sessions to output channel (no rotation)
```

The recent refactor of `localAgentSessionsController.ts` addressed the per-token full-refresh storm by replacing it with `tryUpdateLiveSessionItem()` + `isEqual` dedup. However, the output channel still grows without bound under `--log trace` because the backing file never rotates.

## Fix

Change `log: false` → `log: true` on the Agent Sessions output channel registration. This switches from `FileOutputChannelModel` (which uses `donotRotate: true`) to the standard log channel infrastructure with file rotation, preventing unbounded growth.

## Validation

- [x] TypeScript compilation clean (no new errors)
- [x] Layering check passes
- [x] All 42 agent sessions tests pass
- [x] Hygiene/pre-commit hook passes

## Status

**Draft** — will undraft after confirming the fix prevents memory growth in the next `--log trace` incident.