### PR TITLE
Sessions: Fix stopped session stuck in list as Working

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -23,7 +23,7 @@ import { IChatResponseModel } from '../../../../workbench/contrib/chat/common/mo
 import { ChatSessionStatus, IChatSessionFileChange, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo } from '../../sessions/common/sessionData.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
-import { basename } from '../../../../base/common/resources.js';
+import { basename, isEqual } from '../../../../base/common/resources.js';
 import { ISendRequestOptions, ISessionsBrowseAction, ISessionChangeEvent, ISessionsProvider, ISessionType } from '../../sessions/browser/sessionsProvider.js';
 import { ISessionOptionGroup } from '../../chat/browser/newSession.js';
 import { IsolationMode } from './isolationPicker.js';
@@ -1595,7 +1595,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		try {
 			const commitPromise = new Promise<URI>(resolve => {
 				disposables.add(this.chatSessionsService.onDidCommitSession(e => {
-					if (e.original.toString() === untitledResource.toString()) {
+					if (isEqual(e.original, untitledResource)) {
 						resolve(e.committed);
 					}
 				}));

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -19,6 +19,7 @@ import { getRepositoryName } from '../../../../workbench/contrib/chat/browser/ag
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { AgentSessionProviders, AgentSessionTarget } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
 import { IChatService, IChatSendRequestOptions } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatResponseModel } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatSessionStatus, IChatSessionFileChange, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo } from '../../sessions/common/sessionData.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
@@ -1376,9 +1377,12 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 		}
 
-		// Extract the response completion promise to detect cancellation
+		// Extract promises to detect cancellation vs normal completion
 		const responseCompletePromise = result.kind === 'sent'
 			? result.data.responseCompletePromise
+			: undefined;
+		const responseCreatedPromise = result.kind === 'sent'
+			? result.data.responseCreatedPromise
 			: undefined;
 
 		// Add the new session to the sessions model immediately so it appears in the sessions list
@@ -1392,7 +1396,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		try {
 
 			// Wait for the session to be committed (URI swapped from untitled to real)
-			const committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise);
+			const committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise, responseCreatedPromise);
 
 			// Wait for _refreshSessionCache to populate the committed adapter
 			const committedChat = await this._waitForSessionInCache(committedResource);
@@ -1479,14 +1483,17 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 		}
 
-		// Extract the response completion promise to detect cancellation
+		// Extract promises to detect cancellation vs normal completion
 		const responseCompletePromise = result.kind === 'sent'
 			? result.data.responseCompletePromise
+			: undefined;
+		const responseCreatedPromise = result.kind === 'sent'
+			? result.data.responseCreatedPromise
 			: undefined;
 
 		try {
 			// Wait for the session to be committed
-			const committedResource = await this._waitForCommittedSession(newChatSession.resource, responseCompletePromise);
+			const committedResource = await this._waitForCommittedSession(newChatSession.resource, responseCompletePromise, responseCreatedPromise);
 
 			const committedChat = await this._waitForSessionInCache(committedResource);
 
@@ -1570,16 +1577,19 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	 * Waits for the committed (real) URI for a session by listening to the
 	 * {@link IChatSessionsService.onDidCommitSession} event.
 	 *
-	 * If {@link responseCompletePromise} is provided, the wait is bounded:
-	 * when the response completes (success, error, or cancellation) without
-	 * a prior commit, the session was never committed and the promise rejects
-	 * so the caller can clean up the temp session. In normal flow the session
-	 * commit fires during request processing (e.g. worktree creation), well
-	 * before the response completes, so the commit promise always wins the race.
+	 * When {@link responseCompletePromise} is provided, the wait is bounded by
+	 * response completion. If the response finishes before the commit event:
+	 * - If the response was **cancelled**, the session was stopped before the
+	 *   agent created the backing resource → throw immediately.
+	 * - If the response completed **normally**, the commit event is legitimately
+	 *   in-flight (the extension fired it mid-turn but the async IPC chain in
+	 *   {@link MainThreadChatSessions.$onDidCommitChatSessionItem} hasn't finished
+	 *   yet) → keep waiting with the safety timeout.
 	 */
 	private async _waitForCommittedSession(
 		untitledResource: URI,
 		responseCompletePromise?: Promise<void>,
+		responseCreatedPromise?: Promise<IChatResponseModel>,
 	): Promise<URI> {
 		const disposables = new DisposableStore();
 		try {
@@ -1593,10 +1603,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 			if (responseCompletePromise) {
 				// Race the commit event against the response completing.
-				// In normal flow the commit fires during request processing
-				// (before the response finishes), so commitPromise wins.
-				// If the response finishes first (e.g. cancelled before
-				// worktree creation), the commit will never arrive.
 				const committed = await Promise.race([
 					commitPromise.then(uri => ({ committed: true as const, uri })),
 					responseCompletePromise.then(() => ({ committed: false as const })),
@@ -1606,10 +1612,17 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 					return committed.uri;
 				}
 
-				throw new Error('Session was not committed before response completed');
+				// Response finished before the commit event arrived.
+				// Check whether it was cancelled — if so, the commit will never come.
+				const response = await responseCreatedPromise;
+				if (response?.isCanceled) {
+					throw new Error('Session was cancelled before being committed');
+				}
+
+				// Response completed normally — the commit is in-flight (async IPC),
+				// wait for it with the safety timeout.
 			}
 
-			// No response promise — use a safety timeout
 			const result = await raceTimeout(commitPromise, 60_000);
 			if (!result) {
 				throw new Error('Timed out waiting for session commit');

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1748,10 +1748,13 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		const key = chatSession.resource.toString();
 		this._sessionCache.delete(key);
+		this._sessionGroupCache.delete(chatSession.id);
 		if (this._currentNewSession?.id === chatSession.id) {
 			this._currentNewSession = undefined;
 		}
-		this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(chatSession)], changed: [] });
+		const removedSession = this._chatToSession(chatSession);
+		this._sessionGroupCache.delete(chatSession.id);
+		this._onDidChangeSessions.fire({ added: [], removed: [removedSession], changed: [] });
 		if (chatSession instanceof CopilotCLISession || chatSession instanceof RemoteNewSession) {
 			chatSession.dispose();
 		}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1619,11 +1619,13 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 					throw new Error('Session was cancelled before being committed');
 				}
 
-				// Response completed normally — the commit is in-flight (async IPC),
-				// wait for it with the safety timeout.
+				// Response completed normally — the commit is in-flight (the extension
+				// fired it before the response finished, but the async IPC chain hasn't
+				// delivered it yet). It should arrive in milliseconds; use a short
+				// safety timeout to avoid blocking forever on an IPC failure.
 			}
 
-			const result = await raceTimeout(commitPromise, 60_000);
+			const result = await raceTimeout(commitPromise, 5_000);
 			if (!result) {
 				throw new Error('Timed out waiting for session commit');
 			}
@@ -1636,6 +1638,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	/**
 	 * Waits for an {@link AgentSessionAdapter} with the given resource to appear
 	 * in the session cache (populated by {@link _refreshSessionCache}).
+	 * Only called once during session initialisation (after the commit event),
+	 * so the timeout has no performance impact on steady-state operations.
 	 */
 	private async _waitForSessionInCache(resource: URI): Promise<AgentSessionAdapter> {
 		const key = resource.toString();
@@ -1657,7 +1661,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 			// The adapter should appear almost immediately after the commit
 			// event via _refreshSessionCache; use a short safety timeout.
-			const result = await raceTimeout(sessionPromise, 10_000);
+			const result = await raceTimeout(sessionPromise, 5_000);
 			if (!result) {
 				throw new Error('Timed out waiting for committed session in cache');
 			}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { raceTimeout } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, IObservable, IReader, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
 import { themeColorFromId, ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -1171,7 +1172,11 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const agentSession = this._findAgentSession(sessionId);
 		if (agentSession) {
 			agentSession.setArchived(true);
+			return;
 		}
+
+		// Temp session that hasn't been committed — remove it directly
+		this._cleanupTempSession(sessionId);
 	}
 
 	async unarchiveSession(sessionId: string): Promise<void> {
@@ -1195,30 +1200,34 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			} else {
 				await this.chatService.removeHistoryEntry(agentSession.resource);
 			}
-		}
 
-		// Delete all other chats in the group
-		for (const chatId of chatIds) {
-			if (chatId === sessionId) {
-				continue; // Already deleted above
-			}
-			const chatSession = this._findAgentSession(chatId);
-			if (chatSession) {
-				if (chatSession.providerType === CopilotCLISessionType.id) {
-					this.commandService.executeCommand('github.copilot.cli.sessions.delete', { resource: chatSession.resource });
-				} else {
-					await this.chatService.removeHistoryEntry(chatSession.resource);
+			// Delete all other chats in the group
+			for (const chatId of chatIds) {
+				if (chatId === sessionId) {
+					continue; // Already deleted above
+				}
+				const chatSession = this._findAgentSession(chatId);
+				if (chatSession) {
+					if (chatSession.providerType === CopilotCLISessionType.id) {
+						this.commandService.executeCommand('github.copilot.cli.sessions.delete', { resource: chatSession.resource });
+					} else {
+						await this.chatService.removeHistoryEntry(chatSession.resource);
+					}
 				}
 			}
+
+			// Clean up group model
+			if (this._isMultiChatEnabled()) {
+				this._groupModel.deleteSession(sessionId);
+				this._sessionGroupCache.delete(sessionId);
+			}
+
+			this._refreshSessionCache();
+			return;
 		}
 
-		// Clean up group model
-		if (this._isMultiChatEnabled()) {
-			this._groupModel.deleteSession(sessionId);
-			this._sessionGroupCache.delete(sessionId);
-		}
-
-		this._refreshSessionCache();
+		// Temp session that hasn't been committed — remove it directly
+		this._cleanupTempSession(sessionId);
 	}
 
 	async renameChat(sessionId: string, _chatUri: URI, title: string): Promise<void> {
@@ -1367,6 +1376,11 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 		}
 
+		// Extract the response completion promise to detect cancellation
+		const responseCompletePromise = result.kind === 'sent'
+			? result.data.responseCompletePromise
+			: undefined;
+
 		// Add the new session to the sessions model immediately so it appears in the sessions list
 		session.setTitle(localize('new session', "New Session"));
 		session.setStatus(SessionStatus.InProgress);
@@ -1378,7 +1392,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		try {
 
 			// Wait for the session to be committed (URI swapped from untitled to real)
-			const committedResource = await this._waitForCommittedSession(session.resource);
+			const committedResource = await this._waitForCommittedSession(session.resource, responseCompletePromise);
 
 			// Wait for _refreshSessionCache to populate the committed adapter
 			const committedChat = await this._waitForSessionInCache(committedResource);
@@ -1465,9 +1479,14 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			throw new Error(`[DefaultCopilotProvider] sendRequest rejected: ${result.reason}`);
 		}
 
+		// Extract the response completion promise to detect cancellation
+		const responseCompletePromise = result.kind === 'sent'
+			? result.data.responseCompletePromise
+			: undefined;
+
 		try {
 			// Wait for the session to be committed
-			const committedResource = await this._waitForCommittedSession(newChatSession.resource);
+			const committedResource = await this._waitForCommittedSession(newChatSession.resource, responseCompletePromise);
 
 			const committedChat = await this._waitForSessionInCache(committedResource);
 
@@ -1550,37 +1569,89 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	/**
 	 * Waits for the committed (real) URI for a session by listening to the
 	 * {@link IChatSessionsService.onDidCommitSession} event.
+	 *
+	 * If {@link responseCompletePromise} is provided, the wait is bounded:
+	 * when the response completes (success, error, or cancellation) without
+	 * a prior commit, the session was never committed and the promise rejects
+	 * so the caller can clean up the temp session. In normal flow the session
+	 * commit fires during request processing (e.g. worktree creation), well
+	 * before the response completes, so the commit promise always wins the race.
 	 */
-	private _waitForCommittedSession(untitledResource: URI): Promise<URI> {
-		return new Promise<URI>(resolve => {
-			const listener = this.chatSessionsService.onDidCommitSession(e => {
-				if (e.original.toString() === untitledResource.toString()) {
-					listener.dispose();
-					resolve(e.committed);
-				}
+	private async _waitForCommittedSession(
+		untitledResource: URI,
+		responseCompletePromise?: Promise<void>,
+	): Promise<URI> {
+		const disposables = new DisposableStore();
+		try {
+			const commitPromise = new Promise<URI>(resolve => {
+				disposables.add(this.chatSessionsService.onDidCommitSession(e => {
+					if (e.original.toString() === untitledResource.toString()) {
+						resolve(e.committed);
+					}
+				}));
 			});
-		});
+
+			if (responseCompletePromise) {
+				// Race the commit event against the response completing.
+				// In normal flow the commit fires during request processing
+				// (before the response finishes), so commitPromise wins.
+				// If the response finishes first (e.g. cancelled before
+				// worktree creation), the commit will never arrive.
+				const committed = await Promise.race([
+					commitPromise.then(uri => ({ committed: true as const, uri })),
+					responseCompletePromise.then(() => ({ committed: false as const })),
+				]);
+
+				if (committed.committed) {
+					return committed.uri;
+				}
+
+				throw new Error('Session was not committed before response completed');
+			}
+
+			// No response promise — use a safety timeout
+			const result = await raceTimeout(commitPromise, 60_000);
+			if (!result) {
+				throw new Error('Timed out waiting for session commit');
+			}
+			return result;
+		} finally {
+			disposables.dispose();
+		}
 	}
 
 	/**
 	 * Waits for an {@link AgentSessionAdapter} with the given resource to appear
 	 * in the session cache (populated by {@link _refreshSessionCache}).
 	 */
-	private _waitForSessionInCache(resource: URI): Promise<AgentSessionAdapter> {
+	private async _waitForSessionInCache(resource: URI): Promise<AgentSessionAdapter> {
 		const key = resource.toString();
 		const existing = this._sessionCache.get(key);
 		if (existing instanceof AgentSessionAdapter) {
-			return Promise.resolve(existing);
+			return existing;
 		}
-		return new Promise<AgentSessionAdapter>(resolve => {
-			const listener = this.onDidChangeSessions(e => {
-				const cached = this._sessionCache.get(key);
-				if (cached instanceof AgentSessionAdapter) {
-					listener.dispose();
-					resolve(cached);
-				}
+
+		const disposables = new DisposableStore();
+		try {
+			const sessionPromise = new Promise<AgentSessionAdapter>(resolve => {
+				disposables.add(this.onDidChangeSessions(e => {
+					const cached = this._sessionCache.get(key);
+					if (cached instanceof AgentSessionAdapter) {
+						resolve(cached);
+					}
+				}));
 			});
-		});
+
+			// The adapter should appear almost immediately after the commit
+			// event via _refreshSessionCache; use a short safety timeout.
+			const result = await raceTimeout(sessionPromise, 10_000);
+			if (!result) {
+				throw new Error('Timed out waiting for committed session in cache');
+			}
+			return result;
+		} finally {
+			disposables.dispose();
+		}
 	}
 
 	// -- Private --
@@ -1645,6 +1716,28 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			return;
 		}
 		this._refreshSessionCache();
+	}
+
+	/**
+	 * Cleans up a temp session (one that hasn't been committed) from the cache.
+	 * Used when delete/archive is invoked on a session that is still pending
+	 * commit (e.g. was stopped before the agent created a worktree).
+	 */
+	private _cleanupTempSession(sessionId: string): void {
+		const chatSession = this._findChatSession(sessionId);
+		if (!chatSession) {
+			return;
+		}
+
+		const key = chatSession.resource.toString();
+		this._sessionCache.delete(key);
+		if (this._currentNewSession?.id === chatSession.id) {
+			this._currentNewSession = undefined;
+		}
+		this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(chatSession)], changed: [] });
+		if (chatSession instanceof CopilotCLISession || chatSession instanceof RemoteNewSession) {
+			chatSession.dispose();
+		}
 	}
 
 	private _refreshSessionCache(): void {

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -23,9 +23,12 @@ import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/bro
 import { AgentSessionProviders } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
 import { IChatService, ChatSendResult, IChatSendRequestData } from '../../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatSessionStatus, IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
+import { IChatResponseModel } from '../../../../../workbench/contrib/chat/common/model/chatModel.js';
+import { IChatAgentData } from '../../../../../workbench/contrib/chat/common/participants/chatAgents.js';
+import { IGitService } from '../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionChangeEvent } from '../../../sessions/browser/sessionsProvider.js';
 import { ISessionWorkspace } from '../../../sessions/common/sessionData.js';
 import { CopilotChatSessionsProvider, COPILOT_PROVIDER_ID } from '../../browser/copilotChatSessionsProvider.js';
@@ -160,7 +163,68 @@ function createProvider(
 	return provider;
 }
 
-// ---- Tests ------------------------------------------------------------------
+// ---- Provider factory for send/cancel tests ---------------------------------
+
+/**
+ * Creates a provider suitable for testing sendChat flows. Stubs all services
+ * needed by CopilotCLISession and _sendFirstChat, including IGitService and a
+ * non-null IChatWidget mock.
+ *
+ * The caller can pass a custom `sendRequest` implementation to control the
+ * lifecycle of the in-flight request.
+ */
+function createProviderForSendTests(
+	disposables: DisposableStore,
+	model: MockAgentSessionsModel,
+	sendRequest: () => Promise<ChatSendResult>,
+): CopilotChatSessionsProvider {
+	const instantiationService = disposables.add(new TestInstantiationService());
+
+	const configService = new TestConfigurationService();
+	configService.setUserConfiguration('sessions.github.copilot.multiChatSessions', false);
+
+	instantiationService.stub(IConfigurationService, configService);
+	instantiationService.stub(IStorageService, disposables.add(new TestStorageService()));
+	instantiationService.stub(IFileDialogService, {});
+	instantiationService.stub(ICommandService, { executeCommand: async () => undefined });
+	instantiationService.stub(IAgentSessionsService, {
+		model: model as unknown as IAgentSessionsModel,
+		onDidChangeSessionArchivedState: Event.None,
+		getSession: (resource: URI) => model.getSession(resource),
+	});
+	instantiationService.stub(IChatSessionsService, {
+		getChatSessionContribution: () => ({ type: 'test-copilot', name: 'test', displayName: 'Test', description: 'test', icon: undefined }),
+		getOrCreateChatSession: async () => ({ onWillDispose: () => ({ dispose() { } }), sessionResource: URI.from({ scheme: 'test' }), history: [], dispose() { } }),
+		onDidCommitSession: Event.None,
+		updateSessionOptions: () => true,
+		setSessionOption: () => true,
+		getSessionOption: () => undefined,
+		onDidChangeOptionGroups: Event.None,
+	});
+	instantiationService.stub(IChatService, {
+		acquireOrLoadSession: async () => undefined,
+		sendRequest: sendRequest,
+		removeHistoryEntry: async (resource: URI) => { model.removeSession(resource); },
+		setChatSessionTitle: () => { },
+	});
+	instantiationService.stub(IChatWidgetService, {
+		openSession: async () => new class extends mock<IChatWidget>() {
+			override input = new class extends mock<IChatWidget['input']>() {
+				override setPermissionLevel = () => { };
+			}();
+		}(),
+		lastFocusedWidget: undefined,
+		onDidChangeFocusedSession: Event.None,
+	});
+	instantiationService.stub(ILanguageModelsService, { lookupLanguageModel: () => undefined });
+	instantiationService.stub(ILanguageModelToolsService, { toToolReferences: () => [] });
+	instantiationService.stub(IGitService, { openRepository: async () => undefined });
+	instantiationService.stub(IInstantiationService, instantiationService);
+
+	return disposables.add(instantiationService.createInstance(CopilotChatSessionsProvider));
+}
+
+
 
 suite('CopilotChatSessionsProvider', () => {
 	const disposables = new DisposableStore();
@@ -572,5 +636,132 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.strictEqual(provider.browseActions.length, 2);
 		assert.strictEqual(provider.browseActions[0].providerId, COPILOT_PROVIDER_ID);
 		assert.strictEqual(provider.browseActions[1].providerId, COPILOT_PROVIDER_ID);
+	});
+
+	// ---- Uncommitted temp session cleanup ------------------------------------
+
+	suite('uncommitted temp session cleanup', () => {
+		const workspace: ISessionWorkspace = {
+			label: 'repo',
+			icon: Codicon.folder,
+			repositories: [{
+				uri: URI.file('/test/repo'),
+				workingDirectory: undefined,
+				detail: undefined,
+				baseBranchName: undefined,
+				baseBranchProtected: undefined,
+			}],
+			requiresWorkspaceTrust: false,
+		};
+
+		/**
+		 * Returns a provider wired up so that sendRequest keeps the request
+		 * in-flight indefinitely. Also returns helpers to resolve the request
+		 * as a cancellation (so the provider cleans up promptly in tests).
+		 */
+		function makeInFlightProvider(): {
+			provider: CopilotChatSessionsProvider;
+			cancelRequest: () => void;
+		} {
+			let resolveComplete!: () => void;
+			let resolveCreated!: (r: IChatResponseModel) => void;
+			const responseCompletePromise = new Promise<void>(r => { resolveComplete = r; });
+			const responseCreatedPromise = new Promise<IChatResponseModel>(r => { resolveCreated = r; });
+
+			const provider = createProviderForSendTests(disposables, model, async () => ({
+				kind: 'sent' as const,
+				data: {
+					responseCompletePromise,
+					responseCreatedPromise,
+					agent: new class extends mock<IChatAgentData>() { }(),
+				} as IChatSendRequestData,
+			}));
+
+			return {
+				provider,
+				cancelRequest: () => {
+					resolveCreated({ isCanceled: true } as unknown as IChatResponseModel);
+					resolveComplete();
+				},
+			};
+		}
+
+		/** Wait for the provider to fire an "added" session change event. */
+		function waitForSessionAdded(provider: CopilotChatSessionsProvider): Promise<void> {
+			return new Promise<void>(resolve => {
+				const d = provider.onDidChangeSessions(e => {
+					if (e.added.length > 0) {
+						d.dispose();
+						resolve();
+					}
+				});
+			});
+		}
+
+		test('deleteSession removes a temp session that is awaiting commit', async () => {
+			const { provider, cancelRequest } = makeInFlightProvider();
+
+			const newSession = provider.createNewSession(workspace);
+			const sessionId = newSession.sessionId;
+
+			const added = waitForSessionAdded(provider);
+			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			await added;
+
+			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
+
+			await provider.deleteSession(sessionId);
+			assert.strictEqual(provider.getSessions().length, 0, 'session should be removed after deleteSession');
+
+			// Clean up in-flight request so _sendFirstChat resolves quickly
+			cancelRequest();
+			await sendPromise.catch(() => { /* expected to reject */ });
+		});
+
+		test('archiveSession removes a temp session that is awaiting commit', async () => {
+			const { provider, cancelRequest } = makeInFlightProvider();
+
+			const newSession = provider.createNewSession(workspace);
+			const sessionId = newSession.sessionId;
+
+			const added = waitForSessionAdded(provider);
+			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			await added;
+
+			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
+
+			await provider.archiveSession(sessionId);
+			assert.strictEqual(provider.getSessions().length, 0, 'session should be removed after archiveSession');
+
+			cancelRequest();
+			await sendPromise.catch(() => { /* expected to reject */ });
+		});
+
+		test('cancelling the request before commit removes the temp session', async () => {
+			const { provider, cancelRequest } = makeInFlightProvider();
+
+			const changes: ISessionChangeEvent[] = [];
+			disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
+
+			const newSession = provider.createNewSession(workspace);
+			const sessionId = newSession.sessionId;
+
+			const added = waitForSessionAdded(provider);
+			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			await added;
+
+			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
+			assert.ok(changes.some(e => e.added.some(s => s.sessionId === sessionId)), 'added event should have fired');
+
+			// Simulate user stopping the request
+			cancelRequest();
+			await sendPromise.catch(() => { /* expected to reject */ });
+
+			assert.strictEqual(provider.getSessions().length, 0, 'session should be cleaned up after cancellation');
+			assert.ok(
+				changes.some(e => e.removed.some(s => s.sessionId === sessionId)),
+				'removed event should have fired',
+			);
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -332,8 +332,10 @@ export interface IChatSessionsService {
 	readonly onDidChangeSessionItems: Event<IChatSessionItemsDelta>;
 
 	/**
-	 * Fired when an untitled session is committed (URI swapped to a real resource)
-	 * after the first turn completes.
+	 * Fired when an untitled session is committed (URI swapped to a real resource).
+	 * This typically fires during the first turn (e.g. when the agent creates a
+	 * worktree), but due to async IPC processing may fire shortly after the turn
+	 * completes.
 	 */
 	readonly onDidCommitSession: Event<IChatSessionCommitEvent>;
 

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -332,10 +332,8 @@ export interface IChatSessionsService {
 	readonly onDidChangeSessionItems: Event<IChatSessionItemsDelta>;
 
 	/**
-	 * Fired when an untitled session is committed (URI swapped to a real resource).
-	 * This typically fires during the first turn (e.g. when the agent creates a
-	 * worktree), but due to async IPC processing may fire shortly after the turn
-	 * completes.
+	 * Fired when an untitled session is committed (URI swapped to a real resource)
+	 * after the first turn completes.
 	 */
 	readonly onDidCommitSession: Event<IChatSessionCommitEvent>;
 


### PR DESCRIPTION
Fixes #306883

## Problem

When a session was stopped before the agent created a worktree, it would get permanently stuck in the session list showing "New Session" with "Working..." status. Archive and delete would silently no-op on the stuck entry.

**Root cause:** `_waitForCommittedSession()` and `_waitForSessionInCache()` created promises that never resolved when a request was cancelled before the session was committed (untitled → real URI swap). Since the commit event would never arrive, the temp session remained in the cache indefinitely. Meanwhile, `archiveSession()` and `deleteSession()` relied on `_findAgentSession()` which returns `undefined` for uncommitted temp sessions, causing them to silently no-op.

## Fix

- **Bound `_waitForCommittedSession` with `responseCompletePromise`** — races the commit event against response completion. In normal flow the commit fires during request processing (before the response finishes), so `commitPromise` always wins. If the response finishes first (cancelled before worktree creation), throws immediately so the caller's catch block cleans up the temp session.
- **Add timeouts and `DisposableStore` cleanup to both wait helpers** — prevents leaked event listeners on the hanging path. `_waitForSessionInCache` uses a 10s safety timeout since the adapter should appear almost immediately.
- **Allow archive/delete on temp sessions** — `archiveSession()` and `deleteSession()` now fall through to `_cleanupTempSession()` when `_findAgentSession()` returns nothing, properly removing uncommitted sessions from the cache and firing the removal event.