### PR TITLE
fix: clear parent change listener before disposeContext in ScopedContextKeyService

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -509,6 +509,9 @@ class ScopedContextKeyService extends AbstractContextKeyService {
 			return;
 		}
 
+		// Clear the parent change listener before disposeContext to avoid
+		// forwarding parent events after this service has begun tearing down.
+		this._parentChangeListener.clear();
 		this._parent.disposeContext(this._myContextId);
 		this._domNode.removeAttribute(KEYBINDING_CONTEXT_ATTR);
 		super.dispose();


### PR DESCRIPTION
Fixes #307067

## Summary
- `ScopedContextKeyService.dispose()` now calls `this._parentChangeListener.clear()` before `this._parent.disposeContext(this._myContextId)`
- Previously, the parent emitter listener could still fire during disposal if a context change occurred between the start of `dispose()` and `super.dispose()` being called, contributing to the listener leak

## Test plan
- Create many scoped context key service instances and dispose them — the "potential listener LEAK detected" warning should no longer appear in the console