### PR TITLE
fix: copy path falls back to workspace root when no explorer item selected

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -117,6 +117,12 @@ export function getMultiSelectedResources(commandArg: unknown, listService: ILis
 			if (context.length) {
 				return context.map(c => c.resource);
 			}
+			// Explorer is focused but no item is selected (e.g. clicked blank area),
+			// fall back to the workspace root resources
+			const roots = explorerService.roots;
+			if (roots.length) {
+				return roots.map(r => r.resource);
+			}
 		}
 
 		// Open editors view


### PR DESCRIPTION
## Summary
- When clicking the blank area in Explorer and pressing Alt+Shift+C (Copy Path), the command now copies the workspace folder path instead of doing nothing
- Adds a fallback in `getMultiSelectedResources` to return workspace root resources when the explorer is focused but no items are selected

Fixes #300675

## Test plan
- [ ] Open a workspace in Explorer
- [ ] Click on blank area below file list
- [ ] Press Alt+Shift+C (Copy Path) — should copy workspace folder path
- [ ] Verify normal Copy Path still works when a file is selected