### PR TITLE
Sessions: Add Copilot status indicator to sidebar footer

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -220,40 +220,20 @@ export class AccountWidget extends ActionViewItem {
 			return;
 		}
 
-		const sentiment = this.chatEntitlementService.sentiment;
-		if (sentiment.hidden) {
-			this.copilotStatusContainer.classList.add('hidden');
-			return;
-		}
-
 		this.copilotStatusContainer.classList.remove('hidden');
 
 		let icon = Codicon.copilot.id;
-		let tooltip = localize('copilotStatus', "Copilot Status");
-
 		const chatQuotaExceeded = this.chatEntitlementService.quotas.chat?.percentRemaining === 0;
 		const completionsQuotaExceeded = this.chatEntitlementService.quotas.completions?.percentRemaining === 0;
-		const runningSessionsCount = this.chatSessionsService.getInProgress().reduce((total, item) => total + item.count, 0);
 
-		if (sentiment.disabled || sentiment.untrusted) {
-			icon = 'copilot-unavailable';
-			tooltip = localize('copilotDisabled', "Copilot Disabled");
-		} else if (runningSessionsCount > 0) {
-			icon = 'copilot-in-progress';
-			tooltip = runningSessionsCount > 1
-				? localize('sessionsInProgress', "{0} agent sessions in progress", runningSessionsCount)
-				: localize('sessionInProgress', "1 agent session in progress");
-		} else if (this.chatEntitlementService.entitlement === ChatEntitlement.Unknown) {
+		if (this.chatEntitlementService.entitlement === ChatEntitlement.Unknown) {
 			icon = 'copilot-not-connected';
-			tooltip = localize('copilotSignedOut', "Copilot: Signed Out");
 		} else if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)) {
 			icon = 'copilot-warning';
-			tooltip = localize('copilotQuotaReached', "Copilot: Quota Reached");
 		}
 
 		this.copilotStatusButton.label = `$(${icon})`;
-		this.copilotStatusButton.element.title = tooltip;
-		this.copilotStatusButton.element.setAttribute('aria-label', tooltip);
+		this.copilotStatusButton.element.setAttribute('aria-label', localize('copilotStatus', "Copilot status"));
 
 		// Hide when update button is visible
 		this.updateCopilotStatusVisibility();

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -5,6 +5,7 @@
 
 import '../../../browser/media/sidebarActionButton.css';
 import './media/accountWidget.css';
+import '../../../../workbench/contrib/chat/browser/chatStatus/media/chatStatus.css';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
@@ -17,7 +18,8 @@ import { Menus } from '../../../browser/menus.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { fillInActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
-import { $, append } from '../../../../base/browser/dom.js';
+import { $, append, disposableWindowInterval } from '../../../../base/browser/dom.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 import { ActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
@@ -31,6 +33,10 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 import { URI } from '../../../../base/common/uri.js';
 import { UpdateHoverWidget } from './updateHoverWidget.js';
+import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
+import { ChatStatusDashboard } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
+import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 
 // --- Account Menu Items --- //
 const AccountMenu = new MenuId('SessionsAccountMenu');
@@ -91,6 +97,8 @@ registerUpdateMenuItems(AccountMenu, '3_updates');
 export class AccountWidget extends ActionViewItem {
 
 	private accountButton: Button | undefined;
+	private copilotStatusButton: Button | undefined;
+	private copilotStatusContainer: HTMLElement | undefined;
 	private updateButton: Button | undefined;
 	private readonly updateHoverWidget: UpdateHoverWidget;
 	private readonly viewItemDisposables = this._register(new DisposableStore());
@@ -108,6 +116,9 @@ export class AccountWidget extends ActionViewItem {
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IHostService private readonly hostService: IHostService,
+		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super(undefined, action, { ...options, icon: false, label: false });
 		this.updateHoverWidget = new UpdateHoverWidget(this.updateService, this.productService, this.hoverService);
@@ -134,6 +145,20 @@ export class AccountWidget extends ActionViewItem {
 			buttonSecondaryBorder: undefined,
 		}));
 		this.accountButton.element.classList.add('account-widget-account-button', 'sidebar-action-button');
+
+		// Copilot status button (between account and update)
+		this.copilotStatusContainer = append(container, $('.account-widget-copilot-status'));
+		this.copilotStatusButton = this.viewItemDisposables.add(new Button(this.copilotStatusContainer, {
+			...defaultButtonStyles,
+			secondary: true,
+			title: false,
+			supportIcons: true,
+			buttonSecondaryBackground: 'transparent',
+			buttonSecondaryHoverBackground: undefined,
+			buttonSecondaryForeground: undefined,
+			buttonSecondaryBorder: undefined,
+		}));
+		this.copilotStatusButton.element.classList.add('account-widget-copilot-status-button', 'sidebar-action-button');
 
 		// Update button (right)
 		const updateContainer = append(container, $('.account-widget-update'));
@@ -162,6 +187,19 @@ export class AccountWidget extends ActionViewItem {
 		}));
 
 		this.viewItemDisposables.add(this.updateButton.onDidClick(() => this.update()));
+
+		// Copilot status: update icon and show/hide based on update button
+		this.updateCopilotStatusButton();
+		this.viewItemDisposables.add(this.chatEntitlementService.onDidChangeEntitlement(() => this.updateCopilotStatusButton()));
+		this.viewItemDisposables.add(this.chatEntitlementService.onDidChangeSentiment(() => this.updateCopilotStatusButton()));
+		this.viewItemDisposables.add(this.chatEntitlementService.onDidChangeQuotaExceeded(() => this.updateCopilotStatusButton()));
+		this.viewItemDisposables.add(this.chatSessionsService.onDidChangeInProgress(() => this.updateCopilotStatusButton()));
+
+		this.viewItemDisposables.add(this.copilotStatusButton.onDidClick(e => {
+			e?.preventDefault();
+			e?.stopPropagation();
+			this.showCopilotStatusDashboard(this.copilotStatusButton!.element);
+		}));
 	}
 
 	private showAccountMenu(anchor: HTMLElement): void {
@@ -174,6 +212,84 @@ export class AccountWidget extends ActionViewItem {
 			getAnchor: () => anchor,
 			getActions: () => actions,
 		});
+	}
+
+	private updateCopilotStatusButton(): void {
+		if (!this.copilotStatusButton || !this.copilotStatusContainer) {
+			return;
+		}
+
+		const sentiment = this.chatEntitlementService.sentiment;
+		if (sentiment.hidden) {
+			this.copilotStatusContainer.classList.add('hidden');
+			return;
+		}
+
+		this.copilotStatusContainer.classList.remove('hidden');
+
+		let icon = Codicon.copilot.id;
+		let tooltip = localize('copilotStatus', "Copilot Status");
+
+		const chatQuotaExceeded = this.chatEntitlementService.quotas.chat?.percentRemaining === 0;
+		const completionsQuotaExceeded = this.chatEntitlementService.quotas.completions?.percentRemaining === 0;
+		const runningSessionsCount = this.chatSessionsService.getInProgress().reduce((total, item) => total + item.count, 0);
+
+		if (sentiment.disabled || sentiment.untrusted) {
+			icon = 'copilot-unavailable';
+			tooltip = localize('copilotDisabled', "Copilot Disabled");
+		} else if (runningSessionsCount > 0) {
+			icon = 'copilot-in-progress';
+			tooltip = runningSessionsCount > 1
+				? localize('sessionsInProgress', "{0} agent sessions in progress", runningSessionsCount)
+				: localize('sessionInProgress', "1 agent session in progress");
+		} else if (this.chatEntitlementService.entitlement === ChatEntitlement.Unknown) {
+			icon = 'copilot-not-connected';
+			tooltip = localize('copilotSignedOut', "Copilot: Signed Out");
+		} else if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (chatQuotaExceeded || completionsQuotaExceeded)) {
+			icon = 'copilot-warning';
+			tooltip = localize('copilotQuotaReached', "Copilot: Quota Reached");
+		}
+
+		this.copilotStatusButton.label = `$(${icon})`;
+		this.copilotStatusButton.element.title = tooltip;
+
+		// Hide when update button is visible
+		this.updateCopilotStatusVisibility();
+	}
+
+	private updateCopilotStatusVisibility(): void {
+		if (!this.copilotStatusContainer || !this.updateButton) {
+			return;
+		}
+
+		const updateVisible = !this.updateButton.element.classList.contains('hidden');
+		this.copilotStatusContainer.classList.toggle('hidden', updateVisible || this.chatEntitlementService.sentiment.hidden);
+	}
+
+	private showCopilotStatusDashboard(anchor: HTMLElement): void {
+		const store = new DisposableStore();
+		const dashboardElement = ChatStatusDashboard.instantiateInContents(this.instantiationService, store, {
+			disableInlineSuggestionsSettings: true,
+			disableModelSelection: true,
+			disableProviderOptions: true,
+			disableCompletionsSnooze: true,
+			disableContributions: true,
+		});
+
+		this.hoverService.showInstantHover({
+			content: dashboardElement,
+			target: anchor,
+			position: { hoverPosition: HoverPosition.ABOVE },
+			persistence: { sticky: true, hideOnHover: false },
+			appearance: { skipFadeInAnimation: true },
+		});
+
+		// Dispose the dashboard when the hover is hidden
+		store.add(disposableWindowInterval(mainWindow, () => {
+			if (!dashboardElement.isConnected) {
+				store.dispose();
+			}
+		}, 2000));
 	}
 
 	private async updateAccountButton(): Promise<void> {
@@ -205,26 +321,23 @@ export class AccountWidget extends ActionViewItem {
 			this.updateButton.enabled = true;
 			this.updateButton.label = localize('updateAvailable', "Update Available");
 			this.updateButton.element.title = localize('updateInVSCodeHover', "Updates are managed by VS Code. Click to open VS Code.");
-			return;
-		}
-
-		if (this.shouldHideUpdateButton(state.type)) {
+		} else if (this.shouldHideUpdateButton(state.type)) {
 			this.clearUpdateButtonStyling();
 			this.updateButton.element.classList.add('hidden');
-			return;
+		} else {
+			this.updateButton.element.classList.remove('hidden');
+			this.updateButton.element.style.backgroundImage = '';
+			this.updateButton.enabled = state.type === StateType.Ready;
+			this.updateButton.label = this.getUpdateProgressMessage(state.type);
+
+			if (state.type === StateType.Ready) {
+				this.updateButton.element.classList.add('account-widget-update-button-ready');
+			} else {
+				this.updateButton.element.classList.remove('account-widget-update-button-ready');
+			}
 		}
 
-		this.updateButton.element.classList.remove('hidden');
-		this.updateButton.element.style.backgroundImage = '';
-		this.updateButton.enabled = state.type === StateType.Ready;
-		this.updateButton.label = this.getUpdateProgressMessage(state.type);
-
-		if (state.type === StateType.Ready) {
-			this.updateButton.element.classList.add('account-widget-update-button-ready');
-			return;
-		}
-
-		this.updateButton.element.classList.remove('account-widget-update-button-ready');
+		this.updateCopilotStatusVisibility();
 	}
 
 	private shouldHideUpdateButton(type: StateType): boolean {

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -6,7 +6,7 @@
 import '../../../browser/media/sidebarActionButton.css';
 import './media/accountWidget.css';
 import '../../../../workbench/contrib/chat/browser/chatStatus/media/chatStatus.css';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -102,6 +102,7 @@ export class AccountWidget extends ActionViewItem {
 	private updateButton: Button | undefined;
 	private readonly updateHoverWidget: UpdateHoverWidget;
 	private readonly viewItemDisposables = this._register(new DisposableStore());
+	private readonly copilotDashboardStore = this._register(new MutableDisposable<DisposableStore>());
 
 	constructor(
 		action: IAction,
@@ -252,6 +253,7 @@ export class AccountWidget extends ActionViewItem {
 
 		this.copilotStatusButton.label = `$(${icon})`;
 		this.copilotStatusButton.element.title = tooltip;
+		this.copilotStatusButton.element.setAttribute('aria-label', tooltip);
 
 		// Hide when update button is visible
 		this.updateCopilotStatusVisibility();
@@ -268,6 +270,7 @@ export class AccountWidget extends ActionViewItem {
 
 	private showCopilotStatusDashboard(anchor: HTMLElement): void {
 		const store = new DisposableStore();
+		this.copilotDashboardStore.value = store;
 		const dashboardElement = ChatStatusDashboard.instantiateInContents(this.instantiationService, store, {
 			disableInlineSuggestionsSettings: true,
 			disableModelSelection: true,

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
@@ -56,6 +56,70 @@
 	display: none;
 }
 
+/* Copilot Status Button */
+.account-widget-copilot-status {
+	flex: 0 0 auto;
+	width: fit-content;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.account-widget-copilot-status.hidden {
+	display: none;
+}
+
+.account-widget-copilot-status .account-widget-copilot-status-button {
+	width: auto;
+	max-width: none;
+	padding: 4px 6px;
+}
+
+/* Chat status dashboard shown from sidebar footer */
+.monaco-hover .chat-status-bar-entry-tooltip {
+	font-size: 12px;
+	max-width: 320px;
+	padding: 4px 6px;
+	overflow: hidden;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip div.header {
+	font-size: 12px;
+	margin-bottom: 6px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip div.description {
+	font-size: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip hr {
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip .quota-indicator {
+	margin-bottom: 4px;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip .contribution .body {
+	font-size: 11px;
+	overflow: hidden;
+	min-width: 0;
+}
+
+.monaco-hover .chat-status-bar-entry-tooltip .contribution .body .description,
+.monaco-hover .chat-status-bar-entry-tooltip .contribution .body .detail-item {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
 .monaco-workbench .part.sidebar > .sidebar-footer .account-widget-update .account-widget-update-button {
 	width: auto;
 	max-width: none;

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountWidget.fixture.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountWidget.fixture.ts
@@ -27,6 +27,10 @@ import '../../../../../platform/theme/common/colors/inputColors.js';
 import '../../../../browser/media/sidebarActionButton.css';
 import '../../browser/media/accountWidget.css';
 
+import { ChatEntitlementService, IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
+import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+
 const mockUpdate = { version: '1.0.0' };
 
 function createMockUpdateService(state: State): IUpdateService {
@@ -89,7 +93,7 @@ function renderAccountWidget(ctx: ComponentFixtureContext, state: State, account
 	const openerService = instantiationService.get(IOpenerService);
 	const dialogService = instantiationService.get(IDialogService);
 	const hostService = instantiationService.get(IHostService);
-	const widget = new AccountWidget(action, {}, mockAccountService, mockUpdateService, contextMenuService, menuService, contextKeyService, hoverService, productService, openerService, dialogService, hostService);
+	const widget = new AccountWidget(action, {}, mockAccountService, mockUpdateService, contextMenuService, menuService, contextKeyService, hoverService, productService, openerService, dialogService, hostService, instantiationService.get(IChatEntitlementService) as ChatEntitlementService, instantiationService.get(IChatSessionsService), instantiationService.get(IInstantiationService));
 	ctx.disposableStore.add(widget);
 	widget.render(ctx.container);
 }

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -118,6 +118,19 @@ registerColor('gauge.errorBackground', {
 	hcLight: Color.white
 }, localize('gaugeErrorBackground', "Gauge error background color."));
 
+export interface IChatStatusDashboardOptions {
+	/** When true, disables the Inline Suggestions settings section (toggles for all files, language, next edit). */
+	disableInlineSuggestionsSettings?: boolean;
+	/** When true, disables the inline completions model selection section. */
+	disableModelSelection?: boolean;
+	/** When true, disables the inline completions provider options section. */
+	disableProviderOptions?: boolean;
+	/** When true, disables the completions snooze button. */
+	disableCompletionsSnooze?: boolean;
+	/** When true, disables contributed status items (e.g. Workspace Index). */
+	disableContributions?: boolean;
+}
+
 export class ChatStatusDashboard extends DomWidget {
 
 	readonly element = $('div.chat-status-bar-entry-tooltip');
@@ -128,6 +141,7 @@ export class ChatStatusDashboard extends DomWidget {
 	private readonly quotaOverageFormatter = safeIntl.NumberFormat(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 0 });
 
 	constructor(
+		private readonly options: IChatStatusDashboardOptions | undefined,
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
 		@IChatStatusItemService private readonly chatStatusItemService: IChatStatusItemService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -251,7 +265,7 @@ export class ChatStatusDashboard extends DomWidget {
 		}
 
 		// Contributions
-		{
+		if (!this.options?.disableContributions) {
 			for (const item of this.chatStatusItemService.getEntries()) {
 				addSeparator();
 
@@ -274,8 +288,8 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 		}
 
-		// Settings
-		{
+		// Settings (editor-specific)
+		if (!this.options?.disableInlineSuggestionsSettings) {
 			const chatSentiment = this.chatEntitlementService.sentiment;
 			addSeparator(localize('inlineSuggestions', "Inline Suggestions"), chatSentiment.installed && !chatSentiment.disabled && !chatSentiment.untrusted ? toAction({
 				id: 'workbench.action.openChatSettings',
@@ -288,8 +302,8 @@ export class ChatStatusDashboard extends DomWidget {
 			this.createSettings(this.element, this._store);
 		}
 
-		// Model Selection
-		{
+		// Model Selection (editor-specific)
+		if (!this.options?.disableModelSelection) {
 			const providers = this.languageFeaturesService.inlineCompletionsProvider.allNoModel();
 			const provider = providers.find(p => p.modelInfo && p.modelInfo.models.length > 0);
 
@@ -317,8 +331,8 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 		}
 
-		// Provider Options
-		{
+		// Provider Options (editor-specific)
+		if (!this.options?.disableProviderOptions) {
 			const providers = this.languageFeaturesService.inlineCompletionsProvider.allNoModel();
 			for (const provider of providers) {
 				if (provider.providerOptions && provider.providerOptions.length > 0) {
@@ -345,8 +359,8 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 		}
 
-		// Completions Snooze
-		if (this.canUseChat()) {
+		// Completions Snooze (editor-specific)
+		if (!this.options?.disableCompletionsSnooze && this.canUseChat()) {
 			const snooze = append(this.element, $('div.snooze-completions'));
 			this.createCompletionsSnooze(snooze, localize('settings.snooze', "Snooze"), this._store);
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -203,7 +203,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 					store.add(token.onCancellationRequested(() => {
 						store.dispose();
 					}));
-					const elem = ChatStatusDashboard.instantiateInContents(this.instantiationService, store);
+					const elem = ChatStatusDashboard.instantiateInContents(this.instantiationService, store, undefined);
 
 					// todo@connor4312/@benibenj: workaround for #257923
 					store.add(disposableWindowInterval(mainWindow, () => {


### PR DESCRIPTION
## Summary

Adds a Copilot status indicator to the Agent Sessions window sidebar footer, next to the account widget. The sessions app has no status bar, so the existing `ChatStatusBarEntry` doesn't render there — this brings the same status information into the sessions context.

## What changed

### Copilot status button in `AccountWidget`
- Added a Copilot status button between the account button and the update button in the sidebar footer
- Layout: `[Account (flex:1)] [Copilot status (flex:0)] [Update (flex:0)]`
- The Copilot status button is **hidden when the update button is visible** (they share the right-hand slot)
- Status icon updates based on entitlement, sessions, and quota state (normal → warning → error)
- On click, opens a `ChatStatusDashboard` hover popup with session-relevant sections

### Per-section disable options for `ChatStatusDashboard`
- Added `IChatStatusDashboardOptions` interface with 5 per-section flags:
  - `disableInlineSuggestionsSettings` — hides inline suggestions toggle
  - `disableModelSelection` — hides model picker
  - `disableProviderOptions` — hides provider options
  - `disableCompletionsSnooze` — hides completions snooze control
  - `disableContributions` — hides workspace index section
- The sessions call site disables all 5 (no code editor in sessions app)
- Existing workbench call site passes `undefined` (no change in behavior)

### CSS
- Copilot status button styling with transparent background and hover effects
- Scoped overrides for the dashboard popup in sessions context (max-width, font sizing, overflow handling)

## Files changed
- `src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts` — Copilot status button, state listeners, hover dashboard
- `src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css` — Button and popup styles
- `src/vs/sessions/contrib/accountMenu/test/browser/accountWidget.fixture.ts` — Updated fixture with new service args
- `src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts` — `IChatStatusDashboardOptions` and section gating
- `src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts` — Pass `undefined` options to dashboard