### PR TITLE
fix: scope editor service in window title to own editor groups container

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -55,7 +55,7 @@ import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { safeIntl } from '../../../../base/common/date.js';
 import { IsCompactTitleBarContext, TitleBarVisibleContext } from '../../../common/contextkeys.js';
-import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+stantimport { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 
 export interface ITitleVariable {
 	readonly name: string;
@@ -293,6 +293,8 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 	private readonly windowTitle: WindowTitle;
 
+	protected readonly instantiationService: IInstantiationService;
+
 	constructor(
 		id: string,
 		targetWindow: CodeWindow,
@@ -300,13 +302,13 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IBrowserWorkbenchEnvironmentService protected readonly environmentService: IBrowserWorkbenchEnvironmentService,
-		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IThemeService themeService: IThemeService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@IContextKeyService protected readonly contextKeyService: IContextKeyService,
 		@IHostService private readonly hostService: IHostService,
-		@IEditorService private readonly editorService: IEditorService,
+		@IEditorService editorService: IEditorService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService
 	) {
@@ -318,15 +320,11 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 		this.titleBarStyle = getTitleBarStyle(this.configurationService);
 
-		// Create a scoped editor service that only tracks editors within this
-		// window's editor groups container, so the window title is not affected
-		// by active editor changes in other windows (e.g. auxiliary windows).
-		const titleDisposables = this._register(new DisposableStore());
-		const scopedEditorService = editorService.createScoped(editorGroupsContainer, titleDisposables);
-		const scopedInstantiationService = titleDisposables.add(instantiationService.createChild(new ServiceCollection(
+		const scopedEditorService = editorService.createScoped(editorGroupsContainer, this._store);
+		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection(
 			[IEditorService, scopedEditorService]
 		)));
-		this.windowTitle = this._register(scopedInstantiationService.createInstance(WindowTitle, targetWindow));
+		this.windowTitle = this._register(this.instantiationService.createInstance(WindowTitle, targetWindow));
 
 		this.hoverDelegate = this._register(createInstantHoverDelegate());
 
@@ -722,7 +720,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 			// The editor toolbar menu is handled by the editor group so we do not need to manage it here.
 			// However, depending on the active editor, we need to update the context and action runner of the toolbar menu.
-			if (this.editorActionsEnabled && this.editorService.activeEditor !== undefined) {
+			if (this.editorActionsEnabled && this.editorGroupsContainer.activeGroup.activeEditor !== undefined) {
 				const context: IEditorCommandsContext = { groupId: this.editorGroupsContainer.activeGroup.id };
 
 				this.actionToolBar.actionRunner = this.editorToolbarMenuDisposables.add(new EditorCommandsContextActionRunner(context));

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -55,6 +55,7 @@ import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { safeIntl } from '../../../../base/common/date.js';
 import { IsCompactTitleBarContext, TitleBarVisibleContext } from '../../../common/contextkeys.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 
 export interface ITitleVariable {
 	readonly name: string;
@@ -317,7 +318,15 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 		this.titleBarStyle = getTitleBarStyle(this.configurationService);
 
-		this.windowTitle = this._register(instantiationService.createInstance(WindowTitle, targetWindow));
+		// Create a scoped editor service that only tracks editors within this
+		// window's editor groups container, so the window title is not affected
+		// by active editor changes in other windows (e.g. auxiliary windows).
+		const titleDisposables = this._register(new DisposableStore());
+		const scopedEditorService = editorService.createScoped(editorGroupsContainer, titleDisposables);
+		const scopedInstantiationService = titleDisposables.add(instantiationService.createChild(new ServiceCollection(
+			[IEditorService, scopedEditorService]
+		)));
+		this.windowTitle = this._register(scopedInstantiationService.createInstance(WindowTitle, targetWindow));
 
 		this.hoverDelegate = this._register(createInstantHoverDelegate());
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -314,16 +314,17 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	) {
 		super(id, { hasTitle: false }, themeService, storageService, layoutService);
 
+		const scopedEditorService = editorService.createScoped(editorGroupsContainer, this._store);
+		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection(
+			[IEditorService, scopedEditorService]
+		)));
+
 		this.isAuxiliary = targetWindow.vscodeWindowId !== mainWindow.vscodeWindowId;
 
 		this.isCompactContextKey = IsCompactTitleBarContext.bindTo(this.contextKeyService);
 
 		this.titleBarStyle = getTitleBarStyle(this.configurationService);
 
-		const scopedEditorService = editorService.createScoped(editorGroupsContainer, this._store);
-		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection(
-			[IEditorService, scopedEditorService]
-		)));
 		this.windowTitle = this._register(this.instantiationService.createInstance(WindowTitle, targetWindow));
 
 		this.hoverDelegate = this._register(createInstantHoverDelegate());

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -55,7 +55,7 @@ import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { safeIntl } from '../../../../base/common/date.js';
 import { IsCompactTitleBarContext, TitleBarVisibleContext } from '../../../common/contextkeys.js';
-stantimport { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 
 export interface ITitleVariable {
 	readonly name: string;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The main window's `WindowTitle` uses the global `IEditorService`, which tracks editor groups across all windows including auxiliary windows. When a terminal is moved from the panel to a new auxiliary window via "Move Terminal into New Window", the following sequence occurs:

1. The terminal is removed from the panel group
2. A new auxiliary editor part is created and the terminal opens as an editor there
3. The auxiliary window gains focus
4. The global `EditorParts.activePart` now returns the auxiliary part (based on `getActiveDocument()`)
5. The global `EditorService` fires `onDidActiveEditorChange`
6. The main window's `WindowTitle` reads `editorService.activeEditor`, which resolves through `activePart` to the auxiliary window's terminal editor
7. The main window title incorrectly updates to show the terminal name (e.g. "bash") instead of the open file

This also affects any editor moved to a new auxiliary window, not just terminals.

Closes #267538

## What is the new behavior?

Each `WindowTitle` now receives a scoped `IEditorService` that only tracks editors within its own window's editor groups container. This is done by creating a child instantiation service with a scoped editor service in the `BrowserTitlebarPart` constructor:

- For the **main window**: the editor service is scoped to `editorGroupService.mainPart`, so it only tracks editors in the main window
- For **auxiliary windows**: the scoping is consistent with the existing approach used in `auxiliaryEditorPart.ts` (line 202-203), where a scoped editor service is already created for the auxiliary editor part

After the fix, moving a terminal (or any editor) to a new window no longer affects the original window's title.

## Additional context

The auxiliary window's `WindowTitle` was already getting a correctly scoped editor service via `scopedEditorPartInstantiationService` (created in `auxiliaryEditorPart.ts`). The main window's `WindowTitle` was the only one using the global (unscoped) editor service, which made it susceptible to cross-window active editor changes.

The fix follows the same scoping pattern already established for auxiliary windows but applies it uniformly in `BrowserTitlebarPart` for all windows.