### PR TITLE
feat(chat): add tiers frontmatter and tier parameter to runSubagent tool

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptFileAttributes.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptFileAttributes.ts
@@ -120,6 +120,10 @@ export const customAgentAttributes: Record<string, IAttributeDefinition> = {
 		type: 'scalar | sequence',
 		description: localize('promptHeader.agent.model', 'Specify the model that runs this custom agent. Can also be a list of models. The first available model will be used.'),
 	},
+	[PromptHeaderAttributes.tiers]: {
+		type: 'map',
+		description: localize('promptHeader.agent.tiers', 'Declare model preferences for different capability tiers (e.g., fast, standard, deep). Each tier maps to a model name. Orchestrators choose a tier at call time.'),
+	},
 	[PromptHeaderAttributes.tools]: {
 		type: 'scalar | sequence',
 		description: localize('promptHeader.agent.tools', 'The set of tools that the custom agent has access to.'),

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -216,6 +216,7 @@ export class PromptValidator {
 				}
 				if (isVSCodeOrDefaultTarget(target)) {
 					this.validateModel(attributes, ChatModeKind.Agent, report);
+					this.validateTiers(attributes, report);
 					this.validateHandoffs(attributes, report);
 					await this.validateAgentsAttribute(attributes, header, report);
 					this.validateGithubPermissions(attributes, report);
@@ -378,6 +379,57 @@ export class PromptValidator {
 				report(toMarker(localize('promptValidator.modelNotFound', "Unknown model '{0}'.", modelName), range, MarkerSeverity.Warning));
 			} else if (agentKind === ChatModeKind.Agent && !ILanguageModelChatMetadata.suitableForAgentMode(modelMetadata)) {
 				report(toMarker(localize('promptValidator.modelNotSuited', "Model '{0}' is not suited for agent mode.", modelName), range, MarkerSeverity.Warning));
+			}
+		}
+	}
+
+	private validateTiers(attributes: IHeaderAttribute[], report: (markers: IMarkerData) => void): void {
+		const attribute = attributes.find(attr => attr.key === PromptHeaderAttributes.tiers);
+		if (!attribute) {
+			return;
+		}
+		if (attribute.value.type !== 'map') {
+			report(toMarker(localize('promptValidator.tiersMustBeMap', "The 'tiers' attribute must be a map of tier names to model configurations."), attribute.value.range, MarkerSeverity.Error));
+			return;
+		}
+		if (attribute.value.properties.length === 0) {
+			report(toMarker(localize('promptValidator.tiersMustNotBeEmpty', "The 'tiers' map must define at least one tier."), attribute.value.range, MarkerSeverity.Warning));
+			return;
+		}
+
+		const languageModels = this.languageModelsService.getLanguageModelIds();
+
+		for (const prop of attribute.value.properties) {
+			if (prop.value.type !== 'map') {
+				report(toMarker(localize('promptValidator.tierEntryMustBeMap', "Tier '{0}' must be an object with a 'model' property.", prop.key.value), prop.value.range, MarkerSeverity.Error));
+				continue;
+			}
+			const modelProp = prop.value.properties.find(p => p.key.value === 'model');
+			if (!modelProp) {
+				report(toMarker(localize('promptValidator.tierMissingModel', "Tier '{0}' is missing the required 'model' property.", prop.key.value), prop.key.range, MarkerSeverity.Error));
+				continue;
+			}
+			if (modelProp.value.type !== 'scalar') {
+				report(toMarker(localize('promptValidator.tierModelMustBeString', "The 'model' property in tier '{0}' must be a string.", prop.key.value), modelProp.value.range, MarkerSeverity.Error));
+				continue;
+			}
+			const modelName = modelProp.value.value.trim();
+			if (modelName.length === 0) {
+				report(toMarker(localize('promptValidator.tierModelMustBeNonEmpty', "The 'model' property in tier '{0}' must be a non-empty string.", prop.key.value), modelProp.value.range, MarkerSeverity.Error));
+				continue;
+			}
+			// Warn about unknown models if the language model service is initialized
+			if (languageModels.length > 0) {
+				const modelMetadata = this.findModelByName(modelName);
+				if (!modelMetadata) {
+					report(toMarker(localize('promptValidator.tierModelNotFound', "Unknown model '{0}' in tier '{1}'.", modelName, prop.key.value), modelProp.value.range, MarkerSeverity.Warning));
+				}
+			}
+			// Warn about unknown properties (other than 'model')
+			for (const tierProp of prop.value.properties) {
+				if (tierProp.key.value !== 'model') {
+					report(toMarker(localize('promptValidator.unknownTierProperty', "Unknown property '{0}' in tier '{1}'. Only 'model' is supported.", tierProp.key.value, prop.key.value), tierProp.key.range, MarkerSeverity.Warning));
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -418,10 +418,13 @@ export class PromptValidator {
 				report(toMarker(localize('promptValidator.tierModelMustBeNonEmpty', "The 'model' property in tier '{0}' must be a non-empty string.", prop.key.value), modelProp.value.range, MarkerSeverity.Error));
 				continue;
 			}
-			// Warn about unknown models if the language model service is initialized
+			// Warn about unknown models if the language model service is initialized.
+			// Tier models can be specified as qualified names or direct model IDs,
+			// so try both lookups to match runtime behavior in resolveModelHint.
 			if (languageModels.length > 0) {
-				const modelMetadata = this.findModelByName(modelName);
-				if (!modelMetadata) {
+				const byQualifiedName = this.findModelByName(modelName);
+				const byDirectId = !byQualifiedName ? this.languageModelsService.lookupLanguageModel(modelName) : undefined;
+				if (!byQualifiedName && !byDirectId) {
 					report(toMarker(localize('promptValidator.tierModelNotFound', "Unknown model '{0}' in tier '{1}'.", modelName, prop.key.value), modelProp.value.range, MarkerSeverity.Warning));
 				}
 			}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -927,7 +927,7 @@ function isTrueOrFalse(value: IValue): boolean {
 const allAttributeNames: Record<PromptsType, string[]> = {
 	[PromptsType.prompt]: [PromptHeaderAttributes.name, PromptHeaderAttributes.description, PromptHeaderAttributes.model, PromptHeaderAttributes.tools, PromptHeaderAttributes.mode, PromptHeaderAttributes.agent, PromptHeaderAttributes.argumentHint],
 	[PromptsType.instructions]: [PromptHeaderAttributes.name, PromptHeaderAttributes.description, PromptHeaderAttributes.applyTo, PromptHeaderAttributes.excludeAgent],
-	[PromptsType.agent]: [PromptHeaderAttributes.name, PromptHeaderAttributes.description, PromptHeaderAttributes.model, PromptHeaderAttributes.tools, PromptHeaderAttributes.advancedOptions, PromptHeaderAttributes.handOffs, PromptHeaderAttributes.argumentHint, PromptHeaderAttributes.target, PromptHeaderAttributes.infer, PromptHeaderAttributes.agents, PromptHeaderAttributes.hooks, PromptHeaderAttributes.userInvocable, PromptHeaderAttributes.disableModelInvocation, GithubPromptHeaderAttributes.github],
+	[PromptsType.agent]: [PromptHeaderAttributes.name, PromptHeaderAttributes.description, PromptHeaderAttributes.model, PromptHeaderAttributes.tiers, PromptHeaderAttributes.tools, PromptHeaderAttributes.advancedOptions, PromptHeaderAttributes.handOffs, PromptHeaderAttributes.argumentHint, PromptHeaderAttributes.target, PromptHeaderAttributes.infer, PromptHeaderAttributes.agents, PromptHeaderAttributes.hooks, PromptHeaderAttributes.userInvocable, PromptHeaderAttributes.disableModelInvocation, GithubPromptHeaderAttributes.github],
 	[PromptsType.skill]: [PromptHeaderAttributes.name, PromptHeaderAttributes.description, PromptHeaderAttributes.license, PromptHeaderAttributes.compatibility, PromptHeaderAttributes.metadata, PromptHeaderAttributes.argumentHint, PromptHeaderAttributes.userInvocable, PromptHeaderAttributes.disableModelInvocation],
 	[PromptsType.hook]: [], // hooks are JSON files, not markdown with YAML frontmatter
 };
@@ -1002,6 +1002,8 @@ export function getAttributeDescription(attributeName: string, promptType: Promp
 					return localize('promptHeader.agent.argumentHint', 'The argument-hint describes what inputs the custom agent expects or supports.');
 				case PromptHeaderAttributes.model:
 					return localize('promptHeader.agent.model', 'Specify the model that runs this custom agent. Can also be a list of models. The first available model will be used.');
+				case PromptHeaderAttributes.tiers:
+					return localize('promptHeader.agent.tiers', 'Declare model preferences for different capability tiers (e.g., fast, standard, deep). Each tier maps to a model name. Orchestrators choose a tier at call time.');
 				case PromptHeaderAttributes.tools:
 					return localize('promptHeader.agent.tools', 'The set of tools that the custom agent has access to.');
 				case PromptHeaderAttributes.handOffs:

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
@@ -84,6 +84,7 @@ export namespace PromptHeaderAttributes {
 	export const userInvocable = 'user-invocable';
 	export const disableModelInvocation = 'disable-model-invocation';
 	export const hooks = 'hooks';
+	export const tiers = 'tiers';
 }
 
 export class PromptHeader {
@@ -328,6 +329,35 @@ export class PromptHeader {
 			return attr.value;
 		}
 		return undefined;
+	}
+
+	/**
+	 * Parses `tiers` from the frontmatter. Expected format:
+	 * ```yaml
+	 * tiers:
+	 *   fast:
+	 *     model: claude-haiku-4.5
+	 *   standard:
+	 *     model: claude-sonnet-4.6
+	 * ```
+	 * Returns a map of tier name to `{ model: string }`, or undefined if not present.
+	 */
+	public get tiers(): Record<string, { model: string }> | undefined {
+		const attr = this._parsedHeader.attributes.find(a => a.key === PromptHeaderAttributes.tiers);
+		if (attr?.value.type !== 'map') {
+			return undefined;
+		}
+		const result: Record<string, { model: string }> = {};
+		for (const prop of attr.value.properties) {
+			const tierName = prop.key.value;
+			if (prop.value.type === 'map') {
+				const modelProp = prop.value.properties.find(p => p.key.value === 'model');
+				if (modelProp?.value.type === 'scalar' && modelProp.value.value) {
+					result[tierName] = { model: modelProp.value.value };
+				}
+			}
+		}
+		return Object.keys(result).length > 0 ? result : undefined;
 	}
 
 	private getBooleanAttribute(key: string): boolean | undefined {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -204,6 +204,13 @@ export interface ICustomAgent {
 	readonly model?: readonly string[];
 
 	/**
+	 * Tier-specific model declarations from the `tiers` frontmatter field.
+	 * Maps tier names (e.g., 'fast', 'standard', 'deep') to model qualified names.
+	 * Allows a single agent to serve at different capability/cost levels.
+	 */
+	readonly tiers?: Readonly<Record<string, { readonly model: string }>>;
+
+	/**
 	 * Argument hint metadata in the prompt header that describes what inputs the agent expects or supports.
 	 */
 	readonly argumentHint?: string;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -783,6 +783,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 					tools = mapClaudeTools(tools);
 				}
 
+				// Parse tiers from the frontmatter if present
+				const tiers = ast.header.tiers;
+
 				// Parse hooks from the frontmatter if present
 				let hooks: ChatRequestHooks | undefined;
 				const useCustomAgentHooks = this.configurationService.getValue<boolean>(PromptsConfig.USE_CUSTOM_AGENT_HOOKS);
@@ -793,7 +796,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 					hooks = parseSubagentHooksFromYaml(hooksRaw, workspaceRootUri, userHome, target);
 				}
 
-				return { uri, name, description, model, tools, handOffs, argumentHint, target, visibility, agents, hooks, agentInstructions, source };
+				return { uri, name, description, model, tiers, tools, handOffs, argumentHint, target, visibility, agents, hooks, agentInstructions, source };
 			})
 		);
 

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -56,6 +56,8 @@ export interface IRunSubagentToolInputParams {
 	prompt: string;
 	description: string;
 	agentName?: string;
+	model?: string;
+	tier?: string;
 }
 
 export const RUN_SUBAGENT_MAX_NESTING_DEPTH = 5;
@@ -113,6 +115,17 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				description: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
 			};
 			modelDescription += `\n- If the user asks for a certain agent, you MUST provide that EXACT agent name (case-sensitive) to invoke that specific agent.`;
+
+			inputSchema.properties.model = {
+				type: 'string',
+				description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Examples: claude-sonnet-4-6, claude-haiku-4-5, gpt-4o, gpt-4o-mini.'
+			};
+
+			inputSchema.properties.tier = {
+				type: 'string',
+				description: 'Optional capability tier for this subagent invocation. Selects a model from the agent\'s `tiers` frontmatter. Standard tiers: fast (low cost), standard (balanced), deep (maximum capability).'
+			};
+			modelDescription += `\n- You may optionally specify a \`model\` to run the subagent with a specific language model, or a \`tier\` to select from the agent's predefined capability tiers (fast, standard, deep). Use \`model\` for explicit control or \`tier\` for semantic intent.`;
 		}
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,
@@ -172,7 +185,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 						resolvedModelName = cached.resolvedModelName;
 					} else {
 						// Fallback: resolve the model here if prepare didn't cache it
-						const resolved = this.resolveSubagentModel(subagent, invocation.modelId);
+						const resolved = this.resolveSubagentModel(subagent, invocation.modelId, args.model, args.tier);
 						modeModelId = resolved.modeModelId;
 						resolvedModelName = resolved.resolvedModelName;
 					}
@@ -207,7 +220,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				const cached = this._resolvedModels.get(invocation.callId);
 				if (cached) {
 					this._resolvedModels.delete(invocation.callId);
+					modeModelId = cached.modeModelId ?? modeModelId;
 					resolvedModelName = cached.resolvedModelName;
+				} else if (args.model) {
+					// Call-time model override without a named subagent
+					const resolved = this.resolveSubagentModel(undefined, invocation.modelId, args.model);
+					modeModelId = resolved.modeModelId;
+					resolvedModelName = resolved.resolvedModelName;
 				} else {
 					const resolvedModelMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
 					resolvedModelName = resolvedModelMetadata?.name;
@@ -393,12 +412,19 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	}
 
 	/**
-	 * Resolves the model to be used by a subagent, applying multiplier-based
-	 * fallback to avoid using a more expensive model than the main agent.
+	 * Resolves the model to be used by a subagent. Priority order:
+	 * 1. Call-time `model` parameter (highest precedence)
+	 * 2. Call-time `tier` parameter (resolves from agent's `tiers` frontmatter)
+	 * 3. Agent's top-level `model:` frontmatter qualified names
+	 * 4. Parent model (default)
+	 *
+	 * After resolution, applies a multiplier-based cap to prevent subagents
+	 * from using a more expensive model than the parent agent.
 	 */
-	private resolveSubagentModel(subagent: ICustomAgent | undefined, mainModelId: string | undefined): { modeModelId: string | undefined; resolvedModelName: string | undefined } {
+	private resolveSubagentModel(subagent: ICustomAgent | undefined, mainModelId: string | undefined, callTimeModelHint?: string, callTimeTier?: string): { modeModelId: string | undefined; resolvedModelName: string | undefined } {
 		let modeModelId = mainModelId;
 
+		// Priority 3: Agent's top-level `model:` frontmatter
 		if (subagent) {
 			const modeModelQualifiedNames = subagent.model;
 			if (modeModelQualifiedNames) {
@@ -411,23 +437,67 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					}
 				}
 			}
+		}
 
-			// If the subagent's model has a larger multiplier than the main agent's model,
-			// fall back to the main agent's model to avoid using a more expensive model.
-			if (modeModelId && modeModelId !== mainModelId) {
-				const mainModelMetadata = mainModelId ? this.languageModelsService.lookupLanguageModel(mainModelId) : undefined;
-				const subagentModelMetadata = this.languageModelsService.lookupLanguageModel(modeModelId);
-				const mainMultiplier = mainModelMetadata?.multiplierNumeric;
-				const subagentMultiplier = subagentModelMetadata?.multiplierNumeric;
-				if (mainMultiplier !== undefined && subagentMultiplier !== undefined && subagentMultiplier > mainMultiplier) {
-					this.logService.warn(`[RunSubagentTool] Subagent '${subagent.name}' requested model '${subagentModelMetadata?.name}' (multiplier: ${subagentMultiplier}) which has a larger multiplier than the main agent model '${mainModelMetadata?.name}' (multiplier: ${mainMultiplier}). Falling back to the main agent model.`);
-					modeModelId = mainModelId;
+		// Priority 2: Call-time `tier` parameter (resolves from agent's tiers frontmatter)
+		if (callTimeTier && subagent?.tiers) {
+			const tierConfig = subagent.tiers[callTimeTier];
+			if (tierConfig?.model) {
+				const resolved = this.resolveModelHint(tierConfig.model);
+				if (resolved) {
+					modeModelId = resolved;
+				} else {
+					this.logService.warn(`[RunSubagentTool] Tier '${callTimeTier}' model '${tierConfig.model}' not found in model registry. Using agent's default model.`);
 				}
+			} else {
+				this.logService.warn(`[RunSubagentTool] Tier '${callTimeTier}' not defined in agent '${subagent.name}' tiers. Using agent's default model.`);
 			}
 		}
 
-		const resolvedModelMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
-		return { modeModelId, resolvedModelName: resolvedModelMetadata?.name };
+		// Priority 1: Call-time `model` parameter (highest precedence)
+		if (callTimeModelHint) {
+			const resolved = this.resolveModelHint(callTimeModelHint);
+			if (resolved) {
+				modeModelId = resolved;
+			} else {
+				this.logService.warn(`[RunSubagentTool] Call-time model '${callTimeModelHint}' not found in model registry. Ignoring override.`);
+			}
+		}
+
+		// If the resolved model has a larger multiplier than the main agent's model,
+		// fall back to the main agent's model to avoid using a more expensive model.
+		if (modeModelId && modeModelId !== mainModelId) {
+			const mainModelMetadata = mainModelId ? this.languageModelsService.lookupLanguageModel(mainModelId) : undefined;
+			const resolvedModelMetadata = this.languageModelsService.lookupLanguageModel(modeModelId);
+			const mainMultiplier = mainModelMetadata?.multiplierNumeric;
+			const resolvedMultiplier = resolvedModelMetadata?.multiplierNumeric;
+			if (mainMultiplier !== undefined && resolvedMultiplier !== undefined && resolvedMultiplier > mainMultiplier) {
+				const source = callTimeModelHint ? 'Call-time' : callTimeTier ? `Tier '${callTimeTier}'` : subagent ? `Subagent '${subagent.name}'` : 'Unknown';
+				this.logService.warn(`[RunSubagentTool] ${source} requested model '${resolvedModelMetadata?.name}' (multiplier: ${resolvedMultiplier}) which exceeds the main agent model '${mainModelMetadata?.name}' (multiplier: ${mainMultiplier}). Falling back to the main agent model.`);
+				modeModelId = mainModelId;
+			}
+		}
+
+		const finalMetadata = modeModelId ? this.languageModelsService.lookupLanguageModel(modeModelId) : undefined;
+		return { modeModelId, resolvedModelName: finalMetadata?.name };
+	}
+
+	/**
+	 * Attempts to resolve a model hint string to a model identifier.
+	 * Tries qualified name lookup first, then direct model ID lookup.
+	 */
+	private resolveModelHint(modelHint: string): string | undefined {
+		// Try qualified name lookup first (e.g., "Claude Sonnet 4.6 (Copilot)")
+		const byQualifiedName = this.languageModelsService.lookupLanguageModelByQualifiedName(modelHint);
+		if (byQualifiedName?.identifier) {
+			return byQualifiedName.identifier;
+		}
+		// Try direct model ID lookup (e.g., "claude-sonnet-4-6")
+		const byId = this.languageModelsService.lookupLanguageModel(modelHint);
+		if (byId) {
+			return modelHint;
+		}
+		return undefined;
 	}
 
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
@@ -436,7 +506,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		const subagent = args.agentName ? await this.getSubAgentByName(args.agentName) : undefined;
 
 		// Resolve the model early and cache it for invoke()
-		const resolved = this.resolveSubagentModel(subagent, context.modelId);
+		const resolved = this.resolveSubagentModel(subagent, context.modelId, args.model, args.tier);
 		this._resolvedModels.set(context.toolCallId, resolved);
 
 		return {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -50,7 +50,8 @@ const BaseModelDescription = `Launch a new agent to handle complex, multi-step t
 - When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
 - Each agent invocation is stateless. You will not be able to send additional messages to the agent, nor will the agent be able to communicate with you outside of its final report. Therefore, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
 - The agent's outputs should generally be trusted
-- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user\'s intent`;
+- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user\'s intent
+- **Cost-efficiency**: Before invoking a subagent, assess the complexity of the subtask you are delegating. Use the cheapest model that can reliably complete the task. Reserve expensive models for tasks that genuinely require advanced reasoning. For straightforward tasks like file searches, simple code edits, or data lookups, prefer a fast/cheap model. For multi-step analysis, architectural decisions, or nuanced code generation, use a more capable model. Your role as the orchestrating agent is to maximize output quality per unit cost.`;
 
 export interface IRunSubagentToolInputParams {
 	prompt: string;
@@ -118,14 +119,14 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 			inputSchema.properties.model = {
 				type: 'string',
-				description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Examples: claude-sonnet-4-6, claude-haiku-4-5, gpt-4o, gpt-4o-mini.'
+				description: 'Optional model identifier for this subagent invocation. Overrides the agent definition\'s default model. Choose the model based on subtask complexity: use a cheap/fast model (e.g., claude-haiku-4-5, gpt-4o-mini) for simple lookups, searches, and mechanical edits; use a capable model (e.g., claude-sonnet-4-6, gpt-4o) for multi-step reasoning or complex code generation. Always prefer the latest version of a model family when available.'
 			};
 
 			inputSchema.properties.tier = {
 				type: 'string',
-				description: 'Optional capability tier for this subagent invocation. Selects a model from the agent\'s `tiers` frontmatter. Standard tiers: fast (low cost), standard (balanced), deep (maximum capability).'
+				description: 'Optional capability tier for this subagent invocation. Selects a model from the agent\'s `tiers` frontmatter. Standard tiers: fast (low cost, simple tasks), standard (balanced), deep (maximum capability, complex reasoning). Prefer \'fast\' for most subtasks and escalate only when the task demands it.'
 			};
-			modelDescription += `\n- You may optionally specify a \`model\` to run the subagent with a specific language model, or a \`tier\` to select from the agent's predefined capability tiers (fast, standard, deep). Use \`model\` for explicit control or \`tier\` for semantic intent.`;
+			modelDescription += `\n- You may specify a \`model\` to run the subagent with a specific language model, or a \`tier\` to select from the agent's predefined capability tiers. **Always match the model to the subtask complexity**: use fast/cheap models for file searches, simple edits, lookups, and data gathering; use standard models for code generation and moderate reasoning; reserve expensive models for complex multi-step analysis. When choosing a specific model, prefer the most recent version available in each model family (e.g., prefer claude-sonnet-4-6 over claude-sonnet-4, prefer gpt-4o over gpt-4).`;
 		}
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -221,75 +221,79 @@ suite('RunSubagentTool', () => {
 		});
 	});
 
+	// Shared helpers for model resolution test suites
+	function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
+		return {
+			extension: new ExtensionIdentifier('test.extension'),
+			name,
+			id: name.toLowerCase().replace(/\s+/g, '-'),
+			vendor: 'TestVendor',
+			version: '1.0',
+			family: 'test',
+			maxInputTokens: 128000,
+			maxOutputTokens: 8192,
+			isDefaultForLocation: {},
+			modelPickerCategory: undefined,
+			multiplierNumeric,
+		};
+	}
+
+	function createModelTool(opts: {
+		models: Map<string, ILanguageModelChatMetadata>;
+		qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
+		customAgents?: ICustomAgent[];
+		enableCustomAgents?: boolean;
+	}) {
+		const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+		const configService = opts.enableCustomAgents
+			? new TestConfigurationService({ 'chat.customAgentInSubagent.enabled': true })
+			: new TestConfigurationService();
+		const promptsService = new MockPromptsService();
+		if (opts.customAgents) {
+			promptsService.setCustomModes(opts.customAgents);
+		}
+
+		const mockLanguageModelsService: Partial<ILanguageModelsService> = {
+			lookupLanguageModel(modelId: string) {
+				return opts.models.get(modelId);
+			},
+			lookupLanguageModelByQualifiedName(qualifiedName: string) {
+				return opts.qualifiedNameMap?.get(qualifiedName);
+			},
+		};
+
+		const tool = testDisposables.add(new RunSubagentTool(
+			{} as IChatAgentService,
+			{} as IChatService,
+			mockToolsService,
+			mockLanguageModelsService as ILanguageModelsService,
+			new NullLogService(),
+			mockToolsService,
+			configService,
+			promptsService,
+			{} as IInstantiationService,
+			{} as IProductService,
+		));
+
+		return tool;
+	}
+
+	function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
+		return {
+			uri: URI.parse(`file:///test/${name}.md`),
+			name,
+			description: `Agent ${name}`,
+			tools: ['tool1'],
+			model: modelQualifiedNames,
+			tiers,
+			agentInstructions: { content: 'test', toolReferences: [] },
+			source: { storage: PromptsStorage.local },
+			target: Target.Undefined,
+			visibility: { userInvocable: true, agentInvocable: true }
+		};
+	}
+
 	suite('model fallback behavior', () => {
-		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
-			return {
-				extension: new ExtensionIdentifier('test.extension'),
-				name,
-				id: name.toLowerCase().replace(/\s+/g, '-'),
-				vendor: 'TestVendor',
-				version: '1.0',
-				family: 'test',
-				maxInputTokens: 128000,
-				maxOutputTokens: 8192,
-				isDefaultForLocation: {},
-				modelPickerCategory: undefined,
-				multiplierNumeric,
-			};
-		}
-
-		function createTool(opts: {
-			models: Map<string, ILanguageModelChatMetadata>;
-			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
-			customAgents?: ICustomAgent[];
-		}) {
-			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService();
-			const promptsService = new MockPromptsService();
-			if (opts.customAgents) {
-				promptsService.setCustomModes(opts.customAgents);
-			}
-
-			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
-				lookupLanguageModel(modelId: string) {
-					return opts.models.get(modelId);
-				},
-				lookupLanguageModelByQualifiedName(qualifiedName: string) {
-					return opts.qualifiedNameMap?.get(qualifiedName);
-				},
-			};
-
-			const tool = testDisposables.add(new RunSubagentTool(
-				{} as IChatAgentService,
-				{} as IChatService,
-				mockToolsService,
-				mockLanguageModelsService as ILanguageModelsService,
-				new NullLogService(),
-				mockToolsService,
-				configService,
-				promptsService,
-				{} as IInstantiationService,
-				{} as IProductService,
-			));
-
-			return tool;
-		}
-
-		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
-			return {
-				uri: URI.parse(`file:///test/${name}.md`),
-				name,
-				description: `Agent ${name}`,
-				tools: ['tool1'],
-				model: modelQualifiedNames,
-				tiers,
-				agentInstructions: { content: 'test', toolReferences: [] },
-				source: { storage: PromptsStorage.local },
-				target: Target.Undefined,
-				visibility: { userInvocable: true, agentInvocable: true }
-			};
-		}
-
 		test('falls back to main model when subagent model has higher multiplier', async () => {
 			const mainMeta = createMetadata('GPT-4o', 1);
 			const expensiveMeta = createMetadata('O3 Pro', 50);
@@ -302,7 +306,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('ExpensiveAgent', ['O3 Pro (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'ExpensiveAgent' },
@@ -334,7 +338,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('SameCostAgent', ['Claude Sonnet (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'SameCostAgent' },
@@ -365,7 +369,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('CheapAgent', ['GPT-4o Mini (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'CheapAgent' },
@@ -396,7 +400,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('SubAgent', ['O3 Pro (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'SubAgent' },
@@ -428,7 +432,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('CustomAgent', ['Custom Model (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'CustomAgent' },
@@ -452,7 +456,7 @@ suite('RunSubagentTool', () => {
 			const mainMeta = createMetadata('GPT-4o', 1);
 			const models = new Map([['main-model-id', mainMeta]]);
 
-			const tool = createTool({ models });
+			const tool = createModelTool({ models });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task' },
@@ -476,7 +480,7 @@ suite('RunSubagentTool', () => {
 			const models = new Map([['main-model-id', mainMeta]]);
 
 			const agent = createAgent('NoModelAgent', undefined);
-			const tool = createTool({ models, customAgents: [agent] });
+			const tool = createModelTool({ models, customAgents: [agent] });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test task', agentName: 'NoModelAgent' },
@@ -497,79 +501,9 @@ suite('RunSubagentTool', () => {
 	});
 
 	suite('call-time model parameter', () => {
-		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
-			return {
-				extension: new ExtensionIdentifier('test.extension'),
-				name,
-				id: name.toLowerCase().replace(/\s+/g, '-'),
-				vendor: 'TestVendor',
-				version: '1.0',
-				family: 'test',
-				maxInputTokens: 128000,
-				maxOutputTokens: 8192,
-				isDefaultForLocation: {},
-				modelPickerCategory: undefined,
-				multiplierNumeric,
-			};
-		}
-
-		function createTool(opts: {
-			models: Map<string, ILanguageModelChatMetadata>;
-			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
-			customAgents?: ICustomAgent[];
-		}) {
-			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService({
-				'chat.customAgentInSubagent.enabled': true,
-			});
-			const promptsService = new MockPromptsService();
-			if (opts.customAgents) {
-				promptsService.setCustomModes(opts.customAgents);
-			}
-
-			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
-				lookupLanguageModel(modelId: string) {
-					return opts.models.get(modelId);
-				},
-				lookupLanguageModelByQualifiedName(qualifiedName: string) {
-					return opts.qualifiedNameMap?.get(qualifiedName);
-				},
-			};
-
-			const tool = testDisposables.add(new RunSubagentTool(
-				{} as IChatAgentService,
-				{} as IChatService,
-				mockToolsService,
-				mockLanguageModelsService as ILanguageModelsService,
-				new NullLogService(),
-				mockToolsService,
-				configService,
-				promptsService,
-				{} as IInstantiationService,
-				{} as IProductService,
-			));
-
-			return tool;
-		}
-
-		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
-			return {
-				uri: URI.parse(`file:///test/${name}.md`),
-				name,
-				description: `Agent ${name}`,
-				tools: ['tool1'],
-				model: modelQualifiedNames,
-				tiers,
-				agentInstructions: { content: 'test', toolReferences: [] },
-				source: { storage: PromptsStorage.local },
-				target: Target.Undefined,
-				visibility: { userInvocable: true, agentInvocable: true }
-			};
-		}
-
 		test('includes model and tier properties in schema when custom agents enabled', () => {
 			const models = new Map<string, ILanguageModelChatMetadata>();
-			const tool = createTool({ models });
+			const tool = createModelTool({ models, enableCustomAgents: true });
 			const toolData = tool.getToolData();
 
 			assert.ok(toolData.inputSchema?.properties?.model, 'model should be in schema when custom agents enabled');
@@ -591,7 +525,7 @@ suite('RunSubagentTool', () => {
 			]);
 
 			const agent = createAgent('TestAgent', ['Claude Haiku (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'TestAgent', model: 'Claude Sonnet (TestVendor)' },
@@ -612,7 +546,7 @@ suite('RunSubagentTool', () => {
 				['claude-sonnet', overrideMeta],
 			]);
 
-			const tool = createTool({ models });
+			const tool = createModelTool({ models, enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', model: 'claude-sonnet' },
@@ -633,7 +567,7 @@ suite('RunSubagentTool', () => {
 				['o3-pro', expensiveMeta],
 			]);
 
-			const tool = createTool({ models });
+			const tool = createModelTool({ models, enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', model: 'o3-pro' },
@@ -653,7 +587,7 @@ suite('RunSubagentTool', () => {
 				['main-model-id', mainMeta],
 			]);
 
-			const tool = createTool({ models });
+			const tool = createModelTool({ models, enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', model: 'nonexistent-model' },
@@ -684,7 +618,7 @@ suite('RunSubagentTool', () => {
 			const agent = createAgent('TieredAgent', undefined, {
 				fast: { model: 'Claude Haiku (TestVendor)' },
 			});
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: {
@@ -705,76 +639,6 @@ suite('RunSubagentTool', () => {
 	});
 
 	suite('tier resolution', () => {
-		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
-			return {
-				extension: new ExtensionIdentifier('test.extension'),
-				name,
-				id: name.toLowerCase().replace(/\s+/g, '-'),
-				vendor: 'TestVendor',
-				version: '1.0',
-				family: 'test',
-				maxInputTokens: 128000,
-				maxOutputTokens: 8192,
-				isDefaultForLocation: {},
-				modelPickerCategory: undefined,
-				multiplierNumeric,
-			};
-		}
-
-		function createTool(opts: {
-			models: Map<string, ILanguageModelChatMetadata>;
-			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
-			customAgents?: ICustomAgent[];
-		}) {
-			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService({
-				'chat.customAgentInSubagent.enabled': true,
-			});
-			const promptsService = new MockPromptsService();
-			if (opts.customAgents) {
-				promptsService.setCustomModes(opts.customAgents);
-			}
-
-			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
-				lookupLanguageModel(modelId: string) {
-					return opts.models.get(modelId);
-				},
-				lookupLanguageModelByQualifiedName(qualifiedName: string) {
-					return opts.qualifiedNameMap?.get(qualifiedName);
-				},
-			};
-
-			const tool = testDisposables.add(new RunSubagentTool(
-				{} as IChatAgentService,
-				{} as IChatService,
-				mockToolsService,
-				mockLanguageModelsService as ILanguageModelsService,
-				new NullLogService(),
-				mockToolsService,
-				configService,
-				promptsService,
-				{} as IInstantiationService,
-				{} as IProductService,
-			));
-
-			return tool;
-		}
-
-		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
-			return {
-				uri: URI.parse(`file:///test/${name}.md`),
-				name,
-				description: `Agent ${name}`,
-				tools: ['tool1'],
-				model: modelQualifiedNames,
-				tiers,
-				agentInstructions: { content: 'test', toolReferences: [] },
-				source: { storage: PromptsStorage.local },
-				target: Target.Undefined,
-				visibility: { userInvocable: true, agentInvocable: true }
-			};
-		}
-
 		test('tier resolves to correct model from agent tiers frontmatter', async () => {
 			const mainMeta = createMetadata('GPT-4o', 1);
 			const fastMeta = createMetadata('Claude Haiku', 0.25);
@@ -793,7 +657,7 @@ suite('RunSubagentTool', () => {
 				fast: { model: 'Claude Haiku (TestVendor)' },
 				deep: { model: 'Claude Sonnet (TestVendor)' },
 			});
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'fast' },
@@ -824,7 +688,7 @@ suite('RunSubagentTool', () => {
 			const agent = createAgent('TieredAgent', ['Claude Sonnet (TestVendor)'], {
 				fast: { model: 'Claude Haiku (TestVendor)' },
 			});
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'fast' },
@@ -852,7 +716,7 @@ suite('RunSubagentTool', () => {
 			const agent = createAgent('TieredAgent', undefined, {
 				deep: { model: 'O3 Pro (TestVendor)' },
 			});
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'deep' },
@@ -880,7 +744,7 @@ suite('RunSubagentTool', () => {
 			const agent = createAgent('TieredAgent', ['Claude Sonnet (TestVendor)'], {
 				fast: { model: 'Claude Sonnet (TestVendor)' },
 			});
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'nonexistent' },
@@ -900,7 +764,7 @@ suite('RunSubagentTool', () => {
 				['main-model-id', mainMeta],
 			]);
 
-			const tool = createTool({ models });
+			const tool = createModelTool({ models, enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', tier: 'fast' },
@@ -927,7 +791,7 @@ suite('RunSubagentTool', () => {
 
 			// Agent has a model but no tiers
 			const agent = createAgent('NoTiersAgent', ['Claude Sonnet (TestVendor)']);
-			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+			const tool = createModelTool({ models, qualifiedNameMap, customAgents: [agent], enableCustomAgents: true });
 
 			const result = await tool.prepareToolInvocation({
 				parameters: { prompt: 'test', description: 'test', agentName: 'NoTiersAgent', tier: 'fast' },

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -275,13 +275,14 @@ suite('RunSubagentTool', () => {
 			return tool;
 		}
 
-		function createAgent(name: string, modelQualifiedNames?: string[]): ICustomAgent {
+		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
 			return {
 				uri: URI.parse(`file:///test/${name}.md`),
 				name,
 				description: `Agent ${name}`,
 				tools: ['tool1'],
 				model: modelQualifiedNames,
+				tiers,
 				agentInstructions: { content: 'test', toolReferences: [] },
 				source: { storage: PromptsStorage.local },
 				target: Target.Undefined,
@@ -492,6 +493,452 @@ suite('RunSubagentTool', () => {
 				prompt: 'test',
 				modelName: 'GPT-4o',
 			});
+		});
+	});
+
+	suite('call-time model parameter', () => {
+		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
+			return {
+				extension: new ExtensionIdentifier('test.extension'),
+				name,
+				id: name.toLowerCase().replace(/\s+/g, '-'),
+				vendor: 'TestVendor',
+				version: '1.0',
+				family: 'test',
+				maxInputTokens: 128000,
+				maxOutputTokens: 8192,
+				isDefaultForLocation: {},
+				modelPickerCategory: undefined,
+				multiplierNumeric,
+			};
+		}
+
+		function createTool(opts: {
+			models: Map<string, ILanguageModelChatMetadata>;
+			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
+			customAgents?: ICustomAgent[];
+		}) {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService({
+				'chat.customAgentInSubagent.enabled': true,
+			});
+			const promptsService = new MockPromptsService();
+			if (opts.customAgents) {
+				promptsService.setCustomModes(opts.customAgents);
+			}
+
+			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
+				lookupLanguageModel(modelId: string) {
+					return opts.models.get(modelId);
+				},
+				lookupLanguageModelByQualifiedName(qualifiedName: string) {
+					return opts.qualifiedNameMap?.get(qualifiedName);
+				},
+			};
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				mockToolsService,
+				mockLanguageModelsService as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				promptsService,
+				{} as IInstantiationService,
+				{} as IProductService,
+			));
+
+			return tool;
+		}
+
+		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
+			return {
+				uri: URI.parse(`file:///test/${name}.md`),
+				name,
+				description: `Agent ${name}`,
+				tools: ['tool1'],
+				model: modelQualifiedNames,
+				tiers,
+				agentInstructions: { content: 'test', toolReferences: [] },
+				source: { storage: PromptsStorage.local },
+				target: Target.Undefined,
+				visibility: { userInvocable: true, agentInvocable: true }
+			};
+		}
+
+		test('includes model and tier properties in schema when custom agents enabled', () => {
+			const models = new Map<string, ILanguageModelChatMetadata>();
+			const tool = createTool({ models });
+			const toolData = tool.getToolData();
+
+			assert.ok(toolData.inputSchema?.properties?.model, 'model should be in schema when custom agents enabled');
+			assert.ok(toolData.inputSchema?.properties?.tier, 'tier should be in schema when custom agents enabled');
+		});
+
+		test('model parameter overrides agent frontmatter model via qualified name', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentMeta = createMetadata('Claude Haiku', 0.5);
+			const overrideMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['agent-model-id', agentMeta],
+				['override-model-id', overrideMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Haiku (TestVendor)', { metadata: agentMeta, identifier: 'agent-model-id' }],
+				['Claude Sonnet (TestVendor)', { metadata: overrideMeta, identifier: 'override-model-id' }],
+			]);
+
+			const agent = createAgent('TestAgent', ['Claude Haiku (TestVendor)']);
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'TestAgent', model: 'Claude Sonnet (TestVendor)' },
+				toolCallId: 'model-override-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Sonnet');
+		});
+
+		test('model parameter overrides via direct model ID', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const overrideMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['claude-sonnet', overrideMeta],
+			]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', model: 'claude-sonnet' },
+				toolCallId: 'model-direct-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Sonnet');
+		});
+
+		test('model parameter is subject to multiplier cap', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const expensiveMeta = createMetadata('O3 Pro', 50);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['o3-pro', expensiveMeta],
+			]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', model: 'o3-pro' },
+				toolCallId: 'model-cap-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Should fall back to main model due to multiplier cap
+			assert.strictEqual(result.toolSpecificData?.modelName, 'GPT-4o');
+		});
+
+		test('unknown model hint is ignored gracefully', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+			]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', model: 'nonexistent-model' },
+				toolCallId: 'model-unknown-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Should fall back to main model since override was not found
+			assert.strictEqual(result.toolSpecificData?.modelName, 'GPT-4o');
+		});
+
+		test('model param takes precedence over tier param', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const tierMeta = createMetadata('Claude Haiku', 0.25);
+			const modelMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['haiku-id', tierMeta],
+				['sonnet-id', modelMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Haiku (TestVendor)', { metadata: tierMeta, identifier: 'haiku-id' }],
+				['Claude Sonnet (TestVendor)', { metadata: modelMeta, identifier: 'sonnet-id' }],
+			]);
+
+			const agent = createAgent('TieredAgent', undefined, {
+				fast: { model: 'Claude Haiku (TestVendor)' },
+			});
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: {
+					prompt: 'test', description: 'test',
+					agentName: 'TieredAgent',
+					tier: 'fast',
+					model: 'Claude Sonnet (TestVendor)',
+				},
+				toolCallId: 'precedence-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// model takes precedence over tier
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Sonnet');
+		});
+	});
+
+	suite('tier resolution', () => {
+		function createMetadata(name: string, multiplierNumeric?: number): ILanguageModelChatMetadata {
+			return {
+				extension: new ExtensionIdentifier('test.extension'),
+				name,
+				id: name.toLowerCase().replace(/\s+/g, '-'),
+				vendor: 'TestVendor',
+				version: '1.0',
+				family: 'test',
+				maxInputTokens: 128000,
+				maxOutputTokens: 8192,
+				isDefaultForLocation: {},
+				modelPickerCategory: undefined,
+				multiplierNumeric,
+			};
+		}
+
+		function createTool(opts: {
+			models: Map<string, ILanguageModelChatMetadata>;
+			qualifiedNameMap?: Map<string, ILanguageModelChatMetadataAndIdentifier>;
+			customAgents?: ICustomAgent[];
+		}) {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService({
+				'chat.customAgentInSubagent.enabled': true,
+			});
+			const promptsService = new MockPromptsService();
+			if (opts.customAgents) {
+				promptsService.setCustomModes(opts.customAgents);
+			}
+
+			const mockLanguageModelsService: Partial<ILanguageModelsService> = {
+				lookupLanguageModel(modelId: string) {
+					return opts.models.get(modelId);
+				},
+				lookupLanguageModelByQualifiedName(qualifiedName: string) {
+					return opts.qualifiedNameMap?.get(qualifiedName);
+				},
+			};
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				mockToolsService,
+				mockLanguageModelsService as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				promptsService,
+				{} as IInstantiationService,
+				{} as IProductService,
+			));
+
+			return tool;
+		}
+
+		function createAgent(name: string, modelQualifiedNames?: string[], tiers?: Record<string, { model: string }>): ICustomAgent {
+			return {
+				uri: URI.parse(`file:///test/${name}.md`),
+				name,
+				description: `Agent ${name}`,
+				tools: ['tool1'],
+				model: modelQualifiedNames,
+				tiers,
+				agentInstructions: { content: 'test', toolReferences: [] },
+				source: { storage: PromptsStorage.local },
+				target: Target.Undefined,
+				visibility: { userInvocable: true, agentInvocable: true }
+			};
+		}
+
+		test('tier resolves to correct model from agent tiers frontmatter', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const fastMeta = createMetadata('Claude Haiku', 0.25);
+			const deepMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['haiku-id', fastMeta],
+				['sonnet-id', deepMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Haiku (TestVendor)', { metadata: fastMeta, identifier: 'haiku-id' }],
+				['Claude Sonnet (TestVendor)', { metadata: deepMeta, identifier: 'sonnet-id' }],
+			]);
+
+			const agent = createAgent('TieredAgent', undefined, {
+				fast: { model: 'Claude Haiku (TestVendor)' },
+				deep: { model: 'Claude Sonnet (TestVendor)' },
+			});
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'fast' },
+				toolCallId: 'tier-fast-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Haiku');
+		});
+
+		test('tier overrides agent frontmatter model', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentDefaultMeta = createMetadata('Claude Sonnet', 1);
+			const tierMeta = createMetadata('Claude Haiku', 0.25);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['sonnet-id', agentDefaultMeta],
+				['haiku-id', tierMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Sonnet (TestVendor)', { metadata: agentDefaultMeta, identifier: 'sonnet-id' }],
+				['Claude Haiku (TestVendor)', { metadata: tierMeta, identifier: 'haiku-id' }],
+			]);
+
+			// Agent has both a default model and tiers
+			const agent = createAgent('TieredAgent', ['Claude Sonnet (TestVendor)'], {
+				fast: { model: 'Claude Haiku (TestVendor)' },
+			});
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'fast' },
+				toolCallId: 'tier-override-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Tier takes precedence over agent's default model
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Haiku');
+		});
+
+		test('tier resolution respects multiplier cap', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const expensiveMeta = createMetadata('O3 Pro', 50);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['o3-pro-id', expensiveMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['O3 Pro (TestVendor)', { metadata: expensiveMeta, identifier: 'o3-pro-id' }],
+			]);
+
+			const agent = createAgent('TieredAgent', undefined, {
+				deep: { model: 'O3 Pro (TestVendor)' },
+			});
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'deep' },
+				toolCallId: 'tier-cap-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Should fall back to main model due to multiplier cap
+			assert.strictEqual(result.toolSpecificData?.modelName, 'GPT-4o');
+		});
+
+		test('unknown tier name falls back to agent default model', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['sonnet-id', agentMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Sonnet (TestVendor)', { metadata: agentMeta, identifier: 'sonnet-id' }],
+			]);
+
+			const agent = createAgent('TieredAgent', ['Claude Sonnet (TestVendor)'], {
+				fast: { model: 'Claude Sonnet (TestVendor)' },
+			});
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'TieredAgent', tier: 'nonexistent' },
+				toolCallId: 'tier-unknown-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Falls back to agent's default model (not main model) since tier was not found
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Sonnet');
+		});
+
+		test('tier without a named subagent is ignored', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+			]);
+
+			const tool = createTool({ models });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', tier: 'fast' },
+				toolCallId: 'tier-no-agent-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// tier is ignored when no agent is specified (agent.tiers would be undefined)
+			assert.strictEqual(result.toolSpecificData?.modelName, 'GPT-4o');
+		});
+
+		test('tier with agent that has no tiers defined falls back gracefully', async () => {
+			const mainMeta = createMetadata('GPT-4o', 1);
+			const agentMeta = createMetadata('Claude Sonnet', 1);
+			const models = new Map([
+				['main-model-id', mainMeta],
+				['sonnet-id', agentMeta],
+			]);
+			const qualifiedNameMap = new Map([
+				['Claude Sonnet (TestVendor)', { metadata: agentMeta, identifier: 'sonnet-id' }],
+			]);
+
+			// Agent has a model but no tiers
+			const agent = createAgent('NoTiersAgent', ['Claude Sonnet (TestVendor)']);
+			const tool = createTool({ models, qualifiedNameMap, customAgents: [agent] });
+
+			const result = await tool.prepareToolInvocation({
+				parameters: { prompt: 'test', description: 'test', agentName: 'NoTiersAgent', tier: 'fast' },
+				toolCallId: 'tier-no-tiers-1',
+				modelId: 'main-model-id',
+				chatSessionResource: URI.parse('test://session'),
+			}, CancellationToken.None);
+
+			assert.ok(result);
+			// Falls back to agent's frontmatter model since tiers is undefined
+			assert.strictEqual(result.toolSpecificData?.modelName, 'Claude Sonnet');
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds support for **capability tiers** in agent definitions (`tiers` frontmatter) and a **`tier` parameter** on the `runSubagent` tool, enabling semantic model selection at call time.

Resolves #306717

Related: #306836 / PR #306841 (call-time `model` parameter)

## What Changed

### Prompt file parser (`promptFileParser.ts`)
- New `tiers` constant in `PromptHeaderAttributes`
- New `get tiers()` getter on `PromptHeader` — parses YAML map of `{ tierName: { model: qualifiedName } }`

### Agent interface & service (`promptsService.ts`, `promptsServiceImpl.ts`)
- Added `tiers?: Readonly<Record<string, { readonly model: string }>>` to `ICustomAgent`
- Passthrough in service implementation

### Prompt validation (`promptValidator.ts`, `promptFileAttributes.ts`)
- `tiers` registered as allowed agent attribute (type: `map`)

### RunSubagent tool (`runSubagentTool.ts`)
- Added `model?: string` and `tier?: string` to `IRunSubagentToolInputParams` interface
- Both parameters gated behind `SubagentToolCustomAgents` config flag
- `resolveSubagentModel()` rewritten with 4-level resolution priority:
  1. Call-time `model` parameter (highest)
  2. Call-time `tier` parameter (looks up `agent.tiers[tier].model`)
  3. Agent's top-level `model:` frontmatter
  4. Parent model (default)
- New `resolveModelHint()` helper: tries qualified name → direct ID → undefined
- Multiplier-based cost cap moved outside conditional — applies uniformly to all resolution paths

### Tests (`runSubagentTool.test.ts`)
- `createAgent()` helper extended to accept `tiers` parameter
- **`call-time model parameter` suite** (6 tests): schema, override via qualified name, override via direct ID, multiplier cap, unknown model fallback, precedence over tier
- **`tier resolution` suite** (7 tests): correct model from tiers map, overrides agent default, multiplier cap, unknown tier fallback, no-agent ignored, no-tiers agent fallback, tier-with-tiers-defined

## Example Agent Frontmatter

```yaml
---
agent: DeepResearch
description: Research agent with tiered capabilities
model: claude-sonnet-4-6
tiers:
  fast:
    model: claude-haiku-4-5
  standard:
    model: claude-sonnet-4-6
  deep:
    model: claude-opus-4-6
---
```

```typescript
// Select semantic capability level
runSubagent({ prompt: "quick lookup", tier: "fast", agentName: "DeepResearch" })
// Or explicit model override (takes precedence over tier)
runSubagent({ prompt: "complex analysis", model: "claude-opus-4-6", agentName: "DeepResearch" })
```
