### PR TITLE
fix: resolve non-file scheme URIs in Reveal in Explorer command

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -321,7 +321,18 @@ CommandsRegistry.registerCommand({
 		const explorerService = accessor.get(IExplorerService);
 		const editorService = accessor.get(IEditorService);
 		const listService = accessor.get(IListService);
-		const uri = getResourceForCommand(resource, editorService, listService);
+		let uri = getResourceForCommand(resource, editorService, listService);
+
+		// When the resource has a non-file scheme (e.g. git:, git-original:), try to
+		// map it to a file: URI so that it can be revealed in the explorer. Virtual file
+		// systems such as the git extension use the same path as the underlying file, so
+		// converting the scheme is sufficient to recover the real workspace resource.
+		if (uri && !contextService.isInsideWorkspace(uri) && uri.scheme !== Schemas.file) {
+			const fileUri = uri.with({ scheme: Schemas.file, query: '', fragment: '' });
+			if (contextService.isInsideWorkspace(fileUri)) {
+				uri = fileUri;
+			}
+		}
 
 		if (uri && contextService.isInsideWorkspace(uri)) {
 			const explorerView = await viewService.openView<ExplorerView>(VIEW_ID, false);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a file diff is opened from the Source Control view (e.g. by clicking a modified file to see changes), the editor tab shows a read-only diff. Right-clicking this tab and selecting **Reveal in Explorer View** does nothing.

This happens because the active editor's resource URI uses a non-file scheme (e.g. `git:` for staged changes, or `git:` with a ref query for working tree diffs against HEAD). The `revealInExplorer` command checks `contextService.isInsideWorkspace(uri)`, which returns `false` for non-file scheme URIs since workspace folders use the `file:` scheme. The command silently falls through to the Open Editors fallback path.

Closes #240657

## What is the new behavior?

Before checking whether the URI is inside the workspace, the command now attempts to convert non-file scheme URIs to their underlying `file:` URI. Virtual file systems like the git extension preserve the original file path in the URI, so converting the scheme (and stripping query/fragment metadata) recovers the real workspace resource.

The conversion is guarded: it only applies when the original URI is not already inside the workspace, has a non-file scheme, and the converted URI **is** inside the workspace. This ensures no change in behavior for regular file editors or remote workspaces.

## Additional context

The fix is in `src/vs/workbench/contrib/files/browser/fileCommands.ts` in the `revealInExplorer` command handler. The change is minimal (12 lines added) and uses only existing imports (`Schemas` was already imported).