### PR TITLE
sessions: preserve sidebar toggle focus across workbench surfaces

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -112,6 +112,7 @@ The toggle sidebar action:
 - Shows `layoutSidebarLeftOff` icon when sidebar is hidden
 - Bound to `Ctrl+B` / `Cmd+B` keybinding
 - Announces visibility changes to screen readers
+- Preserves keyboard focus on the toggle as it moves between the titlebar and sidebar surfaces
 
 The Run Script action:
 - Displayed as a split button via `RunScriptDropdownMenuId` submenu on `Menus.TitleBarRight`
@@ -663,6 +664,7 @@ interface IPartVisibilityState {
 | 2026-04-04 | Inverted the default light-theme surface mapping so the sessions window background uses the off-white workbench/sidebar surface while the chat, changes, and panel cards use the brighter editor background; dark and high-contrast mappings remain unchanged. |
 | 2026-04-03 | Updated `SessionsTitleBarWidget` to format active session titles as `{Title} · {repo name} ({git branch/worktree name})` when repository detail metadata is available, falling back to the worktree folder name when needed. |
 | 2026-04-03 | Reduced the sessions left sidebar minimum resizable width from 270px to 170px so it can shrink significantly more while keeping the default 300px width unchanged |
+| 2026-03-31 | Updated the sidebar toggle documentation to reflect the `layoutSidebarLeft` / `layoutSidebarLeftOff` visibility icons and the keyboard focus handoff that keeps focus on the toggle when it moves between the hidden-sidebar titlebar surface and the visible-sidebar sidebar title surface |
 | 2026-03-30 | Adjusted `.agent-sessions-titlebar-container` padding so it sits flush when the sidebar is visible and restores 16px left padding when the sidebar is hidden |
 | 2026-03-26 | Updated the sessions sidebar appear animation so only the body content (`.part.sidebar > .content`) slides/fades in during reveal while the sidebar title/header and footer remain fixed |
 | 2026-03-24 | Polished the sessions task configuration quick input modal to use stronger modal-style header chrome, increased horizontal padding in the quick input/form content, and added an explicit close action in the modal header |

--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { alert } from '../../base/browser/ui/aria/aria.js';
+import { getActiveWindow, isHTMLElement } from '../../base/browser/dom.js';
 import { Codicon } from '../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../base/common/keyCodes.js';
 import { localize, localize2 } from '../../nls.js';
 import { Categories } from '../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../platform/actions/common/actions.js';
 import { Menus } from './menus.js';
+import { clearSidebarToggleFocusRequest, requestSidebarToggleFocus, SidebarToggleFocusTarget } from './sidebarToggleFocus.js';
 import { ServicesAccessor } from '../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
@@ -63,6 +65,15 @@ class ToggleSidebarVisibilityAction extends Action2 {
 	run(accessor: ServicesAccessor): void {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const isCurrentlyVisible = layoutService.isVisible(Parts.SIDEBAR_PART);
+		const targetWindow = getActiveWindow();
+		const activeElement = targetWindow.document.activeElement;
+		const shouldRestoreFocus = isHTMLElement(activeElement) && !!activeElement.closest('.sidebar-toggle-action');
+
+		if (shouldRestoreFocus) {
+			requestSidebarToggleFocus(isCurrentlyVisible ? SidebarToggleFocusTarget.Titlebar : SidebarToggleFocusTarget.Sidebar);
+		} else {
+			clearSidebarToggleFocusRequest();
+		}
 
 		layoutService.setPartHidden(isCurrentlyVisible, Parts.SIDEBAR_PART);
 

--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -11,7 +11,7 @@ import { localize, localize2 } from '../../nls.js';
 import { Categories } from '../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../platform/actions/common/actions.js';
 import { Menus } from './menus.js';
-import { clearSidebarToggleFocusRequest, logSidebarToggleFocus, requestSidebarToggleFocus, SidebarToggleFocusTarget } from './sidebarToggleFocus.js';
+import { clearSidebarToggleFocusRequest, requestSidebarToggleFocus, SidebarToggleFocusTarget } from './sidebarToggleFocus.js';
 import { ServicesAccessor } from '../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
@@ -68,13 +68,6 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		const targetWindow = getActiveWindow();
 		const activeElement = targetWindow.document.activeElement;
 		const shouldRestoreFocus = isHTMLElement(activeElement) && !!activeElement.closest('.sidebar-toggle-action');
-		logSidebarToggleFocus('action-run', {
-			isCurrentlyVisible,
-			shouldRestoreFocus,
-			activeElementTagName: isHTMLElement(activeElement) ? activeElement.tagName : String(activeElement),
-			activeElementClassName: isHTMLElement(activeElement) ? activeElement.className : undefined,
-			activeElementAriaLabel: isHTMLElement(activeElement) ? activeElement.getAttribute('aria-label') : undefined
-		});
 
 		if (shouldRestoreFocus) {
 			requestSidebarToggleFocus(isCurrentlyVisible ? SidebarToggleFocusTarget.Titlebar : SidebarToggleFocusTarget.Sidebar);
@@ -83,10 +76,6 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		}
 
 		layoutService.setPartHidden(isCurrentlyVisible, Parts.SIDEBAR_PART);
-		logSidebarToggleFocus('action-after-setPartHidden', {
-			requestedHidden: isCurrentlyVisible,
-			sidebarVisibleNow: layoutService.isVisible(Parts.SIDEBAR_PART)
-		});
 
 		// Announce visibility change to screen readers
 		const alertMessage = isCurrentlyVisible

--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -11,7 +11,7 @@ import { localize, localize2 } from '../../nls.js';
 import { Categories } from '../../platform/action/common/actionCommonCategories.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../platform/actions/common/actions.js';
 import { Menus } from './menus.js';
-import { clearSidebarToggleFocusRequest, requestSidebarToggleFocus, SidebarToggleFocusTarget } from './sidebarToggleFocus.js';
+import { clearSidebarToggleFocusRequest, logSidebarToggleFocus, requestSidebarToggleFocus, SidebarToggleFocusTarget } from './sidebarToggleFocus.js';
 import { ServicesAccessor } from '../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
@@ -68,6 +68,13 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		const targetWindow = getActiveWindow();
 		const activeElement = targetWindow.document.activeElement;
 		const shouldRestoreFocus = isHTMLElement(activeElement) && !!activeElement.closest('.sidebar-toggle-action');
+		logSidebarToggleFocus('action-run', {
+			isCurrentlyVisible,
+			shouldRestoreFocus,
+			activeElementTagName: isHTMLElement(activeElement) ? activeElement.tagName : String(activeElement),
+			activeElementClassName: isHTMLElement(activeElement) ? activeElement.className : undefined,
+			activeElementAriaLabel: isHTMLElement(activeElement) ? activeElement.getAttribute('aria-label') : undefined
+		});
 
 		if (shouldRestoreFocus) {
 			requestSidebarToggleFocus(isCurrentlyVisible ? SidebarToggleFocusTarget.Titlebar : SidebarToggleFocusTarget.Sidebar);
@@ -76,6 +83,10 @@ class ToggleSidebarVisibilityAction extends Action2 {
 		}
 
 		layoutService.setPartHidden(isCurrentlyVisible, Parts.SIDEBAR_PART);
+		logSidebarToggleFocus('action-after-setPartHidden', {
+			requestedHidden: isCurrentlyVisible,
+			sidebarVisibleNow: layoutService.isVisible(Parts.SIDEBAR_PART)
+		});
 
 		// Announce visibility change to screen readers
 		const alertMessage = isCurrentlyVisible

--- a/src/vs/sessions/browser/sidebarToggleFocus.ts
+++ b/src/vs/sessions/browser/sidebarToggleFocus.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const enum SidebarToggleFocusTarget {
+	Titlebar = 'titlebar',
+	Sidebar = 'sidebar',
+}
+
+let pendingSidebarToggleFocusTarget: SidebarToggleFocusTarget | undefined;
+
+export function requestSidebarToggleFocus(target: SidebarToggleFocusTarget): void {
+	pendingSidebarToggleFocusTarget = target;
+}
+
+export function clearSidebarToggleFocusRequest(): void {
+	pendingSidebarToggleFocusTarget = undefined;
+}
+
+export function consumeSidebarToggleFocusRequest(target: SidebarToggleFocusTarget): boolean {
+	if (pendingSidebarToggleFocusTarget !== target) {
+		return false;
+	}
+
+	pendingSidebarToggleFocusTarget = undefined;
+	return true;
+}

--- a/src/vs/sessions/browser/sidebarToggleFocus.ts
+++ b/src/vs/sessions/browser/sidebarToggleFocus.ts
@@ -10,19 +10,31 @@ export const enum SidebarToggleFocusTarget {
 
 let pendingSidebarToggleFocusTarget: SidebarToggleFocusTarget | undefined;
 
+export function logSidebarToggleFocus(message: string, details?: Record<string, unknown>): void {
+	console.debug('[sessions][sidebar-toggle-focus]', message, details ?? {});
+}
+
+export function peekSidebarToggleFocusRequest(): SidebarToggleFocusTarget | undefined {
+	return pendingSidebarToggleFocusTarget;
+}
+
 export function requestSidebarToggleFocus(target: SidebarToggleFocusTarget): void {
+	logSidebarToggleFocus('request', { target, previous: pendingSidebarToggleFocusTarget });
 	pendingSidebarToggleFocusTarget = target;
 }
 
 export function clearSidebarToggleFocusRequest(): void {
+	logSidebarToggleFocus('clear', { previous: pendingSidebarToggleFocusTarget });
 	pendingSidebarToggleFocusTarget = undefined;
 }
 
 export function consumeSidebarToggleFocusRequest(target: SidebarToggleFocusTarget): boolean {
+	logSidebarToggleFocus('consume-attempt', { target, pending: pendingSidebarToggleFocusTarget });
 	if (pendingSidebarToggleFocusTarget !== target) {
 		return false;
 	}
 
 	pendingSidebarToggleFocusTarget = undefined;
+	logSidebarToggleFocus('consume-success', { target });
 	return true;
 }

--- a/src/vs/sessions/browser/sidebarToggleFocus.ts
+++ b/src/vs/sessions/browser/sidebarToggleFocus.ts
@@ -10,31 +10,19 @@ export const enum SidebarToggleFocusTarget {
 
 let pendingSidebarToggleFocusTarget: SidebarToggleFocusTarget | undefined;
 
-export function logSidebarToggleFocus(message: string, details?: Record<string, unknown>): void {
-	console.warn('[sessions][sidebar-toggle-focus]', message, details ?? {});
-}
-
-export function peekSidebarToggleFocusRequest(): SidebarToggleFocusTarget | undefined {
-	return pendingSidebarToggleFocusTarget;
-}
-
 export function requestSidebarToggleFocus(target: SidebarToggleFocusTarget): void {
-	logSidebarToggleFocus('request', { target, previous: pendingSidebarToggleFocusTarget });
 	pendingSidebarToggleFocusTarget = target;
 }
 
 export function clearSidebarToggleFocusRequest(): void {
-	logSidebarToggleFocus('clear', { previous: pendingSidebarToggleFocusTarget });
 	pendingSidebarToggleFocusTarget = undefined;
 }
 
 export function consumeSidebarToggleFocusRequest(target: SidebarToggleFocusTarget): boolean {
-	logSidebarToggleFocus('consume-attempt', { target, pending: pendingSidebarToggleFocusTarget });
 	if (pendingSidebarToggleFocusTarget !== target) {
 		return false;
 	}
 
 	pendingSidebarToggleFocusTarget = undefined;
-	logSidebarToggleFocus('consume-success', { target });
 	return true;
 }

--- a/src/vs/sessions/browser/sidebarToggleFocus.ts
+++ b/src/vs/sessions/browser/sidebarToggleFocus.ts
@@ -11,7 +11,7 @@ export const enum SidebarToggleFocusTarget {
 let pendingSidebarToggleFocusTarget: SidebarToggleFocusTarget | undefined;
 
 export function logSidebarToggleFocus(message: string, details?: Record<string, unknown>): void {
-	console.debug('[sessions][sidebar-toggle-focus]', message, details ?? {});
+	console.warn('[sessions][sidebar-toggle-focus]', message, details ?? {});
 }
 
 export function peekSidebarToggleFocusRequest(): SidebarToggleFocusTarget | undefined {

--- a/src/vs/sessions/browser/sidebarToggleFocus.ts
+++ b/src/vs/sessions/browser/sidebarToggleFocus.ts
@@ -18,6 +18,10 @@ export function clearSidebarToggleFocusRequest(): void {
 	pendingSidebarToggleFocusTarget = undefined;
 }
 
+export function hasSidebarToggleFocusRequest(target: SidebarToggleFocusTarget): boolean {
+	return pendingSidebarToggleFocusTarget === target;
+}
+
 export function consumeSidebarToggleFocusRequest(target: SidebarToggleFocusTarget): boolean {
 	if (pendingSidebarToggleFocusTarget !== target) {
 		return false;

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/sessionsTitleBarWidget.css';
-import { $, addDisposableListener, append, EventType, getActiveWindow, reset } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, append, EventType, getActiveWindow, getWindow, reset, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
 import { IAction, Separator } from '../../../../base/common/actions.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
@@ -33,6 +33,7 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { consumeSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -350,6 +351,12 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		super.render(container);
 
 		container.classList.add('sidebar-toggle-action');
+		const focusTarget = container.closest('.part.sidebar')
+			? SidebarToggleFocusTarget.Sidebar
+			: SidebarToggleFocusTarget.Titlebar;
+		if (consumeSidebarToggleFocusRequest(focusTarget)) {
+			this._register(scheduleAtNextAnimationFrame(getWindow(container), () => this.focus()));
+		}
 
 		// Add badge element for unread session count
 		this._countBadge = append(container, $('span.sidebar-toggle-badge'));

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,7 +35,7 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { consumeSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
+import { consumeSidebarToggleFocusRequest, hasSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -408,27 +408,36 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		return this._focusTarget;
 	}
 
+	private _canRestoreFocus(container: HTMLElement, focusTarget: SidebarToggleFocusTarget, fromSidebarOpen: boolean): boolean {
+		if (focusTarget === SidebarToggleFocusTarget.Titlebar) {
+			return !fromSidebarOpen && !this.layoutService.isVisible(Parts.SIDEBAR_PART) && this._isFocusable(container);
+		}
+
+		return this.layoutService.isVisible(Parts.SIDEBAR_PART) && this._isFocusable(container);
+	}
+
+	private _isFocusable(container: HTMLElement): boolean {
+		const focusElement = this.label ?? container;
+		return focusElement.isConnected && focusElement.getClientRects().length > 0;
+	}
+
 	private _restoreFocusIfRequested(container: HTMLElement, fromSidebarOpen: boolean = false): void {
 		const focusTarget = this._getFocusTarget(container);
 		if (!focusTarget) {
 			return;
 		}
 
-		if (focusTarget === SidebarToggleFocusTarget.Titlebar) {
-			if (fromSidebarOpen) {
-				return;
-			}
-		} else if (!this.layoutService.isVisible(Parts.SIDEBAR_PART)) {
-			return;
-		}
-
-		if (!consumeSidebarToggleFocusRequest(focusTarget)) {
+		if (!this._canRestoreFocus(container, focusTarget, fromSidebarOpen) || !hasSidebarToggleFocusRequest(focusTarget)) {
 			return;
 		}
 
 		const targetWindow = getWindow(container);
 		this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
 			this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
+				if (!this._canRestoreFocus(container, focusTarget, fromSidebarOpen) || !consumeSidebarToggleFocusRequest(focusTarget)) {
+					return;
+				}
+
 				this.focus();
 			}));
 		}));

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -335,6 +335,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 class SidebarToggleActionViewItem extends ActionViewItem {
 
 	private _countBadge: HTMLElement | undefined;
+	private _focusTarget: SidebarToggleFocusTarget | undefined;
 
 	constructor(
 		context: unknown,
@@ -351,12 +352,10 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		super.render(container);
 
 		container.classList.add('sidebar-toggle-action');
-		const focusTarget = container.closest('.part.sidebar')
+		this._focusTarget = container.closest('.part.sidebar')
 			? SidebarToggleFocusTarget.Sidebar
 			: SidebarToggleFocusTarget.Titlebar;
-		if (consumeSidebarToggleFocusRequest(focusTarget)) {
-			this._register(scheduleAtNextAnimationFrame(getWindow(container), () => this.focus()));
-		}
+		this._restoreFocusIfRequested(container);
 
 		// Add badge element for unread session count
 		this._countBadge = append(container, $('span.sidebar-toggle-badge'));
@@ -381,7 +380,16 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 			}
 			this.updateClass();
 			this._updateBadge();
+			this._restoreFocusIfRequested(container);
 		}));
+	}
+
+	private _restoreFocusIfRequested(container: HTMLElement): void {
+		if (!this._focusTarget || !consumeSidebarToggleFocusRequest(this._focusTarget)) {
+			return;
+		}
+
+		this._register(scheduleAtNextAnimationFrame(getWindow(container), () => this.focus()));
 	}
 
 	protected override getClass(): string | undefined {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,7 +35,7 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { consumeSidebarToggleFocusRequest, logSidebarToggleFocus, peekSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
+import { consumeSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -332,13 +332,15 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 /**
  * Custom action view item for the sidebar toggle button.
- * Renders the tasklist icon with an unread session count badge.
+ * Renders the sidebar toggle icon with an unread session count badge.
  */
 class SidebarToggleActionViewItem extends ActionViewItem {
 
 	private _countBadge: HTMLElement | undefined;
 	private _focusTarget: SidebarToggleFocusTarget | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
+	private readonly _sessionsChanged: ReturnType<typeof observableSignalFromEvent>;
+	private readonly _sidebarVisibilityChanged: ReturnType<typeof observableSignalFromEvent>;
 
 	constructor(
 		context: unknown,
@@ -350,6 +352,12 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		@IPaneCompositePartService private readonly paneCompositePartService: IPaneCompositePartService,
 	) {
 		super(context, action, { ...options, icon: true, label: false });
+		this._sessionsChanged = observableSignalFromEvent(this, this.sessionsManagementService.onDidChangeSessions);
+		this._sidebarVisibilityChanged = observableSignalFromEvent(this, handler => this.layoutService.onDidChangePartVisibility(e => {
+			if (e.partId === Parts.SIDEBAR_PART) {
+				handler(e);
+			}
+		}));
 	}
 
 	override render(container: HTMLElement): void {
@@ -357,29 +365,9 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		super.render(container);
 
 		container.classList.add('sidebar-toggle-action');
-		this._focusTarget = container.closest('.part.sidebar')
-			? SidebarToggleFocusTarget.Sidebar
-			: SidebarToggleFocusTarget.Titlebar;
-		logSidebarToggleFocus('view-item-render', {
-			focusTarget: this._focusTarget,
-			pending: peekSidebarToggleFocusRequest(),
-			sidebarVisible: this.layoutService.isVisible(Parts.SIDEBAR_PART),
-		});
-		if (this.label) {
-			this._renderDisposables.add(addDisposableListener(this.label, EventType.FOCUS, () => {
-				logSidebarToggleFocus('label-focus', { focusTarget: this._focusTarget });
-			}));
-			this._renderDisposables.add(addDisposableListener(this.label, EventType.BLUR, () => {
-				logSidebarToggleFocus('label-blur', { focusTarget: this._focusTarget });
-			}));
-		}
 		this._restoreFocusIfRequested(container);
 		this._renderDisposables.add(this.paneCompositePartService.onDidPaneCompositeOpen(e => {
 			if (e.viewContainerLocation === ViewContainerLocation.Sidebar) {
-				logSidebarToggleFocus('pane-composite-open', {
-					focusTarget: this._focusTarget,
-					pending: peekSidebarToggleFocusRequest(),
-				});
 				this._restoreFocusIfRequested(container, true);
 			}
 		}));
@@ -389,18 +377,13 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		this._countBadge.setAttribute('aria-hidden', 'true');
 		this._updateBadge();
 
-		// Track session list changes, status changes, and sidebar visibility
-		const sessionsChanged = observableSignalFromEvent(this, this.sessionsManagementService.onDidChangeSessions);
-		const listModelChanged = observableSignalFromEvent(this, this.sessionsListModelService.onDidChange);
-		const sidebarVisibilityChanged = observableSignalFromEvent(this, handler => this.layoutService.onDidChangePartVisibility(e => {
-			if (e.partId === Parts.SIDEBAR_PART) {
-				handler(e);
-			}
-		}));
+		// Single autorun that tracks all badge-relevant state:
+		// - session list changes (add/remove) via observableSignalFromEvent
+		// - individual session observable state (status, isRead, isArchived)
+		// - sidebar visibility changes
 		this._renderDisposables.add(autorun(reader => {
-			sessionsChanged.read(reader);
-			listModelChanged.read(reader);
-			sidebarVisibilityChanged.read(reader);
+			this._sessionsChanged.read(reader);
+			this._sidebarVisibilityChanged.read(reader);
 			for (const session of this.sessionsManagementService.getSessions()) {
 				session.isArchived.read(reader);
 				session.status.read(reader);
@@ -411,75 +394,42 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		}));
 	}
 
+	private _getFocusTarget(container: HTMLElement): SidebarToggleFocusTarget | undefined {
+		const focusTarget = container.closest('.part.sidebar')
+			? SidebarToggleFocusTarget.Sidebar
+			: container.closest('.part.titlebar')
+				? SidebarToggleFocusTarget.Titlebar
+				: this._focusTarget;
+
+		if (focusTarget !== this._focusTarget) {
+			this._focusTarget = focusTarget;
+		}
+
+		return this._focusTarget;
+	}
+
 	private _restoreFocusIfRequested(container: HTMLElement, fromSidebarOpen: boolean = false): void {
-		if (!this._focusTarget) {
-			logSidebarToggleFocus('restore-skip-no-target', { fromSidebarOpen });
+		const focusTarget = this._getFocusTarget(container);
+		if (!focusTarget) {
 			return;
 		}
 
-		if (this._focusTarget === SidebarToggleFocusTarget.Titlebar) {
+		if (focusTarget === SidebarToggleFocusTarget.Titlebar) {
 			if (fromSidebarOpen) {
-				logSidebarToggleFocus('restore-skip-titlebar-from-sidebar-open', {
-					focusTarget: this._focusTarget,
-					pending: peekSidebarToggleFocusRequest(),
-				});
 				return;
 			}
 		} else if (!this.layoutService.isVisible(Parts.SIDEBAR_PART)) {
-			logSidebarToggleFocus('restore-skip-sidebar-hidden', {
-				focusTarget: this._focusTarget,
-				fromSidebarOpen,
-				pending: peekSidebarToggleFocusRequest(),
-			});
 			return;
 		}
 
-		if (!consumeSidebarToggleFocusRequest(this._focusTarget)) {
-			logSidebarToggleFocus('restore-skip-no-pending-match', {
-				focusTarget: this._focusTarget,
-				fromSidebarOpen,
-				pending: peekSidebarToggleFocusRequest(),
-			});
+		if (!consumeSidebarToggleFocusRequest(focusTarget)) {
 			return;
 		}
 
 		const targetWindow = getWindow(container);
-		logSidebarToggleFocus('restore-scheduled', {
-			focusTarget: this._focusTarget,
-			fromSidebarOpen,
-			activeElementBeforeSchedule: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
-				tagName: targetWindow.document.activeElement.tagName,
-				className: targetWindow.document.activeElement.className,
-				ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
-			} : String(targetWindow.document.activeElement)
-		});
 		this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
-			logSidebarToggleFocus('restore-first-frame', {
-				focusTarget: this._focusTarget,
-				activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
-					tagName: targetWindow.document.activeElement.tagName,
-					className: targetWindow.document.activeElement.className,
-					ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
-				} : String(targetWindow.document.activeElement)
-			});
 			this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
-				logSidebarToggleFocus('restore-second-frame-before-focus', {
-					focusTarget: this._focusTarget,
-					activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
-						tagName: targetWindow.document.activeElement.tagName,
-						className: targetWindow.document.activeElement.className,
-						ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
-					} : String(targetWindow.document.activeElement)
-				});
 				this.focus();
-				logSidebarToggleFocus('restore-second-frame-after-focus', {
-					focusTarget: this._focusTarget,
-					activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
-						tagName: targetWindow.document.activeElement.tagName,
-						className: targetWindow.document.activeElement.className,
-						ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
-					} : String(targetWindow.document.activeElement)
-				});
 			}));
 		}));
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -18,6 +18,8 @@ import { ContextKeyExpr, IContextKeyService } from '../../../../platform/context
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
+import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
@@ -344,6 +346,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@ISessionsListModelService private readonly sessionsListModelService: ISessionsListModelService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IPaneCompositePartService private readonly paneCompositePartService: IPaneCompositePartService,
 	) {
 		super(context, action, { ...options, icon: true, label: false });
 	}
@@ -356,6 +359,11 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 			? SidebarToggleFocusTarget.Sidebar
 			: SidebarToggleFocusTarget.Titlebar;
 		this._restoreFocusIfRequested(container);
+		this._register(this.paneCompositePartService.onDidPaneCompositeOpen(e => {
+			if (e.viewContainerLocation === ViewContainerLocation.Sidebar) {
+				this._restoreFocusIfRequested(container, true);
+			}
+		}));
 
 		// Add badge element for unread session count
 		this._countBadge = append(container, $('span.sidebar-toggle-badge'));
@@ -384,12 +392,27 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		}));
 	}
 
-	private _restoreFocusIfRequested(container: HTMLElement): void {
-		if (!this._focusTarget || !consumeSidebarToggleFocusRequest(this._focusTarget)) {
+	private _restoreFocusIfRequested(container: HTMLElement, fromSidebarOpen: boolean = false): void {
+		if (!this._focusTarget) {
 			return;
 		}
 
-		this._register(scheduleAtNextAnimationFrame(getWindow(container), () => this.focus()));
+		if (this._focusTarget === SidebarToggleFocusTarget.Titlebar) {
+			if (fromSidebarOpen) {
+				return;
+			}
+		} else if (!this.layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			return;
+		}
+
+		if (!consumeSidebarToggleFocusRequest(this._focusTarget)) {
+			return;
+		}
+
+		const targetWindow = getWindow(container);
+		this._register(scheduleAtNextAnimationFrame(targetWindow, () => {
+			this._register(scheduleAtNextAnimationFrame(targetWindow, () => this.focus()));
+		}));
 	}
 
 	protected override getClass(): string | undefined {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -35,7 +35,7 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { consumeSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
+import { consumeSidebarToggleFocusRequest, logSidebarToggleFocus, peekSidebarToggleFocusRequest, SidebarToggleFocusTarget } from '../../../browser/sidebarToggleFocus.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -358,9 +358,26 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 		this._focusTarget = container.closest('.part.sidebar')
 			? SidebarToggleFocusTarget.Sidebar
 			: SidebarToggleFocusTarget.Titlebar;
+		logSidebarToggleFocus('view-item-render', {
+			focusTarget: this._focusTarget,
+			pending: peekSidebarToggleFocusRequest(),
+			sidebarVisible: this.layoutService.isVisible(Parts.SIDEBAR_PART),
+		});
+		if (this.label) {
+			this._register(addDisposableListener(this.label, EventType.FOCUS, () => {
+				logSidebarToggleFocus('label-focus', { focusTarget: this._focusTarget });
+			}));
+			this._register(addDisposableListener(this.label, EventType.BLUR, () => {
+				logSidebarToggleFocus('label-blur', { focusTarget: this._focusTarget });
+			}));
+		}
 		this._restoreFocusIfRequested(container);
 		this._register(this.paneCompositePartService.onDidPaneCompositeOpen(e => {
 			if (e.viewContainerLocation === ViewContainerLocation.Sidebar) {
+				logSidebarToggleFocus('pane-composite-open', {
+					focusTarget: this._focusTarget,
+					pending: peekSidebarToggleFocusRequest(),
+				});
 				this._restoreFocusIfRequested(container, true);
 			}
 		}));
@@ -394,24 +411,74 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 
 	private _restoreFocusIfRequested(container: HTMLElement, fromSidebarOpen: boolean = false): void {
 		if (!this._focusTarget) {
+			logSidebarToggleFocus('restore-skip-no-target', { fromSidebarOpen });
 			return;
 		}
 
 		if (this._focusTarget === SidebarToggleFocusTarget.Titlebar) {
 			if (fromSidebarOpen) {
+				logSidebarToggleFocus('restore-skip-titlebar-from-sidebar-open', {
+					focusTarget: this._focusTarget,
+					pending: peekSidebarToggleFocusRequest(),
+				});
 				return;
 			}
 		} else if (!this.layoutService.isVisible(Parts.SIDEBAR_PART)) {
+			logSidebarToggleFocus('restore-skip-sidebar-hidden', {
+				focusTarget: this._focusTarget,
+				fromSidebarOpen,
+				pending: peekSidebarToggleFocusRequest(),
+			});
 			return;
 		}
 
 		if (!consumeSidebarToggleFocusRequest(this._focusTarget)) {
+			logSidebarToggleFocus('restore-skip-no-pending-match', {
+				focusTarget: this._focusTarget,
+				fromSidebarOpen,
+				pending: peekSidebarToggleFocusRequest(),
+			});
 			return;
 		}
 
 		const targetWindow = getWindow(container);
+		logSidebarToggleFocus('restore-scheduled', {
+			focusTarget: this._focusTarget,
+			fromSidebarOpen,
+			activeElementBeforeSchedule: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
+				tagName: targetWindow.document.activeElement.tagName,
+				className: targetWindow.document.activeElement.className,
+				ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
+			} : String(targetWindow.document.activeElement)
+		});
 		this._register(scheduleAtNextAnimationFrame(targetWindow, () => {
-			this._register(scheduleAtNextAnimationFrame(targetWindow, () => this.focus()));
+			logSidebarToggleFocus('restore-first-frame', {
+				focusTarget: this._focusTarget,
+				activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
+					tagName: targetWindow.document.activeElement.tagName,
+					className: targetWindow.document.activeElement.className,
+					ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
+				} : String(targetWindow.document.activeElement)
+			});
+			this._register(scheduleAtNextAnimationFrame(targetWindow, () => {
+				logSidebarToggleFocus('restore-second-frame-before-focus', {
+					focusTarget: this._focusTarget,
+					activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
+						tagName: targetWindow.document.activeElement.tagName,
+						className: targetWindow.document.activeElement.className,
+						ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
+					} : String(targetWindow.document.activeElement)
+				});
+				this.focus();
+				logSidebarToggleFocus('restore-second-frame-after-focus', {
+					focusTarget: this._focusTarget,
+					activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
+						tagName: targetWindow.document.activeElement.tagName,
+						className: targetWindow.document.activeElement.className,
+						ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
+					} : String(targetWindow.document.activeElement)
+				});
+			}));
 		}));
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -338,6 +338,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 
 	private _countBadge: HTMLElement | undefined;
 	private _focusTarget: SidebarToggleFocusTarget | undefined;
+	private readonly _renderDisposables = this._register(new DisposableStore());
 
 	constructor(
 		context: unknown,
@@ -352,6 +353,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 	}
 
 	override render(container: HTMLElement): void {
+		this._renderDisposables.clear();
 		super.render(container);
 
 		container.classList.add('sidebar-toggle-action');
@@ -364,15 +366,15 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 			sidebarVisible: this.layoutService.isVisible(Parts.SIDEBAR_PART),
 		});
 		if (this.label) {
-			this._register(addDisposableListener(this.label, EventType.FOCUS, () => {
+			this._renderDisposables.add(addDisposableListener(this.label, EventType.FOCUS, () => {
 				logSidebarToggleFocus('label-focus', { focusTarget: this._focusTarget });
 			}));
-			this._register(addDisposableListener(this.label, EventType.BLUR, () => {
+			this._renderDisposables.add(addDisposableListener(this.label, EventType.BLUR, () => {
 				logSidebarToggleFocus('label-blur', { focusTarget: this._focusTarget });
 			}));
 		}
 		this._restoreFocusIfRequested(container);
-		this._register(this.paneCompositePartService.onDidPaneCompositeOpen(e => {
+		this._renderDisposables.add(this.paneCompositePartService.onDidPaneCompositeOpen(e => {
 			if (e.viewContainerLocation === ViewContainerLocation.Sidebar) {
 				logSidebarToggleFocus('pane-composite-open', {
 					focusTarget: this._focusTarget,
@@ -395,7 +397,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 				handler(e);
 			}
 		}));
-		this._register(autorun(reader => {
+		this._renderDisposables.add(autorun(reader => {
 			sessionsChanged.read(reader);
 			listModelChanged.read(reader);
 			sidebarVisibilityChanged.read(reader);
@@ -451,7 +453,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 				ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
 			} : String(targetWindow.document.activeElement)
 		});
-		this._register(scheduleAtNextAnimationFrame(targetWindow, () => {
+		this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
 			logSidebarToggleFocus('restore-first-frame', {
 				focusTarget: this._focusTarget,
 				activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {
@@ -460,7 +462,7 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 					ariaLabel: targetWindow.document.activeElement.getAttribute('aria-label')
 				} : String(targetWindow.document.activeElement)
 			});
-			this._register(scheduleAtNextAnimationFrame(targetWindow, () => {
+			this._renderDisposables.add(scheduleAtNextAnimationFrame(targetWindow, () => {
 				logSidebarToggleFocus('restore-second-frame-before-focus', {
 					focusTarget: this._focusTarget,
 					activeElement: targetWindow.document.activeElement instanceof targetWindow.HTMLElement ? {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -382,7 +382,6 @@ class SidebarToggleActionViewItem extends ActionViewItem {
 			? ThemeIcon.asClassName(Codicon.layoutSidebarLeft)
 			: ThemeIcon.asClassName(Codicon.layoutSidebarLeftOff);
 	}
-
 	private _updateBadge(): void {
 		if (!this._countBadge) {
 			return;

--- a/src/vs/sessions/test/browser/layoutActions.test.ts
+++ b/src/vs/sessions/test/browser/layoutActions.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import { isIMenuItem, MenuRegistry } from '../../../platform/actions/common/actions.js';
 import { Menus } from '../../browser/menus.js';
+import { clearSidebarToggleFocusRequest, consumeSidebarToggleFocusRequest, hasSidebarToggleFocusRequest, requestSidebarToggleFocus, SidebarToggleFocusTarget } from '../../browser/sidebarToggleFocus.js';
 
 // Import layout actions to trigger menu registration
 import '../../browser/layoutActions.js';
@@ -14,6 +15,9 @@ import '../../browser/layoutActions.js';
 suite('Sessions - Layout Actions', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
+	teardown(() => {
+		clearSidebarToggleFocusRequest();
+	});
 
 	test('always-on-top toggle action is contributed to TitleBarRight', () => {
 		const items = MenuRegistry.getMenuItems(Menus.TitleBarRightLayout);
@@ -23,5 +27,28 @@ suite('Sessions - Layout Actions', () => {
 
 		assert.ok(toggleAlwaysOnTop, 'toggleWindowAlwaysOnTop should be contributed to TitleBarRight');
 		assert.strictEqual(toggleAlwaysOnTop.group, 'navigation');
+	});
+
+	test('sidebar toggle focus request is consumed only by the matching target', () => {
+		requestSidebarToggleFocus(SidebarToggleFocusTarget.Titlebar);
+
+		assert.strictEqual(consumeSidebarToggleFocusRequest(SidebarToggleFocusTarget.Sidebar), false);
+		assert.strictEqual(consumeSidebarToggleFocusRequest(SidebarToggleFocusTarget.Titlebar), true);
+		assert.strictEqual(consumeSidebarToggleFocusRequest(SidebarToggleFocusTarget.Titlebar), false);
+	});
+
+	test('sidebar toggle focus request can be observed without consuming it', () => {
+		requestSidebarToggleFocus(SidebarToggleFocusTarget.Sidebar);
+
+		assert.strictEqual(hasSidebarToggleFocusRequest(SidebarToggleFocusTarget.Titlebar), false);
+		assert.strictEqual(hasSidebarToggleFocusRequest(SidebarToggleFocusTarget.Sidebar), true);
+		assert.strictEqual(consumeSidebarToggleFocusRequest(SidebarToggleFocusTarget.Sidebar), true);
+	});
+
+	test('clearing sidebar toggle focus request prevents later consumption', () => {
+		requestSidebarToggleFocus(SidebarToggleFocusTarget.Sidebar);
+		clearSidebarToggleFocusRequest();
+
+		assert.strictEqual(consumeSidebarToggleFocusRequest(SidebarToggleFocusTarget.Sidebar), false);
 	});
 });


### PR DESCRIPTION
## Summary

This preserves keyboard focus on the Agent Sessions sidebar toggle when toggling the primary side bar across the two different workbench surfaces that render it.

- keep focus on the toggle when closing the side bar from the sidebar title area
- hand focus across to the title bar copy of the toggle when the side bar closes
- hand focus back to the sidebar copy of the toggle when the side bar reopens
- keep the focus handoff implementation scoped to the custom sessions toggle view item

## Why

The toggle is rendered in different parts of the sessions workbench depending on whether the primary side bar is visible. Without explicitly handing focus across those surfaces, keyboard users can lose focus when closing and reopening the side bar.

This PR is stacked on top of #306878 so the diff stays focused on the keyboard behavior. After #306878 merges, this PR can be retargeted to `main`.

## Validation

- `npm run compile-check-ts-native`
- `npm run precommit`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/browser/sidebarToggleFocus.ts src/vs/sessions/browser/layoutActions.ts src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts`