### PR TITLE
sessions: show status of remote connections, reconnect AH connects

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -9,10 +9,19 @@ import { Disposable, IDisposable, toDisposable } from '../../../base/common/life
 import { basename, dirname } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { createFileSystemProviderError, FilePermission, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileChange, IFileDeleteOptions, IFileOverwriteOptions, IFileSystemProvider, IFileWriteOptions, IStat } from '../../files/common/files.js';
-import { type IAgentConnection } from './agentService.js';
 import { fromAgentHostUri, toAgentHostUri } from './agentHostUri.js';
-import { IDirectoryEntry } from './state/protocol/commands.js';
+import { IBrowseDirectoryResult, IDirectoryEntry, IFetchContentResult } from './state/protocol/commands.js';
 
+/**
+ * Minimal interface for browsing and fetching files from a remote endpoint.
+ *
+ * Both {@link IAgentConnection} (client→server) and client-exposed
+ * filesystems (server→client) satisfy this contract.
+ */
+export interface IRemoteFilesystemConnection {
+	browseDirectory(uri: URI): Promise<IBrowseDirectoryResult>;
+	fetchContent(uri: URI): Promise<IFetchContentResult>;
+}
 
 /**
  * Build a {@link AGENT_HOST_SCHEME} URI for a given connection authority
@@ -57,13 +66,13 @@ export class AgentHostFileSystemProvider extends Disposable implements IFileSyst
 	private readonly _onDidChangeFile = this._register(new Emitter<readonly IFileChange[]>());
 	readonly onDidChangeFile = this._onDidChangeFile.event;
 
-	private readonly _authorityToConnection = new Map<string, IAgentConnection>();
+	private readonly _authorityToConnection = new Map<string, IRemoteFilesystemConnection>();
 
 	/**
 	 * Register a mapping from a URI authority to an agent connection.
 	 * Returns a disposable that unregisters the mapping.
 	 */
-	registerAuthority(authority: string, connection: IAgentConnection): IDisposable {
+	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable {
 		this._authorityToConnection.set(authority, connection);
 		return toDisposable(() => this._authorityToConnection.delete(authority));
 	}

--- a/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
@@ -4,25 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
-import { URI } from '../../../base/common/uri.js';
 import { IFileService } from '../../files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ILabelService } from '../../label/common/label.js';
-import { AgentHostFileSystemProvider } from './agentHostFileSystemProvider.js';
+import { AgentHostFileSystemProvider, type IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME } from './agentHostUri.js';
-import { IBrowseDirectoryResult, IFetchContentResult } from './state/protocol/commands.js';
 
-/**
- * Minimal interface for browsing and fetching files from a remote endpoint.
- *
- * Both {@link IAgentConnection} (client→server) and client-exposed
- * filesystems (server→client) satisfy this contract.
- */
-export interface IRemoteFilesystemConnection {
-	browseDirectory(uri: URI): Promise<IBrowseDirectoryResult>;
-	fetchContent(uri: URI): Promise<IFetchContentResult>;
-}
+export type { IRemoteFilesystemConnection } from './agentHostFileSystemProvider.js';
 
 export const IAgentHostFileSystemService = createDecorator<IAgentHostFileSystemService>('agentHostFileSystemService');
 

--- a/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemService.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
+import { IFileService } from '../../files/common/files.js';
+import { InstantiationType, registerSingleton } from '../../instantiation/common/extensions.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILabelService } from '../../label/common/label.js';
+import { AgentHostFileSystemProvider } from './agentHostFileSystemProvider.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME } from './agentHostUri.js';
+import { IBrowseDirectoryResult, IFetchContentResult } from './state/protocol/commands.js';
+
+/**
+ * Minimal interface for browsing and fetching files from a remote endpoint.
+ *
+ * Both {@link IAgentConnection} (client→server) and client-exposed
+ * filesystems (server→client) satisfy this contract.
+ */
+export interface IRemoteFilesystemConnection {
+	browseDirectory(uri: URI): Promise<IBrowseDirectoryResult>;
+	fetchContent(uri: URI): Promise<IFetchContentResult>;
+}
+
+export const IAgentHostFileSystemService = createDecorator<IAgentHostFileSystemService>('agentHostFileSystemService');
+
+export interface IAgentHostFileSystemService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Register a mapping from a URI authority to a connection so that
+	 * `vscode-agent-host://[authority]/…` URIs resolve through this connection.
+	 */
+	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable;
+}
+
+class AgentHostFileSystemService extends Disposable implements IAgentHostFileSystemService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _fsProvider: AgentHostFileSystemProvider;
+
+	constructor(
+		@IFileService fileService: IFileService,
+		@ILabelService labelService: ILabelService,
+	) {
+		super();
+
+		this._fsProvider = this._register(new AgentHostFileSystemProvider());
+		this._register(fileService.registerProvider(AGENT_HOST_SCHEME, this._fsProvider));
+		this._register(labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
+	}
+
+	registerAuthority(authority: string, connection: IRemoteFilesystemConnection): IDisposable {
+		return this._fsProvider.registerAuthority(authority, connection);
+	}
+}
+
+registerSingleton(IAgentHostFileSystemService, AgentHostFileSystemService, InstantiationType.Delayed);

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -8,6 +8,13 @@ import { connectionTokenQueryName } from '../../../base/common/network.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { IAgentConnection } from './agentService.js';
 
+/** Connection status for a remote agent host. */
+export const enum RemoteAgentHostConnectionStatus {
+	Connected = 'connected',
+	Connecting = 'connecting',
+	Disconnected = 'disconnected',
+}
+
 /** Configuration key for the list of remote agent host addresses. */
 export const RemoteAgentHostsSettingId = 'chat.remoteAgentHosts';
 
@@ -75,6 +82,13 @@ export interface IRemoteAgentHostService {
 	 * Disconnects any active connection and removes the entry from settings.
 	 */
 	removeRemoteAgentHost(address: string): Promise<void>;
+
+	/**
+	 * Forcefully reconnect to a configured remote host.
+	 * Tears down any existing connection and starts a fresh connect attempt
+	 * with reset backoff.
+	 */
+	reconnect(address: string): void;
 }
 
 /** Metadata about a single remote connection. */
@@ -83,6 +97,7 @@ export interface IRemoteAgentHostConnectionInfo {
 	readonly name: string;
 	readonly clientId: string;
 	readonly defaultDirectory?: string;
+	readonly status: RemoteAgentHostConnectionStatus;
 }
 
 export class NullRemoteAgentHostService implements IRemoteAgentHostService {
@@ -95,6 +110,7 @@ export class NullRemoteAgentHostService implements IRemoteAgentHostService {
 		throw new Error('Remote agent host connections are not supported in this environment.');
 	}
 	async removeRemoteAgentHost(_address: string): Promise<void> { }
+	reconnect(_address: string): void { }
 }
 
 export function parseRemoteAgentHostInput(input: string): RemoteAgentHostInputParseResult {

--- a/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
@@ -233,6 +233,14 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _connectTo(address: string, connectionToken?: string): void {
+		// Dispose any existing entry for this address before creating a new one
+		// to avoid leaking disposables on reconnect.
+		const existingEntry = this._entries.get(address);
+		if (existingEntry) {
+			this._entries.delete(address);
+			existingEntry.store.dispose();
+		}
+
 		const store = new DisposableStore();
 		const client = store.add(this._instantiationService.createInstance(RemoteAgentHostProtocolClient, address, connectionToken));
 		const entry: IConnectionEntry = { store, client, connected: false, status: RemoteAgentHostConnectionStatus.Connecting };

--- a/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
@@ -17,6 +17,7 @@ import { ILogService } from '../../log/common/log.js';
 import type { IAgentConnection } from '../common/agentService.js';
 import {
 	IRemoteAgentHostService,
+	RemoteAgentHostConnectionStatus,
 	RemoteAgentHostsEnabledSettingId,
 	RemoteAgentHostsSettingId,
 	type IRemoteAgentHostConnectionInfo,
@@ -30,10 +31,16 @@ interface IConnectionEntry {
 	readonly store: DisposableStore;
 	readonly client: RemoteAgentHostProtocolClient;
 	connected: boolean;
+	/** Current connection status for UI display. */
+	status: RemoteAgentHostConnectionStatus;
 }
 
 export class RemoteAgentHostService extends Disposable implements IRemoteAgentHostService {
 	private static readonly ConnectionWaitTimeout = 10000;
+	/** Initial reconnect delay in milliseconds. */
+	private static readonly ReconnectInitialDelay = 1000;
+	/** Maximum reconnect delay in milliseconds. */
+	private static readonly ReconnectMaxDelay = 30000;
 
 	declare readonly _serviceBrand: undefined;
 
@@ -42,7 +49,12 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 
 	private readonly _entries = new Map<string, IConnectionEntry>();
 	private readonly _names = new Map<string, string>();
+	private readonly _tokens = new Map<string, string | undefined>();
 	private readonly _pendingConnectionWaits = new Map<string, DeferredPromise<IRemoteAgentHostConnectionInfo>>();
+	/** Pending reconnect timeouts, keyed by normalized address. */
+	private readonly _reconnectTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+	/** Current reconnect attempt count per address for exponential backoff. */
+	private readonly _reconnectAttempts = new Map<string, number>();
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -65,14 +77,13 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	get connections(): readonly IRemoteAgentHostConnectionInfo[] {
 		const result: IRemoteAgentHostConnectionInfo[] = [];
 		for (const [address, entry] of this._entries) {
-			if (entry.connected) {
-				result.push({
-					address,
-					name: this._names.get(address) ?? address,
-					clientId: entry.client.clientId,
-					defaultDirectory: entry.client.defaultDirectory,
-				});
-			}
+			result.push({
+				address,
+				name: this._names.get(address) ?? address,
+				clientId: entry.client.clientId,
+				defaultDirectory: entry.client.defaultDirectory,
+				status: entry.status,
+			});
 		}
 		return result;
 	}
@@ -85,6 +96,25 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		const normalized = normalizeRemoteAgentHostAddress(address);
 		const entry = this._entries.get(normalized);
 		return entry?.connected ? entry.client : undefined;
+	}
+
+	reconnect(address: string): void {
+		const normalized = normalizeRemoteAgentHostAddress(address);
+		const token = this._tokens.get(normalized);
+
+		// Cancel any pending reconnect
+		this._cancelReconnect(normalized);
+		this._reconnectAttempts.delete(normalized);
+
+		// Tear down existing connection if present
+		const entry = this._entries.get(normalized);
+		if (entry) {
+			this._entries.delete(normalized);
+			entry.store.dispose();
+		}
+
+		// Start fresh connection attempt
+		this._connectTo(normalized, token);
 	}
 
 	async addRemoteAgentHost(input: IRemoteAgentHostEntry): Promise<IRemoteAgentHostConnectionInfo> {
@@ -131,6 +161,9 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		// Eagerly clear in-memory state so the UI updates immediately
 		// (the config change listener will reconcile, but this is instant).
 		this._names.delete(normalized);
+		this._tokens.delete(normalized);
+		this._cancelReconnect(normalized);
+		this._reconnectAttempts.delete(normalized);
 		this._removeConnection(normalized);
 	}
 
@@ -148,9 +181,12 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
 			// Disconnect all when disabled
 			for (const address of [...this._entries.keys()]) {
+				this._cancelReconnect(address);
 				this._removeConnection(address);
 			}
 			this._names.clear();
+			this._tokens.clear();
+			this._reconnectAttempts.clear();
 			return;
 		}
 
@@ -164,8 +200,10 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		let namesChanged = false;
 		const oldNames = new Map(this._names);
 		this._names.clear();
+		this._tokens.clear();
 		for (const entry of entries) {
 			this._names.set(entry.address, entry.name);
+			this._tokens.set(entry.address, entry.connectionToken);
 			if (this._entries.has(entry.address) && oldNames.get(entry.address) !== entry.name) {
 				namesChanged = true;
 			}
@@ -175,6 +213,8 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		for (const address of [...this._entries.keys()]) {
 			if (!desired.has(address)) {
 				this._logService.info(`[RemoteAgentHost] Disconnecting from ${address}`);
+				this._cancelReconnect(address);
+				this._reconnectAttempts.delete(address);
 				this._removeConnection(address);
 			}
 		}
@@ -195,40 +235,100 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	private _connectTo(address: string, connectionToken?: string): void {
 		const store = new DisposableStore();
 		const client = store.add(this._instantiationService.createInstance(RemoteAgentHostProtocolClient, address, connectionToken));
-		const entry: IConnectionEntry = { store, client, connected: false };
+		const entry: IConnectionEntry = { store, client, connected: false, status: RemoteAgentHostConnectionStatus.Connecting };
 		this._entries.set(address, entry);
 
-		// Guard removal against stale callbacks: only remove if the
+		// Guard against stale callbacks: only act if the
 		// current entry for this address is still the one we created.
-		const guardedRemove = () => {
-			if (this._entries.get(address) === entry) {
-				this._removeConnection(address);
-			}
-		};
+		const isCurrentEntry = () => this._entries.get(address) === entry;
 
 		store.add(client.onDidClose(() => {
+			if (!isCurrentEntry()) {
+				return;
+			}
 			this._logService.warn(`[RemoteAgentHost] Connection closed: ${address}`);
-			guardedRemove();
+			entry.connected = false;
+			entry.status = RemoteAgentHostConnectionStatus.Disconnected;
+			this._onDidChangeConnections.fire();
+			// Schedule reconnect if the address is still configured
+			this._scheduleReconnect(address, connectionToken);
 		}));
 
 		this._logService.info(`[RemoteAgentHost] Connecting to ${address}`);
+		this._onDidChangeConnections.fire();
 		client.connect().then(() => {
 			if (store.isDisposed) {
 				return; // removed before connect resolved
 			}
 			this._logService.info(`[RemoteAgentHost] Connected to ${address}`);
 			entry.connected = true;
+			entry.status = RemoteAgentHostConnectionStatus.Connected;
+			this._reconnectAttempts.delete(address);
 			this._resolvePendingConnectionWait(address);
 			this._onDidChangeConnections.fire();
 		}).catch(err => {
+			if (!isCurrentEntry()) {
+				return;
+			}
 			this._logService.error(`[RemoteAgentHost] Failed to connect to ${address}. Verify address and connectionToken`, err);
+			entry.status = RemoteAgentHostConnectionStatus.Disconnected;
+			// Clean up the failed entry
+			this._entries.delete(address);
+			entry.store.dispose();
 			this._rejectPendingConnectionWait(address, err);
-			guardedRemove();
+			this._onDidChangeConnections.fire();
+			// Schedule reconnect if the address is still configured
+			this._scheduleReconnect(address, connectionToken);
 		});
 	}
 
+	/**
+	 * Schedule a reconnect attempt with exponential backoff.
+	 * Only reconnects if the address is still in the configured entries.
+	 */
+	private _scheduleReconnect(address: string, connectionToken?: string): void {
+		// Don't reconnect if the address was removed from settings
+		if (!this._isAddressConfigured(address)) {
+			this._logService.info(`[RemoteAgentHost] Not reconnecting to ${address}: no longer configured`);
+			return;
+		}
+
+		const attempt = (this._reconnectAttempts.get(address) ?? 0) + 1;
+		this._reconnectAttempts.set(address, attempt);
+		const delay = Math.min(
+			RemoteAgentHostService.ReconnectInitialDelay * Math.pow(2, attempt - 1),
+			RemoteAgentHostService.ReconnectMaxDelay,
+		);
+
+		this._logService.info(`[RemoteAgentHost] Scheduling reconnect to ${address} in ${delay}ms (attempt ${attempt})`);
+
+		this._cancelReconnect(address);
+		const timeout = setTimeout(() => {
+			this._reconnectTimeouts.delete(address);
+			if (this._isAddressConfigured(address)) {
+				this._connectTo(address, connectionToken ?? this._tokens.get(address));
+			}
+		}, delay);
+		this._reconnectTimeouts.set(address, timeout);
+	}
+
+	/** Cancel a pending reconnect timeout for the given address. */
+	private _cancelReconnect(address: string): void {
+		const timeout = this._reconnectTimeouts.get(address);
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+			this._reconnectTimeouts.delete(address);
+		}
+	}
+
+	/** Check whether the given normalized address is still in the configured entries. */
+	private _isAddressConfigured(address: string): boolean {
+		const entries = this._getConfiguredEntries();
+		return entries.some(e => normalizeRemoteAgentHostAddress(e.address) === address);
+	}
+
 	private _getConnectionInfo(address: string): IRemoteAgentHostConnectionInfo | undefined {
-		return this.connections.find(connection => connection.address === address);
+		return this.connections.find(connection => connection.address === address && connection.status === RemoteAgentHostConnectionStatus.Connected);
 	}
 
 	private _getConfiguredEntries(): IRemoteAgentHostEntry[] {
@@ -323,6 +423,11 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	override dispose(): void {
+		for (const timeout of this._reconnectTimeouts.values()) {
+			clearTimeout(timeout);
+		}
+		this._reconnectTimeouts.clear();
+		this._reconnectAttempts.clear();
 		for (const [address, wait] of this._pendingConnectionWaits) {
 			void wait.error(new Error(`Remote agent host service disposed before connecting to ${address}`));
 		}

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -12,7 +12,7 @@ import { TestInstantiationService } from '../../../instantiation/test/common/ins
 import { IConfigurationService, type IConfigurationChangeEvent } from '../../../configuration/common/configuration.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { RemoteAgentHostService } from '../../electron-browser/remoteAgentHostServiceImpl.js';
-import { parseRemoteAgentHostInput, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
+import { parseRemoteAgentHostInput, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId, type IRemoteAgentHostEntry } from '../../common/remoteAgentHostService.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 
 // ---- Mock protocol client ---------------------------------------------------
@@ -124,6 +124,13 @@ suite('RemoteAgentHostService', () => {
 	teardown(() => disposables.clear());
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	/** Wait for a connection to reach Connected status. */
+	async function waitForConnected(): Promise<void> {
+		while (!service.connections.some(c => c.status === RemoteAgentHostConnectionStatus.Connected)) {
+			await Event.toPromise(service.onDidChangeConnections);
+		}
+	}
+
 	test('starts with no connections when setting is empty', () => {
 		assert.deepStrictEqual(service.connections, []);
 	});
@@ -151,24 +158,23 @@ suite('RemoteAgentHostService', () => {
 	});
 
 	test('creates connection when setting is updated', async () => {
-		const connectionChanged = Event.toPromise(service.onDidChangeConnections);
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 
 		// Resolve the connect promise
 		assert.strictEqual(createdClients.length, 1);
 		createdClients[0].connectDeferred.complete();
-		await connectionChanged;
+		await waitForConnected();
 
-		assert.strictEqual(service.connections.length, 1);
-		assert.strictEqual(service.connections[0].address, 'host1:8080');
-		assert.strictEqual(service.connections[0].name, 'Host 1');
+		const connected = service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected);
+		assert.strictEqual(connected.length, 1);
+		assert.strictEqual(connected[0].address, 'host1:8080');
+		assert.strictEqual(connected[0].name, 'Host 1');
 	});
 
 	test('getConnection returns client after successful connect', async () => {
-		const connectionChanged = Event.toPromise(service.onDidChangeConnections);
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await connectionChanged;
+		await waitForConnected();
 
 		const connection = service.getConnection('ws://host1:8080');
 		assert.ok(connection);
@@ -179,7 +185,7 @@ suite('RemoteAgentHostService', () => {
 		// Add a connection
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
 		// Remove it
 		const removedEvent = Event.toPromise(service.onDidChangeConnections);
@@ -193,15 +199,18 @@ suite('RemoteAgentHostService', () => {
 	test('fires onDidChangeConnections when connection closes', async () => {
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
-		// Simulate connection close
+		// Simulate connection close — entry transitions to Disconnected
 		const closedEvent = Event.toPromise(service.onDidChangeConnections);
 		createdClients[0].fireClose();
 		await closedEvent;
 
-		assert.strictEqual(service.connections.length, 0);
+		// Connection is still tracked (for reconnect) but getConnection returns undefined
 		assert.strictEqual(service.getConnection('ws://host1:8080'), undefined);
+		const entry = service.connections.find(c => c.address === 'host1:8080');
+		assert.ok(entry);
+		assert.strictEqual(entry.status, RemoteAgentHostConnectionStatus.Disconnected);
 	});
 
 	test('removes connection on connect failure', async () => {
@@ -226,11 +235,10 @@ suite('RemoteAgentHostService', () => {
 
 		assert.strictEqual(createdClients.length, 2);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
 		createdClients[1].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
-		assert.strictEqual(service.connections.length, 2);
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 2);
 
 		const conn1 = service.getConnection('ws://host1:8080');
 		const conn2 = service.getConnection('ws://host2:8080');
@@ -242,7 +250,7 @@ suite('RemoteAgentHostService', () => {
 	test('does not re-create existing connections on setting update', async () => {
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
 		const firstClientId = createdClients[0].clientId;
 
@@ -258,7 +266,8 @@ suite('RemoteAgentHostService', () => {
 		assert.strictEqual(conn.clientId, firstClientId);
 
 		// But name should be updated
-		assert.strictEqual(service.connections[0].name, 'Renamed');
+		const entry = service.connections.find(c => c.address === 'host1:8080');
+		assert.strictEqual(entry?.name, 'Renamed');
 	});
 
 	test('addRemoteAgentHost stores the entry and waits for connection', async () => {
@@ -283,13 +292,14 @@ suite('RemoteAgentHostService', () => {
 			name: 'Host 1',
 			clientId: createdClients[0].clientId,
 			defaultDirectory: undefined,
+			status: RemoteAgentHostConnectionStatus.Connected,
 		});
 	});
 
 	test('addRemoteAgentHost updates existing configured entries without reconnecting', async () => {
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
 		const connection = await service.addRemoteAgentHost({
 			address: 'ws://host1:8080',
@@ -308,6 +318,7 @@ suite('RemoteAgentHostService', () => {
 			name: 'Updated Host',
 			clientId: createdClients[0].clientId,
 			defaultDirectory: undefined,
+			status: RemoteAgentHostConnectionStatus.Connected,
 		});
 	});
 
@@ -361,8 +372,8 @@ suite('RemoteAgentHostService', () => {
 	test('disabling the enabled setting disconnects all remotes', async () => {
 		configService.setEntries([{ address: 'host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
-		assert.strictEqual(service.connections.length, 1);
+		await waitForConnected();
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 1);
 
 		configService.setEnabled(false);
 
@@ -381,8 +392,8 @@ suite('RemoteAgentHostService', () => {
 	test('re-enabling reconnects configured remotes', async () => {
 		configService.setEntries([{ address: 'host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
-		assert.strictEqual(service.connections.length, 1);
+		await waitForConnected();
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 1);
 
 		configService.setEnabled(false);
 		assert.strictEqual(service.connections.length, 0);
@@ -390,8 +401,8 @@ suite('RemoteAgentHostService', () => {
 		configService.setEnabled(true);
 		assert.strictEqual(createdClients.length, 2); // new client created
 		createdClients[1].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
-		assert.strictEqual(service.connections.length, 1);
+		await waitForConnected();
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 1);
 	});
 
 	test('removeRemoteAgentHost removes entry and disconnects', async () => {
@@ -400,17 +411,16 @@ suite('RemoteAgentHostService', () => {
 			{ address: 'ws://host2:9090', name: 'Host 2' },
 		]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
 		createdClients[1].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
-		assert.strictEqual(service.connections.length, 2);
+		await waitForConnected();
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 2);
 
 		await service.removeRemoteAgentHost('ws://host1:8080');
 
 		assert.deepStrictEqual(configService.entries, [
 			{ address: 'ws://host2:9090', name: 'Host 2' },
 		]);
-		assert.strictEqual(service.connections.length, 1);
+		assert.strictEqual(service.connections.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected).length, 1);
 		assert.strictEqual(service.getConnection('ws://host1:8080'), undefined);
 		assert.ok(service.getConnection('ws://host2:9090'));
 	});
@@ -418,7 +428,7 @@ suite('RemoteAgentHostService', () => {
 	test('removeRemoteAgentHost normalizes address before removing', async () => {
 		configService.setEntries([{ address: 'host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await waitForConnected();
 
 		await service.removeRemoteAgentHost('ws://host1:8080');
 

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -443,13 +443,13 @@ export class WorkspacePicker extends Disposable {
 		const md = new MarkdownString(undefined, { supportThemeIcons: true });
 		switch (status) {
 			case RemoteAgentHostConnectionStatus.Connected:
-				md.appendMarkdown('Online');
+				md.appendText(localize('workspacePicker.statusOnline', "Online"));
 				break;
 			case RemoteAgentHostConnectionStatus.Connecting:
-				md.appendMarkdown('Connecting');
+				md.appendText(localize('workspacePicker.statusConnecting', "Connecting"));
 				break;
 			case RemoteAgentHostConnectionStatus.Disconnected:
-				md.appendMarkdown('Offline');
+				md.appendText(localize('workspacePicker.statusOffline', "Offline"));
 				break;
 		}
 		return md;
@@ -459,14 +459,19 @@ export class WorkspacePicker extends Disposable {
 	 * Returns detailed hover text for a remote host's connection status.
 	 */
 	private _getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
-		const addressText = address ? `\n\nAddress: ${address}` : '';
 		switch (status) {
 			case RemoteAgentHostConnectionStatus.Connected:
-				return localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.{0}", addressText);
+				return address
+					? localize('workspacePicker.hoverConnectedAddr', "Remote agent host is connected and ready.\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.");
 			case RemoteAgentHostConnectionStatus.Connecting:
-				return localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...{0}", addressText);
+				return address
+					? localize('workspacePicker.hoverConnectingAddr', "Attempting to connect to remote agent host...\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...");
 			case RemoteAgentHostConnectionStatus.Disconnected:
-				return localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected. Click the gear icon for options.{0}", addressText);
+				return address
+					? localize('workspacePicker.hoverDisconnectedAddr', "Remote agent host is disconnected. Click the gear icon for options.\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected. Click the gear icon for options.");
 		}
 	}
 
@@ -476,7 +481,8 @@ export class WorkspacePicker extends Disposable {
 	 * preventing focus conflicts that cause the quickpick to flash and disappear.
 	 */
 	private _showRemoteHostOptionsDelayed(provider: ISessionsProvider): void {
-		setTimeout(() => this._showRemoteHostOptions(provider), 1);
+		const timeout = setTimeout(() => this._showRemoteHostOptions(provider), 1);
+		this._renderDisposables.add({ dispose: () => clearTimeout(timeout) });
 	}
 
 	private async _showRemoteHostOptions(provider: ISessionsProvider): Promise<void> {

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -7,19 +7,26 @@ import * as dom from '../../../../base/browser/dom.js';
 import { SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
+import { IOutputService } from '../../../../workbench/services/output/common/output.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ISessionWorkspace } from '../../sessions/common/sessionData.js';
 import { ISessionsProvidersService } from '../../sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
-import { ISessionsBrowseAction } from '../../sessions/browser/sessionsProvider.js';
+import { ISessionsBrowseAction, ISessionsProvider } from '../../sessions/browser/sessionsProvider.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 
 const LEGACY_STORAGE_KEY_RECENT_PROJECTS = 'sessions.recentlyPickedProjects';
@@ -52,6 +59,8 @@ interface IWorkspacePickerItem {
 	readonly selection?: IWorkspaceSelection;
 	readonly browseActionIndex?: number;
 	readonly checked?: boolean;
+	/** Remote provider reference for gear menu actions. */
+	readonly remoteProvider?: ISessionsProvider;
 }
 
 /**
@@ -82,6 +91,11 @@ export class WorkspacePicker extends Disposable {
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@IClipboardService private readonly clipboardService: IClipboardService,
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
+		@IOutputService private readonly outputService: IOutputService,
 	) {
 		super();
 
@@ -163,7 +177,10 @@ export class WorkspacePicker extends Disposable {
 		const delegate: IActionListDelegate<IWorkspacePickerItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
-				if (item.browseActionIndex !== undefined) {
+				if (item.remoteProvider && item.browseActionIndex === undefined) {
+					// Disconnected remote host — show options menu after widget hides
+					this._showRemoteHostOptionsDelayed(item.remoteProvider);
+				} else if (item.browseActionIndex !== undefined) {
 					this._executeBrowseAction(item.browseActionIndex);
 				} else if (item.selection) {
 					this._selectProject(item.selection);
@@ -324,11 +341,15 @@ export class WorkspacePicker extends Disposable {
 
 		// Browse actions from all providers
 		const allBrowseActions = this._getAllBrowseActions();
-		if (items.length > 0 && allBrowseActions.length > 0) {
+		// Remote providers with connection status
+		const remoteProviders = allProviders.filter(p => p.connectionStatus !== undefined);
+
+		if (items.length > 0 && (allBrowseActions.length > 0 || remoteProviders.length > 0)) {
 			items.push({ kind: ActionListItemKind.Separator, label: '' });
 		}
-		if (hasMultipleProviders && allBrowseActions.length > 1) {
-			// Show a single "Browse..." entry with provider-grouped submenu actions
+		if (hasMultipleProviders && (allBrowseActions.length + remoteProviders.length) > 1) {
+			// Show a single "Select..." entry with provider-grouped submenu actions
+			// that also includes remote host entries
 			const providerMap = new Map<string, { provider: typeof allProviders[0]; actions: { action: ISessionsBrowseAction; index: number }[] }>();
 			allBrowseActions.forEach((action, i) => {
 				let entry = providerMap.get(action.providerId);
@@ -340,18 +361,25 @@ export class WorkspacePicker extends Disposable {
 				}
 				entry.actions.push({ action, index: i });
 			});
-			const submenuActions = [...providerMap.values()].map(({ provider, actions }) =>
-				new SubmenuAction(
+			const remoteProviderIds = new Map(remoteProviders.map(p => [p.id, p]));
+			const submenuActions = [...providerMap.values()].map(({ provider, actions }) => {
+				const remoteProvider = remoteProviderIds.get(provider.id);
+				const remoteStatus = remoteProvider?.connectionStatus?.get();
+				const actionItems = actions.map(({ action, index }, ci) => toAction({
+					id: `workspacePicker.browse.${index}`,
+					label: localize(`workspacePicker.browse`, "{0}...", action.label),
+					tooltip: ci === 0 ? provider.label : '',
+					enabled: remoteStatus !== RemoteAgentHostConnectionStatus.Disconnected && remoteStatus !== RemoteAgentHostConnectionStatus.Connecting,
+					run: () => this._executeBrowseAction(index),
+				}));
+
+				return new SubmenuAction(
 					`workspacePicker.browse.${provider.id}`,
 					'',
-					actions.map(({ action, index }, ci) => toAction({
-						id: `workspacePicker.browse.${index}`,
-						label: localize(`workspacePicker.browse`, "{0}...", action.label),
-						tooltip: ci === 0 ? provider.label : '',
-						run: () => this._executeBrowseAction(index),
-					})),
-				)
-			);
+					actionItems,
+				);
+			});
+
 			items.push({
 				kind: ActionListItemKind.Action,
 				label: localize('workspacePicker.browse', "Select..."),
@@ -371,7 +399,135 @@ export class WorkspacePicker extends Disposable {
 			}
 		}
 
+		for (const provider of remoteProviders) {
+			const status = provider.connectionStatus!.get();
+			const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
+			const providerBrowseIndex = allBrowseActions.findIndex(a => a.providerId === provider.id);
+
+			if (items.length > 0 && items[items.length - 1].kind !== ActionListItemKind.Separator) {
+				items.push({ kind: ActionListItemKind.Separator, label: '' });
+			}
+
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: provider.label,
+				description: this._getStatusDescription(status),
+				hover: { content: this._getStatusHover(status, provider.remoteAddress) },
+				group: { title: '', icon: Codicon.remote },
+				disabled: !isConnected,
+				item: {
+					browseActionIndex: isConnected && providerBrowseIndex >= 0 ? providerBrowseIndex : undefined,
+					remoteProvider: provider,
+				},
+				toolbarActions: [
+					toAction({
+						id: `workspacePicker.remote.gear.${provider.id}`,
+						label: localize('workspacePicker.remoteOptions', "Options"),
+						class: ThemeIcon.asClassName(Codicon.gear),
+						run: () => {
+							this.actionWidgetService.hide();
+							this._showRemoteHostOptionsDelayed(provider);
+						},
+					}),
+				],
+			});
+		}
+
 		return items;
+	}
+
+	/**
+	 * Returns a short status indicator with a colored circle icon for the description field.
+	 */
+	private _getStatusDescription(status: RemoteAgentHostConnectionStatus): MarkdownString {
+		const md = new MarkdownString(undefined, { supportThemeIcons: true });
+		switch (status) {
+			case RemoteAgentHostConnectionStatus.Connected:
+				md.appendMarkdown('Online');
+				break;
+			case RemoteAgentHostConnectionStatus.Connecting:
+				md.appendMarkdown('Connecting');
+				break;
+			case RemoteAgentHostConnectionStatus.Disconnected:
+				md.appendMarkdown('Offline');
+				break;
+		}
+		return md;
+	}
+
+	/**
+	 * Returns detailed hover text for a remote host's connection status.
+	 */
+	private _getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
+		const addressText = address ? `\n\nAddress: ${address}` : '';
+		switch (status) {
+			case RemoteAgentHostConnectionStatus.Connected:
+				return localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.{0}", addressText);
+			case RemoteAgentHostConnectionStatus.Connecting:
+				return localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...{0}", addressText);
+			case RemoteAgentHostConnectionStatus.Disconnected:
+				return localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected. Click the gear icon for options.{0}", addressText);
+		}
+	}
+
+	/**
+	 * Show the remote host options quickpick after a short delay.
+	 * This ensures the action widget has fully hidden before the quickpick opens,
+	 * preventing focus conflicts that cause the quickpick to flash and disappear.
+	 */
+	private _showRemoteHostOptionsDelayed(provider: ISessionsProvider): void {
+		setTimeout(() => this._showRemoteHostOptions(provider), 1);
+	}
+
+	private async _showRemoteHostOptions(provider: ISessionsProvider): Promise<void> {
+		const address = provider.remoteAddress;
+		if (!address) {
+			return;
+		}
+
+		const status = provider.connectionStatus?.get();
+		const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
+
+		const items: IQuickPickItem[] = [];
+		if (!isConnected) {
+			items.push({ label: '$(debug-restart) ' + localize('workspacePicker.reconnect', "Reconnect"), id: 'reconnect' });
+		}
+		items.push(
+			{ label: '$(trash) ' + localize('workspacePicker.removeRemote', "Remove Remote"), id: 'remove' },
+			{ label: '$(copy) ' + localize('workspacePicker.copyAddress', "Copy Address"), id: 'copy' },
+			{ label: '$(settings-gear) ' + localize('workspacePicker.openSettings', "Open Settings"), id: 'settings' },
+		);
+		if (provider.outputChannelId) {
+			items.push({ label: '$(output) ' + localize('workspacePicker.showOutput', "Show Output"), id: 'output' });
+		}
+
+		const picked = await this.quickInputService.pick(items, {
+			placeHolder: localize('workspacePicker.remoteOptionsTitle', "Options for {0}", provider.label),
+		});
+		if (!picked) {
+			return;
+		}
+
+		const action = (picked as IQuickPickItem & { id: string }).id;
+		switch (action) {
+			case 'reconnect':
+				this.remoteAgentHostService.reconnect(address);
+				break;
+			case 'remove':
+				await this.remoteAgentHostService.removeRemoteAgentHost(address);
+				break;
+			case 'copy':
+				await this.clipboardService.writeText(address);
+				break;
+			case 'settings':
+				await this.preferencesService.openSettings({ query: 'chat.remoteAgentHosts' });
+				break;
+			case 'output':
+				if (provider.outputChannelId) {
+					this.outputService.showChannel(provider.outputChannelId, true);
+				}
+				break;
+		}
 	}
 
 	private _updateTriggerLabel(): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -6,17 +6,15 @@
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as nls from '../../../../nls.js';
-import { AgentHostFileSystemProvider } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
-import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../platform/agentHost/common/agentService.js';
-import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionClientState } from '../../../../platform/agentHost/common/state/sessionClientState.js';
 import { ROOT_STATE_URI, type IAgentInfo, type IRootState } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -32,6 +30,7 @@ import { IAuthenticationService } from '../../../../workbench/services/authentic
 import { ISessionsManagementService } from '../../../contrib/sessions/browser/sessionsManagementService.js';
 import { ISessionsProvidersService } from '../../sessions/browser/sessionsProvidersService.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
+import { IAgentHostFileSystemService } from '../../../../platform/agentHost/common/agentHostFileSystemService.js';
 
 /** Per-connection state bundle, disposed when a connection is removed. */
 class ConnectionState extends Disposable {
@@ -73,9 +72,6 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _providerStores = this._register(new DisposableMap<string, DisposableStore>());
 	private readonly _providerInstances = new Map<string, RemoteAgentHostSessionsProvider>();
 
-	/** Maps sanitized authority strings back to original addresses. */
-	private readonly _fsProvider: AgentHostFileSystemProvider;
-
 	constructor(
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
 		@IChatSessionsService private readonly _chatSessionsService: IChatSessionsService,
@@ -85,17 +81,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
-		@IFileService private readonly _fileService: IFileService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IAgentHostFileSystemService private readonly _agentHostFileSystemService: IAgentHostFileSystemService
 	) {
 		super();
-
-		// Register a single read-only filesystem provider for all remote agent
-		// hosts. Individual connections are identified by the URI authority.
-		this._fsProvider = this._register(new AgentHostFileSystemProvider());
-		this._register(this._fileService.registerProvider(AGENT_HOST_SCHEME, this._fsProvider));
 
 		// Display agent-host URIs with the original file path
 		this._register(this._labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
@@ -132,6 +123,17 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (provider) {
 				const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
 				provider.setConnection(connState.loggedConnection, connectionInfo?.defaultDirectory);
+			}
+		}
+
+		// Update connection status on all providers (including those
+		// that are reconnecting and don't have an active connection).
+		for (const [address, provider] of this._providerInstances) {
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo) {
+				provider.setConnectionStatus(connectionInfo.status);
+			} else {
+				provider.setConnectionStatus(RemoteAgentHostConnectionStatus.Disconnected);
 			}
 		}
 	}
@@ -173,19 +175,33 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	private _reconcileConnections(): void {
-		const currentAddresses = new Set(this._remoteAgentHostService.connections.map(c => c.address));
+		const currentConnections = this._remoteAgentHostService.connections;
+		const connectedAddresses = new Set(
+			currentConnections
+				.filter(c => c.status === RemoteAgentHostConnectionStatus.Connected)
+				.map(c => c.address)
+		);
+		const allAddresses = new Set(currentConnections.map(c => c.address));
 
-		// Remove connections no longer present
+		// Remove contribution state for connections that are no longer present at all
 		for (const [address] of this._connections) {
-			if (!currentAddresses.has(address)) {
+			if (!allAddresses.has(address)) {
 				this._logService.info(`[RemoteAgentHost] Removing contribution for ${address}`);
 				this._providerInstances.get(address)?.clearConnection();
 				this._connections.deleteAndDispose(address);
+			} else if (!connectedAddresses.has(address)) {
+				// Connection exists but is not connected (reconnecting or disconnected).
+				// Keep the contribution state but don't clear the provider —
+				// the session cache is preserved during reconnect.
 			}
 		}
 
 		// Add or update connections
-		for (const connectionInfo of this._remoteAgentHostService.connections) {
+		for (const connectionInfo of currentConnections) {
+			// Only set up contribution state for connected entries
+			if (connectionInfo.status !== RemoteAgentHostConnectionStatus.Connected) {
+				continue;
+			}
 			const existing = this._connections.get(connectionInfo.address);
 			if (existing) {
 				// If the name changed, tear down and re-register with new name
@@ -218,7 +234,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Track authority -> connection mapping for FS provider routing
 		const authority = agentHostAuthority(address);
-		store.add(this._fsProvider.registerAuthority(authority, connection));
+		store.add(this._agentHostFileSystemService.registerAuthority(authority, connection));
 
 		// Forward non-session actions to client state
 		store.add(loggedConnection.onDidAction(envelope => {
@@ -253,6 +269,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Wire connection to existing sessions provider
 		this._providerInstances.get(address)?.setConnection(loggedConnection, connectionInfo.defaultDirectory);
+
+		// Expose the output channel ID so the workspace picker can offer "Show Output"
+		const provider = this._providerInstances.get(address);
+		if (provider) {
+			provider.outputChannelId = channelId;
+		}
 	}
 
 	private _handleRootStateChange(address: string, loggedConnection: LoggingAgentConnection, rootState: IRootState): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as nls from '../../../../nls.js';
-import { AGENT_HOST_LABEL_FORMATTER, agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
@@ -16,7 +16,6 @@ import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '.
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
@@ -82,14 +81,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		@IDefaultAccountService private readonly _defaultAccountService: IDefaultAccountService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
-		@ILabelService private readonly _labelService: ILabelService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IAgentHostFileSystemService private readonly _agentHostFileSystemService: IAgentHostFileSystemService
 	) {
 		super();
-
-		// Display agent-host URIs with the original file path
-		this._register(this._labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
 
 		// Reconcile providers when configured entries change
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
@@ -204,10 +199,9 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			}
 			const existing = this._connections.get(connectionInfo.address);
 			if (existing) {
-				// If the name changed, tear down and re-register with new name
-				if (existing.name !== connectionInfo.name) {
-					this._logService.info(`[RemoteAgentHost] Name changed for ${connectionInfo.address}: ${existing.name} -> ${connectionInfo.name}`);
-					this._providerInstances.get(connectionInfo.address)?.clearConnection();
+				// If the name or clientId changed, tear down and re-register
+				if (existing.name !== connectionInfo.name || existing.clientState.clientId !== connectionInfo.clientId) {
+					this._logService.info(`[RemoteAgentHost] Reconnecting contribution for ${connectionInfo.address}`);
 					this._connections.deleteAndDispose(connectionInfo.address);
 					this._setupConnection(connectionInfo);
 				}
@@ -271,10 +265,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		this._providerInstances.get(address)?.setConnection(loggedConnection, connectionInfo.defaultDirectory);
 
 		// Expose the output channel ID so the workspace picker can offer "Show Output"
-		const provider = this._providerInstances.get(address);
-		if (provider) {
-			provider.outputChannelId = channelId;
-		}
+		this._providerInstances.get(address)?.setOutputChannelId(channelId);
 	}
 
 	private _handleRootStateChange(address: string, loggedConnection: LoggingAgentConnection, rootState: IRootState): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -119,7 +119,8 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	readonly icon: ThemeIcon = Codicon.remote;
 	readonly sessionTypes: readonly ISessionType[];
 	readonly remoteAddress: string;
-	outputChannelId: string | undefined;
+	private _outputChannelId: string | undefined;
+	get outputChannelId(): string | undefined { return this._outputChannelId; }
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.Disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;
@@ -176,6 +177,13 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	 */
 	setConnectionStatus(status: RemoteAgentHostConnectionStatus): void {
 		this._connectionStatus.set(status, undefined);
+	}
+
+	/**
+	 * Set the output channel ID for this provider's IPC log.
+	 */
+	setOutputChannelId(id: string): void {
+		this._outputChannelId = id;
 	}
 
 	// -- Connection Management --

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { basename } from '../../../../base/common/resources.js';
-import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -17,6 +17,7 @@ import { localize } from '../../../../nls.js';
 import { agentHostUri } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_SCHEME, agentHostAuthority, toAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from '../../../../platform/agentHost/common/agentService.js';
+import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -117,6 +118,11 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	readonly label: string;
 	readonly icon: ThemeIcon = Codicon.remote;
 	readonly sessionTypes: readonly ISessionType[];
+	readonly remoteAddress: string;
+	outputChannelId: string | undefined;
+
+	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.Disconnected);
+	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;
 
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
@@ -151,6 +157,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 
 		this.id = `agenthost-${this._connectionAuthority}`;
 		this.label = displayName;
+		this.remoteAddress = config.address;
 
 		this.sessionTypes = [CopilotCLISessionType];
 
@@ -161,6 +168,14 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			providerId: this.id,
 			execute: () => this._browseForFolder(),
 		}];
+	}
+
+	/**
+	 * Update the connection status for this provider.
+	 * Called by the contribution when connection state changes.
+	 */
+	setConnectionStatus(status: RemoteAgentHostConnectionStatus): void {
+		this._connectionStatus.set(status, undefined);
 	}
 
 	// -- Connection Management --

--- a/src/vs/sessions/contrib/sessions/browser/sessionsProvider.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsProvider.ts
@@ -8,6 +8,8 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ISessionData, ISessionWorkspace } from '../common/sessionData.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
+import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IObservable } from '../../../../base/common/observable.js';
 
 /**
  * A platform-level session type identifying an agent backend.
@@ -72,6 +74,25 @@ export interface ISessionsProvider {
 	readonly icon: ThemeIcon;
 	/** Session types this provider supports. */
 	readonly sessionTypes: readonly ISessionType[];
+
+	/**
+	 * Observable connection status for remote providers.
+	 * When defined, indicates the provider represents a remote connection
+	 * and its status should be shown in the workspace picker.
+	 */
+	readonly connectionStatus?: IObservable<RemoteAgentHostConnectionStatus>;
+
+	/**
+	 * The address of the remote agent host, if this provider represents one.
+	 * Used by the workspace picker to offer management actions (reconnect, remove, etc.).
+	 */
+	readonly remoteAddress?: string;
+
+	/**
+	 * Output channel ID for this provider's IPC log.
+	 * When set, a "Show Output" action is available in the workspace picker.
+	 */
+	readonly outputChannelId?: string;
 
 	// -- Workspaces --
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -7,13 +7,11 @@ import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../
 import { URI } from '../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IAgentHostService, AgentHostEnabledSettingId, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
-import { AGENT_HOST_LABEL_FORMATTER } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { isSessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionClientState } from '../../../../../../platform/agentHost/common/state/sessionClientState.js';
 import { ROOT_STATE_URI, type IAgentInfo, type IRootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
@@ -54,7 +52,6 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		@ILogService private readonly _logService: ILogService,
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ILabelService private readonly _labelService: ILabelService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IAgentHostFileSystemService _agentHostFileSystemService: IAgentHostFileSystemService
 	) {
@@ -71,10 +68,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			'agentHostIpc.local',
 			'Agent Host (Local)'));
 
-		_agentHostFileSystemService.registerAuthority('local', this._agentHostService);
-
-		// Display agent-host URIs with the original file path
-		this._register(this._labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));
+		this._register(_agentHostFileSystemService.registerAuthority('local', this._agentHostService));
 
 		// Shared client state for protocol reconciliation
 		this._clientState = this._register(new SessionClientState(this._agentHostService.clientId, this._logService));

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -6,14 +6,12 @@
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { AgentHostFileSystemProvider } from '../../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { IAgentHostService, AgentHostEnabledSettingId, type AgentProvider } from '../../../../../../platform/agentHost/common/agentService.js';
-import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { isSessionAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import { SessionClientState } from '../../../../../../platform/agentHost/common/state/sessionClientState.js';
 import { ROOT_STATE_URI, type IAgentInfo, type IRootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
@@ -26,6 +24,7 @@ import { AgentHostLanguageModelProvider } from './agentHostLanguageModelProvider
 import { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 import { AgentHostSessionListController } from './agentHostSessionListController.js';
 import { LoggingAgentConnection } from './loggingAgentConnection.js';
+import { IAgentHostFileSystemService } from '../../../../../../platform/agentHost/common/agentHostFileSystemService.js';
 
 export { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 export { AgentHostSessionListController } from './agentHostSessionListController.js';
@@ -55,9 +54,9 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		@ILogService private readonly _logService: ILogService,
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IFileService private readonly _fileService: IFileService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IAgentHostFileSystemService _agentHostFileSystemService: IAgentHostFileSystemService
 	) {
 		super();
 
@@ -72,11 +71,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			'agentHostIpc.local',
 			'Agent Host (Local)'));
 
-		// Register a read-only filesystem provider for the local agent host
-		// so that agent-host-scheme URIs with 'local' authority can be resolved.
-		const fsProvider = this._register(new AgentHostFileSystemProvider());
-		this._register(fsProvider.registerAuthority('local', this._agentHostService));
-		this._register(this._fileService.registerProvider(AGENT_HOST_SCHEME, fsProvider));
+		_agentHostFileSystemService.registerAuthority('local', this._agentHostService);
 
 		// Display agent-host URIs with the original file path
 		this._register(this._labelService.registerFormatter(AGENT_HOST_LABEL_FORMATTER));

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -36,6 +36,7 @@ import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { TestFileService } from '../../../../../test/common/workbenchTestServices.js';
 import { ILabelService } from '../../../../../../platform/label/common/label.js';
 import { MockLabelService } from '../../../../../services/label/test/common/mockLabelService.js';
+import { IAgentHostFileSystemService } from '../../../../../../platform/agentHost/common/agentHostFileSystemService.js';
 
 // ---- Mock agent host service ------------------------------------------------
 
@@ -178,6 +179,9 @@ function createTestServices(disposables: DisposableStore) {
 	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null });
 	instantiationService.stub(IChatEditingService, {
 		registerEditingSessionProvider: () => toDisposable(() => { }),
+	});
+	instantiationService.stub(IAgentHostFileSystemService, {
+		registerAuthority: () => toDisposable(() => { }),
 	});
 
 	return { instantiationService, agentHostService, chatAgentService };


### PR DESCRIPTION
- Add automatic reconnect with exponential backoff (1s-30s) when a remote agent host WebSocket connection drops, preserving the session cache during reconnect attempts
- Add RemoteAgentHostConnectionStatus enum (Connected/Connecting/ Disconnected) to IRemoteAgentHostConnectionInfo and expose it on ISessionsProvider via an observable
- Add reconnect(address) method to IRemoteAgentHostService for explicit reconnect with reset backoff
- Always show configured remote hosts in the workspace picker with connection status indicators and a gear button for management
- Gear menu offers Reconnect, Remove Remote, Copy Address, Open Settings, and Show Output actions via quickpick
- Remote host browse actions are grouped into the "Select..." submenu alongside other providers when multiple providers exist

![](https://memes.peet.io/img/26-03-a1f9e614-1775-4055-99bf-3c4b948a5903.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
