### PR TITLE
theme: add notification for auto-updated default themes

### DIFF
--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -249,6 +249,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		await this.migrateAutoDetectColorScheme();
 		const result = await Promise.all([initializeColorTheme(), initializeFileIconTheme(), initializeProductIconTheme()]);
 		this.showNewDefaultThemeNotification();
+		this.showThemeAutoUpdatedNotification();
 		return result;
 	}
 
@@ -272,6 +273,56 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			}]
 		);
 		this._register(Event.once(handle.onDidClose)(() => {
+			this.storageService.store(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+		}));
+	}
+
+	private static readonly THEME_AUTO_UPDATED_NOTIFICATION_KEY = 'workbench.themeAutoUpdatedNotification';
+
+	/**
+	 * Shows a one-time notification to existing users whose color theme changed
+	 * because the product default was updated (e.g. Dark Modern → VS Code Dark).
+	 * Offers the option to browse themes or revert to the previous default.
+	 */
+	private showThemeAutoUpdatedNotification(): void {
+		if (this.storageService.getBoolean(WorkbenchThemeService.THEME_AUTO_UPDATED_NOTIFICATION_KEY, StorageScope.APPLICATION)) {
+			return; // already shown
+		}
+		if (this.storageService.isNew(StorageScope.APPLICATION)) {
+			return; // new user, no migration happened
+		}
+
+		// Target existing users whose theme changed because the default changed.
+		// These users have no explicit user-scoped theme value — they inherited the default.
+		const newDefaultThemes = new Set([ThemeSettingDefaults.COLOR_THEME_DARK, ThemeSettingDefaults.COLOR_THEME_LIGHT]);
+		if (!newDefaultThemes.has(this.currentColorTheme.settingsId)) {
+			return; // not using a new default theme
+		}
+		if (!this.settings.isDefaultColorTheme()) {
+			return; // user explicitly chose this theme
+		}
+
+		const previousSettingsId = this.currentColorTheme.type === ColorScheme.LIGHT ? 'Light Modern' : 'Dark Modern';
+
+		const handle = this.notificationService.prompt(
+			Severity.Info,
+			nls.localize({ key: 'newDefaultThemeAutoUpdated', comment: ['{0} is the name of the current color theme, e.g. "VS Code Dark"'] }, "VS Code has a new look! You can keep {0}, switch to another theme, or go back to your previous one.", this.currentColorTheme.label),
+			[{
+				label: nls.localize('browseThemes', "Browse Themes"),
+				run: () => this.commandService.executeCommand('workbench.action.selectTheme')
+			}, {
+				label: nls.localize('revertTheme', "Revert"),
+				run: () => {
+					const previousTheme = this.colorThemeRegistry.findThemeBySettingsId(previousSettingsId);
+					if (previousTheme) {
+						this.setColorTheme(previousTheme.id, 'auto');
+					}
+				}
+			}]
+		);
+		this._register(Event.once(handle.onDidClose)(() => {
+			this.storageService.store(WorkbenchThemeService.THEME_AUTO_UPDATED_NOTIFICATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+			// Also suppress the "try new themes" notification — this user is already aware of the new themes.
 			this.storageService.store(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 		}));
 	}


### PR DESCRIPTION
This pull request introduces a user-facing improvement to the theme experience in the workbench. Specifically, it adds a one-time notification for users whose color theme was automatically updated due to a change in the product's default theme. This ensures users are aware of the change and provides them with options to revert or explore other themes.

User notification improvements:

* Added a new method `showThemeAutoUpdatedNotification` to `WorkbenchThemeService` that detects when an existing user's theme was auto-updated because of a new product default, and displays a one-time notification with options to browse themes or revert to the previous default.
* Ensured that `showThemeAutoUpdatedNotification` is called during theme initialization, so affected users are properly notified after migration.This PR adds a notification for auto-updated default themes.

Forward port of #306340 to main.