### PR TITLE
sessions: fix welcome page chat input collapsing on first keystroke

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -65,6 +65,8 @@ const configurationKey = 'workbench.startupEditor';
 const MAX_SESSIONS = 6;
 const MAX_REPO_PICKS = 10;
 const MAX_WALKTHROUGHS = 10;
+const WELCOME_CHAT_INPUT_LAYOUT_HEIGHT = 150;
+const WELCOME_CHAT_INPUT_MAX_HEIGHT_OVERRIDE = 272;
 
 /**
  * - visibleDurationMs: Do they close it right away or leave it open (#3)
@@ -804,9 +806,8 @@ export class AgentSessionsWelcomePage extends EditorPane {
 		}
 
 		const chatWidth = Math.min(800, this.lastDimension.width - 80);
-		// Use a reasonable height for the input part - the CSS will hide the list area
-		const inputHeight = 150;
-		this.chatWidget.layout(inputHeight, chatWidth);
+		this.chatWidget.setInputPartMaxHeightOverride(WELCOME_CHAT_INPUT_MAX_HEIGHT_OVERRIDE);
+		this.chatWidget.layout(WELCOME_CHAT_INPUT_LAYOUT_HEIGHT, chatWidth);
 	}
 
 	private layoutSessionsControl(): void {

--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -66,7 +66,10 @@ const MAX_SESSIONS = 6;
 const MAX_REPO_PICKS = 10;
 const MAX_WALKTHROUGHS = 10;
 const WELCOME_CHAT_INPUT_LAYOUT_HEIGHT = 150;
-const WELCOME_CHAT_INPUT_MAX_HEIGHT_OVERRIDE = 272;
+const WELCOME_CHAT_INPUT_RESERVED_LIST_HEIGHT = 50;
+const WELCOME_CHAT_INPUT_RESERVED_CHROME_HEIGHT = 72;
+// Mirror ChatWidget's compact-surface sizing so the hidden list reservation and input chrome do not collapse the editor.
+const WELCOME_CHAT_INPUT_MAX_HEIGHT_OVERRIDE = WELCOME_CHAT_INPUT_LAYOUT_HEIGHT + WELCOME_CHAT_INPUT_RESERVED_LIST_HEIGHT + WELCOME_CHAT_INPUT_RESERVED_CHROME_HEIGHT;
 
 /**
  * - visibleDurationMs: Do they close it right away or leave it open (#3)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/304544
## Problem

Typing in the Agent Sessions welcome page chat input causes the box to collapse so text is not visible (issue #304544). The editor shrinks from ~44px to ~22px after the first keystroke.

## Root Cause

`ChatWidget.layout()` reserves `MIN_LIST_HEIGHT` (50px) for the chat list even when the welcome page hides it via CSS (`display: none !important`). With a layout height of 150px, only 100px remained for the input part. Once the input part's non-editor chrome (~128px for toolbars, padding, attachments area) was subtracted, `_effectiveInputEditorMaxHeight` dropped to **0**, collapsing the editor completely.

## Fix

Call `setInputPartMaxHeightOverride(272)` before `layout()` so the input part has enough height budget independent of the artificially small layout height. This mirrors what other compact chat surfaces (e.g. stacked chat view in `chatViewPane.ts`) already do.

The override value (272) is chosen to be: `150 (layout height) + 50 (MIN_LIST_HEIGHT) + 72 (buffer for chrome growth)`.

Fixes #304544