### PR TITLE
sessions: adjust titlebar container padding based on sidebar visibility

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -87,6 +87,7 @@ The widget:
 - Gets the active session label from `IActiveSessionService.getActiveSession()` and the live model title from `IChatService`, falling back to "New Session" if no active session is found
 - Re-renders automatically when the active session changes via `autorun` on `IActiveSessionService.activeSession`, and when session data changes via `IAgentSessionsService.model.onDidChangeSessions`
 - Is registered via `SessionsTitleBarContribution` (an `IWorkbenchContribution` in `contrib/sessions/browser/sessionsTitleBarWidget.ts`) that calls `IActionViewItemService.register()` to intercept the submenu rendering
+- Uses `padding-left: 0` while the sidebar is visible, and restores `padding-left: 16px` when the sidebar is hidden via the `nosidebar` workbench class
 
 ### 3.3 Left Toolbar
 
@@ -643,6 +644,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-03-30 | Adjusted `.agent-sessions-titlebar-container` padding so it sits flush when the sidebar is visible and restores 16px left padding when the sidebar is hidden |
 | 2026-03-26 | Updated the sessions sidebar appear animation so only the body content (`.part.sidebar > .content`) slides/fades in during reveal while the sidebar title/header and footer remain fixed |
 | 2026-03-25 | Updated Sessions view documentation to reflect the refactored `SessionsView` implementation in `contrib/sessions/browser/views/sessionsView.ts` and documented the left-aligned "+ Session" sidebar action with its inline keybinding hint |
 | 2026-03-24 | Updated the sessions new-chat empty state: removed the watermark, vertically centered the empty-state controls block, restyled the workspace picker as an inline `New session in {dropdown}` title row aligned to the chat input, and tuned empty-state dropdown icon/chevron and local-mode spacing for the final visual polish. |

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -21,6 +21,10 @@
 	cursor: default;
 }
 
+.agent-sessions-workbench:not(.nosidebar) .command-center .agent-sessions-titlebar-container {
+	padding-left: 0;
+}
+
 /* Session pill - clickable area for session picker */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-pill {
 	display: flex;
@@ -123,4 +127,3 @@
 	font-variant-numeric: tabular-nums;
 	line-height: 16px;
 }
-


### PR DESCRIPTION
## Summary

Adjusts the left padding of `.agent-sessions-titlebar-container` (the command center session title widget) based on whether the sidebar is open or closed.

**Before:** The container always had `padding-left: 16px`, which looked disconnected when the sidebar was open.

<img width="1779" height="1161" alt="Screenshot 2026-03-30 at 3 58 13 PM" src="https://github.com/user-attachments/assets/27146b69-0474-4304-8fed-b0f97b6e1fd0" />

**After:**
- Sidebar **open** → `padding-left: 0` (aligns flush with the content below)
- Sidebar **closed** → `padding-left: 16px` (keeps comfortable spacing from the window edge)

<img width="1779" height="1161" alt="Screenshot 2026-03-30 at 3 58 40 PM" src="https://github.com/user-attachments/assets/ab409825-9a63-48a6-ba3d-cc0163684a62" />

## Implementation

The change is purely CSS. It hooks into the existing `nosidebar` workbench class that the layout already applies to `<body>` when the sidebar is hidden:

```css
.agent-sessions-workbench:not(.nosidebar) .command-center .agent-sessions-titlebar-container {
    padding-left: 0;
}
```

No TypeScript changes needed — the existing `LayoutClasses.SIDEBAR_HIDDEN = 'nosidebar'` class toggling in `workbench.ts` already handles the state.

## Files Changed

- `src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css` — add sidebar-state-conditional padding rule
- `src/vs/sessions/LAYOUT.md` — document the padding behaviour and add revision history entry