### PR TITLE
fix: remove unnecessary cancel log in JSON language server

### DIFF
--- a/extensions/json-language-features/server/src/utils/runner.ts
+++ b/extensions/json-language-features/server/src/utils/runner.ts
@@ -65,6 +65,5 @@ export function runSafe<T, E>(runtime: RuntimeEnvironment, func: () => T, errorV
 }
 
 function cancelValue<E>() {
-	console.log('cancelled');
 	return new ResponseError<E>(LSPErrorCodes.RequestCancelled, 'Request cancelled');
 }


### PR DESCRIPTION
Fixes #306030

## Summary
- Removed the `console.log('cancelled')` call from `cancelValue()` in `extensions/json-language-features/server/src/utils/runner.ts`
- This log fired on every cancelled JSON language server request (e.g. during fast typing), producing noise with no diagnostic value

## Test plan
- Open a JSON file and type quickly — no `cancelled` log should appear in the Output panel