### PR TITLE
fix: include additional toggles in find input arrow key navigation

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -174,9 +174,9 @@ export class FindInput extends Widget {
 			}));
 
 			// Arrow-Key support to navigate between options
-			const indexes = [this.caseSensitive.domNode, this.wholeWords.domNode, this.regex.domNode];
 			this.onkeydown(this.domNode, (event: IKeyboardEvent) => {
 				if (event.equals(KeyCode.LeftArrow) || event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Escape)) {
+					const indexes = this.getToggleDomNodes();
 					const index = indexes.indexOf(<HTMLElement>this.domNode.ownerDocument.activeElement);
 					if (index >= 0) {
 						let newIndex: number = -1;
@@ -313,6 +313,23 @@ export class FindInput extends Widget {
 		}
 
 		this.updateInputBoxPadding();
+	}
+
+	protected getToggleDomNodes(): HTMLElement[] {
+		const nodes: HTMLElement[] = [];
+		if (this.caseSensitive) {
+			nodes.push(this.caseSensitive.domNode);
+		}
+		if (this.wholeWords) {
+			nodes.push(this.wholeWords.domNode);
+		}
+		if (this.regex) {
+			nodes.push(this.regex.domNode);
+		}
+		for (const toggle of this.additionalToggles) {
+			nodes.push(toggle.domNode);
+		}
+		return nodes;
 	}
 
 	public setActions(actions: ReadonlyArray<IAction> | undefined, actionViewItemProvider?: IActionViewItemProvider): void {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -282,6 +282,12 @@ export class NotebookFindInput extends FindInput {
 		this._findFilter.applyStyles(this._filterChecked);
 	}
 
+	protected override getToggleDomNodes(): HTMLElement[] {
+		const nodes = super.getToggleDomNodes();
+		nodes.push(this._findFilter.container);
+		return nodes;
+	}
+
 	getCellToolbarActions(menu: IMenu): { primary: IAction[]; secondary: IAction[] } {
 		return getActionBarActions(menu.getActions({ shouldForwardArgs: true }), g => /^inline/.test(g));
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (accessibility)

## What is the current behavior?

When using arrow keys to navigate between toggle buttons in the find input (case sensitive, whole words, regex), only the three standard toggles are reachable. Additional toggles — such as the notebook find filter button (funnel icon) — are excluded from keyboard navigation. This means users who rely on keyboard navigation cannot reach these controls using arrow keys.

Fixes #207765

## What is the new behavior?

Arrow key navigation now includes all toggles in the find input:

1. **`FindInput` base class**: The static `indexes` array (hardcoded to `[caseSensitive, wholeWords, regex]`) is replaced with a dynamic \`getToggleDomNodes()\` method that returns DOM nodes for all standard toggles plus any \`additionalToggles\`.

2. **`NotebookFindInput` subclass**: Overrides \`getToggleDomNodes()\` to also include the filter button container, so the notebook find widget's funnel icon is reachable via arrow keys.

The \`getToggleDomNodes()\` method is \`protected\`, allowing any subclass of \`FindInput\` to extend the set of keyboard-navigable toggles.

## Additional context

The issue was identified by @andreamah, who pointed to the exact location in \`findInput.ts\` where the arrow key indexes were hardcoded. The fix is minimal and scoped:

- \`src/vs/base/browser/ui/findinput/findInput.ts\` — extract toggle DOM node list into overridable method
- \`src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts\` — override to include filter button