### PR TITLE
fix: correct Render Whitespace toggle checked state for default value (#305883)

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -23,7 +23,11 @@ class ToggleRenderWhitespaceAction extends Action2 {
 			},
 			category: Categories.View,
 			f1: true,
-			toggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none'),
+			toggled: ContextKeyExpr.or(
+				ContextKeyExpr.equals('config.editor.renderWhitespace', 'all'),
+				ContextKeyExpr.equals('config.editor.renderWhitespace', 'boundary'),
+				ContextKeyExpr.equals('config.editor.renderWhitespace', 'trailing'),
+			),
 			menu: {
 				id: MenuId.MenubarAppearanceMenu,
 				group: '4_editor',


### PR DESCRIPTION
## Summary

Fixes #305883

**Bug:** The "Render Whitespace" toggle in the View menu appears checked by default on a fresh install, even though whitespace rendering is not actively enabled.

**Root Cause:** The `toggled` condition used `ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none')`, which evaluates to `true` for the default value `'selection'` — causing the menu item to appear checked even though the user has not explicitly turned on whitespace rendering.

**Fix:** Replaced the `notEquals` condition with an explicit `ContextKeyExpr.or()` of `equals` checks for `'all'`, `'boundary'`, and `'trailing'`, so the toggle only appears checked when the user has actively selected one of those render modes.

## Changes

- `src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts`: Replaced `notEquals('config.editor.renderWhitespace', 'none')` with an explicit `or()` of `equals()` checks for `'all'`, `'boundary'`, and `'trailing'` to correctly reflect whether whitespace rendering is actively enabled.

## Testing

1. Open VS Code with default settings (or reset `editor.renderWhitespace` to `'selection'`).
2. Open the View menu and navigate to Appearance.
3. Verify that "Render Whitespace" is **not** checked.
4. Click "Render Whitespace" to toggle it on — verify it now shows as checked.
5. Click again to toggle off — verify it returns to unchecked.
6. Set `editor.renderWhitespace` to `'boundary'` or `'trailing'` via settings — verify the toggle shows as checked.