### PR TITLE
fix(git): respect core.commentChar when stripping commit message comments

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3247,9 +3247,25 @@ export class Repository {
 		return this.getBranch(result.stdout.trim());
 	}
 
-	// TODO: Support core.commentChar
-	stripCommitMessageComments(message: string): string {
-		return message.replace(/^\s*#.*$\n?/gm, '').trim();
+	async getCommentChar(): Promise<string> {
+		try {
+			const result = await this.exec(['config', '--get', 'core.commentChar']);
+			const value = result.stdout.trim();
+
+			if (value === 'auto' || value.length === 0) {
+				return '#';
+			}
+
+			return value;
+		} catch {
+			return '#';
+		}
+	}
+
+	async stripCommitMessageComments(message: string): Promise<string> {
+		const commentChar = await this.getCommentChar();
+		const escapedChar = commentChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		return message.replace(new RegExp(`^\\s*${escapedChar}.*$\\n?`, 'gm'), '').trim();
 	}
 
 	async getSquashMessage(): Promise<string | undefined> {
@@ -3257,7 +3273,7 @@ export class Repository {
 
 		try {
 			const raw = await fs.readFile(squashMsgPath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			return await this.stripCommitMessageComments(raw);
 		} catch {
 			return undefined;
 		}
@@ -3268,7 +3284,7 @@ export class Repository {
 
 		try {
 			const raw = await fs.readFile(mergeMsgPath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			return await this.stripCommitMessageComments(raw);
 		} catch {
 			return undefined;
 		}
@@ -3292,7 +3308,7 @@ export class Repository {
 			}
 
 			const raw = await fs.readFile(templatePath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			return await this.stripCommitMessageComments(raw);
 		} catch (err) {
 			return '';
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `stripCommitMessageComments` method in the git extension hardcodes `#` as the comment character when stripping comments from merge messages, squash messages, and commit templates. Users who configure a custom comment character via `core.commentChar` (e.g., `;` or `*`) have their comment lines included verbatim in commit messages instead of being stripped.

For example, with `core.commentChar = ;`, lines starting with `;` in MERGE_MSG or SQUASH_MSG are left in the final commit message.

Closes #133770

## What is the new behavior?

- Added `getCommentChar()` method that reads `core.commentChar` from git config
- Made `stripCommitMessageComments()` async to read the configured comment character
- The comment character is properly regex-escaped before use in the stripping pattern
- Falls back to `#` when `core.commentChar` is not set, empty, or set to `auto`
- Updated all three callers (`getSquashMessage`, `getMergeMessage`, `getCommitTemplate`) to await the now-async method

This also resolves the `TODO: Support core.commentChar` that was annotated in the code.

## Additional context

The fix addresses a TODO comment that existed in `extensions/git/src/git.ts` at line 3250. The `core.commentChar` git config option has been available since Git 2.0 and allows users to change the character used for comments in commit messages (commonly needed when commit message conventions use `#` for issue references).