### PR TITLE
fix: improve Light+ theme contrast for activity bar, tabs, and title bar

### DIFF
--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -2,6 +2,14 @@
 	"$schema": "vscode://schemas/color-theme",
 	"name": "Light+",
 	"include": "./light_vs.json",
+	"colors": {
+		"activityBar.activeBackground": "#354355",
+		"activityBar.activeBorder": "#d3deeb",
+		"tab.inactiveBackground": "#e7e8e9",
+		"tab.inactiveForeground": "#666666",
+		"titleBar.activeBackground": "#d9dde2",
+		"titleBar.border": "#b3b3b3"
+	},
 	"tokenColors": [ // adds rules to the light vs rules
 		{
 			"name": "Function declarations",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Polish — improves visual contrast and readability of the built-in **Light+** theme.

## What is the current behavior?

The Light+ theme inherits all workbench colors from Light VS, which lacks explicit definitions for several UI elements. This makes it difficult to distinguish:

- The **active item** in the Activity Bar (no visible background highlight)
- **Active vs inactive tabs** (both share the same background and foreground)
- The **title bar** from the rest of the editor (minimal visual separation)

Closes #296897

## What is the new behavior?

Adds a `colors` block to `light_plus.json` with six targeted color overrides:

| Token | Value | Purpose |
|---|---|---|
| `activityBar.activeBackground` | `#354355` | Dark highlight behind active activity bar icon |
| `activityBar.activeBorder` | `#d3deeb` | Subtle border for active item |
| `tab.inactiveBackground` | `#e7e8e9` | Slightly darker background for inactive tabs |
| `tab.inactiveForeground` | `#666666` | Dimmed text for inactive tabs |
| `titleBar.activeBackground` | `#d9dde2` | Slightly darker title bar for better separation |
| `titleBar.border` | `#b3b3b3` | Border under the title bar |

These values are intentionally subtle — they improve clarity without changing the character of the theme. The issue author has used these tweaks personally since 2018.

## Additional context

- Only 1 file changed, 8 lines added
- No token color or semantic highlighting changes
- Light Modern already defines similar overrides for these tokens
- The maintainer (@mrleemurray) [invited a PR](https://github.com/microsoft/vscode/issues/296897#issuecomment-4046665925) on the issue