### PR TITLE
Disassembly view rerender fix 

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -124,7 +124,12 @@ export class DisassemblyView extends EditorPane {
 				const newValue = this._configurationService.getValue<IDebugConfiguration>('debug').disassemblyView.showSourceCode;
 				if (this._enableSourceCodeRender !== newValue) {
 					this._enableSourceCodeRender = newValue;
-					// todo: trigger rerender
+					const location = this.focusedAddressAndOffset;
+					if (location) {
+						this.reloadDisassembly(location.reference, location.offset);
+					} else if (this.focusedInstructionReference) {
+						this.reloadDisassembly(this.focusedInstructionReference, 0);
+					}
 				} else {
 					this._disassembledInstructions?.rerender();
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->This PR implements a total reload of the disassembly instructions view whenever the `debug.disassemblyView.showSourceCode` setting is toggled. 

As noted in the code comments, the `WorkbenchTable` doesn't support dynamic height changes, making a simple `rerender()` call insufficient. By using `reloadDisassembly`, the view correctly re-calculates the heights of all visible rows based on the new setting. The current focus is preserved during the reload by using `focusedAddressAndOffset` or `focusedInstructionReference`.
