### PR TITLE
fix #307574. support opening scm diff in modal.

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -35,7 +35,7 @@ import { EditorGroupColumn, columnToEditorGroup } from '../../../services/editor
 import { EditorGroupLayout, GroupDirection, GroupLocation, GroupsOrder, IEditorGroup, IEditorGroupsService, IEditorReplacement, IModalEditorPart, preferredSideBySideGroupDirection } from '../../../services/editor/common/editorGroupsService.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { IEditorResolverService } from '../../../services/editor/common/editorResolverService.js';
-import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IUntitledTextEditorService } from '../../../services/untitled/common/untitledTextEditorService.js';
 import { DIFF_FOCUS_OTHER_SIDE, DIFF_FOCUS_PRIMARY_SIDE, DIFF_FOCUS_SECONDARY_SIDE, registerDiffEditorCommands } from './diffEditorCommands.js';
@@ -115,6 +115,7 @@ export const TOGGLE_MODAL_EDITOR_SIDEBAR_COMMAND_ID = 'workbench.action.toggleMo
 
 export const API_OPEN_EDITOR_COMMAND_ID = '_workbench.open';
 export const API_OPEN_DIFF_EDITOR_COMMAND_ID = '_workbench.diff';
+export const API_OPEN_DIFF_EDITOR_IN_MODAL_COMMAND_ID = '_workbench.diffInModal';
 export const API_OPEN_WITH_EDITOR_COMMAND_ID = '_workbench.openWith';
 
 export const EDITOR_CORE_NAVIGATION_COMMANDS = [
@@ -424,15 +425,41 @@ function registerEditorGroupsLayoutCommands(): void {
 
 function registerOpenEditorAPICommands(): void {
 
-	function mixinContext(context: IOpenEvent<unknown> | undefined, options: ITextEditorOptions | undefined, column: EditorGroupColumn | undefined): [ITextEditorOptions | undefined, EditorGroupColumn | undefined] {
+	function mixinContext(context: IOpenEvent<unknown> | undefined, options: ITextEditorOptions | undefined, column: EditorGroupColumn | undefined, columnOverride?: EditorGroupColumn): [ITextEditorOptions | undefined, EditorGroupColumn | undefined] {
 		if (!context) {
-			return [options, column];
+			return [options, columnOverride ?? column];
 		}
 
 		return [
 			{ ...context.editorOptions, ...(options ?? Object.create(null)) },
-			context.sideBySide ? SIDE_GROUP : column
+			columnOverride ?? (context.sideBySide ? SIDE_GROUP : column)
 		];
+	}
+
+	async function openDiffEditor(accessor: ServicesAccessor, originalResource: UriComponents, modifiedResource: UriComponents, labelAndOrDescription?: string | { label: string; description: string }, columnAndOptions?: [EditorGroupColumn?, ITextEditorOptions?], context?: IOpenEvent<unknown>, columnOverride?: EditorGroupColumn): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editorGroupsService = accessor.get(IEditorGroupsService);
+		const configurationService = accessor.get(IConfigurationService);
+
+		const [columnArg, optionsArg] = columnAndOptions ?? [];
+		const [options, column] = mixinContext(context, optionsArg, columnArg, columnOverride);
+
+		let label: string | undefined = undefined;
+		let description: string | undefined = undefined;
+		if (typeof labelAndOrDescription === 'string') {
+			label = labelAndOrDescription;
+		} else if (labelAndOrDescription) {
+			label = labelAndOrDescription.label;
+			description = labelAndOrDescription.description;
+		}
+
+		await editorService.openEditor({
+			original: { resource: URI.from(originalResource, true) },
+			modified: { resource: URI.from(modifiedResource, true) },
+			label,
+			description,
+			options
+		}, columnToEditorGroup(editorGroupsService, configurationService, column));
 	}
 
 	// partial, renderer-side API command to open editor only supporting
@@ -513,29 +540,11 @@ function registerOpenEditorAPICommands(): void {
 	});
 
 	CommandsRegistry.registerCommand(API_OPEN_DIFF_EDITOR_COMMAND_ID, async function (accessor: ServicesAccessor, originalResource: UriComponents, modifiedResource: UriComponents, labelAndOrDescription?: string | { label: string; description: string }, columnAndOptions?: [EditorGroupColumn?, ITextEditorOptions?], context?: IOpenEvent<unknown>) {
-		const editorService = accessor.get(IEditorService);
-		const editorGroupsService = accessor.get(IEditorGroupsService);
-		const configurationService = accessor.get(IConfigurationService);
+		await openDiffEditor(accessor, originalResource, modifiedResource, labelAndOrDescription, columnAndOptions, context);
+	});
 
-		const [columnArg, optionsArg] = columnAndOptions ?? [];
-		const [options, column] = mixinContext(context, optionsArg, columnArg);
-
-		let label: string | undefined = undefined;
-		let description: string | undefined = undefined;
-		if (typeof labelAndOrDescription === 'string') {
-			label = labelAndOrDescription;
-		} else if (labelAndOrDescription) {
-			label = labelAndOrDescription.label;
-			description = labelAndOrDescription.description;
-		}
-
-		await editorService.openEditor({
-			original: { resource: URI.from(originalResource, true) },
-			modified: { resource: URI.from(modifiedResource, true) },
-			label,
-			description,
-			options
-		}, columnToEditorGroup(editorGroupsService, configurationService, column));
+	CommandsRegistry.registerCommand(API_OPEN_DIFF_EDITOR_IN_MODAL_COMMAND_ID, async function (accessor: ServicesAccessor, originalResource: UriComponents, modifiedResource: UriComponents, labelAndOrDescription?: string | { label: string; description: string }, columnAndOptions?: [EditorGroupColumn?, ITextEditorOptions?], context?: IOpenEvent<unknown>) {
+		await openDiffEditor(accessor, originalResource, modifiedResource, labelAndOrDescription, columnAndOptions, context, MODAL_GROUP);
 	});
 
 	CommandsRegistry.registerCommand(API_OPEN_WITH_EDITOR_COMMAND_ID, async (accessor: ServicesAccessor, resource: UriComponents, id: string, columnAndOptions?: [EditorGroupColumn?, ITextEditorOptions?]) => {

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -712,7 +712,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.Setup.hidden.negate(),
 					ChatContextKeys.Setup.disabled.negate(),
-					ChatContextKeys.Setup.installed.negate(),
+					ChatContextKeys.Setup.completed.negate(),
 					ContextKeyExpr.in(ResourceContextKey.Resource.key, 'git.mergeChanges'),
 					ContextKeyExpr.equals('git.activeResourceHasMergeConflicts', true)
 				)

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -427,6 +427,15 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			description: localize('scm.graph.showOutgoingChanges', "Controls whether to show outgoing changes in the Source Control Graph view."),
 			default: true
+		},
+		'scm.allowOpenInModalEditor': {
+			type: 'boolean',
+			description: localize('scm.allowOpenInModalEditor', "Controls whether Source Control diff editors open in a modal editor overlay."),
+			default: false,
+			tags: ['experimental'],
+			experiment: {
+				mode: 'auto'
+			}
 		}
 	}
 });
@@ -703,7 +712,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.Setup.hidden.negate(),
 					ChatContextKeys.Setup.disabled.negate(),
-					ChatContextKeys.Setup.completed.negate(),
+					ChatContextKeys.Setup.installed.negate(),
 					ContextKeyExpr.in(ResourceContextKey.Resource.key, 'git.mergeChanges'),
 					ContextKeyExpr.equals('git.activeResourceHasMergeConflicts', true)
 				)

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -60,7 +60,7 @@ import { FileKind } from '../../../../platform/files/common/files.js';
 import { WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { basename } from '../../../../base/common/path.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP } from '../../../services/editor/common/editorService.js';
 import { ScmHistoryItemResolver } from '../../multiDiffEditor/browser/scmMultiDiffSourceResolver.js';
 import { IResourceNode, ResourceTree } from '../../../../base/common/resourceTree.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -2064,12 +2064,13 @@ export class SCMHistoryViewPane extends ViewPane {
 				const modifiedUriTitle = `${basename(historyItemChange.modifiedUri.fsPath)} (${historyItemDisplayId})`;
 
 				const title = `${originalUriTitle} \u2194 ${modifiedUriTitle}`;
+				const useModal = this.configurationService.getValue<boolean>('scm.allowOpenInModalEditor');
 				await this._editorService.openEditor({
 					label: title,
 					original: { resource: historyItemChange.originalUri },
 					modified: { resource: historyItemChange.modifiedUri },
 					options: e.editorOptions
-				});
+				}, useModal ? MODAL_GROUP : undefined);
 			} else if (historyItemChange.modifiedUri) {
 				await this._editorService.openEditor({
 					label: `${basename(historyItemChange.modifiedUri.fsPath)} (${historyItemDisplayId})`,

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -14,7 +14,7 @@ import { IListVirtualDelegate, IIdentityProvider } from '../../../../base/browse
 import { ISCMResourceGroup, ISCMResource, ISCMRepository, ISCMInput, ISCMViewService, ISCMViewVisibleRepositoryChangeEvent, ISCMService, VIEW_PANE_ID, ISCMActionButton, ISCMActionButtonDescriptor, ISCMRepositorySortKey, ViewMode, ISCMRepositorySelectionMode } from '../common/scm.js';
 import { ResourceLabels, IResourceLabel, IFileLabelOptions } from '../../../browser/labels.js';
 import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP } from '../../../services/editor/common/editorService.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IContextKeyService, IContextKey, ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -33,7 +33,7 @@ import { ResourceTree, IResourceNode } from '../../../../base/common/resourceTre
 import { ICompressibleTreeRenderer, ICompressibleKeyboardNavigationLabelProvider } from '../../../../base/browser/ui/tree/objectTree.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
-import { URI } from '../../../../base/common/uri.js';
+import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { FileKind } from '../../../../platform/files/common/files.js';
 import { compareFileNames, comparePaths } from '../../../../base/common/comparers.js';
 import { FuzzyScore, createMatches, IMatch } from '../../../../base/common/filters.js';
@@ -1723,7 +1723,17 @@ export class SCMViewPane extends ViewPane {
 						preserveFocus: true,
 					});
 				} else {
-					await this.commandService.executeCommand(e.element.command.id, ...(e.element.command.arguments || []), e);
+					if (e.element.command.id === API_OPEN_DIFF_EDITOR_COMMAND_ID && this.configurationService.getValue<boolean>('scm.allowOpenInModalEditor')) {
+						const [original, modified, label] = (e.element.command.arguments || []) as [UriComponents, UriComponents, string | undefined];
+						await this.editorService.openEditor({
+							original: { resource: URI.from(original, true) },
+							modified: { resource: URI.from(modified, true) },
+							label,
+							options: e.editorOptions
+						}, MODAL_GROUP);
+					} else {
+						await this.commandService.executeCommand(e.element.command.id, ...(e.element.command.arguments || []), e);
+					}
 				}
 			} else {
 				await e.element.open(!!e.editorOptions.preserveFocus);

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -14,7 +14,7 @@ import { IListVirtualDelegate, IIdentityProvider } from '../../../../base/browse
 import { ISCMResourceGroup, ISCMResource, ISCMRepository, ISCMInput, ISCMViewService, ISCMViewVisibleRepositoryChangeEvent, ISCMService, VIEW_PANE_ID, ISCMActionButton, ISCMActionButtonDescriptor, ISCMRepositorySortKey, ViewMode, ISCMRepositorySelectionMode } from '../common/scm.js';
 import { ResourceLabels, IResourceLabel, IFileLabelOptions } from '../../../browser/labels.js';
 import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
-import { IEditorService, MODAL_GROUP } from '../../../services/editor/common/editorService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IContextKeyService, IContextKey, ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -33,7 +33,7 @@ import { ResourceTree, IResourceNode } from '../../../../base/common/resourceTre
 import { ICompressibleTreeRenderer, ICompressibleKeyboardNavigationLabelProvider } from '../../../../base/browser/ui/tree/objectTree.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
-import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { URI } from '../../../../base/common/uri.js';
 import { FileKind } from '../../../../platform/files/common/files.js';
 import { compareFileNames, comparePaths } from '../../../../base/common/comparers.js';
 import { FuzzyScore, createMatches, IMatch } from '../../../../base/common/filters.js';
@@ -52,7 +52,7 @@ import { RepositoryActionRunner, RepositoryRenderer } from './scmRepositoryRende
 import { isDark } from '../../../../platform/theme/common/theme.js';
 import { LabelFuzzyScore } from '../../../../base/browser/ui/tree/abstractTree.js';
 import { Selection } from '../../../../editor/common/core/selection.js';
-import { API_OPEN_DIFF_EDITOR_COMMAND_ID, API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
+import { API_OPEN_DIFF_EDITOR_COMMAND_ID, API_OPEN_DIFF_EDITOR_IN_MODAL_COMMAND_ID, API_OPEN_EDITOR_COMMAND_ID } from '../../../browser/parts/editor/editorCommands.js';
 import { getFlatContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { Button, ButtonWithDescription, ButtonWithDropdown } from '../../../../base/browser/ui/button/button.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -1724,13 +1724,7 @@ export class SCMViewPane extends ViewPane {
 					});
 				} else {
 					if (e.element.command.id === API_OPEN_DIFF_EDITOR_COMMAND_ID && this.configurationService.getValue<boolean>('scm.allowOpenInModalEditor')) {
-						const [original, modified, label] = (e.element.command.arguments || []) as [UriComponents, UriComponents, string | undefined];
-						await this.editorService.openEditor({
-							original: { resource: URI.from(original, true) },
-							modified: { resource: URI.from(modified, true) },
-							label,
-							options: e.editorOptions
-						}, MODAL_GROUP);
+						await this.commandService.executeCommand(API_OPEN_DIFF_EDITOR_IN_MODAL_COMMAND_ID, ...(e.element.command.arguments || []), e);
 					} else {
 						await this.commandService.executeCommand(e.element.command.id, ...(e.element.command.arguments || []), e);
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When using VS Code on a relatively small monitor (e.g., a laptop), if we have agents view, and file explorer open, it leaves really little space for editor group. This makes it really hard to review changes from time to time since the diff editor is opened in the editor group.

I'd love to propose we allow diff editor (for now limit to sim) to be opened in modal

https://github.com/microsoft/vscode/issues/307574


https://github.com/user-attachments/assets/625a601a-8d6a-4c55-bc57-56659dd8ae69