### PR TITLE
fix: add transparency to opaque colors that should not hide content

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -367,7 +367,7 @@
 		"diffEditor.removedTextBackground": "#892F4688",
 		// "diffEditor.removedTextBorder": "",
 		// Editor: Minimap
-		"minimap.selectionHighlight": "#750000",
+		"minimap.selectionHighlight": "#75000080",
 		// Workbench: Title
 		"titleBar.activeBackground": "#10192c",
 		// "titleBar.activeForeground": "",

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -494,7 +494,7 @@
 		"editor.lineHighlightBackground": "#E4F6D4",
 		"editorLineNumber.activeForeground": "#9769dc",
 		"editor.selectionBackground": "#C9D0D9",
-		"minimap.selectionHighlight": "#C9D0D9",
+		"minimap.selectionHighlight": "#C9D0D980",
 		"panel.background": "#F5F5F5",
 		"sideBar.background": "#F2F2F2",
 		"sideBarSectionHeader.background": "#ede8ef",

--- a/extensions/theme-red/themes/Red-color-theme.json
+++ b/extensions/theme-red/themes/Red-color-theme.json
@@ -22,7 +22,7 @@
 		"editor.foreground": "#F8F8F8",
 		"editorWhitespace.foreground": "#c10000",
 		"editor.selectionBackground": "#750000",
-		"minimap.selectionHighlight": "#750000",
+		"minimap.selectionHighlight": "#75000080",
 		"editorLineNumber.foreground": "#ff777788",
 		"editorLineNumber.activeForeground": "#ffbbbb88",
 		"editorWidget.background": "#300000",

--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -387,7 +387,7 @@
 		"editor.lineHighlightBackground": "#073642",
 		"editorLineNumber.activeForeground": "#949494",
 		"editor.selectionBackground": "#274642",
-		"minimap.selectionHighlight": "#274642",
+		"minimap.selectionHighlight": "#27464280",
 		"editorIndentGuide.background": "#93A1A180",
 		"editorIndentGuide.activeBackground": "#C3E1E180",
 		"editorHoverWidget.background": "#004052",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -373,7 +373,7 @@
 		"editorWhitespace.foreground": "#586E7580",
 		"editor.lineHighlightBackground": "#EEE8D5",
 		"editor.selectionBackground": "#EEE8D5",
-		"minimap.selectionHighlight": "#EEE8D5",
+		"minimap.selectionHighlight": "#EEE8D580",
 		"editorIndentGuide.background": "#586E7580",
 		"editorIndentGuide.activeBackground": "#081E2580",
 		"editorHoverWidget.background": "#CCC4B0",

--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
@@ -14,7 +14,7 @@
 		"editor.background": "#002451",
 		"editor.foreground": "#ffffff",
 		"editor.selectionBackground": "#003f8e",
-		"minimap.selectionHighlight": "#003f8e",
+		"minimap.selectionHighlight": "#003f8e80",
 		"editor.lineHighlightBackground": "#00346e",
 		"editorLineNumber.activeForeground": "#949494",
 		"editorCursor.foreground": "#ffffff",

--- a/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
@@ -63,7 +63,7 @@ export const TERMINAL_FIND_MATCH_BACKGROUND_COLOR = registerColor('terminal.find
 	light: editorFindMatch,
 	// Use regular selection background in high contrast with a thick border
 	hcDark: null,
-	hcLight: '#0F4A85'
+	hcLight: '#0F4A8566'
 }, nls.localize('terminal.findMatchBackground', 'Color of the current search match in the terminal. The color must not be opaque so as not to hide underlying terminal content.'), true);
 export const TERMINAL_HOVER_HIGHLIGHT_BACKGROUND_COLOR = registerColor('terminal.hoverHighlightBackground', transparent(editorHoverHighlight, 0.5), nls.localize('terminal.hoverHighlightBackground', 'Highlight below the word for which a hover is shown. The color must not be opaque so as not to hide underlying decorations.'));
 export const TERMINAL_FIND_MATCH_BORDER_COLOR = registerColor('terminal.findMatchBorder', {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Several color values that are designed to be overlaid on content are defined as opaque, which hides the underlying content instead of allowing it to show through:

1. **`minimap.selectionHighlight`** in 6 built-in themes uses opaque hex values (no alpha channel), hiding minimap content underneath the selection highlight:
   - Red: `#750000`
   - Quiet Light: `#C9D0D9`
   - Abyss: `#750000`
   - Tomorrow Night Blue: `#003f8e`
   - Solarized Light: `#EEE8D5`
   - Solarized Dark: `#274642`

2. **`terminal.findMatchBackground`** for `hcLight` is `#0F4A85` (opaque), despite the color description explicitly stating: *"The color must not be opaque so as not to hide underlying terminal content."* The `registerColor` call even passes `true` for the transparency flag.

Closes #237507

## What is the new behavior?

1. All 6 theme-level `minimap.selectionHighlight` overrides now include a `80` alpha suffix (50% opacity), allowing minimap content to be visible through the selection highlight. This aligns with the default behavior established in PR #283365 where the color registration was updated to reference `editorSelectionBackground` with `true` for transparency.

2. `terminal.findMatchBackground` for `hcLight` is now `#0F4A8566` (40% opacity). The companion `terminal.findMatchBorder` remains opaque (`#0F4A85`) to maintain clear border visibility in the High Contrast Light theme.

## Additional context

This addresses the remaining items from #237507. The minimap default color registrations were already fixed in PR #283365, but the individual theme-level overrides still used opaque values that would take precedence over the transparent defaults. The terminal fix was explicitly left open by the maintainer for the terminal team to address.