### PR TITLE
policyExport: add `included` flag to PolicyDto output

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -50,7 +50,8 @@
                 }
             },
             "type": "string",
-            "default": ""
+            "default": "",
+            "included": false
         },
         {
             "key": "chat.mcp.gallery.serviceUrl",
@@ -64,7 +65,8 @@
                 }
             },
             "type": "string",
-            "default": ""
+            "default": "",
+            "included": false
         },
         {
             "key": "extensions.allowed",
@@ -78,7 +80,8 @@
                 }
             },
             "type": "object",
-            "default": "*"
+            "default": "*",
+            "included": true
         },
         {
             "key": "chat.tools.global.autoApprove",
@@ -92,7 +95,8 @@
                 }
             },
             "type": "boolean",
-            "default": false
+            "default": false,
+            "included": true
         },
         {
             "key": "chat.tools.eligibleForAutoApproval",
@@ -106,7 +110,8 @@
                 }
             },
             "type": "object",
-            "default": {}
+            "default": {},
+            "included": true
         },
         {
             "key": "chat.mcp.access",
@@ -139,7 +144,8 @@
                 "none",
                 "registry",
                 "all"
-            ]
+            ],
+            "included": true
         },
         {
             "key": "chat.extensionTools.enabled",
@@ -153,7 +159,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "chat.agent.enabled",
@@ -167,7 +174,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "chat.editMode.hidden",
@@ -181,7 +189,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "chat.useHooks",
@@ -195,7 +204,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "chat.tools.terminal.enableAutoApprove",
@@ -209,7 +219,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "update.mode",
@@ -247,7 +258,8 @@
                 "manual",
                 "start",
                 "default"
-            ]
+            ],
+            "included": true
         },
         {
             "key": "telemetry.telemetryLevel",
@@ -285,7 +297,8 @@
                 "error",
                 "crash",
                 "off"
-            ]
+            ],
+            "included": true
         },
         {
             "key": "telemetry.feedback.enabled",
@@ -299,7 +312,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "workbench.browser.enableChatTools",
@@ -313,7 +327,8 @@
                 }
             },
             "type": "boolean",
-            "default": false
+            "default": false,
+            "included": true
         },
         {
             "key": "github.copilot.nextEditSuggestions.enabled",
@@ -327,7 +342,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "github.copilot.chat.reviewSelection.enabled",
@@ -341,7 +357,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "github.copilot.chat.reviewAgent.enabled",
@@ -355,7 +372,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         },
         {
             "key": "github.copilot.chat.claudeAgent.enabled",
@@ -369,7 +387,8 @@
                 }
             },
             "type": "boolean",
-            "default": true
+            "default": true,
+            "included": true
         }
     ]
 }

--- a/src/vs/workbench/contrib/policyExport/common/policyDto.ts
+++ b/src/vs/workbench/contrib/policyExport/common/policyDto.ts
@@ -25,6 +25,13 @@ export interface PolicyDto {
 	type?: string | string[];
 	default?: unknown;
 	enum?: string[];
+
+	/**
+	 * When `false`, the setting is not user-configurable and can only be
+	 * managed via policy. Downstream consumers (e.g. docs website) can use
+	 * this to hide the setting from their UI. Defaults to `true`.
+	 */
+	included?: boolean;
 }
 
 export interface ExportedPolicyDataDto {

--- a/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
+++ b/src/vs/workbench/contrib/policyExport/electron-browser/policyExport.contribution.ts
@@ -99,6 +99,7 @@ export class PolicyExportContribution extends Disposable implements IWorkbenchCo
 							type: schema.type,
 							default: schema.default,
 							enum: schema.enum,
+							included: schema.included !== false,
 						});
 					}
 				}
@@ -129,6 +130,7 @@ export class PolicyExportContribution extends Disposable implements IWorkbenchCo
 							},
 							type: 'boolean',
 							default: true,
+							included: true,
 						});
 						added++;
 					}


### PR DESCRIPTION
tracking https://github.com/microsoft/vscode-internalbacklog/issues/7245

## Summary

Adds the `included` boolean field to the exported `PolicyDto` in `policyData.jsonc`, so downstream consumers (docs website, UI generators) can determine whether a policy-managed setting is also user-configurable.

## Motivation

Some configuration properties have `included: false` on their schema (e.g. `ExtensionGalleryServiceUrlConfigKey`), meaning they don't appear in the normal Settings UI and can only be managed via policy. This information was not being propagated to the exported policy data, so downstream consumers had no way to know whether to show the setting in their UI.

## Changes

- **`policyDto.ts`** — Added optional `included?: boolean` field to `PolicyDto` with JSDoc documentation.
- **`policyExport.contribution.ts`** — Populated the field in both export paths:
  - Config registry policies: `schema.included !== false` (resolves to `false` only when the schema explicitly sets `included: false`).
  - Extension policies from distro product.json: always `true` (these are user-configurable by nature).

## Example output

After regenerating `policyData.jsonc`, a policy-only setting like `extensions.gallery.serviceUrl` will include `"included": false`, while normal settings will have `"included": true`.