### PR TITLE
sessions: hide disabled chat input pickers

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -116,6 +116,13 @@
 	box-sizing: border-box;
 }
 
+/* Hide shared chat-session option-group pickers in the sessions app active chat UI.
+ * The sessions workbench provides its own new-session configuration controls and
+ * should not surface the shared workbench chat session pickers here. */
+.agent-sessions-workbench .interactive-session .chat-input-toolbars .chat-sessionPicker-container {
+	display: none;
+}
+
 /* ---- Modal Editor Block ---- */
 
 .agent-sessions-workbench .monaco-modal-editor-block {

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -114,7 +114,7 @@ export class SessionTypePicker extends Disposable {
 	}
 
 	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._slotElement) {
 			return;
 		}
 
@@ -129,7 +129,10 @@ export class SessionTypePicker extends Disposable {
 		labelSpan.textContent = modeLabel;
 
 		const hasMultipleTypes = this._sessionTypes.length > 1;
-		this._slotElement?.classList.toggle('disabled', !hasMultipleTypes);
+		dom.setVisibility(hasMultipleTypes, this._slotElement);
+		this._slotElement.classList.toggle('disabled', false);
+		this._triggerElement.setAttribute('aria-hidden', String(!hasMultipleTypes));
+		this._triggerElement.tabIndex = hasMultipleTypes ? 0 : -1;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 	}
 }

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTypePicker.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { constObservable, observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IActiveSession, ISessionsManagementService } from '../../../sessions/browser/sessionsManagementService.js';
+import { ISessionType } from '../../../sessions/browser/sessionsProvider.js';
+import { SessionStatus } from '../../../sessions/common/sessionData.js';
+import { SessionTypePicker } from '../../browser/sessionTypePicker.js';
+
+function createActiveSession(sessionType: string): IActiveSession {
+	const chat = {
+		resource: URI.parse(`test:///chat/${sessionType}`),
+		createdAt: new Date(),
+		title: constObservable('Chat'),
+		updatedAt: constObservable(new Date()),
+		status: constObservable(SessionStatus.Untitled),
+		changes: constObservable([]),
+		modelId: constObservable(undefined),
+		mode: constObservable(undefined),
+		isArchived: constObservable(false),
+		isRead: constObservable(true),
+		description: constObservable(undefined),
+		lastTurnEnd: constObservable(undefined),
+	};
+
+	return {
+		sessionId: `provider:${sessionType}`,
+		resource: URI.parse(`test:///session/${sessionType}`),
+		providerId: 'provider',
+		sessionType,
+		icon: Codicon.copilot,
+		createdAt: new Date(),
+		workspace: constObservable(undefined),
+		title: constObservable('Session'),
+		updatedAt: constObservable(new Date()),
+		status: constObservable(SessionStatus.Untitled),
+		changes: constObservable([]),
+		modelId: constObservable(undefined),
+		mode: constObservable(undefined),
+		loading: constObservable(false),
+		isArchived: constObservable(false),
+		isRead: constObservable(true),
+		description: constObservable(undefined),
+		lastTurnEnd: constObservable(undefined),
+		gitHubInfo: constObservable(undefined),
+		chats: constObservable([chat]),
+		mainChat: chat,
+		activeChat: constObservable(chat),
+	};
+}
+
+suite('SessionTypePicker', () => {
+
+	const disposables = new DisposableStore();
+	let sessionTypes: ISessionType[];
+	let activeSession: ReturnType<typeof observableValue<IActiveSession | undefined>>;
+	let instantiationService: TestInstantiationService;
+
+	setup(() => {
+		sessionTypes = [];
+		activeSession = observableValue('activeSession', undefined);
+		instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(IActionWidgetService, { isVisible: false, hide: () => { }, show: () => { } });
+		instantiationService.stub(ISessionsManagementService, {
+			activeSession,
+			getSessionTypes: () => sessionTypes,
+			setSessionType: () => {
+				throw new Error('Not implemented');
+			},
+		});
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('hides the picker when only one session type is available', () => {
+		sessionTypes = [{ id: 'copilotcli', label: 'Copilot CLI', icon: Codicon.copilot }];
+		activeSession.set(createActiveSession('copilotcli'), undefined);
+
+		const picker = disposables.add(instantiationService.createInstance(SessionTypePicker));
+		const container = document.createElement('div');
+		picker.render(container);
+
+		const slot = container.querySelector<HTMLElement>('.sessions-chat-picker-slot');
+		assert.ok(slot);
+		assert.strictEqual(slot.style.display, 'none');
+	});
+
+	test('shows the picker when multiple session types are available', () => {
+		sessionTypes = [
+			{ id: 'copilotcli', label: 'Copilot CLI', icon: Codicon.copilot },
+			{ id: 'copilot-cloud-agent', label: 'Cloud', icon: Codicon.cloud },
+		];
+		activeSession.set(createActiveSession('copilotcli'), undefined);
+
+		const picker = disposables.add(instantiationService.createInstance(SessionTypePicker));
+		const container = document.createElement('div');
+		picker.render(container);
+
+		const slot = container.querySelector<HTMLElement>('.sessions-chat-picker-slot');
+		assert.ok(slot);
+		assert.strictEqual(slot.style.display, '');
+	});
+});

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -129,7 +129,7 @@ export class BranchPicker extends Disposable {
 	}
 
 	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._slotElement) {
 			return;
 		}
 		dom.clearNode(this._triggerElement);
@@ -145,8 +145,11 @@ export class BranchPicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
-		this._slotElement?.classList.toggle('disabled', isLoading || isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isLoading || isDisabled));
-		this._triggerElement.tabIndex = (isLoading || isDisabled) ? -1 : 0;
+		const visible = !(isLoading || isDisabled);
+		dom.setVisibility(visible, this._slotElement);
+		this._slotElement.classList.toggle('disabled', false);
+		this._triggerElement.setAttribute('aria-hidden', String(!visible));
+		this._triggerElement.setAttribute('aria-disabled', String(!visible));
+		this._triggerElement.tabIndex = visible ? 0 : -1;
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -29,7 +29,7 @@ import { ISession } from '../../sessions/common/sessionData.js';
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { COPILOT_PROVIDER_ID, CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
 import { COPILOT_CLI_SESSION_TYPE, COPILOT_CLOUD_SESSION_TYPE } from '../../sessions/browser/sessionTypes.js';
-import { ActiveSessionHasGitRepositoryContext, ActiveSessionProviderIdContext, ActiveSessionTypeContext, ChatSessionProviderIdContext } from '../../../common/contextkeys.js';
+import { ActiveSessionHasGitRepositoryContext, ActiveSessionProviderIdContext, ActiveSessionTypeContext, ChatSessionProviderIdContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
 import { IsolationPicker } from './isolationPicker.js';
 import { BranchPicker } from './branchPicker.js';
 import { ModePicker } from './modePicker.js';
@@ -56,6 +56,7 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				order: 1,
 				when: ContextKeyExpr.and(
+					IsNewChatSessionContext,
 					IsActiveSessionCopilotChatCLI,
 					ContextKeyExpr.equals('config.github.copilot.chat.cli.isolationOption.enabled', true),
 				),
@@ -76,7 +77,10 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionRepositoryConfig,
 				group: 'navigation',
 				order: 2,
-				when: IsActiveSessionCopilotChatCLI,
+				when: ContextKeyExpr.and(
+					IsNewChatSessionContext,
+					IsActiveSessionCopilotChatCLI,
+				),
 			}],
 		});
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -160,7 +160,7 @@ export class IsolationPicker extends Disposable {
 	}
 
 	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._slotElement) {
 			return;
 		}
 
@@ -187,9 +187,11 @@ export class IsolationPicker extends Disposable {
 		labelSpan.textContent = modeLabel;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
-		const isDisabled = !this._hasGitRepo;
-		this._slotElement?.classList.toggle('disabled', isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
-		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
+		const visible = this._isolationOptionEnabled && this._hasGitRepo;
+		dom.setVisibility(visible, this._slotElement);
+		this._slotElement.classList.toggle('disabled', false);
+		this._triggerElement.setAttribute('aria-hidden', String(!visible));
+		this._triggerElement.setAttribute('aria-disabled', String(!visible));
+		this._triggerElement.tabIndex = visible ? 0 : -1;
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -223,7 +223,7 @@ export class ModePicker extends Disposable {
 	}
 
 	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._slotElement) {
 			return;
 		}
 
@@ -239,6 +239,10 @@ export class ModePicker extends Disposable {
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
 		const modes = this._getAvailableModes();
-		this._slotElement?.classList.toggle('disabled', modes.length <= 1);
+		const visible = modes.length > 1;
+		dom.setVisibility(visible, this._slotElement);
+		this._slotElement.classList.toggle('disabled', false);
+		this._triggerElement.setAttribute('aria-hidden', String(!visible));
+		this._triggerElement.tabIndex = visible ? 0 : -1;
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
@@ -198,7 +198,7 @@ export class CloudModelPicker extends Disposable {
 	}
 
 	private _updateTriggerLabel(): void {
-		if (!this._triggerElement) {
+		if (!this._triggerElement || !this._slotElement) {
 			return;
 		}
 
@@ -209,7 +209,11 @@ export class CloudModelPicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
-		this._slotElement?.classList.toggle('disabled', this._models.length === 0);
-		this._triggerElement.setAttribute('aria-disabled', String(this._models.length === 0));
+		const visible = this._models.length > 0;
+		dom.setVisibility(visible, this._slotElement);
+		this._slotElement.classList.toggle('disabled', false);
+		this._triggerElement.setAttribute('aria-hidden', String(!visible));
+		this._triggerElement.setAttribute('aria-disabled', String(!visible));
+		this._triggerElement.tabIndex = visible ? 0 : -1;
 	}
 }


### PR DESCRIPTION
Fixes #306455.

## Summary
- hide disabled picker controls in the sessions app new/active chat UI
- stop contributing the worktree and branch repository-config pickers outside the new-session state
- add focused coverage for hiding the session-type picker when only one choice is available

## Notes for reviewers
An intentional decision was made to keep this fix scoped to the sessions app rather than changing shared lower-level workbench chat widgets.

In particular, the remaining active-session dropdowns rendered through the shared `chat-sessionPicker-container` are hidden in the sessions app with scoped CSS (`display: none`) under `src/vs/sessions/browser/media/style.css`.

That was done deliberately to avoid reaching down into lower-level shared widget infrastructure for a sessions-specific UI issue.

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- hygiene on touched sessions files