### PR TITLE
fix: rename hooks button to 'Configure Hooks' in sessions window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1028,9 +1028,9 @@ export class AICustomizationListWidget extends Disposable {
 					});
 				}
 			} else if (!override?.commandId) {
-				// Sessions / non-local: workspace creation only
+				// Sessions / non-local: configure hooks (view + create)
 				actions.push({
-					label: `$(${Codicon.add.id}) New ${typeLabel} (Workspace)`,
+					label: `$(${Codicon.add.id}) Configure Hooks`,
 					enabled: hasWorkspace,
 					tooltip: hasWorkspace ? undefined : localize('createDisabled', "Open a workspace folder to create customizations."),
 					run: () => { this._onDidRequestCreateManual.fire({ type: promptType, target: 'workspace' }); },

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1022,7 +1022,7 @@ export class AICustomizationListWidget extends Disposable {
 				});
 				if (hasWorkspace) {
 					actions.push({
-						label: `$(${Codicon.add.id}) Configure Hooks`,
+						label: `$(${Codicon.add.id}) ${localize('configureHooks', "Configure Hooks")}`,
 						enabled: true,
 						run: () => { this._onDidRequestCreateManual.fire({ type: promptType, target: 'workspace' }); },
 					});
@@ -1030,9 +1030,9 @@ export class AICustomizationListWidget extends Disposable {
 			} else if (!override?.commandId) {
 				// Sessions / non-local: configure hooks (view + create)
 				actions.push({
-					label: `$(${Codicon.add.id}) Configure Hooks`,
+					label: `$(${Codicon.add.id}) ${localize('configureHooks', "Configure Hooks")}`,
 					enabled: hasWorkspace,
-					tooltip: hasWorkspace ? undefined : localize('createDisabled', "Open a workspace folder to create customizations."),
+					tooltip: hasWorkspace ? undefined : localize('configureHooksDisabled', "Open a workspace folder to configure hooks."),
 					run: () => { this._onDidRequestCreateManual.fire({ type: promptType, target: 'workspace' }); },
 				});
 			}


### PR DESCRIPTION
The sessions path used "New Hook (Workspace)" but the action opens `showConfigureHooksQuickPick` which handles both viewing existing hooks and creating new ones. Align with the core path label ("Configure Hooks").

The "Configure Hooks" button label is now properly localized via `localize('configureHooks', "Configure Hooks")` (with the codicon prefix kept outside the localized string). The disabled tooltip copy and key have also been updated from the generic "create customizations" wording to `localize('configureHooksDisabled', "Open a workspace folder to configure hooks.")` to accurately reflect the action's purpose.