### PR TITLE
fix: defer markdown preview refresh when panel is hidden

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -58,6 +58,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 	#currentVersion?: PreviewDocumentVersion;
 	#isScrolling = false;
 	#scrollingTimer?: NodeJS.Timeout;
+	#needsRefresh = false;
 
 	#imageInfo: readonly ImageInfo[] = [];
 	readonly #fileWatchersBySrc = new Map</* src: */ string, vscode.FileSystemWatcher>();
@@ -171,6 +172,13 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			}
 		}));
 
+		this._register(this.#webviewPanel.onDidChangeViewState(() => {
+			if (this.#webviewPanel.visible && this.#needsRefresh) {
+				this.#needsRefresh = false;
+				this.refresh(true);
+			}
+		}));
+
 		this.refresh();
 	}
 
@@ -256,6 +264,13 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			return;
 		}
 
+		if (!this.#webviewPanel.visible) {
+			// Defer the refresh until the webview becomes visible again
+			// to avoid resetting the webview state (e.g. scroll position)
+			this.#needsRefresh = true;
+			return;
+		}
+
 		let document: vscode.TextDocument;
 		try {
 			document = await vscode.workspace.openTextDocument(this.#resource);
@@ -278,7 +293,7 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			return;
 		}
 
-		const shouldReloadPage = forceUpdate || !this.#currentVersion || this.#currentVersion.resource.toString() !== pendingVersion.resource.toString() || !this.#webviewPanel.visible;
+		const shouldReloadPage = forceUpdate || !this.#currentVersion || this.#currentVersion.resource.toString() !== pendingVersion.resource.toString();
 		this.#currentVersion = pendingVersion;
 
 		let selectedLine: number | undefined = undefined;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a markdown file is edited while the preview panel is hidden (e.g., the user switched to another tab), the preview attempts to update the webview immediately. Since the webview is not visible, `shouldReloadPage` evaluates to `true` (due to the `!this.#webviewPanel.visible` condition), causing a full page reload via `webview.html = html`. When the user switches back to the preview tab, the webview context has been destroyed and recreated, which resets the scroll position and causes a visible flash.

Closes #147718

## What is the new behavior?

When the preview panel is not visible, the refresh is deferred by setting a `#needsRefresh` flag and returning early from `#updatePreview()`. An `onDidChangeViewState` listener detects when the panel becomes visible again and triggers a full refresh at that point. This ensures the preview content is always up-to-date when the user returns to it, without resetting the webview state while the panel is hidden.

The `!this.#webviewPanel.visible` condition has been removed from the `shouldReloadPage` expression since the early return above makes it unreachable when the panel is not visible.

## Additional context

This avoids the approach of using `retainContextWhenHidden` (which was discussed and rejected in the previous attempt at fixing this issue in PR #150150 due to memory/performance concerns). Instead, the fix simply defers the update until the panel is visible, which is lightweight and preserves the existing behavior of not retaining the webview context when hidden.