### PR TITLE
fix: improve constant.regexp contrast in Dark VS theme

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -87,7 +87,7 @@
 		{
 			"scope": "constant.regexp",
 			"settings": {
-				"foreground": "#646695"
+				"foreground": "#d16969"
 			}
 		},
 		{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (accessibility / theme contrast)

## What is the current behavior?

The `constant.regexp` token scope in the Dark VS theme (which Dark+ and Dark Modern inherit) uses `#646695` as its foreground color. Against the `#1E1E1E` editor background, this yields a contrast ratio of only **3.08:1** — below the WCAG AA minimum of 4.5:1 for normal text. This makes regex constants hard to read.

Meanwhile, the semantically equivalent `string.regexp` scope uses `#D16969` with a contrast ratio of **4.71:1**, which meets the standard.

Closes #202381

## What is the new behavior?

Changes the `constant.regexp` foreground from `#646695` to `#d16969`, matching the `string.regexp` color. Both scopes represent regular expression literals, so using the same color is semantically consistent and meets WCAG AA contrast requirements.

| Scope | Before | After |
|---|---|---|
| `constant.regexp` | `#646695` (3.08:1) | `#d16969` (4.71:1) |
| `string.regexp` | `#d16969` (4.71:1) | unchanged |

## Additional context

- Dark Modern (`#1F1F1F` bg) also benefits: contrast improves from 3.04:1 to 4.66:1
- The fix is a single color value change in `dark_vs.json`
- HC Dark already uses `#d16969` for `string.regexp` and `#b46695` for `constant.regexp` (which has adequate contrast on its `#000000` background)