### PR TITLE
Fix disable button dropdown for workspace-enabled extensions

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1751,7 +1751,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
…kspace only

When an extension is globally disabled but enabled for a specific workspace (EnablementState.EnabledWorkspace), the Disable button was incorrectly showing a dropdown with both 'Disable' and 'Disable (Workspace)' options.

Fixed by updating DisableGloballyAction.update() to only enable when the extension's enablementState is EnabledGlobally. When it's EnabledWorkspace, the extension is already globally disabled, so only 'Disable (Workspace)' should be available.

Fixes the issue where the disable button dropdown appeared when it should have been a single 'Disable (Workspace)' button without dropdown.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
