### PR TITLE
agentPlugins: prefix skills with plugin name consistent with commands

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -58,7 +58,7 @@ export interface IAgentPluginDiscovery extends IDisposable {
 	start(enablementModel: IEnablementModel): void;
 }
 
-export function getCanonicalPluginCommandId(plugin: IAgentPlugin, commandName: string): string {
+export function getCanonicalPluginCommandId(plugin: { readonly uri: URI }, commandName: string): string {
 	const pluginSegment = basename(plugin.uri);
 	const prefix = normalizePluginToken(pluginSegment);
 	const normalizedCommand = normalizePluginToken(commandName);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -610,7 +610,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 		const parseResults = await Promise.all(slashCommandFiles.map(async promptPath => {
 			try {
 				const parsedPromptFile = await this.parseNew(promptPath.uri, token);
-				const name = parsedPromptFile?.header?.name ?? promptPath.name ?? getCleanPromptName(promptPath.uri);
+				const rawName = parsedPromptFile?.header?.name ?? promptPath.name ?? getCleanPromptName(promptPath.uri);
+				// For plugin resources, ensure the canonical plugin prefix is always preserved even when the
+				// file's frontmatter overrides the name.
+				const name = promptPath.source === PromptFileSource.Plugin && promptPath.pluginUri
+					? getCanonicalPluginCommandId({ uri: promptPath.pluginUri }, rawName)
+					: rawName;
 				const description = parsedPromptFile?.header?.description ?? promptPath.description;
 				const argumentHint = parsedPromptFile?.header?.argumentHint;
 				const userInvocable = parsedPromptFile?.header?.userInvocable;

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -3742,6 +3742,98 @@ suite('PromptsService', () => {
 			assert.ok(noHeaderSkillInFiltered,
 				'Skill without header should be included when applying userInvocable filter (defaults to true)');
 		});
+
+		test('plugin skills include plugin name prefix in slash command name', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.SKILLS_LOCATION_KEY, {});
+
+			const skillUri = URI.file('/plugins/my-plugin/skills/deploy/SKILL.md');
+			await mockFiles(fileService, [
+				{
+					path: skillUri.path,
+					contents: [
+						'---',
+						'description: "Deploy skill from plugin"',
+						'---',
+						'Deploy skill content',
+					],
+				},
+			]);
+
+			const enablement = observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */);
+			const plugin: IAgentPlugin = {
+				uri: URI.file('/plugins/my-plugin'),
+				label: 'my-plugin',
+				enablement,
+				remove: () => { },
+				hooks: observableValue('testPluginHooks', []),
+				commands: observableValue('testPluginCommands', []),
+				skills: observableValue<readonly IAgentPluginSkill[]>('testPluginSkills', [{ uri: skillUri, name: 'deploy' }]),
+				agents: observableValue('testPluginAgents', []),
+				instructions: observableValue('testPluginInstructions', []),
+				mcpServerDefinitions: observableValue('testPluginMcpServerDefinitions', []),
+			};
+
+			testPluginsObservable.set([plugin], undefined);
+
+			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
+
+			// Should be prefixed with plugin name
+			const skillCommand = slashCommands.find(cmd => cmd.name === 'my-plugin:deploy');
+			assert.ok(skillCommand, 'Plugin skill should have plugin prefix in slash command name');
+			assert.strictEqual(skillCommand.storage, PromptsStorage.plugin);
+			assert.strictEqual(skillCommand.type, PromptsType.skill);
+
+			testPluginsObservable.set([], undefined);
+		});
+
+		test('plugin skill frontmatter name is qualified with plugin prefix', async () => {
+			testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.SKILLS_LOCATION_KEY, {});
+
+			const skillUri = URI.file('/plugins/devtools/skills/ci/SKILL.md');
+			await mockFiles(fileService, [
+				{
+					path: skillUri.path,
+					contents: [
+						'---',
+						'name: "run-ci"',
+						'description: "Run CI pipeline"',
+						'---',
+						'CI skill content',
+					],
+				},
+			]);
+
+			const enablement = observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */);
+			const plugin: IAgentPlugin = {
+				uri: URI.file('/plugins/devtools'),
+				label: 'devtools',
+				enablement,
+				remove: () => { },
+				hooks: observableValue('testPluginHooks', []),
+				commands: observableValue('testPluginCommands', []),
+				skills: observableValue<readonly IAgentPluginSkill[]>('testPluginSkills', [{ uri: skillUri, name: 'ci' }]),
+				agents: observableValue('testPluginAgents', []),
+				instructions: observableValue('testPluginInstructions', []),
+				mcpServerDefinitions: observableValue('testPluginMcpServerDefinitions', []),
+			};
+
+			testPluginsObservable.set([plugin], undefined);
+
+			const slashCommands = await service.getPromptSlashCommands(CancellationToken.None);
+
+			// Even when SKILL.md has name: "run-ci", it must be prefixed with the plugin name
+			const skillCommand = slashCommands.find(cmd => cmd.name === 'devtools:run-ci');
+			assert.ok(skillCommand, 'Plugin skill frontmatter name should be qualified with plugin prefix');
+			assert.strictEqual(skillCommand.description, 'Run CI pipeline');
+
+			// The unprefixed name should not appear
+			assert.strictEqual(slashCommands.find(cmd => cmd.name === 'run-ci'), undefined,
+				'Unprefixed skill name should not appear as slash command');
+
+			testPluginsObservable.set([], undefined);
+		});
 	});
 
 	suite('hooks', () => {


### PR DESCRIPTION
- Plugin skills registered via watchPluginPromptFilesForType already get the canonical `<plugin>:<skill>` name, but `computeSlashCommandDiscoveryInfo` was allowing a frontmatter `name:` field to override it, stripping the plugin prefix. This made plugin skills appear as `/<skill>` instead of `/<plugin-name>:<skill>` in chat, inconsistent with plugin commands.
- Applies `getCanonicalPluginCommandId` after resolving the raw name so the plugin prefix is always preserved, whether the name comes from the SKILL.md frontmatter or falls back to the skill directory name.
- Widened the first parameter of `getCanonicalPluginCommandId` from `IAgentPlugin` to `{ readonly uri: URI }` to allow calling it with just a URI.

(Commit message generated by Copilot)