### PR TITLE
Fix: Dummy TextReplacement When Inline Edit Diff Is Empty

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineSuggestionItem.ts
@@ -416,7 +416,7 @@ export class InlineEditItem extends InlineSuggestionItemBase {
 		if (data.action?.kind === 'edit') {
 			const offsetEdit = shouldDiffEdit ? getDiffedStringEdit(textModel, data.action.range, data.action.insertText) : getStringEdit(textModel, data.action.range, data.action.insertText); // TODO compute async
 			const textEdit = TextEdit.fromStringEdit(offsetEdit, textModel);
-			const singleTextEdit = offsetEdit.isEmpty() ? new TextReplacement(new Range(1, 1, 1, 1), '') : textEdit.toReplacement(textModel); // FIXME: .toReplacement() can throw because offsetEdit is empty because we get an empty diff in getStringEdit after diffing
+			const singleTextEdit = offsetEdit.isEmpty() ? new TextReplacement(Range.fromPositions(data.action.range.getStartPosition()), '') : textEdit.toReplacement(textModel);
 
 			edits = offsetEdit.replacements.map(edit => {
 				const replacedRange = Range.fromPositions(textModel.getPositionAt(edit.replaceRange.start), textModel.getTransformer().getPosition(edit.replaceRange.endExclusive));


### PR DESCRIPTION
## Fix: Dummy TextReplacement when inline edit diff is empty

### Overview
This PR resolves a FIXME in `inlineSuggestionItem.ts`. Previously, when an inline edit diff evaluated to an empty result, the implementation fell back to inserting an empty string replacement bound to `new Range(1,1,1,1)`. This behavior was incorrect because it ignored the actual position of the active suggestion.

### Problem
When the diff became empty:
- A dummy replacement was created
- The replacement was always anchored at `Range(1,1,1,1)`
- This could cause incorrect positioning
- In some cases it triggered a `BugIndicatingError`

### Solution
This change replaces the dummy range with a properly calculated anchor based on the current suggestion position:

```ts
data.action.range.getStartPosition()