### PR TITLE
Ensure that ssh2/cpu-features doesn't get shipped

### DIFF
--- a/build/.moduleignore
+++ b/build/.moduleignore
@@ -97,6 +97,8 @@ kerberos/src/**
 kerberos/node_modules/**
 !kerberos/**/*.node
 
+cpu-features/**
+
 ssh2/lib/protocol/crypto/binding.gyp
 ssh2/lib/protocol/crypto/build/**
 ssh2/lib/protocol/crypto/src/**


### PR DESCRIPTION
Optional dependency that we don't want to use. This shouldn't be necessary, but if it somehow ends up getting built/installed at some point, let's strip it from the build

Co-authored-by: Copilot <copilot@github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
