### PR TITLE
fix: exclude extension-owned terminals from confirmOnExit dialog

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -100,6 +100,10 @@ export class TerminalService extends Disposable implements ITerminalService {
 	get foregroundInstances(): ITerminalInstance[] {
 		return this._terminalGroupService.instances.concat(this._terminalEditorService.instances);
 	}
+	/** Gets all non-background terminals that were not created by extensions. */
+	private get _userCreatedForegroundInstances(): ITerminalInstance[] {
+		return this.foregroundInstances.filter(e => !e.shellLaunchConfig.isExtensionOwnedTerminal);
+	}
 	get detachedInstances(): Iterable<IDetachedTerminalInstance> {
 		return this._detachedXterms;
 	}
@@ -652,7 +656,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			const shouldPersistProcesses = this._terminalConfigurationService.config.enablePersistentSessions && reason === ShutdownReason.RELOAD;
 			if (!shouldPersistProcesses) {
 				const hasDirtyInstances = (
-					(this._terminalConfigurationService.config.confirmOnExit === 'always' && this.foregroundInstances.length > 0) ||
+					(this._terminalConfigurationService.config.confirmOnExit === 'always' && this._userCreatedForegroundInstances.length > 0) ||
 					(this._terminalConfigurationService.config.confirmOnExit === 'hasChildProcesses' && this.foregroundInstances.some(e => e.hasChildProcesses))
 				);
 				if (hasDirtyInstances) {
@@ -932,7 +936,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	protected async _showTerminalCloseConfirmation(singleTerminal?: boolean): Promise<boolean> {
 		let message: string;
-		const foregroundInstances = this.foregroundInstances;
+		const foregroundInstances = this._userCreatedForegroundInstances;
 		if (foregroundInstances.length === 1 || singleTerminal) {
 			message = nls.localize('terminalService.terminalCloseConfirmationSingular', "Do you want to terminate the active terminal session?");
 		} else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `terminal.integrated.confirmOnExit` is set to `always`, the "Do you want to terminate the active terminal session?" dialog appears even when only extension-created terminals exist (e.g. Python/Jedi language server terminals). These terminals are visible in the terminal panel but were not created by the user, so the confirmation is unexpected and disruptive.

Previous fix in #240074 excluded `hideFromUser` background terminals by switching from `instances` to `foregroundInstances`. However, some extensions create terminals without `hideFromUser` that still appear as foreground instances. The confirmation dialog still fires for these.

Closes #235575

## What is the new behavior?

For `confirmOnExit === 'always'`, the check now filters out terminals where `shellLaunchConfig.isExtensionOwnedTerminal` is `true`. This excludes terminals created via the extension API (e.g. `vscode.window.createTerminal()`) from triggering the close confirmation.

The `hasChildProcesses` mode continues to check ALL foreground terminals since running child processes are always noteworthy regardless of who created the terminal.

The confirmation message count also uses the filtered list so it accurately reflects only user-created terminals.

### Changes

- Added private `_userCreatedForegroundInstances` getter that filters `foregroundInstances` by `!isExtensionOwnedTerminal`
- Updated `confirmOnExit === 'always'` check in `_onBeforeShutdown` to use the new getter
- Updated `_showTerminalCloseConfirmation` message count to use the new getter

## Additional context

The `isExtensionOwnedTerminal` flag is already set on all terminals created via the extension API (`extHostTerminalService.ts` line 193) and is used elsewhere in the codebase (e.g. to prevent auto-relaunch of extension terminals in `terminalInstance.ts`).