### PR TITLE
fix: settings editor overflow in 2x2 grid layout

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -112,6 +112,10 @@ export class SettingsEditor2 extends EditorPane {
 	private static TOC_MIN_WIDTH: number = 100;
 	private static TOC_RESET_WIDTH: number = 200;
 	private static EDITOR_MIN_WIDTH: number = 500;
+	// The minimum width the settings tree view can shrink to inside the splitview.
+	// This must be smaller than EDITOR_MIN_WIDTH to allow the editor pane to fit
+	// within narrow grid cells (e.g. 2x2 editor grid layouts). See #194412.
+	private static SETTINGS_TREE_MIN_WIDTH: number = 200;
 	// Below NARROW_TOTAL_WIDTH, we only render the editor rather than the ToC.
 	private static NARROW_TOTAL_WIDTH: number = this.TOC_RESET_WIDTH + this.EDITOR_MIN_WIDTH;
 
@@ -413,7 +417,7 @@ export class SettingsEditor2 extends EditorPane {
 		}
 	}
 
-	override get minimumWidth(): number { return SettingsEditor2.EDITOR_MIN_WIDTH; }
+	override get minimumWidth(): number { return SettingsEditor2.SETTINGS_TREE_MIN_WIDTH; }
 	override get maximumWidth(): number { return Number.POSITIVE_INFINITY; }
 	override get minimumHeight() { return 180; }
 
@@ -988,7 +992,7 @@ export class SettingsEditor2 extends EditorPane {
 		this.splitView.addView({
 			onDidChange: Event.None,
 			element: this.settingsTreeContainer,
-			minimumSize: SettingsEditor2.EDITOR_MIN_WIDTH,
+			minimumSize: SettingsEditor2.SETTINGS_TREE_MIN_WIDTH,
 			maximumSize: Number.POSITIVE_INFINITY,
 			layout: (width, _, height) => {
 				this.settingsTreeContainer.style.width = `${width}px`;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using a 2x2 editor grid layout (`View: Grid Editor Layout (2x2)`), the settings editor's inner splitview overflows its bounding grid cell. This happens because the settings editor reports a 500px minimum width to the grid layout system via its `minimumWidth` getter, and the splitview's settings tree view also has a 500px `minimumSize`. On smaller windows, the grid cells can't honor this constraint, causing visible overflow.

Closes #194412

## What is the new behavior?

Introduces a separate `SETTINGS_TREE_MIN_WIDTH` constant (200px) that is used for:
1. The editor pane's `minimumWidth` override - allows the grid to allocate narrower cells
2. The splitview's settings tree view `minimumSize` - allows the splitview to shrink within narrow cells

The existing `EDITOR_MIN_WIDTH` (500px) is preserved for the `NARROW_TOTAL_WIDTH` calculation, so the TOC-hiding behavior at narrow widths continues to work exactly as before. When the settings editor is given less than 700px, the TOC is hidden and the settings tree takes full width, now able to shrink down to 200px without overflow.

## Additional context

Steps to reproduce (from the issue):
1. `View: Grid Editor Layout (2x2)`
2. Make the window small
3. Open Settings (`Ctrl+,`)
4. Previously: inner splitview overflows its grid cell
5. Now: settings editor fits within the grid cell, showing in narrow mode with TOC hidden