### PR TITLE
Sessions: Update changes view title and name

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
@@ -21,7 +21,7 @@ const viewContainersRegistry = Registry.as<IViewContainersRegistry>(ViewContaine
 
 const changesViewContainer = viewContainersRegistry.registerViewContainer({
 	id: CHANGES_VIEW_CONTAINER_ID,
-	title: localize2('artifacts', 'Artifacts'),
+	title: localize2('changes', 'Changes'),
 	ctorDescriptor: new SyncDescriptor(ChangesViewPaneContainer),
 	icon: changesViewIcon,
 	order: 10,
@@ -33,7 +33,7 @@ const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsR
 
 viewsRegistry.registerViews([{
 	id: CHANGES_VIEW_ID,
-	name: localize2('artifacts', 'Artifacts'),
+	name: localize2('changes', 'Changes'),
 	containerIcon: changesViewIcon,
 	ctorDescriptor: new SyncDescriptor(ChangesViewPane),
 	canToggleVisibility: true,


### PR DESCRIPTION
Change the title and name in the changes view from "Artifacts" to "Changes" for improved clarity.

