### PR TITLE
fix: clamp HTML completion replace range for unclosed attribute strings

### DIFF
--- a/extensions/html-language-features/client/src/htmlClient.ts
+++ b/extensions/html-language-features/client/src/htmlClient.ts
@@ -170,7 +170,23 @@ async function startClientWithParticipants(languageParticipants: LanguagePartici
 				function updateRanges(item: CompletionItem) {
 					const range = item.range;
 					if (range instanceof Range && range.end.isAfter(position) && range.start.isBeforeOrEqual(position)) {
-						item.range = { inserting: new Range(range.start, position), replacing: range };
+						// Clamp the replacing range so it does not extend past the current
+						// line or past an opening angle bracket. When completing inside an
+						// unclosed attribute string (e.g. <input type="che</th>), the HTML
+						// scanner treats everything after the opening quote as part of the
+						// attribute value, which causes the replace range to span across
+						// HTML tags and eat content the user did not intend to replace.
+						// See https://github.com/microsoft/vscode/issues/273226
+						let replacingEnd = range.end;
+						if (replacingEnd.line > position.line) {
+							replacingEnd = document.lineAt(position.line).range.end;
+						}
+						const textAfterCursor = document.getText(new Range(position, replacingEnd));
+						const angleBracketIndex = textAfterCursor.indexOf('<');
+						if (angleBracketIndex !== -1) {
+							replacingEnd = position.translate(0, angleBracketIndex);
+						}
+						item.range = { inserting: new Range(range.start, position), replacing: new Range(range.start, replacingEnd) };
 					}
 				}
 				function updateProposals(r: CompletionItem[] | CompletionList | null | undefined): CompletionItem[] | CompletionList | null | undefined {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When completing inside an unclosed attribute string literal (e.g. `<th><input type="che</th>` with the cursor after `che`), selecting a completion like "checkbox" in replace mode deletes everything after the cursor, including subsequent HTML tags. The result is `<th><input type="checkbox` instead of preserving the `</th>`.

This happens because the HTML scanner treats everything after the opening `"` as part of the attribute value string when there is no closing quote. The replace range returned by the language service spans far past the cursor, across HTML tag boundaries.

Closes #273226

## What is the new behavior?

The completion middleware in the HTML client now clamps the replacing range so it does not extend:
1. Past the end of the current line (attribute values don't span lines in HTML)
2. Past an opening angle bracket (`<`), which indicates the start of an HTML tag that should be preserved

The inserting range (used in "insert" mode) is unchanged — it already stops at the cursor position. The fix only affects the replacing range used in "replace" mode.

**Before:** `<th><input type="che</th>` → select "checkbox" → `<th><input type="checkbox`
**After:** `<th><input type="che</th>` → select "checkbox" → `<th><input type="checkbox</th>`

## Additional context

The fix is in the existing completion middleware in `htmlClient.ts` (line ~170) that already splits completion ranges into `inserting` and `replacing` ranges. The change adds boundary detection before using the language service's range as the replacing range.