### PR TITLE
feat: add plugins to chatPromptFiles API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { IMarkdownString } from '../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, IDisposable } from '../../../base/common/lifecycle.js';
+import { autorun } from '../../../base/common/observable.js';
 import { revive } from '../../../base/common/marshalling.js';
 import { Schemas } from '../../../base/common/network.js';
 import { escapeRegExpCharacters } from '../../../base/common/strings.js';
@@ -42,12 +43,13 @@ import { ILanguageModelToolsService } from '../../contrib/chat/common/tools/lang
 import { IExtHostContext, extHostNamedCustomer } from '../../services/extensions/common/extHostCustomers.js';
 import { IExtensionService } from '../../services/extensions/common/extensions.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostChatAgentsShape2, ExtHostContext, IChatAgentInvokeResult, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatNotebookEditDto, IChatParticipantMetadata, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IDynamicChatAgentProps, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from '../common/extHost.protocol.js';
+import { ExtHostChatAgentsShape2, ExtHostContext, IChatAgentInvokeResult, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatNotebookEditDto, IChatParticipantMetadata, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IDynamicChatAgentProps, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, IPluginDto, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from '../common/extHost.protocol.js';
 import { NotebookDto } from './mainThreadNotebookDto.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../contrib/chat/common/customizationHarnessService.js';
 import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
+import { IAgentPluginService } from '../../contrib/chat/common/plugins/agentPluginService.js';
 
 interface AgentData {
 	dispose: () => void;
@@ -133,6 +135,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		@ICustomizationHarnessService private readonly _customizationHarnessService: ICustomizationHarnessService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatAgents2);
@@ -198,6 +201,13 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		void this._pushHooks();
 		this._register(this._promptsService.onDidChangeHooks(() => {
 			void this._pushHooks();
+		}));
+
+		// Push plugins to ext host (reactive via autorun)
+		this._register(autorun(reader => {
+			const plugins = this._agentPluginService.plugins.read(reader);
+			const dtos: IPluginDto[] = plugins.map(p => ({ uri: p.uri }));
+			this._proxy.$acceptPlugins(dtos);
 		}));
 	}
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1749,6 +1749,14 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatPromptFiles');
 				return extHostChatAgents2.onDidChangeHooks(listener, thisArgs, disposables);
 			},
+			get plugins() {
+				checkProposedApiEnabled(extension, 'chatPromptFiles');
+				return extHostChatAgents2.plugins as readonly vscode.ChatResource[];
+			},
+			onDidChangePlugins: (listener, thisArgs?, disposables?) => {
+				checkProposedApiEnabled(extension, 'chatPromptFiles');
+				return extHostChatAgents2.onDidChangePlugins(listener, thisArgs, disposables);
+			},
 			registerChatSessionCustomizationProvider(chatSessionType: string, metadata: vscode.ChatSessionCustomizationProviderMetadata, provider: vscode.ChatSessionCustomizationProvider): vscode.Disposable {
 				checkProposedApiEnabled(extension, 'chatSessionCustomizationProvider');
 				return extHostChatAgents2.registerChatSessionCustomizationProvider(extension, chatSessionType, metadata, provider);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1672,6 +1672,7 @@ export interface ExtHostChatAgentsShape2 {
 	$acceptInstructions(instructions: IInstructionDto[]): void;
 	$acceptSkills(skills: ISkillDto[]): void;
 	$acceptHooks(hooks: IHookDto[]): void;
+	$acceptPlugins(plugins: IPluginDto[]): void;
 }
 
 export interface ICustomAgentDto {
@@ -1687,6 +1688,10 @@ export interface ISkillDto {
 }
 
 export interface IHookDto {
+	uri: UriComponents;
+}
+
+export interface IPluginDto {
 	uri: UriComponents;
 }
 

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -28,7 +28,7 @@ import { LocalChatSessionUri } from '../../contrib/chat/common/model/chatUri.js'
 import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 import { Dto } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostChatAgentsShape2, IChatAgentCompletionItem, IChatAgentHistoryEntryDto, IChatAgentInvokeResult, IChatAgentProgressShape, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, IMainContext, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from './extHost.protocol.js';
+import { ExtHostChatAgentsShape2, IChatAgentCompletionItem, IChatAgentHistoryEntryDto, IChatAgentInvokeResult, IChatAgentProgressShape, IChatSessionCustomizationItemDto, IChatSessionCustomizationProviderMetadataDto, IChatProgressDto, IChatSessionContextDto, ICustomAgentDto, IExtensionChatAgentMetadata, IHookDto, IInstructionDto, IMainContext, IPluginDto, ISkillDto, MainContext, MainThreadChatAgentsShape2 } from './extHost.protocol.js';
 import { CommandsConverter, ExtHostCommands } from './extHostCommands.js';
 import { ExtHostDiagnostics } from './extHostDiagnostics.js';
 import { ExtHostDocuments } from './extHostDocuments.js';
@@ -500,11 +500,14 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	readonly onDidChangeSkills = this._onDidChangeSkills.event;
 	private readonly _onDidChangeHooks = this._register(new Emitter<void>());
 	readonly onDidChangeHooks = this._onDidChangeHooks.event;
+	private readonly _onDidChangePlugins = this._register(new Emitter<void>());
+	readonly onDidChangePlugins = this._onDidChangePlugins.event;
 
 	private _customAgents: vscode.ChatResource[] = [];
 	private _instructions: vscode.ChatResource[] = [];
 	private _skills: vscode.ChatResource[] = [];
 	private _hooks: vscode.ChatResource[] = [];
+	private _plugins: vscode.ChatResource[] = [];
 
 	private _activeChatPanelSessionResource: URI | undefined;
 
@@ -531,6 +534,10 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 		return this._hooks;
 	}
 
+	get plugins(): readonly vscode.ChatResource[] {
+		return this._plugins;
+	}
+
 	$acceptCustomAgents(agents: ICustomAgentDto[]): void {
 		this._customAgents = agents.map(a => Object.freeze({ uri: URI.revive(a.uri) }));
 		this._onDidChangeCustomAgents.fire();
@@ -549,6 +556,11 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	$acceptHooks(hooks: IHookDto[]): void {
 		this._hooks = hooks.map(h => Object.freeze({ uri: URI.revive(h.uri) }));
 		this._onDidChangeHooks.fire();
+	}
+
+	$acceptPlugins(plugins: IPluginDto[]): void {
+		this._plugins = plugins.map(p => Object.freeze({ uri: URI.revive(p.uri) }));
+		this._onDidChangePlugins.fire();
 	}
 
 	constructor(

--- a/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
@@ -171,6 +171,16 @@ declare module 'vscode' {
 		export const hooks: readonly ChatResource[];
 
 		/**
+		 * An event that fires when the list of {@link plugins plugins} changes.
+		 */
+		export const onDidChangePlugins: Event<void>;
+
+		/**
+		 * The list of currently installed agent plugins.
+		 */
+		export const plugins: readonly ChatResource[];
+
+		/**
 		 * Register a provider for custom agents.
 		 * @param provider The custom agent provider.
 		 * @returns A disposable that unregisters the provider when disposed.


### PR DESCRIPTION
Wire installed agent plugins through the chatPromptFiles proposed API so extensions can discover them.

### Changes
- Add `chat.plugins` readonly getter and `chat.onDidChangePlugins` event (uses existing `ChatResource` type)
- Add `IPluginDto` to ext host protocol
- Push plugins from mainThread via `autorun` on `IAgentPluginService.plugins` observable
- Inject `IAgentPluginService` into `MainThreadChatAgents2`

Companion PR: microsoft/vscode-copilot-chat#4962