### PR TITLE
Remove redundant LLM error assessment from terminal output monitor

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -41,8 +41,8 @@ export interface IGetTerminalOutputInputParams {
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		return {
-			invocationMessage: localize('bg.progressive', "Checking terminal output"),
-			pastTenseMessage: localize('bg.past', "Checked terminal output"),
+			invocationMessage: localize('getTerminalOutput.progressive', "Checking terminal output"),
+			pastTenseMessage: localize('getTerminalOutput.past', "Checked terminal output"),
 		};
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -41,8 +41,8 @@ export interface IGetTerminalOutputInputParams {
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		return {
-			invocationMessage: localize('bg.progressive', "Checking background terminal output"),
-			pastTenseMessage: localize('bg.past', "Checked background terminal output"),
+			invocationMessage: localize('bg.progressive', "Checking terminal output"),
+			pastTenseMessage: localize('bg.past', "Checked terminal output"),
 		};
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -173,7 +173,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 					case OutputMonitorState.Idle: {
 						this._logService.trace('OutputMonitor: Entering Idle handler');
 						const idleResult = await this._handleIdleState(token);
-						if (idleResult.shouldContinuePollling) {
+						if (idleResult.shouldContinuePolling) {
 							this._logService.trace('OutputMonitor: Idle handler -> continue polling');
 							this._state = OutputMonitorState.PollingForIdle;
 							continue;
@@ -217,13 +217,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 
-	private async _handleIdleState(token: CancellationToken): Promise<{ resources?: ILinkLocation[]; shouldContinuePollling: boolean; output?: string }> {
+	private async _handleIdleState(token: CancellationToken): Promise<{ resources?: ILinkLocation[]; shouldContinuePolling: boolean; output?: string }> {
 		const output = this._execution.getOutput(this._lastPromptMarker);
 		this._logService.trace(`OutputMonitor: Idle output summary: len=${output.length}, lastLine=${this._formatLastLineForLog(output)}`);
 
 		if (detectsNonInteractiveHelpPattern(output)) {
 			this._logService.trace('OutputMonitor: Idle -> non-interactive help pattern detected, stopping');
-			return { shouldContinuePollling: false, output };
+			return { shouldContinuePolling: false, output };
 		}
 
 		// Check for VS Code's task finish messages (like "press any key to close the terminal").
@@ -233,7 +233,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		if (isTask && detectsVSCodeTaskFinishMessage(output)) {
 			this._logService.trace('OutputMonitor: Idle -> VS Code task finish message detected, stopping');
 			// Task is finished, ignore the "press any key to close" message
-			return { shouldContinuePollling: false, output };
+			return { shouldContinuePolling: false, output };
 		}
 
 		// Check for generic "press any key" prompts from scripts.
@@ -244,7 +244,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			if (autoReply) {
 				this._logService.trace('OutputMonitor: Auto-reply enabled -> not showing free-form prompt for "press any key", stopping');
 				this._cleanupIdleInputListener();
-				return { shouldContinuePollling: false, output };
+				return { shouldContinuePolling: false, output };
 			}
 			this._logService.trace('OutputMonitor: Requesting free-form input for "press any key"');
 			// Register a marker to track this prompt position so we don't re-detect it
@@ -263,10 +263,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			if (receivedTerminalInput) {
 				this._logService.trace('OutputMonitor: Free-form input received for "press any key", continue polling');
 				await timeout(200);
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			} else {
 				this._logService.trace('OutputMonitor: Free-form input declined for "press any key", stopping');
-				return { shouldContinuePollling: false };
+				return { shouldContinuePolling: false };
 			}
 		}
 
@@ -274,7 +274,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		if (this._userInputtedSinceIdleDetected) {
 			this._logService.trace('OutputMonitor: User input detected since idle; skipping prompt and continuing polling');
 			this._cleanupIdleInputListener();
-			return { shouldContinuePollling: true };
+			return { shouldContinuePolling: true };
 		}
 
 		this._logService.trace('OutputMonitor: Determining user input options via language model');
@@ -285,7 +285,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		if (this._userInputtedSinceIdleDetected) {
 			this._logService.trace('OutputMonitor: User input arrived during input-option analysis; continuing polling');
 			this._cleanupIdleInputListener();
-			return { shouldContinuePollling: true };
+			return { shouldContinuePolling: true };
 		}
 
 		if (confirmationPrompt?.detectedRequestForFreeFormInput) {
@@ -293,13 +293,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			if (this._userInputtedSinceIdleDetected) {
 				this._logService.trace('OutputMonitor: User input arrived before showing free-form prompt; continuing polling');
 				this._cleanupIdleInputListener();
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			}
 			const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
 			if (autoReply) {
 				this._logService.trace('OutputMonitor: Auto-reply enabled -> not propagating free-form prompt, stopping');
 				this._cleanupIdleInputListener();
-				return { shouldContinuePollling: false, output };
+				return { shouldContinuePolling: false, output };
 			}
 			// Clean up the input listener now - the prompt will set up its own
 			this._cleanupIdleInputListener();
@@ -311,11 +311,11 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				this._logService.trace('OutputMonitor: Free-form input received; continuing polling');
 				await timeout(200);
 				// Continue polling as we sent the input
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			} else {
 				// User declined
 				this._logService.trace('OutputMonitor: Free-form input declined; stopping');
-				return { shouldContinuePollling: false };
+				return { shouldContinuePolling: false };
 			}
 		}
 
@@ -326,13 +326,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			if (suggestedOptionResult?.sentToTerminal) {
 				// Continue polling as we sent the input
 				this._cleanupIdleInputListener();
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			}
 			// Check again after LLM call - user may have inputted while we were selecting option
 			if (this._userInputtedSinceIdleDetected) {
 				this._logService.trace('OutputMonitor: User input arrived during option selection; continuing polling');
 				this._cleanupIdleInputListener();
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			}
 			// Clean up the input listener now - the prompt will set up its own
 			this._cleanupIdleInputListener();
@@ -341,12 +341,12 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			if (confirmed) {
 				// Continue polling as we sent the input
 				this._logService.trace('OutputMonitor: Option confirmed/sent; continuing polling');
-				return { shouldContinuePollling: true };
+				return { shouldContinuePolling: true };
 			} else {
 				// User declined
 				this._logService.trace('OutputMonitor: Option declined; stopping');
 				this._execution.instance.focus(true);
-				return { shouldContinuePollling: false };
+				return { shouldContinuePolling: false };
 			}
 		}
 
@@ -357,7 +357,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const custom = await this._pollFn?.(this._execution, token, this._taskService);
 		this._logService.trace(`OutputMonitor: Custom poller result: ${custom ? 'provided' : 'none'}`);
 		const resources = custom?.resources;
-		return { resources, shouldContinuePollling: false, output: custom?.output ?? output };
+		return { resources, shouldContinuePolling: false, output: custom?.output ?? output };
 	}
 
 	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -142,7 +142,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	): Promise<void> {
 		const pollStartTime = Date.now();
 
-		let modelOutputEvalResponse;
 		let resources;
 		let output;
 
@@ -179,9 +178,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 							this._state = OutputMonitorState.PollingForIdle;
 							continue;
 						} else {
-							this._logService.trace(`OutputMonitor: Idle handler -> stop polling (hasResources=${!!idleResult.resources}, hasModelEval=${!!idleResult.modelOutputEvalResponse}, outputLen=${idleResult.output?.length ?? 0})`);
+							this._logService.trace(`OutputMonitor: Idle handler -> stop polling (hasResources=${!!idleResult.resources}, outputLen=${idleResult.output?.length ?? 0})`);
 							resources = idleResult.resources;
-							modelOutputEvalResponse = idleResult.modelOutputEvalResponse;
 							output = idleResult.output;
 						}
 						break;
@@ -200,7 +198,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			this._pollingResult = {
 				state: this._state,
 				output: output ?? this._execution.getOutput(),
-				modelOutputEvalResponse: token.isCancellationRequested ? 'Cancelled' : modelOutputEvalResponse,
 				pollDurationMs: Date.now() - pollStartTime,
 				resources
 			};
@@ -220,7 +217,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 
-	private async _handleIdleState(token: CancellationToken): Promise<{ resources?: ILinkLocation[]; modelOutputEvalResponse?: string; shouldContinuePollling: boolean; output?: string }> {
+	private async _handleIdleState(token: CancellationToken): Promise<{ resources?: ILinkLocation[]; shouldContinuePollling: boolean; output?: string }> {
 		const output = this._execution.getOutput(this._lastPromptMarker);
 		this._logService.trace(`OutputMonitor: Idle output summary: len=${output.length}, lastLine=${this._formatLastLineForLog(output)}`);
 
@@ -353,15 +350,14 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			}
 		}
 
-		// Clean up input listener before custom poll/error assessment
+		// Clean up input listener before custom poll
 		this._cleanupIdleInputListener();
 
 		// Let custom poller override if provided
 		const custom = await this._pollFn?.(this._execution, token, this._taskService);
 		this._logService.trace(`OutputMonitor: Custom poller result: ${custom ? 'provided' : 'none'}`);
 		const resources = custom?.resources;
-		const modelOutputEvalResponse = this._pollFn ? undefined : await this._assessOutputForErrors(this._execution.getOutput(), token);
-		return { resources, modelOutputEvalResponse, shouldContinuePollling: false, output: custom?.output ?? output };
+		return { resources, shouldContinuePollling: false, output: custom?.output ?? output };
 	}
 
 	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {
@@ -468,28 +464,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private _cleanupIdleInputListener(): void {
 		this._userInputtedSinceIdleDetected = false;
 		this._userInputListener.clear();
-	}
-
-	private async _assessOutputForErrors(buffer: string, token: CancellationToken): Promise<string | undefined> {
-		const model = await this._getLanguageModel();
-		if (!model) {
-			return 'No models available';
-
-		}
-
-		const response = await this._languageModelsService.sendChatRequest(
-			model,
-			undefined,
-			[{ role: ChatMessageRole.User, content: [{ type: 'text', value: `Evaluate this terminal output to determine if there were errors. If there are errors, return them. Otherwise, return undefined: ${buffer}.` }] }],
-			{},
-			token
-		);
-
-		try {
-			return await getTextResponseFromStream(response);
-		} catch (err) {
-			return 'Error occurred ' + err;
-		}
 	}
 
 	private async _determineUserInputOptions(execution: IExecution, token: CancellationToken): Promise<IConfirmationPrompt | undefined> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
@@ -29,7 +29,6 @@ export interface IExecution {
 export interface IPollingResult {
 	output: string;
 	resources?: ILinkLocation[];
-	modelOutputEvalResponse?: string;
 	state: OutputMonitorState;
 }
 
@@ -41,13 +40,6 @@ export enum OutputMonitorState {
 	Timeout = 'Timeout',
 	Active = 'Active',
 	Cancelled = 'Cancelled',
-}
-
-export interface IRacePollingOrPromptResult {
-	output: string;
-	pollDurationMs?: number;
-	modelOutputEvalResponse?: string;
-	state: OutputMonitorState;
 }
 
 export const enum PollingConsts {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1186,16 +1186,16 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 								? `Note: The tool simplified the command to \`${command}\`, and that command is now running in terminal with ID=${termId}`
 								: `Command is running in terminal with ID=${termId}`
 				);
-				const backgroundOutput = pollingResult?.modelOutputEvalResponse ?? pollingResult?.output;
+				const backgroundOutput = pollingResult?.output;
 				const outputAnalyzerMessage = backgroundOutput
 					? await this._getOutputAnalyzerMessage(undefined, backgroundOutput, command, didSandboxWrapCommand)
 					: undefined;
-				if (pollingResult && pollingResult.modelOutputEvalResponse) {
+				if (pollingResult && pollingResult.state === OutputMonitorState.Idle) {
 					resultText += `\n\ The command became idle with output:\n`;
 					if (outputAnalyzerMessage) {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}
-					resultText += pollingResult.modelOutputEvalResponse;
+					resultText += pollingResult.output;
 				} else if (pollingResult) {
 					resultText += `\n\ The command is still running, with output:\n`;
 					if (outputAnalyzerMessage) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1191,13 +1191,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					? await this._getOutputAnalyzerMessage(undefined, backgroundOutput, command, didSandboxWrapCommand)
 					: undefined;
 				if (pollingResult && pollingResult.state === OutputMonitorState.Idle) {
-					resultText += `\n\ The command became idle with output:\n`;
+					resultText += `\n The command became idle with output:\n`;
 					if (outputAnalyzerMessage) {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}
 					resultText += pollingResult.output;
 				} else if (pollingResult) {
-					resultText += `\n\ The command is still running, with output:\n`;
+					resultText += `\n The command is still running, with output:\n`;
 					if (outputAnalyzerMessage) {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -301,7 +301,7 @@ suite('OutputMonitor', () => {
 		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
 
 		const outputMonitorWithPrivateMethod = monitor as unknown as {
-			[key: string]: ((token: CancellationToken) => Promise<{ shouldContinuePollling: boolean }>) | undefined;
+			[key: string]: ((token: CancellationToken) => Promise<{ shouldContinuePolling: boolean }>) | undefined;
 		};
 		const idleResult = await outputMonitorWithPrivateMethod['_handleIdleState']!(CancellationToken.None);
 		await Event.toPromise(monitor.onDidFinishCommand);
@@ -309,7 +309,7 @@ suite('OutputMonitor', () => {
 
 		assert.strictEqual(sendTextCalled, false, 'sendText should not be called when auto reply is enabled for free-form prompts');
 		assert.strictEqual(sentText, undefined, 'no terminal input should be sent');
-		assert.strictEqual(idleResult.shouldContinuePollling, false, 'monitor should stop polling for free-form prompts in auto reply mode');
+		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop polling for free-form prompts in auto reply mode');
 	});
 
 	test('auto reply does not propagate free-form input requests without explicit input', async () => {
@@ -335,13 +335,13 @@ suite('OutputMonitor', () => {
 			return true;
 		};
 
-		const idleResult = await (outputMonitorWithPrivateMethod['_handleIdleState'] as (token: CancellationToken) => Promise<{ shouldContinuePollling: boolean }>)(CancellationToken.None);
+		const idleResult = await (outputMonitorWithPrivateMethod['_handleIdleState'] as (token: CancellationToken) => Promise<{ shouldContinuePolling: boolean }>)(CancellationToken.None);
 		await Event.toPromise(monitor.onDidFinishCommand);
 		monitorCts.dispose();
 
 		assert.strictEqual(freeFormRequestShown, false, 'free-form elicitation should not be shown when auto reply is enabled');
 		assert.strictEqual(sendTextCalled, false, 'sensitive free-form prompt should not be auto-replied');
-		assert.strictEqual(idleResult.shouldContinuePollling, false, 'monitor should stop instead of propagating free-form prompt');
+		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop instead of propagating free-form prompt');
 	});
 
 	suite('detectsInputRequiredPattern', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -195,8 +195,8 @@ suite('OutputMonitor', () => {
 			const timeoutThenIdle = async (): Promise<IPollingResult> => {
 				pass++;
 				return pass === 1
-					? { state: OutputMonitorState.Timeout, output: execution.getOutput(), modelOutputEvalResponse: 'Timed out' }
-					: { state: OutputMonitorState.Idle, output: execution.getOutput(), modelOutputEvalResponse: 'Done' };
+					? { state: OutputMonitorState.Timeout, output: execution.getOutput() }
+					: { state: OutputMonitorState.Idle, output: execution.getOutput() };
 			};
 
 			monitor = store.add(


### PR DESCRIPTION
Remove `_assessOutputForErrors` — an extra LLM call that evaluated terminal output for errors before returning it to the agent. The agent already receives the raw output and can assess errors with full conversational context, making this zero-context side-channel call redundant, slower, and potentially lossy (it replaced raw output with an LLM summary). The async code path now uses `pollingResult.state === OutputMonitorState.Idle` to distinguish idle vs still-running, matching the actual terminal state rather than using the presence of the LLM response as a proxy.

Also includes follow-up code quality fixes based on review feedback:
- Renamed `shouldContinuePollling` → `shouldContinuePolling` (typo with triple "l") throughout `outputMonitor.ts`
- Removed unnecessary backslash escape sequences (`\n\ `) in string literals in `runInTerminalTool.ts`, replacing them with `\n `