### PR TITLE
sessions: change session description to IMarkdownString and render markdown

### DIFF
--- a/src/vs/sessions/SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/SESSIONS_PROVIDER.md
@@ -65,7 +65,7 @@ The common session interface exposed by all providers. It is a self-contained fa
 | `loading` | `IObservable<boolean>` | Whether the session is initializing |
 | `isArchived` | `IObservable<boolean>` | Archive state |
 | `isRead` | `IObservable<boolean>` | Read/unread state |
-| `description` | `IObservable<string \| undefined>` | Status description (e.g., current agent action) |
+| `description` | `IObservable<IMarkdownString \| undefined>` | Status description (e.g., current agent action), supports markdown |
 | `lastTurnEnd` | `IObservable<Date \| undefined>` | When the last agent turn ended |
 | `pullRequest` | `IObservable<ISessionPullRequest \\| undefined>` | Associated pull request |
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { themeColorFromId, ThemeIcon } from '../../../../base/common/themables.js';
@@ -77,8 +78,8 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 	private readonly _title = observableValue(this, '');
 	readonly title: IObservable<string> = this._title;
 
-	private readonly _description: ReturnType<typeof observableValue<string | undefined>>;
-	readonly description: IObservable<string | undefined>;
+	private readonly _description: ReturnType<typeof observableValue<IMarkdownString | undefined>>;
+	readonly description: IObservable<IMarkdownString | undefined>;
 
 	private readonly _updatedAt = observableValue(this, new Date());
 	readonly updatedAt: IObservable<Date> = this._updatedAt;
@@ -381,7 +382,7 @@ export class RemoteNewSession extends Disposable implements ISessionData {
 
 	readonly isArchived: IObservable<boolean> = observableValue(this, false);
 	readonly isRead: IObservable<boolean> = observableValue(this, true);
-	readonly description: IObservable<string | undefined> = observableValue(this, undefined);
+	readonly description: IObservable<IMarkdownString | undefined> = observableValue(this, undefined);
 	readonly lastTurnEnd: IObservable<Date | undefined> = observableValue(this, undefined);
 	readonly gitHubInfo: IObservable<IGitHubInfo | undefined> = observableValue(this, undefined);
 
@@ -623,8 +624,8 @@ class AgentSessionAdapter implements ISessionData {
 	private readonly _isRead: ReturnType<typeof observableValue<boolean>>;
 	readonly isRead: IObservable<boolean>;
 
-	private readonly _description: ReturnType<typeof observableValue<string | undefined>>;
-	readonly description: IObservable<string | undefined>;
+	private readonly _description: ReturnType<typeof observableValue<IMarkdownString | undefined>>;
+	readonly description: IObservable<IMarkdownString | undefined>;
 
 	private readonly _lastTurnEnd: ReturnType<typeof observableValue<Date | undefined>>;
 	readonly lastTurnEnd: IObservable<Date | undefined>;
@@ -703,11 +704,11 @@ class AgentSessionAdapter implements ISessionData {
 		}
 	}
 
-	private _extractDescription(session: IAgentSession): string | undefined {
+	private _extractDescription(session: IAgentSession): IMarkdownString | undefined {
 		if (!session.description) {
 			return undefined;
 		}
-		return typeof session.description === 'string' ? session.description : session.description.value;
+		return typeof session.description === 'string' ? new MarkdownString(session.description) : session.description;
 	}
 
 	private _extractGitHubInfo(session: IAgentSession): IGitHubInfo | undefined {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -6,6 +6,7 @@
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
@@ -54,7 +55,7 @@ class RemoteSessionAdapter implements ISessionData {
 	readonly loading = observableValue('loading', false);
 	readonly isArchived = observableValue('isArchived', false);
 	readonly isRead = observableValue('isRead', true);
-	readonly description: ISettableObservable<string | undefined>;
+	readonly description: ISettableObservable<IMarkdownString | undefined>;
 	readonly lastTurnEnd: ISettableObservable<Date | undefined>;
 	readonly gitHubInfo = observableValue<IGitHubInfo | undefined>('gitHubInfo', undefined);
 
@@ -79,7 +80,7 @@ class RemoteSessionAdapter implements ISessionData {
 		this.title = observableValue('title', metadata.summary ?? `Session ${rawId.substring(0, 8)}`);
 		this.updatedAt = observableValue('updatedAt', new Date(metadata.modifiedTime));
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
-		this.description = observableValue('description', providerLabel);
+		this.description = observableValue('description', new MarkdownString(providerLabel));
 		this.workspace = observableValue('workspace', metadata.workingDirectory
 			? RemoteAgentHostSessionsProvider.buildWorkspace(metadata.workingDirectory, providerLabel, connectionAuthority)
 			: undefined);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -80,7 +80,7 @@ class RemoteSessionAdapter implements ISessionData {
 		this.title = observableValue('title', metadata.summary ?? `Session ${rawId.substring(0, 8)}`);
 		this.updatedAt = observableValue('updatedAt', new Date(metadata.modifiedTime));
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
-		this.description = observableValue('description', new MarkdownString(providerLabel));
+		this.description = observableValue('description', new MarkdownString().appendText(providerLabel));
 		this.workspace = observableValue('workspace', metadata.workingDirectory
 			? RemoteAgentHostSessionsProvider.buildWorkspace(metadata.workingDirectory, providerLabel, connectionAuthority)
 			: undefined);

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -204,6 +204,13 @@
 		text-overflow: ellipsis;
 	}
 
+	.session-description p {
+		margin: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	.session-description:empty {
 		display: none;
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -21,11 +21,11 @@ import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/l
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { ISessionsManagementService, IsNewChatSessionContext } from './sessionsManagementService.js';
+import { ISessionsManagementService } from './sessionsManagementService.js';
 import { autorun, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
-import { ChatSessionProviderIdContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
+import { ChatSessionProviderIdContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
 import { SessionStatus } from '../common/sessionData.js';
 import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -321,6 +321,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				if (description) {
 					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
 				} else {
+					descriptionDisposable.clear();
 					statusEl.textContent = localize('working', "Working...");
 				}
 				parts.push(statusEl);
@@ -332,6 +333,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				if (description) {
 					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
 				} else {
+					descriptionDisposable.clear();
 					statusEl.textContent = localize('needsInput', "Input needed");
 				}
 				parts.push(statusEl);
@@ -343,6 +345,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				if (description) {
 					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
 				} else {
+					descriptionDisposable.clear();
 					statusEl.textContent = localize('failed', "Failed");
 				}
 				parts.push(statusEl);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -251,6 +251,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 		// Details row — reactive: badge · diff stats · time
 		const timeDisposable = template.elementDisposables.add(new MutableDisposable());
+		const descriptionDisposable = template.elementDisposables.add(new MutableDisposable());
 		template.elementDisposables.add(autorun(reader => {
 			const sessionStatus = element.status.read(reader);
 			const changes = element.changes.read(reader);
@@ -317,22 +318,36 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
 				}
 				const statusEl = DOM.append(template.detailsRow, $('span.session-description'));
-				statusEl.textContent = description ?? localize('working', "Working...");
+				if (description) {
+					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
+				} else {
+					statusEl.textContent = localize('working', "Working...");
+				}
 				parts.push(statusEl);
 			} else if (sessionStatus === SessionStatus.NeedsInput) {
 				if (parts.length > 0) {
 					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
 				}
 				const statusEl = DOM.append(template.detailsRow, $('span.session-description'));
-				statusEl.textContent = description ?? localize('needsInput', "Input needed");
+				if (description) {
+					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
+				} else {
+					statusEl.textContent = localize('needsInput', "Input needed");
+				}
 				parts.push(statusEl);
 			} else if (sessionStatus === SessionStatus.Error) {
 				if (parts.length > 0) {
 					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
 				}
 				const statusEl = DOM.append(template.detailsRow, $('span.session-description'));
-				statusEl.textContent = localize('failed', "Failed");
+				if (description) {
+					descriptionDisposable.value = this.markdownRendererService.render(description, { sanitizerConfig: { replaceWithPlaintext: true } }, statusEl);
+				} else {
+					statusEl.textContent = localize('failed', "Failed");
+				}
 				parts.push(statusEl);
+			} else {
+				descriptionDisposable.clear();
 			}
 
 			// Timestamp — visible when not hiding details

--- a/src/vs/sessions/contrib/sessions/common/sessionData.ts
+++ b/src/vs/sessions/contrib/sessions/common/sessionData.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -116,8 +117,8 @@ export interface ISessionData {
 	readonly isArchived: IObservable<boolean>;
 	/** Whether the session has been read. */
 	readonly isRead: IObservable<boolean>;
-	/** Status description shown while the session is active (e.g., current agent action). */
-	readonly description: IObservable<string | undefined>;
+	/** Status description shown while the session is active (e.g., current agent action). Supports markdown. */
+	readonly description: IObservable<IMarkdownString | undefined>;
 	/** Timestamp of when the last agent turn ended, if any. */
 	readonly lastTurnEnd: IObservable<Date | undefined>;
 	/** GitHub information associated with this session, if any. */
@@ -164,8 +165,8 @@ export interface IChat {
 	readonly isArchived: IObservable<boolean>;
 	/** Whether the chat has been read. */
 	readonly isRead: IObservable<boolean>;
-	/** Status description shown while the chat is active (e.g., current agent action). */
-	readonly description: IObservable<string | undefined>;
+	/** Status description shown while the chat is active (e.g., current agent action). Supports markdown. */
+	readonly description: IObservable<IMarkdownString | undefined>;
 	/** Timestamp of when the last agent turn ended, if any. */
 	readonly lastTurnEnd: IObservable<Date | undefined>;
 	/** GitHub information associated with this session, if any. */
@@ -212,8 +213,8 @@ export interface ISession {
 	readonly isArchived: IObservable<boolean>;
 	/** Whether the session has been read. */
 	readonly isRead: IObservable<boolean>;
-	/** Status description shown while the session is active (e.g., current agent action). */
-	readonly description: IObservable<string | undefined>;
+	/** Status description shown while the session is active (e.g., current agent action). Supports markdown. */
+	readonly description: IObservable<IMarkdownString | undefined>;
 	/** Timestamp of when the last agent turn ended, if any. */
 	readonly lastTurnEnd: IObservable<Date | undefined>;
 	/** GitHub information associated with this session, if any. */


### PR DESCRIPTION
## Summary

Changes the `description` field on session interfaces (`ISessionData`, `IChat`, `ISession`) from `string | undefined` to `IMarkdownString | undefined`, and updates the sessions list UI to render it as markdown.

## What changed

**`sessionData.ts`** — Added `IMarkdownString` import; updated `description` type on `ISessionData`, `IChat`, and `ISession`.

**`copilotChatSessionsProvider.ts`** — Updated `_description` field types in `CopilotCLISession`, `RemoteNewSession`, and `AgentSessionAdapter`. Updated `_extractDescription()` to return `IMarkdownString | undefined` — plain strings are wrapped in `new MarkdownString(...)`, `IMarkdownString` values are passed through.

**`remoteAgentHostSessionsProvider.ts`** — Updated `description` field type; wrapped the initial `providerLabel` string in `new MarkdownString(providerLabel)`.

**`sessionsList.ts`** — Added a `descriptionDisposable: MutableDisposable` to properly track the markdown renderer lifecycle. When a description is present, renders it via `markdownRendererService.render()` with `sanitizerConfig: { replaceWithPlaintext: true }` — matching the existing `agentSessionsViewer.ts` pattern. Fallback status labels ("Working...", "Input needed", "Failed") continue to use plain `textContent`. Clears the disposable when status is not in a described state.

**`sessionsList.css`** — Added `p` override to reset margin and enforce ellipsis on paragraphs emitted by the markdown renderer.

**`SESSIONS_PROVIDER.md`** — Updated `description` field documentation.

## Why

The workbench's existing `agentSessionsViewer.ts` already supports `string | IMarkdownString` for descriptions and renders markdown using `markdownRendererService`. The sessions window view was lagging behind, using plain `textContent`. This change brings it in line with the established pattern.
