### PR TITLE
 fix(inline-chat): resolve session from editor model for rephrase / ask in chat (#306361)

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -622,7 +622,7 @@ export class InlineChatController implements IEditorContribution {
 	}
 
 	async continueSessionInChat(): Promise<void> {
-		const session = this._currentSession.get();
+		const session = this._currentSession.get() ?? (this._editor.hasModel() ? this._inlineChatSessionService.getSessionByTextModel(this._editor.getModel().uri) : undefined);
 		if (!session) {
 			return;
 		}
@@ -631,7 +631,7 @@ export class InlineChatController implements IEditorContribution {
 	}
 
 	async rephraseSession(): Promise<void> {
-		const session = this._currentSession.get();
+		const session = this._currentSession.get() ?? (this._editor.hasModel() ? this._inlineChatSessionService.getSessionByTextModel(this._editor.getModel().uri) : undefined);
 		if (!session) {
 			return;
 		}


### PR DESCRIPTION
Hey, @cwebster-99 
I’m trying to fix #306361 — you click Rephrase or Ask in Chat after a non-code reply, telemetry looks like you did something, but nothing useful happens in the UI.
What I changed: those actions only looked at this._currentSession.get(). If that’s empty for a moment even though there’s still a session for the file you’re editing, we bail out and you get a no-op. I added a fallback: if the editor has a model, I resolve the session with getSessionByTextModel(uri) so we still find the session.
How I tested: npm run compile-check-ts-native. I ran the full OSS build , so yeah — if you can click through inline chat in hover mode on your machine, that’d be the real proof.
Fixes #306361
