### PR TITLE
[POC] Fix Browser Double Zoom Bug

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -292,10 +292,12 @@ export class BrowserView extends Disposable implements ICDPTarget {
 
 		// Focus events
 		webContents.on('focus', () => {
+			webContents.setIgnoreMenuShortcuts(true);
 			this._onDidChangeFocus.fire({ focused: true });
 		});
 
 		webContents.on('blur', () => {
+			webContents.setIgnoreMenuShortcuts(false);
 			this._onDidChangeFocus.fire({ focused: false });
 		});
 


### PR DESCRIPTION
This fixes the issue where the zoom in/out keyboard shortcuts cause the action to be performed twice. But it also breaks undo/redo, so this is not the final solution 