### PR TITLE
chat: clean up per-response maps in disposeElement to reduce memory

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2525,6 +2525,20 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			this.templateDataByRequestId.delete(templateData.currentElement.id);
 		}
 
+		// These maps are only read for the focused response which is always visible,
+		// so we can clean up entries for elements that leave the viewport.
+		const codeBlocks = this.codeBlocksByResponseId.get(node.element.id);
+		if (codeBlocks) {
+			for (const info of codeBlocks) {
+				if (info?.uri) {
+					this.codeBlocksByEditorUri.delete(info.uri);
+				}
+			}
+			this.codeBlocksByResponseId.delete(node.element.id);
+		}
+		this.fileTreesByResponseId.delete(node.element.id);
+		this.focusedFileTreesByResponseId.delete(node.element.id);
+
 		if (isRequestVM(node.element) && node.element.id === this.viewModel?.editing?.id && details?.onScroll) {
 			this._onDidDispose.fire(templateData);
 		}


### PR DESCRIPTION
## Summary

Clean up accumulated per-response map entries in `ChatListItemRenderer.disposeElement()` to reduce memory usage.

## Problem

The chat list renderer maintains several maps indexed by response/element ID:
- `codeBlocksByResponseId` — code block info for each response
- `codeBlocksByEditorUri` — same code block info indexed by editor URI
- `fileTreesByResponseId` — file tree info for each response
- `focusedFileTreesByResponseId` — focused file tree index per response

These maps accumulated entries for every rendered response but were only cleared when the entire view model changed (`updateViewModel`). In a long chat session, this means entries for hundreds of off-screen responses would pile up unnecessarily.

## Fix

Clear these map entries in `disposeElement()` when elements leave the viewport. This is safe because:
- `codeBlocksByResponseId` / `codeBlocksByEditorUri` are only read via `getCodeBlockInfosForResponse()` and `getCodeBlockInfoForEditor()`, which are called for the focused response (always visible)
- `fileTreesByResponseId` / `focusedFileTreesByResponseId` follow the same pattern
- When an element scrolls back into view, `renderElement` repopulates the data