### PR TITLE
Default files.watcherExclude patterns cause CPU stall on large repos due to pathological regex (fix #305923)

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -28,12 +28,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 		'extensions.ignoreRecommendations': true,
 
 		'files.autoSave': 'afterDelay',
-		'files.watcherExclude': {
-			'**/.git/objects/**': true,
-			'**/.git/subtree-cache/**': true,
-			'**/node_modules/*/**': true,
-			'**/.hg/store/**': true
-		},
 
 		'git.autofetch': true,
 		'git.branchRandomName.enable': true,

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -295,7 +295,16 @@ configurationRegistry.registerConfiguration({
 			'patternProperties': {
 				'.*': { 'type': 'boolean' }
 			},
-			'default': { '**/.git/objects/**': true, '**/.git/subtree-cache/**': true, '**/.hg/store/**': true },
+			'default': {
+				// Avoiding a '**' pattern here which results in a very complex
+				// RegExp that can slow things down significantly in large workspaces
+				'.git/objects/**': true,
+				'.git/subtree-cache/**': true,
+				'.hg/store/**': true,
+				'*/.git/objects/**': true,
+				'*/.git/subtree-cache/**': true,
+				'*/.hg/store/**': true
+			},
 			'markdownDescription': nls.localize('watcherExclude', "Configure paths or [glob patterns](https://aka.ms/vscode-glob-patterns) to exclude from file watching. Paths can either be relative to the watched folder or absolute. Glob patterns are matched relative from the watched folder. When you experience the file watcher process consuming a lot of CPU, make sure to exclude large folders that are of less interest (such as build output folders)."),
 			'scope': ConfigurationScope.RESOURCE
 		},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
