### PR TITLE
Allow readonly T[] in TreeDataProvider.getChildren()

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -292,12 +292,12 @@ class TreeViewDataProvider implements ITreeViewDataProvider {
 		this.hasResolve = this._proxy.$hasResolve(this.treeViewId);
 	}
 
-	async getChildren(treeItem?: ITreeItem): Promise<ITreeItem[] | undefined> {
+	async getChildren(treeItem?: ITreeItem): Promise<readonly ITreeItem[] | undefined> {
 		const batches = await this.getChildrenBatch(treeItem ? [treeItem] : undefined);
 		return batches?.[0];
 	}
 
-	getChildrenBatch(treeItems?: ITreeItem[]): Promise<ITreeItem[][] | undefined> {
+	getChildrenBatch(treeItems?: ITreeItem[]): Promise<readonly ITreeItem[][] | undefined> {
 		if (!treeItems) {
 			this.itemsMap.clear();
 		}
@@ -317,7 +317,7 @@ class TreeViewDataProvider implements ITreeViewDataProvider {
 				});
 	}
 
-	private convertTransferChildren(parents: ITreeItem[], children: (number | ITreeItem)[][] | undefined) {
+	private convertTransferChildren(parents: ITreeItem[], children: readonly (number | ITreeItem)[][] | undefined) {
 		const convertedChildren: (ITreeItem[] | undefined)[] = Array(parents.length);
 		if (children) {
 			for (const childGroup of children) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2303,7 +2303,7 @@ export interface ExtHostTreeViewsShape {
 	 * for [x,y] returns
 	 * [[1,z]], where the inner array is [original index, ...children]
 	 */
-	$getChildren(treeViewId: string, treeItemHandles?: string[]): Promise<(number | ITreeItem)[][] | undefined>;
+	$getChildren(treeViewId: string, treeItemHandles?: string[]): Promise<readonly (number | ITreeItem)[][] | undefined>;
 	$handleDrop(destinationViewId: string, requestId: number, treeDataTransfer: DataTransferDTO, targetHandle: string | undefined, token: CancellationToken, operationUuid?: string, sourceViewId?: string, sourceTreeItemHandles?: string[]): Promise<void>;
 	$handleDrag(sourceViewId: string, sourceTreeItemHandles: string[], operationUuid: string, token: CancellationToken): Promise<DataTransferDTO | undefined>;
 	$setExpanded(treeViewId: string, treeItemHandle: string, expanded: boolean): void;

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -164,7 +164,7 @@ export class ExtHostTreeViews extends Disposable implements ExtHostTreeViewsShap
 		return view as vscode.TreeView<T>;
 	}
 
-	async $getChildren(treeViewId: string, treeItemHandles?: string[]): Promise<(number | ITreeItem)[][] | undefined> {
+	async $getChildren(treeViewId: string, treeItemHandles?: string[]): Promise<readonly (number | ITreeItem)[][] | undefined> {
 		const treeView = this._treeViews.get(treeViewId);
 		if (!treeView) {
 			return Promise.reject(new NoTreeViewError(treeViewId));
@@ -488,7 +488,7 @@ class ExtHostTreeView<T> extends Disposable {
 		}
 	}
 
-	async getChildren(parentHandle: TreeItemHandle | Root): Promise<ITreeItem[] | undefined> {
+	async getChildren(parentHandle: TreeItemHandle | Root): Promise<readonly ITreeItem[] | undefined> {
 		const parentElement = parentHandle ? this.getExtensionElement(parentHandle) : undefined;
 		if (parentHandle && !parentElement) {
 			this._logService.error(`No tree item with id \'${parentHandle}\' found.`);

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -876,8 +876,8 @@ export class NoTreeViewError extends Error {
 export interface ITreeViewDataProvider {
 	readonly isTreeEmpty?: boolean;
 	readonly onDidChangeEmpty?: Event<void>;
-	getChildren(element?: ITreeItem): Promise<ITreeItem[] | undefined>;
-	getChildrenBatch?(element?: ITreeItem[]): Promise<ITreeItem[][] | undefined>;
+	getChildren(element?: ITreeItem): Promise<readonly ITreeItem[] | undefined>;
+	getChildrenBatch?(element?: ITreeItem[]): Promise<readonly ITreeItem[][] | undefined>;
 }
 
 export interface ITreeViewDragAndDropController {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -12252,7 +12252,7 @@ declare module 'vscode' {
 		 * @param element The element from which the provider gets children. Can be `undefined`.
 		 * @returns Children of `element` or root if no element is passed.
 		 */
-		getChildren(element?: T): ProviderResult<T[]>;
+		getChildren(element?: T): ProviderResult<readonly T[]>;
 
 		/**
 		 * Optional method to return the parent of `element`.


### PR DESCRIPTION
This change allows `TreeDataProvider.getChildren()` to return `readonly T[]`, enabling type-guarded or immutable children arrays to be returned safely.

- Verified internal usage; no mutations occur on immutable arrays.
- Updated relevant interfaces to accept `readonly T[]`.
- Other components, like `src/vs/base/browser/ui/tree/asyncDataTree.ts`, already operate on `Iterable<T>` and are compatible.
- Improves type safety and simplifies extension code for fixed children arrays.