### PR TITLE
fix: use Math.round for relative date in git blame

### DIFF
--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -659,7 +659,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 	}
 
 	if (seconds < hour) {
-		value = Math.floor(seconds / minute);
+		value = Math.round(seconds / minute);
 		if (appendAgoLabel) {
 			if (value === 1) {
 				return useFullTimeWords
@@ -684,7 +684,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 	}
 
 	if (seconds < day) {
-		value = Math.floor(seconds / hour);
+		value = Math.round(seconds / hour);
 		if (appendAgoLabel) {
 			if (value === 1) {
 				return useFullTimeWords
@@ -709,7 +709,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 	}
 
 	if (seconds < week) {
-		value = Math.floor(seconds / day);
+		value = Math.round(seconds / day);
 		if (appendAgoLabel) {
 			return value === 1
 				? l10n.t('{0} day ago', value)
@@ -722,7 +722,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 	}
 
 	if (seconds < month) {
-		value = Math.floor(seconds / week);
+		value = Math.round(seconds / week);
 		if (appendAgoLabel) {
 			if (value === 1) {
 				return useFullTimeWords
@@ -747,7 +747,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 	}
 
 	if (seconds < year) {
-		value = Math.floor(seconds / month);
+		value = Math.round(seconds / month);
 		if (appendAgoLabel) {
 			if (value === 1) {
 				return useFullTimeWords
@@ -771,7 +771,7 @@ export function fromNow(date: number | Date, appendAgoLabel?: boolean, useFullTi
 		}
 	}
 
-	value = Math.floor(seconds / year);
+	value = Math.round(seconds / year);
 	if (appendAgoLabel) {
 		if (value === 1) {
 			return useFullTimeWords


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `fromNow` function in the git extension uses `Math.floor` to compute relative time values, which causes incorrect rounding for dates. For example, a commit made "3 weeks minus 3 hours" ago is displayed as "2 weeks ago" instead of "3 weeks ago".

Closes #284232

## What is the new behavior?

Changed all `Math.floor` calls in the git extension's `fromNow` function to `Math.round`, matching the behavior of the core VS Code `fromNow` function in `src/vs/base/common/date.ts` which already uses `Math.round`.

With this fix, a commit made 2.98 weeks ago correctly shows "3 weeks ago" instead of "2 weeks ago", consistent with how GitHub and other tools display relative dates.

## Additional context

The core VS Code `fromNow` in `src/vs/base/common/date.ts` uses `Math.round` at every time unit boundary (minutes, hours, days, weeks, months, years). The git extension's copy in `extensions/git/src/util.ts` diverged by using `Math.floor`, which systematically rounds down and produces confusing results when a date is close to but just under a time unit boundary.

The fix changes 6 lines in `extensions/git/src/util.ts`, all within the `fromNow` function.