### PR TITLE
feat: show coverage indicators in minimap

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -25,7 +25,7 @@ import { EditorOption } from '../../../../editor/common/config/editorOptions.js'
 import { Position } from '../../../../editor/common/core/position.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { IEditorContribution } from '../../../../editor/common/editorCommon.js';
-import { IModelDecorationOptions, InjectedTextCursorStops, InjectedTextOptions, ITextModel } from '../../../../editor/common/model.js';
+import { IModelDecorationOptions, InjectedTextCursorStops, InjectedTextOptions, ITextModel, MinimapPosition } from '../../../../editor/common/model.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -39,6 +39,7 @@ import { KeybindingWeight } from '../../../../platform/keybinding/common/keybind
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { bindContextKey, observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IQuickInputButton, IQuickInputService, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
+import { themeColorFromId } from '../../../../platform/theme/common/themeService.js';
 import { ActiveEditorContext } from '../../../common/contextkeys.js';
 import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { getTestingConfiguration, TestingConfigKeys } from '../common/configuration.js';
@@ -52,6 +53,7 @@ import { TestingContextKeys } from '../common/testingContextKeys.js';
 import * as coverUtils from './codeCoverageDisplayUtils.js';
 import { testingCoverageMissingBranch, testingCoverageReport, testingFilterIcon, testingRerunIcon } from './icons.js';
 import { ManagedTestCoverageBars } from './testCoverageBars.js';
+import { testingCoveredMinimapBackground, testingUncoveredMinimapBackground } from './theme.js';
 
 const CLASS_HIT = 'coverage-deco-hit';
 const CLASS_MISS = 'coverage-deco-miss';
@@ -130,10 +132,11 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 			reader => this.hasInlineCoverageDetails.read(reader),
 		));
 
+		const minimapEnabled = observableConfigValue(TestingConfigKeys.CoverageMinimapEnabled, true, configurationService);
 		this._register(autorun(reader => {
 			const c = fileCoverage.read(reader);
 			if (c) {
-				this.apply(editor.getModel()!, c.file, c.testId, coverage.showInline.read(reader));
+				this.apply(editor.getModel()!, c.file, c.testId, coverage.showInline.read(reader), minimapEnabled.read(reader));
 			} else {
 				this.clear();
 			}
@@ -329,7 +332,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 		return false;
 	}
 
-	private async apply(model: ITextModel, coverage: FileCoverage, testId: TestId | undefined, showInlineByDefault: boolean) {
+	private async apply(model: ITextModel, coverage: FileCoverage, testId: TestId | undefined, showInlineByDefault: boolean, showMinimap: boolean) {
 		const details = this.details = await this.loadDetails(coverage, testId, model);
 		if (!details) {
 			this.hasInlineCoverageDetails.set(false, undefined);
@@ -353,6 +356,10 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 						showIfCollapsed: showMissIndicator, // only avoid collapsing if we want to show the miss indicator
 						description: 'coverage-gutter',
 						lineNumberClassName: `coverage-deco-gutter ${cls}`,
+						minimap: showMinimap ? {
+							color: themeColorFromId(hits ? testingCoveredMinimapBackground : testingUncoveredMinimapBackground),
+							position: MinimapPosition.Gutter,
+						} : undefined,
 					};
 
 					const applyHoverOptions = (target: IModelDecorationOptions) => {
@@ -383,6 +390,10 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 						showIfCollapsed: false,
 						description: 'coverage-inline',
 						lineNumberClassName: `coverage-deco-gutter ${cls}`,
+						minimap: showMinimap ? {
+							color: themeColorFromId(detail.count ? testingCoveredMinimapBackground : testingUncoveredMinimapBackground),
+							position: MinimapPosition.Gutter,
+						} : undefined,
 					};
 
 					const applyHoverOptions = (target: IModelDecorationOptions) => {

--- a/src/vs/workbench/contrib/testing/browser/theme.ts
+++ b/src/vs/workbench/contrib/testing/browser/theme.ts
@@ -105,6 +105,20 @@ export const testingUncoveredGutterBackground = registerColor('testing.uncovered
 	hcLight: chartsRed
 }, localize('testing.uncoveredGutterBackground', 'Gutter color of regions where code not covered.'));
 
+export const testingCoveredMinimapBackground = registerColor('testing.coveredMinimapBackground', {
+	dark: transparent(diffInserted, 0.6),
+	light: transparent(diffInserted, 0.6),
+	hcDark: chartsGreen,
+	hcLight: chartsGreen
+}, localize('testing.coveredMinimapBackground', 'Minimap color of regions where code was covered.'));
+
+export const testingUncoveredMinimapBackground = registerColor('testing.uncoveredMinimapBackground', {
+	dark: transparent(diffRemoved, 1.5),
+	light: transparent(diffRemoved, 1.5),
+	hcDark: chartsRed,
+	hcLight: chartsRed
+}, localize('testing.uncoveredMinimapBackground', 'Minimap color of regions where code was not covered.'));
+
 export const testingCoverCountBadgeBackground = registerColor('testing.coverCountBadgeBackground', badgeBackground, localize('testing.coverCountBadgeBackground', 'Background for the badge indicating execution count'));
 
 export const testingCoverCountBadgeForeground = registerColor('testing.coverCountBadgeForeground', badgeForeground, localize('testing.coverCountBadgeForeground', 'Foreground for the badge indicating execution count'));

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -25,6 +25,7 @@ export const enum TestingConfigKeys {
 	ShowCoverageInExplorer = 'testing.showCoverageInExplorer',
 	CoverageBarThresholds = 'testing.coverageBarThresholds',
 	CoverageToolbarEnabled = 'testing.coverageToolbarEnabled',
+	CoverageMinimapEnabled = 'testing.coverageMinimapEnabled',
 	ResultsViewLayout = 'testing.resultsView.layout',
 }
 
@@ -197,6 +198,11 @@ export const testingConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: false, // todo@connor4312: disabled by default until UI sync
 		},
+		[TestingConfigKeys.CoverageMinimapEnabled]: {
+			description: localize('testing.coverageMinimapEnabled', 'Controls whether coverage indicators are shown in the minimap.'),
+			type: 'boolean',
+			default: true,
+		},
 		[TestingConfigKeys.ResultsViewLayout]: {
 			description: localize('testing.resultsView.layout', 'Controls the layout of the Test Results view.'),
 			enum: [
@@ -246,6 +252,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.ShowCoverageInExplorer]: boolean;
 	[TestingConfigKeys.CoverageBarThresholds]: ITestingCoverageBarThresholds;
 	[TestingConfigKeys.CoverageToolbarEnabled]: boolean;
+	[TestingConfigKeys.CoverageMinimapEnabled]: boolean;
 	[TestingConfigKeys.ResultsViewLayout]: TestingResultsViewLayout;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (implements a requested enhancement)

## What is the current behavior?

When test coverage is displayed in the editor, coverage indicators (covered/uncovered lines) are shown in the line number gutter and optionally inline, but there is no coverage visualization in the minimap. Users who want to quickly scan for coverage gaps in a file must scroll through the entire document.

Closes #258961

## What is the new behavior?

Coverage indicators now appear in the minimap gutter, showing covered regions in green and uncovered regions in red. This allows users to see coverage gaps at a glance without scrolling.

### Changes:

- **New color tokens**: `testing.coveredMinimapBackground` and `testing.uncoveredMinimapBackground` registered in `theme.ts`, with defaults matching the existing gutter coverage colors (green for covered, red for uncovered)
- **New setting**: `testing.coverageMinimapEnabled` (boolean, default `true`) in `configuration.ts` to let users toggle minimap coverage indicators independently
- **Minimap decorations**: Both statement and branch coverage decorations in `codeCoverageDecorations.ts` now include `minimap: { color, position: MinimapPosition.Gutter }` when the setting is enabled. The observable config value is read reactively so toggling the setting updates the minimap immediately.

## Additional context

The implementation follows the same pattern used by the SCM quick diff decorator (`quickDiffDecorator.ts`), which adds minimap indicators for added/modified/deleted lines using `themeColorFromId()` and `MinimapPosition.Gutter`.