### PR TITLE
sessions: add telemetry events for Changes panel interactions

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -20,8 +20,23 @@ import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/c
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ICodeReviewSuggestion } from '../../codeReview/browser/codeReviewService.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 
 // --- Types --------------------------------------------------------------------
+
+type AgentFeedbackAddedEvent = {
+	hasExistingFeedback: boolean;
+	hasSuggestion: boolean;
+	isFromPRReview: boolean;
+};
+
+type AgentFeedbackAddedClassification = {
+	owner: 'osortega';
+	comment: 'Tracks when a user adds a review comment (feedback) to a file in the Changes panel.';
+	hasExistingFeedback: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether there was already feedback on this file.' };
+	hasSuggestion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the feedback includes a code suggestion.' };
+	isFromPRReview: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the feedback was converted from a PR review comment.' };
+};
 
 export interface IAgentFeedback {
 	readonly id: string;
@@ -144,6 +159,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@ILogService private readonly _logService: ILogService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 	}
@@ -200,6 +216,12 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		this._onDidChangeNavigation.fire(sessionResource);
 
 		this._onDidChangeFeedback.fire({ sessionResource, feedbackItems });
+
+		this._telemetryService.publicLog2<AgentFeedbackAddedEvent, AgentFeedbackAddedClassification>('changesView/reviewCommentAdded', {
+			hasExistingFeedback: hasExistingForFile,
+			hasSuggestion: !!suggestion,
+			isFromPRReview: !!sourcePRReviewCommentId,
+		});
 
 		return feedback;
 	}

--- a/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
@@ -24,6 +24,7 @@ import { IsAuxiliaryWindowContext, AuxiliaryBarVisibleContext } from '../../../.
 import { getAgentChangesSummary } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { Menus } from '../../../browser/menus.js';
 import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
@@ -31,6 +32,16 @@ import { ISessionsManagementService } from '../../sessions/browser/sessionsManag
 import { CHANGES_VIEW_CONTAINER_ID } from './changesView.js';
 
 const TOGGLE_CHANGES_VIEW_ID = 'workbench.action.agentSessions.toggleChangesView';
+
+type ChangesViewTogglePanelEvent = {
+	visible: boolean;
+};
+
+type ChangesViewTogglePanelClassification = {
+	owner: 'osortega';
+	comment: 'Tracks when the user toggles the Changes panel open or closed.';
+	visible: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the Changes panel is now visible.' };
+};
 
 /**
  * Action view item that renders the diff stats indicator (file change counts)
@@ -182,11 +193,16 @@ registerAction2(class extends Action2 {
 	run(accessor: ServicesAccessor): void {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const paneCompositeService = accessor.get(IPaneCompositePartService);
+		const telemetryService = accessor.get(ITelemetryService);
 
 		const isVisible = !layoutService.isVisible(Parts.AUXILIARYBAR_PART);
 		layoutService.setPartHidden(!isVisible, Parts.AUXILIARYBAR_PART);
 		if (isVisible) {
 			paneCompositeService.openPaneComposite(CHANGES_VIEW_CONTAINER_ID, ViewContainerLocation.AuxiliaryBar);
 		}
+
+		telemetryService.publicLog2<ChangesViewTogglePanelEvent, ChangesViewTogglePanelClassification>('changesView/togglePanel', {
+			visible: isVisible,
+		});
 	}
 });

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -77,6 +77,28 @@ import { EditorResourceAccessor, SideBySideEditor } from '../../../../workbench/
 
 const $ = dom.$;
 
+// --- Telemetry
+
+type ChangesViewVersionModeChangeEvent = {
+	mode: string;
+};
+
+type ChangesViewVersionModeChangeClassification = {
+	owner: 'osortega';
+	comment: 'Tracks when the user switches the version mode in the Changes panel (Branch Changes, All Changes, Last Turn).';
+	mode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version mode selected by the user.' };
+};
+
+type ChangesViewFileSelectEvent = {
+	changeType: string;
+};
+
+type ChangesViewFileSelectClassification = {
+	owner: 'osortega';
+	comment: 'Tracks when the user selects a changed file in the Changes panel.';
+	changeType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of change (added, modified, deleted).' };
+};
+
 // --- Constants
 
 export const CHANGES_VIEW_CONTAINER_ID = 'workbench.view.agentSessions.changesContainer';
@@ -551,7 +573,8 @@ export class ChangesViewPane extends ViewPane {
 		@ISessionsManagementService private readonly sessionManagementService: ISessionsManagementService,
 		@ILabelService private readonly labelService: ILabelService,
 		@ICodeReviewService private readonly codeReviewService: ICodeReviewService,
-		@IGitHubService private readonly gitHubService: IGitHubService
+		@IGitHubService private readonly gitHubService: IGitHubService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super({ ...options, titleMenuId: MenuId.ChatEditingSessionTitleToolbar }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -1118,6 +1141,10 @@ export class ChangesViewPane extends ViewPane {
 				if (!e.element || !isChangesFileItem(e.element)) {
 					return;
 				}
+
+				this.telemetryService.publicLog2<ChangesViewFileSelectEvent, ChangesViewFileSelectClassification>('changesView/fileSelect', {
+					changeType: e.element.changeType,
+				});
 
 				const items = combinedEntriesObs.get();
 				openFileItem(e.element, items, e.sideBySide, !!e.editorOptions?.preserveFocus, !!e.editorOptions?.pinned, items.length > 1);
@@ -1810,7 +1837,7 @@ class ChangesPickerActionItem extends ActionWidgetDropdownActionViewItem {
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ISessionsManagementService sessionManagementService: ISessionsManagementService,
-		@ITelemetryService telemetryService: ITelemetryService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		const actionProvider: IActionWidgetDropdownActionProvider = {
 			getActions: () => {
@@ -1829,6 +1856,9 @@ class ChangesPickerActionItem extends ActionWidgetDropdownActionViewItem {
 						category: { label: 'changes', order: 1, showHeader: false },
 						run: async () => {
 							viewModel.setVersionMode(ChangesVersionMode.BranchChanges);
+							this.telemetryService.publicLog2<ChangesViewVersionModeChangeEvent, ChangesViewVersionModeChangeClassification>('changesView/versionModeChange', {
+								mode: ChangesVersionMode.BranchChanges,
+							});
 							if (this.element) {
 								this.renderLabel(this.element);
 							}
@@ -1845,6 +1875,9 @@ class ChangesPickerActionItem extends ActionWidgetDropdownActionViewItem {
 							viewModel.activeSessionLastCheckpointRefObs.get() !== undefined,
 						run: async () => {
 							viewModel.setVersionMode(ChangesVersionMode.AllChanges);
+							this.telemetryService.publicLog2<ChangesViewVersionModeChangeEvent, ChangesViewVersionModeChangeClassification>('changesView/versionModeChange', {
+								mode: ChangesVersionMode.AllChanges,
+							});
 							if (this.element) {
 								this.renderLabel(this.element);
 							}
@@ -1861,6 +1894,9 @@ class ChangesPickerActionItem extends ActionWidgetDropdownActionViewItem {
 							viewModel.activeSessionLastCheckpointRefObs.get() !== undefined,
 						run: async () => {
 							viewModel.setVersionMode(ChangesVersionMode.LastTurn);
+							this.telemetryService.publicLog2<ChangesViewVersionModeChangeEvent, ChangesViewVersionModeChangeClassification>('changesView/versionModeChange', {
+								mode: ChangesVersionMode.LastTurn,
+							});
 							if (this.element) {
 								this.renderLabel(this.element);
 							}


### PR DESCRIPTION
## Summary

Adds GDPR-compliant telemetry events to track user interactions with the Changes/Files panel in the Sessions window.

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/7257

## Events Added

| Event | Location | Description |
|---|---|---|
| `changesView/togglePanel` | `changesTitleBarWidget.ts` | Fires when user toggles the Changes panel open/closed via the titlebar button |
| `changesView/versionModeChange` | `changesView.ts` | Fires when user switches between Branch Changes, All Changes, or Last Turn's Changes |
| `changesView/fileSelect` | `changesView.ts` | Fires when user selects a changed file in the tree |
| `changesView/reviewCommentAdded` | `agentFeedbackService.ts` | Fires when user adds a review comment (feedback) to a file |

## Notes

- Toolbar button actions (Merge Changes, Run Code Review, View All Changes) are already tracked via the `MenuWorkbenchButtonBar` action framework with `telemetrySource: 'changesView'`.
- All events use `SystemMetaData` classification with `FeatureInsight` purpose — no PII is logged.
