### PR TITLE
feat: add setting to preserve default values in settings file

### DIFF
--- a/src/vs/platform/configuration/common/configurationService.ts
+++ b/src/vs/platform/configuration/common/configurationService.ts
@@ -125,7 +125,7 @@ export class ConfigurationService extends Disposable implements IConfigurationSe
 		}
 
 		// Remove the setting, if the value is same as default value
-		if (equals(value, inspect.defaultValue)) {
+		if (equals(value, inspect.defaultValue) && !this.getValue<boolean>('workbench.settings.preserveDefaultValues')) {
 			value = undefined;
 		}
 

--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -151,7 +151,7 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 		}
 
 		// Remove the setting, if the value is same as default value
-		if (equals(value, inspect.defaultValue)) {
+		if (equals(value, inspect.defaultValue) && !this.getValue<boolean>('workbench.settings.preserveDefaultValues')) {
 			value = undefined;
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1216,7 +1216,7 @@ export class SettingsEditor2 extends EditorPane {
 
 		// If the user is changing the value back to the default, and we're not targeting a workspace scope, do a 'reset' instead
 		const inspected = this.configurationService.inspect(key, overrides);
-		if (!userPassedInManualReset && inspected.defaultValue === value) {
+		if (!userPassedInManualReset && inspected.defaultValue === value && !this.configurationService.getValue<boolean>('workbench.settings.preserveDefaultValues')) {
 			value = undefined;
 		}
 

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -124,6 +124,7 @@ export const LLM_RANKED_SEARCH_PROVIDER_NAME = 'llmRanked';
 export enum WorkbenchSettingsEditorSettings {
 	ShowAISearchToggle = 'workbench.settings.showAISearchToggle',
 	EnableNaturalLanguageSearch = 'workbench.settings.enableNaturalLanguageSearch',
+	PreserveDefaultValues = 'workbench.settings.preserveDefaultValues',
 }
 
 export type ExtensionToggleData = {

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -115,6 +115,12 @@ registry.registerConfiguration({
 			'scope': ConfigurationScope.WINDOW,
 			'tags': ['usesOnlineServices']
 		},
+		'workbench.settings.preserveDefaultValues': {
+			'type': 'boolean',
+			'description': nls.localize('preserveDefaultValues', "Controls whether settings that are set to their default value are preserved in the settings file. When enabled, changing a setting to its default value will keep the entry in the settings file instead of removing it."),
+			'default': false,
+			'scope': ConfigurationScope.WINDOW
+		},
 		'workbench.settings.settingsSearchTocBehavior': {
 			'type': 'string',
 			'enum': ['hide', 'filter'],

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -360,7 +360,9 @@ export class WorkspaceService extends Disposable implements IWorkbenchConfigurat
 
 			// Remove the setting, if the value is same as default value and is updated only in user target
 			if (equals(value, inspect.defaultValue) && targets.length === 1 && (targets[0] === ConfigurationTarget.USER || targets[0] === ConfigurationTarget.USER_LOCAL)) {
-				value = undefined;
+				if (!this.getValue<boolean>('workbench.settings.preserveDefaultValues')) {
+					value = undefined;
+				}
 			}
 		}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (new setting)

## What is the current behavior?

When a setting is changed to its default value (e.g., setting `window.zoomLevel` back to `0`), VS Code automatically removes that setting from `settings.json`. This has two undesirable side effects:

1. **Comments above the removed setting are also deleted** — the JSON edit that removes the setting line can eat adjacent comment lines
2. **Manually organized settings lose their position** — toggling a boolean setting (like `diffEditor.hideUnchangedRegions.enabled`) to `false` removes it, and re-enabling it later appends it to the bottom of the file

Closes #275792

## What is the new behavior?

Adds a new setting `workbench.settings.preserveDefaultValues` (default: `false`) that, when enabled, preserves settings in `settings.json` even when their value matches the default. This prevents:
- Loss of adjacent comments when a setting resets to default
- Disruption of manually organized settings files
- Settings jumping to the bottom of the file after being toggled

The behavior is gated behind a new opt-in boolean setting so existing users are unaffected. The "Reset Setting" context menu action still removes settings as before (it explicitly passes `undefined`).

### Changes

- **`src/vs/workbench/contrib/preferences/common/preferences.ts`** — Added `PreserveDefaultValues` enum member
- **`src/vs/workbench/contrib/preferences/common/preferencesContribution.ts`** — Registered the new `workbench.settings.preserveDefaultValues` boolean setting
- **`src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts`** — Gated the settings editor's default-value-to-undefined conversion with the new setting
- **`src/vs/workbench/services/configuration/browser/configurationService.ts`** — Gated the workbench configuration service's default-value removal with the new setting
- **`src/vs/platform/configuration/common/configurationService.ts`** — Gated the standalone configuration service's default-value removal with the new setting
- **`src/vs/sessions/services/configuration/browser/configurationService.ts`** — Gated the sessions configuration service's default-value removal with the new setting

## Additional context

The maintainer @rzhao271 suggested this approach in the issue: "I believe that adding a setting that causes resets to not clear the setting from the file would help those who are manually organizing their settings.json." This was also supported by the merged duplicate issue #306241.