### PR TITLE
sessions: Update title bar actions and styles for improved navigation

### DIFF
--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -59,15 +59,6 @@
 	align-items: center;
 }
 
-/* Separator before right layout toolbar (only when session actions toolbar also has actions) */
-.monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right > .titlebar-session-actions-container:not(.has-no-actions) + .titlebar-right-layout-container:not(.has-no-actions)::before {
-	content: '';
-	width: 1px;
-	height: 16px;
-	margin: 0 4px;
-	background-color: var(--vscode-disabledForeground);
-}
-
 /* Toggled action buttons in session actions toolbar */
 .monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right > .titlebar-session-actions-container .action-label.checked {
 	background: var(--vscode-toolbar-activeBackground);

--- a/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
@@ -159,7 +159,7 @@ export class ChangesTitleBarContribution extends Disposable implements IWorkbenc
 				toggled: AuxiliaryBarVisibleContext,
 			},
 			group: 'navigation',
-			order: 10, // After Run Script (8) and Terminal toggle (9)
+			order: 11, // After Run Script (8), Open in VS Code (9), and Open Terminal (10)
 			when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 		}));
 

--- a/src/vs/sessions/contrib/changes/browser/media/changesTitleBarWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesTitleBarWidget.css
@@ -5,6 +5,23 @@
 
 /* ---- Changes Titlebar Indicator (in right toolbar) ---- */
 
+/* Separator between local-session actions (Run, VS Code) and fixed toggles (Terminal, Changes).
+ * Targets the action following the VS Code icon (any Codicon.vscode variant). */
+.agent-sessions-workbench .titlebar-session-actions-container .monaco-action-bar .actions-container > .action-item:has(.codicon[class*="codicon-vscode"]) + .action-item {
+	position: relative;
+	margin-left: 17px;
+}
+
+.agent-sessions-workbench .titlebar-session-actions-container .monaco-action-bar .actions-container > .action-item:has(.codicon[class*="codicon-vscode"]) + .action-item::before {
+	content: '';
+	position: absolute;
+	left: -9px;
+	top: 3px;
+	width: 1px;
+	height: 16px;
+	background-color: var(--vscode-disabledForeground);
+}
+
 .agent-sessions-workbench .changes-titlebar-indicator {
 	display: flex;
 	align-items: center;

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -55,8 +55,8 @@ export class OpenSessionWorktreeInVSCodeAction extends Action2 {
 			menu: [{
 				id: Menus.TitleBarSessionMenu,
 				group: 'navigation',
-				order: 100,
-				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated(), IsActiveSessionBackgroundProviderContext),
+				order: 9,
+				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			}]
 		});
 	}

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -510,7 +510,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			this._primaryActionAction.label = this._getPrimaryActionTooltip(runState);
 		}));
 
-		// Dropdown with categorized actions and per-item toolbars
+		// Dropdown with categorized task actions and per-item toolbars
 		const dropdownAction = this._register(new Action('agentSessions.runScriptDropdown', localize('runDropdown', "More Tasks...")));
 		this._dropdown = this._register(new ChevronActionWidgetDropdown(
 			dropdownAction,
@@ -602,8 +602,8 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 		const defaultCategory = { label: '', order: 0, showHeader: false };
 		// Category for worktree-creation tasks
 		const worktreeCategory = { label: localize('worktreeCreationCategory', "Run on Worktree Creation"), order: 1, showHeader: true };
-		// Category for add actions
-		const addCategory = { label: localize('addActionsCategory', "Add"), order: 2, showHeader: true };
+		// Category for task creation and management
+		const tasksCategory = { label: localize('tasksActionsCategory', "Tasks"), order: 2, showHeader: true };
 
 		for (let i = 0; i < tasks.length; i++) {
 			const entry = tasks[i];
@@ -681,7 +681,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			icon: Codicon.add,
 			enabled: canConfigure,
 			class: undefined,
-			category: addCategory,
+			category: tasksCategory,
 			run: async () => {
 				const task = await this._showConfigureQuickPick(session);
 				if (task) {
@@ -702,7 +702,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			icon: Codicon.sparkle,
 			enabled: true,
 			class: undefined,
-			category: addCategory,
+			category: tasksCategory,
 			run: async () => {
 				await this._sessionsManagementService.sendAndCreateChat(session, { query: '/generate-run-commands' });
 			},
@@ -714,7 +714,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 
 /**
  * {@link ActionWidgetDropdownActionViewItem} that renders a chevron-down icon
- * as its label, used as the dropdown arrow in the split button.
+ * for the split button dropdown in the titlebar.
  */
 class ChevronActionWidgetDropdown extends ActionWidgetDropdownActionViewItem {
 	protected override renderLabel(element: HTMLElement): IDisposable | null {

--- a/src/vs/sessions/contrib/chat/test/browser/runScriptAction.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/runScriptAction.test.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { isISubmenuItem, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+
+// Side-effect import to trigger module-level menu registrations.
+// Only import runScriptAction which registers the Run dropdown submenu;
+// avoid chat.contribution.js and sessionsTerminalContribution.js which
+// bootstrap heavy workbench contributions and leak disposables from
+// KeybindingsRegistry in this lightweight test context.
+import '../../browser/runScriptAction.js';
+
+const titleBarSessionMenu = MenuId.for('SessionsTitleBarSessionMenu');
+
+suite('RunScriptContribution', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('contributes run dropdown to TitleBarSessionMenu', () => {
+		const items = MenuRegistry.getMenuItems(titleBarSessionMenu);
+
+		const runAction = items.find(item => isISubmenuItem(item) && item.submenu.id === 'AgentSessionsRunScriptDropdown');
+
+		assert.ok(runAction, 'run dropdown should be contributed to TitleBarSessionMenu');
+		assert.strictEqual(runAction.order, 8);
+	});
+});

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -16,12 +16,12 @@ import { ITerminalInstance, ITerminalService } from '../../../../workbench/contr
 import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { Menus } from '../../../browser/menus.js';
+import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { ISession } from '../../sessions/common/sessionData.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { logSessionsInteraction } from '../../../common/sessionsTelemetry.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { TERMINAL_VIEW_ID } from '../../../../workbench/contrib/terminal/common/terminal.js';
@@ -314,8 +314,8 @@ class OpenSessionInTerminalAction extends Action2 {
 			menu: [{
 				id: Menus.TitleBarSessionMenu,
 				group: 'navigation',
-				order: 9,
-				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated())
+				order: 10,
+				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
 			}]
 		});
 	}


### PR DESCRIPTION
Reorganize the title bar session toolbar for better grouping and navigation.

## Changes

- **Reorder toolbar actions**: Run Script (8) → Open in VS Code (9) → Open Terminal (10) → Changes toggle (11)
- **Always-visible VS Code button**: Removed `IsActiveSessionBackgroundProviderContext` from the menu `when` clause so the Open in VS Code button is visible for all session types, but **disabled** when no worktree is available (via the existing `precondition`). This avoids a hacky placeholder action.
- **Relocated separator**: Moved the toolbar separator from between the two toolbar containers to between session-specific actions (Run, VS Code) and fixed toggles (Terminal, Changes). Uses a broader CSS selector (`[class*="codicon-vscode"]`) for resilience across icon variants.
- **Renamed dropdown category**: "Add" → "Tasks" in the run script dropdown for clarity.
- **New unit test**: Verifies the run dropdown submenu is contributed to `TitleBarSessionMenu` at order 8.

## Files changed

| File | What |
|---|---|
| `titlebarpart.css` | Remove old separator between toolbar containers |
| `changesTitleBarWidget.ts` | Update order to 11 |
| `changesTitleBarWidget.css` | Add new intra-toolbar separator CSS |
| `chat.contribution.ts` | Reorder VS Code action to 9, remove `when` guard so it stays visible but disabled |
| `runScriptAction.ts` | Rename "Add" → "Tasks", update comments |
| `sessionsTerminalContribution.ts` | Reorder terminal action to 10, sort imports |
| `runScriptAction.test.ts` | New test for menu contribution |
