### PR TITLE
sessions: align sticky section headers in sessions list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -13,7 +13,7 @@
 	}
 
 	.pane-body & .monaco-tree-sticky-container {
-		padding: 0 6px;
+		padding: 0 10px;
 	}
 
 	.monaco-list-row {


### PR DESCRIPTION
## Summary
- align the sticky sessions list header inset with the scrollable list body
- keep workspace and date section headers from shifting horizontally when they stick during scroll
- fix the folder-name jump caused by the sticky overlay using different horizontal padding than the main list

## Testing
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `npm run precommit`
- `./scripts/test.sh --run src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts` *(currently blocked in this environment: `test/unit/electron/index.js` crashes before tests start because `app.setPath(...)` is called on an undefined Electron `app`)*