### PR TITLE
Agents: Update codicon color in titlebar left toolbar

### DIFF
--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -102,8 +102,8 @@
 	align-items: center;
 }
 
-.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left > .left-toolbar-container .codicon {
-	color: inherit;
+.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left > .left-toolbar-container .monaco-action-bar .action-item:not(.disabled) .codicon {
+	color: var(--vscode-icon-foreground);
 }
 
 .monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-left > .left-toolbar-container .monaco-action-bar .action-item {


### PR DESCRIPTION
Adjust the codicon color in the titlebar left toolbar to utilize the icon foreground variable for improved consistency and theming.

