### PR TITLE
feat(git): add to closest .gitignore instead of root

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2558,26 +2558,63 @@ export class Repository implements Disposable {
 
 	async ignore(files: Uri[]): Promise<void> {
 		return await this.run(Operation.Ignore, async () => {
-			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
-			const textToAppend = files
-				.map(uri => relativePath(this.repository.root, uri.fsPath)
-					.replace(/\\|\[/g, match => match === '\\' ? '/' : `\\${match}`))
-				.join('\n');
+			// Group files by their closest .gitignore file
+			const repoRoot = this.repository.root;
+			const filesByIgnoreFile = new Map<string, Uri[]>();
 
-			const document = await new Promise(c => fs.exists(ignoreFile, c))
-				? await workspace.openTextDocument(ignoreFile)
-				: await workspace.openTextDocument(Uri.file(ignoreFile).with({ scheme: 'untitled' }));
+			for (const file of files) {
+				const ignoreFile = await this.findClosestGitignore(file.fsPath, repoRoot);
+				const group = filesByIgnoreFile.get(ignoreFile);
+				if (group) {
+					group.push(file);
+				} else {
+					filesByIgnoreFile.set(ignoreFile, [file]);
+				}
+			}
 
-			await window.showTextDocument(document);
+			for (const [ignoreFile, groupedFiles] of filesByIgnoreFile) {
+				const ignoreFileDir = path.dirname(ignoreFile);
+				const textToAppend = groupedFiles
+					.map(uri => relativePath(ignoreFileDir, uri.fsPath)
+						.replace(/\\|\[/g, match => match === '\\' ? '/' : `\\${match}`))
+					.join('\n');
 
-			const edit = new WorkspaceEdit();
-			const lastLine = document.lineAt(document.lineCount - 1);
-			const text = lastLine.isEmptyOrWhitespace ? `${textToAppend}\n` : `\n${textToAppend}\n`;
+				const document = await new Promise(c => fs.exists(ignoreFile, c))
+					? await workspace.openTextDocument(ignoreFile)
+					: await workspace.openTextDocument(Uri.file(ignoreFile).with({ scheme: 'untitled' }));
 
-			edit.insert(document.uri, lastLine.range.end, text);
-			await workspace.applyEdit(edit);
-			await document.save();
+				await window.showTextDocument(document);
+
+				const edit = new WorkspaceEdit();
+				const lastLine = document.lineAt(document.lineCount - 1);
+				const text = lastLine.isEmptyOrWhitespace ? `${textToAppend}\n` : `\n${textToAppend}\n`;
+
+				edit.insert(document.uri, lastLine.range.end, text);
+				await workspace.applyEdit(edit);
+				await document.save();
+			}
 		});
+	}
+
+	private async findClosestGitignore(filePath: string, repoRoot: string): Promise<string> {
+		const rootGitignore = `${repoRoot}${path.sep}.gitignore`;
+
+		// Start from the file's parent directory and walk up to the repo root
+		let currentDir = path.dirname(filePath);
+		while (isDescendant(repoRoot, currentDir) && currentDir.length >= repoRoot.length) {
+			const candidate = `${currentDir}${path.sep}.gitignore`;
+			if (await new Promise<boolean>(c => fs.exists(candidate, c))) {
+				return candidate;
+			}
+
+			const parentDir = path.dirname(currentDir);
+			if (parentDir === currentDir) {
+				break;
+			}
+			currentDir = parentDir;
+		}
+
+		return rootGitignore;
 	}
 
 	async rebaseAbort(): Promise<void> {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature enhancement

## What is the current behavior?
The "Add to .gitignore" command (`git.ignore`) always writes entries to the root `.gitignore` file in the repository, even when a closer `.gitignore` file exists in the directory hierarchy.

Closes #157839

## What is the new behavior?
When adding files to `.gitignore`, the command now walks up the directory hierarchy from each file's parent directory to the repository root, looking for the closest existing `.gitignore` file. Files are grouped by their closest `.gitignore` and entries are written relative to that `.gitignore`'s directory.

- If a subdirectory has its own `.gitignore`, entries for files in that subtree are added there
- If no `.gitignore` exists in any ancestor directory, falls back to root `.gitignore` (preserving existing behavior)
- Paths written to each `.gitignore` are relative to that `.gitignore`'s directory, not the repo root

### Example
Given a project structure:
```
repo/
├── .gitignore          (root)
├── src/
│   ├── .gitignore      (closer)
│   └── temp.log        (file to ignore)
└── docs/
    └── draft.txt       (file to ignore)
```

- Ignoring `src/temp.log` writes `temp.log` to `src/.gitignore`
- Ignoring `docs/draft.txt` writes `docs/draft.txt` to the root `.gitignore`

## Additional context
Only 1 file changed (`extensions/git/src/repository.ts`). The new `findClosestGitignore` private method is added to the `Repository` class to handle the directory traversal. TypeScript compilation passes with zero errors.