### PR TITLE
fix: normalize leading ./ in ResourceGlobMatcher expressions (#304130)

### DIFF
--- a/src/vs/workbench/common/resources.ts
+++ b/src/vs/workbench/common/resources.ts
@@ -147,6 +147,13 @@ export class ResourceGlobMatcher extends Disposable {
 
 			let massagedKey = key;
 
+			// Normalize relative paths that start with './' or '.\\'.
+			// so that they match correctly against relative resource paths.
+			// For example, './src/**' should match the same as 'src/**'.
+			if (massagedKey.startsWith('./') || massagedKey.startsWith('.\\')) {
+				massagedKey = massagedKey.substring(2);
+			}
+
 			const driveLetter = getDriveLetter(massagedKey, true /* probe for windows */);
 			if (driveLetter) {
 				const driveLetterLower = driveLetter.toLowerCase();

--- a/src/vs/workbench/test/common/resources.test.ts
+++ b/src/vs/workbench/test/common/resources.test.ts
@@ -11,6 +11,8 @@ import { TestConfigurationService } from '../../../platform/configuration/test/c
 import { IWorkspaceContextService } from '../../../platform/workspace/common/workspace.js';
 import { ResourceGlobMatcher } from '../../common/resources.js';
 import { TestContextService } from './workbenchTestServices.js';
+import { testWorkspace } from '../../../platform/workspace/test/common/testWorkspace.js';
+import { isWindows } from '../../../base/common/platform.js';
 
 suite('ResourceGlobMatcher', () => {
 
@@ -74,6 +76,20 @@ suite('ResourceGlobMatcher', () => {
 
 		assert.equal(matcher.matches(URI.file('/bar/foo.1')), true);
 		assert.equal(matcher.matches(URI.file('C:/bar/foo.1')), true);
+	});
+
+	test("relative path prefix ./ is normalized (issue #304130)", async () => {
+		// Regression test: patterns like './src/**' in files.readonlyInclude must behave
+		// the same as 'src/**'. The ResourceGlobMatcher used to leave the leading './' in
+		// place, so the glob never matched the workspace-relative resource path.
+		const wsRoot = isWindows ? 'C:\\testWorkspace' : '/testWorkspace';
+		const workspaceCtx = new TestContextService(testWorkspace(URI.file(wsRoot)));
+		await configurationService.setUserConfiguration(SETTING, { ["./src/**"]: true });
+		// eslint-disable-next-line local/code-no-any-casts
+		configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: (key: string) => key === SETTING } as any);
+		const resource = URI.file(wsRoot + (isWindows ? '\\src\\file.ts' : '/src/file.ts'));
+		const matcher = disposables.add(new ResourceGlobMatcher(() => configurationService.getValue(SETTING), e => e.affectsConfiguration(SETTING), workspaceCtx, configurationService));
+		assert.equal(matcher.matches(resource), true, '"./src/**" should match a resource under src/ within the workspace');
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
Fixes #304130

**Bug:** Patterns like `./src/**` in `files.readonlyInclude` (set via a `.code-workspace` file) were never matched because the leading `./` was preserved in the parsed glob expression, while the resource path matched against is workspace-relative (e.g. `src/file.ts`).

**Root Cause:** `ResourceGlobMatcher.doGetExpression()` did not normalize keys that begin with `./` or `.\`, so the resulting glob never matched a relative path that naturally lacks the `./` prefix.

**Fix:** Strip a leading `./` or `.\` from each expression key during normalization, making `./src/**` behave identically to `src/**`.

## Changes

- `src/vs/workbench/common/resources.ts`: In `doGetExpression()`, added a normalization step that removes a leading `./` or `.\` from each expression key before it is stored in the massaged expression.
- `src/vs/workbench/test/common/resources.test.ts`: Added a regression test that verifies a pattern of `./src/**` matches a workspace-relative resource path `src/file.ts`.

## Testing

1. Open a multi-root workspace (`.code-workspace`) and add an entry to `files.readonlyInclude` using a relative-path prefix, e.g.:
   ```json
   "files.readonlyInclude": {
     "./src/**": true
   }
   ```
2. Open a file under `src/` in that workspace — it should now be marked read-only.
3. Run the unit test: `src/vs/workbench/test/common/resources.test.ts` — the new test `relative path prefix ./ is normalized (issue #304130)` should pass.
4. All existing `ResourceGlobMatcher` tests continue to pass.