### PR TITLE
Increase minimum width for SidebarPart

### DIFF
--- a/src/vs/sessions/browser/parts/sidebarPart.ts
+++ b/src/vs/sessions/browser/parts/sidebarPart.ts
@@ -72,7 +72,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 
 	//#region IView
 
-	readonly minimumWidth: number = 170;
+	readonly minimumWidth: number = 270;
 	readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	readonly minimumHeight: number = 0;
 	readonly maximumHeight: number = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
Adjust the minimum width of the SidebarPart to 270px to enhance layout consistency across the application. This change improves the user interface by ensuring better alignment and usability.

