### PR TITLE
Agents: Update session terminology and enhance layout

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -329,20 +329,6 @@
 	text-transform: uppercase;
 	/* align with session item padding */
 	padding: 0 6px;
-	gap: 4px;
-
-	.session-section-icon {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-		color: var(--vscode-descriptionForeground);
-
-		> .codicon {
-			font-size: 12px;
-			line-height: 1;
-		}
-	}
 
 	.session-section-label {
 		flex: 0 1 auto;

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -111,18 +111,7 @@
 		line-height: 17px;
 
 		> .codicon {
-		gap: 4px;
 			flex-shrink: 0;
-		.session-section-icon {
-			display: flex;
-			align-items: center;
-			color: var(--vscode-descriptionForeground);
-
-			> .codicon {
-				font-size: 12px;
-			}
-		}
-
 			font-size: 12px;
 			height: 16px;
 			display: flex;

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -111,7 +111,18 @@
 		line-height: 17px;
 
 		> .codicon {
+		gap: 4px;
 			flex-shrink: 0;
+		.session-section-icon {
+			display: flex;
+			align-items: center;
+			color: var(--vscode-descriptionForeground);
+
+			> .codicon {
+				font-size: 12px;
+			}
+		}
+
 			font-size: 12px;
 			height: 16px;
 			display: flex;
@@ -318,13 +329,28 @@
 	text-transform: uppercase;
 	/* align with session item padding */
 	padding: 0 6px;
+	gap: 4px;
+
+	.session-section-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		color: var(--vscode-descriptionForeground);
+
+		> .codicon {
+			font-size: 12px;
+			line-height: 1;
+		}
+	}
 
 	.session-section-label {
-		flex: 1;
+		flex: 0 1 auto;
 	}
 
 	.session-section-count {
 		opacity: 0.7;
+		margin-left: auto;
 		margin-right: 4px;
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -498,6 +498,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 interface ISessionSectionTemplate {
 	readonly container: HTMLElement;
+	readonly icon: HTMLElement;
 	readonly label: HTMLElement;
 	readonly count: HTMLElement;
 	readonly toolbar: MenuWorkbenchToolBar;
@@ -520,6 +521,7 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 
 		container.classList.add('session-section');
 		const label = DOM.append(container, $('span.session-section-label'));
+		const icon = DOM.append(container, $('span.session-section-icon'));
 		const count = DOM.append(container, $('span.session-section-count'));
 		const toolbarContainer = DOM.append(container, $('.session-section-toolbar'));
 
@@ -529,13 +531,20 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, label, count, toolbar, contextKeyService, disposables };
+		return { container, icon, label, count, toolbar, contextKeyService, disposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionSectionTemplate): void {
 		const element = node.element;
 		if (!isSessionSection(element)) {
 			return;
+		}
+		DOM.clearNode(template.icon);
+		if (element.id === 'archived') {
+			DOM.append(template.icon, $(`span${ThemeIcon.asCSSSelector(Codicon.check)}`));
+			template.icon.style.display = '';
+		} else {
+			template.icon.style.display = 'none';
 		}
 		template.label.textContent = element.label;
 		if (this.hideSectionCount) {
@@ -875,7 +884,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		// Add archived section at the bottom
 		if (archived.length > 0) {
-			sections.push({ id: 'archived', label: localize('archived', "Marked as Done"), sessions: archived });
+			sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
 		}
 
 		const hasTodaySessions = sections.some(s => s.id === 'today' && s.sessions.length > 0);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -875,7 +875,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 		// Add archived section at the bottom
 		if (archived.length > 0) {
-			sections.push({ id: 'archived', label: localize('archived', "Archived"), sessions: archived });
+			sections.push({ id: 'archived', label: localize('archived', "Marked as Done"), sessions: archived });
 		}
 
 		const hasTodaySessions = sections.some(s => s.id === 'today' && s.sessions.length > 0);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -498,7 +498,6 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 interface ISessionSectionTemplate {
 	readonly container: HTMLElement;
-	readonly icon: HTMLElement;
 	readonly label: HTMLElement;
 	readonly count: HTMLElement;
 	readonly toolbar: MenuWorkbenchToolBar;
@@ -521,7 +520,6 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 
 		container.classList.add('session-section');
 		const label = DOM.append(container, $('span.session-section-label'));
-		const icon = DOM.append(container, $('span.session-section-icon'));
 		const count = DOM.append(container, $('span.session-section-count'));
 		const toolbarContainer = DOM.append(container, $('.session-section-toolbar'));
 
@@ -531,20 +529,13 @@ class SessionSectionRenderer implements ITreeRenderer<SessionListItem, FuzzyScor
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, icon, label, count, toolbar, contextKeyService, disposables };
+		return { container, label, count, toolbar, contextKeyService, disposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionSectionTemplate): void {
 		const element = node.element;
 		if (!isSessionSection(element)) {
 			return;
-		}
-		DOM.clearNode(template.icon);
-		if (element.id === 'archived') {
-			DOM.append(template.icon, $(`span${ThemeIcon.asCSSSelector(Codicon.check)}`));
-			template.icon.style.display = '';
-		} else {
-			template.icon.style.display = 'none';
 		}
 		template.label.textContent = element.label;
 		if (this.hideSectionCount) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -335,7 +335,7 @@ export class SessionsView extends ViewPane {
 			constructor() {
 				super({
 					id: 'sessionsViewPane.filterArchived',
-					title: localize('filterArchived', "Marked as Done"),
+					title: localize('filterArchived', "Done"),
 					toggled: ContextKeyExpr.equals(archivedContextKey.key, true),
 					menu: [{
 						id: SessionsViewFilterOptionsSubMenu,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -335,7 +335,7 @@ export class SessionsView extends ViewPane {
 			constructor() {
 				super({
 					id: 'sessionsViewPane.filterArchived',
-					title: localize('filterArchived', "Archived"),
+					title: localize('filterArchived', "Marked as Done"),
 					toggled: ContextKeyExpr.equals(archivedContextKey.key, true),
 					menu: [{
 						id: SessionsViewFilterOptionsSubMenu,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -276,8 +276,8 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sectionArchive',
-			title: localize2('archiveSection', "Archive All"),
-			icon: Codicon.archive,
+			title: localize2('archiveSection', "Mark All as Done"),
+			icon: Codicon.check,
 			menu: [{
 				id: SessionSectionToolbarMenuId,
 				group: 'navigation',
@@ -299,10 +299,10 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 		if (!skipConfirmation) {
 			const confirmed = await dialogService.confirm({
 				message: context.sessions.length === 1
-					? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to archive 1 session from '{0}'?", context.label)
-					: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} sessions from '{1}'?", context.sessions.length, context.label),
-				detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
-				primaryButton: localize('archiveSectionSessions.archive', "Archive All"),
+					? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to mark 1 session from '{0}' as done?", context.label)
+					: localize('archiveSectionSessions.confirm', "Are you sure you want to mark {0} sessions from '{1}' as done?", context.sessions.length, context.label),
+				detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
+				primaryButton: localize('archiveSectionSessions.archive', "Mark All as Done"),
 				checkbox: {
 					label: localize('doNotAskAgain', "Do not ask me again")
 				}
@@ -327,7 +327,7 @@ registerAction2(class UnarchiveSectionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sectionUnarchive',
-			title: localize2('unarchiveSection', "Unarchive All"),
+			title: localize2('unarchiveSection', "Restore All"),
 			icon: Codicon.unarchive,
 			menu: [{
 				id: SessionSectionToolbarMenuId,
@@ -350,8 +350,8 @@ registerAction2(class UnarchiveSectionAction extends Action2 {
 			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 			if (!skipConfirmation) {
 				const confirmed = await dialogService.confirm({
-					message: localize('unarchiveSectionSessions.confirm', "Are you sure you want to unarchive {0} sessions?", context.sessions.length),
-					primaryButton: localize('unarchiveSectionSessions.unarchive', "Unarchive All"),
+					message: localize('unarchiveSectionSessions.confirm', "Are you sure you want to restore {0} sessions?", context.sessions.length),
+					primaryButton: localize('unarchiveSectionSessions.unarchive', "Restore All"),
 					checkbox: {
 						label: localize('doNotAskAgain2', "Do not ask me again")
 					}
@@ -455,8 +455,8 @@ registerAction2(class ArchiveSessionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsViewPane.archiveSession',
-			title: localize2('archiveSession', "Archive"),
-			icon: Codicon.archive,
+			title: localize2('archiveSession', "Mark as Done"),
+			icon: Codicon.check,
 			menu: [{
 				id: SessionItemToolbarMenuId,
 				group: 'navigation',
@@ -486,7 +486,7 @@ registerAction2(class UnarchiveSessionAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsViewPane.unarchiveSession',
-			title: localize2('unarchiveSession', "Unarchive"),
+			title: localize2('unarchiveSession', "Restore"),
 			icon: Codicon.unarchive,
 			menu: [{
 				id: SessionItemToolbarMenuId,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -328,7 +328,7 @@ registerAction2(class UnarchiveSectionAction extends Action2 {
 		super({
 			id: 'sessionsView.sectionUnarchive',
 			title: localize2('unarchiveSection', "Restore All"),
-			icon: Codicon.unarchive,
+			icon: Codicon.discard,
 			menu: [{
 				id: SessionSectionToolbarMenuId,
 				group: 'navigation',
@@ -487,7 +487,7 @@ registerAction2(class UnarchiveSessionAction extends Action2 {
 		super({
 			id: 'sessionsViewPane.unarchiveSession',
 			title: localize2('unarchiveSession', "Restore"),
-			icon: Codicon.unarchive,
+			icon: Codicon.discard,
 			menu: [{
 				id: SessionItemToolbarMenuId,
 				group: 'navigation',


### PR DESCRIPTION
Revise terminology for archived sessions to "Done" and improve the layout of the session section with icons. Simplify the session filter title and update action icons for archiving and unarchiving sessions. This enhances clarity and usability in managing session states.

Addresses: https://github.com/microsoft/vscode/issues/307225