### PR TITLE
fix: treat unrecognized @-prefixed text as regular filter in test explorer

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
+++ b/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
@@ -146,12 +146,15 @@ export class TestExplorerFilterState extends Disposable implements ITestExplorer
 			let nextIndex = match.index + match[0].length;
 
 			const tag = match[0];
-			if (allTestFilterTerms.includes(tag as TestFilterTerm)) {
+			const isFilterTerm = allTestFilterTerms.includes(tag as TestFilterTerm);
+			if (isFilterTerm) {
 				this.termFilterState[tag as TestFilterTerm] = true;
 			}
 
 			// recognize and parse @ctrlId:tagId or quoted like @ctrlId:"tag \\"id"
+			let isTag = false;
 			if (text[nextIndex] === ':') {
+				isTag = true;
 				nextIndex++;
 
 				let delimiter = text[nextIndex];
@@ -178,6 +181,12 @@ export class TestExplorerFilterState extends Disposable implements ITestExplorer
 					this.includeTags.add(namespaceTestTag(match[1], tagId));
 				}
 				nextIndex++;
+			}
+
+			// If the @-prefixed text is not a known filter term or tag,
+			// treat it as regular filter text (e.g., a test named "@smoke")
+			if (!isFilterTerm && !isTag) {
+				continue;
 			}
 
 			globText += text.slice(lastIndex, match.index);

--- a/src/vs/workbench/contrib/testing/test/common/testExplorerFilterState.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testExplorerFilterState.test.ts
@@ -88,4 +88,31 @@ suite('TestExplorerFilterState', () => {
 		assert.deepStrictEqual([...t.includeTags], ['hello\0world"1']);
 		assert.deepStrictEqual(t.excludeTags, new Set());
 	});
+
+	test('treats unrecognized @-prefixed text as regular filter text', () => {
+		t.setText('@smoke');
+		assert.deepStrictEqual(t.globList, [{ text: '@smoke', include: true }]);
+		assert.deepStrictEqual(t.includeTags, new Set());
+		assert.deepStrictEqual(t.excludeTags, new Set());
+		assertFilteringFor(termFiltersOff);
+	});
+
+	test('treats unrecognized @-prefixed text as filter text in mixed input', () => {
+		t.setText('@smoke @doc hello');
+		assert.deepStrictEqual(t.globList, [{ text: '@smoke hello', include: true }]);
+		assert.deepStrictEqual(t.includeTags, new Set());
+		assert.deepStrictEqual(t.excludeTags, new Set());
+		assertFilteringFor({
+			...termFiltersOff,
+			[TestFilterTerm.CurrentDoc]: true,
+		});
+	});
+
+	test('negated unrecognized @-prefixed text works as exclusion filter', () => {
+		t.setText('!@smoke');
+		assert.deepStrictEqual(t.globList, [{ text: '@smoke', include: false }]);
+		assert.deepStrictEqual(t.includeTags, new Set());
+		assert.deepStrictEqual(t.excludeTags, new Set());
+		assertFilteringFor(termFiltersOff);
+	});
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When typing text containing `@` in the test explorer filter (e.g., `@smoke` to find a test named "my @smoke test"), the `@`-prefixed text is consumed by the tag/filter-term regex but doesn't match any known filter term (`@failed`, `@doc`, etc.) or tag syntax (`@ctrlId:tagId`). This causes the text to silently disappear from the glob filter, making it impossible to search for tests with `@` in their names.

For example, typing `@smoke` in the filter produces an empty glob list instead of filtering for tests matching "@smoke".

Closes #159708

## What is the new behavior?

Unrecognized `@`-prefixed text that is neither a known filter term nor a tag is now preserved as regular glob filter text. This means:

- `@smoke` → filters for tests matching "@smoke" (previously produced no filter)
- `@smoke @doc hello` → filters for "@smoke hello" with the `@doc` term active (previously only `@doc` was active)
- `!@smoke` → excludes tests matching "@smoke" (previously had no effect)

Known filter terms (`@failed`, `@doc`, `@executed`, `@openedFiles`, `@hidden`) and tag syntax (`@ctrlId:tagId`) continue to work exactly as before.

## Additional context

The fix adds tracking variables (`isFilterTerm`, `isTag`) to determine whether a regex match was actually consumed as a special filter construct. If not, the loop `continue`s without advancing `lastIndex`, so the `@`-prefixed text naturally flows into `globText`.

Three test cases are added covering the plain, mixed, and negated scenarios.