### PR TITLE
feat(chat): add 'model' parameter to runSubagent tool for call-time model override

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -113,14 +113,14 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				type: 'string',
 				description: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
 			};
+			inputSchema.properties.model = {
+				type: 'string',
+				description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Examples: claude-sonnet-4-6, claude-haiku-4-5, gpt-4o, gpt-4o-mini.'
+			};
 			modelDescription += `\n- If the user asks for a certain agent, you MUST provide that EXACT agent name (case-sensitive) to invoke that specific agent.`;
+			modelDescription += `\n- You may optionally specify a \`model\` to run the subagent with a specific language model. Use this when a task needs a different capability level than your current model.`;
 		}
 
-		inputSchema.properties.model = {
-			type: 'string',
-			description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Examples: claude-sonnet-4-6, claude-haiku-4-5, gpt-4o, gpt-4o-mini.'
-		};
-		modelDescription += `\n- You may optionally specify a \`model\` to run the subagent with a specific language model. Use this when a task needs a different capability level than your current model.`;
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,
 			toolReferenceName: VSCodeToolReference.runSubagent,

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -56,6 +56,7 @@ export interface IRunSubagentToolInputParams {
 	prompt: string;
 	description: string;
 	agentName?: string;
+	model?: string;
 }
 
 export const RUN_SUBAGENT_MAX_NESTING_DEPTH = 5;
@@ -114,6 +115,12 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			};
 			modelDescription += `\n- If the user asks for a certain agent, you MUST provide that EXACT agent name (case-sensitive) to invoke that specific agent.`;
 		}
+
+		inputSchema.properties.model = {
+			type: 'string',
+			description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Examples: claude-sonnet-4-6, claude-haiku-4-5, gpt-4o, gpt-4o-mini.'
+		};
+		modelDescription += `\n- You may optionally specify a \`model\` to run the subagent with a specific language model. Use this when a task needs a different capability level than your current model.`;
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,
 			toolReferenceName: VSCodeToolReference.runSubagent,
@@ -172,7 +179,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 						resolvedModelName = cached.resolvedModelName;
 					} else {
 						// Fallback: resolve the model here if prepare didn't cache it
-						const resolved = this.resolveSubagentModel(subagent, invocation.modelId);
+						const resolved = this.resolveSubagentModel(subagent, invocation.modelId, args.model);
 						modeModelId = resolved.modeModelId;
 						resolvedModelName = resolved.resolvedModelName;
 					}
@@ -207,7 +214,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				const cached = this._resolvedModels.get(invocation.callId);
 				if (cached) {
 					this._resolvedModels.delete(invocation.callId);
+					modeModelId = cached.modeModelId ?? modeModelId;
 					resolvedModelName = cached.resolvedModelName;
+				} else if (args.model) {
+					// Call-time model override without a named subagent
+					const resolved = this.resolveSubagentModel(undefined, invocation.modelId, args.model);
+					modeModelId = resolved.modeModelId;
+					resolvedModelName = resolved.resolvedModelName;
 				} else {
 					const resolvedModelMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
 					resolvedModelName = resolvedModelMetadata?.name;
@@ -393,10 +406,15 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	}
 
 	/**
-	 * Resolves the model to be used by a subagent, applying multiplier-based
-	 * fallback to avoid using a more expensive model than the main agent.
+	 * Resolves the model to be used by a subagent. Priority order:
+	 * 1. Call-time `model` parameter (highest precedence)
+	 * 2. Agent's `model:` frontmatter qualified names
+	 * 3. Parent model (default)
+	 *
+	 * After resolution, applies a multiplier-based cap to prevent subagents
+	 * from using a more expensive model than the parent agent.
 	 */
-	private resolveSubagentModel(subagent: ICustomAgent | undefined, mainModelId: string | undefined): { modeModelId: string | undefined; resolvedModelName: string | undefined } {
+	private resolveSubagentModel(subagent: ICustomAgent | undefined, mainModelId: string | undefined, callTimeModelHint?: string): { modeModelId: string | undefined; resolvedModelName: string | undefined } {
 		let modeModelId = mainModelId;
 
 		if (subagent) {
@@ -411,23 +429,52 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					}
 				}
 			}
+		}
 
-			// If the subagent's model has a larger multiplier than the main agent's model,
-			// fall back to the main agent's model to avoid using a more expensive model.
-			if (modeModelId && modeModelId !== mainModelId) {
-				const mainModelMetadata = mainModelId ? this.languageModelsService.lookupLanguageModel(mainModelId) : undefined;
-				const subagentModelMetadata = this.languageModelsService.lookupLanguageModel(modeModelId);
-				const mainMultiplier = mainModelMetadata?.multiplierNumeric;
-				const subagentMultiplier = subagentModelMetadata?.multiplierNumeric;
-				if (mainMultiplier !== undefined && subagentMultiplier !== undefined && subagentMultiplier > mainMultiplier) {
-					this.logService.warn(`[RunSubagentTool] Subagent '${subagent.name}' requested model '${subagentModelMetadata?.name}' (multiplier: ${subagentMultiplier}) which has a larger multiplier than the main agent model '${mainModelMetadata?.name}' (multiplier: ${mainMultiplier}). Falling back to the main agent model.`);
-					modeModelId = mainModelId;
-				}
+		// Call-time model override takes highest precedence
+		if (callTimeModelHint) {
+			const resolved = this.resolveModelHint(callTimeModelHint);
+			if (resolved) {
+				modeModelId = resolved;
+			} else {
+				this.logService.warn(`[RunSubagentTool] Call-time model '${callTimeModelHint}' not found in model registry. Ignoring override.`);
 			}
 		}
 
-		const resolvedModelMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
-		return { modeModelId, resolvedModelName: resolvedModelMetadata?.name };
+		// If the resolved model has a larger multiplier than the main agent's model,
+		// fall back to the main agent's model to avoid using a more expensive model.
+		if (modeModelId && modeModelId !== mainModelId) {
+			const mainModelMetadata = mainModelId ? this.languageModelsService.lookupLanguageModel(mainModelId) : undefined;
+			const resolvedModelMetadata = this.languageModelsService.lookupLanguageModel(modeModelId);
+			const mainMultiplier = mainModelMetadata?.multiplierNumeric;
+			const resolvedMultiplier = resolvedModelMetadata?.multiplierNumeric;
+			if (mainMultiplier !== undefined && resolvedMultiplier !== undefined && resolvedMultiplier > mainMultiplier) {
+				const source = callTimeModelHint ? 'Call-time' : subagent ? `Subagent '${subagent.name}'` : 'Unknown';
+				this.logService.warn(`[RunSubagentTool] ${source} requested model '${resolvedModelMetadata?.name}' (multiplier: ${resolvedMultiplier}) which exceeds the main agent model '${mainModelMetadata?.name}' (multiplier: ${mainMultiplier}). Falling back to the main agent model.`);
+				modeModelId = mainModelId;
+			}
+		}
+
+		const finalMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
+		return { modeModelId, resolvedModelName: finalMetadata?.name };
+	}
+
+	/**
+	 * Attempts to resolve a model hint string to a model identifier.
+	 * Tries qualified name lookup first, then direct model ID lookup.
+	 */
+	private resolveModelHint(modelHint: string): string | undefined {
+		// Try qualified name lookup first (e.g., "Claude Sonnet 4.6 (Copilot)")
+		const byQualifiedName = this.languageModelsService.lookupLanguageModelByQualifiedName(modelHint);
+		if (byQualifiedName?.identifier) {
+			return byQualifiedName.identifier;
+		}
+		// Try direct model ID lookup (e.g., "claude-sonnet-4-6")
+		const byId = this.languageModelsService.lookupLanguageModel(modelHint);
+		if (byId) {
+			return modelHint;
+		}
+		return undefined;
 	}
 
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
@@ -436,7 +483,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		const subagent = args.agentName ? await this.getSubAgentByName(args.agentName) : undefined;
 
 		// Resolve the model early and cache it for invoke()
-		const resolved = this.resolveSubagentModel(subagent, context.modelId);
+		const resolved = this.resolveSubagentModel(subagent, context.modelId, args.model);
 		this._resolvedModels.set(context.toolCallId, resolved);
 
 		return {

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -155,9 +155,11 @@ suite('RunSubagentTool', () => {
 
 			assert.ok(toolData.inputSchema?.properties?.agentName, 'agentName should be in schema when custom agents enabled');
 		});
-		test('includes model property in schema', () => {
+		test('includes model property in schema when custom agents enabled', () => {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService();
+			const configService = new TestConfigurationService({
+				'chat.customAgentInSubagent.enabled': true,
+			});
 			const promptsService = new MockPromptsService();
 
 			const tool = testDisposables.add(new RunSubagentTool(
@@ -175,7 +177,7 @@ suite('RunSubagentTool', () => {
 
 			const toolData = tool.getToolData();
 
-			assert.ok(toolData.inputSchema?.properties?.model, 'model should be in schema');
+			assert.ok(toolData.inputSchema?.properties?.model, 'model should be in schema when custom agents enabled');
 			assert.strictEqual(toolData.inputSchema?.properties?.model.type, 'string');
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -155,6 +155,29 @@ suite('RunSubagentTool', () => {
 
 			assert.ok(toolData.inputSchema?.properties?.agentName, 'agentName should be in schema when custom agents enabled');
 		});
+		test('includes model property in schema', () => {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService();
+			const promptsService = new MockPromptsService();
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				promptsService,
+				{} as IInstantiationService,
+				{} as IProductService,
+			));
+
+			const toolData = tool.getToolData();
+
+			assert.ok(toolData.inputSchema?.properties?.model, 'model should be in schema');
+			assert.strictEqual(toolData.inputSchema?.properties?.model.type, 'string');
+		});
 	});
 
 	suite('onDidInvokeTool event', () => {
@@ -491,6 +514,256 @@ suite('RunSubagentTool', () => {
 				agentName: 'NoModelAgent',
 				prompt: 'test',
 				modelName: 'GPT-4o',
+			});
+		});
+	});
+
+	suite('call-time model parameter', () => {
+		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
+			return {
+				extension: new ExtensionIdentifier('test.extension'),
+				name,
+				id: name.toLowerCase().replace(/\s+/g, '-'),
+				vendor: 'TestVendor',
+				version: '1.0',
+				family: 'test',
+				maxInputTokens: 128000,
+				maxOutputTokens: 8192,
+				isDefaultForLocation: {},
+				modelPickerCategory: undefined,
+				multiplierNumeric,
+			};
+		}
+
+		function createTool(opts: {
+			models: Map<string, ILanguageModelChatMetadata>;
+			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
+			customAgents?: ICustomAgent[];
+		}) {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService();
+			const promptsService = new MockPromptsService();
+			if (opts.customAgents) {
+				promptsService.setCustomModes(opts.customAgents);
+			}
+
+			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
+				lookupLanguageModel(modelId: string) {
+					return opts.models.get(modelId);
+				},
+				lookupLanguageModelByQualifiedName(qualifiedName: string) {
+					return opts.qualifiedNameMap?.get(qualifiedName);
+				},
+			};
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				mockToolsService,
+				mockLanguageModelsService as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				promptsService,
+				{} as IInstantiationService,
+				{} as IProductService,
+			));
+
+			return tool;
+		}
+
+		function createAgent(name: string, modelQualifiedNames?: string[]): ICustomAgent {
+			return {
+				uri: URI.parse(`file:///test/${name}.md`),
+				name,
+				description: `Agent ${name}`,
+				tools: ['tool1'],
+				model: modelQualifiedNames,
+				agentInstructions: { content: 'test', toolReferences: [] },
+				source: { storage: PromptsStorage.local },
+				target: Target.Undefined,
+				visibility: { userInvocable: true, agentInvocable: true }
+			};
+		}
+
+		test('overrides model via qualified name without a subagent', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const overrideMeta = createMetadata('Claude Haiku', 0.25);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['haiku-model-id', overrideMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Haiku (TestVendor)', { metadata: overrideMeta, identifier: 'haiku-model-id' }],
+			]);
+
+			const tool = createTool({ models, qualifiedNameMap });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', model: 'Claude Haiku (TestVendor)' },
+				toolCallId: 'call-model-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: undefined,
+				prompt: 'test',
+				modelName: 'Claude Haiku',
+			});
+		});
+
+		test('overrides model via direct model ID without a subagent', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const overrideMeta = createMetadata('Claude Haiku', 0.25);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['claude-haiku-4-5', overrideMeta],
+			]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', model: 'claude-haiku-4-5' },
+				toolCallId: 'call-model-2',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: undefined,
+				prompt: 'test',
+				modelName: 'Claude Haiku',
+			});
+		});
+
+		test('call-time model takes precedence over agent model frontmatter', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentMeta = createMetadata('Claude Sonnet', 1);
+			const overrideMeta = createMetadata('Claude Haiku', 0.25);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['sonnet-model-id', agentMeta],
+				['haiku-model-id', overrideMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Sonnet (TestVendor)', { metadata: agentMeta, identifier: 'sonnet-model-id' }],
+				['Claude Haiku (TestVendor)', { metadata: overrideMeta, identifier: 'haiku-model-id' }],
+			]);
+
+			const agent = createAgent('SonnetAgent', ['Claude Sonnet (TestVendor)']);
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', agentName: 'SonnetAgent', model: 'Claude Haiku (TestVendor)' },
+				toolCallId: 'call-model-3',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Call-time 'model' should override the agent's configured Claude Sonnet
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: 'SonnetAgent',
+				prompt: 'test',
+				modelName: 'Claude Haiku',
+			});
+		});
+
+		test('call-time model respects multiplier cap', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const expensiveMeta = createMetadata('O3 Pro', 50);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['expensive-model-id', expensiveMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['O3 Pro (TestVendor)', { metadata: expensiveMeta, identifier: 'expensive-model-id' }],
+			]);
+
+			const tool = createTool({ models, qualifiedNameMap });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', model: 'O3 Pro (TestVendor)' },
+				toolCallId: 'call-model-4',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Should fall back to main model due to multiplier cap
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: undefined,
+				prompt: 'test',
+				modelName: 'GPT-4o',
+			});
+		});
+
+		test('unknown call-time model falls back gracefully', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const models = new Map([['main-model-id', mainMeta]]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', model: 'nonexistent-model' },
+				toolCallId: 'call-model-5',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Should fall back to main model when the model hint is unresolvable
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: undefined,
+				prompt: 'test',
+				modelName: 'GPT-4o',
+			});
+		});
+
+		test('call-time model override with cheaper model on named agent', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentMeta = createMetadata('Claude Sonnet', 1);
+			const cheapMeta = createMetadata('GPT-4o Mini', 0.25);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['sonnet-model-id', agentMeta],
+				['mini-model-id', cheapMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Sonnet (TestVendor)', { metadata: agentMeta, identifier: 'sonnet-model-id' }],
+			]);
+
+			const agent = createAgent('SonnetAgent', ['Claude Sonnet (TestVendor)']);
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test task', agentName: 'SonnetAgent', model: 'mini-model-id' },
+				toolCallId: 'call-model-6',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Call-time model by ID should override agent config, and it's cheaper so no cap
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'test task',
+				agentName: 'SonnetAgent',
+				prompt: 'test',
+				modelName: 'GPT-4o Mini',
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Add an optional `model` parameter to the `runSubagent` built-in tool, allowing callers to specify which language model a subagent invocation should use at call time, independent of the agent's `model:` frontmatter configuration.

## Motivation

Currently, subagent model assignment is static — determined by the agent definition's `model:` frontmatter and resolved at agent load time. This works for fixed agent pipelines, but leaves orchestrator agents unable to route individual tasks to the most appropriate model based on task complexity.

**Use cases:**
- **Cost optimization**: An orchestrator routes simple lookups to a cheaper model (`claude-haiku-4-5`) and reserves the parent model for complex reasoning.
- **Capability matching**: A task requiring strong code generation gets a code-specialized model, while a summarization task gets a general-purpose one.
- **Dynamic routing**: MCP tools that surface available models (e.g., `list_language_models`) enable the LLM to make informed model selection decisions.

## Design

### Resolution Priority
The model resolution in `resolveSubagentModel()` now follows this priority order:
1. **Call-time `model` parameter** (highest precedence) — from the tool invocation
2. **Agent's `model:` frontmatter** — qualified names from `.agent.md`
3. **Parent model** (default) — inherited from the orchestrator

### Model Resolution
The new `resolveModelHint()` helper resolves a model hint string by:
1. Trying qualified name lookup via `lookupLanguageModelByQualifiedName()` (e.g., `"Claude Sonnet 4.6 (Copilot)"`)
2. Falling back to direct model ID lookup via `lookupLanguageModel()` (e.g., `"claude-sonnet-4-6"`)
3. Returning `undefined` if neither resolves, with a warn-level log

### Cost Safety
The existing multiplier-based cost cap continues to apply — the resolved model's `multiplierNumeric` must not exceed the parent agent's multiplier. This cap was moved outside the `if (subagent)` block to apply uniformly to all resolution paths.

## Changes

### `runSubagentTool.ts` (+65 lines)
- Add `model?: string` to `IRunSubagentToolInputParams`
- Add `model` to the tool's input schema in `getToolData()`
- Extract `resolveModelHint()` helper for dual-lookup model resolution
- Extend `resolveSubagentModel()` with optional `callTimeModelHint` parameter
- Move multiplier cap to apply uniformly to all resolution paths
- Update `invoke()` no-subagent branch to handle model override from cache
- Update `prepareToolInvocation()` to pass `args.model` through

### `runSubagentTool.test.ts` (+273 lines)
- Schema test: `model` property present in tool data
- 6 new tests in `call-time model parameter` suite:
  - Override via qualified name without a subagent
  - Override via direct model ID without a subagent
  - Call-time model takes precedence over agent `model:` frontmatter
  - Call-time model respects multiplier cap (falls back to parent)
  - Unknown model name falls back gracefully to parent model
  - Override with cheaper model on a named agent

## Testing

All 24 tests in the `RunSubagentTool` test suite pass, including the 7 new tests.

## Related

- Fixes #306836
- Companion to #306717 (tiered agent model routing)
