### PR TITLE
contextkey: fix scanner returning '>=' instead of '>' for greater-than operator

### DIFF
--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -133,7 +133,7 @@ export class Scanner {
 			case TokenType.LtEq:
 				return '<=';
 			case TokenType.Gt:
-				return '>=';
+				return '>';
 			case TokenType.GtEq:
 				return '>=';
 			case TokenType.RegexOp:


### PR DESCRIPTION
### Problem

`Scanner.getLexeme()` returns `'>='` for both `TokenType.Gt` and `TokenType.GtEq`, making the two operators produce identical text. The `Lt`/`LtEq` pair correctly returns `'<'` and `'<='` respectively, but the `Gt` case was set to `'>='` instead of `'>'`.

### Fix

Change the return value for `TokenType.Gt` from `'>='` to `'>'`.