### PR TITLE
chat: improve ChatSessionCustomizationProvider API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -647,7 +647,13 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		};
 		let hiddenSections: string[] | undefined;
 		if (metadata.supportedTypes) {
-			const supportedSections = new Set(metadata.supportedTypes.map(t => typeToSection[t]).filter(Boolean));
+			const supportedSections = new Set<string>();
+			for (const t of metadata.supportedTypes) {
+				const section = typeToSection[t];
+				if (section) {
+					supportedSections.add(section);
+				}
+			}
 			hiddenSections = Object.values(typeToSection).filter(section => !supportedSections.has(section));
 		}
 

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -642,6 +642,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 				case 'instructions': return AICustomizationManagementSection.Instructions;
 				case 'prompt': return AICustomizationManagementSection.Prompts;
 				case 'hook': return AICustomizationManagementSection.Hooks;
+				case 'plugins': return AICustomizationManagementSection.Plugins;
 				default: return type;
 			}
 		});

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -634,18 +634,22 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			},
 		};
 
-		// Convert metadata to a harness descriptor
-		const hiddenSections = metadata.unsupportedTypes?.map(type => {
-			switch (type) {
-				case 'agent': return AICustomizationManagementSection.Agents;
-				case 'skill': return AICustomizationManagementSection.Skills;
-				case 'instructions': return AICustomizationManagementSection.Instructions;
-				case 'prompt': return AICustomizationManagementSection.Prompts;
-				case 'hook': return AICustomizationManagementSection.Hooks;
-				case 'plugins': return AICustomizationManagementSection.Plugins;
-				default: return type;
-			}
-		});
+		// Convert supportedTypes whitelist to hiddenSections blacklist.
+		// Sections not in the supported list are hidden. When supportedTypes
+		// is omitted, all sections are shown.
+		const typeToSection: Record<string, string> = {
+			'agent': AICustomizationManagementSection.Agents,
+			'skill': AICustomizationManagementSection.Skills,
+			'instructions': AICustomizationManagementSection.Instructions,
+			'prompt': AICustomizationManagementSection.Prompts,
+			'hook': AICustomizationManagementSection.Hooks,
+			'plugins': AICustomizationManagementSection.Plugins,
+		};
+		let hiddenSections: string[] | undefined;
+		if (metadata.supportedTypes) {
+			const supportedSections = new Set(metadata.supportedTypes.map(t => typeToSection[t]).filter(Boolean));
+			hiddenSections = Object.values(typeToSection).filter(section => !supportedSections.has(section));
+		}
 
 		const descriptor: IHarnessDescriptor = {
 			id: chatSessionType,

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -45,7 +45,7 @@ import { ExtHostChatAgentsShape2, ExtHostContext, IChatSessionCustomizationItemD
 import { NotebookDto } from './mainThreadNotebookDto.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../contrib/chat/common/customizationHarnessService.js';
-import { AICustomizationManagementSection } from '../../contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 
 interface AgentData {
@@ -659,7 +659,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			getStorageSourceFilter: () => ({
 				// Extension-provided harnesses manage their own items via the provider,
 				// so we show all sources for storage-filter-based flows.
-				sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, PromptsStorage.extension],
+				sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, PromptsStorage.extension, BUILTIN_STORAGE],
 			}),
 			itemProvider,
 		};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1681,7 +1681,7 @@ export interface ISkillDto {
 export interface IChatSessionCustomizationProviderMetadataDto {
 	readonly label: string;
 	readonly iconId?: string;
-	readonly unsupportedTypes?: readonly string[];
+	readonly supportedTypes?: readonly string[];
 }
 
 export interface IChatSessionCustomizationItemDto {

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -671,7 +671,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		const metadataDto: IChatSessionCustomizationProviderMetadataDto = {
 			label: metadata.label,
 			iconId: metadata.iconId,
-			unsupportedTypes: metadata.unsupportedTypes?.map(t => typeConvert.ChatSessionCustomizationType.from(t)),
+			supportedTypes: metadata.supportedTypes?.map(t => typeConvert.ChatSessionCustomizationType.from(t)),
 		};
 
 		this._proxy.$registerChatSessionCustomizationProvider(handle, chatSessionType, metadataDto, extension.identifier);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3574,6 +3574,7 @@ export class ChatSessionCustomizationType {
 	static readonly Instructions = new ChatSessionCustomizationType('instructions');
 	static readonly Prompt = new ChatSessionCustomizationType('prompt');
 	static readonly Hook = new ChatSessionCustomizationType('hook');
+	static readonly Plugins = new ChatSessionCustomizationType('plugins');
 
 	constructor(public readonly id: string) { }
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
@@ -9,7 +9,7 @@ import { IPromptsService, PromptsStorage, IPromptPath } from '../../common/promp
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
 import { AICustomizationManagementSection } from './aiCustomizationManagement.js';
-import { IExternalCustomizationItemProvider } from '../../common/customizationHarnessService.js';
+import { IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
 
 /**
  * Maps section ID to prompt type. Duplicated from aiCustomizationListWidget
@@ -48,8 +48,9 @@ export async function generateCustomizationDebugReport(
 	promptsService: IPromptsService,
 	workspaceService: IAICustomizationWorkspaceService,
 	widgetState: IDebugWidgetState,
-	externalProvider?: IExternalCustomizationItemProvider,
+	activeDescriptor?: IHarnessDescriptor,
 ): Promise<string> {
+	const externalProvider = activeDescriptor?.itemProvider;
 	const promptType = sectionToPromptType(section);
 	const filter = workspaceService.getStorageSourceFilter(promptType);
 	const lines: string[] = [];
@@ -59,6 +60,22 @@ export async function generateCustomizationDebugReport(
 	lines.push(`Active root: ${workspaceService.getActiveProjectRoot()?.fsPath ?? '(none)'}`);
 	lines.push(`Sections: [${workspaceService.managementSections.join(', ')}]`);
 	lines.push(`Filter sources: [${filter.sources.join(', ')}]`);
+
+	// Dump active harness descriptor
+	if (activeDescriptor) {
+		lines.push('');
+		lines.push('--- Active Harness ---');
+		lines.push(`  id: ${activeDescriptor.id}`);
+		lines.push(`  label: ${activeDescriptor.label}`);
+		lines.push(`  hasItemProvider: ${!!activeDescriptor.itemProvider}`);
+		lines.push(`  hasSyncProvider: ${!!activeDescriptor.syncProvider}`);
+		lines.push(`  hiddenSections: ${activeDescriptor.hiddenSections ? `[${activeDescriptor.hiddenSections.join(', ')}]` : '(none)'}`);
+		lines.push(`  workspaceSubpaths: ${activeDescriptor.workspaceSubpaths ? `[${activeDescriptor.workspaceSubpaths.join(', ')}]` : '(none)'}`);
+		lines.push(`  hideGenerateButton: ${activeDescriptor.hideGenerateButton ?? false}`);
+		lines.push(`  requiredAgentId: ${activeDescriptor.requiredAgentId ?? '(none)'}`);
+		lines.push(`  instructionFileFilter: ${activeDescriptor.instructionFileFilter ? `[${activeDescriptor.instructionFileFilter.join(', ')}]` : '(none)'}`);
+	}
+	lines.push('');
 	if (filter.includedUserFileRoots) {
 		lines.push(`Filter includedUserFileRoots:`);
 		for (const r of filter.includedUserFileRoots) {
@@ -109,6 +126,19 @@ async function appendExternalProviderData(lines: string[], provider: IExternalCu
 			if (item.description) {
 				lines.push(`      desc: ${item.description}`);
 			}
+			if (item.groupKey) {
+				lines.push(`      groupKey: ${item.groupKey}`);
+			}
+			if (item.badge) {
+				lines.push(`      badge: ${item.badge}`);
+			}
+			if (item.status) {
+				lines.push(`      status: ${item.status}${item.statusMessage ? ` (${item.statusMessage})` : ''}`);
+			}
+			if (item.enabled === false) {
+				lines.push(`      enabled: false`);
+			}
+			lines.push(`      scheme: ${item.uri.scheme}`);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
@@ -35,7 +35,7 @@ function sectionToPromptType(section: AICustomizationManagementSection): Prompts
  * Snapshot of the list widget's internal state, passed in to avoid coupling.
  */
 export interface IDebugWidgetState {
-	readonly allItems: readonly { readonly storage?: PromptsStorage }[];
+	readonly allItems: readonly { readonly name?: string; readonly storage?: PromptsStorage; readonly groupKey?: string }[];
 	readonly displayEntries: readonly { type: string; label?: string; count?: number; collapsed?: boolean }[];
 }
 
@@ -238,6 +238,11 @@ function appendWidgetState(lines: string[], state: IDebugWidgetState): void {
 	lines.push(`    user:      ${state.allItems.filter(i => i.storage === PromptsStorage.user).length}`);
 	lines.push(`    extension: ${state.allItems.filter(i => i.storage === PromptsStorage.extension).length}`);
 	lines.push(`    plugin:    ${state.allItems.filter(i => i.storage === PromptsStorage.plugin).length}`);
+
+	// Show each item with its groupKey and storage
+	for (const item of state.allItems) {
+		lines.push(`    - ${item.name} [storage=${item.storage ?? '?'}, groupKey=${item.groupKey ?? '(none)'}]`);
+	}
 
 	lines.push(`  displayEntries (after filterItems): ${state.displayEntries.length}`);
 	const fileEntries = state.displayEntries.filter(e => e.type === 'file-item');

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1231,25 +1231,38 @@ export class AICustomizationListWidget extends Disposable {
 
 	/**
 	 * Fetches and filters items for a given section.
-	 * Shared between `loadItems` (active section) and `computeItemCountForSection` (any section).
+	 * Delegates to the provider path or core path based on the active harness.
 	 */
 	private async fetchItemsForSection(section: AICustomizationManagementSection): Promise<IAICustomizationListItem[]> {
 		const promptType = sectionToPromptType(section);
-
-		// When the active harness has an external item provider, delegate to it
-		// instead of querying promptsService and applying filters.
-		// When the harness also has a syncProvider, include local items with
-		// sync toggles alongside the remote items.
 		const activeDescriptor = this.harnessService.getActiveDescriptor();
+
 		if (activeDescriptor.itemProvider && promptType) {
-			const remoteItems = await this.fetchItemsFromProvider(activeDescriptor.itemProvider, promptType);
-			if (!activeDescriptor.syncProvider) {
-				return remoteItems;
-			}
-			const localItems = await this.fetchLocalSyncableItems(promptType, activeDescriptor.syncProvider);
-			return [...remoteItems, ...localItems];
+			return this.fetchProviderItemsForSection(activeDescriptor, promptType);
 		}
 
+		return this.fetchCoreItemsForSection(promptType);
+	}
+
+	/**
+	 * Fetches items from an external customization provider.
+	 * When a syncProvider is present, blends remote items with local sync items.
+	 */
+	private async fetchProviderItemsForSection(descriptor: ReturnType<ICustomizationHarnessService['getActiveDescriptor']>, promptType: PromptsType): Promise<IAICustomizationListItem[]> {
+		const remoteItems = await this.fetchItemsFromProvider(descriptor.itemProvider!, promptType);
+		if (!descriptor.syncProvider) {
+			return remoteItems;
+		}
+		const localItems = await this.fetchLocalSyncableItems(promptType, descriptor.syncProvider);
+		return [...remoteItems, ...localItems];
+	}
+
+	/**
+	 * Fetches items from the core promptsService with full filtering pipeline.
+	 * This is the legacy path used when no external provider is active.
+	 * TODO: Remove when provider API is the sole code path.
+	 */
+	private async fetchCoreItemsForSection(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
 		const items: IAICustomizationListItem[] = [];
 		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
 		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -2025,7 +2025,7 @@ export class AICustomizationListWidget extends Disposable {
 			this.promptsService,
 			this.workspaceService,
 			{ allItems: this.allItems, displayEntries: this.displayEntries },
-			activeDescriptor.itemProvider,
+			activeDescriptor,
 		);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1813,7 +1813,7 @@ export class AICustomizationListWidget extends Disposable {
 					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
 					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
 					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => visibleSources.has(g.groupKey as PromptsStorage) || g.groupKey === 'agents' || g.groupKey === BUILTIN_STORAGE);
+				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
 
 		for (const item of matchedItems) {
 			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1632,6 +1632,18 @@ export class AICustomizationListWidget extends Disposable {
 
 		const workspaceFolders = this.workspaceContextService.getWorkspace().folders;
 
+		// Build a URI→description lookup from promptsService for items the provider
+		// doesn't supply descriptions for (e.g. skills and instructions from ChatResource).
+		const descriptionsByUri = new ResourceMap<string>();
+		if (promptType === PromptsType.skill) {
+			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
+			for (const s of skills ?? []) {
+				if (s.description) {
+					descriptionsByUri.set(s.uri, s.description);
+				}
+			}
+		}
+
 		return allItems
 			.filter(item => item.type === promptType)
 			.map((item: IExternalCustomizationItem) => {
@@ -1643,7 +1655,7 @@ export class AICustomizationListWidget extends Disposable {
 					uri: item.uri,
 					name: item.name,
 					filename: basename(item.uri),
-					description: item.description,
+					description: item.description ?? descriptionsByUri.get(item.uri),
 					promptType,
 					disabled: item.enabled === false,
 					status: item.status,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1161,7 +1161,12 @@ export class AICustomizationListWidget extends Disposable {
 	 */
 	private async loadItems(): Promise<void> {
 		const section = this.currentSection;
-		const items = await this.fetchItemsForSection(section);
+		let items: IAICustomizationListItem[];
+		try {
+			items = await this.fetchItemsForSection(section);
+		} catch (err) {
+			items = [];
+		}
 
 		if (this.currentSection !== section) {
 			return; // section changed while loading
@@ -1616,37 +1621,56 @@ export class AICustomizationListWidget extends Disposable {
 
 		return allItems
 			.filter(item => item.type === promptType)
-			.map((item: IExternalCustomizationItem) => ({
-				id: item.uri.toString(),
-				uri: item.uri,
-				name: item.name,
-				filename: basename(item.uri),
-				description: item.description,
-				promptType,
-				disabled: item.enabled === false,
-				status: item.status,
-				statusMessage: item.statusMessage,
-				groupKey: item.groupKey,
-				badge: item.badge,
-				badgeTooltip: item.badgeTooltip,
-				// Infer storage from URI when provider doesn't set groupKey,
-				// so the list widget can auto-group into Workspace vs User.
-				storage: item.groupKey ? undefined : this._inferStorageFromUri(item.uri, workspaceFolders),
-			}))
+			.map((item: IExternalCustomizationItem) => {
+				const { storage, groupKey } = item.groupKey
+					? { storage: undefined, groupKey: item.groupKey }
+					: this._inferStorageAndGroup(item.uri, workspaceFolders);
+				return {
+					id: item.uri.toString(),
+					uri: item.uri,
+					name: item.name,
+					filename: basename(item.uri),
+					description: item.description,
+					promptType,
+					disabled: item.enabled === false,
+					status: item.status,
+					statusMessage: item.statusMessage,
+					groupKey,
+					badge: item.badge,
+					badgeTooltip: item.badgeTooltip,
+					storage,
+				};
+			})
 			.sort((a, b) => a.name.localeCompare(b.name));
 	}
 
 	/**
-	 * Infers the storage source from a URI by checking whether it falls
-	 * under a workspace folder (local) or not (user).
+	 * Infers storage and groupKey from a URI for auto-grouping.
+	 *
+	 * - `file:` URIs under a workspace folder → storage `local` (Workspace group)
+	 * - `file:` URIs elsewhere (e.g. `~/.copilot/`) → storage `user` (User group)
+	 * - `vscode-userdata:` URIs (extension globalStorage) → storage `extension` (read-only, Extensions group)
+	 * - Non-file schemes (synthetic URIs like `copilotcli:`) → groupKey `builtin` (Built-in group)
 	 */
-	private _inferStorageFromUri(uri: URI, workspaceFolders: readonly { uri: URI }[]): PromptsStorage {
+	private _inferStorageAndGroup(uri: URI, workspaceFolders: readonly { uri: URI }[]): { storage?: PromptsStorage; groupKey?: string } {
+		// Non-file schemes are synthetic/built-in
+		if (uri.scheme !== Schemas.file) {
+			// vscode-userdata: = extension-contributed (read-only)
+			if (uri.scheme === Schemas.vscodeUserData) {
+				return { storage: PromptsStorage.extension };
+			}
+			return { groupKey: BUILTIN_STORAGE };
+		}
+
+		// file: URI under a workspace folder = workspace (local)
 		for (const folder of workspaceFolders) {
 			if (isEqualOrParent(uri, folder.uri)) {
-				return PromptsStorage.local;
+				return { storage: PromptsStorage.local };
 			}
 		}
-		return PromptsStorage.user;
+
+		// file: URI elsewhere = user directory
+		return { storage: PromptsStorage.user };
 	}
 
 	/**
@@ -1727,54 +1751,46 @@ export class AICustomizationListWidget extends Disposable {
 			}
 		}
 
-		// When items come from an external provider, skip storage-based grouping
-		// and render a flat list. When a syncProvider is also present, show
-		// remote items first, then local items below with sync checkboxes.
-		// Synced local items sort to the top of the local group; unsynced
-		// items appear greyed out below them.
+		// When items come from an external provider WITH a syncProvider,
+		// show remote items first, then local items with sync checkboxes.
 		const activeDescriptor = this.harnessService.getActiveDescriptor();
-		if (activeDescriptor.itemProvider) {
-			if (activeDescriptor.syncProvider) {
-				const remoteItems = matchedItems.filter(i => !i.syncable);
-				const localItems = matchedItems.filter(i => i.syncable);
-				const entries: IListEntry[] = [];
+		if (activeDescriptor.itemProvider && activeDescriptor.syncProvider) {
+			const remoteItems = matchedItems.filter(i => !i.syncable);
+			const localItems = matchedItems.filter(i => i.syncable);
+			const entries: IListEntry[] = [];
 
-				// Remote items first (flat, no group header)
-				for (const item of remoteItems.sort((a, b) => a.name.localeCompare(b.name))) {
-					entries.push({ type: 'file-item' as const, item });
-				}
-
-				// Local items below with a group header, synced items first
-				if (localItems.length > 0) {
-					const syncedCount = localItems.filter(i => i.synced).length;
-					entries.push({
-						type: 'group-header' as const,
-						id: 'group-sync-local',
-						groupKey: 'sync-local',
-						label: localize('localGroup', "Local"),
-						icon: Codicon.folder,
-						count: syncedCount,
-						isFirst: remoteItems.length === 0,
-						description: localize('localGroupDescription', "Local customizations available to sync to the remote agent."),
-						collapsed: false,
-					});
-					// Sort: synced items first, then alphabetical within each group
-					const sorted = localItems.sort((a, b) => {
-						if (a.synced !== b.synced) {
-							return a.synced ? -1 : 1;
-						}
-						return a.name.localeCompare(b.name);
-					});
-					for (const item of sorted) {
-						entries.push({ type: 'file-item' as const, item: item.synced ? item : { ...item, disabled: true } });
-					}
-				}
-
-				this.displayEntries = entries;
-			} else {
-				matchedItems.sort((a, b) => a.name.localeCompare(b.name));
-				this.displayEntries = matchedItems.map(item => ({ type: 'file-item' as const, item }));
+			// Remote items first (flat, no group header)
+			for (const item of remoteItems.sort((a, b) => a.name.localeCompare(b.name))) {
+				entries.push({ type: 'file-item' as const, item });
 			}
+
+			// Local items below with a group header, synced items first
+			if (localItems.length > 0) {
+				const syncedCount = localItems.filter(i => i.synced).length;
+				entries.push({
+					type: 'group-header' as const,
+					id: 'group-sync-local',
+					groupKey: 'sync-local',
+					label: localize('localGroup', "Local"),
+					icon: Codicon.folder,
+					count: syncedCount,
+					isFirst: remoteItems.length === 0,
+					description: localize('localGroupDescription', "Local customizations available to sync to the remote agent."),
+					collapsed: false,
+				});
+				// Sort: synced items first, then alphabetical within each group
+				const sorted = localItems.sort((a, b) => {
+					if (a.synced !== b.synced) {
+						return a.synced ? -1 : 1;
+					}
+					return a.name.localeCompare(b.name);
+				});
+				for (const item of sorted) {
+					entries.push({ type: 'file-item' as const, item: item.synced ? item : { ...item, disabled: true } });
+				}
+			}
+
+			this.displayEntries = entries;
 			this.list.splice(0, this.list.length, this.displayEntries);
 			this.updateEmptyState();
 			return matchedItems.length;
@@ -1797,7 +1813,7 @@ export class AICustomizationListWidget extends Disposable {
 					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
 					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
 					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => visibleSources.has(g.groupKey as PromptsStorage) || g.groupKey === 'agents');
+				].filter(g => visibleSources.has(g.groupKey as PromptsStorage) || g.groupKey === 'agents' || g.groupKey === BUILTIN_STORAGE);
 
 		for (const item of matchedItems) {
 			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1662,16 +1662,11 @@ export class AICustomizationListWidget extends Disposable {
 	 *
 	 * - `file:` URIs under a workspace folder → storage `local` (Workspace group)
 	 * - `file:` URIs elsewhere (e.g. `~/.copilot/`) → storage `user` (User group)
-	 * - `vscode-userdata:` URIs (extension globalStorage) → storage `extension` (read-only, Extensions group)
-	 * - Non-file schemes (synthetic URIs like `copilotcli:`) → groupKey `builtin` (Built-in group)
+	 * - Non-file schemes (synthetic URIs, vscode-userdata:, etc.) → groupKey `builtin` (Built-in group)
 	 */
 	private _inferStorageAndGroup(uri: URI, workspaceFolders: readonly { uri: URI }[]): { storage?: PromptsStorage; groupKey?: string } {
-		// Non-file schemes are synthetic/built-in
+		// Non-file schemes are synthetic/built-in (includes vscode-userdata: for extension-contributed items)
 		if (uri.scheme !== Schemas.file) {
-			// vscode-userdata: = extension-contributed (read-only)
-			if (uri.scheme === Schemas.vscodeUserData) {
-				return { storage: PromptsStorage.extension };
-			}
 			return { groupKey: BUILTIN_STORAGE };
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1612,6 +1612,8 @@ export class AICustomizationListWidget extends Disposable {
 			return [];
 		}
 
+		const workspaceFolders = this.workspaceContextService.getWorkspace().folders;
+
 		return allItems
 			.filter(item => item.type === promptType)
 			.map((item: IExternalCustomizationItem) => ({
@@ -1624,8 +1626,27 @@ export class AICustomizationListWidget extends Disposable {
 				disabled: item.enabled === false,
 				status: item.status,
 				statusMessage: item.statusMessage,
+				groupKey: item.groupKey,
+				badge: item.badge,
+				badgeTooltip: item.badgeTooltip,
+				// Infer storage from URI when provider doesn't set groupKey,
+				// so the list widget can auto-group into Workspace vs User.
+				storage: item.groupKey ? undefined : this._inferStorageFromUri(item.uri, workspaceFolders),
 			}))
 			.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	/**
+	 * Infers the storage source from a URI by checking whether it falls
+	 * under a workspace folder (local) or not (user).
+	 */
+	private _inferStorageFromUri(uri: URI, workspaceFolders: readonly { uri: URI }[]): PromptsStorage {
+		for (const folder of workspaceFolders) {
+			if (isEqualOrParent(uri, folder.uri)) {
+				return PromptsStorage.local;
+			}
+		}
+		return PromptsStorage.user;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1723,112 +1723,46 @@ export class AICustomizationListWidget extends Disposable {
 	/**
 	 * Filters items based on the current search query and builds grouped display entries.
 	 */
-	private filterItems(): number {
-		let matchedItems: IAICustomizationListItem[];
-
+	/**
+	 * Applies the search query to items, returning matched items with highlight info.
+	 */
+	private applySearchFilter(items: IAICustomizationListItem[]): IAICustomizationListItem[] {
 		if (!this.searchQuery.trim()) {
-			matchedItems = this.allItems.map(item => ({ ...item, nameMatches: undefined, descriptionMatches: undefined }));
-		} else {
-			const query = this.searchQuery.toLowerCase();
-			matchedItems = [];
-
-			for (const item of this.allItems) {
-				// Compute matches against the formatted display name so highlight positions
-				// are correct even after .md stripping and title-casing.
-				const displayName = item.displayName ?? formatDisplayName(item.name);
-				const nameMatches = matchesContiguousSubString(query, displayName);
-				const descriptionMatches = item.description ? matchesContiguousSubString(query, item.description) : null;
-				const filenameMatches = matchesContiguousSubString(query, item.filename);
-				const badgeMatches = item.badge ? matchesContiguousSubString(query, item.badge) : null;
-
-				if (nameMatches || descriptionMatches || filenameMatches || badgeMatches) {
-					matchedItems.push({
-						...item,
-						nameMatches: nameMatches || undefined,
-						descriptionMatches: descriptionMatches || undefined,
-					});
-				}
-			}
+			return items.map(item => ({ ...item, nameMatches: undefined, descriptionMatches: undefined }));
 		}
 
-		// When items come from an external provider WITH a syncProvider,
-		// show remote items first, then local items with sync checkboxes.
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-		if (activeDescriptor.itemProvider && activeDescriptor.syncProvider) {
-			const remoteItems = matchedItems.filter(i => !i.syncable);
-			const localItems = matchedItems.filter(i => i.syncable);
-			const entries: IListEntry[] = [];
+		const query = this.searchQuery.toLowerCase();
+		const matched: IAICustomizationListItem[] = [];
 
-			// Remote items first (flat, no group header)
-			for (const item of remoteItems.sort((a, b) => a.name.localeCompare(b.name))) {
-				entries.push({ type: 'file-item' as const, item });
-			}
+		for (const item of items) {
+			const displayName = item.displayName ?? formatDisplayName(item.name);
+			const nameMatches = matchesContiguousSubString(query, displayName);
+			const descriptionMatches = item.description ? matchesContiguousSubString(query, item.description) : null;
+			const filenameMatches = matchesContiguousSubString(query, item.filename);
+			const badgeMatches = item.badge ? matchesContiguousSubString(query, item.badge) : null;
 
-			// Local items below with a group header, synced items first
-			if (localItems.length > 0) {
-				const syncedCount = localItems.filter(i => i.synced).length;
-				entries.push({
-					type: 'group-header' as const,
-					id: 'group-sync-local',
-					groupKey: 'sync-local',
-					label: localize('localGroup', "Local"),
-					icon: Codicon.folder,
-					count: syncedCount,
-					isFirst: remoteItems.length === 0,
-					description: localize('localGroupDescription', "Local customizations available to sync to the remote agent."),
-					collapsed: false,
+			if (nameMatches || descriptionMatches || filenameMatches || badgeMatches) {
+				matched.push({
+					...item,
+					nameMatches: nameMatches || undefined,
+					descriptionMatches: descriptionMatches || undefined,
 				});
-				// Sort: synced items first, then alphabetical within each group
-				const sorted = localItems.sort((a, b) => {
-					if (a.synced !== b.synced) {
-						return a.synced ? -1 : 1;
-					}
-					return a.name.localeCompare(b.name);
-				});
-				for (const item of sorted) {
-					entries.push({ type: 'file-item' as const, item: item.synced ? item : { ...item, disabled: true } });
-				}
-			}
-
-			this.displayEntries = entries;
-			this.list.splice(0, this.list.length, this.displayEntries);
-			this.updateEmptyState();
-			return matchedItems.length;
-		}
-
-		// Group items by storage
-		const promptType = sectionToPromptType(this.currentSection);
-		const visibleSources = new Set(this.workspaceService.getStorageSourceFilter(promptType).sources);
-		const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] =
-			this.currentSection === AICustomizationManagementSection.Instructions
-				? [
-					{ groupKey: 'agent-instructions', label: localize('agentInstructionsGroup', "Agent Instructions"), icon: instructionsIcon, description: localize('agentInstructionsGroupDescription', "Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md)."), items: [] },
-					{ groupKey: 'context-instructions', label: localize('contextInstructionsGroup', "Included Based on Context"), icon: instructionsIcon, description: localize('contextInstructionsGroupDescription', "Instructions automatically loaded when matching files are part of the context."), items: [] },
-					{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
-				]
-				: [
-					{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
-					{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
-					{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
-					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
-					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
-					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
-
-		for (const item of matchedItems) {
-			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
-			const group = groups.find(g => g.groupKey === key);
-			if (group) {
-				group.items.push(item);
 			}
 		}
 
+		return matched;
+	}
+
+	/**
+	 * Builds grouped display entries from items assigned to groups.
+	 * Empty groups are omitted. Collapsed groups show only their header.
+	 */
+	private buildGroupedEntries(groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[]): void {
 		// Sort items within each group
 		for (const group of groups) {
 			group.items.sort((a, b) => a.name.localeCompare(b.name));
 		}
 
-		// Build display entries: group header + items (hidden if collapsed)
 		this.displayEntries = [];
 		let isFirstGroup = true;
 		for (const group of groups) {
@@ -1857,9 +1791,131 @@ export class AICustomizationListWidget extends Disposable {
 				}
 			}
 		}
+	}
 
+	/**
+	 * Commits the current displayEntries to the list and updates empty state.
+	 */
+	private commitDisplayEntries(): void {
 		this.list.splice(0, this.list.length, this.displayEntries);
 		this.updateEmptyState();
+	}
+
+	/**
+	 * Filters and groups items from an external provider.
+	 * When a syncProvider is present, shows remote items + local sync items.
+	 * Otherwise, groups items by inferred storage/groupKey.
+	 */
+	private filterItemsForProvider(matchedItems: IAICustomizationListItem[]): void {
+		const activeDescriptor = this.harnessService.getActiveDescriptor();
+
+		if (activeDescriptor.syncProvider) {
+			// Sync layout: remote items flat, then local items with sync checkboxes
+			const remoteItems = matchedItems.filter(i => !i.syncable);
+			const localItems = matchedItems.filter(i => i.syncable);
+			const entries: IListEntry[] = [];
+
+			for (const item of remoteItems.sort((a, b) => a.name.localeCompare(b.name))) {
+				entries.push({ type: 'file-item' as const, item });
+			}
+
+			if (localItems.length > 0) {
+				const syncedCount = localItems.filter(i => i.synced).length;
+				entries.push({
+					type: 'group-header' as const,
+					id: 'group-sync-local',
+					groupKey: 'sync-local',
+					label: localize('localGroup', "Local"),
+					icon: Codicon.folder,
+					count: syncedCount,
+					isFirst: remoteItems.length === 0,
+					description: localize('localGroupDescription', "Local customizations available to sync to the remote agent."),
+					collapsed: false,
+				});
+				const sorted = localItems.sort((a, b) => {
+					if (a.synced !== b.synced) {
+						return a.synced ? -1 : 1;
+					}
+					return a.name.localeCompare(b.name);
+				});
+				for (const item of sorted) {
+					entries.push({ type: 'file-item' as const, item: item.synced ? item : { ...item, disabled: true } });
+				}
+			}
+
+			this.displayEntries = entries;
+		} else {
+			// Standard provider layout: group by inferred storage/groupKey
+			const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] = [
+				{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
+				{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
+				{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
+				{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
+			];
+
+			for (const item of matchedItems) {
+				const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
+				const group = groups.find(g => g.groupKey === key);
+				if (group) {
+					group.items.push(item);
+				}
+			}
+
+			this.buildGroupedEntries(groups);
+		}
+
+		this.commitDisplayEntries();
+	}
+
+	/**
+	 * Filters and groups items from the core promptsService (static harness path).
+	 * Instructions use semantic categories; other sections use storage-based groups.
+	 */
+	private filterItemsForCore(matchedItems: IAICustomizationListItem[]): void {
+		const promptType = sectionToPromptType(this.currentSection);
+		const visibleSources = new Set(this.workspaceService.getStorageSourceFilter(promptType).sources);
+
+		const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] =
+			this.currentSection === AICustomizationManagementSection.Instructions
+				? [
+					{ groupKey: 'agent-instructions', label: localize('agentInstructionsGroup', "Agent Instructions"), icon: instructionsIcon, description: localize('agentInstructionsGroupDescription', "Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md)."), items: [] },
+					{ groupKey: 'context-instructions', label: localize('contextInstructionsGroup', "Included Based on Context"), icon: instructionsIcon, description: localize('contextInstructionsGroupDescription', "Instructions automatically loaded when matching files are part of the context."), items: [] },
+					{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
+				]
+				: [
+					{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
+					{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
+					{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
+					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
+					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
+					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
+				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
+
+		for (const item of matchedItems) {
+			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
+			const group = groups.find(g => g.groupKey === key);
+			if (group) {
+				group.items.push(item);
+			}
+		}
+
+		this.buildGroupedEntries(groups);
+		this.commitDisplayEntries();
+	}
+
+	/**
+	 * Filters items based on the current search query and builds grouped display entries.
+	 */
+	private filterItems(): number {
+		const matchedItems = this.applySearchFilter(this.allItems);
+		const activeDescriptor = this.harnessService.getActiveDescriptor();
+
+		if (activeDescriptor.itemProvider) {
+			this.filterItemsForProvider(matchedItems);
+		} else {
+			this.filterItemsForCore(matchedItems);
+		}
+
 		return matchedItems.length;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -8,6 +8,7 @@ import * as DOM from '../../../../../base/browser/dom.js';
 import { ActionBar } from '../../../../../base/browser/ui/actionbar/actionbar.js';
 import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { autorun } from '../../../../../base/common/observable.js';
@@ -1165,6 +1166,7 @@ export class AICustomizationListWidget extends Disposable {
 		try {
 			items = await this.fetchItemsForSection(section);
 		} catch (err) {
+			onUnexpectedError(err);
 			items = [];
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -639,6 +639,7 @@ class AICustomizationManagementActionsContribution extends Disposable implements
 					id: AICustomizationManagementCommands.GenerateDebugReport,
 					title: localize2('generateDebugReport', "Generate Customization Debug Report"),
 					category: Categories.Developer,
+					precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.has(`config.${ChatConfiguration.ChatCustomizationMenuEnabled}`)),
 					f1: true,
 				});
 			}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -12,6 +12,7 @@ import { basename, dirname, isEqualOrParent } from '../../../../../base/common/r
 import { URI } from '../../../../../base/common/uri.js';
 import { getCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { localize, localize2 } from '../../../../../nls.js';
+import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -628,6 +629,34 @@ class AICustomizationManagementActionsContribution extends Disposable implements
 				if (section && pane instanceof AICustomizationManagementEditor) {
 					pane.selectSectionById(section);
 				}
+			}
+		}));
+
+		// Generate Debug Report
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: AICustomizationManagementCommands.GenerateDebugReport,
+					title: localize2('generateDebugReport', "Generate Customization Debug Report"),
+					category: Categories.Developer,
+					f1: true,
+				});
+			}
+
+			async run(accessor: ServicesAccessor): Promise<void> {
+				const editorService = accessor.get(IEditorService);
+				// Open the customizations editor if not already open
+				const input = AICustomizationManagementEditorInput.getOrCreate();
+				const pane = await editorService.openEditor(input, { pinned: true });
+				if (!(pane instanceof AICustomizationManagementEditor)) {
+					return;
+				}
+				const report = await pane.generateDebugReport();
+				await editorService.openEditor({
+					resource: undefined,
+					contents: report,
+					languageId: 'plaintext',
+				});
 			}
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -32,6 +32,7 @@ export const AICustomizationManagementCommands = {
 	CreateNewSkill: 'aiCustomization.createNewSkill',
 	CreateNewInstructions: 'aiCustomization.createNewInstructions',
 	CreateNewPrompt: 'aiCustomization.createNewPrompt',
+	GenerateDebugReport: 'aiCustomization.generateDebugReport',
 } as const;
 
 /**

--- a/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
@@ -25,6 +25,8 @@ declare module 'vscode' {
 		static readonly Prompt: ChatSessionCustomizationType;
 		/** Hook customization (event-driven automation). */
 		static readonly Hook: ChatSessionCustomizationType;
+		/** Plugin customization (agent runtime plugins). */
+		static readonly Plugins: ChatSessionCustomizationType;
 
 		/**
 		 * The string identifier for this customization type.

--- a/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionCustomizationProvider.d.ts
@@ -58,11 +58,11 @@ declare module 'vscode' {
 		readonly iconId?: string;
 
 		/**
-		 * Customization types that this provider does **not** support.
-		 * The corresponding sections will be hidden in the management UI
-		 * when this provider is active.
+		 * Customization types that this provider supports.
+		 * Only the corresponding sections will be shown in the management UI
+		 * when this provider is active. When omitted, all sections are shown.
 		 */
-		readonly unsupportedTypes?: readonly ChatSessionCustomizationType[];
+		readonly supportedTypes?: readonly ChatSessionCustomizationType[];
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the AI customization and chat agent management features. 

- The main focus is on enhancing the extensibility and grouping logic for customization items, transitioning to a `supportedTypes` whitelist for agent metadata, and improving debug and grouping capabilities for customization items. The changes also add support for a new "plugins" customization type and improve error handling and diagnostics.
- Also refactors the widget to allow for easier code deletion in the future once the provideAPI is enabled as the defaults
- Adds a developer debug command dumping provided customizations (`GenerateDebugReport`)
