### PR TITLE
fix: fix typos in CLI Rust source files

### DIFF
--- a/cli/src/tunnels/shutdown_signal.rs
+++ b/cli/src/tunnels/shutdown_signal.rs
@@ -12,7 +12,7 @@ use crate::util::{
 	sync::{new_barrier, Barrier, Receivable},
 };
 
-/// Describes the signal to manully stop the server
+/// Describes the signal to manually stop the server
 #[derive(Copy, Clone)]
 pub enum ShutdownSignal {
 	CtrlC,

--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -268,7 +268,7 @@ impl std::fmt::Display for InvalidRequestedVersion {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(
             f,
-            "The reqested version is invalid, expected one of 'stable', 'insiders', version number (x.y.z), or absolute path.",
+            "The requested version is invalid, expected one of 'stable', 'insiders', version number (x.y.z), or absolute path.",
         )
 	}
 }

--- a/cli/src/util/os.rs
+++ b/cli/src/util/os.rs
@@ -6,7 +6,7 @@
 #[cfg(windows)]
 pub fn os_release() -> Result<String, std::io::Error> {
 	// The windows API *had* nice GetVersionEx/A APIs, but these were deprecated
-	// in Winodws 8 and there's no newer win API to get version numbers. So
+	// in Windows 8 and there's no newer win API to get version numbers. So
 	// instead read the registry.
 
 	use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};


### PR DESCRIPTION
Fix minor typos found via codespell in the CLI Rust source:\n- 'reqested' → 'requested' in errors.rs (error message string)\n- 'Winodws' → 'Windows' in os.rs (comment)\n- 'manully' → 'manually' in shutdown_signal.rs (code comment)