### PR TITLE
sessions: update icon in left sidebar visibility toggle button

### DIFF
--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -18,7 +18,8 @@ import { IWorkbenchLayoutService, Parts } from '../../workbench/services/layout/
 
 // Register Icons
 const panelCloseIcon = registerIcon('agent-panel-close', Codicon.close, localize('agentPanelCloseIcon', "Icon to close the panel."));
-const sidebarToggleIcon = registerIcon('agent-sidebar-toggle', Codicon.tasklist, localize('agentSidebarToggleIcon', "Icon to toggle the sessions sidebar."));
+const sidebarToggleClosedIcon = registerIcon('agent-sidebar-toggle-closed', Codicon.layoutSidebarLeftOff, localize('agentSidebarToggleClosedIcon', "Icon for the sessions sidebar when closed."));
+const sidebarToggleOpenIcon = registerIcon('agent-sidebar-toggle-open', Codicon.layoutSidebarLeft, localize('agentSidebarToggleOpenIcon', "Icon for the sessions sidebar when open."));
 
 class ToggleSidebarVisibilityAction extends Action2 {
 
@@ -28,9 +29,10 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		super({
 			id: ToggleSidebarVisibilityAction.ID,
 			title: localize2('toggleSidebar', 'Toggle Primary Side Bar Visibility'),
-			icon: sidebarToggleIcon,
+			icon: sidebarToggleClosedIcon,
 			toggled: {
 				condition: SideBarVisibleContext,
+				icon: sidebarToggleOpenIcon,
 			},
 			metadata: {
 				description: localize('openAndCloseSidebar', 'Open/Show and Close/Hide Sidebar'),

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -24,6 +24,7 @@ import { IActionViewItemService } from '../../../../platform/actions/browser/act
 import { ISessionsManagementService } from './sessionsManagementService.js';
 import { autorun, observableSignalFromEvent } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { ChatSessionProviderIdContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from './sessionsProvidersService.js';
@@ -335,6 +336,21 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 			}
 			this._updateBadge();
 		}));
+	}
+
+	protected override getClass(): string | undefined {
+		// Show layout-sidebar-left when sidebar is visible (checked),
+		// layout-sidebar-left-off when sidebar is hidden (unchecked).
+		return this.action.checked
+			? ThemeIcon.asClassName(Codicon.layoutSidebarLeft)
+			: ThemeIcon.asClassName(Codicon.layoutSidebarLeftOff);
+	}
+
+	protected override updateChecked(): void {
+		super.updateChecked();
+		// Re-apply the icon class whenever the checked state changes so
+		// the open/closed codicon stays in sync with sidebar visibility.
+		this.updateClass();
 	}
 
 	private _updateBadge(): void {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -334,23 +334,15 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 				session.status.read(reader);
 				session.isRead.read(reader);
 			}
+			this.updateClass();
 			this._updateBadge();
 		}));
 	}
 
 	protected override getClass(): string | undefined {
-		// Show layout-sidebar-left when sidebar is visible (checked),
-		// layout-sidebar-left-off when sidebar is hidden (unchecked).
-		return this.action.checked
+		return this.layoutService.isVisible(Parts.SIDEBAR_PART)
 			? ThemeIcon.asClassName(Codicon.layoutSidebarLeft)
 			: ThemeIcon.asClassName(Codicon.layoutSidebarLeftOff);
-	}
-
-	protected override updateChecked(): void {
-		super.updateChecked();
-		// Re-apply the icon class whenever the checked state changes so
-		// the open/closed codicon stays in sync with sidebar visibility.
-		this.updateClass();
 	}
 
 	private _updateBadge(): void {


### PR DESCRIPTION
## Summary

This updates the Agent Sessions sidebar toggle to use the sidebar layout codicons instead of the generic task list icon.

- use `layout-sidebar-left-off` when the primary side bar is hidden
- use `layout-sidebar-left` when the primary side bar is visible
- preserve the unread badge on the custom title bar action when the side bar is closed

<img width="1775" height="1153" alt="Screenshot 2026-03-31 at 1 31 00 PM" src="https://github.com/user-attachments/assets/e6c1d74d-6ac2-4517-ae6c-90b925b6c2dd"/>
<img width="1775" height="1153" alt="Screenshot 2026-03-31 at 1 31 03 PM" src="https://github.com/user-attachments/assets/517f0791-e3c3-452a-bfd3-69143d71bb44"/>

## Why

The toggle now communicates the open and closed states more clearly while keeping the hidden-state unread badge behavior intact.

## Validation

- `npm run compile-check-ts-native`
- `npm run precommit`