### PR TITLE
fix: show last update time instead of creation time in agent sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
@@ -44,7 +44,7 @@ export const deleteButton: IQuickInputButton = {
 
 export function getSessionDescription(session: IAgentSession): string {
 	const descriptionText = typeof session.description === 'string' ? session.description : session.description ? renderAsPlaintext(session.description) : undefined;
-	const timeAgo = sessionDateFromNow(session.timing.created);
+	const timeAgo = sessionDateFromNow(session.timing.lastRequestEnded ?? session.timing.created);
 	const descriptionParts = [descriptionText, session.providerLabel, timeAgo].filter(part => !!part);
 
 	return descriptionParts.join(' • ');

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -494,9 +494,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			}
 
 			if (!timeLabel) {
-				const date = this.options.isSortedByUpdated?.()
-					? session.timing.lastRequestEnded ?? session.timing.created
-					: session.timing.created;
+				const date = session.timing.lastRequestEnded ?? session.timing.created;
 				const seconds = Math.round((new Date().getTime() - date) / 1000);
 				if (seconds < 60) {
 					timeLabel = localize('secondsDuration', "now");

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { getSessionDescription } from '../../../browser/agentSessions/agentSessionsPicker.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSession, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -1430,5 +1431,56 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		assert.deepStrictEqual(pinnedSessions.length, 1);
 		assert.deepStrictEqual(archivedSessions.length, 1);
 		assert.deepStrictEqual(todaySessions.length, 0);
+	});
+});
+
+suite('getSessionDescription (issue #306025 - last update time)', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createSession(overrides: {
+		id?: string;
+		created: number;
+		lastRequestEnded?: number;
+	}): IAgentSession {
+		return {
+			providerType: 'test',
+			providerLabel: 'Test',
+			resource: URI.parse('test://session/' + (overrides.id ?? 'default')),
+			status: ChatSessionStatus.Completed,
+			label: 'Session ' + (overrides.id ?? 'default'),
+			icon: Codicon.terminal,
+			timing: {
+				created: overrides.created,
+				lastRequestEnded: overrides.lastRequestEnded,
+				lastRequestStarted: undefined,
+			},
+			changes: undefined,
+			metadata: undefined,
+			isArchived: () => false,
+			setArchived: () => { },
+			isPinned: () => false,
+			setPinned: () => { },
+			isRead: () => true,
+			isMarkedUnread: () => false,
+			setRead: () => { },
+		};
+	}
+
+	test('uses lastRequestEnded when available', () => {
+		const now = Date.now();
+		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+		const session = createSession({ id: 'updated', created: tenDaysAgo, lastRequestEnded: now });
+		const description = getSessionDescription(session);
+		// Should show 'now' or a very recent time, not '10 days'
+		assert.ok(!description.includes('10 days'), 'Expected recent time, not 10 days: ' + description);
+	});
+
+	test('falls back to created when lastRequestEnded is undefined', () => {
+		const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+		const session = createSession({ id: 'created-only', created: tenDaysAgo });
+		const description = getSessionDescription(session);
+		// Should show the creation time (~10 days)
+		assert.ok(description.includes('10 days') || description.includes('day'), 'Expected ~10 days: ' + description);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #306025

**Bug:** Agent session items always displayed the session creation time, even after the session had been updated with new requests.

**Root Cause:** Both `agentSessionsViewer.ts` and `agentSessionsPicker.ts` were using `session.timing.created` unconditionally to compute the displayed time label, ignoring `session.timing.lastRequestEnded`.

**Fix:** Changed both files to use `session.timing.lastRequestEnded ?? session.timing.created` so the most recent activity time is shown when available, falling back to the creation time for sessions that have never had a completed request.

## Changes

- `src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts`: Removed the conditional that only used `lastRequestEnded` when the list was sorted by updated time; now always prefers `lastRequestEnded` over `created` for the time label.
- `src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts`: Updated `getSessionDescription` to use `session.timing.lastRequestEnded ?? session.timing.created` instead of always `session.timing.created`.
- `src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts`: Added regression tests for `getSessionDescription` verifying it shows the last update time when available and falls back to creation time otherwise.

## Testing

- Added regression tests in `src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts` in a new suite `getSessionDescription (issue #306025 - last update time)` that verifies:
  - `getSessionDescription` returns a recent time when `lastRequestEnded` is set to now (not the 10-days-ago creation time)
  - `getSessionDescription` falls back to `created` when `lastRequestEnded` is undefined
- All existing tests pass