### PR TITLE
build: normalize darwin bundle icon paths for case-sensitive FS (#129665)

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -80,11 +80,12 @@ function darwinBundleDocumentType(extensions: string[], icon: string, nameOrSuff
 /**
  * Generate several `DarwinDocumentType`s with unique names and a shared icon.
  * @param types A map of file type names to their associated file extensions.
- * @param icon A darwin icon resource to use. For example, `'HTML'` would refer to `resources/darwin/html.icns`
+ * @param icon Basename of a darwin icon resource under `resources/darwin/` (without `.icns`). The value is
+ * lowercased before building the path so builds succeed on case-sensitive filesystems (see #129665).
  *
  * Examples:
  * ```
- * darwinBundleDocumentTypes({ 'C header file': 'h', 'C source code': 'c' },'c')
+ * darwinBundleDocumentTypes({ 'C header file': 'h', 'C source code': 'c' }, 'c')
  * darwinBundleDocumentTypes({ 'React source code': ['jsx', 'tsx'] }, 'react')
  * ```
  */
@@ -96,7 +97,7 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 			role: 'Editor',
 			ostypes: ['TEXT', 'utxt', 'TUTX', '****'],
 			extensions: Array.isArray(extensions) ? extensions : [extensions],
-			iconFile: 'resources/darwin/' + icon + '.icns'
+			iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns'
 		};
 	});
 }

--- a/build/lib/test/electronDarwinIcons.test.ts
+++ b/build/lib/test/electronDarwinIcons.test.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import path from 'path';
+import { config } from '../electron.ts';
+
+suite('Electron Darwin bundle document icon paths', () => {
+	test('darwinBundleDocumentTypes iconFile paths use lowercase basenames for case-sensitive volumes (#129665)', () => {
+		for (const docType of config.darwinBundleDocumentTypes) {
+			const { iconFile } = docType;
+			assert.ok(iconFile.startsWith('resources/darwin/'), iconFile);
+			assert.ok(iconFile.endsWith('.icns'), iconFile);
+			const base = path.basename(iconFile, '.icns');
+			assert.strictEqual(base, base.toLowerCase(), `icon basename must be lowercase: ${iconFile}`);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
Follow-up for [#129665](https://github.com/microsoft/vscode/issues/129665): document-type icon paths must use lowercase basenames so `node build/lib/electron.ts` (gulp-electron glob) succeeds on **case-sensitive** APFS.

The primary fix for the reported `Bower.icns` vs `bower.icns` failure is already on `main` via [#216492](https://github.com/microsoft/vscode/pull/216492) (`darwinBundleDocumentType` uses `icon.toLowerCase()`).

This PR:
- Applies the same normalization in `darwinBundleDocumentTypes` so a future call with mixed-case `icon` cannot reintroduce the bug.
- Adds a regression test that asserts every `config.darwinBundleDocumentTypes` entry has a lowercase `.icns` basename.

## How to test
- `./node_modules/.bin/tsgo --project build/tsconfig.json` (from repo root)
- `npm run test-build-scripts` (requires Node version matching repo CI, e.g. 22+)

Fixes #129665