### PR TITLE
actionWidget: fix submenu group label rendered as item description

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1243,13 +1243,20 @@ export class ActionListWidget<T> extends Disposable {
 		const groupsWithActions = submenuGroups.filter(g => g.actions.length > 0);
 		for (let gi = 0; gi < groupsWithActions.length; gi++) {
 			const group = groupsWithActions[gi];
+			if (group.label) {
+				submenuItems.push({
+					kind: ActionListItemKind.Header,
+					group: { title: group.label },
+					label: group.label,
+				});
+			}
 			for (let ci = 0; ci < group.actions.length; ci++) {
 				const child = group.actions[ci];
 				submenuItems.push({
 					item: child,
 					kind: ActionListItemKind.Action,
 					label: child.label,
-					description: ci === 0 && group.label ? group.label : (child.tooltip || undefined),
+					description: child.tooltip || undefined,
 					group: { title: '', icon: ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id) },
 					hideIcon: false,
 					hover: {},

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -343,11 +343,11 @@ export class WorkspacePicker extends Disposable {
 			const submenuActions = [...providerMap.values()].map(({ provider, actions }) =>
 				new SubmenuAction(
 					`workspacePicker.browse.${provider.id}`,
-					provider.label,
-					actions.map(({ action, index }) => toAction({
+					'',
+					actions.map(({ action, index }, ci) => toAction({
 						id: `workspacePicker.browse.${index}`,
 						label: localize(`workspacePicker.browse`, "{0}...", action.label),
-						tooltip: '',
+						tooltip: ci === 0 ? provider.label : '',
 						run: () => this._executeBrowseAction(index),
 					})),
 				)


### PR DESCRIPTION
## Summary

Fixes #306250 — "Thinking effort" submenu header was rendered as the description of the first item instead of as a proper section header.

## What changed

**`actionList.ts`** — In `_showSubmenuForElement`, when a `SubmenuAction` group has a label, emit a proper `ActionListItemKind.Header` item before the group's actions instead of inlining the label as the first item's `description`. This restores the original behavior from the initial submenu support (bf56017b36b) that was regressed in f6218ecb334.

**`sessionWorkspacePicker.ts`** — The sessions workspace picker intentionally wants the provider label (e.g. "Copilot Chat", "Local Agent Host") shown as a description on the first submenu item rather than as a header. Moved the provider label from `SubmenuAction.label` to the first child action's `tooltip`, so `_showSubmenuForElement` picks it up as a description naturally.

## Testing

- Model picker: "Thinking effort" renders as a section header in the submenu ✅
- Workspace picker: Provider labels render as descriptions on the first submenu item ✅