### PR TITLE
Add General Purpose agent support behind experimental setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1359,6 +1359,15 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
+		[ChatConfiguration.GeneralPurposeAgentEnabled]: {
+			type: 'boolean',
+			description: nls.localize('chat.generalPurposeAgent.enabled', "Controls whether the built-in General Purpose agent is available as a subagent."),
+			default: false,
+			tags: ['experimental'],
+			experiment: {
+				mode: 'auto'
+			}
+		},
 		[ChatConfiguration.SubagentsAllowInvocationsFromSubagents]: {
 			type: 'boolean',
 			description: nls.localize('chat.subagents.allowInvocationsFromSubagents', "Allow subagents to invoke subagents."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1363,7 +1363,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.generalPurposeAgent.enabled', "Controls whether the built-in General Purpose agent is available as a subagent."),
 			default: false,
-			tags: ['experimental'],
+			tags: ['experimental', 'advanced'],
 			experiment: {
 				mode: 'auto'
 			}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -196,3 +196,9 @@ export const ChatEditorTitleMaxLength = 30;
 export const CHAT_TERMINAL_OUTPUT_MAX_PREVIEW_LINES = 1000;
 export const CONTEXT_MODELS_EDITOR = new RawContextKey<boolean>('inModelsEditor', false);
 export const CONTEXT_MODELS_SEARCH_FOCUS = new RawContextKey<boolean>('inModelsSearch', false);
+
+/**
+ * The built-in general-purpose agent name. When the model uses this name,
+ * the subagent inherits the parent's system prompt, model, and tools.
+ */
+export const GeneralPurposeAgentName = 'General Purpose';

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -48,6 +48,7 @@ export enum ChatConfiguration {
 	ChatViewProgressBadgeEnabled = 'chat.viewProgressBadge.enabled',
 	ChatContextUsageEnabled = 'chat.contextUsage.enabled',
 	SubagentToolCustomAgents = 'chat.customAgentInSubagent.enabled',
+	GeneralPurposeAgentEnabled = 'chat.generalPurposeAgent.enabled',
 	SubagentsAllowInvocationsFromSubagents = 'chat.subagents.allowInvocationsFromSubagents',
 	ShowCodeBlockProgressAnimation = 'chat.agent.codeBlockProgress',
 	RestoreLastPanelSession = 'chat.restoreLastPanelSession',

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -31,7 +31,6 @@ import { ChatConfiguration, ChatModeKind, GeneralPurposeAgentName } from '../con
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { hash } from '../../../../../base/common/hash.js';
 import { IAgentPlugin, IAgentPluginService } from '../plugins/agentPluginService.js';
-import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 
 export type InstructionsCollectionEvent = {
 	applyingInstructionsCount: number;
@@ -79,7 +78,6 @@ export class ComputeAutomaticInstructions {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
 		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
-		@IWorkbenchAssignmentService private readonly _assignmentService: IWorkbenchAssignmentService,
 	) {
 	}
 
@@ -434,12 +432,7 @@ export class ComputeAutomaticInstructions {
 			}
 		}
 		if (runSubagentTool) {
-			let generalPurposeAgentEnabled = false;
-			try {
-				generalPurposeAgentEnabled = !!(await this._assignmentService.getTreatment<boolean>('chat.generalPurposeAgent'));
-			} catch (error) {
-				this._logService.error('[AutomaticInstructions] Failed to resolve treatment chat.generalPurposeAgent', error);
-			}
+			const generalPurposeAgentEnabled = !!this._configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
 
 			const customAgentsEnabled = !!this._configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents);
 			const canUseAgent = (() => {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -433,7 +433,7 @@ export class ComputeAutomaticInstructions {
 				entries.push('</skills>', '', ''); // add trailing newline
 			}
 		}
-		if (runSubagentTool && this._configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents)) {
+		if (runSubagentTool) {
 			let generalPurposeAgentEnabled = false;
 			try {
 				generalPurposeAgentEnabled = !!(await this._assignmentService.getTreatment<boolean>('chat.generalPurposeAgent'));
@@ -441,19 +441,7 @@ export class ComputeAutomaticInstructions {
 				this._logService.error('[AutomaticInstructions] Failed to resolve treatment chat.generalPurposeAgent', error);
 			}
 
-			if (generalPurposeAgentEnabled) {
-				entries.push('<agents>');
-				entries.push('Here is a list of agents that can be used when running a subagent.');
-				entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
-				entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
-
-				// Built-in General Purpose agent, always available
-				entries.push('<agent>');
-				entries.push(`<name>${GeneralPurposeAgentName}</name>`);
-				entries.push(`<description>Full-capability agent for complex multi-step tasks requiring the complete toolset and high-quality reasoning. Has access to all tools. Inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
-				entries.push('</agent>');
-			}
-
+			const customAgentsEnabled = !!this._configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents);
 			const canUseAgent = (() => {
 				if (!this._enabledSubagents || this._enabledSubagents.includes('*')) {
 					return (agent: ICustomAgent) => agent.visibility.agentInvocable;
@@ -462,17 +450,23 @@ export class ComputeAutomaticInstructions {
 					return (agent: ICustomAgent) => subagents.includes(agent.name);
 				}
 			})();
-			const agents = await this._promptsService.getCustomAgents(token);
-			if (!generalPurposeAgentEnabled && agents.length === 0) {
-				// No agents to show at all when experiment is off and no custom agents
-			} else {
-				if (!generalPurposeAgentEnabled) {
-					// Only render the agents block header when not already rendered by GP
-					entries.push('<agents>');
-					entries.push('Here is a list of agents that can be used when running a subagent.');
-					entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
-					entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
+			const agents = customAgentsEnabled ? await this._promptsService.getCustomAgents(token) : [];
+
+			if (generalPurposeAgentEnabled || agents.length > 0) {
+				entries.push('<agents>');
+				entries.push('Here is a list of agents that can be used when running a subagent.');
+				entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
+				entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
+
+				if (generalPurposeAgentEnabled) {
+					// Built-in General Purpose agent, always available when experiment is on
+					entries.push('<agent>');
+					entries.push(`<name>${GeneralPurposeAgentName}</name>`);
+					entries.push(`<description>Full-capability agent for complex multi-step tasks requiring the complete toolset and high-quality reasoning. Has access to all tools. Inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
+					entries.push('</agent>');
 				}
+				}
+
 				for (const agent of agents) {
 					if (canUseAgent(agent)) {
 						entries.push('<agent>');

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -462,7 +462,7 @@ export class ComputeAutomaticInstructions {
 					// Built-in General Purpose agent, always available when experiment is on
 					entries.push('<agent>');
 					entries.push(`<name>${GeneralPurposeAgentName}</name>`);
-					entries.push(`<description>Full-capability agent for complex multi-step tasks requiring the complete toolset and high-quality reasoning. Has access to all tools. Inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
+					entries.push(`<description>Full-capability agent for complex multi-step tasks requiring high-quality reasoning. Has access to the same tools and capabilities as the current agent and inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
 					entries.push('</agent>');
 				}
 				}

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -27,10 +27,11 @@ import { ParsedPromptFile } from './promptFileParser.js';
 import { AgentInstructionFileType, IAgentSkill, ICustomAgent, IInstructionFile, IPromptsService } from './service/promptsService.js';
 import { AGENT_DEBUG_LOG_ENABLED_SETTING, AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING, TROUBLESHOOT_SKILL_PATH } from './promptTypes.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
-import { ChatConfiguration, ChatModeKind } from '../constants.js';
+import { ChatConfiguration, ChatModeKind, GeneralPurposeAgentName } from '../constants.js';
 import { UserSelectedTools } from '../participants/chatAgents.js';
 import { hash } from '../../../../../base/common/hash.js';
 import { IAgentPlugin, IAgentPluginService } from '../plugins/agentPluginService.js';
+import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
 
 export type InstructionsCollectionEvent = {
 	applyingInstructionsCount: number;
@@ -78,6 +79,7 @@ export class ComputeAutomaticInstructions {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
 		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
+		@IWorkbenchAssignmentService private readonly _assignmentService: IWorkbenchAssignmentService,
 	) {
 	}
 
@@ -432,6 +434,21 @@ export class ComputeAutomaticInstructions {
 			}
 		}
 		if (runSubagentTool && this._configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents)) {
+			const generalPurposeAgentEnabled = !!(await this._assignmentService.getTreatment<boolean>('chat.generalPurposeAgent'));
+
+			if (generalPurposeAgentEnabled) {
+				entries.push('<agents>');
+				entries.push('Here is a list of agents that can be used when running a subagent.');
+				entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
+				entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
+
+				// Built-in General Purpose agent, always available
+				entries.push('<agent>');
+				entries.push(`<name>${GeneralPurposeAgentName}</name>`);
+				entries.push(`<description>Full-capability agent for complex multi-step tasks requiring the complete toolset and high-quality reasoning. Has access to all tools. Inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
+				entries.push('</agent>');
+			}
+
 			const canUseAgent = (() => {
 				if (!this._enabledSubagents || this._enabledSubagents.includes('*')) {
 					return (agent: ICustomAgent) => agent.visibility.agentInvocable;
@@ -441,11 +458,16 @@ export class ComputeAutomaticInstructions {
 				}
 			})();
 			const agents = await this._promptsService.getCustomAgents(token);
-			if (agents.length > 0) {
-				entries.push('<agents>');
-				entries.push('Here is a list of agents that can be used when running a subagent.');
-				entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
-				entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
+			if (!generalPurposeAgentEnabled && agents.length === 0) {
+				// No agents to show at all when experiment is off and no custom agents
+			} else {
+				if (!generalPurposeAgentEnabled) {
+					// Only render the agents block header when not already rendered by GP
+					entries.push('<agents>');
+					entries.push('Here is a list of agents that can be used when running a subagent.');
+					entries.push('Each agent has optionally a description with the agent\'s purpose and expertise. When asked to run a subagent, choose the most appropriate agent from this list.');
+					entries.push(`Use the ${runSubagentTool.variable} tool with the agent name to run the subagent.`);
+				}
 				for (const agent of agents) {
 					if (canUseAgent(agent)) {
 						entries.push('<agent>');

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -434,7 +434,12 @@ export class ComputeAutomaticInstructions {
 			}
 		}
 		if (runSubagentTool && this._configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents)) {
-			const generalPurposeAgentEnabled = !!(await this._assignmentService.getTreatment<boolean>('chat.generalPurposeAgent'));
+			let generalPurposeAgentEnabled = false;
+			try {
+				generalPurposeAgentEnabled = !!(await this._assignmentService.getTreatment<boolean>('chat.generalPurposeAgent'));
+			} catch (error) {
+				this._logService.error('[AutomaticInstructions] Failed to resolve treatment chat.generalPurposeAgent', error);
+			}
 
 			if (generalPurposeAgentEnabled) {
 				entries.push('<agents>');

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -458,7 +458,6 @@ export class ComputeAutomaticInstructions {
 					entries.push(`<description>Full-capability agent for complex multi-step tasks requiring high-quality reasoning. Has access to the same tools and capabilities as the current agent and inherits the parent agent's model and system prompt. Use for tasks that don't fit a more specialized agent.</description>`);
 					entries.push('</agent>');
 				}
-				}
 
 				for (const agent of agents) {
 					if (canUseAgent(agent)) {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { Event } from '../../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
@@ -66,7 +66,8 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 	static readonly Id = 'runSubagent';
 
-	readonly onDidUpdateToolData: Event<void>;
+	private readonly _onDidUpdateToolData = this._register(new Emitter<void>());
+	readonly onDidUpdateToolData: Event<void> = this._onDidUpdateToolData.event;
 
 	/** Hack to port data between prepare/invoke */
 	private readonly _resolvedModels = new Map<string, { modeModelId: string | undefined; resolvedModelName: string | undefined }>();
@@ -91,11 +92,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	) {
 		super();
 
-		const configEvent = Event.filter(this.configurationService.onDidChangeConfiguration, e =>
+		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e =>
 			e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents)
-		);
-		const refetchEvent = Event.map(this.assignmentService.onDidRefetchAssignments, () => { });
-		this.onDidUpdateToolData = Event.any(configEvent as Event<void>, refetchEvent);
+		)((() => this._onDidUpdateToolData.fire())));
 
 		// Resolve the experiment value asynchronously and re-resolve on refetch
 		this._resolveExperiment();
@@ -104,7 +103,11 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 	private _resolveExperiment(): void {
 		this.assignmentService.getTreatment<boolean>('chat.generalPurposeAgent').then(value => {
+			const changed = this._generalPurposeAgentEnabled !== !!value;
 			this._generalPurposeAgentEnabled = !!value;
+			if (changed) {
+				this._onDidUpdateToolData.fire();
+			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -94,7 +94,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e =>
 			e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents)
-		)((() => this._onDidUpdateToolData.fire())));
+		)(() => this._onDidUpdateToolData.fire()));
 
 		// Resolve the experiment value asynchronously and re-resolve on refetch
 		this._resolveExperiment();
@@ -108,6 +108,8 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			if (changed) {
 				this._onDidUpdateToolData.fire();
 			}
+		}, (error: unknown) => {
+			this.logService.error(`[RunSubagentTool] Failed to resolve treatment chat.generalPurposeAgent: ${error}`);
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -12,13 +12,14 @@ import { Disposable, DisposableStore } from '../../../../../../base/common/lifec
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
-import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
+import { IWorkbenchAssignmentService } from '../../../../../services/assignment/common/assignmentService.js';
 import { ChatRequestVariableSet } from '../../attachments/chatVariableEntries.js';
 import { IChatProgress, IChatService } from '../../chatService/chatService.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../constants.js';
+import { ChatAgentLocation, ChatConfiguration, ChatModeKind, GeneralPurposeAgentName } from '../../constants.js';
 import { ILanguageModelsService } from '../../languageModels.js';
 import { ChatModel, IChatRequestModeInstructions } from '../../model/chatModel.js';
 import { IChatAgentRequest, IChatAgentResult, IChatAgentService } from '../../participants/chatAgents.js';
@@ -50,7 +51,8 @@ const BaseModelDescription = `Launch a new agent to handle complex, multi-step t
 - When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
 - Each agent invocation is stateless. You will not be able to send additional messages to the agent, nor will the agent be able to communicate with you outside of its final report. Therefore, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
 - The agent's outputs should generally be trusted
-- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user\'s intent`;
+- Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user\'s intent
+- If the user asks for a certain agent, you MUST provide that EXACT agent name (case-sensitive) to invoke that specific agent.`;
 
 export interface IRunSubagentToolInputParams {
 	prompt: string;
@@ -64,7 +66,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 	static readonly Id = 'runSubagent';
 
-	readonly onDidUpdateToolData: Event<IConfigurationChangeEvent>;
+	readonly onDidUpdateToolData: Event<void>;
 
 	/** Hack to port data between prepare/invoke */
 	private readonly _resolvedModels = new Map<string, { modeModelId: string | undefined; resolvedModelName: string | undefined }>();
@@ -72,26 +74,42 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	/** Tracks the current subagent nesting depth per session to detect and limit recursion. */
 	private readonly _sessionDepth = new Map<string, number>();
 
+	/** Cached experiment value for whether the General Purpose agent is enabled. */
+	private _generalPurposeAgentEnabled = false;
+
 	constructor(
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatService private readonly chatService: IChatService,
 		@ILanguageModelToolsService private readonly languageModelToolsService: ILanguageModelToolsService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@ILogService private readonly logService: ILogService,
-		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IPromptsService private readonly promptsService: IPromptsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IProductService private readonly productService: IProductService,
+		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
 	) {
 		super();
-		this.onDidUpdateToolData = Event.filter(this.configurationService.onDidChangeConfiguration, e =>
+
+		const configEvent = Event.filter(this.configurationService.onDidChangeConfiguration, e =>
 			e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents)
 		);
+		const refetchEvent = Event.map(this.assignmentService.onDidRefetchAssignments, () => { });
+		this.onDidUpdateToolData = Event.any(configEvent as Event<void>, refetchEvent);
+
+		// Resolve the experiment value asynchronously and re-resolve on refetch
+		this._resolveExperiment();
+		this._register(this.assignmentService.onDidRefetchAssignments(() => this._resolveExperiment()));
+	}
+
+	private _resolveExperiment(): void {
+		this.assignmentService.getTreatment<boolean>('chat.generalPurposeAgent').then(value => {
+			this._generalPurposeAgentEnabled = !!value;
+		});
 	}
 
 	getToolData(): IToolData {
-		let modelDescription = BaseModelDescription;
+		const modelDescription = BaseModelDescription;
 		const inputSchema: IJSONSchema & { properties: IJSONSchemaMap } = {
 			type: 'object',
 			properties: {
@@ -102,18 +120,18 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				description: {
 					type: 'string',
 					description: 'A short (3-5 word) description of the task'
+				},
+				agentName: {
+					type: 'string',
+					description: this._generalPurposeAgentEnabled
+						? 'Name of the agent to invoke.'
+						: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
 				}
 			},
-			required: ['prompt', 'description']
+			required: this._generalPurposeAgentEnabled
+				? ['prompt', 'description', 'agentName']
+				: ['prompt', 'description']
 		};
-
-		if (this.configurationService.getValue(ChatConfiguration.SubagentToolCustomAgents)) {
-			inputSchema.properties.agentName = {
-				type: 'string',
-				description: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
-			};
-			modelDescription += `\n- If the user asks for a certain agent, you MUST provide that EXACT agent name (case-sensitive) to invoke that specific agent.`;
-		}
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,
 			toolReferenceName: VSCodeToolReference.runSubagent,
@@ -161,7 +179,10 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			let resolvedModelName: string | undefined;
 
 			const subAgentName = args.agentName;
-			if (subAgentName) {
+			// Defensive: model may omit agentName despite schema requiring it
+			const isGeneralPurpose = this._generalPurposeAgentEnabled && (!subAgentName || subAgentName === GeneralPurposeAgentName);
+
+			if (subAgentName && !isGeneralPurpose) {
 				subagent = await this.getSubAgentByName(subAgentName);
 				if (subagent) {
 					// Check the pre-resolved model cache from prepareToolInvocation
@@ -195,12 +216,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					modeInstructions = instructions && {
 						name: subAgentName,
 						content: instructions.content,
-						toolReferences: this.toolsService.toToolReferences(instructions.toolReferences),
+						toolReferences: this.languageModelToolsService.toToolReferences(instructions.toolReferences),
 						metadata: instructions.metadata,
 						isBuiltin: isBuiltinAgent(subagent.source, subagent.uri, this.productService),
 					};
 				} else {
-					throw new Error(`Requested agent '${subAgentName}' not found. Try again with the correct agent name, or omit the agentName to use the current agent.`);
+					this._resolvedModels.delete(invocation.callId);
+					throw new Error(`Requested agent '${subAgentName}' not found. Use '${GeneralPurposeAgentName}' for a full-capability agent.`);
 				}
 			} else {
 				// No subagent name - clean up any cached entry and resolve model name from main model
@@ -433,7 +455,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		const args = context.parameters as IRunSubagentToolInputParams;
 
-		const subagent = args.agentName ? await this.getSubAgentByName(args.agentName) : undefined;
+		// Defensive: model may omit agentName despite schema requiring it
+		const isGeneralPurpose = this._generalPurposeAgentEnabled && (!args.agentName || args.agentName === GeneralPurposeAgentName);
+		const subagent = (args.agentName && !isGeneralPurpose) ? await this.getSubAgentByName(args.agentName) : undefined;
 
 		// Resolve the model early and cache it for invoke()
 		const resolved = this.resolveSubagentModel(subagent, context.modelId);
@@ -444,7 +468,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			toolSpecificData: {
 				kind: 'subagent',
 				description: args.description,
-				agentName: subagent?.name,
+				agentName: isGeneralPurpose ? GeneralPurposeAgentName : (subagent?.name ?? args.agentName),
 				prompt: args.prompt,
 				modelName: resolved.resolvedModelName,
 			},

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -16,7 +16,6 @@ import { IConfigurationService } from '../../../../../../platform/configuration/
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
-import { IWorkbenchAssignmentService } from '../../../../../services/assignment/common/assignmentService.js';
 import { ChatRequestVariableSet } from '../../attachments/chatVariableEntries.js';
 import { IChatProgress, IChatService } from '../../chatService/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, GeneralPurposeAgentName } from '../../constants.js';
@@ -75,9 +74,6 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 	/** Tracks the current subagent nesting depth per session to detect and limit recursion. */
 	private readonly _sessionDepth = new Map<string, number>();
 
-	/** Cached experiment value for whether the General Purpose agent is enabled. */
-	private _generalPurposeAgentEnabled = false;
-
 	constructor(
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatService private readonly chatService: IChatService,
@@ -88,29 +84,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		@IPromptsService private readonly promptsService: IPromptsService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IProductService private readonly productService: IProductService,
-		@IWorkbenchAssignmentService private readonly assignmentService: IWorkbenchAssignmentService,
 	) {
 		super();
 
 		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e =>
-			e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents)
+			e.affectsConfiguration(ChatConfiguration.SubagentToolCustomAgents) ||
+			e.affectsConfiguration(ChatConfiguration.GeneralPurposeAgentEnabled)
 		)(() => this._onDidUpdateToolData.fire()));
-
-		// Resolve the experiment value asynchronously and re-resolve on refetch
-		this._resolveExperiment();
-		this._register(this.assignmentService.onDidRefetchAssignments(() => this._resolveExperiment()));
-	}
-
-	private _resolveExperiment(): void {
-		this.assignmentService.getTreatment<boolean>('chat.generalPurposeAgent').then(value => {
-			const changed = this._generalPurposeAgentEnabled !== !!value;
-			this._generalPurposeAgentEnabled = !!value;
-			if (changed) {
-				this._onDidUpdateToolData.fire();
-			}
-		}, (error: unknown) => {
-			this.logService.error(`[RunSubagentTool] Failed to resolve treatment chat.generalPurposeAgent: ${error}`);
-		});
 	}
 
 	getToolData(): IToolData {
@@ -128,12 +108,12 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				},
 				agentName: {
 					type: 'string',
-					description: this._generalPurposeAgentEnabled
+					description: this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled)
 						? 'Name of the agent to invoke.'
 						: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
 				}
 			},
-			required: this._generalPurposeAgentEnabled
+			required: this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled)
 				? ['prompt', 'description', 'agentName']
 				: ['prompt', 'description']
 		};
@@ -185,7 +165,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 			const subAgentName = args.agentName;
 			// Defensive: model may omit agentName despite schema requiring it
-			const isGeneralPurpose = this._generalPurposeAgentEnabled && (!subAgentName || subAgentName === GeneralPurposeAgentName);
+			const isGeneralPurpose = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled) && (!subAgentName || subAgentName === GeneralPurposeAgentName);
 
 			if (subAgentName && !isGeneralPurpose) {
 				subagent = await this.getSubAgentByName(subAgentName);
@@ -227,7 +207,11 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					};
 				} else {
 					this._resolvedModels.delete(invocation.callId);
-					throw new Error(`Requested agent '${subAgentName}' not found. Use '${GeneralPurposeAgentName}' for a full-capability agent.`);
+					const gpEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
+					const hint = gpEnabled
+						? ` Use '${GeneralPurposeAgentName}' for a full-capability agent.`
+						: '';
+					throw new Error(`Requested agent '${subAgentName}' not found.${hint}`);
 				}
 			} else {
 				// No subagent name - clean up any cached entry and resolve model name from main model
@@ -461,7 +445,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		const args = context.parameters as IRunSubagentToolInputParams;
 
 		// Defensive: model may omit agentName despite schema requiring it
-		const isGeneralPurpose = this._generalPurposeAgentEnabled && (!args.agentName || args.agentName === GeneralPurposeAgentName);
+		const isGeneralPurpose = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled) && (!args.agentName || args.agentName === GeneralPurposeAgentName);
 		const subagent = (args.agentName && !isGeneralPurpose) ? await this.getSubAgentByName(args.agentName) : undefined;
 
 		// Resolve the model early and cache it for invoke()

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -95,27 +95,38 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 	getToolData(): IToolData {
 		const modelDescription = BaseModelDescription;
+		const generalPurposeAgentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
+		const customAgentsEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.SubagentToolCustomAgents);
+
+		const properties: IJSONSchemaMap = {
+			prompt: {
+				type: 'string',
+				description: 'A detailed description of the task for the agent to perform'
+			},
+			description: {
+				type: 'string',
+				description: 'A short (3-5 word) description of the task'
+			}
+		};
+
+		if (customAgentsEnabled || generalPurposeAgentEnabled) {
+			properties.agentName = {
+				type: 'string',
+				description: generalPurposeAgentEnabled
+					? 'Name of the agent to invoke.'
+					: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
+			};
+		}
+
+		const required: string[] = ['prompt', 'description'];
+		if (generalPurposeAgentEnabled) {
+			required.push('agentName');
+		}
+
 		const inputSchema: IJSONSchema & { properties: IJSONSchemaMap } = {
 			type: 'object',
-			properties: {
-				prompt: {
-					type: 'string',
-					description: 'A detailed description of the task for the agent to perform'
-				},
-				description: {
-					type: 'string',
-					description: 'A short (3-5 word) description of the task'
-				},
-				agentName: {
-					type: 'string',
-					description: this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled)
-						? 'Name of the agent to invoke.'
-						: 'Optional name of a specific agent to invoke. If not provided, uses the current agent.'
-				}
-			},
-			required: this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled)
-				? ['prompt', 'description', 'agentName']
-				: ['prompt', 'description']
+			properties,
+			required
 		};
 		const runSubagentToolData: IToolData = {
 			id: RunSubagentTool.Id,
@@ -165,10 +176,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 			const subAgentName = args.agentName;
 			// Defensive: model may omit agentName despite schema requiring it
-			const isGeneralPurpose = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled) && (!subAgentName || subAgentName === GeneralPurposeAgentName);
+			const gpEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
+			const customAgentsEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.SubagentToolCustomAgents);
+			const isGeneralPurpose = gpEnabled && (!subAgentName || subAgentName === GeneralPurposeAgentName);
+			const effectiveSubAgentName = isGeneralPurpose ? GeneralPurposeAgentName : subAgentName;
 
 			if (subAgentName && !isGeneralPurpose) {
-				subagent = await this.getSubAgentByName(subAgentName);
+				subagent = customAgentsEnabled ? await this.getSubAgentByName(subAgentName) : undefined;
 				if (subagent) {
 					// Check the pre-resolved model cache from prepareToolInvocation
 					const cached = this._resolvedModels.get(invocation.callId);
@@ -207,11 +221,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 					};
 				} else {
 					this._resolvedModels.delete(invocation.callId);
-					const gpEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
-					const hint = gpEnabled
-						? ` Use '${GeneralPurposeAgentName}' for a full-capability agent.`
-						: '';
-					throw new Error(`Requested agent '${subAgentName}' not found.${hint}`);
+					const baseHint = ' Try again with the correct agent name, or omit agentName to use the current agent.';
+					const gpHint = gpEnabled ? ` Additionally, you can use '${GeneralPurposeAgentName}' for a full-capability agent.` : '';
+					throw new Error(`Requested agent '${subAgentName}' not found.${baseHint}${gpHint}`);
 				}
 			} else {
 				// No subagent name - clean up any cached entry and resolve model name from main model
@@ -323,7 +335,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				variables: { variables: variableSet.asArray() },
 				location: ChatAgentLocation.Chat,
 				subAgentInvocationId: subAgentInvocationId,
-				subAgentName: subAgentName,
+				subAgentName: effectiveSubAgentName,
 				userSelectedModelId: modeModelId,
 				modelConfiguration: modeModelId ? this.languageModelsService.getModelConfiguration(modeModelId) : undefined,
 				userSelectedTools: modeTools,
@@ -445,8 +457,10 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 		const args = context.parameters as IRunSubagentToolInputParams;
 
 		// Defensive: model may omit agentName despite schema requiring it
-		const isGeneralPurpose = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled) && (!args.agentName || args.agentName === GeneralPurposeAgentName);
-		const subagent = (args.agentName && !isGeneralPurpose) ? await this.getSubAgentByName(args.agentName) : undefined;
+		const gpEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.GeneralPurposeAgentEnabled);
+		const customAgentsEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.SubagentToolCustomAgents);
+		const isGeneralPurpose = gpEnabled && (!args.agentName || args.agentName === GeneralPurposeAgentName);
+		const subagent = (args.agentName && !isGeneralPurpose && customAgentsEnabled) ? await this.getSubAgentByName(args.agentName) : undefined;
 
 		// Resolve the model early and cache it for invoke()
 		const resolved = this.resolveSubagentModel(subagent, context.modelId);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -1572,6 +1572,44 @@ suite('ComputeAutomaticInstructions', () => {
 			assert.equal(xmlContents(agents[1], 'description')[0], 'Test agent 1');
 		});
 
+		test('should include General Purpose agent even without custom agents config', async () => {
+			workspaceContextService.setWorkspace(testWorkspace(URI.file('/gp-only-test')));
+
+			// Explicitly do NOT set chat.customAgentInSubagent.enabled
+
+			// Override the assignment service to enable the GP experiment
+			instaService.stub(IWorkbenchAssignmentService, {
+				_serviceBrand: undefined,
+				onDidRefetchAssignments: Event.None,
+				async getCurrentExperiments() { return []; },
+				async getTreatment<T>(name: string): Promise<T | undefined> {
+					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
+				},
+				addTelemetryAssignmentFilter() { },
+			} as IWorkbenchAssignmentService);
+
+			const contextComputer = instaService.createInstance(
+				ComputeAutomaticInstructions,
+				ChatModeKind.Agent,
+				{ 'vscode_runSubagent': true },
+				['*'],
+				undefined
+			);
+			const variables = new ChatRequestVariableSet();
+
+			await contextComputer.collect(variables, CancellationToken.None);
+
+			const textVariables = variables.asArray().filter(v => isPromptTextVariableEntry(v));
+			assert.equal(textVariables.length, 1, 'There should be one text variable for agents list');
+
+			const agentsList = xmlContents(textVariables[0].value, 'agents');
+			assert.equal(agentsList.length, 1, 'There should be one agents list');
+
+			const agents = xmlContents(agentsList[0], 'agent');
+			assert.equal(agents.length, 1, 'There should be only the GP agent');
+			assert.equal(xmlContents(agents[0], 'name')[0], GeneralPurposeAgentName);
+		});
+
 		test('should include skills list when readFile tool available', async () => {
 			const rootFolderName = 'skills-list-test';
 			const rootFolder = `/${rootFolderName}`;

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -1537,7 +1537,6 @@ suite('ComputeAutomaticInstructions', () => {
 				ChatModeKind.Agent,
 				{ 'vscode_runSubagent': true },
 				['*'],
-				undefined
 			);
 			const variables = new ChatRequestVariableSet();
 
@@ -1571,7 +1570,6 @@ suite('ComputeAutomaticInstructions', () => {
 				ChatModeKind.Agent,
 				{ 'vscode_runSubagent': true },
 				['*'],
-				undefined
 			);
 			const variables = new ChatRequestVariableSet();
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -50,8 +50,6 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IAgentPlugin, IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
-import { IWorkbenchAssignmentService } from '../../../../../services/assignment/common/assignmentService.js';
-import { NullWorkbenchAssignmentService } from '../../../../../services/assignment/test/common/nullAssignmentService.js';
 
 suite('ComputeAutomaticInstructions', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -194,8 +192,6 @@ suite('ComputeAutomaticInstructions', () => {
 			plugins: observableValue('testPlugins', []),
 			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
-
-		instaService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
 
 		service = disposables.add(instaService.createInstance(PromptsService));
 		instaService.stub(IPromptsService, service);
@@ -1518,16 +1514,7 @@ suite('ComputeAutomaticInstructions', () => {
 
 			testConfigService.setUserConfiguration('chat.customAgentInSubagent.enabled', true);
 
-			// Override the assignment service to enable the GP experiment
-			instaService.stub(IWorkbenchAssignmentService, {
-				_serviceBrand: undefined,
-				onDidRefetchAssignments: Event.None,
-				async getCurrentExperiments() { return []; },
-				async getTreatment<T>(name: string): Promise<T | undefined> {
-					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
-				},
-				addTelemetryAssignmentFilter() { },
-			} as IWorkbenchAssignmentService);
+			testConfigService.setUserConfiguration('chat.generalPurposeAgent.enabled', true);
 
 			testConfigService.setUserConfiguration(PromptsConfig.AGENTS_LOCATION_KEY, {
 				[AGENTS_SOURCE_FOLDER]: true,
@@ -1577,16 +1564,7 @@ suite('ComputeAutomaticInstructions', () => {
 
 			// Explicitly do NOT set chat.customAgentInSubagent.enabled
 
-			// Override the assignment service to enable the GP experiment
-			instaService.stub(IWorkbenchAssignmentService, {
-				_serviceBrand: undefined,
-				onDidRefetchAssignments: Event.None,
-				async getCurrentExperiments() { return []; },
-				async getTreatment<T>(name: string): Promise<T | undefined> {
-					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
-				},
-				addTelemetryAssignmentFilter() { },
-			} as IWorkbenchAssignmentService);
+			testConfigService.setUserConfiguration('chat.generalPurposeAgent.enabled', true);
 
 			const contextComputer = instaService.createInstance(
 				ComputeAutomaticInstructions,

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -45,11 +45,13 @@ import { ILanguageModelToolsService } from '../../../common/tools/languageModelT
 import { IRemoteAgentService } from '../../../../../../workbench/services/remote/common/remoteAgentService.js';
 import { basename } from '../../../../../../base/common/resources.js';
 import { match } from '../../../../../../base/common/glob.js';
-import { ChatModeKind } from '../../../common/constants.js';
+import { ChatModeKind, GeneralPurposeAgentName } from '../../../common/constants.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IAgentPlugin, IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
+import { IWorkbenchAssignmentService } from '../../../../../services/assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../../../services/assignment/test/common/nullAssignmentService.js';
 
 suite('ComputeAutomaticInstructions', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -192,6 +194,8 @@ suite('ComputeAutomaticInstructions', () => {
 			plugins: observableValue('testPlugins', []),
 			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
+
+		instaService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
 
 		service = disposables.add(instaService.createInstance(PromptsService));
 		instaService.stub(IPromptsService, service);
@@ -1503,6 +1507,69 @@ suite('ComputeAutomaticInstructions', () => {
 
 			assert.equal(xmlContents(agents[2], 'description')[0], 'Test agent 5');
 			assert.equal(xmlContents(agents[2], 'name')[0], `test-agent-5`);
+		});
+
+		test('should include General Purpose agent first when experiment is enabled', async () => {
+			const rootFolderName = 'gp-agents-list-test';
+			const rootFolder = `/${rootFolderName}`;
+			const rootFolderUri = URI.file(rootFolder);
+
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+
+			testConfigService.setUserConfiguration('chat.customAgentInSubagent.enabled', true);
+
+			// Override the assignment service to enable the GP experiment
+			instaService.stub(IWorkbenchAssignmentService, {
+				_serviceBrand: undefined,
+				onDidRefetchAssignments: Event.None,
+				async getCurrentExperiments() { return []; },
+				async getTreatment<T>(name: string): Promise<T | undefined> {
+					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
+				},
+				addTelemetryAssignmentFilter() { },
+			} as IWorkbenchAssignmentService);
+
+			testConfigService.setUserConfiguration(PromptsConfig.AGENTS_LOCATION_KEY, {
+				[AGENTS_SOURCE_FOLDER]: true,
+			});
+
+			await mockFiles(fileService, [
+				{
+					path: `${rootFolder}/.github/agents/test-agent-1.agent.md`,
+					contents: [
+						'---',
+						'description: \'Test agent 1\'',
+						'---',
+						'Test agent content',
+					]
+				},
+			]);
+
+			const contextComputer = instaService.createInstance(
+				ComputeAutomaticInstructions,
+				ChatModeKind.Agent,
+				{ 'vscode_runSubagent': true },
+				['*'],
+				undefined
+			);
+			const variables = new ChatRequestVariableSet();
+
+			await contextComputer.collect(variables, CancellationToken.None);
+
+			const textVariables = variables.asArray().filter(v => isPromptTextVariableEntry(v));
+			assert.equal(textVariables.length, 1, 'There should be one text variable for agents list');
+
+			const agentsList = xmlContents(textVariables[0].value, 'agents');
+			assert.equal(agentsList.length, 1, 'There should be one agents list');
+
+			const agents = xmlContents(agentsList[0], 'agent');
+			assert.equal(agents.length, 2, 'There should be two agents (General Purpose + 1 custom)');
+
+			// First agent should always be the built-in General Purpose agent
+			assert.equal(xmlContents(agents[0], 'name')[0], GeneralPurposeAgentName);
+
+			assert.equal(xmlContents(agents[1], 'name')[0], 'test-agent-1');
+			assert.equal(xmlContents(agents[1], 'description')[0], 'Test agent 1');
 		});
 
 		test('should include skills list when readFile tool available', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -303,8 +303,8 @@ suite('PromptsService', () => {
 			assert.deepEqual(
 				result1.body.variableReferences,
 				[
-					{ name: 'my-tool', range: new Range(10, 10, 10, 17), offset: 240 },
-					{ name: 'my-other-tool', range: new Range(11, 10, 11, 23), offset: 257 },
+					{ name: 'my-tool', range: new Range(10, 10, 10, 17), offset: 240, fullLength: 13 },
+					{ name: 'my-other-tool', range: new Range(11, 10, 11, 23), offset: 257, fullLength: 19 },
 				]
 			);
 
@@ -850,7 +850,7 @@ suite('PromptsService', () => {
 					tools: ['tool1', 'tool2'],
 					agentInstructions: {
 						content: 'Do it with #tool:tool1',
-						toolReferences: [{ name: 'tool1', range: { start: 11, endExclusive: 17 } }],
+						toolReferences: [{ name: 'tool1', range: { start: 11, endExclusive: 22 } }],
 						metadata: undefined
 					},
 					handOffs: undefined,
@@ -868,8 +868,8 @@ suite('PromptsService', () => {
 					agentInstructions: {
 						content: 'First use #tool:tool2\nThen use #tool:tool1',
 						toolReferences: [
-							{ name: 'tool1', range: { start: 31, endExclusive: 37 } },
-							{ name: 'tool2', range: { start: 10, endExclusive: 16 } }
+							{ name: 'tool1', range: { start: 31, endExclusive: 42 } },
+							{ name: 'tool2', range: { start: 10, endExclusive: 21 } }
 						],
 						metadata: undefined
 					},

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -55,8 +55,6 @@ import { IContextKeyService, IContextKeyChangeEvent } from '../../../../../../..
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from '../../../../common/plugins/agentPluginService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../../platform/workspace/common/workspaceTrust.js';
-import { IWorkbenchAssignmentService } from '../../../../../../services/assignment/common/assignmentService.js';
-import { NullWorkbenchAssignmentService } from '../../../../../../services/assignment/test/common/nullAssignmentService.js';
 
 suite('PromptsService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -180,8 +178,6 @@ suite('PromptsService', () => {
 			plugins: testPluginsObservable,
 			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
-
-		instaService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
 
 		service = disposables.add(instaService.createInstance(PromptsService));
 		instaService.stub(IPromptsService, service);

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -55,6 +55,8 @@ import { IContextKeyService, IContextKeyChangeEvent } from '../../../../../../..
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginHook, IAgentPluginInstruction, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from '../../../../common/plugins/agentPluginService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../../platform/workspace/common/workspaceTrust.js';
+import { IWorkbenchAssignmentService } from '../../../../../../services/assignment/common/assignmentService.js';
+import { NullWorkbenchAssignmentService } from '../../../../../../services/assignment/test/common/nullAssignmentService.js';
 
 suite('PromptsService', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -179,6 +181,8 @@ suite('PromptsService', () => {
 			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
 
+		instaService.stub(IWorkbenchAssignmentService, new NullWorkbenchAssignmentService());
+
 		service = disposables.add(instaService.createInstance(PromptsService));
 		instaService.stub(IPromptsService, service);
 	});
@@ -299,8 +303,8 @@ suite('PromptsService', () => {
 			assert.deepEqual(
 				result1.body.variableReferences,
 				[
-					{ name: 'my-tool', range: new Range(10, 10, 10, 17), offset: 240, fullLength: 13 },
-					{ name: 'my-other-tool', range: new Range(11, 10, 11, 23), offset: 257, fullLength: 19 },
+					{ name: 'my-tool', range: new Range(10, 10, 10, 17), offset: 240 },
+					{ name: 'my-other-tool', range: new Range(11, 10, 11, 23), offset: 257 },
 				]
 			);
 
@@ -846,7 +850,7 @@ suite('PromptsService', () => {
 					tools: ['tool1', 'tool2'],
 					agentInstructions: {
 						content: 'Do it with #tool:tool1',
-						toolReferences: [{ name: 'tool1', range: { start: 11, endExclusive: 22 } }],
+						toolReferences: [{ name: 'tool1', range: { start: 11, endExclusive: 17 } }],
 						metadata: undefined
 					},
 					handOffs: undefined,
@@ -864,8 +868,8 @@ suite('PromptsService', () => {
 					agentInstructions: {
 						content: 'First use #tool:tool2\nThen use #tool:tool1',
 						toolReferences: [
-							{ name: 'tool1', range: { start: 31, endExclusive: 42 } },
-							{ name: 'tool2', range: { start: 10, endExclusive: 21 } }
+							{ name: 'tool1', range: { start: 31, endExclusive: 37 } },
+							{ name: 'tool2', range: { start: 10, endExclusive: 16 } }
 						],
 						metadata: undefined
 					},

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -23,9 +23,6 @@ import { ExtensionIdentifier } from '../../../../../../../platform/extensions/co
 import { IToolInvocation, ToolProgress } from '../../../../common/tools/languageModelToolsService.js';
 import { IChatModel } from '../../../../common/model/chatModel.js';
 import { ChatConfiguration, GeneralPurposeAgentName } from '../../../../common/constants.js';
-import { NullWorkbenchAssignmentService } from '../../../../../../services/assignment/test/common/nullAssignmentService.js';
-import { IWorkbenchAssignmentService } from '../../../../../../services/assignment/common/assignmentService.js';
-import { Event } from '../../../../../../../base/common/event.js';
 
 suite('RunSubagentTool', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -77,7 +74,6 @@ suite('RunSubagentTool', () => {
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
-				new NullWorkbenchAssignmentService(),
 			));
 
 			const result = await tool.prepareToolInvocation(
@@ -110,15 +106,6 @@ suite('RunSubagentTool', () => {
 			if (opts?.customAgents) {
 				promptsService.setCustomModes(opts.customAgents);
 			}
-			const assignmentService: IWorkbenchAssignmentService = {
-				_serviceBrand: undefined,
-				onDidRefetchAssignments: Event.None,
-				async getCurrentExperiments() { return []; },
-				async getTreatment<T>(name: string): Promise<T | undefined> {
-					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
-				},
-				addTelemetryAssignmentFilter() { },
-			};
 
 			const tool = testDisposables.add(new RunSubagentTool(
 				{} as IChatAgentService,
@@ -126,19 +113,16 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				new TestConfigurationService(),
+				new TestConfigurationService({ [ChatConfiguration.GeneralPurposeAgentEnabled]: true }),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
-				assignmentService,
 			));
 			return tool;
 		}
 
 		async function createToolWithGPReady(opts?: { customAgents?: ICustomAgent[] }) {
-			const tool = createToolWithGP(opts);
-			await Event.toPromise(tool.onDidUpdateToolData);
-			return tool;
+			return createToolWithGP(opts);
 		}
 
 		test('treats undefined agentName as General Purpose when experiment is enabled', async () => {
@@ -245,7 +229,6 @@ suite('RunSubagentTool', () => {
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
-				new NullWorkbenchAssignmentService(),
 			));
 
 			const toolData = tool.getToolData();
@@ -261,15 +244,6 @@ suite('RunSubagentTool', () => {
 		test('marks agentName as required when GP experiment is enabled', async () => {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
 			const promptsService = new MockPromptsService();
-			const assignmentService: IWorkbenchAssignmentService = {
-				_serviceBrand: undefined,
-				onDidRefetchAssignments: Event.None,
-				async getCurrentExperiments() { return []; },
-				async getTreatment<T>(name: string): Promise<T | undefined> {
-					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
-				},
-				addTelemetryAssignmentFilter() { },
-			};
 
 			const tool = testDisposables.add(new RunSubagentTool(
 				{} as IChatAgentService,
@@ -277,15 +251,11 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				new TestConfigurationService(),
+				new TestConfigurationService({ [ChatConfiguration.GeneralPurposeAgentEnabled]: true }),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
-				assignmentService,
 			));
-
-			// Wait for the constructor's async experiment resolution via onDidUpdateToolData
-			await Event.toPromise(tool.onDidUpdateToolData);
 
 			const toolData = tool.getToolData();
 			assert.ok(toolData.inputSchema?.properties?.agentName);
@@ -404,7 +374,6 @@ suite('RunSubagentTool', () => {
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
-				new NullWorkbenchAssignmentService(),
 			));
 
 			return tool;
@@ -681,7 +650,6 @@ suite('RunSubagentTool', () => {
 				promptsService,
 				mockInstantiationService as IInstantiationService,
 				{} as IProductService,
-				new NullWorkbenchAssignmentService(),
 			));
 
 			return { tool, mockChatAgentService };

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -120,7 +120,7 @@ suite('RunSubagentTool', () => {
 				addTelemetryAssignmentFilter() { },
 			};
 
-			return testDisposables.add(new RunSubagentTool(
+			const tool = testDisposables.add(new RunSubagentTool(
 				{} as IChatAgentService,
 				{} as IChatService,
 				mockToolsService,
@@ -132,11 +132,17 @@ suite('RunSubagentTool', () => {
 				{} as IProductService,
 				assignmentService,
 			));
+			return tool;
+		}
+
+		async function createToolWithGPReady(opts?: { customAgents?: ICustomAgent[] }) {
+			const tool = createToolWithGP(opts);
+			await Event.toPromise(tool.onDidUpdateToolData);
+			return tool;
 		}
 
 		test('treats undefined agentName as General Purpose when experiment is enabled', async () => {
-			const tool = createToolWithGP();
-			await new Promise(resolve => setTimeout(resolve, 0));
+			const tool = await createToolWithGPReady();
 
 			const result = await tool.prepareToolInvocation(
 				{
@@ -158,8 +164,7 @@ suite('RunSubagentTool', () => {
 		});
 
 		test('treats empty string agentName as General Purpose when experiment is enabled', async () => {
-			const tool = createToolWithGP();
-			await new Promise(resolve => setTimeout(resolve, 0));
+			const tool = await createToolWithGPReady();
 
 			const result = await tool.prepareToolInvocation(
 				{
@@ -181,8 +186,7 @@ suite('RunSubagentTool', () => {
 		});
 
 		test('treats explicit General Purpose agentName as GP path', async () => {
-			const tool = createToolWithGP();
-			await new Promise(resolve => setTimeout(resolve, 0));
+			const tool = await createToolWithGPReady();
 
 			const result = await tool.prepareToolInvocation(
 				{
@@ -204,8 +208,7 @@ suite('RunSubagentTool', () => {
 		});
 
 		test('passes through unknown agentName when experiment is enabled', async () => {
-			const tool = createToolWithGP();
-			await new Promise(resolve => setTimeout(resolve, 0));
+			const tool = await createToolWithGPReady();
 
 			const result = await tool.prepareToolInvocation(
 				{
@@ -281,8 +284,8 @@ suite('RunSubagentTool', () => {
 				assignmentService,
 			));
 
-			// Wait a tick for the constructor's async experiment resolution
-			await new Promise(resolve => setTimeout(resolve, 0));
+			// Wait for the constructor's async experiment resolution via onDidUpdateToolData
+			await Event.toPromise(tool.onDidUpdateToolData);
 
 			const toolData = tool.getToolData();
 			assert.ok(toolData.inputSchema?.properties?.agentName);

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -22,7 +22,10 @@ import { MockPromptsService } from '../../promptSyntax/service/mockPromptsServic
 import { ExtensionIdentifier } from '../../../../../../../platform/extensions/common/extensions.js';
 import { IToolInvocation, ToolProgress } from '../../../../common/tools/languageModelToolsService.js';
 import { IChatModel } from '../../../../common/model/chatModel.js';
-import { ChatConfiguration } from '../../../../common/constants.js';
+import { ChatConfiguration, GeneralPurposeAgentName } from '../../../../common/constants.js';
+import { NullWorkbenchAssignmentService } from '../../../../../../services/assignment/test/common/nullAssignmentService.js';
+import { IWorkbenchAssignmentService } from '../../../../../../services/assignment/common/assignmentService.js';
+import { Event } from '../../../../../../../base/common/event.js';
 
 suite('RunSubagentTool', () => {
 	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -50,7 +53,6 @@ suite('RunSubagentTool', () => {
 	suite('prepareToolInvocation', () => {
 		test('returns correct toolSpecificData', async () => {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService();
 
 			const promptsService = new MockPromptsService();
 			const customMode: ICustomAgent = {
@@ -71,11 +73,11 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				mockToolsService,
-				configService,
+				new TestConfigurationService(),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
+				new NullWorkbenchAssignmentService(),
 			));
 
 			const result = await tool.prepareToolInvocation(
@@ -101,12 +103,133 @@ suite('RunSubagentTool', () => {
 				modelName: undefined,
 			});
 		});
+
+		function createToolWithGP(opts?: { customAgents?: ICustomAgent[] }) {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const promptsService = new MockPromptsService();
+			if (opts?.customAgents) {
+				promptsService.setCustomModes(opts.customAgents);
+			}
+			const assignmentService: IWorkbenchAssignmentService = {
+				_serviceBrand: undefined,
+				onDidRefetchAssignments: Event.None,
+				async getCurrentExperiments() { return []; },
+				async getTreatment<T>(name: string): Promise<T | undefined> {
+					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
+				},
+				addTelemetryAssignmentFilter() { },
+			};
+
+			return testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				new TestConfigurationService(),
+				promptsService,
+				{} as IInstantiationService,
+				{} as IProductService,
+				assignmentService,
+			));
+		}
+
+		test('treats undefined agentName as General Purpose when experiment is enabled', async () => {
+			const tool = createToolWithGP();
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			const result = await tool.prepareToolInvocation(
+				{
+					parameters: { prompt: 'Test prompt', description: 'Test task', agentName: undefined },
+					toolCallId: 'test-call-undef',
+					chatSessionResource: URI.parse('test://session'),
+				},
+				CancellationToken.None
+			);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'Test task',
+				agentName: GeneralPurposeAgentName,
+				prompt: 'Test prompt',
+				modelName: undefined,
+			});
+		});
+
+		test('treats empty string agentName as General Purpose when experiment is enabled', async () => {
+			const tool = createToolWithGP();
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			const result = await tool.prepareToolInvocation(
+				{
+					parameters: { prompt: 'Test prompt', description: 'Test task', agentName: '' },
+					toolCallId: 'test-call-empty',
+					chatSessionResource: URI.parse('test://session'),
+				},
+				CancellationToken.None
+			);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'Test task',
+				agentName: GeneralPurposeAgentName,
+				prompt: 'Test prompt',
+				modelName: undefined,
+			});
+		});
+
+		test('treats explicit General Purpose agentName as GP path', async () => {
+			const tool = createToolWithGP();
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			const result = await tool.prepareToolInvocation(
+				{
+					parameters: { prompt: 'Test prompt', description: 'Test task', agentName: GeneralPurposeAgentName },
+					toolCallId: 'test-call-gp',
+					chatSessionResource: URI.parse('test://session'),
+				},
+				CancellationToken.None
+			);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'Test task',
+				agentName: GeneralPurposeAgentName,
+				prompt: 'Test prompt',
+				modelName: undefined,
+			});
+		});
+
+		test('passes through unknown agentName when experiment is enabled', async () => {
+			const tool = createToolWithGP();
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			const result = await tool.prepareToolInvocation(
+				{
+					parameters: { prompt: 'Test prompt', description: 'Test task', agentName: 'NonExistentAgent' },
+					toolCallId: 'test-call-unknown',
+					chatSessionResource: URI.parse('test://session'),
+				},
+				CancellationToken.None
+			);
+
+			assert.ok(result);
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'Test task',
+				agentName: 'NonExistentAgent',
+				prompt: 'Test prompt',
+				modelName: undefined,
+			});
+		});
 	});
 
 	suite('getToolData', () => {
 		test('returns basic tool data', () => {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService();
 			const promptsService = new MockPromptsService();
 
 			const tool = testDisposables.add(new RunSubagentTool(
@@ -115,11 +238,11 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				mockToolsService,
-				configService,
+				new TestConfigurationService(),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
+				new NullWorkbenchAssignmentService(),
 			));
 
 			const toolData = tool.getToolData();
@@ -128,15 +251,22 @@ suite('RunSubagentTool', () => {
 			assert.ok(toolData.inputSchema);
 			assert.ok(toolData.inputSchema.properties?.prompt);
 			assert.ok(toolData.inputSchema.properties?.description);
+			assert.ok(toolData.inputSchema.properties?.agentName);
 			assert.deepStrictEqual(toolData.inputSchema.required, ['prompt', 'description']);
 		});
 
-		test('includes agentName property when SubagentToolCustomAgents is enabled', () => {
+		test('marks agentName as required when GP experiment is enabled', async () => {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService({
-				'chat.customAgentInSubagent.enabled': true,
-			});
 			const promptsService = new MockPromptsService();
+			const assignmentService: IWorkbenchAssignmentService = {
+				_serviceBrand: undefined,
+				onDidRefetchAssignments: Event.None,
+				async getCurrentExperiments() { return []; },
+				async getTreatment<T>(name: string): Promise<T | undefined> {
+					return (name === 'chat.generalPurposeAgent' ? true : undefined) as T | undefined;
+				},
+				addTelemetryAssignmentFilter() { },
+			};
 
 			const tool = testDisposables.add(new RunSubagentTool(
 				{} as IChatAgentService,
@@ -144,16 +274,19 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				mockToolsService,
-				configService,
+				new TestConfigurationService(),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
+				assignmentService,
 			));
 
-			const toolData = tool.getToolData();
+			// Wait a tick for the constructor's async experiment resolution
+			await new Promise(resolve => setTimeout(resolve, 0));
 
-			assert.ok(toolData.inputSchema?.properties?.agentName, 'agentName should be in schema when custom agents enabled');
+			const toolData = tool.getToolData();
+			assert.ok(toolData.inputSchema?.properties?.agentName);
+			assert.deepStrictEqual(toolData.inputSchema.required, ['prompt', 'description', 'agentName']);
 		});
 	});
 
@@ -244,7 +377,6 @@ suite('RunSubagentTool', () => {
 			customAgents?: ICustomAgent[];
 		}) {
 			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
-			const configService = new TestConfigurationService();
 			const promptsService = new MockPromptsService();
 			if (opts.customAgents) {
 				promptsService.setCustomModes(opts.customAgents);
@@ -265,11 +397,11 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				mockLanguageModelsService as ILanguageModelsService,
 				new NullLogService(),
-				mockToolsService,
-				configService,
+				new TestConfigurationService(),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,
+				new NullWorkbenchAssignmentService(),
 			));
 
 			return tool;
@@ -542,11 +674,11 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				{} as ILanguageModelsService,
 				new NullLogService(),
-				mockToolsService,
 				configService,
 				promptsService,
 				mockInstantiationService as IInstantiationService,
 				{} as IProductService,
+				new NullWorkbenchAssignmentService(),
 			));
 
 			return { tool, mockChatAgentService };

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -237,7 +237,7 @@ suite('RunSubagentTool', () => {
 			assert.ok(toolData.inputSchema);
 			assert.ok(toolData.inputSchema.properties?.prompt);
 			assert.ok(toolData.inputSchema.properties?.description);
-			assert.ok(toolData.inputSchema.properties?.agentName);
+			assert.strictEqual(toolData.inputSchema.properties?.agentName, undefined, 'agentName should not be in schema when neither GP nor custom agents is enabled');
 			assert.deepStrictEqual(toolData.inputSchema.required, ['prompt', 'description']);
 		});
 
@@ -370,7 +370,7 @@ suite('RunSubagentTool', () => {
 				mockToolsService,
 				mockLanguageModelsService as ILanguageModelsService,
 				new NullLogService(),
-				new TestConfigurationService(),
+				new TestConfigurationService({ [ChatConfiguration.SubagentToolCustomAgents]: true }),
 				promptsService,
 				{} as IInstantiationService,
 				{} as IProductService,


### PR DESCRIPTION
Add a built-in "General Purpose" agent to the `runSubagent` tool, gated behind the `chat.generalPurposeAgent.enabled` experimental setting.

Based on #295494, rebased and adapted to the current codebase.

## Changes

### `constants.ts`
- Added `GeneralPurposeAgentName = 'General Purpose'` constant
- Added `GeneralPurposeAgentEnabled = 'chat.generalPurposeAgent.enabled'` to `ChatConfiguration` enum

### `chat.contribution.ts`
- Registered the `chat.generalPurposeAgent.enabled` setting with `type: 'boolean'`, `default: false`, `tags: ['experimental', 'advanced']`, `experiment: { mode: 'auto' }`
- The `advanced` tag hides the setting from the Settings UI by default on Stable

### `runSubagentTool.ts`
- Replaced `IWorkbenchAssignmentService` experiment checks with synchronous `configurationService.getValue(ChatConfiguration.GeneralPurposeAgentEnabled)` reads
- Removed cached `_generalPurposeAgentEnabled` field, `_resolveExperiment()` method, and `onDidRefetchAssignments` listener
- **Schema gating**: `agentName` parameter only appears in the tool schema when `SubagentToolCustomAgents` or `GeneralPurposeAgentEnabled` is enabled; required when GP is enabled
- **Name normalization**: When GP is enabled, `undefined`/empty/`"General Purpose"` agent names are normalized to `effectiveSubAgentName = GeneralPurposeAgentName`, used consistently in `agentRequest.subAgentName` and `toolMetadata.agentName`
- **Custom agent gating**: `getSubAgentByName()` lookups are gated behind `SubagentToolCustomAgents` setting in both `invoke()` and `prepareToolInvocation()`
- **Error hints**: Unknown agent errors now always include a base recovery hint ("Try again with the correct agent name, or omit agentName"), with an additional GP-specific hint when enabled
- `onDidUpdateToolData` fires on config changes for both `SubagentToolCustomAgents` and `GeneralPurposeAgentEnabled`

### `computeAutomaticInstructions.ts`
- Removed `IWorkbenchAssignmentService` injection (replaced async `getTreatment` with synchronous `configurationService.getValue`)
- When setting is enabled, renders GP agent entry first in the agents instruction block with a full description
- Custom agents are appended after the GP agent entry

### Tests
- Removed all `IWorkbenchAssignmentService` stubs and `NullWorkbenchAssignmentService` usage from GP-related tests
- GP-enabled tests now use `TestConfigurationService({ [ChatConfiguration.GeneralPurposeAgentEnabled]: true })`
- Model resolution tests now enable `SubagentToolCustomAgents` via `TestConfigurationService`
- Schema test validates `agentName` is absent when neither GP nor custom agents is enabled
- Removed `await Event.toPromise(tool.onDidUpdateToolData)` waits (no longer async)

## Decisions
- Old experiment key `chat.generalPurposeAgent` intentionally dropped — this PR has not been merged yet, so no backward compatibility needed
- Setting uses `experiment: { mode: 'auto' }` so experiments can still override the default value
- Setting tagged `['experimental', 'advanced']` — hidden by default on Stable, visible on Insiders
- `agentName` schema gated behind `customAgentsEnabled || gpEnabled` to avoid exposing the parameter when neither feature is active
- Custom agent lookup gated behind `SubagentToolCustomAgents` to prevent resolving agents when that setting is off