### PR TITLE
fix: resolve debug console file links to remote filesystem in devcontainers

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -252,13 +252,18 @@ export class LinkDetector implements ILinkDetector {
 				const remoteAuthority = this.environmentService.remoteAuthority;
 				if (remoteAuthority) {
 					const remoteUri = URI.from({ scheme: Schemas.vscodeRemote, authority: remoteAuthority, path: uri.path });
-					const existsRemote = await this.fileService.exists(remoteUri);
-					if (existsRemote) {
-						await this.editorService.openEditor({
-							resource: remoteUri,
-							options: { pinned: true, selection },
-						});
-						return;
+					try {
+						const existsRemote = await this.fileService.exists(remoteUri);
+						if (existsRemote) {
+							await this.editorService.openEditor({
+								resource: remoteUri,
+								options: { pinned: true, selection },
+							});
+							return;
+						}
+					} catch {
+						// Remote provider may not be available (e.g. transient disconnect).
+						// Fall through to local filesystem resolution below.
 					}
 				}
 
@@ -313,27 +318,31 @@ export class LinkDetector implements ILinkDetector {
 		link.tabIndex = 0;
 		const uri = URI.file(osPath.normalize(path));
 
-		// When connected to a remote, try the remote filesystem first
-		// since the debug adapter likely produces paths from the remote host
+		// When connected to a remote, defer resolution to click time to avoid
+		// doubling filesystem round-trips during linkification (render time).
+		// At click time we try the remote filesystem first, then fall back to local.
 		// https://github.com/microsoft/vscode/issues/111143
 		const remoteAuthority = this.environmentService.remoteAuthority;
 		if (remoteAuthority) {
 			const remoteUri = URI.from({ scheme: Schemas.vscodeRemote, authority: remoteAuthority, path: uri.path });
-			this.fileService.stat(remoteUri).then(stat => {
-				if (stat.isDirectory) {
-					return;
-				}
-				this.decorateLink(link, remoteUri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: remoteUri, options: { ...options, preserveFocus } }));
-			}).catch(() => {
-				// Remote file not found, fall back to local filesystem
-				this.fileService.stat(uri).then(stat => {
-					if (stat.isDirectory) {
+			this.decorateLink(link, remoteUri, fulltext, hoverBehavior, async (preserveFocus: boolean) => {
+				try {
+					const stat = await this.fileService.stat(remoteUri);
+					if (!stat.isDirectory) {
+						await this.editorService.openEditor({ resource: remoteUri, options: { ...options, preserveFocus } });
 						return;
 					}
-					this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
-				}).catch(() => {
+				} catch {
+					// Remote file not found or provider unavailable, fall back to local
+				}
+				try {
+					const stat = await this.fileService.stat(uri);
+					if (!stat.isDirectory) {
+						await this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } });
+					}
+				} catch {
 					// If the uri can not be resolved we should not spam the console with error, remain quiet #86587
-				});
+				}
 			});
 		} else {
 			this.fileService.stat(uri).then(stat => {

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -244,6 +244,23 @@ export class LinkDetector implements ILinkDetector {
 				const fsPath = uri.fsPath;
 				const path = await this.pathService.path;
 				const fileUrl = osPath.normalize(((path.sep === osPath.posix.sep) && platform.isWindows) ? fsPath.replace(/\\/g, osPath.posix.sep) : fsPath);
+				const selection = lineCol ? { startLineNumber: +lineCol[1], startColumn: lineCol[2] ? +lineCol[2] : 1 } : undefined;
+
+				// When connected to a remote, try the remote filesystem first
+				// since the debug adapter likely produces paths from the remote host
+				// https://github.com/microsoft/vscode/issues/111143
+				const remoteAuthority = this.environmentService.remoteAuthority;
+				if (remoteAuthority) {
+					const remoteUri = URI.from({ scheme: Schemas.vscodeRemote, authority: remoteAuthority, path: uri.path });
+					const existsRemote = await this.fileService.exists(remoteUri);
+					if (existsRemote) {
+						await this.editorService.openEditor({
+							resource: remoteUri,
+							options: { pinned: true, selection },
+						});
+						return;
+					}
+				}
 
 				const fileUri = URI.parse(fileUrl);
 				const exists = await this.fileService.exists(fileUri);
@@ -253,10 +270,7 @@ export class LinkDetector implements ILinkDetector {
 
 				await this.editorService.openEditor({
 					resource: fileUri,
-					options: {
-						pinned: true,
-						selection: lineCol ? { startLineNumber: +lineCol[1], startColumn: lineCol[2] ? +lineCol[2] : 1 } : undefined,
-					},
+					options: { pinned: true, selection },
 				});
 				return;
 			}
@@ -298,14 +312,39 @@ export class LinkDetector implements ILinkDetector {
 		const link = this.createLink(text);
 		link.tabIndex = 0;
 		const uri = URI.file(osPath.normalize(path));
-		this.fileService.stat(uri).then(stat => {
-			if (stat.isDirectory) {
-				return;
-			}
-			this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
-		}).catch(() => {
-			// If the uri can not be resolved we should not spam the console with error, remain quite #86587
-		});
+
+		// When connected to a remote, try the remote filesystem first
+		// since the debug adapter likely produces paths from the remote host
+		// https://github.com/microsoft/vscode/issues/111143
+		const remoteAuthority = this.environmentService.remoteAuthority;
+		if (remoteAuthority) {
+			const remoteUri = URI.from({ scheme: Schemas.vscodeRemote, authority: remoteAuthority, path: uri.path });
+			this.fileService.stat(remoteUri).then(stat => {
+				if (stat.isDirectory) {
+					return;
+				}
+				this.decorateLink(link, remoteUri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: remoteUri, options: { ...options, preserveFocus } }));
+			}).catch(() => {
+				// Remote file not found, fall back to local filesystem
+				this.fileService.stat(uri).then(stat => {
+					if (stat.isDirectory) {
+						return;
+					}
+					this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
+				}).catch(() => {
+					// If the uri can not be resolved we should not spam the console with error, remain quiet #86587
+				});
+			});
+		} else {
+			this.fileService.stat(uri).then(stat => {
+				if (stat.isDirectory) {
+					return;
+				}
+				this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
+			}).catch(() => {
+				// If the uri can not be resolved we should not spam the console with error, remain quiet #86587
+			});
+		}
 		return link;
 	}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When connected to a remote environment (e.g., devcontainer), clicking a `file:///path/to/file` link or an absolute path link in the Debug Console opens the file from the **host** filesystem instead of the remote filesystem. The terminal handles this correctly, but the debug console does not.

Closes #111143

## What is the new behavior?

When `environmentService.remoteAuthority` is set (remote/devcontainer context), the debug console link detector now:

1. **For `file:` URI web links** (`createWebLink`): Constructs a `vscode-remote` URI using the remote authority and checks if the file exists on the remote filesystem first. If found, opens from remote. Falls back to local filesystem if not found.

2. **For absolute path links** (`createPathLink`): Same approach — tries the remote filesystem first via `vscode-remote` scheme, falls back to local on failure.

This matches how the terminal already resolves file links in remote environments, as suggested in the [maintainer comment](https://github.com/microsoft/vscode/issues/111143#issuecomment-1303815858).

## Additional context

- Only one file changed: `src/vs/workbench/contrib/debug/browser/linkDetector.ts`
- Uses the existing `Schemas.vscodeRemote` and `IWorkbenchEnvironmentService.remoteAuthority` which are already imported/injected
- The `URI.from({ scheme: Schemas.vscodeRemote, authority: remoteAuthority, path: uri.path })` pattern follows established codebase conventions (e.g., `promptFilesLocator.ts`)
- Preserves full backward compatibility — when not connected to a remote, behavior is unchanged
- No new dependencies or imports required