### PR TITLE
feat: add Insert Link to Header in File command for markdown

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -189,6 +189,12 @@
         "title": "%markdown.editor.insertImageFromWorkspace%",
         "category": "Markdown",
         "enablement": "editorLangId =~ /^(markdown|prompt|instructions|chatagent|skill)$/ && !activeEditorIsReadonly"
+      },
+      {
+        "command": "markdown.editor.insertHeaderLink",
+        "title": "%markdown.editor.insertHeaderLink%",
+        "category": "Markdown",
+        "enablement": "editorLangId =~ /^(markdown|prompt|instructions|chatagent|skill)$/ && !activeEditorIsReadonly"
       }
     ],
     "menus": {

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -27,6 +27,7 @@
 	"markdown.findAllFileReferences": "Find File References",
 	"markdown.editor.insertLinkFromWorkspace": "Insert Link to File in Workspace",
 	"markdown.editor.insertImageFromWorkspace": "Insert Image from Workspace",
+	"markdown.editor.insertHeaderLink": "Insert Link to Header in File",
 	"configuration.markdown.preview.openMarkdownLinks.description": "Controls how links to other Markdown files in the Markdown preview should be opened.",
 	"configuration.markdown.preview.openMarkdownLinks.inEditor": "Try to open links in the editor.",
 	"configuration.markdown.preview.openMarkdownLinks.inPreview": "Try to open links in the Markdown preview.",

--- a/extensions/markdown-language-features/src/commands/index.ts
+++ b/extensions/markdown-language-features/src/commands/index.ts
@@ -9,7 +9,7 @@ import { MarkdownItEngine } from '../markdownEngine';
 import { MarkdownPreviewManager } from '../preview/previewManager';
 import { ContentSecurityPolicyArbiter, PreviewSecuritySelector } from '../preview/security';
 import { TelemetryReporter } from '../telemetryReporter';
-import { InsertLinkFromWorkspace, InsertImageFromWorkspace } from './insertResource';
+import { InsertLinkFromWorkspace, InsertImageFromWorkspace, InsertHeaderLink } from './insertResource';
 import { RefreshPreviewCommand } from './refreshPreview';
 import { ReloadPlugins } from './reloadPlugins';
 import { RenderDocument } from './renderDocument';
@@ -42,6 +42,7 @@ export function registerMarkdownCommands(
 	commandManager.register(new ReloadPlugins(previewManager, engine));
 	commandManager.register(new InsertLinkFromWorkspace());
 	commandManager.register(new InsertImageFromWorkspace());
+	commandManager.register(new InsertHeaderLink(engine.slugifier));
 
 	return commandManager;
 }

--- a/extensions/markdown-language-features/src/commands/insertResource.ts
+++ b/extensions/markdown-language-features/src/commands/insertResource.ts
@@ -94,6 +94,7 @@ export class InsertHeaderLink implements Command {
 		const headers = this.#flattenHeaders(symbols);
 
 		if (!headers.length) {
+			vscode.window.showInformationMessage(vscode.l10n.t("No headers found in this document."));
 			return;
 		}
 
@@ -133,7 +134,9 @@ export class InsertHeaderLink implements Command {
 	#flattenHeaders(symbols: vscode.DocumentSymbol[]): { name: string }[] {
 		const result: { name: string }[] = [];
 		for (const symbol of symbols) {
-			result.push({ name: symbol.name });
+			if (symbol.kind === vscode.SymbolKind.String) {
+				result.push({ name: symbol.name });
+			}
 			if (symbol.children.length) {
 				result.push(...this.#flattenHeaders(symbol.children));
 			}

--- a/extensions/markdown-language-features/src/commands/insertResource.ts
+++ b/extensions/markdown-language-features/src/commands/insertResource.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { Command } from '../commandManager';
 import { createUriListSnippet, linkEditKind } from '../languageFeatures/copyFiles/shared';
+import { ISlugifier } from '../slugify';
 import { mediaFileExtensions } from '../util/mimes';
 import { coalesce } from '../util/arrays';
 import { getParentDocumentUri } from '../util/document';
@@ -63,6 +64,81 @@ export class InsertImageFromWorkspace implements Command {
 		}
 
 		return insertLink(activeEditor, resources, true);
+	}
+}
+
+export class InsertHeaderLink implements Command {
+	public readonly id = 'markdown.editor.insertHeaderLink';
+
+	readonly #slugifier: ISlugifier;
+
+	constructor(slugifier: ISlugifier) {
+		this.#slugifier = slugifier;
+	}
+
+	public async execute() {
+		const activeEditor = vscode.window.activeTextEditor;
+		if (!activeEditor) {
+			return;
+		}
+
+		const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+			'vscode.executeDocumentSymbolProvider',
+			activeEditor.document.uri
+		);
+
+		if (!symbols?.length) {
+			return;
+		}
+
+		const headers = this.#flattenHeaders(symbols);
+
+		if (!headers.length) {
+			return;
+		}
+
+		const slugBuilder = this.#slugifier.createBuilder();
+
+		const items: vscode.QuickPickItem[] = headers.map(header => {
+			const slug = slugBuilder.add(header.name);
+			return {
+				label: header.name,
+				description: slug.value,
+			};
+		});
+
+		const picked = await vscode.window.showQuickPick(items, {
+			placeHolder: vscode.l10n.t("Select a header to link to"),
+		});
+
+		if (!picked) {
+			return;
+		}
+
+		const slug = picked.description!;
+		const selectionText = activeEditor.document.getText(activeEditor.selection);
+		const linkText = selectionText || picked.label;
+		const snippet = new vscode.SnippetString();
+		snippet.appendText('[');
+		if (selectionText) {
+			snippet.appendText(linkText);
+		} else {
+			snippet.appendPlaceholder(linkText);
+		}
+		snippet.appendText('](#' + slug + ')');
+
+		await activeEditor.insertSnippet(snippet);
+	}
+
+	#flattenHeaders(symbols: vscode.DocumentSymbol[]): { name: string }[] {
+		const result: { name: string }[] = [];
+		for (const symbol of symbols) {
+			result.push({ name: symbol.name });
+			if (symbol.children.length) {
+				result.push(...this.#flattenHeaders(symbol.children));
+			}
+		}
+		return result;
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature — adds a new command to the markdown-language-features extension.

## What is the current behavior?

When writing markdown links to headers (e.g., `[text](#header-name)`), users must type the slugified header name with dashes instead of spaces in the suggest widget. There is no way to search for headers using their natural text with spaces.

Closes #174999

## What is the new behavior?

Adds a new **Markdown: Insert Link to Header in File** command (`markdown.editor.insertHeaderLink`) that:

1. Retrieves all headers from the current document via `vscode.executeDocumentSymbolProvider`
2. Shows a quick pick with all headers listed by their natural text (e.g., "A header with spaces in the title")
3. Displays the corresponding slug in the description (e.g., `a-header-with-spaces-in-the-title`)
4. Uses VS Code's fuzzy matching so users can search by natural text with spaces
5. Inserts a properly formatted markdown link `[Header Text](#slug)` at the cursor position
6. If text is selected, uses the selection as the link text instead

This follows the approach suggested by @mjbvz in the issue: a dedicated command with a quick pick UI, similar to how `Markdown: Insert Link to File in Workspace` works.

### Implementation details

- New `InsertHeaderLink` class in `insertResource.ts`, following the same `Command` pattern as `InsertLinkFromWorkspace` and `InsertImageFromWorkspace`
- Uses the existing `ISlugifier` (GitHub-compatible) to generate correct slugs, including handling of duplicate headers
- Recursively flattens nested `DocumentSymbol` hierarchy to collect all headers
- Inserts via `SnippetString` with a placeholder for the link text when no text is selected

## Additional context

The command is available in the Command Palette as "Markdown: Insert Link to Header in File" whenever a markdown file is active in the editor.