### PR TITLE
Refactor button configuration and improve layout

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1000,13 +1000,7 @@ export class ChangesViewPane extends ViewPane {
 						menuOptions: sessionResource
 							? { args: [sessionResource, this.agentSessionsService.getSession(sessionResource)?.metadata] }
 							: { shouldForwardArgs: true },
-						buttonConfigProvider: (action) => {
-							if (
-								action.id === 'chatEditing.viewAllSessionChanges' ||
-								action.id === 'github.copilot.chat.openPullRequestCopilotCLIAgentSession.openPR'
-							) {
-								return { showIcon: true, showLabel: false, isSecondary: true };
-							}
+						buttonConfigProvider: (action, index) => {
 							if (action.id === 'github.copilot.chat.createPullRequestCopilotCLIAgentSession.updatePR') {
 								const customLabel = outgoingChanges > 0
 									? `${action.label} ${outgoingChanges}↑`
@@ -1023,6 +1017,12 @@ export class ChangesViewPane extends ViewPane {
 								return { showIcon: true, showLabel: false, isSecondary: true };
 							}
 							if (
+								action.id === 'chatEditing.viewAllSessionChanges' ||
+								action.id === 'github.copilot.chat.openPullRequestCopilotCLIAgentSession.openPR'
+							) {
+								return { showIcon: true, showLabel: false, isSecondary: true };
+							}
+							if (
 								action.id === 'github.copilot.chat.createPullRequestCopilotCLIAgentSession.createPR' ||
 								action.id === 'github.copilot.chat.mergeCopilotCLIAgentSessionChanges.merge' ||
 								action.id === 'github.copilot.sessions.initializeRepository' ||
@@ -1032,7 +1032,10 @@ export class ChangesViewPane extends ViewPane {
 								return { showIcon: true, showLabel: true, isSecondary: false };
 							}
 
-							return undefined;
+							// Unknown actions (e.g. extension-contributed):
+							// first action is primary, rest are icon-only secondary
+							const isSecondary = index > 0;
+							return { showIcon: true, showLabel: !isSecondary, isSecondary };
 						}
 					}
 				));

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1037,8 +1037,17 @@ export class ChangesViewPane extends ViewPane {
 								return { showIcon: true, showLabel: true, isSecondary: false };
 							}
 
-							// Unknown actions (e.g. extension-contributed): icon-only secondary
-							return { showIcon: true, showLabel: false, isSecondary: true };
+							// Unknown actions (e.g. extension-contributed): only hide the label when an icon is present.
+							if (action instanceof MenuItemAction) {
+								const icon = action.item.icon;
+								if (icon) {
+									// Icon-only button (no forced secondary state so primary/secondary can be inferred).
+									return { showIcon: true, showLabel: false };
+								}
+							}
+
+							// Fall back to default button behavior for actions without an icon.
+							return undefined;
 						}
 					}
 				));

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1022,6 +1022,9 @@ export class ChangesViewPane extends ViewPane {
 							) {
 								return { showIcon: true, showLabel: false, isSecondary: true };
 							}
+							if (action.id === 'agentFeedbackEditor.action.submitActiveSession') {
+								return { showIcon: false, showLabel: true, isSecondary: false };
+							}
 							if (
 								action.id === 'github.copilot.chat.createPullRequestCopilotCLIAgentSession.createPR' ||
 								action.id === 'github.copilot.chat.mergeCopilotCLIAgentSessionChanges.merge' ||

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -1000,7 +1000,7 @@ export class ChangesViewPane extends ViewPane {
 						menuOptions: sessionResource
 							? { args: [sessionResource, this.agentSessionsService.getSession(sessionResource)?.metadata] }
 							: { shouldForwardArgs: true },
-						buttonConfigProvider: (action, index) => {
+						buttonConfigProvider: (action) => {
 							if (action.id === 'github.copilot.chat.createPullRequestCopilotCLIAgentSession.updatePR') {
 								const customLabel = outgoingChanges > 0
 									? `${action.label} ${outgoingChanges}↑`
@@ -1025,6 +1025,8 @@ export class ChangesViewPane extends ViewPane {
 							if (
 								action.id === 'github.copilot.chat.createPullRequestCopilotCLIAgentSession.createPR' ||
 								action.id === 'github.copilot.chat.mergeCopilotCLIAgentSessionChanges.merge' ||
+								action.id === 'github.copilot.chat.checkoutPullRequestReroute' ||
+								action.id === 'pr.checkoutFromChat' ||
 								action.id === 'github.copilot.sessions.initializeRepository' ||
 								action.id === 'github.copilot.sessions.commitChanges' ||
 								action.id === 'agentSession.markAsDone'
@@ -1032,10 +1034,8 @@ export class ChangesViewPane extends ViewPane {
 								return { showIcon: true, showLabel: true, isSecondary: false };
 							}
 
-							// Unknown actions (e.g. extension-contributed):
-							// first action is primary, rest are icon-only secondary
-							const isSecondary = index > 0;
-							return { showIcon: true, showLabel: !isSecondary, isSecondary };
+							// Unknown actions (e.g. extension-contributed): icon-only secondary
+							return { showIcon: true, showLabel: false, isSecondary: true };
 						}
 					}
 				));

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -157,17 +157,32 @@
 /* Primary button grows to fill available space */
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button:not(.secondary) {
 	flex: 1;
+	min-width: 0;
+}
+
+.changes-view-body .chat-editing-session-actions.outside-card .monaco-button:not(.secondary) > span:not(.codicon) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* ButtonWithDropdown container grows to fill available space */
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button-dropdown {
 	flex: 1;
+	min-width: 0;
 	display: flex;
 }
 
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button-dropdown > .monaco-button {
 	flex: 1;
+	min-width: 0;
 	box-sizing: border-box;
+}
+
+.changes-view-body .chat-editing-session-actions.outside-card .monaco-button-dropdown > .monaco-button > span:not(.codicon) {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button-dropdown > .monaco-button-dropdown-separator {

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -149,7 +149,7 @@
 /* Larger action buttons matching SCM ActionButton style */
 .changes-view-body .chat-editing-session-actions.outside-card .monaco-button {
 	height: 26px;
-	padding: 4px 14px;
+	padding: 4px;
 	font-size: 12px;
 	line-height: 18px;
 }

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -7,7 +7,7 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: 8px;
+	padding: 4px 8px 8px 8px;
 	box-sizing: border-box;
 }
 
@@ -136,7 +136,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;
-	gap: 6px;
+	gap: 4px;
 	align-items: center;
 }
 


### PR DESCRIPTION
Refactor button configuration in the ChangesViewPane for better action handling and adjust CSS padding and gap for an improved layout.

All secondary buttons now use codicons. Only primary buttons use text label:

<img width="275" height="114" alt="image" src="https://github.com/user-attachments/assets/8004655a-e7ff-4e6e-9ae8-ab919f83d583" />

<img width="273" height="112" alt="image" src="https://github.com/user-attachments/assets/815d0987-b1ae-4729-8966-8c3625acf6b9" />

<img width="277" height="120" alt="image" src="https://github.com/user-attachments/assets/b195c026-e8e9-4ce4-b19f-f8736bfc1f8c" />

<img width="288" height="121" alt="image" src="https://github.com/user-attachments/assets/993fb57f-ec18-4a26-b894-122fea04c14a" />

Addresses:

- https://github.com/microsoft/vscode/issues/305868
- https://github.com/microsoft/vscode/issues/301483



