### PR TITLE
fix: add cp857 (Turkish DOS) to SUPPORTED_ENCODINGS

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -772,6 +772,11 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
 		order: 48
+	},
+	cp857: {
+		labelLong: 'Turkish DOS (CP 857)',
+		labelShort: 'CP 857',
+		order: 49
 	}
 };
 

--- a/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
+++ b/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
@@ -463,5 +463,13 @@ suite('Encoding', () => {
 		}
 	});
 
+	test('cp857 is present in SUPPORTED_ENCODINGS (issue #300041)', function () {
+		// Regression test: CP857 (Turkish DOS) was missing from document encoding support
+		// while already being supported by the terminal.
+		assert.ok('cp857' in encoding.SUPPORTED_ENCODINGS, 'cp857 should be in SUPPORTED_ENCODINGS');
+		assert.strictEqual(encoding.SUPPORTED_ENCODINGS['cp857'].labelLong, 'Turkish DOS (CP 857)');
+		assert.strictEqual(encoding.SUPPORTED_ENCODINGS['cp857'].labelShort, 'CP 857');
+	});
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });


### PR DESCRIPTION
## Summary

Fixes #300041

**Bug:** CP857 (Turkish DOS codepage) was missing from document encoding support in VS Code, even though the terminal already supported it via `@vscode/iconv-lite-umd`.

**Root Cause:** The `SUPPORTED_ENCODINGS` map in `encoding.ts` was never updated to include `cp857`, so users could not select it as a file encoding in the editor.

**Fix:** Added `cp857` to `SUPPORTED_ENCODINGS` with labels `'Turkish DOS (CP 857)'` / `'CP 857'` at order 49, consistent with the existing DOS codepage entries (`cp850`, `cp852`, `cp865`).

## Changes

- `src/vs/workbench/services/textfile/common/encoding.ts`: Added `cp857` entry to `SUPPORTED_ENCODINGS`.
- `src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts`: Added regression test that verifies `cp857` is present in `SUPPORTED_ENCODINGS` with the correct labels.

## Testing

- Added regression test `'cp857 is present in SUPPORTED_ENCODINGS (issue #300041)'` in `src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts` that verifies the entry exists and has correct `labelLong` / `labelShort` values.
- The existing `encodingExists` test will also cover `cp857` since it iterates all entries and checks iconv support — confirming the codec is available at runtime.
- All existing tests pass.