### PR TITLE
fix: improve test coverage filter quickpick readability

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -928,7 +928,7 @@ registerAction2(class FilterCoverageToTestInEditor extends Action2 {
 		const result = coverage.fromResult;
 		const previousSelection = testCoverageService.filterToTest.get();
 
-		type TItem = { label: string; testId: TestId | undefined; buttons?: IQuickInputButton[] };
+		type TItem = { label: string; description?: string; testId: TestId | undefined; buttons?: IQuickInputButton[] };
 
 		const buttons: IQuickInputButton[] = [{
 			iconClass: 'codicon-go-to-file',
@@ -937,7 +937,7 @@ registerAction2(class FilterCoverageToTestInEditor extends Action2 {
 		const items: QuickPickInput<TItem>[] = [
 			{ label: coverUtils.labels.allTests, testId: undefined },
 			{ type: 'separator' },
-			...tests.map(id => ({ label: coverUtils.getLabelForItem(result, id, commonPrefix), testId: id, buttons })),
+			...tests.map(id => ({ ...coverUtils.getLabelForItem(result, id, commonPrefix), testId: id, buttons })),
 		];
 
 		// These handle the behavior that reveals the start of coverage when the

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDisplayUtils.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDisplayUtils.ts
@@ -67,7 +67,7 @@ export const calculateDisplayedStat = (coverage: CoverageBarSource, method: Test
 	}
 };
 
-export function getLabelForItem(result: LiveTestResult, testId: TestId, commonPrefixLen: number) {
+export function getLabelForItem(result: LiveTestResult, testId: TestId, commonPrefixLen: number): { label: string; description?: string } {
 	const parts: string[] = [];
 	for (const id of testId.idsFromRoot()) {
 		const item = result.getTestById(id.toString());
@@ -78,13 +78,21 @@ export function getLabelForItem(result: LiveTestResult, testId: TestId, commonPr
 		parts.push(item.label);
 	}
 
-	return parts.slice(commonPrefixLen).join(' \u203a ');
+	const relevant = parts.slice(commonPrefixLen);
+	if (relevant.length <= 1) {
+		return { label: relevant[0] ?? '' };
+	}
+
+	return {
+		label: relevant[relevant.length - 1],
+		description: relevant.slice(0, -1).join(' › '),
+	};
 }
 
 export namespace labels {
 	export const showingFilterFor = (label: string) => localize('testing.coverageForTest', "Showing \"{0}\"", label);
 	export const clickToChangeFiltering = localize('changePerTestFilter', 'Click to view coverage for a single test');
 	export const percentCoverage = (percent: number, precision?: number) => localize('testing.percentCoverage', '{0} Coverage', displayPercent(percent, precision));
-	export const allTests = localize('testing.allTests', 'All tests');
+	export const allTests = localize('testing.allTests', 'Entire run');
 	export const pickShowCoverage = localize('testing.pickTest', 'Pick a test to show coverage for');
 }

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDisplayUtils.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDisplayUtils.ts
@@ -85,7 +85,7 @@ export function getLabelForItem(result: LiveTestResult, testId: TestId, commonPr
 
 	return {
 		label: relevant[relevant.length - 1],
-		description: relevant.slice(0, -1).join(' › '),
+		description: relevant.slice(0, -1).join(' \u203A '),
 	};
 }
 

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -741,12 +741,12 @@ registerAction2(class TestCoverageChangePerTestFilterAction extends Action2 {
 		const previousSelection = coverageService.filterToTest.get();
 		const previousSelectionStr = previousSelection?.toString();
 
-		type TItem = { label: string; testId?: TestId };
+		type TItem = { label: string; description?: string; testId?: TestId };
 
 		const items: QuickPickInput<TItem>[] = [
 			{ label: coverUtils.labels.allTests, id: undefined },
 			{ type: 'separator' },
-			...tests.map(testId => ({ label: coverUtils.getLabelForItem(result, testId, commonPrefix), testId })),
+			...tests.map(testId => ({ ...coverUtils.getLabelForItem(result, testId, commonPrefix), testId })),
 		];
 
 		quickInputService.pick(items, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Polish / Bug fix

## What is the current behavior?

The test coverage filter quickpick (used to filter coverage to a specific test) displays test items with the full ancestry chain as a flat string in the label field:

```
Suite › Subsuite › TestName
```

This makes it hard to scan when there are many tests with long ancestry paths. Additionally, the "All tests" option is confusing because it includes code executed during global initialization (e.g. comments, setup code), not just test functions.

Closes #229920
Closes #235347

## What is the new behavior?

1. **Test name first, ancestry as description**: The quickpick now shows the test name as the primary `label` and the ancestor chain as the `description`, matching the convention used by the file picker:

   ```
   TestName    Suite › Subsuite
   ```

   This makes it much easier to scan for specific tests.

2. **Rename "All tests" to "Entire run"**: As suggested by @connor4312 in #235347, this clarifies that the unfiltered view includes all code executed during the run (including global initialization), not just test function bodies.

## Additional context

Both changes apply to the two places where the coverage filter quickpick is shown:
- `FilterCoverageToTestInEditor` (editor title bar filter)
- `TestCoverageChangePerTestFilterAction` (coverage view toolbar filter)

The `getLabelForItem` function now returns `{ label, description? }` instead of a flat string, and callers spread the result into quickpick items.