### PR TITLE
fix: reveal error line when navigating to failed notebook cell

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -812,7 +812,14 @@ registerAction2(class RevealLastFailedCellAction extends NotebookAction {
 		if (lastFailedCellHandle !== undefined) {
 			const lastFailedCell = context.notebookEditor.getCellByHandle(lastFailedCellHandle);
 			if (lastFailedCell) {
-				context.notebookEditor.focusNotebookCell(lastFailedCell, 'container');
+				const errorLocation = lastFailedCell.internalMetadata.error?.location;
+				if (errorLocation) {
+					await context.notebookEditor.focusNotebookCell(lastFailedCell, 'editor', {
+						focusEditorLine: errorLocation.startLineNumber + 1
+					});
+				} else {
+					context.notebookEditor.focusNotebookCell(lastFailedCell, 'container');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a notebook cell fails execution and the user clicks "Go to Most Recently Failed Cell" from the toolbar, the notebook scrolls to show the **top** of the failed cell. For large cells where the error occurs near the end, the user still has to manually scroll within the cell to find the error line.

Closes #245617

## What is the new behavior?

The "Go to Most Recently Failed Cell" action now checks the cell's internal metadata for an error location. When available, it focuses the editor directly at the error line (using `focusEditorLine`), scrolling the specific line into view. When no error location is available (e.g., for errors without stack trace information), it falls back to the previous behavior of focusing the cell container.

This uses the same error location data that `CellDiagnostics` and the "Show Cell Failure Actions" command already rely on (`cell.internalMetadata.error.location`), ensuring consistency across error navigation features.

## Additional context

The fix is a minimal change (8 lines added, 1 removed) in `RevealLastFailedCellAction.runWithContext()`. It leverages existing infrastructure:
- `IFocusNotebookCellOptions.focusEditorLine` for line-level reveal
- `NotebookCellInternalMetadata.error.location` for error position (0-based, so +1 is applied)
- Falls back gracefully when error location is unavailable