### PR TITLE
Sessions: Remove line-height from changes-decoration-badge styles in changesView.css

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -270,7 +270,6 @@
 	min-width: 16px;
 	font-size: 11px;
 	font-weight: 600;
-	line-height: 1;
 	margin-right: 2px;
 	opacity: 0.9;
 }


### PR DESCRIPTION
Eliminate the line-height property from button styles to improve visual consistency in the changes view. Testing involves checking the appearance of buttons in the changes view to ensure they render correctly without the line-height adjustment.

