### PR TITLE
fix: correct OS_ID parsing for quoted values in /etc/os-release

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
## Summary

Fixes #232159

`check-requirements-linux.sh` uses `grep -Eo 'ID=([^"]+)'` to extract the OS ID from `/etc/os-release`. This fails when the file contains quoted values like `ID="rocky"` (common on Rocky Linux 8.5+), producing an empty string and causing the script to behave incorrectly.

## Changes

- Replace `grep -Eo` + `sed` pipeline with `source /etc/os-release && echo $ID`, which correctly handles both quoted and unquoted values.

## Testing

- Verified that `source /etc/os-release && echo $ID` correctly extracts the ID regardless of quoting style.
- The `/etc/os-release` format guarantees shell-safe values, so sourcing is safe here.