### PR TITLE
fix: increase quick pick separator border contrast in 2026 themes

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -224,7 +224,7 @@
 		"extensionButton.prominentBackground": "#297AA0",
 		"extensionButton.prominentForeground": "#FFFFFF",
 		"extensionButton.prominentHoverBackground": "#2B7DA3",
-		"pickerGroup.border": "#2A2B2CFF",
+		"pickerGroup.border": "#333536",
 		"pickerGroup.foreground": "#bfbfbf",
 		"quickInput.background": "#202122",
 		"quickInput.foreground": "#bfbfbf",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -228,7 +228,7 @@
 		"extensionButton.prominentBackground": "#0069CC",
 		"extensionButton.prominentForeground": "#FFFFFF",
 		"extensionButton.prominentHoverBackground": "#0064CC",
-		"pickerGroup.border": "#EEEEF1",
+		"pickerGroup.border": "#D8D8D8",
 		"pickerGroup.foreground": "#202020",
 		"quickInput.background": "#FAFAFD",
 		"quickInput.foreground": "#202020",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — theme color adjustment

## What is the current behavior?

The quick pick separator lines (between groups like "light themes" and "dark themes") are invisible in both 2026 Dark and 2026 Light experimental themes. The `pickerGroup.border` color is nearly identical to the `quickInput.background`, making the divider lines disappear.

Closes #290413

**2026 Dark:**
- `pickerGroup.border`: `#2A2B2CFF` vs `quickInput.background`: `#202122` — almost no contrast

**2026 Light:**
- `pickerGroup.border`: `#EEEEF1` vs `quickInput.background`: `#FAFAFD` — almost no contrast

## What is the new behavior?

Updated `pickerGroup.border` to match each theme's `quickInput.border` value, which provides clear visual separation:

- **2026 Dark**: `#2A2B2CFF` → `#333536` (consistent with `quickInput.border`)
- **2026 Light**: `#EEEEF1` → `#D8D8D8` (consistent with `quickInput.border`)

This matches the approach used in the parent themes (Dark Modern uses `#3C3C3C`, Light Modern uses `#E5E5E5`), where the picker group border is clearly distinguishable from the background.

## Additional context

The separator border should be visible but subtle — using the same value as `quickInput.border` ensures consistency with the overall widget chrome while making group divisions clear.