### PR TITLE
build: exclude ssh2 native component to address universal failure

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -97,6 +97,10 @@ kerberos/src/**
 kerberos/node_modules/**
 !kerberos/**/*.node
 
+ssh2/lib/protocol/crypto/binding.gyp
+ssh2/lib/protocol/crypto/build/**
+ssh2/lib/protocol/crypto/src/**
+
 node-pty/binding.gyp
 node-pty/build/**
 node-pty/src/**


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/304882

It was decided the implementation does not depend on the native addon from the ssh2 dependency, remove the relevant files from the final package, it will additionally address the universal failures from https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build/results?buildId=426489&view=logs&j=12844632-35fb-5b51-892a-9f6fe8a80e65&t=5293457f-efe2-5297-7c98-176ec4c1dd46

cc @roblourens 