### PR TITLE
fix: prevent surrogate pair splitting in computeMoreMinimalEdits

### DIFF
--- a/src/vs/editor/common/services/editorWebWorker.ts
+++ b/src/vs/editor/common/services/editorWebWorker.ts
@@ -5,6 +5,7 @@
 
 import { stringDiff } from '../../../base/common/diff/diff.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { isHighSurrogate, isLowSurrogate } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
 import { IWebWorkerServerRequestHandler } from '../../../base/common/worker/webWorker.js';
 import { Position } from '../core/position.js';
@@ -277,10 +278,37 @@ export class EditorWorker implements IDisposable, IWorkerTextModelSyncChannelSer
 			const editOffset = model.offsetAt(Range.lift(range).getStartPosition());
 
 			for (const change of changes) {
-				const start = model.positionAt(editOffset + change.originalStart);
-				const end = model.positionAt(editOffset + change.originalStart + change.originalLength);
+				// Adjust the change boundaries so they do not split surrogate pairs.
+				// stringDiff operates on UTF-16 code units, so its offsets can land
+				// in the middle of a surrogate pair, producing broken edits.
+				let { originalStart, originalLength, modifiedStart, modifiedLength } = change;
+
+				// If the start of the change lands on a low surrogate,
+				// expand backward to include the preceding high surrogate.
+				if (originalStart > 0 && isLowSurrogate(original.charCodeAt(originalStart))) {
+					originalStart--;
+					originalLength++;
+				}
+				if (modifiedStart > 0 && isLowSurrogate(text.charCodeAt(modifiedStart))) {
+					modifiedStart--;
+					modifiedLength++;
+				}
+
+				// If the end of the change lands on a high surrogate
+				// (i.e. the next char is its low surrogate), expand forward.
+				const originalEnd = originalStart + originalLength;
+				if (originalEnd < original.length && isHighSurrogate(original.charCodeAt(originalEnd - 1)) && isLowSurrogate(original.charCodeAt(originalEnd))) {
+					originalLength++;
+				}
+				const modifiedEnd = modifiedStart + modifiedLength;
+				if (modifiedEnd < text.length && isHighSurrogate(text.charCodeAt(modifiedEnd - 1)) && isLowSurrogate(text.charCodeAt(modifiedEnd))) {
+					modifiedLength++;
+				}
+
+				const start = model.positionAt(editOffset + originalStart);
+				const end = model.positionAt(editOffset + originalStart + originalLength);
 				const newEdit: TextEdit = {
-					text: text.substr(change.modifiedStart, change.modifiedLength),
+					text: text.substr(modifiedStart, modifiedLength),
 					range: { startLineNumber: start.lineNumber, startColumn: start.column, endLineNumber: end.lineNumber, endColumn: end.column }
 				};
 

--- a/src/vs/editor/test/common/services/editorWebWorker.test.ts
+++ b/src/vs/editor/test/common/services/editorWebWorker.test.ts
@@ -181,6 +181,41 @@ suite('EditorWebWorker', () => {
 		});
 	});
 
+	test('MoreMinimal, issue #248268 surrogate pairs', async function () {
+		const model = worker.addModel(['🌟 🌈 🚀 🎉']);
+
+		const edits = await worker.$computeMoreMinimalEdits(model.uri.toString(), [{
+			text: '🎉 🚀 🌟 🌈',
+			range: new Range(1, 1, 1, 12)
+		}], false);
+
+		// Apply the minimal edits and verify the result is correct.
+		// Before the fix, stringDiff would split surrogate pairs at the
+		// boundaries of minimal edits, producing lone surrogates.
+		let result = '🌟 🌈 🚀 🎉';
+		for (const edit of [...edits].reverse()) {
+			const range = Range.lift(edit.range);
+			const startOffset = model.offsetAt(range.getStartPosition());
+			const endOffset = model.offsetAt(range.getEndPosition());
+			result = result.substring(0, startOffset) + edit.text + result.substring(endOffset);
+		}
+		assert.strictEqual(result, '🎉 🚀 🌟 🌈');
+
+		// Verify that no edit text contains lone surrogates
+		for (const edit of edits) {
+			for (let i = 0; i < edit.text.length; i++) {
+				const code = edit.text.charCodeAt(i);
+				if (code >= 0xD800 && code <= 0xDBFF) {
+					const next = edit.text.charCodeAt(i + 1);
+					assert.ok(next >= 0xDC00 && next <= 0xDFFF, 'High surrogate not followed by low surrogate at ' + i);
+				} else if (code >= 0xDC00 && code <= 0xDFFF) {
+					const prev = edit.text.charCodeAt(i - 1);
+					assert.ok(prev >= 0xD800 && prev <= 0xDBFF, 'Low surrogate not preceded by high surrogate at ' + i);
+				}
+			}
+		}
+	});
+
 	async function testEdits(lines: string[], edits: TextEdit[]): Promise<unknown> {
 		const model = worker.addModel(lines);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When replacing text containing emoji (or other astral Unicode characters), the `computeMoreMinimalEdits` function in the editor web worker can produce edits with lone surrogates, corrupting the document.

For example, replacing `🌟 🌈 🚀 🎉` with `🎉 🚀 🌟 🌈` results in `☐ 🚀 ☐ 🌈` (where ☐ represents a broken surrogate pair).

This happens because `stringDiff` operates on individual UTF-16 code units via `charCodeAt()`. When it finds a common subsequence, individual surrogate code units (e.g. `\uD83C`) can be matched across different codepoints. The resulting diff change boundaries can therefore land between the high and low surrogate of an astral code point, producing edit ranges that split surrogate pairs.

Closes #248268

## What is the new behavior?

After computing the character-level diff, each change boundary is checked and expanded so it never splits a surrogate pair:

- **Start boundary**: If it lands on a low surrogate, it is moved back by 1 to include the preceding high surrogate.
- **End boundary**: If the last character in the range is a high surrogate and the next character is its low surrogate, the range is extended by 1.

Both the original and modified (replacement) text sides are adjusted independently, since the LCS may match surrogates from different codepoints.

## Additional context

The fix uses the existing `isHighSurrogate` / `isLowSurrogate` utilities from `vs/base/common/strings`. A test is included that verifies:
1. Applying the minimal edits produces the correct final text
2. No edit text contains lone surrogates

The `computeHumanReadableDiff` function is not affected because it uses line-based diffing rather than character-level diffing.