### PR TITLE
extHost: fix LanguageModelDataPart serialization compatibility

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3696,12 +3696,16 @@ export namespace ChatAgentResult {
 			} else if (value.$mid === MarshalledId.LanguageModelDataPart) {
 				let buffer: Uint8Array;
 				// correction for old data serialized pre-303151
-				if (typeof value.data === 'object' && value.data.type === 'Buffer' && Array.isArray(value.data.data)) {
+				if (value.data && typeof value.data === 'object' && value.data.type === 'Buffer' && Array.isArray(value.data.data)) {
 					buffer = new Uint8Array(value.data.data);
 				} else if (typeof value.data === 'string') {
-					buffer = decodeBase64(value.data).buffer;
+					try {
+						buffer = decodeBase64(value.data).buffer;
+					} catch {
+						buffer = new Uint8Array(0);
+					}
 				} else {
-					buffer = value; // ?
+					buffer = new Uint8Array(0);
 				}
 
 				return new types.LanguageModelDataPart(buffer, value.mimeType, value.audience);

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -5,7 +5,7 @@
 
 import type * as vscode from 'vscode';
 import { asArray, coalesce, isNonEmptyArray } from '../../../base/common/arrays.js';
-import { VSBuffer, encodeBase64 } from '../../../base/common/buffer.js';
+import { VSBuffer, decodeBase64, encodeBase64 } from '../../../base/common/buffer.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { IDataTransferFile, IDataTransferItem, UriList } from '../../../base/common/dataTransfer.js';
 import { createSingleCallFunction } from '../../../base/common/functional.js';
@@ -3694,7 +3694,17 @@ export namespace ChatAgentResult {
 			} else if (value.$mid === MarshalledId.LanguageModelPromptTsxPart) {
 				return new types.LanguageModelPromptTsxPart(value.value);
 			} else if (value.$mid === MarshalledId.LanguageModelDataPart) {
-				return new types.LanguageModelDataPart(value.data, value.mimeType, value.audience);
+				let buffer: Uint8Array;
+				// correction for old data serialized pre-303151
+				if (typeof value.data === 'object' && value.data.type === 'Buffer' && Array.isArray(value.data.data)) {
+					buffer = new Uint8Array(value.data.data);
+				} else if (typeof value.data === 'string') {
+					buffer = decodeBase64(value.data).buffer;
+				} else {
+					buffer = value; // ?
+				}
+
+				return new types.LanguageModelDataPart(buffer, value.mimeType, value.audience);
 			}
 
 			return undefined;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -5,7 +5,7 @@
 
 import type * as vscode from 'vscode';
 import { asArray } from '../../../base/common/arrays.js';
-import { VSBuffer } from '../../../base/common/buffer.js';
+import { encodeBase64, VSBuffer } from '../../../base/common/buffer.js';
 import { illegalArgument, SerializedError } from '../../../base/common/errors.js';
 import { IRelativePattern } from '../../../base/common/glob.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
@@ -4026,7 +4026,7 @@ export class LanguageModelDataPart implements vscode.LanguageModelDataPart2 {
 		return {
 			$mid: MarshalledId.LanguageModelDataPart,
 			mimeType: this.mimeType,
-			data: this.data,
+			data: encodeBase64(VSBuffer.wrap(this.data)),
 			audience: this.audience
 		};
 	}

--- a/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTypeConverter.test.ts
@@ -6,11 +6,12 @@
 
 import assert from 'assert';
 import * as extHostTypes from '../../common/extHostTypes.js';
-import { MarkdownString, NotebookCellOutputItem, NotebookData, LanguageSelector, WorkspaceEdit } from '../../common/extHostTypeConverters.js';
+import { ChatAgentResult, MarkdownString, NotebookCellOutputItem, NotebookData, LanguageSelector, WorkspaceEdit } from '../../common/extHostTypeConverters.js';
 import { isEmptyObject } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceTextEditDto } from '../../common/extHost.protocol.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { MarshalledId } from '../../../../base/common/marshallingIds.js';
 
 suite('ExtHostTypeConverter', function () {
 
@@ -141,5 +142,48 @@ suite('ExtHostTypeConverter', function () {
 		const dto2 = WorkspaceEdit.from(ws2);
 		const first2 = <IWorkspaceTextEditDto>dto2.edits[0];
 		assert.strictEqual(first2.textEdit.insertAsSnippet, true);
+	});
+});
+
+suite('ChatAgentResult', function () {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reviveMetadata - roundtrips base64-encoded LanguageModelDataPart', function () {
+		const originalData = new Uint8Array([10, 20, 30, 40]);
+		const part = new extHostTypes.LanguageModelDataPart(originalData, 'image/png');
+		const serialized = part.toJSON();
+
+		const result = ChatAgentResult.to({ metadata: { part: serialized } });
+		const revived = result.metadata!.part as extHostTypes.LanguageModelDataPart;
+
+		assert.ok(revived instanceof extHostTypes.LanguageModelDataPart);
+		assert.deepStrictEqual(Array.from(revived.data), Array.from(originalData));
+		assert.strictEqual(revived.mimeType, 'image/png');
+	});
+
+	test('reviveMetadata - decodes legacy Buffer-like LanguageModelDataPart shape', function () {
+		const legacySerialized = {
+			$mid: MarshalledId.LanguageModelDataPart,
+			data: { type: 'Buffer', data: [1, 2, 3] },
+			mimeType: 'image/jpeg',
+		};
+
+		const result = ChatAgentResult.to({ metadata: { part: legacySerialized } });
+		const revived = result.metadata!.part as extHostTypes.LanguageModelDataPart;
+
+		assert.ok(revived instanceof extHostTypes.LanguageModelDataPart);
+		assert.deepStrictEqual(Array.from(revived.data), [1, 2, 3]);
+		assert.strictEqual(revived.mimeType, 'image/jpeg');
+	});
+
+	test('reviveMetadata - does not throw on malformed LanguageModelDataPart shape', function () {
+		const malformed = {
+			$mid: MarshalledId.LanguageModelDataPart,
+			data: null,
+			mimeType: 'image/png',
+		};
+
+		assert.doesNotThrow(() => ChatAgentResult.to({ metadata: { part: malformed } }));
 	});
 });


### PR DESCRIPTION
- Encodes LanguageModelDataPart payloads as base64 to avoid transport/runtime mismatches with raw Uint8Array marshaling and preserve binary integrity across extension host boundaries.
- Adds backward-compatible decoding for previously serialized payload shapes so older persisted data and in-flight responses continue to load instead of failing or producing invalid content.
- Hardens deserialization paths around chat agent result parts to prevent breakage while rolling out the new serialization format.

Fixes #303151

(Commit message generated by Copilot)
