### PR TITLE
Remove chat.statusWidget.anonymous setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -835,15 +835,6 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			tags: ['experimental'],
 		},
-		['chat.statusWidget.anonymous']: {
-			type: 'boolean',
-			description: nls.localize('chat.statusWidget.anonymous.description', "Controls whether anonymous users see the status widget in new chat sessions when rate limited."),
-			default: false,
-			tags: ['experimental', 'advanced'],
-			experiment: {
-				mode: 'auto'
-			}
-		},
 		[mcpDiscoverySection]: {
 			type: 'object',
 			properties: Object.fromEntries(allDiscoverySources.map(k => [k, { type: 'boolean', description: discoverySourceSettingsLabel[k] }])),

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget.ts
@@ -9,7 +9,6 @@ import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } f
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { defaultButtonStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
@@ -23,7 +22,7 @@ const $ = dom.$;
 
 /**
  * Widget that displays a status message with an optional action button.
- * Only shown for free tier users when the setting is enabled (experiment controlled via onExP tag).
+ * Only shown for anonymous and free tier users.
  */
 export class ChatStatusWidget extends Disposable implements IChatInputPartWidget {
 
@@ -37,7 +36,6 @@ export class ChatStatusWidget extends Disposable implements IChatInputPartWidget
 	constructor(
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@ICommandService private readonly commandService: ICommandService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
@@ -51,7 +49,7 @@ export class ChatStatusWidget extends Disposable implements IChatInputPartWidget
 		const entitlement = this.chatEntitlementService.entitlement;
 		const isAnonymous = this.chatEntitlementService.anonymous;
 
-		if (isAnonymous && this.configurationService.getValue<boolean>('chat.statusWidget.anonymous')) {
+		if (isAnonymous) {
 			this.createWidgetContent('anonymous');
 		} else if (entitlement === ChatEntitlement.Free) {
 			this.createWidgetContent('free');

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget.ts
@@ -22,7 +22,8 @@ const $ = dom.$;
 
 /**
  * Widget that displays a status message with an optional action button.
- * Only shown for anonymous and free tier users.
+ * Shown only when chat quota is exceeded and the chat session is empty, and only for
+ * anonymous or free tier users.
  */
 export class ChatStatusWidget extends Disposable implements IChatInputPartWidget {
 


### PR DESCRIPTION
**Configuration changes:**

* Removed the `chat.statusWidget.anonymous` configuration option, which previously allowed experimental control over showing the status widget to anonymous users.

**Code cleanup and logic simplification:**

* Removed the dependency on `IConfigurationService` and related code, as the widget is now always shown for anonymous users without checking configuration. [[1]](diffhunk://#diff-bff843ea69db00cb2b6640ec24a352d0ef6f27a57e6c0c9b444d454ddb6cc51cL12) [[2]](diffhunk://#diff-bff843ea69db00cb2b6640ec24a352d0ef6f27a57e6c0c9b444d454ddb6cc51cL40)
* Updated the `ChatStatusWidget` logic to display the widget for anonymous users unconditionally, instead of gating it behind the removed configuration option. [[1]](diffhunk://#diff-bff843ea69db00cb2b6640ec24a352d0ef6f27a57e6c0c9b444d454ddb6cc51cL26-R25) [[2]](diffhunk://#diff-bff843ea69db00cb2b6640ec24a352d0ef6f27a57e6c0c9b444d454ddb6cc51cL54-R52)