### PR TITLE
feat: add ChatHookProvider to chatPromptFiles API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -30,7 +30,7 @@ import { AgentSessionProviders, getAgentSessionProvider } from '../../contrib/ch
 import { AddDynamicVariableAction, IAddDynamicVariableContext } from '../../contrib/chat/browser/attachments/chatDynamicVariables.js';
 import { IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../contrib/chat/common/participants/chatAgents.js';
 import { IPromptFileContext, IPromptsService, PromptsStorage } from '../../contrib/chat/common/promptSyntax/service/promptsService.js';
-import { isValidPromptType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
+import { isValidPromptType, PromptsType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IChatModel } from '../../contrib/chat/common/model/chatModel.js';
 import { ChatRequestAgentPart } from '../../contrib/chat/common/requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../../contrib/chat/common/requestParser/chatRequestParser.js';
@@ -42,7 +42,7 @@ import { ILanguageModelToolsService } from '../../contrib/chat/common/tools/lang
 import { IExtHostContext, extHostNamedCustomer } from '../../services/extensions/common/extHostCustomers.js';
 import { IExtensionService } from '../../services/extensions/common/extensions.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostChatAgentsShape2, ExtHostContext, IChatAgentInvokeResult, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatNotebookEditDto, IChatParticipantMetadata, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IDynamicChatAgentProps, IExtensionChatAgentMetadata, IInstructionDto, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from '../common/extHost.protocol.js';
+import { ExtHostChatAgentsShape2, ExtHostContext, IChatAgentInvokeResult, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatNotebookEditDto, IChatParticipantMetadata, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IDynamicChatAgentProps, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from '../common/extHost.protocol.js';
 import { NotebookDto } from './mainThreadNotebookDto.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../contrib/chat/common/customizationHarnessService.js';
@@ -193,6 +193,12 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._register(this._promptsService.onDidChangeSkills(() => {
 			void this._pushSkills();
 		}));
+
+		// Push hooks to ext host
+		void this._pushHooks();
+		this._register(this._promptsService.onDidChangeHooks(() => {
+			void this._pushHooks();
+		}));
 	}
 
 	private _acceptActiveChatSession(widget: IChatWidget | undefined): void {
@@ -228,6 +234,16 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 			this._proxy.$acceptSkills(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push skills to extension host', error);
+		}
+	}
+
+	private async _pushHooks(): Promise<void> {
+		try {
+			const hookFiles = await this._promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
+			const dtos: IHookDto[] = hookFiles.map(hookFile => ({ uri: hookFile.uri }));
+			this._proxy.$acceptHooks(dtos);
+		} catch (error) {
+			this._logService.error('[chat] Failed to push hooks to extension host', error);
 		}
 	}
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1705,6 +1705,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatPromptFiles');
 				return extHostChatAgents2.registerPromptFileProvider(extension, PromptsType.skill, provider);
 			},
+			registerHookProvider(provider: vscode.ChatHookProvider): vscode.Disposable {
+				checkProposedApiEnabled(extension, 'chatPromptFiles');
+				return extHostChatAgents2.registerPromptFileProvider(extension, PromptsType.hook, provider);
+			},
 			registerChatDebugLogProvider(provider: vscode.ChatDebugLogProvider): vscode.Disposable {
 				checkProposedApiEnabled(extension, 'chatDebug');
 				return extHostChatDebug.registerChatDebugLogProvider(provider);
@@ -1736,6 +1740,14 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			onDidChangeSkills: (listener, thisArgs?, disposables?) => {
 				checkProposedApiEnabled(extension, 'chatPromptFiles');
 				return extHostChatAgents2.onDidChangeSkills(listener, thisArgs, disposables);
+			},
+			get hooks() {
+				checkProposedApiEnabled(extension, 'chatPromptFiles');
+				return extHostChatAgents2.hooks as readonly vscode.ChatResource[];
+			},
+			onDidChangeHooks: (listener, thisArgs?, disposables?) => {
+				checkProposedApiEnabled(extension, 'chatPromptFiles');
+				return extHostChatAgents2.onDidChangeHooks(listener, thisArgs, disposables);
 			},
 			registerChatSessionCustomizationProvider(chatSessionType: string, metadata: vscode.ChatSessionCustomizationProviderMetadata, provider: vscode.ChatSessionCustomizationProvider): vscode.Disposable {
 				checkProposedApiEnabled(extension, 'chatSessionCustomizationProvider');

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1671,6 +1671,7 @@ export interface ExtHostChatAgentsShape2 {
 	$acceptCustomAgents(agents: ICustomAgentDto[]): void;
 	$acceptInstructions(instructions: IInstructionDto[]): void;
 	$acceptSkills(skills: ISkillDto[]): void;
+	$acceptHooks(hooks: IHookDto[]): void;
 }
 
 export interface ICustomAgentDto {
@@ -1682,6 +1683,10 @@ export interface IInstructionDto {
 }
 
 export interface ISkillDto {
+	uri: UriComponents;
+}
+
+export interface IHookDto {
 	uri: UriComponents;
 }
 

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -28,7 +28,7 @@ import { LocalChatSessionUri } from '../../contrib/chat/common/model/chatUri.js'
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostChatAgentsShape2, IChatAgentCompletionItem, IChatAgentHistoryEntryDto, IChatAgentInvokeResult, IChatAgentProgressShape, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IExtensionChatAgentMetadata, IInstructionDto, IMainContext, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from './extHost.protocol.js';
+import { ExtHostChatAgentsShape2, IChatAgentCompletionItem, IChatAgentHistoryEntryDto, IChatAgentInvokeResult, IChatAgentProgressShape, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, IMainContext, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from './extHost.protocol.js';
 import { CommandsConverter, ExtHostCommands } from './extHostCommands.js';
 import { ExtHostDiagnostics } from './extHostDiagnostics.js';
 import { ExtHostDocuments } from './extHostDocuments.js';
@@ -473,7 +473,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	private readonly _participantDetectionProviders = new Map<number, ExtHostParticipantDetector>();
 
 	private static _contributionsProviderIdPool = 0;
-	private readonly _promptFileProviders = new Map<number, { extension: IExtensionDescription; provider: vscode.ChatCustomAgentProvider | vscode.ChatInstructionsProvider | vscode.ChatPromptFileProvider | vscode.ChatSkillProvider }>();
+	private readonly _promptFileProviders = new Map<number, { extension: IExtensionDescription; provider: vscode.ChatCustomAgentProvider | vscode.ChatInstructionsProvider | vscode.ChatPromptFileProvider | vscode.ChatSkillProvider | vscode.ChatHookProvider }>();
 
 	private static _customizationProviderIdPool = 0;
 	private readonly _customizationProviders = new Map<number, { extension: IExtensionDescription; provider: vscode.ChatSessionCustomizationProvider }>();
@@ -498,10 +498,13 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	readonly onDidChangeInstructions = this._onDidChangeInstructions.event;
 	private readonly _onDidChangeSkills = this._register(new Emitter<void>());
 	readonly onDidChangeSkills = this._onDidChangeSkills.event;
+	private readonly _onDidChangeHooks = this._register(new Emitter<void>());
+	readonly onDidChangeHooks = this._onDidChangeHooks.event;
 
 	private _customAgents: vscode.ChatResource[] = [];
 	private _instructions: vscode.ChatResource[] = [];
 	private _skills: vscode.ChatResource[] = [];
+	private _hooks: vscode.ChatResource[] = [];
 
 	private _activeChatPanelSessionResource: URI | undefined;
 
@@ -524,6 +527,10 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		return this._skills;
 	}
 
+	get hooks(): readonly vscode.ChatResource[] {
+		return this._hooks;
+	}
+
 	$acceptCustomAgents(agents: ICustomAgentDto[]): void {
 		this._customAgents = agents.map(a => Object.freeze({ uri: URI.revive(a.uri) }));
 		this._onDidChangeCustomAgents.fire();
@@ -537,6 +544,11 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	$acceptSkills(skills: ISkillDto[]): void {
 		this._skills = skills.map(s => Object.freeze({ uri: URI.revive(s.uri) }));
 		this._onDidChangeSkills.fire();
+	}
+
+	$acceptHooks(hooks: IHookDto[]): void {
+		this._hooks = hooks.map(h => Object.freeze({ uri: URI.revive(h.uri) }));
+		this._onDidChangeHooks.fire();
 	}
 
 	constructor(
@@ -600,7 +612,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	 * Internal method that handles all prompt file provider types.
 	 * Routes custom agents, instructions, prompt files, and skills to the unified internal implementation.
 	 */
-	registerPromptFileProvider(extension: IExtensionDescription, type: PromptsType, provider: vscode.ChatCustomAgentProvider | vscode.ChatInstructionsProvider | vscode.ChatPromptFileProvider | vscode.ChatSkillProvider): vscode.Disposable {
+	registerPromptFileProvider(extension: IExtensionDescription, type: PromptsType, provider: vscode.ChatCustomAgentProvider | vscode.ChatInstructionsProvider | vscode.ChatPromptFileProvider | vscode.ChatSkillProvider | vscode.ChatHookProvider): vscode.Disposable {
 		const handle = ExtHostChatAgents2._contributionsProviderIdPool++;
 		this._promptFileProviders.set(handle, { extension, provider });
 		this._proxy.$registerPromptFileProvider(handle, type, extension.identifier);
@@ -622,6 +634,9 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				break;
 			case PromptsType.skill:
 				changeEvent = (provider as vscode.ChatSkillProvider).onDidChangeSkills;
+				break;
+			case PromptsType.hook:
+				changeEvent = (provider as vscode.ChatHookProvider).onDidChangeHooks;
 				break;
 		}
 
@@ -659,6 +674,9 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 				break;
 			case PromptsType.skill:
 				resources = await (provider as vscode.ChatSkillProvider).provideSkills(context, token) ?? undefined;
+				break;
+			case PromptsType.hook:
+				resources = await (provider as vscode.ChatHookProvider).provideHooks(context, token) ?? undefined;
 				break;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1646,6 +1646,11 @@ export class AICustomizationListWidget extends Disposable {
 			}
 		}
 
+		// Hooks: expand file-level items into individual hook entries (matching core path display)
+		if (promptType === PromptsType.hook) {
+			return this._expandProviderHookItems(allItems, workspaceFolders);
+		}
+
 		return allItems
 			.filter(item => item.type === promptType)
 			.map((item: IExternalCustomizationItem) => {
@@ -1669,6 +1674,70 @@ export class AICustomizationListWidget extends Disposable {
 				};
 			})
 			.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	/**
+	 * Expands provider hook items (file-level) into individual hook entries
+	 * with hook type labels and command descriptions, matching the core path display.
+	 */
+	private async _expandProviderHookItems(allItems: readonly IExternalCustomizationItem[], workspaceFolders: readonly { uri: URI }[]): Promise<IAICustomizationListItem[]> {
+		const hookFileItems = allItems.filter(item => item.type === PromptsType.hook);
+		const items: IAICustomizationListItem[] = [];
+		const activeRoot = this.workspaceService.getActiveProjectRoot();
+		const userHomeUri = await this.pathService.userHome();
+		const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
+
+		for (const item of hookFileItems) {
+			const { storage } = item.groupKey
+				? { storage: undefined }
+				: this._inferStorageAndGroup(item.uri, workspaceFolders);
+
+			let parsedHooks = false;
+			try {
+				const content = await this.fileService.readFile(item.uri);
+				const json = parseJSONC(content.value.toString());
+				const { hooks } = parseHooksFromFile(item.uri, json, activeRoot, userHome);
+
+				if (hooks.size > 0) {
+					parsedHooks = true;
+					for (const [hookType, entry] of hooks) {
+						const hookMeta = HOOK_METADATA[hookType];
+						for (let i = 0; i < entry.hooks.length; i++) {
+							const hook = entry.hooks[i];
+							const cmdLabel = formatHookCommandLabel(hook, OS);
+							const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
+							items.push({
+								id: `${item.uri.toString()}#${entry.originalId}[${i}]`,
+								uri: item.uri,
+								name: hookMeta?.label ?? entry.originalId,
+								filename: basename(item.uri),
+								description: truncatedCmd || localize('hookUnset', "(unset)"),
+								storage,
+								promptType: PromptsType.hook,
+								disabled: item.enabled === false,
+							});
+						}
+					}
+				}
+			} catch {
+				// Parse failed — fall through to show raw file
+			}
+
+			if (!parsedHooks) {
+				items.push({
+					id: item.uri.toString(),
+					uri: item.uri,
+					name: item.name,
+					filename: basename(item.uri),
+					description: item.description,
+					storage,
+					promptType: PromptsType.hook,
+					disabled: item.enabled === false,
+				});
+			}
+		}
+
+		return items;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -604,8 +604,13 @@ export interface IPromptsService extends IDisposable {
 	readonly onDidChangeSkills: Event<void>;
 
 	/**
+	 * Event that is triggered when the effective hook availability or configuration changes.
+	 */
+	readonly onDidChangeHooks: Event<void>;
+
+	/**
 	 * Gets all hooks collected from hooks.json files.
-	 * The result is cached and invalidated when hook files change.
+	 * The result is cached and invalidated when the effective hook availability or configuration changes.
 	 */
 	getHooks(token: CancellationToken): Promise<IConfiguredHooksInfo | undefined>;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1130,6 +1130,10 @@ export class PromptsService extends Disposable implements IPromptsService {
 		return this.cachedSkills.onDidChangePromise;
 	}
 
+	public get onDidChangeHooks(): Event<void> {
+		return this.cachedHooks.onDidChangePromise;
+	}
+
 	public async findAgentSkills(token: CancellationToken): Promise<IAgentSkill[] | undefined> {
 		const useAgentSkills = this.configurationService.getValue(PromptsConfig.USE_AGENT_SKILLS);
 		if (!useAgentSkills) {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
@@ -71,4 +71,5 @@ export class MockPromptsService implements IPromptsService {
 	onDidChangeInstructions: Event<void> = Event.None;
 	onDidChangePromptFiles: Event<void> = Event.None;
 	onDidChangeSkills: Event<void> = Event.None;
+	onDidChangeHooks: Event<void> = Event.None;
 }

--- a/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
@@ -78,6 +78,28 @@ declare module 'vscode' {
 
 	// #endregion
 
+	// #region HookProvider
+
+	/**
+	 * A provider that supplies hook configuration resources (from hooks JSON files).
+	 */
+	export interface ChatHookProvider {
+		/**
+		 * An optional event to signal that hooks have changed.
+		 */
+		readonly onDidChangeHooks?: Event<void>;
+
+		/**
+		 * Provide the list of hook configuration files available.
+		 * @param context Context for the provide call.
+		 * @param token A cancellation token.
+		 * @returns An array of hook resources or a promise that resolves to such.
+		 */
+		provideHooks(context: unknown, token: CancellationToken): ProviderResult<ChatResource[]>;
+	}
+
+	// #endregion
+
 	// #region SkillProvider
 
 	/**
@@ -137,6 +159,18 @@ declare module 'vscode' {
 		export const skills: readonly ChatResource[];
 
 		/**
+		 * An event that fires when the list of {@link hooks hooks} changes.
+		 */
+		export const onDidChangeHooks: Event<void>;
+
+		/**
+		 * The list of currently available hook configuration files.
+		 * These are JSON files that define lifecycle hooks from all sources
+		 * (workspace, user, and extension-provided).
+		 */
+		export const hooks: readonly ChatResource[];
+
+		/**
 		 * Register a provider for custom agents.
 		 * @param provider The custom agent provider.
 		 * @returns A disposable that unregisters the provider when disposed.
@@ -163,6 +197,13 @@ declare module 'vscode' {
 		 * @returns A disposable that unregisters the provider when disposed.
 		 */
 		export function registerSkillProvider(provider: ChatSkillProvider): Disposable;
+
+		/**
+		 * Register a provider for hooks.
+		 * @param provider The hook provider.
+		 * @returns A disposable that unregisters the provider when disposed.
+		 */
+		export function registerHookProvider(provider: ChatHookProvider): Disposable;
 	}
 
 	// #endregion


### PR DESCRIPTION
Wire hooks through the same `chatPromptFiles` proposed API surface used by agents, instructions, and skills.

### Changes
- Add `ChatHookProvider` interface with `onDidChangeHooks`/`provideHooks`
- Add `chat.hooks` readonly getter and `chat.onDidChangeHooks` event
- Add `chat.registerHookProvider()` registration function
- Add `IHookDto` and `$acceptHooks` to ext host protocol
- Add `onDidChangeHooks` to `IPromptsService` interface and impl (delegates to existing `cachedHooks.onDidChangePromise`)
- Push hook files from mainThread to ext host on change via `_pushHooks()`
- Fix `MockPromptsService` for new interface member

### Why
The `chatPromptFiles` API had no hook support. Extensions (like Copilot Chat) that need to react to hook file changes had no way to discover them through the API. This blocked the CopilotCLI customization provider from reporting hooks in the Chat Customizations UI.

Companion PR: https://github.com/microsoft/vscode-copilot-chat/pull/4952