### PR TITLE
align whitespace menu option with setting

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -100,6 +100,7 @@ export class MenuId {
 	static readonly EditorTabsBarShowTabsSubmenu = new MenuId('EditorTabsBarShowTabsSubmenu');
 	static readonly EditorTabsBarShowTabsZenModeSubmenu = new MenuId('EditorTabsBarShowTabsZenModeSubmenu');
 	static readonly EditorActionsPositionSubmenu = new MenuId('EditorActionsPositionSubmenu');
+	static readonly EditorRenderWhitespaceSubmenu = new MenuId('EditorRenderWhitespaceSubmenu');
 	static readonly EditorSplitMoveSubmenu = new MenuId('EditorSplitMoveSubmenu');
 	static readonly ExplorerContext = new MenuId('ExplorerContext');
 	static readonly ExplorerContextShare = new MenuId('ExplorerContextShare');

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -17,7 +17,8 @@ class RenderWhitespaceNoneAction extends Action2 {
 	constructor() {
 		super({
 			id: RenderWhitespaceNoneAction.ID,
-			title: localize2('renderWhitespace.none', "None"),
+			title: localize2('renderWhitespace.setNone', "Set Render Whitespace to None"),
+			shortTitle: localize2('renderWhitespace.none', "None"),
 			category: Categories.View,
 			f1: false,
 		});
@@ -32,7 +33,8 @@ class RenderWhitespaceBoundaryAction extends Action2 {
 	constructor() {
 		super({
 			id: RenderWhitespaceBoundaryAction.ID,
-			title: localize2('renderWhitespace.boundary', "Boundary"),
+			title: localize2('renderWhitespace.setBoundary', "Set Render Whitespace to Boundary"),
+			shortTitle: localize2('renderWhitespace.boundary', "Boundary"),
 			category: Categories.View,
 			f1: false,
 		});
@@ -47,7 +49,8 @@ class RenderWhitespaceSelectionAction extends Action2 {
 	constructor() {
 		super({
 			id: RenderWhitespaceSelectionAction.ID,
-			title: localize2('renderWhitespace.selection', "Selection"),
+			title: localize2('renderWhitespace.setSelection', "Set Render Whitespace to Selection"),
+			shortTitle: localize2('renderWhitespace.selection', "Selection"),
 			category: Categories.View,
 			f1: false,
 		});
@@ -62,7 +65,8 @@ class RenderWhitespaceTrailingAction extends Action2 {
 	constructor() {
 		super({
 			id: RenderWhitespaceTrailingAction.ID,
-			title: localize2('renderWhitespace.trailing', "Trailing"),
+			title: localize2('renderWhitespace.setTrailing', "Set Render Whitespace to Trailing"),
+			shortTitle: localize2('renderWhitespace.trailing', "Trailing"),
 			category: Categories.View,
 			f1: false,
 		});
@@ -77,7 +81,8 @@ class RenderWhitespaceAllAction extends Action2 {
 	constructor() {
 		super({
 			id: RenderWhitespaceAllAction.ID,
-			title: localize2('renderWhitespace.all', "All"),
+			title: localize2('renderWhitespace.setAll', "Set Render Whitespace to All"),
+			shortTitle: localize2('renderWhitespace.all', "All"),
 			category: Categories.View,
 			f1: false,
 		});

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -4,11 +4,88 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../nls.js';
-import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+
+const renderWhitespaceSetting = 'editor.renderWhitespace';
+
+class RenderWhitespaceNoneAction extends Action2 {
+	static readonly ID = 'editor.action.renderWhitespace.none';
+	constructor() {
+		super({
+			id: RenderWhitespaceNoneAction.ID,
+			title: localize2('renderWhitespace.none', "None"),
+			category: Categories.View,
+			f1: false,
+		});
+	}
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IConfigurationService).updateValue(renderWhitespaceSetting, 'none');
+	}
+}
+
+class RenderWhitespaceBoundaryAction extends Action2 {
+	static readonly ID = 'editor.action.renderWhitespace.boundary';
+	constructor() {
+		super({
+			id: RenderWhitespaceBoundaryAction.ID,
+			title: localize2('renderWhitespace.boundary', "Boundary"),
+			category: Categories.View,
+			f1: false,
+		});
+	}
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IConfigurationService).updateValue(renderWhitespaceSetting, 'boundary');
+	}
+}
+
+class RenderWhitespaceSelectionAction extends Action2 {
+	static readonly ID = 'editor.action.renderWhitespace.selection';
+	constructor() {
+		super({
+			id: RenderWhitespaceSelectionAction.ID,
+			title: localize2('renderWhitespace.selection', "Selection"),
+			category: Categories.View,
+			f1: false,
+		});
+	}
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IConfigurationService).updateValue(renderWhitespaceSetting, 'selection');
+	}
+}
+
+class RenderWhitespaceTrailingAction extends Action2 {
+	static readonly ID = 'editor.action.renderWhitespace.trailing';
+	constructor() {
+		super({
+			id: RenderWhitespaceTrailingAction.ID,
+			title: localize2('renderWhitespace.trailing', "Trailing"),
+			category: Categories.View,
+			f1: false,
+		});
+	}
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IConfigurationService).updateValue(renderWhitespaceSetting, 'trailing');
+	}
+}
+
+class RenderWhitespaceAllAction extends Action2 {
+	static readonly ID = 'editor.action.renderWhitespace.all';
+	constructor() {
+		super({
+			id: RenderWhitespaceAllAction.ID,
+			title: localize2('renderWhitespace.all', "All"),
+			category: Categories.View,
+			f1: false,
+		});
+	}
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IConfigurationService).updateValue(renderWhitespaceSetting, 'all');
+	}
+}
 
 class ToggleRenderWhitespaceAction extends Action2 {
 
@@ -17,25 +94,16 @@ class ToggleRenderWhitespaceAction extends Action2 {
 	constructor() {
 		super({
 			id: ToggleRenderWhitespaceAction.ID,
-			title: {
-				...localize2('toggleRenderWhitespace', "Toggle Render Whitespace"),
-				mnemonicTitle: localize({ key: 'miToggleRenderWhitespace', comment: ['&& denotes a mnemonic'] }, "&&Render Whitespace"),
-			},
+			title: localize2('toggleRenderWhitespace', "Toggle Render Whitespace"),
 			category: Categories.View,
 			f1: true,
-			toggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none'),
-			menu: {
-				id: MenuId.MenubarAppearanceMenu,
-				group: '4_editor',
-				order: 4
-			}
 		});
 	}
 
 	override run(accessor: ServicesAccessor): Promise<void> {
 		const configurationService = accessor.get(IConfigurationService);
 
-		const renderWhitespace = configurationService.getValue<string>('editor.renderWhitespace');
+		const renderWhitespace = configurationService.getValue<string>(renderWhitespaceSetting);
 
 		let newRenderWhitespace: string;
 		if (renderWhitespace === 'none') {
@@ -44,8 +112,26 @@ class ToggleRenderWhitespaceAction extends Action2 {
 			newRenderWhitespace = 'none';
 		}
 
-		return configurationService.updateValue('editor.renderWhitespace', newRenderWhitespace);
+		return configurationService.updateValue(renderWhitespaceSetting, newRenderWhitespace);
 	}
 }
 
+registerAction2(RenderWhitespaceNoneAction);
+registerAction2(RenderWhitespaceBoundaryAction);
+registerAction2(RenderWhitespaceSelectionAction);
+registerAction2(RenderWhitespaceTrailingAction);
+registerAction2(RenderWhitespaceAllAction);
 registerAction2(ToggleRenderWhitespaceAction);
+
+MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
+	submenu: MenuId.EditorRenderWhitespaceSubmenu,
+	title: localize('renderWhitespace', "Render Whitespace"),
+	group: '4_editor',
+	order: 4
+});
+
+MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceNoneAction.ID, title: localize('renderWhitespace.none', "None"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'none') }, group: '1_config', order: 1 });
+MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceBoundaryAction.ID, title: localize('renderWhitespace.boundary', "Boundary"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'boundary') }, group: '1_config', order: 2 });
+MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceSelectionAction.ID, title: localize('renderWhitespace.selection', "Selection"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'selection') }, group: '1_config', order: 3 });
+MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceTrailingAction.ID, title: localize('renderWhitespace.trailing', "Trailing"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'trailing') }, group: '1_config', order: 4 });
+MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceAllAction.ID, title: localize('renderWhitespace.all', "All"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'all') }, group: '1_config', order: 5 });

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -21,6 +21,8 @@ class RenderWhitespaceNoneAction extends Action2 {
 			shortTitle: localize2('renderWhitespace.none', "None"),
 			category: Categories.View,
 			f1: false,
+			toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'none'),
+			menu: { id: MenuId.EditorRenderWhitespaceSubmenu, group: '1_config', order: 1 },
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -37,6 +39,8 @@ class RenderWhitespaceBoundaryAction extends Action2 {
 			shortTitle: localize2('renderWhitespace.boundary', "Boundary"),
 			category: Categories.View,
 			f1: false,
+			toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'boundary'),
+			menu: { id: MenuId.EditorRenderWhitespaceSubmenu, group: '1_config', order: 2 },
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -53,6 +57,8 @@ class RenderWhitespaceSelectionAction extends Action2 {
 			shortTitle: localize2('renderWhitespace.selection', "Selection"),
 			category: Categories.View,
 			f1: false,
+			toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'selection'),
+			menu: { id: MenuId.EditorRenderWhitespaceSubmenu, group: '1_config', order: 3 },
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -69,6 +75,8 @@ class RenderWhitespaceTrailingAction extends Action2 {
 			shortTitle: localize2('renderWhitespace.trailing', "Trailing"),
 			category: Categories.View,
 			f1: false,
+			toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'trailing'),
+			menu: { id: MenuId.EditorRenderWhitespaceSubmenu, group: '1_config', order: 4 },
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -85,6 +93,8 @@ class RenderWhitespaceAllAction extends Action2 {
 			shortTitle: localize2('renderWhitespace.all', "All"),
 			category: Categories.View,
 			f1: false,
+			toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'all'),
+			menu: { id: MenuId.EditorRenderWhitespaceSubmenu, group: '1_config', order: 5 },
 		});
 	}
 	override run(accessor: ServicesAccessor): Promise<void> {
@@ -134,9 +144,3 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	group: '4_editor',
 	order: 4
 });
-
-MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceNoneAction.ID, title: localize('renderWhitespace.none', "None"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'none') }, group: '1_config', order: 1 });
-MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceBoundaryAction.ID, title: localize('renderWhitespace.boundary', "Boundary"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'boundary') }, group: '1_config', order: 2 });
-MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceSelectionAction.ID, title: localize('renderWhitespace.selection', "Selection"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'selection') }, group: '1_config', order: 3 });
-MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceTrailingAction.ID, title: localize('renderWhitespace.trailing', "Trailing"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'trailing') }, group: '1_config', order: 4 });
-MenuRegistry.appendMenuItem(MenuId.EditorRenderWhitespaceSubmenu, { command: { id: RenderWhitespaceAllAction.ID, title: localize('renderWhitespace.all', "All"), toggled: ContextKeyExpr.equals(`config.${renderWhitespaceSetting}`, 'all') }, group: '1_config', order: 5 });


### PR DESCRIPTION
Addresses the misleading **View → Appearance → Render Whitespace** menu state by replacing the single toggle with a dedicated submenu that reflects the actual `editor.renderWhitespace` mode.

## Changes Made

- Introduces a new `EditorRenderWhitespaceSubmenu` menu id.
- Reworks the Appearance menu entry into a "Render Whitespace" submenu with explicit modes (None/Boundary/Selection/Trailing/All).
- Keeps the existing "Toggle Render Whitespace" command (F1) but removes it from the menubar Appearance menu.
- Each mode command uses a descriptive `title` (e.g. "Set Render Whitespace to None") so it is unambiguous when surfaced in keyboard shortcuts settings, and a `shortTitle` (e.g. "None") for concise display.
- Submenu placement (`menu` property) and toggle state (`toggled`) are declared directly in each `Action2` descriptor, eliminating duplicate `MenuRegistry.appendMenuItem` calls. Only the submenu header registration remains as a separate `MenuRegistry` call.