### PR TITLE
chat: disable cloud handoff for sessions without git repos

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -39,7 +39,9 @@ import { ChatSendResult, IChatService } from '../../common/chatService/chatServi
 import { ResolvedChatSessionsExtensionPoint, IChatSessionsService } from '../../common/chatSessionsService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { PROMPT_LANGUAGE_ID } from '../../common/promptSyntax/promptTypes.js';
+import { Iterable } from '../../../../../base/common/iterator.js';
 import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../agentSessions/agentSessions.js';
+import { IGitService } from '../../../git/common/gitService.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { IChatWidget, IChatWidgetService, isIChatViewViewContext } from '../chat.js';
 import { ctxHasEditorModification } from '../chatEditing/chatEditingEditorContextKeys.js';
@@ -163,10 +165,11 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IOpenerService openerService: IOpenerService,
-		@ITelemetryService telemetryService: ITelemetryService
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IGitService gitService: IGitService,
 	) {
 		super(action, {
-			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, location),
+			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, gitService, location),
 			actionBarActions: ChatContinueInSessionActionItem.getActionBarActions(openerService),
 			reporter: { id: 'ChatContinueInSession', name: 'ChatContinueInSession', includeOptions: true },
 		}, actionWidgetService, keybindingService, contextKeyService, telemetryService);
@@ -186,11 +189,12 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		}];
 	}
 
-	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, location: ActionLocation): IActionWidgetDropdownActionProvider {
+	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, gitService: IGitService, location: ActionLocation): IActionWidgetDropdownActionProvider {
 		return {
 			getActions: () => {
 				const actions: IActionWidgetDropdownAction[] = [];
 				const contributions = chatSessionsService.getAllChatSessionContributions();
+				const hasGitRepo = !Iterable.isEmpty(gitService.repositories);
 
 				// Continue in Background
 				const backgroundContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Background);
@@ -198,9 +202,9 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 					actions.push(this.toAction(AgentSessionProviders.Background, backgroundContrib, instantiationService, location));
 				}
 
-				// Continue in Cloud
+				// Continue in Cloud (requires a git repository)
 				const cloudContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Cloud);
-				if (cloudContrib && cloudContrib.canDelegate) {
+				if (cloudContrib && cloudContrib.canDelegate && hasGitRepo) {
 					actions.push(this.toAction(AgentSessionProviders.Cloud, cloudContrib, instantiationService, location));
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -235,7 +235,7 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 			enabled,
 			icon: getAgentSessionProviderIcon(provider),
 			class: undefined,
-			description: enabled ? `@${contrib.name}` : localize('chat.cloudRequiresGit', "Requires a Git repository"),
+			description: `@${contrib.name}`,
 			label: getAgentSessionProviderName(provider),
 			tooltip: localize('continueSessionIn', "Continue in {0}", getAgentSessionProviderName(provider)),
 			category: { label: localize('continueIn', "Continue In"), order: 0, showHeader: true },

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -206,10 +206,10 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 					actions.push(this.toAction(AgentSessionProviders.Background, backgroundContrib, instantiationService, location));
 				}
 
-				// Continue in Cloud (requires a git repository)
+				// Continue in Cloud (disabled when no git repository)
 				const cloudContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Cloud);
-				if (cloudContrib && cloudContrib.canDelegate && hasGitRepo) {
-					actions.push(this.toAction(AgentSessionProviders.Cloud, cloudContrib, instantiationService, location));
+				if (cloudContrib && cloudContrib.canDelegate) {
+					actions.push(this.toAction(AgentSessionProviders.Cloud, cloudContrib, instantiationService, location, hasGitRepo));
 				}
 
 				// Offer actions to enter setup if we have no contributions
@@ -223,13 +223,13 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		};
 	}
 
-	private static toAction(provider: AgentSessionProviders, contrib: ResolvedChatSessionsExtensionPoint, instantiationService: IInstantiationService, location: ActionLocation): IActionWidgetDropdownAction {
+	private static toAction(provider: AgentSessionProviders, contrib: ResolvedChatSessionsExtensionPoint, instantiationService: IInstantiationService, location: ActionLocation, enabled: boolean = true): IActionWidgetDropdownAction {
 		return {
 			id: contrib.type,
-			enabled: true,
+			enabled,
 			icon: getAgentSessionProviderIcon(provider),
 			class: undefined,
-			description: `@${contrib.name}`,
+			description: enabled ? `@${contrib.name}` : localize('chat.cloudRequiresGit', "Requires a Git repository"),
 			label: getAgentSessionProviderName(provider),
 			tooltip: localize('continueSessionIn', "Continue in {0}", getAgentSessionProviderName(provider)),
 			category: { label: localize('continueIn', "Continue In"), order: 0, showHeader: true },

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -39,9 +39,8 @@ import { ChatSendResult, IChatService } from '../../common/chatService/chatServi
 import { ResolvedChatSessionsExtensionPoint, IChatSessionsService } from '../../common/chatSessionsService.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { PROMPT_LANGUAGE_ID } from '../../common/promptSyntax/promptTypes.js';
-import { Iterable } from '../../../../../base/common/iterator.js';
 import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../agentSessions/agentSessions.js';
-import { IGitService } from '../../../git/common/gitService.js';
+import { ISCMService } from '../../../scm/common/scm.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { IChatWidget, IChatWidgetService, isIChatViewViewContext } from '../chat.js';
 import { ctxHasEditorModification } from '../chatEditing/chatEditingEditorContextKeys.js';
@@ -166,11 +165,10 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IOpenerService openerService: IOpenerService,
 		@ITelemetryService telemetryService: ITelemetryService,
-		@IGitService gitService: IGitService,
-		@IChatWidgetService chatWidgetService: IChatWidgetService,
+		@ISCMService scmService: ISCMService,
 	) {
 		super(action, {
-			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, gitService, chatWidgetService, location),
+			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, scmService, location),
 			actionBarActions: ChatContinueInSessionActionItem.getActionBarActions(openerService),
 			reporter: { id: 'ChatContinueInSession', name: 'ChatContinueInSession', includeOptions: true },
 		}, actionWidgetService, keybindingService, contextKeyService, telemetryService);
@@ -190,15 +188,12 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		}];
 	}
 
-	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, gitService: IGitService, chatWidgetService: IChatWidgetService, location: ActionLocation): IActionWidgetDropdownActionProvider {
+	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, scmService: ISCMService, location: ActionLocation): IActionWidgetDropdownActionProvider {
 		return {
 			getActions: () => {
 				const actions: IActionWidgetDropdownAction[] = [];
 				const contributions = chatSessionsService.getAllChatSessionContributions();
-				const widget = chatWidgetService.lastFocusedWidget;
-				const hasGitRepo = widget?.viewModel?.model.repoData
-					? true
-					: !Iterable.isEmpty(gitService.repositories);
+				const hasGitRepo = scmService.repositoryCount > 0;
 
 				// Continue in Background
 				const backgroundContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Background);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -167,9 +167,10 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		@IOpenerService openerService: IOpenerService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IGitService gitService: IGitService,
+		@IChatWidgetService chatWidgetService: IChatWidgetService,
 	) {
 		super(action, {
-			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, gitService, location),
+			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, gitService, chatWidgetService, location),
 			actionBarActions: ChatContinueInSessionActionItem.getActionBarActions(openerService),
 			reporter: { id: 'ChatContinueInSession', name: 'ChatContinueInSession', includeOptions: true },
 		}, actionWidgetService, keybindingService, contextKeyService, telemetryService);
@@ -189,12 +190,15 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		}];
 	}
 
-	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, gitService: IGitService, location: ActionLocation): IActionWidgetDropdownActionProvider {
+	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, gitService: IGitService, chatWidgetService: IChatWidgetService, location: ActionLocation): IActionWidgetDropdownActionProvider {
 		return {
 			getActions: () => {
 				const actions: IActionWidgetDropdownAction[] = [];
 				const contributions = chatSessionsService.getAllChatSessionContributions();
-				const hasGitRepo = !Iterable.isEmpty(gitService.repositories);
+				const widget = chatWidgetService.lastFocusedWidget;
+				const hasGitRepo = widget?.viewModel?.model.repoData
+					? true
+					: !Iterable.isEmpty(gitService.repositories);
 
 				// Continue in Background
 				const backgroundContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Background);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -41,6 +41,7 @@ import { ChatAgentLocation } from '../../common/constants.js';
 import { PROMPT_LANGUAGE_ID } from '../../common/promptSyntax/promptTypes.js';
 import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../agentSessions/agentSessions.js';
 import { ISCMService } from '../../../scm/common/scm.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { IChatWidget, IChatWidgetService, isIChatViewViewContext } from '../chat.js';
 import { ctxHasEditorModification } from '../chatEditing/chatEditingEditorContextKeys.js';
@@ -166,9 +167,10 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		@IOpenerService openerService: IOpenerService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@ISCMService scmService: ISCMService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 	) {
 		super(action, {
-			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, scmService, location),
+			actionProvider: ChatContinueInSessionActionItem.actionProvider(chatSessionsService, instantiationService, scmService, workspaceContextService, location),
 			actionBarActions: ChatContinueInSessionActionItem.getActionBarActions(openerService),
 			reporter: { id: 'ChatContinueInSession', name: 'ChatContinueInSession', includeOptions: true },
 		}, actionWidgetService, keybindingService, contextKeyService, telemetryService);
@@ -188,12 +190,21 @@ export class ChatContinueInSessionActionItem extends ActionWidgetDropdownActionV
 		}];
 	}
 
-	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, scmService: ISCMService, location: ActionLocation): IActionWidgetDropdownActionProvider {
+	private static actionProvider(chatSessionsService: IChatSessionsService, instantiationService: IInstantiationService, scmService: ISCMService, workspaceContextService: IWorkspaceContextService, location: ActionLocation): IActionWidgetDropdownActionProvider {
 		return {
 			getActions: () => {
 				const actions: IActionWidgetDropdownAction[] = [];
 				const contributions = chatSessionsService.getAllChatSessionContributions();
-				const hasGitRepo = scmService.repositoryCount > 0;
+				const folders = workspaceContextService.getWorkspace().folders;
+				let hasGitRepo = false;
+				if (folders.length > 0) {
+					for (const repo of scmService.repositories) {
+						if (repo.provider.rootUri && workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
+							hasGitRepo = true;
+							break;
+						}
+					}
+				}
 
 				// Continue in Background
 				const backgroundContrib = contributions.find(contrib => contrib.type === AgentSessionProviders.Background);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -98,6 +98,11 @@ export interface ISessionTypePickerDelegate {
 	 * and update pickers accordingly.
 	 */
 	onDidChangeActiveSessionProvider?: Event<AgentSessionTarget>;
+	/**
+	 * Returns whether the current session's workspace has a git repository.
+	 * Used to gate cloud delegation which requires a GitHub repository.
+	 */
+	hasGitRepository?(): boolean;
 }
 
 export const IChatWidgetService = createDecorator<IChatWidgetService>('chatWidgetService');

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -69,6 +69,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../../
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { ISharedWebContentExtractorService } from '../../../../../../platform/webContentExtractor/common/webContentExtractor.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../../../platform/workspace/common/workspace.js';
+import { ISCMService } from '../../../../scm/common/scm.js';
 import { IWorkbenchLayoutService, Position } from '../../../../../services/layout/browser/layoutService.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../../common/views.js';
 import { ResourceLabels } from '../../../../../browser/labels.js';
@@ -545,6 +546,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		@IChatContextService private readonly chatContextService: IChatContextService,
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@ISCMService private readonly scmService: ISCMService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IViewDescriptorService private readonly viewDescriptorService: IViewDescriptorService,
 		@IChatAttachmentWidgetRegistry private readonly _chatAttachmentWidgetRegistry: IChatAttachmentWidgetRegistry,
@@ -2289,7 +2291,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.refreshChatSessionPickers();
 						},
 						hasGitRepository: () => {
-							return !!this._widget?.viewModel?.model.repoData;
+							return this.scmService.repositoryCount > 0;
 						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;
@@ -2391,7 +2393,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.refreshChatSessionPickers();
 						},
 						hasGitRepository: () => {
-							return !!this._widget?.viewModel?.model.repoData;
+							return this.scmService.repositoryCount > 0;
 						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2291,7 +2291,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.refreshChatSessionPickers();
 						},
 						hasGitRepository: () => {
-							return this.scmService.repositoryCount > 0;
+							const folders = this.workspaceContextService.getWorkspace().folders;
+							if (folders.length === 0) {
+								return false;
+							}
+							for (const repo of this.scmService.repositories) {
+								if (repo.provider.rootUri && this.workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
+									return true;
+								}
+							}
+							return false;
 						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;
@@ -2393,7 +2402,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.refreshChatSessionPickers();
 						},
 						hasGitRepository: () => {
-							return this.scmService.repositoryCount > 0;
+							const folders = this.workspaceContextService.getWorkspace().folders;
+							if (folders.length === 0) {
+								return false;
+							}
+							for (const repo of this.scmService.repositories) {
+								if (repo.provider.rootUri && this.workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
+									return true;
+								}
+							}
+							return false;
 						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2288,6 +2288,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.updateAgentSessionTypeContextKey();
 							this.refreshChatSessionPickers();
 						},
+						hasGitRepository: () => {
+							return !!this._widget?.viewModel?.model.repoData;
+						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;
 					const Picker = (action.id === OpenSessionTargetPickerAction.ID || isWelcomeViewMode) ? SessionTypePickerActionItem : DelegationSessionPickerActionItem;
@@ -2386,6 +2389,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.updateWidgetLockStateFromSessionType(provider);
 							this.updateAgentSessionTypeContextKey();
 							this.refreshChatSessionPickers();
+						},
+						hasGitRepository: () => {
+							return !!this._widget?.viewModel?.model.repoData;
 						},
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1822,6 +1822,19 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	}
 
+	private hasWorkspaceScmRepository(): boolean {
+		const folders = this.workspaceContextService.getWorkspace().folders;
+		if (folders.length === 0) {
+			return false;
+		}
+		for (const repo of this.scmService.repositories) {
+			if (repo.provider.rootUri && this.workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private getEffectiveSessionType(ctx: IChatSessionContext | undefined, delegate: ISessionTypePickerDelegate | undefined): string {
 		return this.options.sessionTypePickerDelegate?.getActiveSessionProvider?.() || (ctx && getChatSessionType(ctx.chatSessionResource)) || '';
 	}
@@ -2290,18 +2303,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.updateAgentSessionTypeContextKey();
 							this.refreshChatSessionPickers();
 						},
-						hasGitRepository: () => {
-							const folders = this.workspaceContextService.getWorkspace().folders;
-							if (folders.length === 0) {
-								return false;
-							}
-							for (const repo of this.scmService.repositories) {
-								if (repo.provider.rootUri && this.workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
-									return true;
-								}
-							}
-							return false;
-						},
+						hasGitRepository: () => this.hasWorkspaceScmRepository(),
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;
 					const Picker = (action.id === OpenSessionTargetPickerAction.ID || isWelcomeViewMode) ? SessionTypePickerActionItem : DelegationSessionPickerActionItem;
@@ -2401,18 +2403,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.updateAgentSessionTypeContextKey();
 							this.refreshChatSessionPickers();
 						},
-						hasGitRepository: () => {
-							const folders = this.workspaceContextService.getWorkspace().folders;
-							if (folders.length === 0) {
-								return false;
-							}
-							for (const repo of this.scmService.repositories) {
-								if (repo.provider.rootUri && this.workspaceContextService.getWorkspaceFolder(repo.provider.rootUri)) {
-									return true;
-								}
-							}
-							return false;
-						},
+						hasGitRepository: () => this.hasWorkspaceScmRepository(),
 					};
 					const isWelcomeViewMode = !!this.options.sessionTypePickerDelegate?.setActiveSessionProvider;
 					const Picker = (action.id === OpenSessionTargetPickerAction.ID || isWelcomeViewMode) ? SessionTypePickerActionItem : DelegationSessionPickerActionItem;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -95,6 +95,9 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 	}
 
 	private _hasGitRepository(): boolean {
+		if (this.delegate.hasGitRepository) {
+			return this.delegate.hasGitRepository();
+		}
 		return !Iterable.isEmpty(this.gitService.repositories);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -104,6 +104,11 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 			return false;
 		}
 
+		// Cloud delegation requires a git repository
+		if (type === AgentSessionProviders.Cloud && !this._hasGitRepository()) {
+			return false;
+		}
+
 		if (this.delegate.getActiveSessionProvider() === type) {
 			return true; // Always show active session type
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem.ts
@@ -107,11 +107,6 @@ export class DelegationSessionPickerActionItem extends SessionTypePickerActionIt
 			return false;
 		}
 
-		// Cloud delegation requires a git repository
-		if (type === AgentSessionProviders.Cloud && !this._hasGitRepository()) {
-			return false;
-		}
-
 		if (this.delegate.getActiveSessionProvider() === type) {
 			return true; // Always show active session type
 		}

--- a/src/vs/workbench/test/browser/componentFixtures/chatInput.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chatInput.fixture.ts
@@ -51,6 +51,7 @@ import { IUpdateService, StateType } from '../../../../platform/update/common/up
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IListService, ListService } from '../../../../platform/list/browser/listService.js';
 import { INotebookDocumentService } from '../../../services/notebook/common/notebookDocumentService.js';
+import { ISCMService } from '../../../contrib/scm/common/scm.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from './fixtureUtils.js';
 
 import '../../../contrib/chat/browser/widget/media/chat.css';
@@ -133,6 +134,12 @@ async function renderChatInput(context: ComponentFixtureContext, fixtureOptions:
 			reg.defineInstance(IChatContextPickService, new class extends mock<IChatContextPickService>() { }());
 			reg.defineInstance(IListService, new ListService());
 			reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());
+			reg.defineInstance(ISCMService, new class extends mock<ISCMService>() {
+				override readonly onDidAddRepository = Event.None;
+				override readonly onDidRemoveRepository = Event.None;
+				override readonly repositories = [];
+				override readonly repositoryCount = 0;
+			}());
 			reg.defineInstance(IActionWidgetService, new class extends mock<IActionWidgetService>() { override show() { } override hide() { } override get isVisible() { return false; } }());
 			reg.defineInstance(IProductService, new class extends mock<IProductService>() { }());
 			reg.defineInstance(IUpdateService, new class extends mock<IUpdateService>() { override onStateChange = Event.None; override get state() { return { type: StateType.Uninitialized as const }; } }());


### PR DESCRIPTION
## Summary

Fix cloud handoff availability so it is determined from the active session workspace instead of global git/SCM state.

- add a per-session `hasGitRepository` delegate hook for chat session pickers
- compute git availability by checking whether any SCM repository belongs to the current workspace folders
- use that per-workspace check in both the delegation picker and the `Continue In` action
- keep the Cloud option visible but disabled when the active session workspace is not a git repository
- extract the duplicated chat input SCM/workspace check into a helper for clarity

## Why

The previous logic could pick up repositories from other sessions or other global state in the same window, which caused Cloud to appear available for sessions whose active workspace was not actually a git repository.

## Validation

- `npm run compile-check-ts-native` ✅
- `npm run valid-layers-check` ✅
- `npm run hygiene` ⚠️ fails on an unrelated pre-existing file:
  - `extensions/mermaid-chat-features/chat-webview-out/codicon.css: Missing or bad copyright statement`

## Notes

This change keeps the existing UX pattern of showing Cloud in the dropdown but graying it out when it is not available for the active session.