### PR TITLE
feat: add 'Open Changes with Working File' to timeline context menu

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -900,6 +900,11 @@
         "category": "Git"
       },
       {
+        "command": "git.timeline.openDiffWithWorking",
+        "title": "%command.timelineOpenDiffWithWorking%",
+        "category": "Git"
+      },
+      {
         "command": "git.rebaseAbort",
         "title": "%command.rebaseAbort%",
         "category": "Git",
@@ -1698,6 +1703,10 @@
         },
         {
           "command": "git.timeline.viewCommit",
+          "when": "false"
+        },
+        {
+          "command": "git.timeline.openDiffWithWorking",
           "when": "false"
         },
         {
@@ -2914,8 +2923,13 @@
           "when": "config.git.enabled && !git.missing && timelineItem =~ /git:file\\b/ && !listMultiSelection"
         },
         {
-          "command": "git.timeline.viewCommit",
+          "command": "git.timeline.openDiffWithWorking",
           "group": "1_actions@2",
+          "when": "config.git.enabled && !git.missing && timelineItem =~ /git:file:commit\\b/ && !listMultiSelection"
+        },
+        {
+          "command": "git.timeline.viewCommit",
+          "group": "1_actions@3",
           "when": "config.git.enabled && !git.missing && timelineItem =~ /git:file:commit\\b/ && !listMultiSelection"
         },
         {

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -133,6 +133,7 @@
 	"command.timelineCopyCommitMessage": "Copy Commit Message",
 	"command.timelineSelectForCompare": "Select for Compare",
 	"command.timelineCompareWithSelected": "Compare with Selected",
+	"command.timelineOpenDiffWithWorking": "Open Changes with Working File",
 	"command.manageUnsafeRepositories": "Manage Unsafe Repositories",
 	"command.openRepositoriesInParentFolders": "Open Repositories In Parent Folders",
 	"command.viewChanges": "Open Changes",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4817,6 +4817,29 @@ export class CommandCenter {
 		};
 	}
 
+
+	@command('git.timeline.openDiffWithWorking', { repository: false })
+	async timelineOpenDiffWithWorking(item: TimelineItem, uri: Uri | undefined, _source: string) {
+		if (uri === undefined || uri === null || !GitTimelineItem.is(item)) {
+			return;
+		}
+
+		const basename = path.basename(uri.fsPath);
+		const title = l10n.t('{0} ({1}) ↔ {0} (Working Tree)', basename, item.shortRef);
+
+		await commands.executeCommand(
+			'vscode.diff',
+			toGitUri(uri, item.ref),
+			uri,
+			title,
+			{
+				preserveFocus: true,
+				preview: true,
+				viewColumn: ViewColumn.Active
+			} satisfies TextDocumentShowOptions,
+		);
+	}
+
 	@command('git.timeline.viewCommit', { repository: false })
 	async timelineViewCommit(item: TimelineItem, uri: Uri | undefined, _source: string) {
 		if (!GitTimelineItem.is(item)) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature (new command for Git Timeline view)

## What is the current behavior?
When right-clicking a commit in the Timeline view, users can "Open Changes" (which shows the diff between the selected commit and its parent) or use "Select for Compare" + "Compare with Selected" (a two-step workflow to compare two commits). However, there is no direct way to compare a historical commit with the current working tree version of the file.

Closes #175499

## What is the new behavior?
Adds a new context menu command **"Open Changes with Working File"** (`git.timeline.openDiffWithWorking`) to the Timeline view's commit context menu. When selected, it opens a diff editor comparing the file at the selected commit with the current working tree version.

The command appears in the `1_actions` group (between "Open Changes" and "View Commit") and is only shown for commit items (not for staged/working tree entries, since comparing working tree with itself would be meaningless).

### Changes:
- **`extensions/git/package.json`**: Register the new command, hide it from the command palette, and add it to the `timeline/item/context` menu
- **`extensions/git/package.nls.json`**: Add the localized command title
- **`extensions/git/src/commands.ts`**: Implement `timelineOpenDiffWithWorking` following the same pattern as existing timeline commands

## Additional context
The implementation follows the exact same patterns used by existing timeline commands (`timelineOpenDiff`, `timelineCompareWithSelected`). The diff title format matches the existing convention: `filename (shortRef) ↔ filename (Working Tree)`.

TypeScript compilation passes with no errors.