### PR TITLE
Fix remote agent host session issues in Sessions app

### DIFF
--- a/src/vs/platform/agentHost/node/agentEventMapper.ts
+++ b/src/vs/platform/agentHost/node/agentEventMapper.ts
@@ -7,6 +7,7 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import type {
 	IAgentDeltaEvent,
 	IAgentErrorEvent,
+	IAgentMessageEvent,
 	IAgentProgressEvent,
 	IAgentReasoningEvent,
 	IAgentTitleChangedEvent,
@@ -203,8 +204,30 @@ export class AgentEventMapper {
 				};
 			}
 
-			case 'message':
-				return undefined;
+			case 'message': {
+				// The SDK fires a `message` event with the complete assembled
+				// content after all streaming deltas. If delta events already
+				// captured the text (tracked via _currentMarkdownPartId), skip.
+				// Otherwise the text arrived without preceding deltas (e.g.
+				// after tool calls), so emit a new response part.
+				const e = event as IAgentMessageEvent;
+				if (e.role !== 'assistant' || !e.content) {
+					return undefined;
+				}
+				const existingPartId = this._currentMarkdownPartId.get(session);
+				if (existingPartId) {
+					// Deltas already streamed the content for this part
+					return undefined;
+				}
+				const partId = generateUuid();
+				this._currentMarkdownPartId.set(session, partId);
+				return {
+					type: ActionType.SessionResponsePart,
+					session,
+					turnId,
+					part: { kind: ResponsePartKind.Markdown, id: partId, content: e.content },
+				};
+			}
 
 			default:
 				return undefined;

--- a/src/vs/platform/agentHost/test/node/agentEventMapper.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentEventMapper.test.ts
@@ -235,7 +235,7 @@ suite('AgentEventMapper', () => {
 		assert.strictEqual(reasoning.partId, partId);
 	});
 
-	test('message event returns undefined', () => {
+	test('message event with no prior deltas creates responsePart', () => {
 		const event: IAgentMessageEvent = {
 			session,
 			type: 'message',
@@ -244,6 +244,71 @@ suite('AgentEventMapper', () => {
 			content: 'Some full message',
 		};
 
+		const actions = mapToArray(mapper.mapProgressEventToActions(event, session.toString(), turnId));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].type, 'session/responsePart');
+		const part = (actions[0] as IResponsePartAction).part;
+		assert.strictEqual(part.kind, 'markdown');
+		assert.strictEqual(part.content, 'Some full message');
+	});
+
+	test('message event after deltas returns undefined', () => {
+		// First send a delta so the mapper tracks a current markdown part
+		const delta: IAgentDeltaEvent = { session, type: 'delta', messageId: 'msg-1', content: 'hello' };
+		mapper.mapProgressEventToActions(delta, session.toString(), turnId);
+
+		const event: IAgentMessageEvent = {
+			session,
+			type: 'message',
+			role: 'assistant',
+			messageId: 'msg-1',
+			content: 'hello',
+		};
+
+		const result = mapper.mapProgressEventToActions(event, session.toString(), turnId);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('message event after tool_start creates responsePart for post-tool text', () => {
+		// Delta before tool call
+		const delta: IAgentDeltaEvent = { session, type: 'delta', messageId: 'msg-1', content: 'before' };
+		mapper.mapProgressEventToActions(delta, session.toString(), turnId);
+
+		// Tool call clears the current markdown part
+		const toolStart: IAgentToolStartEvent = {
+			session, type: 'tool_start',
+			toolCallId: 'tc-1', toolName: 'bash', displayName: 'Bash',
+			invocationMessage: 'Running', toolInput: 'ls',
+		};
+		mapper.mapProgressEventToActions(toolStart, session.toString(), turnId);
+
+		// Message event with text that came after the tool call
+		const msg: IAgentMessageEvent = {
+			session, type: 'message', role: 'assistant',
+			messageId: 'msg-2', content: 'after tool',
+		};
+		const actions = mapToArray(mapper.mapProgressEventToActions(msg, session.toString(), turnId));
+		assert.strictEqual(actions.length, 1);
+		assert.strictEqual(actions[0].type, 'session/responsePart');
+		const part = (actions[0] as IResponsePartAction).part;
+		assert.strictEqual(part.kind, 'markdown');
+		assert.strictEqual(part.content, 'after tool');
+	});
+
+	test('message event with user role returns undefined', () => {
+		const event: IAgentMessageEvent = {
+			session, type: 'message', role: 'user',
+			messageId: 'msg-1', content: 'user text',
+		};
+		const result = mapper.mapProgressEventToActions(event, session.toString(), turnId);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('message event with empty content returns undefined', () => {
+		const event: IAgentMessageEvent = {
+			session, type: 'message', role: 'assistant',
+			messageId: 'msg-1', content: '',
+		};
 		const result = mapper.mapProgressEventToActions(event, session.toString(), turnId);
 		assert.strictEqual(result, undefined);
 	});

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -3,11 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { raceTimeout } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { basename } from '../../../../base/common/resources.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -128,18 +129,31 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
 
+	private readonly _onDidReplaceSession = this._register(new Emitter<{ readonly from: ISessionData; readonly to: ISessionData }>());
+	readonly onDidReplaceSession: Event<{ readonly from: ISessionData; readonly to: ISessionData }> = this._onDidReplaceSession.event;
+
 	readonly browseActions: readonly ISessionsBrowseAction[];
 
 	/** Cache of adapted sessions, keyed by raw session ID. */
 	private readonly _sessionCache = new Map<string, RemoteSessionAdapter>();
 
+	/**
+	 * Temporary session that has been sent (first turn dispatched) but not yet
+	 * committed to a real backend session. Shown in the session list until the
+	 * server creates the backend session, at which point it is replaced via
+	 * {@link _onDidReplaceSession}.
+	 */
+	private _pendingSession: ISessionData | undefined;
+
 	/** Selected model for the current new session. */
 	private _selectedModelId: string | undefined;
+	/** Settable status for the current new session, kept to avoid unsafe cast from IObservable. */
+	private _currentNewSessionStatus: ISettableObservable<SessionStatus> | undefined;
 
 	private _connection: IAgentConnection | undefined;
 	private _defaultDirectory: string | undefined;
 	private readonly _connectionListeners = this._register(new DisposableStore());
-	private readonly _disconnectListeners = this._register(new DisposableStore());
+	private readonly _onDidDisconnect = this._register(new Emitter<void>());
 	private readonly _connectionAuthority: string;
 
 	constructor(
@@ -227,11 +241,15 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	 */
 	clearConnection(): void {
 		this._connectionListeners.clear();
-		this._disconnectListeners.clear();
+		this._onDidDisconnect.fire();
 		this._connection = undefined;
 		this._defaultDirectory = undefined;
 
-		const removed = Array.from(this._sessionCache.values());
+		const removed: ISessionData[] = Array.from(this._sessionCache.values());
+		if (this._pendingSession) {
+			removed.push(this._pendingSession);
+			this._pendingSession = undefined;
+		}
 		this._sessionCache.clear();
 		this._cacheInitialized = false;
 		if (removed.length > 0) {
@@ -276,7 +294,11 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 
 	getSessions(): ISessionData[] {
 		this._ensureSessionCache();
-		return Array.from(this._sessionCache.values());
+		const sessions: ISessionData[] = Array.from(this._sessionCache.values());
+		if (this._pendingSession) {
+			sessions.push(this._pendingSession);
+		}
+		return sessions;
 	}
 
 	// -- Session Lifecycle --
@@ -302,6 +324,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		this._selectedModelId = undefined;
 
 		const resource = URI.from({ scheme: this._sessionTypeForProvider('copilot'), path: `/untitled-${generateUuid()}` });
+		const status = observableValue<SessionStatus>(this, SessionStatus.Untitled);
 		const session: ISessionData = {
 			id: `${this.id}:${resource.toString()}`,
 			resource,
@@ -312,7 +335,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			workspace: observableValue(this, workspace),
 			title: observableValue(this, ''),
 			updatedAt: observableValue(this, new Date()),
-			status: observableValue(this, SessionStatus.Untitled),
+			status,
 			changes: observableValue<readonly IChatSessionFileChange[]>(this, []),
 			modelId: observableValue(this, undefined),
 			mode: observableValue(this, undefined),
@@ -324,6 +347,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			gitHubInfo: observableValue(this, undefined),
 		};
 		this._currentNewSession = session;
+		this._currentNewSessionStatus = status;
 		return session;
 	}
 
@@ -421,7 +445,10 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			modelRef.dispose();
 		}
 
-		// Track existing sessions before sending so we can detect the new one
+		// Capture existing session keys before sending so we can detect the new
+		// backend session. Must be captured before sendRequest because the
+		// backend session may be created during the send and arrive via
+		// notification before sendRequest resolves.
 		const existingKeys = new Set(this._sessionCache.keys());
 
 		// Send request through the chat service, which delegates to the
@@ -431,13 +458,34 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			throw new Error(`[RemoteAgentHost] sendRequest rejected: ${result.reason}`);
 		}
 
-		// After sending, the session handler creates the backend session.
-		this._currentNewSession = undefined;
-		this._selectedModelId = undefined;
+		// Add the untitled session to the pending set so it stays visible in the
+		// session list while the turn is in progress. It will be replaced
+		// by the committed session once the backend session appears.
+		this._currentNewSessionStatus?.set(SessionStatus.InProgress, undefined);
+		this._pendingSession = session;
+		this._onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });
 
-		// Wait for the new session to appear via notification or refresh
-		const newSession = await this._waitForNewSession(existingKeys);
-		return newSession ?? session;
+		this._selectedModelId = undefined;
+		this._currentNewSessionStatus = undefined;
+
+		// Wait for the real backend session to appear (via server notification
+		// after the handler creates it), then replace the temporary entry.
+		try {
+			const committedSession = await this._waitForNewSession(existingKeys);
+			if (committedSession) {
+				this._currentNewSession = undefined;
+				this._onDidReplaceSession.fire({ from: session, to: committedSession });
+				return committedSession;
+			}
+		} catch {
+			// Connection lost or timeout — clean up
+		} finally {
+			this._pendingSession = undefined;
+		}
+
+		// Fallback: keep the temp session visible
+		this._currentNewSession = undefined;
+		return session;
 	}
 
 	// -- Private: Session Cache --
@@ -498,7 +546,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	/**
 	 * Wait for a new session to appear in the cache that wasn't present before.
 	 * Tries an immediate refresh, then listens for the session-added notification.
-	 * Rejects if the connection is cleared before a session appears.
+	 * Returns `undefined` if the connection is lost or a timeout expires.
 	 */
 	private async _waitForNewSession(existingKeys: Set<string>): Promise<ISessionData | undefined> {
 		// First, try an immediate refresh
@@ -509,30 +557,26 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			}
 		}
 
-		// If not found yet, wait for the next onDidChangeSessions event
-		// or reject if the connection is cleared.
-		return new Promise<ISessionData | undefined>((resolve, reject) => {
-			let settled = false;
-			const listener = this._onDidChangeSessions.event(e => {
-				const newSession = e.added.find(s => {
-					const rawId = s.resource.path.substring(1);
-					return !existingKeys.has(rawId);
-				});
-				if (newSession) {
-					settled = true;
-					listener.dispose();
-					disconnectListener.dispose();
-					resolve(newSession);
-				}
+		// If not found yet, wait for the next onDidChangeSessions event,
+		// bounded by a timeout and aborted on disconnect.
+		const waitDisposables = new DisposableStore();
+		try {
+			const sessionPromise = new Promise<ISessionData | undefined>((resolve) => {
+				waitDisposables.add(this._onDidChangeSessions.event(e => {
+					const newSession = e.added.find(s => {
+						const rawId = s.resource.path.substring(1);
+						return !existingKeys.has(rawId);
+					});
+					if (newSession) {
+						resolve(newSession);
+					}
+				}));
+				waitDisposables.add(this._onDidDisconnect.event(() => resolve(undefined)));
 			});
-			const disconnectListener = toDisposable(() => {
-				if (!settled) {
-					listener.dispose();
-					reject(new Error('Connection lost while waiting for session'));
-				}
-			});
-			this._disconnectListeners.add(disconnectListener);
-		});
+			return await raceTimeout(sessionPromise, 30_000);
+		} finally {
+			waitDisposables.dispose();
+		}
 	}
 
 	private _handleSessionAdded(summary: { resource: string; provider: string; title: string; createdAt: number; modifiedAt: number; workingDirectory?: string }): void {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsProvider.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsProvider.ts
@@ -110,9 +110,6 @@ export interface ISessionsProvider {
 	/**
 	 * Optional. Fires when a temporary (untitled) session is atomically replaced
 	 * by a committed session after the first turn.
-	 *
-	 * @internal This is an implementation detail of the Copilot Chat sessions
-	 * provider. Do not implement or consume this event in other providers.
 	 */
 	readonly onDidReplaceSession?: Event<{ readonly from: ISessionData; readonly to: ISessionData }>;
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -565,7 +565,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			// translation as _handleTurn, but pipe output to progressObs/isCompleteObs
 			const turnStore = new DisposableStore();
 			turnProgressDisposable.value = turnStore;
-			this._trackServerTurnProgress(backendSession, activeTurn.id, chatSession, sessionResource, turnStore);
+			this._trackServerTurnProgress(backendSession, activeTurn.id, chatSession, turnStore);
 		}));
 
 		this._serverTurnWatchers.set(sessionResource, disposables);
@@ -580,7 +580,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		backendSession: URI,
 		turnId: string,
 		chatSession: AgentHostChatSession,
-		sessionResource: URI,
 		turnDisposables: DisposableStore,
 	): void {
 		const sessionStr = backendSession.toString();
@@ -601,101 +600,117 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			}
 			finished = true;
 			for (const [, invocation] of activeToolInvocations) {
-				invocation.didExecuteTool(undefined);
+				if (!IChatToolInvocation.isComplete(invocation)) {
+					invocation.didExecuteTool(undefined);
+				}
 			}
 			activeToolInvocations.clear();
 			chatSession.isCompleteObs.set(true, undefined);
 		});
 
-		turnDisposables.add(this._clientState.onDidChangeSessionState(e => {
-			throttler.queue(async () => {
-				if (e.session !== sessionStr) {
-					return;
-				}
+		const processState = (sessionState: ISessionState) => {
+			if (finished) {
+				return;
+			}
+			const activeTurn = sessionState.activeTurn;
+			const isActive = activeTurn?.id === turnId;
+			const responseParts = isActive
+				? activeTurn.responseParts
+				: sessionState.turns.find(t => t.id === turnId)?.responseParts;
 
-				const activeTurn = e.state.activeTurn;
-				const isActive = activeTurn?.id === turnId;
-				const responseParts = isActive
-					? activeTurn.responseParts
-					: e.state.turns.find(t => t.id === turnId)?.responseParts;
-
-				if (responseParts) {
-					for (const rp of responseParts) {
-						switch (rp.kind) {
-							case ResponsePartKind.Markdown: {
-								const lastLen = lastEmittedLengths.get(rp.id) ?? 0;
-								if (rp.content.length > lastLen) {
-									const delta = rp.content.substring(lastLen);
-									lastEmittedLengths.set(rp.id, rp.content.length);
-									progress([{ kind: 'markdownContent', content: new MarkdownString(delta, { supportHtml: true }) }]);
-								}
-								break;
+			if (responseParts) {
+				for (const rp of responseParts) {
+					switch (rp.kind) {
+						case ResponsePartKind.Markdown: {
+							const lastLen = lastEmittedLengths.get(rp.id) ?? 0;
+							if (rp.content.length > lastLen) {
+								const delta = rp.content.substring(lastLen);
+								lastEmittedLengths.set(rp.id, rp.content.length);
+								progress([{ kind: 'markdownContent', content: new MarkdownString(delta, { supportHtml: true }) }]);
 							}
-							case ResponsePartKind.Reasoning: {
-								const lastLen = lastEmittedLengths.get(rp.id) ?? 0;
-								if (rp.content.length > lastLen) {
-									const delta = rp.content.substring(lastLen);
-									lastEmittedLengths.set(rp.id, rp.content.length);
-									progress([{ kind: 'thinking', value: delta }]);
-								}
-								break;
+							break;
+						}
+						case ResponsePartKind.Reasoning: {
+							const lastLen = lastEmittedLengths.get(rp.id) ?? 0;
+							if (rp.content.length > lastLen) {
+								const delta = rp.content.substring(lastLen);
+								lastEmittedLengths.set(rp.id, rp.content.length);
+								progress([{ kind: 'thinking', value: delta }]);
 							}
-							case ResponsePartKind.ToolCall: {
-								const tc = rp.toolCall;
-								const toolCallId = tc.toolCallId;
-								let existing = activeToolInvocations.get(toolCallId);
+							break;
+						}
+						case ResponsePartKind.ToolCall: {
+							const tc = rp.toolCall;
+							const toolCallId = tc.toolCallId;
+							let existing = activeToolInvocations.get(toolCallId);
 
-								if (!existing) {
-									existing = toolCallStateToInvocation(tc);
-									activeToolInvocations.set(toolCallId, existing);
-									progress([existing]);
+							if (!existing) {
+								existing = toolCallStateToInvocation(tc);
+								activeToolInvocations.set(toolCallId, existing);
+								progress([existing]);
 
-									if (tc.status === ToolCallStatus.PendingConfirmation) {
-										this._awaitToolConfirmation(existing, toolCallId, backendSession, turnId, CancellationToken.None);
-									}
-								} else if (tc.status === ToolCallStatus.PendingConfirmation) {
+								if (tc.status === ToolCallStatus.PendingConfirmation) {
+									this._awaitToolConfirmation(existing, toolCallId, backendSession, turnId, CancellationToken.None);
+								}
+							} else if (tc.status === ToolCallStatus.PendingConfirmation) {
+								// Running → PendingConfirmation (re-confirmation).
+								// Only replace if the existing invocation is not already
+								// waiting for confirmation (avoids flickering on duplicate
+								// state change events).
+								const existingState = existing.state.get();
+								if (existingState.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
 									existing.didExecuteTool(undefined);
 									const confirmInvocation = toolCallStateToInvocation(tc);
 									activeToolInvocations.set(toolCallId, confirmInvocation);
 									progress([confirmInvocation]);
 									this._awaitToolConfirmation(confirmInvocation, toolCallId, backendSession, turnId, CancellationToken.None);
-								} else if (tc.status === ToolCallStatus.Running) {
-									existing.invocationMessage = typeof tc.invocationMessage === 'string'
-										? tc.invocationMessage
-										: new MarkdownString(tc.invocationMessage.markdown);
-									if (getToolKind(tc) === 'terminal' && tc.toolInput) {
-										existing.toolSpecificData = {
-											kind: 'terminal',
-											commandLine: { original: tc.toolInput },
-											language: getToolLanguage(tc) ?? 'shellscript',
-										};
-									}
 								}
-
-								if (existing && (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) && !IChatToolInvocation.isComplete(existing)) {
-									activeToolInvocations.delete(toolCallId);
-									const fileEdits = finalizeToolInvocation(existing, tc);
-									if (fileEdits.length > 0) {
-										// File edits from server-initiated turns are not routed through
-										// the editing session here; the request is not yet available
-										// in the ChatModel at this point.
-									}
+							} else if (tc.status === ToolCallStatus.Running) {
+								existing.invocationMessage = typeof tc.invocationMessage === 'string'
+									? tc.invocationMessage
+									: new MarkdownString(tc.invocationMessage.markdown);
+								if (getToolKind(tc) === 'terminal' && tc.toolInput) {
+									existing.toolSpecificData = {
+										kind: 'terminal',
+										commandLine: { original: tc.toolInput },
+										language: getToolLanguage(tc) ?? 'shellscript',
+									};
 								}
-								break;
 							}
+
+							if (existing && (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) && !IChatToolInvocation.isComplete(existing)) {
+								finalizeToolInvocation(existing, tc);
+							}
+							break;
 						}
 					}
 				}
+			}
 
-				if (!isActive && !finished) {
-					const lastTurn = e.state.turns.find(t => t.id === turnId);
-					if (lastTurn?.state === TurnState.Error && lastTurn.error) {
-						progress([{ kind: 'markdownContent', content: new MarkdownString(`\n\nError: (${lastTurn.error.errorType}) ${lastTurn.error.message}`) }]);
-					}
-					finish();
+			if (!isActive && !finished) {
+				const lastTurn = sessionState.turns.find(t => t.id === turnId);
+				if (lastTurn?.state === TurnState.Error && lastTurn.error) {
+					progress([{ kind: 'markdownContent', content: new MarkdownString(`\n\nError: (${lastTurn.error.errorType}) ${lastTurn.error.message}`) }]);
 				}
-			});
+				finish();
+			}
+		};
+
+		turnDisposables.add(this._clientState.onDidChangeSessionState(e => {
+			if (e.session !== sessionStr) {
+				return;
+			}
+			throttler.queue(async () => processState(e.state));
 		}));
+
+		// Immediately reconcile against the current state to close any gap
+		// between turn detection and listener registration. The state change
+		// that triggered server-initiated turn detection may already contain
+		// response parts (e.g. markdown content) that arrived in the same batch.
+		const currentState = this._clientState.getSessionState(sessionStr);
+		if (currentState) {
+			throttler.queue(async () => processState(currentState));
+		}
 	}
 
 	// ---- Turn handling (state-driven) ---------------------------------------
@@ -838,11 +853,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 									}
 								} else if (tc.status === ToolCallStatus.PendingConfirmation) {
 									// Running → PendingConfirmation (re-confirmation).
-									existing.didExecuteTool(undefined);
-									const confirmInvocation = toolCallStateToInvocation(tc);
-									activeToolInvocations.set(toolCallId, confirmInvocation);
-									progress([confirmInvocation]);
-									this._awaitToolConfirmation(confirmInvocation, toolCallId, session, turnId, cancellationToken);
+									const existingState = existing.state.get();
+									if (existingState.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+										existing.didExecuteTool(undefined);
+										const confirmInvocation = toolCallStateToInvocation(tc);
+										activeToolInvocations.set(toolCallId, confirmInvocation);
+										progress([confirmInvocation]);
+										this._awaitToolConfirmation(confirmInvocation, toolCallId, session, turnId, cancellationToken);
+									}
 								} else if (tc.status === ToolCallStatus.Running) {
 									// Streaming → Running: update with now-available parameters.
 									existing.invocationMessage = typeof tc.invocationMessage === 'string'
@@ -1055,11 +1073,14 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 								}
 							} else if (tc.status === ToolCallStatus.PendingConfirmation) {
 								// Running -> PendingConfirmation (re-confirmation).
-								existing.didExecuteTool(undefined);
-								const confirmInvocation = toolCallStateToInvocation(tc);
-								activeToolInvocations.set(toolCallId, confirmInvocation);
-								chatSession.appendProgress([confirmInvocation]);
-								this._awaitToolConfirmation(confirmInvocation, toolCallId, backendSession, turnId, cts.token);
+								const existingState = existing.state.get();
+								if (existingState.type !== IChatToolInvocation.StateKind.WaitingForConfirmation) {
+									existing.didExecuteTool(undefined);
+									const confirmInvocation = toolCallStateToInvocation(tc);
+									activeToolInvocations.set(toolCallId, confirmInvocation);
+									chatSession.appendProgress([confirmInvocation]);
+									this._awaitToolConfirmation(confirmInvocation, toolCallId, backendSession, turnId, cts.token);
+								}
 							} else if (tc.status === ToolCallStatus.Running) {
 								existing.invocationMessage = typeof tc.invocationMessage === 'string'
 									? tc.invocationMessage
@@ -1075,7 +1096,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 							// Finalize terminal-state tools
 							if (existing && (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) && !IChatToolInvocation.isComplete(existing)) {
-								activeToolInvocations.delete(toolCallId);
 								finalizeToolInvocation(existing, tc);
 								// Note: file edits from reconnection are not routed through
 								// the editing session pipeline as there is no active request

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -10,6 +10,7 @@ import { DisposableStore, toDisposable } from '../../../../../../base/common/lif
 import { URI } from '../../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { timeout } from '../../../../../../base/common/async.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -349,7 +350,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('session ID resolution', () => {
 
-		test('creates new SDK session for untitled resource', async () => {
+		test('creates new SDK session for untitled resource', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, { message: 'Hello' });
@@ -360,9 +361,9 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(agentHostService.dispatchedActions[0].action.type, 'session/turnStarted');
 			assert.strictEqual((agentHostService.dispatchedActions[0].action as ITurnStartedAction).userMessage.text, 'Hello');
 			assert.ok(AgentSession.id(URI.parse(session)).startsWith('sdk-session-'));
-		});
+		}));
 
-		test('reuses SDK session for same resource on second message', async () => {
+		test('reuses SDK session for same resource on second message', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const resource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-reuse' });
@@ -399,9 +400,9 @@ suite('AgentHostChatContribution', () => {
 				(agentHostService.dispatchedActions[0].action as ITurnStartedAction).session.toString(),
 				(agentHostService.dispatchedActions[1].action as ITurnStartedAction).session.toString(),
 			);
-		});
+		}));
 
-		test('uses sessionId from agent-host scheme resource', async () => {
+		test('uses sessionId from agent-host scheme resource', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -412,9 +413,9 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 
 			assert.strictEqual(AgentSession.id(URI.parse(session)), 'existing-session-42');
-		});
+		}));
 
-		test('agent-host scheme with untitled path creates new session via mapping', async () => {
+		test('agent-host scheme with untitled path creates new session via mapping', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -426,8 +427,8 @@ suite('AgentHostChatContribution', () => {
 
 			// Should create a new SDK session, not use "untitled-abc123" literally
 			assert.ok(AgentSession.id(URI.parse(session)).startsWith('sdk-session-'));
-		});
-		test('passes raw model id extracted from language model identifier', async () => {
+		}));
+		test('passes raw model id extracted from language model identifier', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -439,9 +440,9 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
 			assert.strictEqual(agentHostService.createSessionCalls[0].model, 'claude-sonnet-4-20250514');
-		});
+		}));
 
-		test('passes model id as-is when no vendor prefix', async () => {
+		test('passes model id as-is when no vendor prefix', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -453,7 +454,7 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
 			assert.strictEqual(agentHostService.createSessionCalls[0].model, 'gpt-4o');
-		});
+		}));
 
 		test('does not create backend session eagerly for untitled sessions', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
@@ -471,7 +472,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('progress routing', () => {
 
-		test('delta events become markdownContent progress', async () => {
+		test('delta events become markdownContent progress', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -486,9 +487,9 @@ suite('AgentHostChatContribution', () => {
 			const markdownParts = collected.flat().filter((p): p is IChatMarkdownContent => p.kind === 'markdownContent');
 			const totalContent = markdownParts.map(p => p.content.value).join('');
 			assert.strictEqual(totalContent, 'hello world');
-		});
+		}));
 
-		test('tool_start events become toolInvocation progress', async () => {
+		test('tool_start events become toolInvocation progress', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -501,9 +502,9 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(collected.length, 1);
 			assert.strictEqual(collected[0][0].kind, 'toolInvocation');
-		});
+		}));
 
-		test('tool_complete event transitions toolInvocation to completed', async () => {
+		test('tool_complete event transitions toolInvocation to completed', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -523,9 +524,9 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(invocation.kind, 'toolInvocation');
 			assert.strictEqual(invocation.toolCallId, 'tc-2');
 			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
-		});
+		}));
 
-		test('tool_complete with failure sets error state', async () => {
+		test('tool_complete with failure sets error state', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -544,9 +545,9 @@ suite('AgentHostChatContribution', () => {
 			const invocation = collected[0][0] as IChatToolInvocation;
 			assert.strictEqual(invocation.kind, 'toolInvocation');
 			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
-		});
+		}));
 
-		test('malformed toolArguments does not throw', async () => {
+		test('malformed toolArguments does not throw', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -559,9 +560,9 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(collected.length, 1);
 			assert.strictEqual(collected[0][0].kind, 'toolInvocation');
-		});
+		}));
 
-		test('outstanding tool invocations are completed on idle', async () => {
+		test('outstanding tool invocations are completed on idle', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -577,9 +578,9 @@ suite('AgentHostChatContribution', () => {
 			const invocation = collected[0][0] as IChatToolInvocation;
 			assert.strictEqual(invocation.kind, 'toolInvocation');
 			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
-		});
+		}));
 
-		test('events from other sessions are ignored', async () => {
+		test('events from other sessions are ignored', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -597,14 +598,14 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(collected.length, 1);
 			assert.strictEqual((collected[0][0] as IChatMarkdownContent).content.value, 'right');
-		});
+		}));
 	});
 
 	// ---- Cancellation -----------------------------------------------------
 
 	suite('cancellation', () => {
 
-		test('cancellation resolves the agent invoke', async () => {
+		test('cancellation resolves the agent invoke', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
@@ -618,9 +619,9 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 
 			assert.ok(agentHostService.dispatchedActions.some(a => a.action.type === 'session/turnCancelled'));
-		});
+		}));
 
-		test('cancellation force-completes outstanding tool invocations', async () => {
+		test('cancellation force-completes outstanding tool invocations', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
@@ -642,9 +643,9 @@ suite('AgentHostChatContribution', () => {
 			for (const inv of toolInvocations) {
 				assert.strictEqual(IChatToolInvocation.isComplete(inv as IChatToolInvocation), true);
 			}
-		});
+		}));
 
-		test('cancellation calls abortSession on the agent host service', async () => {
+		test('cancellation calls abortSession on the agent host service', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
@@ -659,14 +660,14 @@ suite('AgentHostChatContribution', () => {
 
 			// Cancellation now dispatches session/turnCancelled action
 			assert.ok(agentHostService.dispatchedActions.some(a => a.action.type === 'session/turnCancelled'));
-		});
+		}));
 	});
 
 	// ---- Error events -------------------------------------------------------
 
 	suite('error events', () => {
 
-		test('error event renders error message and finishes the request', async () => {
+		test('error event renders error message and finishes the request', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -688,14 +689,14 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(collected.length >= 1);
 			const errorPart = collected.flat().find(p => p.kind === 'markdownContent' && (p as IChatMarkdownContent).content.value.includes('Something went wrong'));
 			assert.ok(errorPart, 'Should have found a markdownContent part containing the error message');
-		});
+		}));
 	});
 
 	// ---- Permission requests -----------------------------------------------
 
 	suite('permission requests', () => {
 
-		test('permission_request event shows confirmation and responds when confirmed', async () => {
+		test('permission_request event shows confirmation and responds when confirmed', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -735,9 +736,9 @@ suite('AgentHostChatContribution', () => {
 
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
-		});
+		}));
 
-		test('permission_request denied when user skips', async () => {
+		test('permission_request denied when user skips', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -769,9 +770,9 @@ suite('AgentHostChatContribution', () => {
 
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
-		});
+		}));
 
-		test('shell permission shows terminal-style confirmation data', async () => {
+		test('shell permission shows terminal-style confirmation data', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -793,9 +794,9 @@ suite('AgentHostChatContribution', () => {
 			await timeout(10);
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
-		});
+		}));
 
-		test('read permission shows input-style confirmation data', async () => {
+		test('read permission shows input-style confirmation data', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -813,7 +814,7 @@ suite('AgentHostChatContribution', () => {
 			await timeout(10);
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
-		});
+		}));
 	});
 
 	// ---- History loading ---------------------------------------------------
@@ -871,7 +872,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('tool invocation rendering', () => {
 
-		test('bash tool renders as terminal command block with output', async () => {
+		test('bash tool renders as terminal command block with output', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -907,9 +908,9 @@ suite('AgentHostChatContribution', () => {
 				outputText: 'hello\n',
 				exitCode: 0,
 			});
-		});
+		}));
 
-		test('bash tool failure sets exit code 1 and error output', async () => {
+		test('bash tool failure sets exit code 1 and error output', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -935,9 +936,9 @@ suite('AgentHostChatContribution', () => {
 				outputText: 'command not found: bad_cmd',
 				exitCode: 1,
 			});
-		});
+		}));
 
-		test('generic tool has invocation message and no toolSpecificData', async () => {
+		test('generic tool has invocation message and no toolSpecificData', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -962,9 +963,9 @@ suite('AgentHostChatContribution', () => {
 				pastTenseMessage: 'Used "custom_tool"',
 				toolSpecificData: undefined,
 			});
-		});
+		}));
 
-		test('bash tool without arguments has no terminal data', async () => {
+		test('bash tool without arguments has no terminal data', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -989,9 +990,9 @@ suite('AgentHostChatContribution', () => {
 				pastTenseMessage: 'Ran Bash command',
 				toolSpecificData: undefined,
 			});
-		});
+		}));
 
-		test('view tool shows file path in messages', async () => {
+		test('view tool shows file path in messages', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -1014,7 +1015,7 @@ suite('AgentHostChatContribution', () => {
 				invocationMessage: 'Reading /tmp/test.txt',
 				pastTenseMessage: 'Read /tmp/test.txt',
 			});
-		});
+		}));
 	});
 
 	// ---- History with tool events ----------------------------------------
@@ -1149,7 +1150,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('server error handling', () => {
 
-		test('server-side error resolves the agent invoke without throwing', async () => {
+		test('server-side error resolves the agent invoke without throwing', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
@@ -1167,7 +1168,7 @@ suite('AgentHostChatContribution', () => {
 			});
 
 			await turnPromise;
-		});
+		}));
 	});
 
 	// ---- Session list provider filtering --------------------------------
@@ -1242,7 +1243,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('attachment context', () => {
 
-		test('file variable with file:// URI becomes file attachment', async () => {
+		test('file variable with file:// URI becomes file attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1261,9 +1262,9 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(turnAction.userMessage.attachments, [
 				{ type: 'file', path: URI.file('/workspace/test.ts').fsPath, displayName: 'test.ts' },
 			]);
-		});
+		}));
 
-		test('directory variable with file:// URI becomes directory attachment', async () => {
+		test('directory variable with file:// URI becomes directory attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1282,9 +1283,9 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(turnAction.userMessage.attachments, [
 				{ type: 'directory', path: URI.file('/workspace/src').fsPath, displayName: 'src' },
 			]);
-		});
+		}));
 
-		test('implicit selection variable becomes selection attachment', async () => {
+		test('implicit selection variable becomes selection attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1303,9 +1304,9 @@ suite('AgentHostChatContribution', () => {
 			assert.deepStrictEqual(turnAction.userMessage.attachments, [
 				{ type: 'selection', path: URI.file('/workspace/foo.ts').fsPath, displayName: 'selection' },
 			]);
-		});
+		}));
 
-		test('non-file URIs are skipped', async () => {
+		test('non-file URIs are skipped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1323,9 +1324,9 @@ suite('AgentHostChatContribution', () => {
 			const turnAction = agentHostService.dispatchedActions[0].action as ITurnStartedAction;
 			// No attachments because it's not a file:// URI
 			assert.strictEqual(turnAction.userMessage.attachments, undefined);
-		});
+		}));
 
-		test('tool variables are skipped', async () => {
+		test('tool variables are skipped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1342,9 +1343,9 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 			const turnAction = agentHostService.dispatchedActions[0].action as ITurnStartedAction;
 			assert.strictEqual(turnAction.userMessage.attachments, undefined);
-		});
+		}));
 
-		test('mixed variables extracts only supported types', async () => {
+		test('mixed variables extracts only supported types', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1367,9 +1368,9 @@ suite('AgentHostChatContribution', () => {
 				{ type: 'file', path: URI.file('/workspace/a.ts').fsPath, displayName: 'a.ts' },
 				{ type: 'directory', path: URI.file('/workspace/lib').fsPath, displayName: 'lib' },
 			]);
-		});
+		}));
 
-		test('no variables results in no attachments argument', async () => {
+		test('no variables results in no attachments argument', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
@@ -1381,14 +1382,14 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 			const turnAction = agentHostService.dispatchedActions[0].action as ITurnStartedAction;
 			assert.strictEqual(turnAction.userMessage.attachments, undefined);
-		});
+		}));
 	});
 
 	// ---- AgentHostContribution discovery ---------------------------------
 
 	suite('dynamic discovery', () => {
 
-		test('setting gate prevents registration', async () => {
+		test('setting gate prevents registration', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { instantiationService } = createTestServices(disposables);
 			instantiationService.stub(IConfigurationService, { getValue: () => false });
 
@@ -1397,7 +1398,7 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(contribution);
 			// Let async work settle
 			await timeout(10);
-		});
+		}));
 	});
 
 	// ---- IAgentConnection unification -------------------------------------
@@ -1444,7 +1445,7 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(registered.data.extensionDisplayName, 'Agent Host');
 		});
 
-		test('handler uses resolveWorkingDirectory callback', async () => {
+		test('handler uses resolveWorkingDirectory callback', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
 
 			const handler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -1464,7 +1465,39 @@ suite('AgentHostChatContribution', () => {
 
 			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
 			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory?.toString(), URI.file('/custom/working/dir').toString());
-		});
+		}));
+
+		test('handler passes vscode-agent-host URI as-is to createSession', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			// The workspace repository URI in the Sessions app is a
+			// vscode-agent-host:// URI. It must be passed through unchanged
+			// because the connection's createSession already converts it via
+			// fromAgentHostUri before sending to the remote server.
+			const agentHostUri = URI.from({
+				scheme: 'vscode-agent-host',
+				authority: 'my-server',
+				path: '/file/-/home/user/project',
+			});
+
+			const handler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
+				provider: 'copilot' as const,
+				agentId: 'workdir-agenthost-test',
+				sessionType: 'workdir-agenthost-test',
+				fullName: 'Test',
+				description: 'test',
+				connection: agentHostService,
+				connectionAuthority: 'my-server',
+				resolveWorkingDirectory: () => agentHostUri,
+			}));
+
+			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables);
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
+			assert.strictEqual(agentHostService.createSessionCalls[0].workingDirectory?.toString(), agentHostUri.toString());
+		}));
 
 		test('list controller includes description in items', async () => {
 			const { instantiationService, agentHostService } = createTestServices(disposables);
@@ -1492,7 +1525,7 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(controller.items[0].description, undefined);
 		});
 
-		test('handler works with any IAgentConnection, not just IAgentHostService', async () => {
+		test('handler works with any IAgentConnection, not just IAgentHostService', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 
 			// Create handler with agentHostService as IAgentConnection (not IAgentHostService)
@@ -1521,7 +1554,7 @@ suite('AgentHostChatContribution', () => {
 			// Turn dispatched via connection.dispatchAction
 			assert.strictEqual(agentHostService.dispatchedActions.length, 1);
 			assert.strictEqual((agentHostService.dispatchedActions[0].action as ITurnStartedAction).userMessage.text, 'Test message');
-		});
+		}));
 	});
 
 	// ---- Reconnection to active turn ----------------------------------------
@@ -1638,7 +1671,7 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(cancelAction, 'Should dispatch session/turnCancelled');
 		});
 
-		test('streams new text deltas into progressObs after reconnection', async () => {
+		test('streams new text deltas into progressObs after reconnection', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const sessionUri = AgentSession.uri('copilot', 'reconnect-stream');
@@ -1666,9 +1699,9 @@ suite('AgentHostChatContribution', () => {
 			const lastMarkdown = [...progress].reverse().find(p => p.kind === 'markdownContent') as IChatMarkdownContent;
 			assert.ok(lastMarkdown, 'Should have a new markdown delta');
 			assert.strictEqual(lastMarkdown.content.value, ' and more');
-		});
+		}));
 
-		test('marks session complete when turn finishes', async () => {
+		test('marks session complete when turn finishes', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const sessionUri = AgentSession.uri('copilot', 'reconnect-complete');
@@ -1690,7 +1723,7 @@ suite('AgentHostChatContribution', () => {
 			await timeout(10);
 
 			assert.strictEqual(session.isCompleteObs?.get(), true, 'Should be complete after turnComplete');
-		});
+		}));
 
 		test('handles active turn with running tool call', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
@@ -1720,7 +1753,7 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(toolInvocation!.toolCallId, 'tc-running');
 		});
 
-		test('handles active turn with pending tool confirmation', async () => {
+		test('handles active turn with pending tool confirmation', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const sessionUri = AgentSession.uri('copilot', 'reconnect-perm');
@@ -1755,7 +1788,7 @@ suite('AgentHostChatContribution', () => {
 				origin: undefined,
 			});
 			await timeout(10);
-		});
+		}));
 
 		test('no active turn loads completed history only with isComplete true', async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
@@ -1808,7 +1841,7 @@ suite('AgentHostChatContribution', () => {
 
 	suite('server-initiated turns', () => {
 
-		test('detects server-initiated turn and fires onDidStartServerRequest', async () => {
+		test('detects server-initiated turn and fires onDidStartServerRequest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			// Create and subscribe a session
@@ -1854,9 +1887,9 @@ suite('AgentHostChatContribution', () => {
 
 			// isCompleteObs should be false (turn in progress)
 			assert.strictEqual(chatSession.isCompleteObs!.get(), false);
-		});
+		}));
 
-		test('server-initiated turn streams progress through progressObs', async () => {
+		test('server-initiated turn streams progress through progressObs', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-progress' });
@@ -1909,9 +1942,9 @@ suite('AgentHostChatContribution', () => {
 			await timeout(10);
 
 			assert.strictEqual(chatSession.isCompleteObs!.get(), true);
-		});
+		}));
 
-		test('client-dispatched turns are not treated as server-initiated', async () => {
+		test('client-dispatched turns are not treated as server-initiated', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-no-dupe' });
@@ -1934,6 +1967,121 @@ suite('AgentHostChatContribution', () => {
 			await turnPromise;
 
 			assert.strictEqual(serverRequestEvents.length, 0, 'Client-dispatched turns should not trigger onDidStartServerRequest');
-		});
+		}));
+
+		test('server-initiated turn does not duplicate tool calls on repeated state changes', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-tool-dedup' });
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			// First, do a normal turn so the backend session is created
+			const turn1Promise = chatSession.requestHandler!(
+				makeRequest({ message: 'Init', sessionResource }),
+				() => { }, [], CancellationToken.None,
+			);
+			await timeout(10);
+			const dispatch1 = agentHostService.dispatchedActions[0];
+			const action1 = dispatch1.action as ITurnStartedAction;
+			const session = action1.session;
+			agentHostService.fireAction({ action: dispatch1.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch1.clientSeq } });
+			agentHostService.fireAction({ action: { type: 'session/turnComplete', session, turnId: action1.turnId } as ISessionAction, serverSeq: 2, origin: undefined });
+			await turn1Promise;
+
+			// Server-initiated turn
+			const serverTurnId = 'server-turn-tool-dedup';
+			agentHostService.fireAction({
+				action: { type: 'session/turnStarted', session, turnId: serverTurnId, userMessage: { text: 'queued' } } as ISessionAction,
+				serverSeq: 3, origin: undefined,
+			});
+			await timeout(10);
+
+			// Tool start + ready (auto-confirmed)
+			agentHostService.fireAction({
+				action: { type: 'session/toolCallStart', session, turnId: serverTurnId, toolCallId: 'tc-srv-1', toolName: 'bash', displayName: 'Bash' } as ISessionAction,
+				serverSeq: 4, origin: undefined,
+			});
+			agentHostService.fireAction({
+				action: { type: 'session/toolCallReady', session, turnId: serverTurnId, toolCallId: 'tc-srv-1', invocationMessage: 'Running Bash', confirmed: 'not-needed' } as ISessionAction,
+				serverSeq: 5, origin: undefined,
+			});
+			await timeout(50);
+
+			// Tool complete
+			agentHostService.fireAction({
+				action: { type: 'session/toolCallComplete', session, turnId: serverTurnId, toolCallId: 'tc-srv-1', result: { success: true, pastTenseMessage: 'Ran Bash' } } as ISessionAction,
+				serverSeq: 6, origin: undefined,
+			});
+			await timeout(50);
+
+			// Fire additional state changes that might cause re-processing
+			agentHostService.fireAction({
+				action: { type: 'session/responsePart', session, turnId: serverTurnId, part: { kind: 'markdown', id: 'md-after', content: 'Done.' } } as ISessionAction,
+				serverSeq: 7, origin: undefined,
+			});
+			agentHostService.fireAction({
+				action: { type: 'session/turnComplete', session, turnId: serverTurnId } as ISessionAction,
+				serverSeq: 8, origin: undefined,
+			});
+			await timeout(50);
+
+			// Count tool invocations in progressObs — should be exactly 1
+			const progress = chatSession.progressObs!.get();
+			const toolInvocations = progress.filter(p => p.kind === 'toolInvocation');
+			assert.strictEqual(toolInvocations.length, 1, 'Tool call should not be duplicated');
+		}));
+
+		test('server-initiated turn picks up markdown arriving with turnStarted', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const { sessionHandler, agentHostService } = createContribution(disposables);
+
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-md-initial' });
+			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
+			disposables.add(toDisposable(() => chatSession.dispose()));
+
+			// First, do a normal turn so the backend session is created
+			const turn1Promise = chatSession.requestHandler!(
+				makeRequest({ message: 'Init', sessionResource }),
+				() => { }, [], CancellationToken.None,
+			);
+			await timeout(10);
+			const dispatch1 = agentHostService.dispatchedActions[0];
+			const action1 = dispatch1.action as ITurnStartedAction;
+			const session = action1.session;
+			agentHostService.fireAction({ action: dispatch1.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch1.clientSeq } });
+			agentHostService.fireAction({ action: { type: 'session/turnComplete', session, turnId: action1.turnId } as ISessionAction, serverSeq: 2, origin: undefined });
+			await turn1Promise;
+
+			// Fire turnStarted followed immediately by a response part.
+			// In production, these can arrive in rapid succession from the
+			// WebSocket, and the immediate reconciliation in
+			// _trackServerTurnProgress ensures content already in the state
+			// is not missed.
+			const serverTurnId = 'server-turn-md-initial';
+			agentHostService.fireAction({
+				action: { type: 'session/turnStarted', session, turnId: serverTurnId, userMessage: { text: 'queued' } } as ISessionAction,
+				serverSeq: 3, origin: undefined,
+			});
+			agentHostService.fireAction({
+				action: { type: 'session/responsePart', session, turnId: serverTurnId, part: { kind: 'markdown', id: 'md-init', content: 'Initial text' } } as ISessionAction,
+				serverSeq: 4, origin: undefined,
+			});
+			await timeout(50);
+
+			// The markdown should appear in progressObs
+			const progress = chatSession.progressObs!.get();
+			const markdownParts = progress.filter((p): p is IChatMarkdownContent => p.kind === 'markdownContent');
+			const totalContent = markdownParts.map(p => p.content.value).join('');
+			assert.strictEqual(totalContent, 'Initial text', 'Markdown arriving with/right after turnStarted should be picked up');
+
+			// Complete the turn
+			agentHostService.fireAction({
+				action: { type: 'session/turnComplete', session, turnId: serverTurnId } as ISessionAction,
+				serverSeq: 5, origin: undefined,
+			});
+			await timeout(10);
+
+			assert.strictEqual(chatSession.isCompleteObs!.get(), true);
+		}));
 	});
 });


### PR DESCRIPTION
Fixes several issues with remote agent host sessions in the Sessions app:

## Missing markdown in chat responses

The `AgentEventMapper` was dropping `message` events from the Copilot SDK (returning `undefined`). When the model produces text after tool calls complete, the text arrives in the `message` event — not via incremental `delta` events. The mapper now creates a `session/responsePart` action for `message` events when no preceding deltas captured the text.

## Tool call confirmation flickering

Tool confirmations would briefly flash and then get auto-dismissed. This happened because repeated `onDidChangeSessionState` events (from optimistic state recomputation) re-entered the `PendingConfirmation` branch, calling `didExecuteTool(undefined)` on the existing invocation (dismissing it) and creating a new one. Added a guard: only treat `PendingConfirmation` as a re-confirmation transition when the existing invocation is NOT already in `WaitingForConfirmation` state.

## Tool call duplication in server-initiated turns

In `_trackServerTurnProgress` and `_reconnectToActiveTurn`, completed/cancelled tool calls were deleted from the `activeToolInvocations` map. On subsequent state change events, the same tool call would be seen as "new" and duplicated in the progress array. Fixed by keeping finalized tool calls in the map (consistent with `_handleTurn`). Also added an `isComplete` guard in `finish()` to avoid overwriting finalized tool call state.

## Session disappearing from list after first message

`RemoteAgentHostSessionsProvider.sendRequest` cleared `_currentNewSession` immediately after the chat service accepted the request, then waited for the backend session. This caused the session to vanish from the list during the first turn. Fixed by:
- Adding `_pendingSession` tracking separate from the server-backed cache
- Adding `onDidReplaceSession` event for atomic temp→committed session transition
- Using `raceTimeout` for bounded waits with proper cleanup

## Test improvements

- Wrapped all tests using real timeouts with `runWithFakedTimers`
- Added tests for tool call dedup, markdown arrival, message event handling, and working directory passthrough

(Written by Copilot)