### PR TITLE
Fix native macOS text navigation shortcuts in editable Integrated Browser inputs

### DIFF
--- a/src/vs/platform/browserView/common/browserViewKeyRouting.ts
+++ b/src/vs/platform/browserView/common/browserViewKeyRouting.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface IBrowserViewKeyRoutingEvent {
+	key: string;
+	code: string;
+	ctrlKey: boolean;
+	shiftKey: boolean;
+	altKey: boolean;
+	metaKey: boolean;
+}
+
+export interface IBrowserViewKeyRoutingContext {
+	isMac: boolean;
+	isEditableTarget: boolean;
+}
+
+function isNativeTextNavigationShortcut(event: IBrowserViewKeyRoutingEvent, isMac: boolean): boolean {
+	const ctrlCmd = isMac ? event.metaKey : event.ctrlKey;
+	if (!ctrlCmd || event.altKey) {
+		return false;
+	}
+
+	switch (event.key) {
+		case 'ArrowLeft':
+		case 'ArrowRight':
+		case 'ArrowUp':
+		case 'ArrowDown':
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function shouldForwardBrowserViewKeydown(event: IBrowserViewKeyRoutingEvent, context: IBrowserViewKeyRoutingContext): boolean {
+	const isNonEditingKey =
+		event.key === 'Escape' ||
+		/^F\d+$/.test(event.key) ||
+		event.key.startsWith('Audio') || event.key.startsWith('Media') || event.key.startsWith('Browser');
+
+	// Most plain key events should be handled natively by the browser and not forwarded.
+	if (!(event.ctrlKey || event.altKey || event.metaKey) && !isNonEditingKey) {
+		return false;
+	}
+
+	// Alt+Key special character handling (Alt + Numpad keys on Windows/Linux, Alt + any key on Mac).
+	if (event.altKey && !event.ctrlKey && !event.metaKey) {
+		if (context.isMac || /^Numpad\d+$/.test(event.code)) {
+			return false;
+		}
+	}
+
+	// Allow common native editing shortcuts to stay within the browser.
+	const ctrlCmd = context.isMac ? event.metaKey : event.ctrlKey;
+	if (ctrlCmd && !event.altKey) {
+		const key = event.key.toLowerCase();
+		if (!event.shiftKey && (key === 'a' || key === 'c' || key === 'v' || key === 'x' || key === 'z')) {
+			return false;
+		}
+		if (event.shiftKey && (key === 'v' || key === 'z')) {
+			return false;
+		}
+		if (!event.shiftKey && key === 'y' && !context.isMac) {
+			return false;
+		}
+		if (context.isEditableTarget && isNativeTextNavigationShortcut(event, context.isMac)) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/vs/platform/browserView/electron-browser/preload-browserView.ts
+++ b/src/vs/platform/browserView/electron-browser/preload-browserView.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { shouldForwardBrowserViewKeydown } from '../common/browserViewKeyRouting.js';
+
 /* eslint-disable no-restricted-globals */
 
 /**
@@ -18,6 +20,11 @@
 (function () {
 
 	const { contextBridge, ipcRenderer } = require('electron');
+
+	function isEditableTarget(target: EventTarget | null): boolean {
+		const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+		return !!element?.closest('input, textarea, [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]');
+	}
 
 	// #######################################################################
 	// ###                                                                 ###
@@ -40,40 +47,9 @@
 			return;
 		}
 
-		const isNonEditingKey =
-			event.key === 'Escape' ||
-			/^F\d+$/.test(event.key) ||
-			event.key.startsWith('Audio') || event.key.startsWith('Media') || event.key.startsWith('Browser');
-
-		// Only forward if there's a command modifier or it's a non-editing key
-		// (most plain key events should just be handled natively by the browser and not forwarded)
-		if (!(event.ctrlKey || event.altKey || event.metaKey) && !isNonEditingKey) {
-			return;
-		}
-
 		const isMac = navigator.platform.indexOf('Mac') >= 0;
-
-		// Alt+Key special character handling (Alt + Numpad keys on Windows/Linux, Alt + any key on Mac)
-		if (event.altKey && !event.ctrlKey && !event.metaKey) {
-			if (isMac || /^Numpad\d+$/.test(event.code)) {
-				return;
-			}
-		}
-
-		// Allow native shortcuts (copy, paste, cut, undo, redo, select all) to be handled by the browser
-		const ctrlCmd = isMac ? event.metaKey : event.ctrlKey;
-		if (ctrlCmd && !event.altKey) {
-			const key = event.key.toLowerCase();
-			if (!event.shiftKey && (key === 'a' || key === 'c' || key === 'v' || key === 'x' || key === 'z')) {
-				return;
-			}
-			if (event.shiftKey && (key === 'v' || key === 'z')) {
-				return;
-			}
-			// Ctrl+Y is redo on Windows/Linux
-			if (!event.shiftKey && key === 'y' && !isMac) {
-				return;
-			}
+		if (!shouldForwardBrowserViewKeydown(event, { isMac, isEditableTarget: isEditableTarget(event.target) })) {
+			return;
 		}
 
 		// Everything else should be forwarded to the workbench for potential shortcut handling.

--- a/src/vs/platform/browserView/test/common/browserViewKeyRouting.test.ts
+++ b/src/vs/platform/browserView/test/common/browserViewKeyRouting.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { shouldForwardBrowserViewKeydown, type IBrowserViewKeyRoutingEvent } from '../../common/browserViewKeyRouting.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+function testEvent(overrides: Partial<IBrowserViewKeyRoutingEvent>): IBrowserViewKeyRoutingEvent {
+	return {
+		key: 'l',
+		code: 'KeyL',
+		ctrlKey: false,
+		shiftKey: false,
+		altKey: false,
+		metaKey: false,
+		...overrides
+	};
+}
+
+suite('BrowserViewKeyRouting', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('preserves Cmd+Left in editable targets on macOS', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'ArrowLeft', code: 'ArrowLeft', metaKey: true }), { isMac: true, isEditableTarget: true }), false);
+	});
+
+	test('preserves Cmd+Right in editable targets on macOS', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'ArrowRight', code: 'ArrowRight', metaKey: true }), { isMac: true, isEditableTarget: true }), false);
+	});
+
+	test('preserves Shift+Cmd+Left selection navigation in editable targets on macOS', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'ArrowLeft', code: 'ArrowLeft', metaKey: true, shiftKey: true }), { isMac: true, isEditableTarget: true }), false);
+	});
+
+	test('preserves Ctrl+ArrowLeft in editable targets on non-mac platforms', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'ArrowLeft', code: 'ArrowLeft', ctrlKey: true }), { isMac: false, isEditableTarget: true }), false);
+	});
+
+	test('still forwards non-navigation shortcuts from editable targets', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'l', code: 'KeyL', metaKey: true }), { isMac: true, isEditableTarget: true }), true);
+	});
+
+	test('still forwards Cmd+Left when the target is not editable', () => {
+		assert.strictEqual(shouldForwardBrowserViewKeydown(testEvent({ key: 'ArrowLeft', code: 'ArrowLeft', metaKey: true }), { isMac: true, isEditableTarget: false }), true);
+	});
+});


### PR DESCRIPTION
## Summary

This addresses a regression in the macOS Integrated Browser where native text navigation shortcuts in editable inputs are swallowed instead of being handled by the page.

In plain editable targets such as `input`, `textarea`, and `contenteditable`, `Cmd+Left` / `Cmd+Right` should move the caret to the beginning / end of the line. Instead, those key events were being forwarded into the workbench shortcut pipeline and prevented from reaching the embedded page.

## Regression Context

- Related to #307355
- Earlier history: #303908, #304490, #306198
- The observed good/bad build boundary pointed strongly at #306198
- The likely regression point is #306198, which expanded preload-side browser key forwarding and started calling `preventDefault()` / `stopPropagation()` before forwarding unhandled modifier-based key events

## Fix

- Introduce a focused browser view key routing helper
- Preserve native handling for editable targets
- Keep forwarding behavior unchanged for non-editable targets
- Keep the scope narrow to native text navigation in editable inputs rather than loosening shortcut routing globally

At minimum this covers the reported `Cmd/Ctrl+Left` and `Cmd/Ctrl+Right` behavior, and the same narrow editable-target navigation family for arrow-based line navigation.

## Tests

Ran:

```bash
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test-node -- --run src/vs/platform/browserView/test/common/browserViewKeyRouting.test.ts
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run transpile-client
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run compile
```

Added focused unit coverage for:

- editable macOS `Cmd+Left`
- editable macOS `Cmd+Right`
- editable macOS selection navigation variant
- editable non-mac `Ctrl+ArrowLeft`
- non-editable targets still forwarding the same shortcut
- unrelated editable-target shortcuts still forwarding

## Validation Notes

- Local manual validation in the dev build confirmed that `Cmd+Left` / `Cmd+Right` now preserve native caret movement in editable Integrated Browser inputs on macOS
- This PR intentionally does not broaden the change to unrelated shortcut classes
