### PR TITLE
sessions: add rerun action for failed CI checks in PR checks view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -66,6 +66,7 @@ class CICheckListRenderer implements IListRenderer<ICICheckListItem, ICICheckTem
 	constructor(
 		private readonly _labels: ResourceLabels,
 		private readonly _openerService: IOpenerService,
+		private readonly _getModel: () => GitHubPullRequestCIModel | undefined,
 	) { }
 
 	renderTemplate(container: HTMLElement): ICICheckTemplateData {
@@ -103,6 +104,18 @@ class CICheckListRenderer implements IListRenderer<ICICheckListItem, ICICheckTem
 		});
 
 		const actions: Action[] = [];
+
+		if (element.group === CICheckGroup.Failed) {
+			actions.push(templateData.elementDisposables.add(new Action(
+				'ci.rerunCheck',
+				localize('ci.rerunCheck', "Rerun Check"),
+				ThemeIcon.asClassName(Codicon.debugRerun),
+				true,
+				async () => {
+					await this._getModel()?.rerunFailedCheck(element.check);
+				},
+			)));
+		}
 
 		if (element.check.detailsUrl) {
 			actions.push(templateData.elementDisposables.add(new Action(
@@ -210,7 +223,7 @@ export class CIStatusWidget extends Disposable {
 			'CIStatusWidget',
 			listContainer,
 			new CICheckListDelegate(),
-			[new CICheckListRenderer(this._labels, this._openerService)],
+			[new CICheckListRenderer(this._labels, this._openerService, () => this._model)],
 			{
 				multipleSelectionSupport: false,
 				openOnSingleClick: false,

--- a/src/vs/sessions/contrib/github/browser/fetchers/githubPRCIFetcher.ts
+++ b/src/vs/sessions/contrib/github/browser/fetchers/githubPRCIFetcher.ts
@@ -69,6 +69,17 @@ export class GitHubPRCIFetcher {
 	}
 
 	/**
+	 * Rerun failed jobs in a GitHub Actions workflow run.
+	 */
+	async rerunFailedJobs(owner: string, repo: string, runId: number): Promise<void> {
+		await this._apiClient.request<void>(
+			'POST',
+			`/repos/${e(owner)}/${e(repo)}/actions/runs/${runId}/rerun-failed-jobs`,
+			'githubApi.rerunFailedJobs'
+		);
+	}
+
+	/**
 	 * Get logs/output for a specific check run.
 	 *
 	 * Tries multiple sources in order:

--- a/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
+++ b/src/vs/sessions/contrib/github/browser/models/githubPullRequestCIModel.ts
@@ -61,6 +61,20 @@ export class GitHubPullRequestCIModel extends Disposable {
 	}
 
 	/**
+	 * Rerun a failed check by extracting the workflow run ID from its details URL
+	 * and calling the GitHub Actions rerun-failed-jobs API, then refresh status.
+	 */
+	async rerunFailedCheck(check: IGitHubCICheck): Promise<void> {
+		const runId = parseWorkflowRunId(check.detailsUrl);
+		if (!runId) {
+			this._logService.warn(`${LOG_PREFIX} Cannot rerun check "${check.name}": no workflow run ID found in detailsUrl`);
+			return;
+		}
+		await this._fetcher.rerunFailedJobs(this.owner, this.repo, runId);
+		await this.refresh();
+	}
+
+	/**
 	 * Start periodic polling. Each cycle refreshes CI check data.
 	 */
 	startPolling(intervalMs: number = DEFAULT_POLL_INTERVAL_MS): void {
@@ -87,4 +101,17 @@ export class GitHubPullRequestCIModel extends Disposable {
 		this._disposed = true;
 		super.dispose();
 	}
+}
+
+/**
+ * Extract the GitHub Actions workflow run ID from a check run's details URL.
+ * URLs follow the pattern: `https://github.com/{owner}/{repo}/actions/runs/{run_id}/job/{job_id}`
+ */
+function parseWorkflowRunId(detailsUrl: string | undefined): number | undefined {
+	if (!detailsUrl) {
+		return undefined;
+	}
+	const match = /\/actions\/runs\/(?<runId>\d+)/.exec(detailsUrl);
+	const runId = match?.groups?.runId;
+	return runId ? parseInt(runId, 10) : undefined;
 }


### PR DESCRIPTION
## Summary

Adds a **Rerun Check** action button on each failed CI check in the PR checks view of the Agent Sessions changes panel.

## Changes

### Fetcher (`githubPRCIFetcher.ts`)
- Added `rerunFailedJobs(owner, repo, runId)` — calls `POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs`

### Model (`githubPullRequestCIModel.ts`)
- Added `rerunFailedCheck(check)` — parses the workflow run ID from the check's `detailsUrl` and calls the rerun API, then refreshes check statuses
- Added `parseWorkflowRunId()` helper — extracts the run ID from GitHub Actions URLs (`/actions/runs/{run_id}/...`)

### UI Widget (`ciStatusWidget.ts`)
- Added a per-check **Rerun** button (🔄 `debugRerun` icon) on failed checks in the list, alongside the existing "Open on GitHub" action

## Notes for reviewers

- Uses the GitHub Actions `rerun-failed-jobs` endpoint (not `check-runs/{id}/rerequest`) since the latter requires GitHub App permissions not available with user OAuth tokens
- The workflow run ID is extracted from `detailsUrl` which follows the pattern `https://github.com/{owner}/{repo}/actions/runs/{run_id}/job/{job_id}`
- After rerun, the model automatically refreshes check statuses to reflect the updated state
