### PR TITLE
sessions: use newSessionResource directly to avoid duplicate session entry

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1377,8 +1377,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		try {
 
-			// Wait for the session to be committed (URI swapped from untitled to real)
-			const committedResource = await this._waitForCommittedSession(session.resource);
+			// Use the committed URI directly if available, otherwise fall back to waiting for the IPC event
+			const committedResource = (result.kind === 'sent' && result.newSessionResource)
+				? result.newSessionResource
+				: await this._waitForCommittedSession(session.resource);
 
 			// Wait for _refreshSessionCache to populate the committed adapter
 			const committedChat = await this._waitForSessionInCache(committedResource);
@@ -1466,8 +1468,10 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		}
 
 		try {
-			// Wait for the session to be committed
-			const committedResource = await this._waitForCommittedSession(newChatSession.resource);
+			// Use the committed URI directly if available, otherwise fall back to waiting for the IPC event
+			const committedResource = (result.kind === 'sent' && result.newSessionResource)
+				? result.newSessionResource
+				: await this._waitForCommittedSession(newChatSession.resource);
 
 			const committedChat = await this._waitForSessionInCache(committedResource);
 


### PR DESCRIPTION
## Problem

When a new agent session is created and a chat is sent, two entries briefly appear in the session list — the temporary "New Session..." entry and the real committed session — before the temp one disappears.

## Root Cause

In `_sendFirstChat` (and `_sendSubsequentChat`), after `sendRequest()` returns, the code always calls `_waitForCommittedSession()` which listens for the `onDidCommitSession` IPC event to get the committed URI. However, `sendRequest()` already returns the committed URI synchronously as `result.newSessionResource`.

Meanwhile, `agentSessionsService.model.onDidChangeSessions` fires as soon as the agent model is updated, causing `_refreshSessionCache` to add the real `AgentSessionAdapter` to the cache — making the real session appear in the UI. But the temp session isn't removed until `_waitForCommittedSession` resolves from the later IPC event, creating a window where both entries are visible.

## Fix

Both `_sendFirstChat` and `_sendSubsequentChat` now use `result.newSessionResource` directly when available, falling back to `_waitForCommittedSession()` only when it is not set. This eliminates the duplicate entry flicker by skipping the unnecessary async wait.