### PR TITLE
fix #291582: themes: add scrollbar shadow to 2026 themes

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -46,7 +46,7 @@
 		"inputValidation.errorBackground": "#3A1D1D",
 		"inputValidation.errorBorder": "#BE1100",
 		"inputValidation.errorForeground": "#bfbfbf",
-		"scrollbar.shadow": "#191B1D4D",
+		"scrollbar.shadow": "#7f8b96be",
 		"scrollbarSlider.background": "#83848533",
 		"scrollbarSlider.hoverBackground": "#83848566",
 		"scrollbarSlider.activeBackground": "#83848599",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -48,7 +48,7 @@
 		"inputValidation.errorBackground": "#FDEDED",
 		"inputValidation.errorBorder": "#ad0707",
 		"inputValidation.errorForeground": "#202020",
-		"scrollbar.shadow": "#00000000",
+		"scrollbar.shadow": "#989898ce",
 		"widget.shadow": "#00000000",
 		"widget.border": "#E2E2E5",
 		"editorStickyScroll.shadow": "#00000000",

--- a/src/vs/workbench/contrib/themes/test/node/themeTransparency.test.ts
+++ b/src/vs/workbench/contrib/themes/test/node/themeTransparency.test.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from '../../../../../base/common/path.js';
+import assert from 'assert';
+import { Color } from '../../../../../base/common/color.js';
+import { FileAccess } from '../../../../../base/common/network.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+
+suite('Theme Transparency', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const themesPath = FileAccess.asFileUri('vs/../../extensions/theme-defaults/themes').fsPath;
+
+	async function getScrollbarShadowAlpha(themeFileName: string): Promise<number | undefined> {
+		const themePath = path.join(themesPath, themeFileName);
+		const content = (await fs.promises.readFile(themePath)).toString();
+		const match = content.match(/"scrollbar\.shadow"\s*:\s*"#([0-9a-fA-F]+)"/);
+		if (match && match[1]) {
+			const color = Color.fromHex('#' + match[1]);
+			return color.rgba.a;
+		}
+		return undefined;
+	}
+
+	test('scrollbar.shadow alpha should be below 0.85', async () => {
+		const lightAlpha = await getScrollbarShadowAlpha('2026-light.json');
+		const darkAlpha = await getScrollbarShadowAlpha('2026-dark.json');
+
+		const threshold = 0.85; // Threshold for transparency value
+
+		if (lightAlpha !== undefined) {
+			// Checks Light Theme
+			assert.ok(lightAlpha < threshold, `Light theme scrollbar.shadow alpha (${lightAlpha}) should be below ${threshold}`);
+		} else {
+			assert.fail('Light theme scrollbar.shadow not found');
+		}
+
+		if (darkAlpha !== undefined) {
+			// Checks Dark Theme
+			assert.ok(darkAlpha < threshold, `Dark theme scrollbar.shadow alpha (${darkAlpha}) should be below ${threshold}`);
+		} else {
+			assert.fail('Dark theme scrollbar.shadow not found');
+		}
+	});
+});


### PR DESCRIPTION
Fixes #291582

**Description of proposed changes:**
Updates the `scrollbar.shadow` color in both `2026-dark.json` and `2026-light.json` with more opaque hex values that match the existing color palette of each theme while ensuring proper visibility. 

Includes an automated test to ensure the `scrollbar.shadow` alpha in the 2026 themes remains below a threshold of `0.85`.

**Screenshots:**
<img width="298" height="329" alt="Screenshot LightTheme" src="https://github.com/user-attachments/assets/07cfff69-03e6-4581-a5bd-4604161d895c" />
<img width="301" height="329" alt="Screenshot DarkTheme" src="https://github.com/user-attachments/assets/0b7226d3-4372-4c5d-8193-af09d61d2e12" />

**How to test:**
1. Fill the chatbox with enough lines to trigger the scrollbar and scroll down to observe the new top shadow.
2. Run the test suite to verify the newly added alpha threshold test passes.