### PR TITLE
fix: prevent bash shell integration sequences leaking into redirected files

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -352,8 +352,13 @@ __vsc_command_output_start() {
 	if [[ -z "${__vsc_first_prompt-}" ]]; then
 		builtin return
 	fi
-	builtin printf '\e]633;E;%s;%s\a' "$(__vsc_escape_value "${__vsc_current_command}")" $__vsc_nonce
-	builtin printf '\e]633;C\a'
+	# Write to /dev/tty to avoid the sequences being captured by the command's
+	# stdout/stderr redirections. In bash the DEBUG trap fires after the shell
+	# has already applied the command's redirections, so a plain printf would
+	# write into the user's redirect target (e.g. a file) instead of the
+	# terminal.
+	builtin printf '\e]633;E;%s;%s\a' "$(__vsc_escape_value "${__vsc_current_command}")" $__vsc_nonce > /dev/tty
+	builtin printf '\e]633;C\a' > /dev/tty
 }
 
 __vsc_continuation_start() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a command with stdout/stderr redirection runs in VS Code's integrated terminal with bash shell integration enabled, the OSC 633 escape sequences (`633;E` and `633;C`) emitted by the preexec hook (`__vsc_command_output_start`) leak into the redirect target file.

For example:
```bash
for i in 1 2 3; do echo Hey; done > /tmp/myfile.txt && cat -A /tmp/myfile.txt
```
produces:
```
^[]633;E;for i in 1 2 3;626d5160-3c6e-4585-8da3-26c10d43fd2b^G^[]633;C^GHey$
Hey$
Hey$
```

The escape sequences pollute the first line of the output file.

Closes #275598

## What is the new behavior?

The two `builtin printf` calls in `__vsc_command_output_start` now write to `/dev/tty` instead of stdout. Since `/dev/tty` always refers to the controlling terminal regardless of any active redirections, the OSC 633 sequences reach the terminal emulator without being captured by the user's redirect.

The same command now produces the expected clean output:
```
Hey$
Hey$
Hey$
```

## Why this happens

In bash, the DEBUG trap (used as the preexec hook) fires **after** the shell has already applied the command's I/O redirections. This is different from zsh, where the `preexec` hook fires before redirections are set up. As a result, any `printf` to stdout during the DEBUG trap writes into whatever fd 1 has been redirected to — in this case, the user's output file.

## Additional context

- Only `__vsc_command_output_start` is affected because it is the only function that writes to stdout during the DEBUG trap / preexec phase. All other OSC 633 emitters run during `PROMPT_COMMAND` (precmd), where stdout is the terminal.
- `/dev/tty` is available on all POSIX systems where bash runs (Linux, macOS, WSL, Cygwin/MSYS2).
- The zsh shell integration script does not need this fix because zsh's preexec hook fires before redirections.