### PR TITLE
Add configuration options for modal editor dimensions

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -62,6 +62,8 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 		'workbench.tips.enabled': false,
 		'workbench.layoutControl.type': 'toggles',
 		'workbench.editor.useModal': 'all',
+		'workbench.editor.modalMinWidth': 600,
+		'workbench.editor.modalMinHeight': 400,
 		'workbench.panel.showLabels': false,
 		'workbench.colorTheme': ThemeSettingDefaults.COLOR_THEME_DARK,
 

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -40,8 +40,8 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { CLOSE_MODAL_EDITOR_COMMAND_ID, MOVE_MODAL_EDITOR_TO_MAIN_COMMAND_ID, MOVE_MODAL_EDITOR_TO_WINDOW_COMMAND_ID, NAVIGATE_MODAL_EDITOR_NEXT_COMMAND_ID, NAVIGATE_MODAL_EDITOR_PREVIOUS_COMMAND_ID, TOGGLE_MODAL_EDITOR_MAXIMIZED_COMMAND_ID, TOGGLE_MODAL_EDITOR_SIDEBAR_COMMAND_ID } from './editorCommands.js';
 import { IModalEditorNavigation, IModalEditorPartOptions, IModalEditorSidebar } from '../../../../platform/editor/common/editor.js';
 
-const MODAL_MIN_WIDTH = 400;
-const MODAL_MIN_HEIGHT = 300;
+const MODAL_MIN_WIDTH_DEFAULT = 400;
+const MODAL_MIN_HEIGHT_DEFAULT = 300;
 const MODAL_MAX_DEFAULT_WIDTH = 1400;
 const MODAL_MAX_DEFAULT_HEIGHT = 900;
 const MODAL_BORDER_SIZE = 2; // 1px border on each side
@@ -193,8 +193,10 @@ export class ModalEditorPart {
 		const resizableElement = new ResizableHTMLElement();
 		disposables.add(toDisposable(() => resizableElement.dispose()));
 		resizableElement.domNode.classList.add('modal-editor-resizable');
-		const effectiveMinWidth = MODAL_MIN_WIDTH + (options?.sidebar ? MODAL_SIDEBAR_MIN_WIDTH : 0);
-		resizableElement.minSize = new Dimension(effectiveMinWidth, MODAL_MIN_HEIGHT);
+		const modalMinWidth = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinWidth') || MODAL_MIN_WIDTH_DEFAULT);
+		const modalMinHeight = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinHeight') || MODAL_MIN_HEIGHT_DEFAULT);
+		const effectiveMinWidth = modalMinWidth + (options?.sidebar ? MODAL_SIDEBAR_MIN_WIDTH : 0);
+		resizableElement.minSize = new Dimension(effectiveMinWidth, modalMinHeight);
 		modalElement.appendChild(resizableElement.domNode);
 
 		const shadowElement = resizableElement.domNode.appendChild($('.modal-editor-shadow'));
@@ -258,7 +260,7 @@ export class ModalEditorPart {
 		const actionBarContainer = append(headerElement, $('div.modal-editor-action-container'));
 
 		// Sidebar
-		const sidebarResult = this.createSidebar(editorPartContainer, options?.sidebar, disposables);
+		const sidebarResult = this.createSidebar(editorPartContainer, options?.sidebar, modalMinWidth, disposables);
 		if (sidebarResult) {
 			if (sidebarResult.isVisible()) {
 				editorPartContainer.classList.add('has-sidebar');
@@ -657,7 +659,7 @@ export class ModalEditorPart {
 		};
 	}
 
-	private createSidebar(container: HTMLElement, content: IModalEditorSidebar | undefined, disposables: DisposableStore): IModalEditorSidebarController | undefined {
+	private createSidebar(container: HTMLElement, content: IModalEditorSidebar | undefined, modalMinWidth: number, disposables: DisposableStore): IModalEditorSidebarController | undefined {
 		if (!content) {
 			return undefined;
 		}
@@ -696,7 +698,7 @@ export class ModalEditorPart {
 			}
 
 			const delta = e.currentX - e.startX;
-			const maxWidth = Math.max(MODAL_SIDEBAR_MIN_WIDTH, container.clientWidth - MODAL_MIN_WIDTH);
+			const maxWidth = Math.max(MODAL_SIDEBAR_MIN_WIDTH, container.clientWidth - modalMinWidth);
 			sidebarWidth = Math.min(maxWidth, Math.max(MODAL_SIDEBAR_MIN_WIDTH, sashStartWidth + delta));
 			customWidth = true;
 			sidebarContainer.style.width = `${sidebarWidth}px`;
@@ -704,7 +706,7 @@ export class ModalEditorPart {
 			onDidResizeEmitter.fire();
 		}));
 		disposables.add(sash.onDidReset(() => {
-			const maxWidth = Math.max(MODAL_SIDEBAR_MIN_WIDTH, container.clientWidth - MODAL_MIN_WIDTH);
+			const maxWidth = Math.max(MODAL_SIDEBAR_MIN_WIDTH, container.clientWidth - modalMinWidth);
 			sidebarWidth = Math.min(maxWidth, MODAL_SIDEBAR_DEFAULT_WIDTH);
 			customWidth = false;
 			sidebarContainer.style.width = `${sidebarWidth}px`;
@@ -717,8 +719,8 @@ export class ModalEditorPart {
 			getWidth: () => visible ? sidebarWidth : 0,
 			hasCustomWidth: () => customWidth,
 			clampWidth: (modalWidth: number) => {
-				if (sidebarWidth + MODAL_MIN_WIDTH > modalWidth) {
-					sidebarWidth = Math.min(MODAL_SIDEBAR_DEFAULT_WIDTH, Math.max(MODAL_SIDEBAR_MIN_WIDTH, modalWidth - MODAL_MIN_WIDTH));
+				if (sidebarWidth + modalMinWidth > modalWidth) {
+					sidebarWidth = Math.min(MODAL_SIDEBAR_DEFAULT_WIDTH, Math.max(MODAL_SIDEBAR_MIN_WIDTH, modalWidth - modalMinWidth));
 					customWidth = false;
 					sidebarContainer.style.width = `${sidebarWidth}px`;
 					sash.layout();

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -193,8 +193,12 @@ export class ModalEditorPart {
 		const resizableElement = new ResizableHTMLElement();
 		disposables.add(toDisposable(() => resizableElement.dispose()));
 		resizableElement.domNode.classList.add('modal-editor-resizable');
-		const modalMinWidth = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinWidth') ?? MODAL_MIN_WIDTH_DEFAULT);
-		const modalMinHeight = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinHeight') ?? MODAL_MIN_HEIGHT_DEFAULT);
+		const configuredModalMinWidth = this.configurationService.getValue<number>('workbench.editor.modalMinWidth');
+		const safeModalMinWidth = Number.isFinite(configuredModalMinWidth) ? configuredModalMinWidth : MODAL_MIN_WIDTH_DEFAULT;
+		const modalMinWidth = Math.max(200, safeModalMinWidth);
+		const configuredModalMinHeight = this.configurationService.getValue<number>('workbench.editor.modalMinHeight');
+		const safeModalMinHeight = Number.isFinite(configuredModalMinHeight) ? configuredModalMinHeight : MODAL_MIN_HEIGHT_DEFAULT;
+		const modalMinHeight = Math.max(200, safeModalMinHeight);
 		const effectiveMinWidth = modalMinWidth + (options?.sidebar ? MODAL_SIDEBAR_MIN_WIDTH : 0);
 		resizableElement.minSize = new Dimension(effectiveMinWidth, modalMinHeight);
 		modalElement.appendChild(resizableElement.domNode);

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -193,8 +193,8 @@ export class ModalEditorPart {
 		const resizableElement = new ResizableHTMLElement();
 		disposables.add(toDisposable(() => resizableElement.dispose()));
 		resizableElement.domNode.classList.add('modal-editor-resizable');
-		const modalMinWidth = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinWidth') || MODAL_MIN_WIDTH_DEFAULT);
-		const modalMinHeight = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinHeight') || MODAL_MIN_HEIGHT_DEFAULT);
+		const modalMinWidth = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinWidth') ?? MODAL_MIN_WIDTH_DEFAULT);
+		const modalMinHeight = Math.max(200, this.configurationService.getValue<number>('workbench.editor.modalMinHeight') ?? MODAL_MIN_HEIGHT_DEFAULT);
 		const effectiveMinWidth = modalMinWidth + (options?.sidebar ? MODAL_SIDEBAR_MIN_WIDTH : 0);
 		resizableElement.minSize = new Dimension(effectiveMinWidth, modalMinHeight);
 		modalElement.appendChild(resizableElement.domNode);

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -363,7 +363,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.editor.modalMinWidth': {
 				'type': 'number',
-				'description': localize('modalMinWidth', "Controls the minimum width of the modal editor overlay in pixels."),
+				'description': localize('modalMinWidth', "Controls the minimum width of the editor area in the modal editor overlay in pixels. The overall overlay may be wider when a sidebar is visible."),
 				'default': 400,
 				'minimum': 200,
 				'tags': ['experimental']

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,6 +361,18 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': 'some'
 			},
+			'workbench.editor.modalMinWidth': {
+				'type': 'number',
+				'description': localize('modalMinWidth', "Controls the minimum width of the modal editor overlay in pixels."),
+				'default': 400,
+				'minimum': 200
+			},
+			'workbench.editor.modalMinHeight': {
+				'type': 'number',
+				'description': localize('modalMinHeight', "Controls the minimum height of the modal editor overlay in pixels."),
+				'default': 300,
+				'minimum': 200
+			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
 				'description': localize('swipeToNavigate', "Navigate between open files using three-finger swipe horizontally. Note that System Preferences > Trackpad > More Gestures > 'Swipe between pages' must be set to 'Swipe with two or three fingers'."),

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,18 +361,6 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': 'some'
 			},
-			'workbench.editor.modalMinWidth': {
-				'type': 'number',
-				'description': localize('modalMinWidth', "Controls the minimum width of the modal editor overlay in pixels."),
-				'default': 400,
-				'minimum': 200
-			},
-			'workbench.editor.modalMinHeight': {
-				'type': 'number',
-				'description': localize('modalMinHeight', "Controls the minimum height of the modal editor overlay in pixels."),
-				'default': 300,
-				'minimum': 200
-			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
 				'description': localize('swipeToNavigate', "Navigate between open files using three-finger swipe horizontally. Note that System Preferences > Trackpad > More Gestures > 'Swipe between pages' must be set to 'Swipe with two or three fingers'."),

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,6 +361,20 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': 'some'
 			},
+			'workbench.editor.modalMinWidth': {
+				'type': 'number',
+				'description': localize('modalMinWidth', "Controls the minimum width of the modal editor overlay in pixels."),
+				'default': 400,
+				'minimum': 200,
+				'tags': ['experimental']
+			},
+			'workbench.editor.modalMinHeight': {
+				'type': 'number',
+				'description': localize('modalMinHeight', "Controls the minimum height of the modal editor overlay in pixels."),
+				'default': 300,
+				'minimum': 200,
+				'tags': ['experimental']
+			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
 				'description': localize('swipeToNavigate', "Navigate between open files using three-finger swipe horizontally. Note that System Preferences > Trackpad > More Gestures > 'Swipe between pages' must be set to 'Swipe with two or three fingers'."),


### PR DESCRIPTION
Introduce configuration options for setting minimum width and height of the modal editor overlay. Refactor existing code to utilize these new settings, ensuring a more flexible and customizable user experience.

**Before**
<img width="533" height="385" alt="image" src="https://github.com/user-attachments/assets/1c729dd4-b4c9-4b06-9a8a-5c86b2a3e564" />


**After**
<img width="700" height="537" alt="image" src="https://github.com/user-attachments/assets/298205e1-34f3-44ff-9399-40ac9b7ca14c" />


