### PR TITLE
fix: preserve line insertion behavior when paste providers handle full-line paste

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -327,6 +327,13 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return;
 		}
 
+		// When the copy was from an empty selection (full line copy), adjust the paste
+		// ranges to the beginning of each line. This mirrors the default paste behavior
+		// which inserts the line above the current line instead of at the cursor column.
+		if (metadata?.defaultPastePayload.pasteOnNewLine && selections.every(s => s.isEmpty())) {
+			selections = selections.map(s => Selection.fromPositions({ lineNumber: s.startLineNumber, column: 1 }));
+		}
+
 		const editorStateCts = new EditorStateCancellationTokenSource(editor, CodeEditorStateFlag.Value | CodeEditorStateFlag.Selection, undefined);
 
 		const p = createCancelablePromise(async (pToken) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When copying a full line (empty selection, `Ctrl+C`) that contains an importable symbol and pasting it into another file (`Ctrl+V`, also with empty selection), the text is inserted at the cursor column instead of at the beginning of the line. This happens because paste providers like TypeScript's "paste with imports" intercept the paste and apply edits at the cursor position, ignoring the `pasteOnNewLine` metadata.

The default paste handler correctly uses `pasteOnNewLine` to insert the line at column 1 (inserting above the current line), but the `CopyPasteController`'s provider code path passes the original cursor position to providers without this adjustment.

Closes #236799

## What is the new behavior?

When `metadata.defaultPastePayload.pasteOnNewLine` is true and all selections are empty (matching the conditions in the default paste handler), the selections are adjusted to column 1 before being passed to paste providers. This ensures that:

1. Providers receive the correct paste location (beginning of line)
2. `createCombinedWorkspaceEdit` applies the insert text at the right position
3. The TypeScript server computes additional edits (import additions) relative to the correct insertion point

The fix is a 7-line addition in `CopyPasteController.doPasteInline()`, applied before any provider interaction.

## Additional context

The root cause is in `src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts`. The default paste handler in `cursorTypeEditOperations.ts` (`PasteOperation._simplePaste`) has always handled `pasteOnNewLine` correctly by adjusting the range to `(lineNumber, 1, lineNumber, 1)`. But when `CopyPasteController` calls `e.setHandled()` to intercept the paste for providers, this adjustment was never applied to the selections passed downstream.