### PR TITLE
sessions: fix multi-select context menu to operate on all selected items

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { coalesce } from '../../../../base/common/arrays.js';
 import { IReader, autorun, observableValue } from '../../../../base/common/observable.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, registerAction2, MenuId, MenuRegistry, isIMenuItem } from '../../../../platform/actions/common/actions.js';
@@ -349,17 +350,18 @@ class CopilotSessionContextMenuBridge extends Disposable implements IWorkbenchCo
 			this._bridgedIds.add(commandId);
 
 			const wrapperId = `sessionsViewPane.bridge.${commandId}`;
-			this._register(CommandsRegistry.registerCommand(wrapperId, (accessor, sessionData?: ISession) => {
-				if (!sessionData) {
+			this._register(CommandsRegistry.registerCommand(wrapperId, (accessor, context?: ISession | ISession[]) => {
+				if (!context) {
 					return;
 				}
-				const agentSession = this.agentSessionsService.getSession(sessionData.resource);
-				if (!agentSession) {
+				const sessions = Array.isArray(context) ? context : [context];
+				const agentSessions = coalesce(sessions.map(s => this.agentSessionsService.getSession(s.resource)));
+				if (agentSessions.length === 0) {
 					return;
 				}
 				return this.commandService.executeCommand(commandId, {
-					session: agentSession,
-					sessions: [agentSession],
+					session: agentSessions[0],
+					sessions: agentSessions,
 					$mid: MarshalledId.AgentSessionContext,
 				});
 			}));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -959,7 +959,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		}
 
 		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
-		const selectedSessions = selection.includes(element) ? selection : [element];
+		const selectedSessions = selection.includes(element) ? [element, ...selection.filter(s => s !== element)] : [element];
 
 		const contextOverlay: [string, boolean | string][] = [
 			[IsSessionPinnedContext.key, this.isSessionPinned(element)],

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -958,6 +958,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 			return;
 		}
 
+		const selection = this.tree.getSelection().filter((s): s is ISession => !!s && !isSessionSection(s) && !isSessionShowMore(s));
+		const selectedSessions = selection.includes(element) ? selection : [element];
+
 		const contextOverlay: [string, boolean | string][] = [
 			[IsSessionPinnedContext.key, this.isSessionPinned(element)],
 			[IsSessionArchivedContext.key, element.isArchived.get()],
@@ -969,7 +972,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const menu = this.menuService.createMenu(SessionItemContextMenuId, this.contextKeyService.createOverlay(contextOverlay));
 
 		this.contextMenuService.showContextMenu({
-			getActions: () => Separator.join(...menu.getActions({ arg: element, shouldForwardArgs: true }).map(([, actions]) => actions)),
+			getActions: () => Separator.join(...menu.getActions({ arg: selectedSessions, shouldForwardArgs: true }).map(([, actions]) => actions)),
 			getAnchor: () => e.anchor,
 			getKeyBinding: (action) => this.keybindingService.lookupKeybinding(action.id) ?? undefined,
 		});

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -400,13 +400,16 @@ registerAction2(class PinSessionAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, context?: ISession): void {
+	run(accessor: ServicesAccessor, context?: ISession | ISession[]): void {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const viewsService = accessor.get(IViewsService);
 		const view = viewsService.getViewWithId<SessionsView>(SessionsViewId);
-		view?.sessionsControl?.pinSession(context);
+		for (const session of sessions) {
+			view?.sessionsControl?.pinSession(session);
+		}
 	}
 });
 
@@ -435,13 +438,16 @@ registerAction2(class UnpinSessionAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, context?: ISession): void {
+	run(accessor: ServicesAccessor, context?: ISession | ISession[]): void {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const viewsService = accessor.get(IViewsService);
 		const view = viewsService.getViewWithId<SessionsView>(SessionsViewId);
-		view?.sessionsControl?.unpinSession(context);
+		for (const session of sessions) {
+			view?.sessionsControl?.unpinSession(session);
+		}
 	}
 });
 
@@ -464,12 +470,15 @@ registerAction2(class ArchiveSessionAction extends Action2 {
 			}]
 		});
 	}
-	async run(accessor: ServicesAccessor, context?: ISession): Promise<void> {
+	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
-		await sessionsManagementService.archiveSession(context);
+		for (const session of sessions) {
+			await sessionsManagementService.archiveSession(session);
+		}
 	}
 });
 
@@ -492,12 +501,15 @@ registerAction2(class UnarchiveSessionAction extends Action2 {
 			}]
 		});
 	}
-	async run(accessor: ServicesAccessor, context?: ISession): Promise<void> {
+	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
-		await sessionsManagementService.unarchiveSession(context);
+		for (const session of sessions) {
+			await sessionsManagementService.unarchiveSession(session);
+		}
 	}
 });
 
@@ -517,12 +529,15 @@ registerAction2(class MarkSessionReadAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, context?: ISession): void {
+	run(accessor: ServicesAccessor, context?: ISession | ISession[]): void {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
-		sessionsManagementService.setRead(context, true);
+		for (const session of sessions) {
+			sessionsManagementService.setRead(session, true);
+		}
 	}
 });
 
@@ -542,12 +557,15 @@ registerAction2(class MarkSessionUnreadAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, context?: ISession): void {
+	run(accessor: ServicesAccessor, context?: ISession | ISession[]): void {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
-		sessionsManagementService.setRead(context, false);
+		for (const session of sessions) {
+			sessionsManagementService.setRead(session, false);
+		}
 	}
 });
 
@@ -563,15 +581,18 @@ registerAction2(class OpenSessionInNewWindowAction extends Action2 {
 			}]
 		});
 	}
-	async run(accessor: ServicesAccessor, context?: ISession): Promise<void> {
+	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
 		if (!context) {
 			return;
 		}
+		const sessions = Array.isArray(context) ? context : [context];
 		const chatWidgetService = accessor.get(IChatWidgetService);
-		await chatWidgetService.openSession(context.resource, AUX_WINDOW_GROUP, {
-			auxiliary: { compact: true, bounds: { width: 800, height: 640 } },
-			pinned: true
-		});
+		for (const session of sessions) {
+			await chatWidgetService.openSession(session.resource, AUX_WINDOW_GROUP, {
+				auxiliary: { compact: true, bounds: { width: 800, height: 640 } },
+				pinned: true
+			});
+		}
 	}
 });
 


### PR DESCRIPTION
## Summary

Context menu actions in the sessions list only operated on the right-clicked item, ignoring other selected items in a multi-selection.

## Changes

### `sessionsList.ts`
- Collect tree selection via `getSelection()` and filter to `ISession` items
- Pass the full selected sessions array (or just the clicked item if not part of selection) as the `arg` to context menu actions

### `sessionsViewActions.ts`
- Update all 7 session item actions (Pin, Unpin, Archive, Unarchive, Mark Read, Mark Unread, Open in New Window) to accept `ISession | ISession[]` and iterate over all provided sessions

### `copilotChatSessionsActions.ts`
- Update `CopilotSessionContextMenuBridge` wrapper commands to handle `ISession[]` — resolves all sessions to agent sessions and passes them in the marshalled context