### PR TITLE
fix: scope code action diagnostics to specific marker from Problems view

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1164,6 +1164,8 @@ export const enum CodeActionTriggerType {
 export interface CodeActionContext {
 	only?: string;
 	trigger: CodeActionTriggerType;
+	/** When set, only these diagnostics are included in the code action request sent to providers. */
+	diagnostics?: readonly IMarkerData[];
 }
 
 export interface CodeActionList extends IDisposable {

--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -114,6 +114,7 @@ export async function getCodeActions(
 	const codeActionContext: languages.CodeActionContext = {
 		only: filter.include?.value,
 		trigger: trigger.type,
+		diagnostics: trigger.diagnostics,
 	};
 
 	const cts = new TextModelCancellationTokenSource(model, token);

--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -9,6 +9,7 @@ import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
 import { Position } from '../../../common/core/position.js';
 import * as languages from '../../../common/languages.js';
 import { ActionSet } from '../../../../platform/actionWidget/common/actionWidget.js';
+import { IMarkerData } from '../../../../platform/markers/common/markers.js';
 
 export const CodeActionKind = new class {
 	public readonly QuickFix = new HierarchicalKind('quickfix');
@@ -127,6 +128,8 @@ export interface CodeActionTrigger {
 		readonly notAvailableMessage: string;
 		readonly position: Position;
 	};
+	/** When set, only these diagnostics are included in the code action request context. */
+	readonly diagnostics?: readonly IMarkerData[];
 }
 
 export class CodeActionCommandArgs {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -474,13 +474,19 @@ class CodeActionAdapter {
 		const ran = Selection.isISelection(rangeOrSelection)
 			? <vscode.Selection>typeConvert.Selection.to(rangeOrSelection)
 			: <vscode.Range>typeConvert.Range.to(rangeOrSelection);
-		const allDiagnostics: vscode.Diagnostic[] = [];
-
-		for (const diagnostic of this._diagnostics.getDiagnostics(resource)) {
-			if (ran.intersection(diagnostic.range)) {
-				const newLen = allDiagnostics.push(diagnostic);
-				if (newLen > CodeActionAdapter._maxCodeActionsPerFile) {
-					break;
+		let allDiagnostics: vscode.Diagnostic[];
+		if (context.diagnostics) {
+			// When the request originates from a specific diagnostic (e.g. Problems view),
+			// use only those diagnostics instead of gathering all diagnostics at the range.
+			allDiagnostics = context.diagnostics.map(typeConvert.Diagnostic.to);
+		} else {
+			allDiagnostics = [];
+			for (const diagnostic of this._diagnostics.getDiagnostics(resource)) {
+				if (ran.intersection(diagnostic.range)) {
+					const newLen = allDiagnostics.push(diagnostic);
+					if (newLen > CodeActionAdapter._maxCodeActionsPerFile) {
+						break;
+					}
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -637,7 +637,7 @@ export class MarkerViewModel extends Disposable {
 					if (!this.codeActionsPromise) {
 						this.codeActionsPromise = createCancelablePromise(cancellationToken => {
 							return getCodeActions(this.languageFeaturesService.codeActionProvider, model, new Range(this.marker.range.startLineNumber, this.marker.range.startColumn, this.marker.range.endLineNumber, this.marker.range.endColumn), {
-								type: CodeActionTriggerType.Invoke, triggerAction: CodeActionTriggerSource.ProblemsView, filter: { include: CodeActionKind.QuickFix }
+								type: CodeActionTriggerType.Invoke, triggerAction: CodeActionTriggerSource.ProblemsView, filter: { include: CodeActionKind.QuickFix }, diagnostics: [this.marker.marker]
 							}, Progress.None, cancellationToken).then(actions => {
 								return this._register(actions);
 							});
@@ -650,7 +650,24 @@ export class MarkerViewModel extends Disposable {
 	}
 
 	private toActions(codeActions: CodeActionSet): IAction[] {
-		return codeActions.validActions.map(item => toAction({
+		// Filter code actions to only those relevant to the specific marker.
+		// Keep actions that either have no diagnostics or have at least one
+		// diagnostic matching this marker's range and message.
+		const marker = this.marker.marker;
+		const relevant = codeActions.validActions.filter(item => {
+			const diagnostics = item.action.diagnostics;
+			if (!diagnostics || diagnostics.length === 0) {
+				return true;
+			}
+			return diagnostics.some(d =>
+				d.message === marker.message &&
+				d.startLineNumber === marker.startLineNumber &&
+				d.startColumn === marker.startColumn &&
+				d.endLineNumber === marker.endLineNumber &&
+				d.endColumn === marker.endColumn
+			);
+		});
+		return relevant.map(item => toAction({
 			id: item.action.command ? item.action.command.id : item.action.title,
 			label: item.action.title,
 			run: async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When clicking on a specific diagnostic in the Problems view to get quick fixes, the `textDocument/codeAction` request sent to language servers includes **all** diagnostics at that range in the context, not just the one that was clicked. This causes language servers to compute and return code actions for unrelated diagnostics, showing irrelevant quick fixes for the selected marker.

For example, if two different diagnostics share the same range (e.g., an "upgrade available" warning and a "vulnerability found" warning), clicking on one shows quick fixes for both.

Closes #161331

## What is the new behavior?

Two complementary fixes:

1. **Scoped diagnostic context**: The `CodeActionContext` interface now supports an optional `diagnostics` field. When requesting code actions from the Problems view, only the specific marker's diagnostic is included in the request context. This allows language servers to compute only the relevant code actions.

2. **Client-side filtering**: Returned code actions are filtered to only show those whose `diagnostics` array matches the clicked marker (by message and range). Code actions without diagnostics are still shown, as they may be general-purpose actions.

### Changes

- `src/vs/editor/common/languages.ts`: Added optional `diagnostics` field to `CodeActionContext`
- `src/vs/editor/contrib/codeAction/common/types.ts`: Added optional `diagnostics` field to `CodeActionTrigger`
- `src/vs/editor/contrib/codeAction/browser/codeAction.ts`: Pass trigger diagnostics through to the context
- `src/vs/workbench/api/common/extHostLanguageFeatures.ts`: When context diagnostics are provided, use those instead of gathering all diagnostics at the range
- `src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts`: Pass the specific marker as the diagnostic when requesting code actions, and filter returned actions

### Layering

- `IMarkerData` from `platform/markers` is already used throughout `editor/contrib/codeAction/` (e.g., in `codeActionController.ts`, `codeActionModel.ts`, and tests), so the new import in `types.ts` follows existing patterns.
- The `diagnostics` field on `CodeActionContext` is optional and purely additive — all existing callers continue to work unchanged (diagnostics are gathered from the range as before when the field is not set).