### PR TITLE
feat: add #region and #endregion snippet completions for Python

### DIFF
--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -47,6 +47,12 @@
         "path": "./syntaxes/MagicRegExp.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "python",
+        "path": "./snippets/python.code-snippets"
+      }
+    ],
     "configurationDefaults": {
       "[python]": {
         "diffEditor.ignoreTrimWhitespace": false,

--- a/extensions/python/snippets/python.code-snippets
+++ b/extensions/python/snippets/python.code-snippets
@@ -1,0 +1,16 @@
+{
+	"Region Start": {
+		"prefix": "#region",
+		"body": [
+			"# region $0"
+		],
+		"description": "Folding Region Start"
+	},
+	"Region End": {
+		"prefix": "#endregion",
+		"body": [
+			"# endregion"
+		],
+		"description": "Folding Region End"
+	}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature (snippet completions for Python folding region markers)

## What is the current behavior?
The Python language configuration already defines folding markers for `# region` / `# endregion` patterns ([language-configuration.json](https://github.com/microsoft/vscode/blob/main/extensions/python/language-configuration.json#L45-L48)), but there are no snippet completions to help users discover and insert these markers. Other languages like C#, C++, and C already provide `#region` / `#endregion` snippet completions.

Closes #103445

## What is the new behavior?
When typing `#region` or `#endregion` in a Python file, autocomplete now suggests the corresponding folding region markers:

- `#region` expands to `# region ` (with cursor positioned after the space for typing a region name)
- `#endregion` expands to `# endregion`

The snippets use Python's comment convention with a space after `#` (i.e., `# region` rather than `#region`), which matches the folding marker regex and follows PEP 8 style.

## Additional context
This follows the exact same pattern used by the built-in C#, C++, and C language extensions which already provide region snippet completions:
- `extensions/csharp/snippets/csharp.code-snippets`
- `extensions/cpp/snippets/cpp.code-snippets`
- `extensions/cpp/snippets/c.code-snippets`

Changes:
1. New file: `extensions/python/snippets/python.code-snippets` with region start/end snippets
2. Modified: `extensions/python/package.json` to register the snippets contribution