### PR TITLE
Fix: point linux desktop exec path to wrapper script instead of raw binary

### DIFF
--- a/build/gulpfile.vscode.linux.ts
+++ b/build/gulpfile.vscode.linux.ts
@@ -53,7 +53,7 @@ function prepareDebPackage(arch: string) {
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
 			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
 			.pipe(replace('@@NAME@@', product.applicationName))
-			.pipe(replace('@@EXEC@@', `/usr/share/${product.applicationName}/${product.applicationName}`))
+			.pipe(replace('@@EXEC@@', `/usr/bin/${product.applicationName}`))
 			.pipe(replace('@@ICON@@', product.linuxIconName))
 			.pipe(replace('@@URLPROTOCOL@@', product.urlProtocol));
 
@@ -163,7 +163,7 @@ function prepareRpmPackage(arch: string) {
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
 			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
 			.pipe(replace('@@NAME@@', product.applicationName))
-			.pipe(replace('@@EXEC@@', `/usr/share/${product.applicationName}/${product.applicationName}`))
+			.pipe(replace('@@EXEC@@', `/usr/bin/${product.applicationName}`))
 			.pipe(replace('@@ICON@@', product.linuxIconName))
 			.pipe(replace('@@URLPROTOCOL@@', product.urlProtocol));
 


### PR DESCRIPTION
Fixes #226391

### Motivation / Proposed Changes
Currently, the DEB and RPM build processes hardcode the `Exec` path in the `.desktop` file to the raw binary in `/usr/share/code/code`. On modern Linux distributions like Ubuntu 24.04 LTS, stricter kernel restrictions on unprivileged user namespaces cause this binary to fail with a SIGSEGV (exit code 139) when launched without the proper environment setup provided by the wrapper script.

By changing the `@@EXEC@@` replacement to `/usr/bin/code` (which is a symlink to `/usr/share/code/bin/code`), we ensure the desktop entry utilizes the official wrapper script, which correctly handles sandboxing and environment initialization, preventing syslog flooding and crashes.

### How to test
1. Build the `.deb` or `.rpm` package using the Linux build tasks.
2. Install the generated package on Ubuntu 24.04 LTS.
3. Launch VS Code via the desktop environment application menu (which triggers the `.desktop` file).
4. Verify that the application launches successfully and that `tail -f /var/log/syslog` no longer shows `GPU process exited unexpectedly: exit_code=139`.