### PR TITLE
sessions: update signed-out text from Copilot to Agents

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts
@@ -95,8 +95,8 @@ function getCopilotPresentation(
 			source: 'copilot',
 			kind: 'prominent',
 			icon: Codicon.account,
-			label: localize('copilotSignedOut', "Copilot Signed Out"),
-			ariaLabel: localize('copilotSignedOutAria', "GitHub Copilot is signed out"),
+			label: localize('agentsSignedOut', "Agents Signed Out"),
+			ariaLabel: localize('agentsSignedOutAria', "Agents is signed out"),
 		};
 	}
 

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
@@ -139,7 +139,7 @@ suite('Sessions - Account Title Bar State', () => {
 			kind: state.kind,
 		}, {
 			source: 'copilot',
-			label: 'Copilot Signed Out',
+			label: 'Agents Signed Out',
 			kind: 'prominent',
 		});
 	});


### PR DESCRIPTION
## Summary

Updates the account menu signed-out messaging in the sessions (Agents) app to use "Agents" branding instead of "Copilot".

## Changes

- **Label**: "Copilot Signed Out" → "Agents Signed Out"
- **ARIA text**: "GitHub Copilot is signed out" → "Agents is signed out"
- Updated corresponding test assertion

## Files changed

- `src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts`
- `src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts`