### PR TITLE
fix: handle non-Map session options at runtime boundaries

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContinueInAction.ts
@@ -475,16 +475,16 @@ export class CreateRemoteAgentJobAction {
 					: userPrompt;
 
 				// Extract repository info from the source session to pass to the target session
-				const initialSessionOptions: { optionId: string; value: string }[] = [];
+				const initialSessionOptions = new Map<string, string>();
 				const repoNwo = await this.extractRepoNwoFromSession(agentSessionsService, chatSessionsService, fileService, sessionResource, chatModel);
 				if (repoNwo) {
-					initialSessionOptions.push({ optionId: 'repositories', value: repoNwo });
+					initialSessionOptions.set('repositories', repoNwo);
 				}
 
 				await commandService.executeCommand(actionId, {
 					prompt: delegationPrompt,
 					attachedContext: attachedContext.asArray(),
-					initialSessionOptions: initialSessionOptions.length > 0 ? initialSessionOptions : undefined,
+					initialSessionOptions: initialSessionOptions.size > 0 ? initialSessionOptions : undefined,
 				});
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1363,7 +1363,7 @@ async function openChatSession(accessor: ServicesAccessor, openOptions: NewChatS
 			// Set initial session options on the model before sending the request,
 			// so that the contributed session provider can read them.
 			if (chatSendOptions.initialSessionOptions) {
-				chatSessionService.updateSessionOptions(resource, chatSendOptions.initialSessionOptions);
+				chatSessionService.updateSessionOptions(resource, normalizeSessionOptions(chatSendOptions.initialSessionOptions));
 			}
 
 			let attachedContext = chatSendOptions.attachedContext;
@@ -1376,6 +1376,22 @@ async function openChatSession(accessor: ServicesAccessor, openOptions: NewChatS
 			logService.error(`Failed to send initial request to '${openOptions.type}' chat session with contextOptions: ${JSON.stringify(chatSendOptions)}`, e);
 		}
 	}
+}
+
+/**
+ * Normalizes session options that may arrive as either a Map or an array of
+ * `{optionId, value}` objects (e.g. from command arguments that bypass static
+ * type checking) into a proper Map.
+ */
+function normalizeSessionOptions(options: ReadonlyChatSessionOptionsMap | ReadonlyArray<{ optionId: string; value: string | IChatSessionProviderOptionItem }>): ReadonlyChatSessionOptionsMap {
+	if (options instanceof Map) {
+		return options;
+	}
+	if (Array.isArray(options)) {
+		return new Map(options.map(o => [o.optionId, o.value]));
+	}
+	// Plain object fallback (e.g. from JSON deserialization)
+	return ChatSessionOptionsMap.fromRecord(options as unknown as Record<string, string | IChatSessionProviderOptionItem>);
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1379,9 +1379,15 @@ async function openChatSession(accessor: ServicesAccessor, openOptions: NewChatS
 }
 
 /**
- * Normalizes session options that may arrive as either a Map or an array of
- * `{optionId, value}` objects (e.g. from command arguments that bypass static
- * type checking) into a proper Map.
+ * Normalizes session options that may arrive in one of three runtime shapes
+ * into a proper `ReadonlyChatSessionOptionsMap`:
+ *
+ * - **Map** — returned as-is.
+ * - **Array** of `{optionId, value}` objects — e.g. from command arguments
+ *   that bypass static type checking.
+ * - **Plain record** (`Record<string, string | IChatSessionProviderOptionItem>`)
+ *   — e.g. from JSON deserialization across process boundaries where a Map
+ *   loses its prototype.
  */
 function normalizeSessionOptions(options: ReadonlyChatSessionOptionsMap | ReadonlyArray<{ optionId: string; value: string | IChatSessionProviderOptionItem }>): ReadonlyChatSessionOptionsMap {
 	if (options instanceof Map) {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -271,7 +271,8 @@ export namespace ChatSessionOptionsMap {
 
 	export function toRecord(map: ReadonlyChatSessionOptionsMap): Record<string, string | IChatSessionProviderOptionItem> {
 		const record: Record<string, string | IChatSessionProviderOptionItem> = Object.create(null);
-		for (const [key, value] of map) {
+		const entries = ensureIterable(map);
+		for (const [key, value] of entries) {
 			record[key] = value;
 		}
 		return record;
@@ -281,7 +282,21 @@ export namespace ChatSessionOptionsMap {
 		if (!map) {
 			return undefined;
 		}
-		return Array.from(map, ([optionId, value]) => ({ optionId, value: typeof value === 'string' ? value : value.id }));
+		const entries = ensureIterable(map);
+		return Array.from(entries, ([optionId, value]) => ({ optionId, value: typeof value === 'string' ? value : value.id }));
+	}
+
+	/**
+	 * Ensures the input is iterable. If a plain object is passed (e.g. due to
+	 * serialization across process boundaries losing the Map prototype), it is
+	 * converted to Map entries on the fly.
+	 */
+	function ensureIterable(map: ReadonlyChatSessionOptionsMap): Iterable<[string, string | IChatSessionProviderOptionItem]> {
+		if (map instanceof Map) {
+			return map;
+		}
+		// Fallback: treat as a plain record (e.g. from JSON deserialization)
+		return Object.entries(map as unknown as Record<string, string | IChatSessionProviderOptionItem>);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatSessions/chatSessionsService.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ChatSessionsService } from '../../../browser/chatSessions/chatSessions.contribution.js';
+import { ChatSessionOptionsMap, ReadonlyChatSessionOptionsMap } from '../../../common/chatSessionsService.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 
 suite.skip('ChatSessionsService', () => {
@@ -102,6 +103,69 @@ suite.skip('ChatSessionsService', () => {
 			const input = '   Check [](file:///test.js)   ';
 			const result = callExtractFileNameFromLink(input);
 			assert.strictEqual(result, '   Check test.js   ');
+		});
+	});
+});
+
+suite('ChatSessionOptionsMap', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('toStrValueArray', () => {
+
+		test('should return undefined for undefined input', () => {
+			assert.strictEqual(ChatSessionOptionsMap.toStrValueArray(undefined), undefined);
+		});
+
+		test('should convert a Map to an array of {optionId, value}', () => {
+			const map = new Map([['models', 'gpt-4'], ['repo', 'my-repo']]);
+			assert.deepStrictEqual(ChatSessionOptionsMap.toStrValueArray(map), [
+				{ optionId: 'models', value: 'gpt-4' },
+				{ optionId: 'repo', value: 'my-repo' },
+			]);
+		});
+
+		test('should extract .id from IChatSessionProviderOptionItem values', () => {
+			const map: ReadonlyChatSessionOptionsMap = new Map([
+				['agent', { id: 'copilot', name: 'Copilot' }],
+			]);
+			assert.deepStrictEqual(ChatSessionOptionsMap.toStrValueArray(map), [
+				{ optionId: 'agent', value: 'copilot' },
+			]);
+		});
+
+		test('should handle a plain object as if it were a record (defensive fallback)', () => {
+			// Simulates a Map that lost its prototype during serialization
+			const plainObject = { models: 'gpt-4', repo: 'my-repo' } as unknown as ReadonlyChatSessionOptionsMap;
+			assert.deepStrictEqual(ChatSessionOptionsMap.toStrValueArray(plainObject), [
+				{ optionId: 'models', value: 'gpt-4' },
+				{ optionId: 'repo', value: 'my-repo' },
+			]);
+		});
+	});
+
+	suite('toRecord', () => {
+
+		test('should convert a Map to a record', () => {
+			const map = new Map([['models', 'gpt-4']]);
+			const record = ChatSessionOptionsMap.toRecord(map);
+			assert.strictEqual(record['models'], 'gpt-4');
+		});
+
+		test('should handle a plain object as if it were a record (defensive fallback)', () => {
+			const plainObject = { models: 'gpt-4' } as unknown as ReadonlyChatSessionOptionsMap;
+			const record = ChatSessionOptionsMap.toRecord(plainObject);
+			assert.strictEqual(record['models'], 'gpt-4');
+		});
+	});
+
+	suite('fromRecord', () => {
+
+		test('should convert a record to a Map', () => {
+			const map = ChatSessionOptionsMap.fromRecord({ models: 'gpt-4', repo: 'my-repo' });
+			assert.strictEqual(map.get('models'), 'gpt-4');
+			assert.strictEqual(map.get('repo'), 'my-repo');
+			assert.strictEqual(map.size, 2);
 		});
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/304823
## Problem

After PR #303329 changed `initialSessionOptions` from an array to a `Map`, several callers still pass arrays or plain objects at runtime, causing `"is not iterable"` errors:

1. **`chatContinueInAction.ts`** — `CreateRemoteAgentJobAction` constructed `initialSessionOptions` as an array of `{optionId, value}` objects. When `updateSessionOptions` tried to iterate it with `for (const [optionId, value] of updates)`, it failed because array elements are objects, not `[key, value]` pairs.

2. **`toStrValueArray` / `toRecord`** — These helpers call `Array.from(map, ...)` which requires `Symbol.iterator`. When a Map crosses a process boundary (e.g. sessions host), JSON serialization strips the Map prototype, leaving a plain `{}` that is truthy but not iterable.

## Fix

- **`chatContinueInAction.ts`**: Use `new Map<string, string>()` instead of an array
- **`chatSessionsService.ts`**: Add `ensureIterable()` fallback in `toStrValueArray` / `toRecord` — if input isn't a real `Map`, fall back to `Object.entries()`
- **`chatSessions.contribution.ts`**: Add `normalizeSessionOptions()` at the `openChatSession` boundary to defensively handle Map, array, or plain object inputs from command arguments (which are untyped at runtime)
- **Tests**: Add unit tests for `ChatSessionOptionsMap.toStrValueArray`, `toRecord`, and `fromRecord` covering both Map and plain-object inputs