### PR TITLE
fix: add keyboard toggle support for notebook find widget options

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFind.ts
@@ -27,7 +27,7 @@ import { registerNotebookContribution } from '../../notebookEditorExtensions.js'
 import { CellUri, NotebookFindScopeType } from '../../../common/notebookCommon.js';
 import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { CONTEXT_FIND_WIDGET_VISIBLE } from '../../../../../../editor/contrib/find/browser/findModel.js';
+import { CONTEXT_FIND_WIDGET_VISIBLE, ToggleCaseSensitiveKeybinding, ToggleWholeWordKeybinding, ToggleRegexKeybinding } from '../../../../../../editor/contrib/find/browser/findModel.js';
 
 registerNotebookContribution(NotebookFindContrib.id, NotebookFindContrib);
 
@@ -317,3 +317,80 @@ registerAction2(class extends Action2 {
 	}
 });
 
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.toggleFindCaseSensitive',
+			title: localize2('notebookActions.toggleFindCaseSensitive', 'Notebook Find: Toggle Match Case'),
+			keybinding: {
+				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE),
+				primary: ToggleCaseSensitiveKeybinding.primary,
+				mac: ToggleCaseSensitiveKeybinding.mac,
+				weight: KeybindingWeight.WorkbenchContrib + 1
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		controller?.toggleCaseSensitive();
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.toggleFindWholeWord',
+			title: localize2('notebookActions.toggleFindWholeWord', 'Notebook Find: Toggle Match Whole Word'),
+			keybinding: {
+				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE),
+				primary: ToggleWholeWordKeybinding.primary,
+				mac: ToggleWholeWordKeybinding.mac,
+				weight: KeybindingWeight.WorkbenchContrib + 1
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		controller?.toggleWholeWord();
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.toggleFindRegex',
+			title: localize2('notebookActions.toggleFindRegex', 'Notebook Find: Toggle Use Regular Expression'),
+			keybinding: {
+				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, CONTEXT_FIND_WIDGET_VISIBLE),
+				primary: ToggleRegexKeybinding.primary,
+				mac: ToggleRegexKeybinding.mac,
+				weight: KeybindingWeight.WorkbenchContrib + 1
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+		if (!editor) {
+			return;
+		}
+
+		const controller = editor.getContribution<NotebookFindContrib>(NotebookFindContrib.id);
+		controller?.toggleRegex();
+	}
+});

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -92,6 +92,27 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 			this._widget.value.findPrevious();
 		}
 	}
+
+	toggleCaseSensitive(): void {
+		if (this._widget.rawValue) {
+			const state = this._widget.value.state;
+			state.change({ matchCase: !state.matchCase }, false);
+		}
+	}
+
+	toggleWholeWord(): void {
+		if (this._widget.rawValue) {
+			const state = this._widget.value.state;
+			state.change({ wholeWord: !state.wholeWord }, false);
+		}
+	}
+
+	toggleRegex(): void {
+		if (this._widget.rawValue) {
+			const state = this._widget.value.state;
+			state.change({ isRegex: !state.isRegex }, false);
+		}
+	}
 }
 
 class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEditorContribution {
@@ -156,6 +177,10 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 
 	get findModel(): FindModel {
 		return this._findModel;
+	}
+
+	get state(): FindReplaceState<NotebookFindFilters> {
+		return this._state;
 	}
 
 	get isFocused(): boolean {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the notebook find widget is open, keyboard shortcuts for toggling **Match Case** (`Alt+C`), **Whole Word** (`Alt+W`), and **Regular Expression** (`Alt+R`) do not work. Pressing these keys either does nothing or toggles the per-cell editor find state instead of the notebook-level find widget state.

This means users must click the toggle buttons with the mouse to change these find options in notebooks, unlike in regular editors where keyboard shortcuts work.

Closes #200295

## What is the new behavior?

Three new actions are registered that respond to the standard find toggle keybindings when the notebook editor is focused and the find widget is visible:

- `notebook.toggleFindCaseSensitive` — `Alt+C` (Mac: `Cmd+Alt+C`)
- `notebook.toggleFindWholeWord` — `Alt+W` (Mac: `Cmd+Alt+W`)
- `notebook.toggleFindRegex` — `Alt+R` (Mac: `Cmd+Alt+R`)

These toggle the corresponding state on the notebook find widget's `FindReplaceState`, which updates both the UI toggle buttons and the search behavior. This follows the same pattern used by the terminal find widget (`TerminalFindCommandId.ToggleFindCaseSensitive`, etc.).

## Additional context

**Files changed:**
- `notebookFind.ts` — Added three `registerAction2` calls with keybinding definitions using the same constants (`ToggleCaseSensitiveKeybinding`, etc.) as the editor find controller
- `notebookFindWidget.ts` — Added `toggleCaseSensitive()`, `toggleWholeWord()`, `toggleRegex()` methods to `NotebookFindContrib`, and a `state` getter on `NotebookFindWidget` to expose the `FindReplaceState`

The keybinding weight is `KeybindingWeight.WorkbenchContrib + 1` to win over the editor-level toggle commands when the notebook find widget is visible.