### PR TITLE
fix: preserve 'Wait for Breakpoint' selection when reopening breakpoint widget

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -277,6 +277,9 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 		const breakpointOptions = this.buildBreakpointOptions();
 
 		const index = this.availableBreakpoints.findIndex((bp) => this.breakpoint?.triggeredBy === bp.getId());
+		if (index !== -1) {
+			this.triggeredByBreakpointInput = this.availableBreakpoints[index];
+		}
 
 		const selectBreakpointBox = this.selectBreakpointBox = this.store.add(new SelectBox(breakpointOptions, index + 1, this.contextViewService, defaultSelectBoxStyles, { ariaLabel: nls.localize('selectBreakpoint', 'Select breakpoint'), useCustomDrawn: !hasNativeContextMenu(this._configurationService) }));
 		this.store.add(selectBreakpointBox.onDidSelect(e => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When editing a breakpoint that already has a "Wait for Breakpoint" trigger configured, reopening the breakpoint widget and clicking OK (without changing the selection) clears the trigger. The select box visually displays the correct trigger breakpoint, but the underlying `triggeredByBreakpointInput` field is never initialized from the existing breakpoint's `triggeredBy` value. Since it remains `undefined`, saving writes `undefined` back, erasing the configuration.

Closes #305887

## What is the new behavior?

When `createTriggerBreakpointInput` builds the select box, it now initializes `triggeredByBreakpointInput` from the existing breakpoint's `triggeredBy` value (when one exists). This ensures that clicking OK without changing the selection preserves the existing trigger breakpoint configuration.

## Additional context

The fix mirrors how the `onDidSelect` handler already sets `triggeredByBreakpointInput` from the available breakpoints array — it simply does the same initialization at widget creation time using the index that was already being computed for the select box.