### PR TITLE
fix(git): open file in correct editor group from diff editor toolbar

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5,7 +5,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { Command, commands, Disposable, MessageOptions, Position, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider, InputBoxValidationSeverity, TabInputText, TabInputTextMerge, QuickPickItemKind, TextDocument, LogOutputChannel, l10n, Memento, UIKind, QuickInputButton, ThemeIcon, SourceControlHistoryItem, SourceControl, InputBoxValidationMessage, Tab, TabInputNotebook, QuickInputButtonLocation, languages, SourceControlArtifact, ProgressLocation } from 'vscode';
+import { Command, commands, Disposable, MessageOptions, Position, QuickPickItem, Range, SourceControlResourceState, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace, WorkspaceEdit, WorkspaceFolder, TimelineItem, env, Selection, TextDocumentContentProvider, InputBoxValidationSeverity, TabInputText, TabInputTextDiff, TabInputTextMerge, QuickPickItemKind, TextDocument, LogOutputChannel, l10n, Memento, UIKind, QuickInputButton, ThemeIcon, SourceControlHistoryItem, SourceControl, InputBoxValidationMessage, Tab, TabInputNotebook, QuickInputButtonLocation, languages, SourceControlArtifact, ProgressLocation } from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import type { CommitOptions, RemoteSourcePublisher, Remote, Branch, Ref } from './api/git';
 import { ForcePushMode, GitErrorCodes, RefType, Status } from './api/git.constants';
@@ -1331,11 +1331,28 @@ export class CommandCenter {
 		const previousURI = activeTextEditor?.document.uri;
 		const previousSelection = activeTextEditor?.selection;
 
+		// When triggered from an editor title action on a diff editor,
+		// open the file in the same editor group as the source editor
+		// instead of always using the active group (fixes #265405)
+		let viewColumn = ViewColumn.Active;
+		if (arg instanceof Uri) {
+			const argStr = arg.toString();
+			for (const group of window.tabGroups.all) {
+				if (group.tabs.some(tab =>
+					(tab.input instanceof TabInputText && tab.input.uri.toString() === argStr) ||
+					(tab.input instanceof TabInputTextDiff && (tab.input.original.toString() === argStr || tab.input.modified.toString() === argStr))
+				)) {
+					viewColumn = group.viewColumn;
+					break;
+				}
+			}
+		}
+
 		for (const uri of uris) {
 			const opts: TextDocumentShowOptions = {
 				preserveFocus,
 				preview: false,
-				viewColumn: ViewColumn.Active
+				viewColumn
 			};
 
 			await commands.executeCommand('vscode.open', uri, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When two diff editors are open in separate split panels, clicking the **Open File** (`git.openFile`) toolbar button on the non-focused diff editor opens the file in the focused (active) editor group instead of the same group as the source diff editor.

This is disorienting because the user expects the file to open alongside (replacing) the diff they were looking at, not in a completely different split.

Closes #265405

## What is the new behavior?

When the command is triggered with a URI argument (which indicates it was invoked from an editor title action rather than a keybinding or command palette), the command searches through all tab groups to find the one containing a tab whose URI matches the source editor. It then uses that group's `viewColumn` instead of unconditionally using `ViewColumn.Active`.

The lookup checks both `TabInputText` and `TabInputTextDiff` inputs to handle cases where the source is either a regular editor or a diff editor.

When no matching tab group is found (e.g., the command is triggered via other means), the behavior falls back to `ViewColumn.Active`, preserving backward compatibility.

## Additional context

- Added `TabInputTextDiff` to the imports from `vscode`
- The fix applies to all callers of `git.openFile` that pass a URI argument, which includes the editor title toolbar buttons for diff editors and non-diff git editors
- The same `ViewColumn.Active` pattern exists in `git.openHEADFile` (line ~4786) and `git.stageChange` (line ~4831) but those commands have different UX expectations so they are left unchanged