### PR TITLE
Telemetry of skills actually used

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -171,6 +171,7 @@ import { ChatWidgetService } from './widget/chatWidgetService.js';
 import { ILanguageModelsConfigurationService } from '../common/languageModelsConfiguration.js';
 import { ChatWindowNotifier } from './chatWindowNotifier.js';
 import { ChatRepoInfoContribution } from './chatRepoInfo.js';
+import { SkillContentReadTelemetry } from './skillContentReadTelemetry.js';
 import { VALID_PROMPT_FOLDER_PATTERN } from '../common/promptSyntax/utils/promptFilesLocator.js';
 import { ChatTipService, IChatTipService } from './chatTipService.js';
 import { ChatQueuePickerRendering } from './widget/input/chatQueuePickerActionItem.js';
@@ -1883,6 +1884,7 @@ registerWorkbenchContribution2(ChatWindowNotifier.ID, ChatWindowNotifier, Workbe
 registerWorkbenchContribution2(ChatRepoInfoContribution.ID, ChatRepoInfoContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(AgentPluginsViewsContribution.ID, AgentPluginsViewsContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(AgentPluginRecommendations.ID, AgentPluginRecommendations, WorkbenchPhase.Eventually);
+registerWorkbenchContribution2(SkillContentReadTelemetry.ID, SkillContentReadTelemetry, WorkbenchPhase.Eventually);
 
 registerChatActions();
 registerChatAccessibilityActions();

--- a/src/vs/workbench/contrib/chat/browser/skillContentReadTelemetry.ts
+++ b/src/vs/workbench/contrib/chat/browser/skillContentReadTelemetry.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { hash } from '../../../../base/common/hash.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ResourceMap } from '../../../../base/common/map.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IAgentPlugin, IAgentPluginService } from '../common/plugins/agentPluginService.js';
+import { IAgentSkill, IPromptsService } from '../common/promptSyntax/service/promptsService.js';
+import { IToolCompletedEvent, ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
+
+export class SkillContentReadTelemetry extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.skillContentReadTelemetry';
+
+	/** Cached mapping from normalized skill path → skill, lazily populated. */
+	private _skillsByPath: Map<string, IAgentSkill> | undefined;
+	/** Cached mapping from plugin URI → plugin, refreshed alongside skills cache. */
+	private _pluginByUri: ResourceMap<IAgentPlugin> | undefined;
+
+	constructor(
+		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
+		@IPromptsService private readonly _promptsService: IPromptsService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._register(toolsService.onDidCompleteToolInvocation(e => this._onToolCompleted(e)));
+		this._register(this._promptsService.onDidChangeSkills(() => {
+			this._skillsByPath = undefined;
+			this._pluginByUri = undefined;
+		}));
+	}
+
+	private _onToolCompleted(event: IToolCompletedEvent): void {
+		if (event.toolReferenceName !== 'readFile') {
+			return;
+		}
+
+		const filePath = event.parameters['filePath'];
+		if (typeof filePath !== 'string') {
+			return;
+		}
+
+		const lowerPath = filePath.toLowerCase();
+		if (lowerPath.endsWith('/skill.md') || lowerPath.endsWith('\\skill.md')) {
+			// Fire-and-forget: resolve skill match and log telemetry asynchronously
+			this._logSkillContentReadIfMatch(filePath, event).catch(err => {
+				this._logService.error('[SkillContentReadTelemetry] Failed to log skill content read telemetry', err);
+			});
+		}
+	}
+
+	private async _logSkillContentReadIfMatch(filePath: string, event: IToolCompletedEvent): Promise<void> {
+		const skill = await this._findSkillForPath(filePath);
+		if (!skill) {
+			return;
+		}
+
+		// Extract text content from the tool result for hashing
+		const textPart = event.result.content.find(part => part.kind === 'text');
+		const textContent = textPart?.kind === 'text' ? textPart.value : undefined;
+
+		type SkillContentReadEvent = {
+			skillNameHash: string;
+			skillStorage: string;
+			extensionIdHash: string;
+			extensionVersion: string;
+			pluginNameHash: string;
+			pluginVersion: string;
+			contentHash: string;
+		};
+
+		type SkillContentReadClassification = {
+			skillNameHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Numeric hash of the skill name that was read by the model.' };
+			skillStorage: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The storage source of the skill (local, user, extension, plugin, internal).' };
+			extensionIdHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Numeric hash of the contributing extension identifier, empty if none.' };
+			extensionVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Semver version of the contributing extension, empty if none.' };
+			pluginNameHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Numeric hash of the plugin display name, empty if not from a plugin.' };
+			pluginVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Semver version of the plugin, empty if unavailable.' };
+			contentHash: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Numeric hash of the skill file content that was read by the model.' };
+			owner: 'manishj,dbreshears';
+			comment: 'Tracks when the model reads a skill file via the readFile tool, including provenance metadata.';
+		};
+
+		try {
+			const skillPlugin = skill.pluginUri ? this._pluginByUri?.get(skill.pluginUri) : undefined;
+
+			const hashOrEmpty = (value: string | undefined) => {
+				return value !== undefined ? String(hash(value)) : '';
+			};
+
+			this._telemetryService.publicLog2<SkillContentReadEvent, SkillContentReadClassification>('skillContentRead', {
+				skillNameHash: hashOrEmpty(skill.name),
+				skillStorage: skill.storage,
+				extensionIdHash: hashOrEmpty(skill.extension?.identifier.value),
+				extensionVersion: skill.extension?.version ?? '',
+				pluginNameHash: hashOrEmpty(skillPlugin?.label),
+				pluginVersion: skillPlugin?.fromMarketplace?.version ?? '',
+				contentHash: hashOrEmpty(textContent),
+			});
+		} catch (err) {
+			this._logService.error('[SkillContentReadTelemetry] Failed to log skill content read telemetry', err);
+		}
+	}
+
+	private async _findSkillForPath(filePath: string): Promise<IAgentSkill | undefined> {
+		const normalizedPath = filePath.replace(/\\/g, '/').toLowerCase();
+
+		// Try cached lookup first
+		const cached = this._skillsByPath?.get(normalizedPath);
+		if (cached) {
+			return cached;
+		}
+
+		// Refresh cache and try again
+		await this._refreshCache();
+		return this._skillsByPath?.get(normalizedPath);
+	}
+
+	private async _refreshCache(): Promise<void> {
+		const skills = await this._promptsService.findAgentSkills(CancellationToken.None);
+		if (!skills) {
+			this._skillsByPath = undefined;
+			this._pluginByUri = undefined;
+			return;
+		}
+
+		// Key by normalized path (forward slashes, lowercase) to match across
+		// local file:// and vscodeRemote:// schemes
+		const skillMap = new Map<string, IAgentSkill>();
+		for (const skill of skills) {
+			const normalizedPath = skill.uri.path.toLowerCase();
+			skillMap.set(normalizedPath, skill);
+		}
+		this._skillsByPath = skillMap;
+
+		const pluginMap = new ResourceMap<IAgentPlugin>();
+		for (const plugin of this._agentPluginService.plugins.get()) {
+			pluginMap.set(plugin.uri, plugin);
+		}
+		this._pluginByUri = pluginMap;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -49,7 +49,7 @@ import { ChatToolInvocation } from '../../common/model/chatProgressTypes/chatToo
 import { chatSessionResourceToId, getChatSessionType } from '../../common/model/chatUri.js';
 import { HookType } from '../../common/promptSyntax/hookTypes.js';
 import { ILanguageModelToolsConfirmationService } from '../../common/tools/languageModelToolsConfirmationService.js';
-import { CountTokensCallback, createToolSchemaUri, IBeginToolCallOptions, IExternalPreToolUseHookResult, ILanguageModelToolsService, IPreparedToolInvocation, isToolSet, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolResultInputOutputDetails, IToolSet, SpecedToolAliases, stringifyPromptTsxPart, ToolDataSource, ToolInvocationPresentation, toolMatchesModel, ToolSet, ToolSetForModel, VSCodeToolReference } from '../../common/tools/languageModelToolsService.js';
+import { CountTokensCallback, createToolSchemaUri, IBeginToolCallOptions, IExternalPreToolUseHookResult, ILanguageModelToolsService, IPreparedToolInvocation, isToolSet, IToolAndToolSetEnablementMap, IToolCompletedEvent, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolResultInputOutputDetails, IToolSet, SpecedToolAliases, stringifyPromptTsxPart, ToolDataSource, ToolInvocationPresentation, toolMatchesModel, ToolSet, ToolSetForModel, VSCodeToolReference } from '../../common/tools/languageModelToolsService.js';
 import { getToolConfirmationAlert } from '../accessibility/chatAccessibilityProvider.js';
 import { IChatWidgetService } from '../chat.js';
 
@@ -104,6 +104,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	readonly onDidPrepareToolCallBecomeUnresponsive = this._onDidPrepareToolCallBecomeUnresponsive.event;
 	private readonly _onDidInvokeTool = this._register(new Emitter<IToolInvokedEvent>());
 	readonly onDidInvokeTool = this._onDidInvokeTool.event;
+	private readonly _onDidCompleteToolInvocation = this._register(new Emitter<IToolCompletedEvent>());
+	readonly onDidCompleteToolInvocation = this._onDidCompleteToolInvocation.event;
 
 	/** Throttle tools updates because it sends all tools and runs on context key updates */
 	private readonly _onDidChangeToolsScheduler = this._register(new RunOnceScheduler(() => this._onDidChangeTools.fire(), 750));
@@ -676,6 +678,16 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					prepareTimeMs: prepareTimeWatch?.elapsed(),
 					invocationTimeMs: invocationTimeWatch?.elapsed(),
 				});
+
+			this._onDidCompleteToolInvocation.fire({
+				toolId: tool.data.id,
+				toolReferenceName: tool.data.toolReferenceName ?? '',
+				parameters: dto.parameters,
+				result: toolResult,
+				sessionResource: dto.context?.sessionResource,
+				requestId: dto.chatRequestId,
+			});
+
 			return toolResult;
 		} catch (err) {
 			const result = isCancellationError(err) ? 'userCancelled' : 'error';

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -502,6 +502,16 @@ export interface IToolInvokedEvent {
 	readonly subagentInvocationId: string | undefined;
 }
 
+/** Fired after a tool invocation completes successfully. */
+export interface IToolCompletedEvent {
+	readonly toolId: string;
+	readonly toolReferenceName: string;
+	readonly parameters: Record<string, unknown>;
+	readonly result: IToolResult;
+	readonly sessionResource: URI | undefined;
+	readonly requestId: string | undefined;
+}
+
 export const ILanguageModelToolsService = createDecorator<ILanguageModelToolsService>('ILanguageModelToolsService');
 
 export type CountTokensCallback = (input: string, token: CancellationToken) => Promise<number>;
@@ -515,6 +525,7 @@ export interface ILanguageModelToolsService {
 	readonly onDidChangeTools: Event<void>;
 	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ readonly sessionResource: URI; readonly toolData: IToolData }>;
 	readonly onDidInvokeTool: Event<IToolInvokedEvent>;
+	readonly onDidCompleteToolInvocation: Event<IToolCompletedEvent>;
 	registerToolData(toolData: IToolData): IDisposable;
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable;
 	registerTool(toolData: IToolData, tool: IToolImpl): IDisposable;

--- a/src/vs/workbench/contrib/chat/test/browser/skillContentReadTelemetry.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/skillContentReadTelemetry.test.ts
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { hash } from '../../../../../base/common/hash.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ExtensionIdentifier, IExtensionDescription } from '../../../../../platform/extensions/common/extensions.js';
+import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IAgentPlugin, IAgentPluginService } from '../../common/plugins/agentPluginService.js';
+import { IAgentSkill, IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { IToolCompletedEvent, ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
+import { MockLanguageModelToolsService } from '../common/tools/mockLanguageModelToolsService.js';
+import { SkillContentReadTelemetry } from '../../browser/skillContentReadTelemetry.js';
+
+function makeToolCompletedEvent(overrides: Partial<IToolCompletedEvent> = {}): IToolCompletedEvent {
+	return {
+		toolId: 'copilot_readFile',
+		toolReferenceName: 'readFile',
+		parameters: { filePath: '/workspace/.github/skills/my-skill/SKILL.md' },
+		result: { content: [{ kind: 'text', value: '# My Skill\nDo something useful.' }] },
+		sessionResource: undefined,
+		requestId: undefined,
+		...overrides,
+	};
+}
+
+function makeSkill(overrides: Partial<IAgentSkill> = {}): IAgentSkill {
+	return {
+		uri: URI.file('/workspace/.github/skills/my-skill/SKILL.md'),
+		storage: PromptsStorage.local,
+		name: 'my-skill',
+		description: 'A test skill',
+		disableModelInvocation: false,
+		userInvocable: true,
+		...overrides,
+	};
+}
+
+suite('SkillContentReadTelemetry', () => {
+	const disposables = new DisposableStore();
+	let instaService: TestInstantiationService;
+	let mockToolsService: MockLanguageModelToolsService;
+	let telemetryEvents: { eventName: string; data: Record<string, unknown> }[];
+	let onDidChangeSkillsEmitter: Emitter<void>;
+	let findAgentSkillsResult: IAgentSkill[] | undefined;
+
+	setup(() => {
+		instaService = disposables.add(new TestInstantiationService());
+
+		mockToolsService = disposables.add(new MockLanguageModelToolsService());
+		instaService.stub(ILanguageModelToolsService, mockToolsService);
+
+		instaService.stub(ILogService, new NullLogService());
+
+		telemetryEvents = [];
+		instaService.stub(ITelemetryService, {
+			publicLog2: (eventName: string, data: Record<string, unknown>) => {
+				telemetryEvents.push({ eventName, data });
+			}
+		} as unknown as ITelemetryService);
+
+		onDidChangeSkillsEmitter = disposables.add(new Emitter<void>());
+		findAgentSkillsResult = [makeSkill()];
+		instaService.stub(IPromptsService, {
+			findAgentSkills: () => Promise.resolve(findAgentSkillsResult),
+			onDidChangeSkills: onDidChangeSkillsEmitter.event,
+			// Stubs for other events the service may require
+			onDidChangeSlashCommands: Event.None,
+			onDidChangeCustomAgents: Event.None,
+			onDidChangeInstructions: Event.None,
+		});
+
+		instaService.stub(IAgentPluginService, {
+			plugins: observableValue('testPlugins', [] as readonly IAgentPlugin[]),
+		});
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	async function fireAndAwait(event: IToolCompletedEvent): Promise<void> {
+		mockToolsService.fireOnDidCompleteToolInvocation(event);
+		// Allow the fire-and-forget async telemetry to complete
+		await new Promise<void>(resolve => setTimeout(resolve, 50));
+	}
+
+	test('should emit telemetry when readFile completes for a known SKILL.md', async () => {
+		const contribution = disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+		assert.ok(contribution);
+
+		await fireAndAwait(makeToolCompletedEvent());
+
+		const event = telemetryEvents.find(e => e.eventName === 'skillContentRead');
+		assert.ok(event, 'Should emit skillContentRead telemetry');
+		assert.deepStrictEqual(event.data, {
+			skillNameHash: String(hash('my-skill')),
+			skillStorage: PromptsStorage.local,
+			extensionIdHash: '',
+			extensionVersion: '',
+			pluginNameHash: '',
+			pluginVersion: '',
+			contentHash: String(hash('# My Skill\nDo something useful.')),
+		});
+	});
+
+	test('should not emit telemetry for non-readFile tools', async () => {
+		disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+
+		await fireAndAwait(makeToolCompletedEvent({
+			toolReferenceName: 'editFile',
+			toolId: 'copilot_editFile',
+		}));
+
+		assert.strictEqual(
+			telemetryEvents.filter(e => e.eventName === 'skillContentRead').length,
+			0,
+			'Should not emit telemetry for non-readFile tools'
+		);
+	});
+
+	test('should not emit telemetry for non-SKILL.md files', async () => {
+		disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+
+		await fireAndAwait(makeToolCompletedEvent({
+			parameters: { filePath: '/workspace/src/index.ts' },
+		}));
+
+		assert.strictEqual(
+			telemetryEvents.filter(e => e.eventName === 'skillContentRead').length,
+			0,
+			'Should not emit telemetry for non-SKILL.md files'
+		);
+	});
+
+	test('should not emit telemetry for SKILL.md not in the skills list', async () => {
+		disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+
+		await fireAndAwait(makeToolCompletedEvent({
+			parameters: { filePath: '/workspace/.github/skills/unknown-skill/SKILL.md' },
+		}));
+
+		assert.strictEqual(
+			telemetryEvents.filter(e => e.eventName === 'skillContentRead').length,
+			0,
+			'Should not emit telemetry for unknown skills'
+		);
+	});
+
+	test('should include extension and plugin provenance', async () => {
+		const pluginUri = URI.parse('plugin://my-plugin');
+		findAgentSkillsResult = [makeSkill({
+			storage: PromptsStorage.extension,
+			extension: {
+				identifier: new ExtensionIdentifier('publisher.my-ext'),
+				version: '2.0.0',
+			} as IExtensionDescription,
+			pluginUri,
+		})];
+
+		instaService.stub(IAgentPluginService, {
+			plugins: observableValue('testPlugins', [{
+				uri: pluginUri,
+				label: 'my-plugin',
+				fromMarketplace: { version: '3.1.0' },
+			}] as unknown as readonly IAgentPlugin[]),
+		});
+
+		disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+
+		await fireAndAwait(makeToolCompletedEvent());
+
+		const event = telemetryEvents.find(e => e.eventName === 'skillContentRead');
+		assert.ok(event, 'Should emit skillContentRead telemetry');
+		assert.deepStrictEqual(event.data, {
+			skillNameHash: String(hash('my-skill')),
+			skillStorage: PromptsStorage.extension,
+			extensionIdHash: String(hash('publisher.my-ext')),
+			extensionVersion: '2.0.0',
+			pluginNameHash: String(hash('my-plugin')),
+			pluginVersion: '3.1.0',
+			contentHash: String(hash('# My Skill\nDo something useful.')),
+		});
+	});
+
+	test('should clear cache when skills change', async () => {
+		disposables.add(instaService.createInstance(SkillContentReadTelemetry));
+
+		// First call populates cache
+		await fireAndAwait(makeToolCompletedEvent());
+		assert.strictEqual(telemetryEvents.filter(e => e.eventName === 'skillContentRead').length, 1);
+
+		// Change skills to empty → fire change event
+		findAgentSkillsResult = [];
+		onDidChangeSkillsEmitter.fire();
+
+		// Next call should re-fetch and find no match
+		await fireAndAwait(makeToolCompletedEvent());
+		assert.strictEqual(
+			telemetryEvents.filter(e => e.eventName === 'skillContentRead').length,
+			1,
+			'Should not emit after skills were cleared'
+		);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/tools/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/mockLanguageModelToolsService.ts
@@ -16,7 +16,7 @@ import { ChatRequestToolReferenceEntry } from '../../../common/attachments/chatV
 import { IVariableReference } from '../../../common/chatModes.js';
 import { IChatToolInvocation } from '../../../common/chatService/chatService.js';
 import { ILanguageModelChatMetadata } from '../../../common/languageModels.js';
-import { CountTokensCallback, IBeginToolCallOptions, ILanguageModelToolsService, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolSet, ToolDataSource, ToolSet } from '../../../common/tools/languageModelToolsService.js';
+import { CountTokensCallback, IBeginToolCallOptions, ILanguageModelToolsService, IToolAndToolSetEnablementMap, IToolCompletedEvent, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolSet, ToolDataSource, ToolSet } from '../../../common/tools/languageModelToolsService.js';
 
 export class MockLanguageModelToolsService extends Disposable implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
@@ -26,6 +26,7 @@ export class MockLanguageModelToolsService extends Disposable implements ILangua
 	agentToolSet: ToolSet = new ToolSet('agent', 'agent', ThemeIcon.fromId(Codicon.agent.id), ToolDataSource.Internal, undefined, undefined, new MockContextKeyService());
 
 	private readonly _onDidInvokeTool = this._register(new Emitter<IToolInvokedEvent>());
+	private readonly _onDidCompleteToolInvocation = this._register(new Emitter<IToolCompletedEvent>());
 
 	private readonly _registeredToolIds = new Set<string>();
 	private readonly _registeredToolSetNames = new Set<string>();
@@ -38,9 +39,14 @@ export class MockLanguageModelToolsService extends Disposable implements ILangua
 	readonly onDidChangeTools: Event<void> = Event.None;
 	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ sessionResource: URI; toolData: IToolData }> = Event.None;
 	readonly onDidInvokeTool = this._onDidInvokeTool.event;
+	readonly onDidCompleteToolInvocation = this._onDidCompleteToolInvocation.event;
 
 	fireOnDidInvokeTool(event: IToolInvokedEvent): void {
 		this._onDidInvokeTool.fire(event);
+	}
+
+	fireOnDidCompleteToolInvocation(event: IToolCompletedEvent): void {
+		this._onDidCompleteToolInvocation.fire(event);
 	}
 
 	registerToolData(toolData: IToolData): IDisposable {


### PR DESCRIPTION
Builds on https://github.com/microsoft/vscode/pull/303110 — to give us insights on when a skill is actually used.

Broader level changes
New event: \onDidCompleteToolInvocation\ on \ILanguageModelToolsService\ — fires after successful tool invocation with the tool result. Added a subscriber \SkillContentReadTelemetry\ , filters to
eadFile\ calls targeting \SKILL.md\ files, resolves skill provenance, and logs telemetry
The telemetry logged is similar to what was captured in the other PR. Additionally we also capture a hash of skill content.

In terms of optimization, the cache of skills that we read is scoped to a session and is populated once on first SKILL.md read.