### PR TITLE
sessions: fix title bar context menu and session type icons

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -640,7 +640,7 @@ class AgentSessionAdapter implements ISessionData {
 		this.resource = session.resource;
 		this.providerId = providerId;
 		this.sessionType = session.providerType;
-		this.icon = session.icon;
+		this.icon = this._getSessionTypeIcon(session);
 		this.createdAt = new Date(session.timing.created);
 		this._workspace = observableValue(this, this._buildWorkspace(session));
 		this.workspace = this._workspace;
@@ -690,6 +690,17 @@ class AgentSessionAdapter implements ISessionData {
 			this._lastTurnEnd.set(session.timing.lastRequestEnded ? new Date(session.timing.lastRequestEnded) : undefined, tx);
 			this._gitHubInfo.set(this._extractGitHubInfo(session), tx);
 		});
+	}
+
+	private _getSessionTypeIcon(session: IAgentSession): ThemeIcon {
+		switch (session.providerType) {
+			case AgentSessionProviders.Background:
+				return CopilotCLISessionType.icon;
+			case AgentSessionProviders.Cloud:
+				return CopilotCloudSessionType.icon;
+			default:
+				return session.icon;
+		}
 	}
 
 	private _extractDescription(session: IAgentSession): string | undefined {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -21,7 +21,7 @@ import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/l
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { ISessionsManagementService } from './sessionsManagementService.js';
+import { ISessionsManagementService, IsNewChatSessionContext } from './sessionsManagementService.js';
 import { autorun, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
@@ -30,6 +30,8 @@ import { ISessionsProvidersService } from './sessionsProvidersService.js';
 import { SessionStatus } from '../common/sessionData.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
+import { SessionsView, SessionsViewId } from './views/sessionsView.js';
+import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -66,6 +68,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IViewsService private readonly viewsService: IViewsService,
 	) {
 		super(undefined, action, options);
 
@@ -256,8 +259,13 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			return;
 		}
 
+		if (this.contextKeyService.getContextKeyValue<boolean>(IsNewChatSessionContext.key)) {
+			return;
+		}
+
+		const isPinned = this.viewsService.getViewWithId<SessionsView>(SessionsViewId)?.sessionsControl?.isSessionPinned(sessionData) ?? false;
 		const contextOverlay: [string, boolean | string][] = [
-			[IsSessionPinnedContext.key, false],
+			[IsSessionPinnedContext.key, isPinned],
 			[IsSessionArchivedContext.key, sessionData.isArchived.get()],
 			[IsSessionReadContext.key, sessionData.isRead.get()],
 			['chatSessionType', sessionData.sessionType],


### PR DESCRIPTION
## Summary

Three fixes for the Agent Sessions title bar and session icons:

### 1. Fix Unpin action missing from title bar context menu
The `_showContextMenu` in `SessionsTitleBarWidget` hardcoded `IsSessionPinnedContext` to `false`, so the "Unpin" action never appeared in the context menu for pinned sessions. Now it looks up the actual pinned state via `SessionsView.sessionsControl.isSessionPinned()`.

### 2. Remove context menu for new sessions
When the title bar shows "New Session" (before any request has been sent), the context menu showed actions like delete, pin, and archive that don't apply. Now the context menu is suppressed when `IsNewChatSessionContext` is true.

### 3. Use session type icons for existing sessions
`AgentSessionAdapter` was using `session.icon` from the old `agentSessionsModel` (e.g., `Codicon.worktree` for CLI sessions), instead of using the session type icons defined by the Copilot provider (`Codicon.copilot` for CLI, `Codicon.cloud` for Cloud). Added a `_getSessionTypeIcon()` method that maps provider types to session type icons.

## Changed files
- `src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts` — context menu fixes
- `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts` — session type icon mapping