### PR TITLE
Use URI for workingDirectory across agent host layer

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -37,7 +37,7 @@ export interface IAgentSessionMetadata {
 	readonly startTime: number;
 	readonly modifiedTime: number;
 	readonly summary?: string;
-	readonly workingDirectory?: string;
+	readonly workingDirectory?: URI;
 }
 
 export type AgentProvider = string;
@@ -100,7 +100,7 @@ export interface IAgentCreateSessionConfig {
 	readonly provider?: AgentProvider;
 	readonly model?: string;
 	readonly session?: URI;
-	readonly workingDirectory?: string;
+	readonly workingDirectory?: URI;
 }
 
 /** Serializable attachment passed alongside a message to the agent host. */

--- a/src/vs/platform/agentHost/electron-browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/electron-browser/remoteAgentHostProtocolClient.ts
@@ -15,6 +15,7 @@ import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentSession, IAgentConnection, IAgentCreateSessionConfig, IAgentDescriptor, IAgentSessionMetadata, IAuthenticateParams, IAuthenticateResult, IResourceMetadata } from '../common/agentService.js';
+import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
 import type { IClientNotificationMap, ICommandMap } from '../common/state/protocol/messages.js';
 import type { IActionEnvelope, INotification, ISessionAction } from '../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../common/state/sessionCapabilities.js';
@@ -36,6 +37,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	private readonly _clientId = generateUuid();
 	private readonly _transport: WebSocketClientTransport;
+	private readonly _connectionAuthority: string;
 	private _serverSeq = 0;
 	private _nextClientSeq = 1;
 	private _defaultDirectory: string | undefined;
@@ -71,6 +73,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+		this._connectionAuthority = agentHostAuthority(address);
 		this._transport = this._register(new WebSocketClientTransport(address, connectionToken));
 		this._register(this._transport.onMessage(msg => this._handleMessage(msg)));
 		this._register(this._transport.onClose(() => this._onDidClose.fire()));
@@ -132,7 +135,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			session: session.toString(),
 			provider,
 			model: config?.model,
-			workingDirectory: config?.workingDirectory,
+			workingDirectory: config?.workingDirectory ? fromAgentHostUri(config.workingDirectory).toString() : undefined,
 		});
 		return session;
 	}
@@ -189,7 +192,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			startTime: s.createdAt,
 			modifiedTime: s.modifiedAt,
 			summary: s.title,
-			workingDirectory: typeof s.workingDirectory === 'string' ? s.workingDirectory : undefined,
+			workingDirectory: typeof s.workingDirectory === 'string' ? toAgentHostUri(URI.parse(s.workingDirectory), this._connectionAuthority) : undefined,
 		}));
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -153,7 +153,7 @@ async function startWebSocketServer(agentService: AgentService, logService: ILog
 			await agentService.createSession({
 				provider: command.provider,
 				model: command.model,
-				workingDirectory: command.workingDirectory,
+				workingDirectory: command.workingDirectory ? URI.parse(command.workingDirectory) : undefined,
 				session: URI.parse(command.session),
 			});
 		},
@@ -169,10 +169,9 @@ async function startWebSocketServer(agentService: AgentService, logService: ILog
 				status: SessionStatus.Idle,
 				createdAt: s.startTime,
 				modifiedAt: s.modifiedTime,
-				workingDirectory: s.workingDirectory,
+				workingDirectory: s.workingDirectory?.toString(),
 			}));
 		},
-
 		handleGetResourceMetadata() {
 			return agentService.getResourceMetadataSync();
 		},

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -156,7 +156,7 @@ export class AgentService extends Disposable implements IAgentService {
 			status: SessionStatus.Idle,
 			createdAt: Date.now(),
 			modifiedAt: Date.now(),
-			workingDirectory: config?.workingDirectory,
+			workingDirectory: config?.workingDirectory?.toString(),
 		};
 		this._stateManager.createSession(summary);
 		this._stateManager.dispatchServerAction({ type: ActionType.SessionReady, session: session.toString() });

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -364,7 +364,7 @@ export class AgentSideEffects extends Disposable implements IProtocolSideEffectH
 		await agent.createSession({
 			provider,
 			model: command.model,
-			workingDirectory: command.workingDirectory,
+			workingDirectory: command.workingDirectory ? URI.parse(command.workingDirectory) : undefined,
 			session: URI.parse(session),
 		});
 		const summary: ISessionSummary = {
@@ -461,7 +461,7 @@ export class AgentSideEffects extends Disposable implements IProtocolSideEffectH
 			status: SessionStatus.Idle,
 			createdAt: meta.startTime,
 			modifiedAt: meta.modifiedTime,
-			workingDirectory: meta.workingDirectory,
+			workingDirectory: meta.workingDirectory?.toString(),
 		};
 
 		this._stateManager.restoreSession(summary, turns);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -11,6 +11,7 @@ import { FileAccess } from '../../../../base/common/network.js';
 import type { IAuthorizationProtectedResourceMetadata } from '../../../../base/common/oauth.js';
 import { delimiter, dirname } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { AgentSession, IAgent, IAgentAttachment, IAgentCreateSessionConfig, IAgentDescriptor, IAgentMessageEvent, IAgentModelInfo, IAgentProgressEvent, IAgentSessionMetadata, IAgentToolCompleteEvent, IAgentToolStartEvent } from '../../common/agentService.js';
@@ -150,7 +151,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			startTime: s.startTime.getTime(),
 			modifiedTime: s.modifiedTime.getTime(),
 			summary: s.summary,
-			workingDirectory: typeof s.context?.cwd === 'string' ? s.context.cwd : undefined,
+			workingDirectory: typeof s.context?.cwd === 'string' ? URI.file(s.context.cwd) : undefined,
 		}));
 		this._logService.info(`[Copilot] Found ${result.length} sessions`);
 		return result;
@@ -185,7 +186,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				model: config?.model,
 				sessionId: config?.session ? AgentSession.id(config.session) : undefined,
 				streaming: true,
-				workingDirectory: config?.workingDirectory,
+				workingDirectory: config?.workingDirectory?.fsPath,
 				onPermissionRequest: callbacks.onPermissionRequest,
 				hooks: callbacks.hooks,
 			});
@@ -283,8 +284,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * and returns it. The caller must call {@link CopilotAgentSession.initializeSession}
 	 * to wire up the SDK session.
 	 */
-	private _createAgentSession(wrapperFactory: SessionWrapperFactory, workingDirectory: string | undefined, sessionIdOverride?: string): CopilotAgentSession {
-		const rawId = sessionIdOverride ?? crypto.randomUUID();
+	private _createAgentSession(wrapperFactory: SessionWrapperFactory, workingDirectory: URI | undefined, sessionIdOverride?: string): CopilotAgentSession {
+		const rawId = sessionIdOverride ?? generateUuid();
 		const sessionUri = AgentSession.uri(this.id, rawId);
 
 		const agentSession = this._instantiationService.createInstance(

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -8,6 +8,7 @@ import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
 import { localize } from '../../../../nls.js';
@@ -118,12 +119,12 @@ export class CopilotAgentSession extends Disposable {
 	/** SDK session wrapper, set by {@link initializeSession}. */
 	private _wrapper!: CopilotSessionWrapper;
 
-	private readonly _workingDirectory: string | undefined;
+	private readonly _workingDirectory: URI | undefined;
 
 	constructor(
 		sessionUri: URI,
 		rawSessionId: string,
-		workingDirectory: string | undefined,
+		workingDirectory: URI | undefined,
 		private readonly _onDidSessionProgress: Emitter<IAgentProgressEvent>,
 		private readonly _wrapperFactory: SessionWrapperFactory,
 		@IFileService private readonly _fileService: IFileService,
@@ -240,7 +241,7 @@ export class CopilotAgentSession extends Disposable {
 		// Auto-approve reads inside the working directory
 		if (request.kind === 'read') {
 			const requestPath = typeof request.path === 'string' ? request.path : undefined;
-			if (requestPath && this._workingDirectory && requestPath.startsWith(this._workingDirectory)) {
+			if (requestPath && this._workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(URI.file(requestPath), this._workingDirectory)) {
 				this._logService.trace(`[Copilot:${this.sessionId}] Auto-approving read inside working directory: ${requestPath}`);
 				return { kind: 'approved' };
 			}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -8,7 +8,7 @@ import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
+import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
 import { localize } from '../../../../nls.js';
@@ -241,7 +241,7 @@ export class CopilotAgentSession extends Disposable {
 		// Auto-approve reads inside the working directory
 		if (request.kind === 'read') {
 			const requestPath = typeof request.path === 'string' ? request.path : undefined;
-			if (requestPath && this._workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(URI.file(requestPath), this._workingDirectory)) {
+			if (requestPath && this._workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(URI.file(requestPath)), this._workingDirectory)) {
 				this._logService.trace(`[Copilot:${this.sessionId}] Auto-approving read inside working directory: ${requestPath}`);
 				return { kind: 'approved' };
 			}

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -430,7 +430,7 @@ suite('AgentSideEffects', () => {
 		});
 
 		test('preserves workingDirectory from agent metadata', async () => {
-			agent.sessionMetadataOverrides = { workingDirectory: '/home/user/project' };
+			agent.sessionMetadataOverrides = { workingDirectory: URI.file('/home/user/project') };
 			const session = await agent.createSession();
 			const sessions = await agent.listSessions();
 			const sessionResource = sessions[0].session.toString();
@@ -444,7 +444,7 @@ suite('AgentSideEffects', () => {
 
 			const state = stateManager.getSessionState(sessionResource);
 			assert.ok(state);
-			assert.strictEqual(state!.summary.workingDirectory, '/home/user/project');
+			assert.strictEqual(state!.summary.workingDirectory, URI.file('/home/user/project').toString());
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -81,7 +81,7 @@ function createMockSessionDataService(): ISessionDataService {
 	};
 }
 
-async function createAgentSession(disposables: DisposableStore, options?: { workingDirectory?: string }): Promise<{
+async function createAgentSession(disposables: DisposableStore, options?: { workingDirectory?: URI }): Promise<{
 	session: CopilotAgentSession;
 	mockSession: MockCopilotSession;
 	progressEvents: IAgentProgressEvent[];
@@ -129,7 +129,7 @@ suite('CopilotAgentSession', () => {
 	suite('permission handling', () => {
 
 		test('auto-approves read inside working directory', async () => {
-			const { session } = await createAgentSession(disposables, { workingDirectory: '/workspace' });
+			const { session } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
 			const result = await session.handlePermissionRequest({
 				kind: 'read',
 				path: '/workspace/src/file.ts',
@@ -139,7 +139,7 @@ suite('CopilotAgentSession', () => {
 		});
 
 		test('does not auto-approve read outside working directory', async () => {
-			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: '/workspace' });
+			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
 
 			// Kick off permission request but don't await — it will block
 			const resultPromise = session.handlePermissionRequest({

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../
 import { URI } from '../../../../base/common/uri.js';
 import * as nls from '../../../../nls.js';
 import { AgentHostFileSystemProvider } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
-import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
@@ -306,11 +306,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		const displayName = configuredName || `${agent.displayName} (${address})`;
 
 		// Per-agent working directory cache, scoped to the agent store lifetime
-		const sessionWorkingDirs = new Map<string, string>();
+		const sessionWorkingDirs = new Map<string, URI>();
 		agentStore.add(toDisposable(() => sessionWorkingDirs.clear()));
 
 		// Capture the working directory from the active session for new sessions
-		const resolveWorkingDirectory = (resourceKey: string): string | undefined => {
+		const resolveWorkingDirectory = (resourceKey: string): URI | undefined => {
 			const cached = sessionWorkingDirs.get(resourceKey);
 			if (cached) {
 				return cached;
@@ -318,12 +318,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			const activeSession = this._sessionsManagementService.activeSession.get();
 			const repoUri = activeSession?.workspace.get()?.repositories[0]?.uri;
 			if (repoUri) {
-				// The repository URI may be wrapped as a vscode-agent-host:// URI.
-				// Unwrap to get the original filesystem path.
-				const originalUri = repoUri.scheme === AGENT_HOST_SCHEME ? fromAgentHostUri(repoUri) : repoUri;
-				const dir = originalUri.path;
-				sessionWorkingDirs.set(resourceKey, dir);
-				return dir;
+				sessionWorkingDirs.set(resourceKey, repoUri);
+				return repoUri;
 			}
 			return undefined;
 		};

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -220,14 +220,12 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	/**
 	 * Builds workspace metadata from a working directory path on the remote host.
 	 */
-	static buildWorkspace(workingDirectory: string, providerLabel: string, connectionAuthority: string): ISessionWorkspace {
-		const directoryUri = URI.file(workingDirectory);
-		const folderName = basename(directoryUri) || workingDirectory;
-		const uri = toAgentHostUri(directoryUri, connectionAuthority);
+	static buildWorkspace(workingDirectory: URI, providerLabel: string, _connectionAuthority: string): ISessionWorkspace {
+		const folderName = basename(workingDirectory) || workingDirectory.path;
 		return {
 			label: `${folderName} [${providerLabel}]`,
 			icon: Codicon.remote,
-			repositories: [{ uri, workingDirectory: undefined, detail: providerLabel, baseBranchName: undefined, baseBranchProtected: undefined }],
+			repositories: [{ uri: workingDirectory, workingDirectory: undefined, detail: providerLabel, baseBranchName: undefined, baseBranchProtected: undefined }],
 			requiresWorkspaceTrust: false,
 		};
 	}
@@ -521,7 +519,9 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		}
 
 		const provider = AgentSession.provider(sessionUri) ?? 'copilot';
-		const workingDir = typeof summary.workingDirectory === 'string' ? summary.workingDirectory : undefined;
+		const workingDir = typeof summary.workingDirectory === 'string'
+			? toAgentHostUri(URI.parse(summary.workingDirectory), this._connectionAuthority)
+			: undefined;
 		const meta: IAgentSessionMetadata = {
 			session: sessionUri,
 			startTime: summary.createdAt,

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -70,7 +70,7 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 
 // ---- Test helpers -----------------------------------------------------------
 
-function createSession(id: string, opts?: { provider?: string; summary?: string; workingDirectory?: string; startTime?: number; modifiedTime?: number }): IAgentSessionMetadata {
+function createSession(id: string, opts?: { provider?: string; summary?: string; workingDirectory?: URI; startTime?: number; modifiedTime?: number }): IAgentSessionMetadata {
 	return {
 		session: AgentSession.uri(opts?.provider ?? 'copilot', id),
 		startTime: opts?.startTime ?? 1000,
@@ -364,7 +364,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 	// ---- Session data adapter -------
 
 	test('session adapter has correct workspace from working directory', async () => {
-		connection.addSession(createSession('ws-sess', { summary: 'WS Test', workingDirectory: '/home/user/myrepo' }));
+		connection.addSession(createSession('ws-sess', { summary: 'WS Test', workingDirectory: URI.parse('vscode-agent-host://localhost__4321/file/-/home/user/myrepo') }));
 
 		const provider = createProvider(disposables, connection);
 		provider.getSessions();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -151,7 +151,7 @@ export interface IAgentHostSessionHandlerConfig {
 	 * Optional callback to resolve a working directory for a new session.
 	 * If not provided, falls back to the first workspace folder.
 	 */
-	readonly resolveWorkingDirectory?: (resourceKey: string) => string | undefined;
+	readonly resolveWorkingDirectory?: (resourceKey: string) => URI | undefined;
 	/**
 	 * Optional callback invoked when the server rejects an operation because
 	 * authentication is required. Should trigger interactive authentication
@@ -1189,7 +1189,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const rawModelId = this._extractRawModelId(modelId);
 		const resourceKey = sessionResource.path.substring(1);
 		const workingDirectory = this._config.resolveWorkingDirectory?.(resourceKey)
-			?? this._workspaceContextService.getWorkspace().folders[0]?.uri.fsPath;
+			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
 
 		this._logService.trace(`[AgentHost] Creating new session, model=${rawModelId ?? '(default)'}, provider=${this._config.provider}`);
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -41,7 +41,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		this._register(this._connection.onDidNotification(n => {
 			if (n.type === 'notify/sessionAdded' && n.summary.provider === this._provider) {
 				const rawId = AgentSession.id(n.summary.resource);
-				const workingDir = typeof n.summary.workingDirectory === 'string' ? n.summary.workingDirectory : undefined;
+				const workingDir = typeof n.summary.workingDirectory === 'string' ? URI.parse(n.summary.workingDirectory) : undefined;
 				const item: IChatSessionItem = {
 					resource: URI.from({ scheme: this._sessionType, path: `/${rawId}` }),
 					label: n.summary.title ?? `Session ${rawId.substring(0, 8)}`,
@@ -104,13 +104,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
 	}
 
-	private _buildMetadata(workingDirectory?: string): { readonly [key: string]: unknown } | undefined {
+	private _buildMetadata(workingDirectory?: URI): { readonly [key: string]: unknown } | undefined {
 		if (!this._description) {
 			return undefined;
 		}
 		const result: { [key: string]: unknown } = { remoteAgentHost: this._description };
 		if (workingDirectory) {
-			result.workingDirectoryPath = workingDirectory;
+			result.workingDirectoryPath = workingDirectory.fsPath;
 		}
 		return result;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -1451,7 +1451,7 @@ suite('AgentHostChatContribution', () => {
 				description: 'test',
 				connection: agentHostService,
 				connectionAuthority: 'local',
-				resolveWorkingDirectory: () => '/custom/working/dir',
+				resolveWorkingDirectory: () => URI.file('/custom/working/dir'),
 			}));
 
 			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables);
@@ -1459,7 +1459,7 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 
 			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
-			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory, '/custom/working/dir');
+			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory?.fsPath, '/custom/working/dir');
 		});
 
 		test('list controller includes description in items', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -1459,7 +1459,7 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 
 			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
-			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory?.fsPath, '/custom/working/dir');
+			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory?.toString(), URI.file('/custom/working/dir').toString());
 		});
 
 		test('list controller includes description in items', async () => {


### PR DESCRIPTION
Changes `workingDirectory` from `string` to `URI` throughout the agent host layer, with proper boundary conversions:

- **Type changes:** `IAgentCreateSessionConfig.workingDirectory` and `IAgentSessionMetadata.workingDirectory` are now `URI`
- **SDK boundary (CopilotAgent):** Raw path strings from the SDK are converted to `URI.file()` on entry; `URI.fsPath` is used when passing back to the SDK
- **Protocol boundary (remoteAgentHostProtocolClient):** Remote `file://` URIs are converted to `agenthost://` URIs via `toAgentHostUri()` when entering the renderer; `agenthost://` URIs are converted back to `file://` via `fromAgentHostUri()` when sent to the remote host
- **resolveWorkingDirectory callback:** Now returns `URI` instead of `string`, eliminating the `fromAgentHostUri` unwrapping that was previously needed at the callsite
- **Permission auto-approval:** Uses `extUriBiasedIgnorePathCase.isEqualOrParent()` with proper URI comparison instead of raw `startsWith`
- **Session ID generation:** Uses `generateUuid()` from `vs/base/common/uuid` instead of `crypto.randomUUID()`
- Properly registers event subscription disposables in `CopilotAgentSession`
- Adds `SessionWrapperFactory` pattern for testability and `CopilotAgentSession` unit tests

The key architectural improvement: feature code in the renderer process now works exclusively with `agenthost://` URIs for remote working directories, with scheme transformation happening at the protocol client boundary — similar to how remote extension hosts handle URI mapping.

(Written by Copilot)