### PR TITLE
feat(git): add Pull action to push rejected error notifications

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5592,10 +5592,14 @@ export class CommandCenter {
 						break;
 					case GitErrorCodes.PushRejected:
 						message = l10n.t('Can\'t push refs to remote. Try running "Pull" first to integrate your changes.');
+						choices.set(l10n.t('Pull'), () => commands.executeCommand('git.pull'));
+						options.modal = false;
 						break;
 					case GitErrorCodes.ForcePushWithLeaseRejected:
 					case GitErrorCodes.ForcePushWithLeaseIfIncludesRejected:
 						message = l10n.t('Can\'t force push refs to remote. The tip of the remote-tracking branch has been updated since the last checkout. Try running "Pull" first to pull the latest changes from the remote branch first.');
+						choices.set(l10n.t('Pull'), () => commands.executeCommand('git.pull'));
+						options.modal = false;
 						break;
 					case GitErrorCodes.Conflict:
 						message = l10n.t('There are merge conflicts. Please resolve them before committing your changes.');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (UX improvement)

## What is the current behavior?

When `git push` is rejected because the remote branch has new commits (e.g., a colleague pushed first), VS Code shows an error notification with the message _"Can't push refs to remote. Try running 'Pull' first to integrate your changes."_ However, the notification only provides "Open Git Log" and "Show Command Output" buttons — there is no actionable "Pull" button.

The same issue applies to force push with lease rejections.

Closes #171382

## What is the new behavior?

The push rejected error notification now includes a **"Pull"** button that directly triggers `git.pull`, allowing users to resolve the issue with a single click. The notification is also changed from modal to non-modal, consistent with other actionable error notifications in the git extension (e.g., merge conflict notifications).

This applies to both:
- `PushRejected` errors (regular push)
- `ForcePushWithLeaseRejected` / `ForcePushWithLeaseIfIncludesRejected` errors (force push with lease)

## Additional context

The implementation follows the exact same pattern already used for `Conflict` and `StashConflict` error cases in the same switch statement, which add a "Show Changes" action button. The change is minimal: 4 lines added across 2 error cases in `extensions/git/src/commands.ts`.