### PR TITLE
fix: prevent catastrophic regex backtracking in _extractImagesFromOutput

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1452,15 +1452,20 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 * Returns data content parts for any found images that exist on disk.
 	 */
 	private async _extractImagesFromOutput(output: string, cwd: URI | undefined): Promise<IToolResult['content']> {
-		const normalizedOutput = output.replace(/\r?\n/g, '');
-
-		// Match paths ending with image extensions. A leading / or \ is sufficient
-		// to identify a path segment; the full path up to the extension is captured.
-		const pathPattern = /(?:[^\s]*[\/\\][^\s]*\.(?:png|jpe?g|gif|webp|bmp))/gi;
+		// Match paths containing at least one / or \ and ending with an image
+		// extension. Each atom uses [^\s/\\]* so it cannot consume separators,
+		// which keeps the [/\\] tokens unambiguous and prevents catastrophic
+		// backtracking on long strings.
+		const pathPattern = /[^\s/\\]*(?:[/\\][^\s/\\]*)+\.(?:png|jpe?g|gif|webp|bmp)/gi;
 
 		const matches = new Set<string>();
-		for (const match of normalizedOutput.matchAll(pathPattern)) {
-			matches.add(match[0]);
+		for (const line of output.split(/\r?\n/)) {
+			if (line.length > 10_000) {
+				continue;
+			}
+			for (const match of line.matchAll(pathPattern)) {
+				matches.add(match[0]);
+			}
 		}
 
 		if (matches.size === 0) {


### PR DESCRIPTION
Fixes #307431

## Problem

`_extractImagesFromOutput` in `RunInTerminalTool` freezes the renderer main thread for 15–20 seconds on large terminal output. The root cause is a two-step pattern:

1. **Line 1291** `output.replace(/\r?\n/g, '')` strips all newlines, producing a single mega-string.
2. **Line 1294** the regex `/(?:[^\s]*[\/\\][^\s]*\.(?:png|jpe?g|gif|webp|bmp))/gi` has ambiguity — `[^\s]*` can consume `/` and `\`, overlapping with the `[\/\\]` separator. On a long string the engine explores an exponential number of split-points, causing O(2ⁿ) backtracking.

Profiler evidence: 14/14 renderer-hang samples land on `RegExpStringIterator.next` inside `_extractImagesFromOutput`.

## Fix

- **Process per-line instead of collapsing newlines** — file paths never span lines, so collapsing was unnecessary and is the direct trigger of the mega-string.
- **Skip lines longer than 10 000 chars** — defensive guard against pathological single lines.
- **Rewrite regex atoms from `[^\s]*` to `[^\s/\\]*`** — each atom can no longer consume path separators, making the `[/\\]` tokens unambiguous and eliminating backtracking entirely.