### PR TITLE
fix: show helpful error when syncing with divergent branches

### DIFF
--- a/extensions/git/src/api/git.constants.ts
+++ b/extensions/git/src/api/git.constants.ts
@@ -95,4 +95,5 @@ export const GitErrorCodes = Object.freeze({
 	WorktreeContainsChanges: 'WorktreeContainsChanges',
 	WorktreeAlreadyExists: 'WorktreeAlreadyExists',
 	WorktreeBranchAlreadyUsed: 'WorktreeBranchAlreadyUsed',
+	PullWithReconcileNotConfigured: 'PullWithReconcileNotConfigured',
 }) satisfies Record<keyof typeof git.GitErrorCodes, string>;

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -509,5 +509,6 @@ export const enum GitErrorCodes {
 	CherryPickConflict = 'CherryPickConflict',
 	WorktreeContainsChanges = 'WorktreeContainsChanges',
 	WorktreeAlreadyExists = 'WorktreeAlreadyExists',
-	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed'
+	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed',
+	PullWithReconcileNotConfigured = 'PullWithReconcileNotConfigured'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5643,6 +5643,9 @@ export class CommandCenter {
 						choices.set(l10n.t('Show Changes'), () => commands.executeCommand('workbench.view.scm'));
 						options.modal = false;
 						break;
+					case GitErrorCodes.PullWithReconcileNotConfigured:
+						message = l10n.t('Your local and remote branches have diverged. Please configure how to reconcile divergent branches by running "git config pull.rebase false" for merge or "git config pull.rebase true" for rebase.');
+						break;
 					default: {
 						const hintLines = (err.stderr || err.stdout || err.message || String(err))
 							.replace(/^error: /mi, '')

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2491,6 +2491,8 @@ export class Repository {
 				err.gitErrorCode = GitErrorCodes.CantRebaseMultipleBranches;
 			} else if (/! \[rejected\].*\(would clobber existing tag\)/m.test(err.stderr || '')) {
 				err.gitErrorCode = GitErrorCodes.TagConflict;
+			} else if (/Need to specify how to reconcile divergent branches/i.test(err.stderr || '')) {
+				err.gitErrorCode = GitErrorCodes.PullWithReconcileNotConfigured;
 			}
 
 			throw err;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When syncing changes with divergent branches and `pull.rebase` is not configured in git, VS Code shows an unhelpful generic error message. The raw git error "Need to specify how to reconcile divergent branches" is not user-friendly and doesn't tell the user how to fix the problem.

Closes #198210

## What is the new behavior?

The git extension now detects the "divergent branches" error and shows a clear, localized message:

> "Your local and remote branches have diverged. Please configure how to reconcile divergent branches by running "git config pull.rebase false" for merge or "git config pull.rebase true" for rebase."

### Changes:
- Added `PullWithReconcileNotConfigured` error code to `GitErrorCodes` enum (`git.d.ts`, `git.constants.ts`)
- Added error pattern detection in the `pull()` method (`git.ts`) for the "Need to specify how to reconcile divergent branches" fatal message
- Added a dedicated error handler case in the global command error handler (`commands.ts`) with a helpful message explaining the available reconciliation strategies