### PR TITLE
sessions: fix Show All Sessions filter out of sync with view on reload

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -390,7 +390,7 @@ export class SessionsView extends ViewPane {
 				for (const { key, getDefault } of filterContextKeys.values()) {
 					key.set(getDefault());
 				}
-				workspaceGroupCappedContextKey?.set(true);
+				workspaceGroupCappedContextKey?.set(sessionsControl.isWorkspaceGroupCapped());
 			}
 		}));
 	}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -53,6 +53,7 @@ export class SessionsView extends ViewPane {
 	private currentSorting: SessionsSorting = SessionsSorting.Created;
 	private groupingContextKey: IContextKey | undefined;
 	private sortingContextKey: IContextKey | undefined;
+	private workspaceGroupCappedContextKey: IContextKey<boolean> | undefined;
 	private readonly filterContextKeys = new Map<string, { key: IContextKey<boolean>; getDefault: () => boolean }>();
 
 	constructor(
@@ -89,6 +90,9 @@ export class SessionsView extends ViewPane {
 		this.groupingContextKey.set(this.currentGrouping);
 		this.sortingContextKey = SessionsViewSortingContext.bindTo(contextKeyService);
 		this.sortingContextKey.set(this.currentSorting);
+
+		// Bind workspace group capped context key (will be synced with persisted state in renderBody)
+		this.workspaceGroupCappedContextKey = IsWorkspaceGroupCappedContext.bindTo(contextKeyService);
 	}
 
 	protected override renderBody(parent: HTMLElement): void {
@@ -186,6 +190,9 @@ export class SessionsView extends ViewPane {
 			onSessionOpen: (resource, preserveFocus) => this.sessionsManagementService.openSession(resource, { preserveFocus }),
 		}));
 		this._register(this.onDidChangeBodyVisibility(visible => sessionsControl.setVisible(visible)));
+
+		// Sync workspace group capped context key with persisted state
+		this.workspaceGroupCappedContextKey?.set(sessionsControl.isWorkspaceGroupCapped());
 
 		// Register session type filter actions (re-register when session types change)
 		this.registerSessionTypeFilters(sessionsControl);
@@ -365,6 +372,7 @@ export class SessionsView extends ViewPane {
 
 		// Reset filter action
 		const filterContextKeys = this.filterContextKeys;
+		const workspaceGroupCappedContextKey = this.workspaceGroupCappedContextKey;
 		this._register(registerAction2(class extends Action2 {
 			constructor() {
 				super({
@@ -382,6 +390,7 @@ export class SessionsView extends ViewPane {
 				for (const { key, getDefault } of filterContextKeys.values()) {
 					key.set(getDefault());
 				}
+				workspaceGroupCappedContextKey?.set(true);
 			}
 		}));
 	}


### PR DESCRIPTION
Fixes - https://github.com/microsoft/vscode/issues/306425

## Problem

After reloading, the **Show All Sessions** menu checkmark was always checked (✓), even when the user had previously selected "Show Recent Sessions". The view itself would be correct (showing the persisted filter), but the menu checkmark was out of sync.

## Root cause

`IsWorkspaceGroupCappedContext` — the context key that drives the menu checkmarks — was never initialized from persisted storage on reload. It defaulted to `true` (the `RawContextKey` default), which made "Show All Sessions" always appear checked regardless of the stored value.

There was also a secondary issue: the **Reset** action called `sessionsControl.resetFilters()` (which resets `workspaceGroupCapped` to `true` internally and persists it) but did not update the context key accordingly.

## Fix

1. **Bind the context key** in the `SessionsView` constructor alongside the other context keys (`groupingContextKey`, `sortingContextKey`).
2. **Sync it from persisted state** in `renderBody` after `SessionsList` is created, using `sessionsControl.isWorkspaceGroupCapped()`.
3. **Reset it in the Reset action** — capture the context key as a closure variable and set it to `true` when filters are reset.