### PR TITLE
sessions: show welcome overlay on explicit sign-out

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -7,7 +7,7 @@ import './media/welcomeOverlay.css';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { $, append } from '../../../../base/browser/dom.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { autorun, observableValue } from '../../../../base/common/observable.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
@@ -28,6 +28,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
 const WELCOME_COMPLETE_KEY = 'workbench.agentsession.welcomeComplete';
 
@@ -136,6 +137,14 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 	private readonly overlayRef = this._register(new MutableDisposable<DisposableStore>());
 	private readonly watcherRef = this._register(new MutableDisposable());
 
+	/**
+	 * Tracks whether the user has explicitly signed out. Used to include
+	 * {@link ChatEntitlement.Unknown} in setup checks only after a genuine
+	 * sign-out (account removed), avoiding false positives from token refreshes
+	 * where the account stays non-null.
+	 */
+	private readonly signedOut = observableValue(this, false);
+
 	constructor(
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
@@ -144,6 +153,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		@IStorageService private readonly storageService: IStorageService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -183,23 +193,33 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 	 * completed. If the user's state changes such that setup is needed again
 	 * (e.g. extension uninstalled/disabled), shows the welcome overlay.
 	 *
-	 * {@link ChatEntitlement.Unknown} is intentionally ignored here: it is
-	 * almost always a transient state caused by a stale OAuth token being
-	 * refreshed after an update. A genuine sign-out will be caught on the
-	 * next app launch via the initial {@link showOverlayIfNeeded} check.
+	 * {@link ChatEntitlement.Unknown} is intentionally ignored unless the
+	 * default account has been removed, which reliably indicates a genuine
+	 * user-initiated sign-out rather than a transient token refresh (where
+	 * the account object stays non-null).
 	 */
 	private watchEntitlementState(): void {
+		this.signedOut.set(false, undefined);
 		let setupComplete = !this._needsChatSetup(false);
-		this.watcherRef.value = autorun(reader => {
+		const store = new DisposableStore();
+
+		store.add(this.defaultAccountService.onDidChangeDefaultAccount(account => {
+			this.signedOut.set(account === null, undefined);
+		}));
+
+		store.add(autorun(reader => {
 			this.chatEntitlementService.sentimentObs.read(reader);
 			this.chatEntitlementService.entitlementObs.read(reader);
+			const isSignedOut = this.signedOut.read(reader);
 
-			const needsSetup = this._needsChatSetup(false);
+			const needsSetup = this._needsChatSetup(isSignedOut);
 			if (setupComplete && needsSetup) {
 				this.showOverlay();
 			}
 			setupComplete = !needsSetup;
-		});
+		}));
+
+		this.watcherRef.value = store;
 	}
 
 	private _needsChatSetup(includeUnknown: boolean = true): boolean {

--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Event } from '../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ISettableObservable, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -53,11 +54,15 @@ suite('SessionsWelcomeContribution', () => {
 	const disposables = new DisposableStore();
 	let instantiationService: TestInstantiationService;
 	let mockEntitlementService: MockChatEntitlementService;
+	let defaultAccountEmitter: Emitter<unknown>;
 
 	setup(() => {
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 		mockEntitlementService = new MockChatEntitlementService();
 		instantiationService.stub(IChatEntitlementService, mockEntitlementService as unknown as IChatEntitlementService);
+
+		defaultAccountEmitter = disposables.add(new Emitter<unknown>());
+		instantiationService.stub(IDefaultAccountService, { onDidChangeDefaultAccount: defaultAccountEmitter.event } as Partial<IDefaultAccountService> as IDefaultAccountService);
 
 		// Ensure product has a defaultChatAgent so the contribution activates
 		const productService = instantiationService.get(IProductService);
@@ -205,5 +210,23 @@ suite('SessionsWelcomeContribution', () => {
 		});
 
 		assert.strictEqual(isOverlayVisible(), true, 'should show overlay for Available entitlement');
+	});
+
+	test('returning user: explicit sign-out shows overlay', () => {
+		markReturningUser();
+		mockEntitlementService.entitlementObs.set(ChatEntitlement.Free, undefined);
+		mockEntitlementService.sentimentObs.set({ completed: true } as IChatSentiment, undefined);
+
+		const contribution = disposables.add(instantiationService.createInstance(SessionsWelcomeContribution));
+		assert.ok(contribution);
+		assert.strictEqual(isOverlayVisible(), false, 'should not show initially');
+
+		// Simulate explicit sign-out: account removed then entitlement goes Unknown
+		defaultAccountEmitter.fire(null);
+		transaction(tx => {
+			mockEntitlementService.entitlementObs.set(ChatEntitlement.Unknown, tx);
+		});
+
+		assert.strictEqual(isOverlayVisible(), true, 'should show overlay after explicit sign-out');
 	});
 });


### PR DESCRIPTION
When the user signs out via the account menu in the Sessions window, the welcome/login overlay now appears immediately instead of waiting for the next app launch.

## Problem

After signing out, users were left staring at the sessions UI with no way to re-authenticate without restarting the app. The welcome overlay (which prompts sign-in) was intentionally not shown because `ChatEntitlement.Unknown` was excluded from the runtime watcher to avoid false positives from OAuth token refreshes.

## Solution

Introduce a `signedOut` observable that tracks whether the default account has been removed. When `IDefaultAccountService.onDidChangeDefaultAccount` fires with `null`, this observable flips to `true`, which causes the existing watcher autorun to include `ChatEntitlement.Unknown` in its setup check — triggering the welcome overlay.

This avoids the race condition of calling `showOverlay()` directly from the account listener (where entitlement hasn't updated yet and the overlay would instantly dismiss itself). Token refresh safety is preserved: the account stays non-null during refresh, so `signedOut` stays `false` and `Unknown` remains excluded.

## Changes

- Add `signedOut` observable to `SessionsWelcomeContribution` that tracks account removal
- Listen to `IDefaultAccountService.onDidChangeDefaultAccount` in `watchEntitlementState()` to update the observable
- The watcher autorun reads `signedOut` and passes it as `includeUnknown` to `_needsChatSetup()`, so `ChatEntitlement.Unknown` only triggers the overlay after a genuine sign-out
- Updated JSDoc to reflect the new behavior