### PR TITLE
Fix #256037: wrong indentation caused by incorrect bracket matcing

### DIFF
--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -468,7 +468,8 @@ export class InterceptorElectricCharOperation {
 			return null;
 		}
 		if (electricAction.matchOpenBracket) {
-			const endColumn = (lineTokens.getLineContent() + ch).lastIndexOf(electricAction.matchOpenBracket) + 1;
+			const lastOpenBracketIndex = (lineTokens.getLineContent() + ch).lastIndexOf(electricAction.matchOpenBracket);
+			const endColumn = lastOpenBracketIndex === -1 ? 0 : position.column;
 			const match = model.bracketPairs.findMatchingBracketUp(electricAction.matchOpenBracket, {
 				lineNumber: position.lineNumber,
 				column: endColumn

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -4912,6 +4912,59 @@ suite('Editor Controller', () => {
 		});
 	});
 
+	test('issue #256037: correct indentation when typing } before ] (correctly-indented)', () => {
+
+		usingCursor({
+			text: [
+				'const x = {',
+				'    arr: [{',
+				'        foo: 1',
+				'    ]',
+				'}'
+			],
+			languageId: electricCharLanguageId
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 4, 5);
+			viewModel.type('}', 'keyboard');
+			assert.deepStrictEqual(model.getLineContent(4), '    }]');
+		});
+	});
+
+	test('issue #256037: correct indentation when typing ] before ) (over-indented)', () => {
+
+		usingCursor({
+			text: [
+				'def example():',
+				'    data = ([',
+				'        "Ana"',
+				'                )'
+			],
+			languageId: electricCharLanguageId
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 4, 17);
+			viewModel.type(']', 'keyboard');
+			assert.deepStrictEqual(model.getLineContent(4), '    ])');
+		});
+	});
+
+	test('issue #256037: correct indentation when typing } before ) (under-indented)', () => {
+
+		usingCursor({
+			text: [
+				'function example() {',
+				'    const data = ({',
+				'        name: "Ana",',
+				');',
+				'}'
+			],
+			languageId: electricCharLanguageId
+		}, (editor, model, viewModel) => {
+			moveTo(editor, viewModel, 4, 1);
+			viewModel.type('}', 'keyboard');
+			assert.deepStrictEqual(model.getLineContent(4), '    });');
+		});
+	});
+
 	test('ElectricCharacter - appends text', () => {
 		usingCursor({
 			text: [


### PR DESCRIPTION
When typing a closing bracket immediately before another closing token, the auto-indent logic could start searching from the wrong column. This sometimes led to matching the wrong opening bracket, causing incorrect indentation.

This has been fixed by using the cursor column (where the closing bracket is inserted) as the search bound, or 0 when no valid opening bracket is found.

Added regression tests covering different scenarios, including cases like } before ) and ], and ] before ), with varying initial indentation levels.

Fixes #256037

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
