### PR TITLE
fix: show symbol labels in disassembly view

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -31,7 +31,7 @@ import { WorkbenchTable } from '../../../../platform/list/browser/listService.js
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
+import { asCssVariable, editorBackground, textLinkForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { EditorPane } from '../../../browser/parts/editor/editorPane.js';
@@ -855,7 +855,7 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 		templateData.currentElement.element = element;
 		const instruction = element.instruction;
 		templateData.sourcecode.innerText = '';
-		const symbolPrefix = instruction.symbol ? instruction.symbol + ':\n' : '';
+		const hasSymbol = !!instruction.symbol;
 		const sb = new StringBuilder(1000);
 
 		if (this._disassemblyView.isSourceCodeRender && element.showSourceLocation && instruction.location?.path && instruction.line !== undefined) {
@@ -889,14 +889,17 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 						break;
 					}
 
-					templateData.sourcecode.innerText = symbolPrefix + sourceSB.build();
+					templateData.sourcecode.innerText = '';
+					this._renderSymbolLabel(templateData.sourcecode, instruction.symbol);
+					templateData.sourcecode.appendChild(document.createTextNode(sourceSB.build()));
 				}
 			}
 		}
 
 		// Show symbol label even when source code rendering is disabled
-		if (symbolPrefix && !templateData.sourcecode.innerText) {
-			templateData.sourcecode.innerText = instruction.symbol + ':';
+		if (hasSymbol && !templateData.sourcecode.innerText && templateData.sourcecode.childElementCount === 0) {
+			templateData.sourcecode.innerText = '';
+			this._renderSymbolLabel(templateData.sourcecode, instruction.symbol);
 		}
 
 		let spacesToAppend = 10;
@@ -975,6 +978,18 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 				}
 			});
 		}
+	}
+
+	private _renderSymbolLabel(container: HTMLElement, symbol: string | undefined): void {
+		if (!symbol) {
+			return;
+		}
+		const symbolSpan = document.createElement('span');
+		symbolSpan.style.color = asCssVariable(textLinkForeground);
+		symbolSpan.style.fontWeight = 'bold';
+		symbolSpan.textContent = symbol + ':';
+		container.appendChild(symbolSpan);
+		container.appendChild(document.createTextNode('\n'));
 	}
 
 	private getUriFromSource(instruction: DebugProtocol.DisassembledInstruction): URI {

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -208,18 +208,21 @@ export class DisassemblyView extends EditorPane {
 		const delegate = new class implements ITableVirtualDelegate<IDisassembledInstructionEntry> {
 			headerRowHeight: number = 0; // No header
 			getHeight(row: IDisassembledInstructionEntry): number {
+				const hasSymbol = !!row.instruction.symbol;
+				const symbolLines = hasSymbol ? 1 : 0;
+
 				if (thisOM.isSourceCodeRender && row.showSourceLocation && row.instruction.location?.path && row.instruction.line) {
-					// instruction line + source lines
+					// instruction line + source lines + optional symbol label
 					if (row.instruction.endLine) {
-						return lineHeight * Math.max(2, (row.instruction.endLine - row.instruction.line + 2));
+						return lineHeight * Math.max(2 + symbolLines, (row.instruction.endLine - row.instruction.line + 2 + symbolLines));
 					} else {
 						// source is only a single line.
-						return lineHeight * 2;
+						return lineHeight * (2 + symbolLines);
 					}
 				}
 
-				// just instruction line
-				return lineHeight;
+				// instruction line + optional symbol label
+				return lineHeight * (1 + symbolLines);
 			}
 		};
 
@@ -852,6 +855,7 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 		templateData.currentElement.element = element;
 		const instruction = element.instruction;
 		templateData.sourcecode.innerText = '';
+		const symbolPrefix = instruction.symbol ? instruction.symbol + ':\n' : '';
 		const sb = new StringBuilder(1000);
 
 		if (this._disassemblyView.isSourceCodeRender && element.showSourceLocation && instruction.location?.path && instruction.line !== undefined) {
@@ -885,9 +889,14 @@ class InstructionRenderer extends Disposable implements ITableRenderer<IDisassem
 						break;
 					}
 
-					templateData.sourcecode.innerText = sourceSB.build();
+					templateData.sourcecode.innerText = symbolPrefix + sourceSB.build();
 				}
 			}
+		}
+
+		// Show symbol label even when source code rendering is disabled
+		if (symbolPrefix && !templateData.sourcecode.innerText) {
+			templateData.sourcecode.innerText = instruction.symbol + ':';
 		}
 
 		let spacesToAppend = 10;
@@ -1000,6 +1009,9 @@ class AccessibilityProvider implements IListAccessibilityProvider<IDisassembledI
 		const instruction = element.instruction;
 		if (instruction.address !== '-1') {
 			label += `${localize('instructionAddress', "Address")}: ${instruction.address}`;
+		}
+		if (instruction.symbol) {
+			label += `, ${localize('instructionSymbol', "Symbol")}: ${instruction.symbol}`;
 		}
 		if (instruction.instructionBytes) {
 			label += `, ${localize('instructionBytes', "Bytes")}: ${instruction.instructionBytes}`;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The DAP protocol's `DisassembledInstruction` type includes an optional `symbol` field that provides the name of the function/symbol at a given instruction address. VS Code's disassembly view completely ignores this field, showing only raw addresses and instructions without any symbol labels.

For example, a debug adapter may return:
```json
{
  "address": "0x000001e6",
  "instructionBytes": "02 00 fa",
  "instruction": "lnk #0x2",
  "symbol": "_main"
}
```

But VS Code only displays the address and instruction, with no indication of the `_main` symbol.

Closes #286322

## What is the new behavior?

When a debug adapter provides a `symbol` field on a disassembled instruction, VS Code now displays the symbol name as a label (e.g., `_main:`) above the instruction in the disassembly view. This works in three scenarios:

1. **Source code enabled + symbol present**: Symbol label appears above the source code line
2. **Source code disabled + symbol present**: Symbol label appears above the instruction
3. **No symbol**: No change to existing behavior

### Changes

- **Row height calculation** (`getHeight`): Adds an extra line of height when `instruction.symbol` is present
- **Instruction rendering** (`renderElementInner`): Displays the symbol as a label (e.g., `_main:`) in the source code area
- **Accessibility** (`getAriaLabel`): Includes the symbol name in screen reader labels

## Additional context

The `symbol` field is defined in the [DAP specification](https://microsoft.github.io/debug-adapter-protocol/specification#Types_DisassembledInstruction) as:
> "Name of the symbol that corresponds with the location of this instruction, if any."

This is consistent with how traditional disassemblers (objdump, gdb) display function boundaries in disassembly output.