### PR TITLE
Fix: Throw error on model mismatch in TextModelValueReference

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/textModelValueReference.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/textModelValueReference.ts
@@ -39,8 +39,9 @@ export class TextModelValueReference extends AbstractText {
 
 	private _assertValid(): void {
 		if (this._textModel.getVersionId() !== this._version) {
-			onUnexpectedError(new Error(`TextModel has changed: expected version ${this._version}, got ${this._textModel.getVersionId()}`));
-			// TODO: throw here!
+			const error = new Error(`TextModel has changed: expected version ${this._version}, got ${this._textModel.getVersionId()}`);
+			onUnexpectedError(error);
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
Fixes #306580

### Overview
This PR resolves a `TODO` in `textModelValueReference.ts`. The class's stated purpose is to throw an error if the underlying model has mutated, ensuring cross-component data consistency. 

### Problem
The class is clearly documented with: `"Like TextModelText but throws if the underlying model has changed"`. However, the implementation inside `_assertValid()` merely triggered an `onUnexpectedError` call and left behind a `// TODO: throw here!`. Not actually throwing weakened the strict behavior rules of the class.

### Solution
This enforces the intended throw behavior to prevent silent downstream corruption and to completely fulfill the class contract:

```typescript
private _assertValid(): void {
    if (this._textModel.getVersionId() !== this._version) {
        const error = new Error(`TextModel has changed: expected version ${this._version}, got ${this._textModel.getVersionId()}`);
        onUnexpectedError(error);
        throw error;
    }
}
