### PR TITLE
chat: add startup telemetry for live chat model counts

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1751,7 +1751,7 @@ class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContr
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
-		this.logTelemetry();
+		void this.logTelemetry();
 	}
 
 	private async logTelemetry(): Promise<void> {
@@ -1768,7 +1768,7 @@ class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContr
 				modelsOpenInWidgets++;
 			} else {
 				backgroundModels++;
-				if (model.hasPendingEdits) {
+				if (model.hasPendingEdits && model.referenceCount === 1) {
 					modelsKeptAliveOnlyForEdits++;
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1725,6 +1725,64 @@ class ChatForegroundSessionCountContribution extends Disposable implements IWork
 	}
 }
 
+type ChatModelsAtStartupEvent = {
+	totalModels: number;
+	modelsOpenInWidgets: number;
+	backgroundModels: number;
+	modelsKeptAliveOnlyForEdits: number;
+};
+
+type ChatModelsAtStartupClassification = {
+	totalModels: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of live chat models after startup revival.' };
+	modelsOpenInWidgets: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models that are open in a chat widget or editor.' };
+	backgroundModels: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models kept alive in the background without a widget.' };
+	modelsKeptAliveOnlyForEdits: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models kept alive solely because they have unaccepted edits.' };
+	owner: 'roblourens';
+	comment: 'Tracks chat model counts at startup after reviving sessions with pending edits.';
+};
+
+class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.chatModelsAtStartupTelemetry';
+
+	constructor(
+		@IChatService private readonly chatService: IChatService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+	) {
+		super();
+		this.logTelemetry();
+	}
+
+	private async logTelemetry(): Promise<void> {
+		await this.chatService.whenSessionsRevived;
+
+		const snapshot = this.chatService.getChatModelReferenceDebugInfo();
+
+		let modelsOpenInWidgets = 0;
+		let backgroundModels = 0;
+		let modelsKeptAliveOnlyForEdits = 0;
+
+		for (const model of snapshot.models) {
+			if (this.chatWidgetService.getWidgetBySessionResource(model.sessionResource)) {
+				modelsOpenInWidgets++;
+			} else {
+				backgroundModels++;
+				if (model.hasPendingEdits) {
+					modelsKeptAliveOnlyForEdits++;
+				}
+			}
+		}
+
+		this.telemetryService.publicLog2<ChatModelsAtStartupEvent, ChatModelsAtStartupClassification>('chat.modelsAtStartup', {
+			totalModels: snapshot.totalModels,
+			modelsOpenInWidgets,
+			backgroundModels,
+			modelsKeptAliveOnlyForEdits,
+		});
+	}
+}
+
 
 /**
  * Given builtin and custom modes, returns only the custom mode IDs that should have actions registered.
@@ -1932,6 +1990,7 @@ registerWorkbenchContribution2(UsagesToolContribution.ID, UsagesToolContribution
 registerWorkbenchContribution2(RenameToolContribution.ID, RenameToolContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatAgentSettingContribution.ID, ChatAgentSettingContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatForegroundSessionCountContribution.ID, ChatForegroundSessionCountContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(ChatModelsAtStartupTelemetry.ID, ChatModelsAtStartupTelemetry, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatAgentActionsContribution.ID, ChatAgentActionsContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(HookSchemaAssociationContribution.ID, HookSchemaAssociationContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ToolReferenceNamesContribution.ID, ToolReferenceNamesContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1431,6 +1431,11 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionResource: URI | undefined;
 
+	/**
+	 * Promise that resolves when sessions with pending edits have been revived at startup.
+	 */
+	readonly whenSessionsRevived: Promise<void>;
+
 	readonly onDidSubmitRequest: Event<{ readonly chatSessionResource: URI; readonly message?: IParsedChatRequest }>;
 
 	readonly onDidCreateModel: Event<IChatModel>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -209,7 +209,9 @@ export class ChatService extends Disposable implements IChatService {
 			this._transferredSessionResource = transferredData;
 		}
 
-		this.whenSessionsRevived = this.reviveSessionsWithEdits();
+		this.whenSessionsRevived = this.reviveSessionsWithEdits().catch(error => {
+			this.logService.error('Failed to revive chat sessions with edits', error);
+		});
 
 		this._register(storageService.onWillSaveState(() => this.saveState()));
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -132,6 +132,8 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _chatServiceTelemetry: ChatServiceTelemetry;
 	private readonly _chatSessionStore: ChatSessionStore;
 
+	readonly whenSessionsRevived: Promise<void>;
+
 	readonly requestInProgressObs: IObservable<boolean>;
 
 	readonly chatModels: IObservable<Iterable<IChatModel>>;
@@ -207,7 +209,7 @@ export class ChatService extends Disposable implements IChatService {
 			this._transferredSessionResource = transferredData;
 		}
 
-		this.reviveSessionsWithEdits();
+		this.whenSessionsRevived = this.reviveSessionsWithEdits();
 
 		this._register(storageService.onWillSaveState(() => this.saveState()));
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -20,6 +20,7 @@ export class MockChatService implements IChatService {
 	_serviceBrand: undefined;
 	editingSessions = [];
 	transferredSessionResource = undefined;
+	whenSessionsRevived = Promise.resolve();
 	readonly onDidSubmitRequest = Event.None;
 
 	private readonly _onDidCreateModel = new Emitter<IChatModel>();


### PR DESCRIPTION
After reviving sessions with pending edits at startup, fire a `chat.modelsAtStartup` telemetry event with:

- **totalModels** — total live chat models
- **modelsOpenInWidgets** — models currently displayed in a chat widget/editor (via `IChatWidgetService.getWidgetBySessionResource`)
- **backgroundModels** — models alive but not in any widget
- **modelsKeptAliveOnlyForEdits** — background models kept alive solely because they have unaccepted edits

### Implementation details

- Exposes `whenSessionsRevived` promise on `IChatService` so consumers can await session revival completion
- Telemetry lives in a browser-layer `WorkbenchPhase.AfterRestored` contribution, so it runs after widgets have restored **and** after revival completes
- Uses `IChatWidgetService.getWidgetBySessionResource()` to classify models (no hard-coded holder strings)