### PR TITLE
actionWidget: fix submenu group label rendered as item description (#306327)

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1243,13 +1243,20 @@ export class ActionListWidget<T> extends Disposable {
 		const groupsWithActions = submenuGroups.filter(g => g.actions.length > 0);
 		for (let gi = 0; gi < groupsWithActions.length; gi++) {
 			const group = groupsWithActions[gi];
+			if (group.label) {
+				submenuItems.push({
+					kind: ActionListItemKind.Header,
+					group: { title: group.label },
+					label: group.label,
+				});
+			}
 			for (let ci = 0; ci < group.actions.length; ci++) {
 				const child = group.actions[ci];
 				submenuItems.push({
 					item: child,
 					kind: ActionListItemKind.Action,
 					label: child.label,
-					description: ci === 0 && group.label ? group.label : (child.tooltip || undefined),
+					description: child.tooltip || undefined,
 					group: { title: '', icon: ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id) },
 					hideIcon: false,
 					hover: {},

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -343,11 +343,11 @@ export class WorkspacePicker extends Disposable {
 			const submenuActions = [...providerMap.values()].map(({ provider, actions }) =>
 				new SubmenuAction(
 					`workspacePicker.browse.${provider.id}`,
-					provider.label,
-					actions.map(({ action, index }) => toAction({
+					'',
+					actions.map(({ action, index }, ci) => toAction({
 						id: `workspacePicker.browse.${index}`,
 						label: localize(`workspacePicker.browse`, "{0}...", action.label),
-						tooltip: '',
+						tooltip: ci === 0 ? provider.label : '',
 						run: () => this._executeBrowseAction(index),
 					})),
 				)


### PR DESCRIPTION
The submenu header (e.g. 'Thinking effort') was incorrectly shown as the description of the first action item instead of as a proper section header.

Regression from f6218ecb334 which replaced ActionListItemKind.Header items with inline description on the first child action.

Restore proper Header rendering for SubmenuAction groups that have a label. For the sessions workspace picker, move the provider label to the first child action's tooltip so it renders as a description instead of a header.

Fixes #306250

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>