### PR TITLE
window: promote chat session focus events to stable API

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { join } from 'path';
 import { CancellationTokenSource, commands, MarkdownString, TabInputNotebook, Position, QuickPickItem, Selection, StatusBarAlignment, TextEditor, TextEditorSelectionChangeKind, TextEditorViewColumnChangeEvent, TabInputText, Uri, ViewColumn, window, workspace, TabInputTextDiff, UIKind, env } from 'vscode';
-import { assertNoRpc, asPromise, closeAllEditors, createRandomFile, pathEquals } from '../utils';
+import { assertNoRpc, closeAllEditors, createRandomFile, pathEquals } from '../utils';
 
 
 suite('vscode API - window', () => {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -1065,10 +1065,16 @@ suite('vscode API - window', () => {
 		// Verify the API surface exists
 		assert.strictEqual(typeof window.onDidChangeActiveChatSession, 'function');
 
-		// Subscribe and wait until we see a non-undefined Uri payload
-		const sessionUriPromise = new Promise<Uri>(resolve => {
+		// Subscribe and wait until we see a non-undefined Uri payload (with timeout)
+		const timeout = env.uiKind === UIKind.Desktop ? 5000 : 15000;
+		const sessionUriPromise = new Promise<Uri>((resolve, reject) => {
+			const handle = setTimeout(() => {
+				subscription.dispose();
+				reject(new Error('onDidChangeActiveChatSession did not fire with a Uri within timeout'));
+			}, timeout);
 			const subscription = window.onDidChangeActiveChatSession(value => {
 				if (value instanceof Uri) {
+					clearTimeout(handle);
 					subscription.dispose();
 					resolve(value);
 				}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -1065,16 +1065,24 @@ suite('vscode API - window', () => {
 		// Verify the API surface exists
 		assert.strictEqual(typeof window.onDidChangeActiveChatSession, 'function');
 
-		// Open a new chat and verify the event fires with a URI
-		const sessionChanged = asPromise(window.onDidChangeActiveChatSession);
-		await commands.executeCommand('workbench.action.chat.newChat');
-		const uri = await sessionChanged;
-		assert.ok(uri === undefined || uri instanceof Uri, 'activeChatSession event payload should be Uri or undefined');
+		// Subscribe and wait until we see a non-undefined Uri payload
+		const sessionUriPromise = new Promise<Uri>(resolve => {
+			const subscription = window.onDidChangeActiveChatSession(value => {
+				if (value instanceof Uri) {
+					subscription.dispose();
+					resolve(value);
+				}
+			});
+		});
 
-		// After the event, activeChatSessionUri should match
-		if (uri) {
-			assert.strictEqual(window.activeChatSessionUri?.toString(), uri.toString());
-		}
+		// Open a new chat and verify the event eventually fires with a Uri
+		await commands.executeCommand('workbench.action.chat.newChat');
+		const uri = await sessionUriPromise;
+		assert.ok(uri instanceof Uri, 'activeChatSession event payload should eventually be a Uri');
+
+		// After receiving the Uri event, activeChatSessionUri should match
+		assert.ok(window.activeChatSessionUri instanceof Uri, 'window.activeChatSessionUri should be set to a Uri');
+		assert.strictEqual(window.activeChatSessionUri!.toString(), uri.toString());
 	});
 
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/window.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { join } from 'path';
 import { CancellationTokenSource, commands, MarkdownString, TabInputNotebook, Position, QuickPickItem, Selection, StatusBarAlignment, TextEditor, TextEditorSelectionChangeKind, TextEditorViewColumnChangeEvent, TabInputText, Uri, ViewColumn, window, workspace, TabInputTextDiff, UIKind, env } from 'vscode';
-import { assertNoRpc, closeAllEditors, createRandomFile, pathEquals } from '../utils';
+import { assertNoRpc, asPromise, closeAllEditors, createRandomFile, pathEquals } from '../utils';
 
 
 suite('vscode API - window', () => {
@@ -1060,4 +1060,21 @@ suite('vscode API - window', () => {
 
 		item.dispose();
 	});
+
+	test('activeChatSessionUri and onDidChangeActiveChatSession', async function () {
+		// Verify the API surface exists
+		assert.strictEqual(typeof window.onDidChangeActiveChatSession, 'function');
+
+		// Open a new chat and verify the event fires with a URI
+		const sessionChanged = asPromise(window.onDidChangeActiveChatSession);
+		await commands.executeCommand('workbench.action.chat.newChat');
+		const uri = await sessionChanged;
+		assert.ok(uri === undefined || uri instanceof Uri, 'activeChatSession event payload should be Uri or undefined');
+
+		// After the event, activeChatSessionUri should match
+		if (uri) {
+			assert.strictEqual(window.activeChatSessionUri?.toString(), uri.toString());
+		}
+	});
+
 });

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -847,6 +847,12 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			onDidChangeActiveTerminal(listener, thisArg?, disposables?) {
 				return _asExtensionEvent(extHostTerminalService.onDidChangeActiveTerminal)(listener, thisArg, disposables);
 			},
+			get activeChatSessionUri() {
+				return extHostChatAgents2.activeChatPanelSessionResource;
+			},
+			onDidChangeActiveChatSession(listener, thisArg?, disposables?) {
+				return _asExtensionEvent(extHostChatAgents2.onDidChangeActiveChatPanelSessionResource)(listener, thisArg, disposables);
+			},
 			onDidChangeTerminalDimensions(listener, thisArg?, disposables?) {
 				checkProposedApiEnabled(extension, 'terminalDimensions');
 				return _asExtensionEvent(extHostTerminalService.onDidChangeTerminalDimensions)(listener, thisArg, disposables);

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11174,6 +11174,20 @@ declare module 'vscode' {
 		export const onDidChangeActiveTerminal: Event<Terminal | undefined>;
 
 		/**
+		 * The URI of the currently active chat panel session, or `undefined`
+		 * if no chat session is active.
+		 */
+		export const activeChatSessionUri: Uri | undefined;
+
+		/**
+		 * An {@link Event} which fires when the active chat panel session changes.
+		 * This occurs when the user switches between chat conversations,
+		 * or when a new conversation is started. The event payload is the URI
+		 * of the newly active session, or `undefined` if no session is active.
+		 */
+		export const onDidChangeActiveChatSession: Event<Uri | undefined>;
+
+		/**
 		 * An {@link Event} which fires when a terminal has been created, either through the
 		 * {@link window.createTerminal createTerminal} API or commands.
 		 */

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -11176,6 +11176,9 @@ declare module 'vscode' {
 		/**
 		 * The URI of the currently active chat panel session, or `undefined`
 		 * if no chat session is active.
+		 *
+		 * *Note:* This currently only tracks local chat sessions. Sessions
+		 * backed by non-local providers may not be reflected.
 		 */
 		export const activeChatSessionUri: Uri | undefined;
 
@@ -11184,6 +11187,9 @@ declare module 'vscode' {
 		 * This occurs when the user switches between chat conversations,
 		 * or when a new conversation is started. The event payload is the URI
 		 * of the newly active session, or `undefined` if no session is active.
+		 *
+		 * *Note:* This currently only tracks local chat sessions. Sessions
+		 * backed by non-local providers may not be reflected.
 		 */
 		export const onDidChangeActiveChatSession: Event<Uri | undefined>;
 


### PR DESCRIPTION
## Summary

Promote `activeChatSessionUri` and `onDidChangeActiveChatSession` from proposed API to stable `window` namespace, enabling extensions to react to chat panel focus changes without adopting a proposed API.

Closes microsoft/vscode#306497

## Problem

Extensions that manage per-chat state — such as branch-per-chat workflows, session-scoped terminals, or context-aware tooling — need to know which chat panel the user is interacting with. The `activeChatPanelSessionResource` and `onDidChangeChatPanelActiveSession` events exist on `ExtHostChatAgents2` but are gated behind a proposed API. This means:

1. Extensions must enable `chatParticipantAdditions` proposed API to access the events
2. Extensions using proposed APIs cannot be published to the Marketplace
3. The events are not discoverable through standard `vscode.window` API surface

## Approach

Expose two new members on the `window` namespace, ungated:

```typescript
// Get the URI of the currently focused chat session (undefined if none)
const uri = vscode.window.activeChatSessionUri;

// React to chat session focus changes
vscode.window.onDidChangeActiveChatSession(uri => {
    console.log('Active chat session:', uri?.toString());
});
```

**Implementation:**
- `extHost.api.impl.ts`: Added `activeChatSessionUri` getter and `onDidChangeActiveChatSession` event to the `window` namespace object, delegating to `extHostChatAgents2.activeChatPanelSessionResource` and the corresponding event.
- `vscode.d.ts`: Stable type declarations in the `window` namespace (placed after `onDidChangeActiveTerminal` for logical grouping with other focus-change events).

**Design notes:**
- No proposed API gate — these are stable additions. The underlying implementation already exists and is exercised by the chat participant system.
- The event reuses the existing `ExtHostChatAgents2` infrastructure, so there is no new IPC channel or protocol change.
- Returns `Uri | undefined` consistent with other `active*` properties on `window`.

## Use Cases

- **Branch-per-chat session management**: When the user focuses a different chat panel, the extension switches the visible branch/worktree to match that session's context.
- **Session-scoped terminals**: An extension can create and show a terminal tied to the active chat session, automatically switching when focus changes.
- **Context-aware tool configuration**: MCP servers or tool providers can adjust their behavior based on which chat session is active.
- **Session state persistence**: Extensions can save/restore per-session state (open files, cursor positions, debug configs) keyed by chat session URI.

## Testing

Manual verification that:
1. `vscode.window.activeChatSessionUri` returns the URI of the focused chat panel
2. `vscode.window.onDidChangeActiveChatSession` fires when switching between chat panels
3. Both return `undefined` when no chat panel is focused
