### PR TITLE
build: normalize darwin bundle icon paths for case-sensitive FS (#129…

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -80,11 +80,12 @@ function darwinBundleDocumentType(extensions: string[], icon: string, nameOrSuff
 /**
  * Generate several `DarwinDocumentType`s with unique names and a shared icon.
  * @param types A map of file type names to their associated file extensions.
- * @param icon A darwin icon resource to use. For example, `'HTML'` would refer to `resources/darwin/html.icns`
+ * @param icon Basename of a darwin icon resource under `resources/darwin/` (without `.icns`). The value is
+ * lowercased before building the path so builds succeed on case-sensitive filesystems (see #129665).
  *
  * Examples:
  * ```
- * darwinBundleDocumentTypes({ 'C header file': 'h', 'C source code': 'c' },'c')
+ * darwinBundleDocumentTypes({ 'C header file': 'h', 'C source code': 'c' }, 'c')
  * darwinBundleDocumentTypes({ 'React source code': ['jsx', 'tsx'] }, 'react')
  * ```
  */
@@ -96,7 +97,7 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 			role: 'Editor',
 			ostypes: ['TEXT', 'utxt', 'TUTX', '****'],
 			extensions: Array.isArray(extensions) ? extensions : [extensions],
-			iconFile: 'resources/darwin/' + icon + '.icns'
+			iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns'
 		};
 	});
 }

--- a/build/lib/test/electronDarwinIcons.test.ts
+++ b/build/lib/test/electronDarwinIcons.test.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import path from 'path';
+import { config } from '../electron.ts';
+
+suite('Electron Darwin bundle document icon paths', () => {
+	test('darwinBundleDocumentTypes iconFile paths use lowercase basenames for case-sensitive volumes (#129665)', () => {
+		for (const docType of config.darwinBundleDocumentTypes) {
+			const { iconFile } = docType;
+			assert.ok(iconFile.startsWith('resources/darwin/'), iconFile);
+			assert.ok(iconFile.endsWith('.icns'), iconFile);
+			const base = path.basename(iconFile, '.icns');
+			assert.strictEqual(base, base.toLowerCase(), `icon basename must be lowercase: ${iconFile}`);
+		}
+	});
+});


### PR DESCRIPTION
Hi,
This PR is for #129665. On a case-sensitive Mac disk, the build could look for Bower.icns while the file on disk is actually bower.icns, and the Electron step would fail.
That case was already fixed for one code path in #216492. I’m doing the same thing for the other helper (darwinBundleDocumentTypes) so we don’t accidentally break this again if someone passes a mixed-case icon name later.
I also added a small test that checks every Darwin document icon path uses a lowercase basename.
How you can verify: run npm run test-build-scripts from the repo root (use Node 22 like .nvmrc says).
Fixes #129665