### PR TITLE
fix: avoid splitting surrogate pairs in computeMoreMinimalEdits

### DIFF
--- a/src/vs/editor/common/services/editorWebWorker.ts
+++ b/src/vs/editor/common/services/editorWebWorker.ts
@@ -5,6 +5,7 @@
 
 import { stringDiff } from '../../../base/common/diff/diff.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { isHighSurrogate, isLowSurrogate } from '../../../base/common/strings.js';
 import { URI } from '../../../base/common/uri.js';
 import { IWebWorkerServerRequestHandler } from '../../../base/common/worker/webWorker.js';
 import { Position } from '../core/position.js';
@@ -277,10 +278,30 @@ export class EditorWorker implements IDisposable, IWorkerTextModelSyncChannelSer
 			const editOffset = model.offsetAt(Range.lift(range).getStartPosition());
 
 			for (const change of changes) {
-				const start = model.positionAt(editOffset + change.originalStart);
-				const end = model.positionAt(editOffset + change.originalStart + change.originalLength);
+				let { originalStart, originalLength, modifiedStart, modifiedLength } = change;
+
+				// Adjust boundaries to avoid splitting surrogate pairs.
+				// stringDiff operates on UTF-16 code units, so a change boundary
+				// may land between the high and low surrogate of an astral code
+				// point (e.g. emoji). When that happens we expand the change to
+				// include the full surrogate pair on both the original and
+				// modified side.
+				if (originalStart > 0 && isHighSurrogate(original.charCodeAt(originalStart - 1)) && isLowSurrogate(original.charCodeAt(originalStart))) {
+					originalStart--;
+					originalLength++;
+					modifiedStart--;
+					modifiedLength++;
+				}
+				const originalEnd = originalStart + originalLength;
+				if (originalEnd < original.length && isHighSurrogate(original.charCodeAt(originalEnd - 1)) && isLowSurrogate(original.charCodeAt(originalEnd))) {
+					originalLength++;
+					modifiedLength++;
+				}
+
+				const start = model.positionAt(editOffset + originalStart);
+				const end = model.positionAt(editOffset + originalStart + originalLength);
 				const newEdit: TextEdit = {
-					text: text.substr(change.modifiedStart, change.modifiedLength),
+					text: text.substr(modifiedStart, modifiedLength),
 					range: { startLineNumber: start.lineNumber, startColumn: start.column, endLineNumber: end.lineNumber, endColumn: end.column }
 				};
 

--- a/src/vs/editor/test/common/services/editorWebWorker.test.ts
+++ b/src/vs/editor/test/common/services/editorWebWorker.test.ts
@@ -181,6 +181,42 @@ suite('EditorWebWorker', () => {
 		});
 	});
 
+
+	test('MoreMinimal, issue #248268 surrogate pairs not split', async function () {
+
+		const model = worker.addModel([
+			'🌟 🌈 🚀 🎉'
+		], '\n');
+
+		const edits = await worker.$computeMoreMinimalEdits(model.uri.toString(), [{
+			text: '🎉 🚀 🌟 🌈',
+			range: new Range(1, 1, 1, 12)
+		}], false);
+
+		// Verify that all edit texts contain only valid surrogate pairs
+		for (const edit of edits) {
+			for (let i = 0; i < edit.text.length; i++) {
+				const code = edit.text.charCodeAt(i);
+				if (code >= 0xD800 && code <= 0xDBFF) {
+					const next = edit.text.charCodeAt(i + 1);
+					assert.ok(next >= 0xDC00 && next <= 0xDFFF, 'High surrogate at ' + i + ' not followed by low surrogate');
+				} else if (code >= 0xDC00 && code <= 0xDFFF) {
+					const prev = i > 0 ? edit.text.charCodeAt(i - 1) : 0;
+					assert.ok(prev >= 0xD800 && prev <= 0xDBFF, 'Low surrogate at ' + i + ' not preceded by high surrogate');
+				}
+			}
+		}
+
+		// Apply edits to original and verify the result is correct
+		let result = model.getValue();
+		for (const edit of [...edits].reverse()) {
+			const startOff = model.offsetAt({ lineNumber: edit.range.startLineNumber, column: edit.range.startColumn });
+			const endOff = model.offsetAt({ lineNumber: edit.range.endLineNumber, column: edit.range.endColumn });
+			result = result.substring(0, startOff) + edit.text + result.substring(endOff);
+		}
+		assert.strictEqual(result, '🎉 🚀 🌟 🌈');
+	});
+
 	async function testEdits(lines: string[], edits: TextEdit[]): Promise<unknown> {
 		const model = worker.addModel(lines);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When replacing text that contains emoji or other characters outside the Basic Multilingual Plane (astral Unicode, represented as surrogate pairs in UTF-16), `$computeMoreMinimalEdits` produces corrupted edit text. For example, replacing `🌟 🌈 🚀 🎉` with `🎉 🚀 🌟 🌈` results in `� 🚀 � 🌈` (broken surrogate halves).

This affects:
- The search panel **Replace All** (Ctrl+Shift+H)
- `vscode.workspace.applyEdit()` from extensions
- Any code path that goes through `computeMoreMinimalEdits` in the editor worker

The in-editor **Find and Replace** widget is not affected because it does not use `computeMoreMinimalEdits`.

Closes #248268

## What is the new behavior?

After the character-level `stringDiff` computes minimal edit boundaries, we check whether each boundary lands between the high and low surrogate of a surrogate pair. If so, we expand the change by one code unit in both the original and modified strings so that the full surrogate pair stays together.

The fix is minimal and self-contained: only the loop in `$computeMoreMinimalEdits` is changed, with no alterations to the diff algorithm itself.

## Additional context

**Root cause:** `stringDiff` (via `StringDiffSequence`) operates on individual UTF-16 code units (`charCodeAt`). When the LCS diff finds a common subsequence that happens to split a surrogate pair at its boundary, the resulting `originalStart`/`modifiedStart` offsets point at a low surrogate, and `text.substr(modifiedStart, modifiedLength)` produces an orphaned surrogate — which renders as `�`.

**Why this approach:** Rather than modifying the general-purpose `stringDiff` or `commonPrefixLength`/`commonSuffixLength` functions (which would affect many callers), the fix adjusts boundaries only where they are consumed as text edit ranges. This keeps the change focused and low-risk.

A test is included that verifies both:
1. No edit text contains split surrogate pairs
2. Applying the edits produces the correct final result