### PR TITLE
css: resolve bare module specifiers to node_modules in @import

### DIFF
--- a/extensions/css-language-features/server/src/test/links.test.ts
+++ b/extensions/css-language-features/server/src/test/links.test.ts
@@ -97,4 +97,24 @@ suite('Links', () => {
 			[{ offset: 29, value: '"~foo/hello.html"', target: getTestResource('node_modules/foo/hello.html') }], testUri, folders
 		);
 	});
+
+	test('bare module specifier resolving without tilde', async function () {
+
+		const testUri = getTestResource('about.css');
+		const folders = [{ name: 'x', uri: getTestResource('') }];
+
+		await assertLinks('@import "foo/hello.html|"',
+			[{ offset: 9, value: '"foo/hello.html"', target: getTestResource('node_modules/foo/hello.html') }], testUri, folders
+		);
+	});
+
+	test('bare module specifier resolving from subfolder', async function () {
+
+		const testUri = getTestResource('subdir/about.css');
+		const folders = [{ name: 'x', uri: getTestResource('') }];
+
+		await assertLinks('@import "foo/hello.html|"',
+			[{ offset: 9, value: '"foo/hello.html"', target: getTestResource('node_modules/foo/hello.html') }], testUri, folders
+		);
+	});
 });

--- a/extensions/css-language-features/server/src/utils/documentContext.ts
+++ b/extensions/css-language-features/server/src/utils/documentContext.ts
@@ -8,6 +8,11 @@ import { endsWith, startsWith } from '../utils/strings';
 import { WorkspaceFolder } from 'vscode-languageserver';
 import { Utils, URI } from 'vscode-uri';
 
+function isBareModuleSpecifier(ref: string): boolean {
+	// A bare module specifier doesn't start with '.', '..', '/', '~', or a protocol
+	return !/^(\.\.?\/|\/|~|[a-z][a-z0-9+\-.]*:)/i.test(ref);
+}
+
 export function getDocumentContext(documentUri: string, workspaceFolders: WorkspaceFolder[]): DocumentContext {
 	function getRootFolder(): string | undefined {
 		for (const folder of workspaceFolders) {
@@ -28,6 +33,15 @@ export function getDocumentContext(documentUri: string, workspaceFolders: Worksp
 				const folderUri = getRootFolder();
 				if (folderUri) {
 					return folderUri + ref.substring(1);
+				}
+			}
+			// For bare module specifiers (e.g., "some-module/style.css"),
+			// resolve against node_modules in the workspace root as a
+			// fallback, similar to how bundlers like Vite resolve imports.
+			if (isBareModuleSpecifier(ref)) {
+				const folderUri = getRootFolder();
+				if (folderUri) {
+					return Utils.resolvePath(URI.parse(folderUri), 'node_modules', ref).toString(true);
 				}
 			}
 			const baseUri = URI.parse(base);


### PR DESCRIPTION
## Summary

Add node_modules resolution for bare module specifiers in CSS `@import` statements. When a path like `"some-module/style.css"` is used (without a leading `./`, `../`, `/`, or `~`), resolve it against `node_modules/` in the workspace root.

This enables Ctrl+click navigation for CSS imports that use bundler-style module resolution (Vite, webpack, etc.), which is a common pattern in modern frontend projects.

## Before

```css
@import "bootstrap/dist/css/bootstrap.css";
/* Ctrl+click → resolves to ./bootstrap/dist/css/bootstrap.css (doesn't exist) */
```

## After

```css
@import "bootstrap/dist/css/bootstrap.css";
/* Ctrl+click → resolves to node_modules/bootstrap/dist/css/bootstrap.css ✓ */
```

## Implementation

Added a `isBareModuleSpecifier()` check in `documentContext.ts`'s `resolveReference()` function. If a reference doesn't start with `.`, `..`, `/`, `~`, or a protocol scheme, it's treated as a bare module specifier and resolved against `node_modules/` in the workspace root.

This is consistent with how the tilde (`~`) prefix already resolves to node_modules, but removes the need for the tilde prefix that most modern bundlers don't require.

## Files changed

| File | Change |
|------|--------|
| `extensions/css-language-features/server/src/utils/documentContext.ts` | Add bare module specifier detection and node_modules resolution |
| `extensions/css-language-features/server/src/test/links.test.ts` | Add tests for bare module resolution with and without subfolder |

Fixes #295074