### PR TITLE
sessions: fix sidebar layout when customizations toolbar changes

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -29,7 +29,7 @@ const $ = DOM.$;
 const CUSTOMIZATIONS_COLLAPSED_KEY = 'agentSessions.customizationsCollapsed';
 
 export interface IAICustomizationShortcutsWidgetOptions {
-	readonly onDidToggleCollapse?: () => void;
+	readonly onDidChangeLayout?: () => void;
 }
 
 export class AICustomizationShortcutsWidget extends Disposable {
@@ -86,10 +86,15 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		// Toolbar container
 		const toolbarContainer = DOM.append(container, $('.ai-customization-toolbar-content.sidebar-action-list'));
 
-		this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SidebarCustomizations, {
+		const toolbar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, Menus.SidebarCustomizations, {
 			hiddenItemStrategy: HiddenItemStrategy.NoHide,
 			toolbarOptions: { primaryGroup: () => true },
 			telemetrySource: 'sidebarCustomizations',
+		}));
+
+		// Re-layout when toolbar items change (e.g., Plugins item appearing after extension activation)
+		this._register(toolbar.onDidChangeMenuItems(() => {
+			options?.onDidChangeLayout?.();
 		}));
 
 		let updateCountRequestId = 0;
@@ -130,7 +135,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			// Re-layout after the transition
 			transitionListener.value = DOM.addDisposableListener(toolbarContainer, 'transitionend', () => {
 				transitionListener.clear();
-				options?.onDidToggleCollapse?.();
+				options?.onDidChangeLayout?.();
 			});
 		};
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -5,6 +5,7 @@
 
 .sessions-list-control {
 	flex: 1 1 auto;
+	height: 100%;
 	min-height: 0;
 
 	.pane-body & .monaco-scrollable-element {

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -5,7 +5,6 @@
 
 .sessions-list-control {
 	flex: 1 1 auto;
-	height: 100%;
 	min-height: 0;
 
 	.pane-body & .monaco-scrollable-element {

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -40,7 +40,7 @@
 		flex: 1;
 		overflow: hidden;
 		min-height: 0;
-		margin-bottom: 12px;
+		margin-bottom: 6px;
 	}
 
 	.agent-sessions-header {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -224,7 +224,7 @@ export class SessionsView extends ViewPane {
 
 		// AI Customization toolbar (bottom, fixed height)
 		this._register(this.instantiationService.createInstance(AICustomizationShortcutsWidget, sessionsContainer, {
-			onDidToggleCollapse: () => {
+			onDidChangeLayout: () => {
 				if (this.viewPaneContainer) {
 					const { offsetHeight, offsetWidth } = this.viewPaneContainer;
 					this.layoutBody(offsetHeight, offsetWidth);


### PR DESCRIPTION
## Summary

Fixes layout issues in the sessions sidebar where the sessions list and customizations section don't properly coordinate their sizing.

## Changes

- **Re-layout on toolbar item changes**: The `AICustomizationShortcutsWidget` now listens to the toolbar's `onDidChangeMenuItems` event and triggers a layout update. Previously, layout was only recalculated on collapse/expand toggle — so when toolbar items were dynamically added (e.g., Plugins appearing after extension activation), the sessions list kept stale height dimensions.

- **Remove redundant CSS**: Removed `height: 100%` from `.sessions-list-control` since `flex: 1 1 auto` already handles sizing. The redundant height could cause unexpected flex-basis calculations.

- **Reduce section margin**: Reduced `.agent-sessions-section` bottom margin from 12px to 6px for tighter spacing between the sessions list and customizations toolbar.

- **Rename callback**: Renamed `onDidToggleCollapse` → `onDidChangeLayout` to accurately reflect it handles any layout-affecting change, not just collapse toggles.