### PR TITLE
Sessions: preserve cancelled session content in list

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1600,13 +1600,13 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	 * {@link IChatSessionsService.onDidCommitSession} event.
 	 *
 	 * When {@link responseCompletePromise} is provided, the wait is bounded by
-	 * response completion. If the response finishes before the commit event:
-	 * - If the response was **cancelled**, the session was stopped before the
-	 *   agent created the backing resource → throw immediately.
-	 * - If the response completed **normally**, the commit event is legitimately
-	 *   in-flight (the extension fired it mid-turn but the async IPC chain in
-	 *   {@link MainThreadChatSessions.$onDidCommitChatSessionItem} hasn't finished
-	 *   yet) → keep waiting with the safety timeout.
+	 * response completion. If the response finishes before the commit event,
+	 * the commit may still be in-flight (e.g. the user cancelled after the
+	 * worktree was initiated but before the commit IPC finished, or the
+	 * extension fired the commit mid-turn but it hasn't been delivered yet).
+	 * In both cases we wait with the safety timeout. Only if the timeout
+	 * expires *and* the response was cancelled do we throw a
+	 * {@link CancellationError} — signalling that the commit will never come.
 	 */
 	private async _waitForCommittedSession(
 		untitledResource: URI,
@@ -1635,20 +1635,19 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				}
 
 				// Response finished before the commit event arrived.
-				// Check whether it was cancelled — if so, the commit will never come.
-				const response = await responseCreatedPromise;
-				if (response?.isCanceled) {
-					throw new CancellationError();
-				}
-
-				// Response completed normally — the commit is in-flight (the extension
-				// fired it before the response finished, but the async IPC chain hasn't
-				// delivered it yet). It should arrive in milliseconds; use a short
-				// safety timeout to avoid blocking forever on an IPC failure.
+				// The commit may still be in-flight — the agent could have
+				// initiated the worktree before the user cancelled, and the
+				// async IPC chain hasn't delivered the event yet. Fall through
+				// to the safety timeout to give it a chance to arrive.
 			}
 
 			const result = await raceTimeout(commitPromise, 5_000);
 			if (!result) {
+				// Timed out — check whether this was a cancellation
+				const response = responseCreatedPromise ? await responseCreatedPromise : undefined;
+				if (response?.isCanceled) {
+					throw new CancellationError();
+				}
 				throw new Error('Timed out waiting for session commit');
 			}
 			return result;

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -6,6 +6,7 @@
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { raceTimeout } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { CancellationError } from '../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, IObservable, IReader, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
@@ -1417,10 +1418,20 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 			return committedSession;
 		} catch (error) {
-			// Clean up temp session on error
+			this._currentNewSession = undefined;
+
+			if (error instanceof CancellationError) {
+				// Session was stopped before the agent created a worktree.
+				// Keep the temp session in the list so the user can review
+				// whatever content the agent produced before cancellation.
+				session.setStatus(SessionStatus.Completed);
+				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [newSession] });
+				return newSession;
+			}
+
+			// Unexpected error — clean up the temp session entirely
 			this._sessionCache.delete(key);
 			this._sessionGroupCache.delete(session.id);
-			this._currentNewSession = undefined;
 			this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(session)], changed: [] });
 			session.dispose();
 			throw error;
@@ -1516,11 +1527,22 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 			return updatedSession;
 		} catch (error) {
-			// Clean up on error — fire changed on the parent session group
+			this._currentNewSession = undefined;
+
+			if (error instanceof CancellationError) {
+				// Cancelled before commit — keep the chat in the group so the
+				// user can review the content the agent produced.
+				newChatSession.setStatus(SessionStatus.Completed);
+				this._sessionGroupCache.delete(sessionId);
+				const updatedSession = this._chatToSession(newChatSession);
+				this._onDidChangeSessions.fire({ added: [], removed: [], changed: [updatedSession] });
+				return updatedSession;
+			}
+
+			// Unexpected error — clean up on error, fire changed on the parent session group
 			this._sessionCache.delete(key);
 			this._groupModel.removeChat(newChatSession.id);
 			this._sessionGroupCache.delete(sessionId);
-			this._currentNewSession = undefined;
 			newChatSession.dispose();
 			// Find the parent session's primary chat to fire a valid changed event
 			const parentChatIds = this._groupModel.getChatIds(sessionId);
@@ -1616,7 +1638,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				// Check whether it was cancelled — if so, the commit will never come.
 				const response = await responseCreatedPromise;
 				if (response?.isCanceled) {
-					throw new Error('Session was cancelled before being committed');
+					throw new CancellationError();
 				}
 
 				// Response completed normally — the commit is in-flight (the extension

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -778,9 +778,6 @@ suite('CopilotChatSessionsProvider', () => {
 		test('stopping a committed session keeps it in the list', async () => {
 			const { provider, commitSession, cancelRequest } = makeCommittableProvider();
 
-			const changes: ISessionChangeEvent[] = [];
-			disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
-
 			const newSession = provider.createNewSession(workspace);
 			const sessionId = newSession.sessionId;
 

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -177,6 +177,7 @@ function createProviderForSendTests(
 	disposables: DisposableStore,
 	model: MockAgentSessionsModel,
 	sendRequest: () => Promise<ChatSendResult>,
+	opts?: { onDidCommitSession?: Event<{ original: URI; committed: URI }> },
 ): CopilotChatSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
@@ -195,7 +196,7 @@ function createProviderForSendTests(
 	instantiationService.stub(IChatSessionsService, {
 		getChatSessionContribution: () => ({ type: 'test-copilot', name: 'test', displayName: 'Test', description: 'test', icon: undefined }),
 		getOrCreateChatSession: async () => ({ onWillDispose: () => ({ dispose() { } }), sessionResource: URI.from({ scheme: 'test' }), history: [], dispose() { } }),
-		onDidCommitSession: Event.None,
+		onDidCommitSession: opts?.onDidCommitSession ?? Event.None,
 		updateSessionOptions: () => true,
 		setSessionOption: () => true,
 		getSessionOption: () => undefined,
@@ -737,7 +738,81 @@ suite('CopilotChatSessionsProvider', () => {
 			await sendPromise.catch(() => { /* expected to reject */ });
 		});
 
-		test('cancelling the request before commit removes the temp session', async () => {
+		/**
+		 * Returns a provider where the commit event is controllable. The
+		 * caller can fire the commit event at the right moment to simulate
+		 * the session being committed mid-request, then cancel the request
+		 * afterwards. The session should persist after cancellation.
+		 */
+		function makeCommittableProvider(): {
+			provider: CopilotChatSessionsProvider;
+			commitSession: (original: URI, committed: URI) => void;
+			cancelRequest: () => void;
+		} {
+			let resolveComplete!: () => void;
+			let resolveCreated!: (r: IChatResponseModel) => void;
+			const responseCompletePromise = new Promise<void>(r => { resolveComplete = r; });
+			const responseCreatedPromise = new Promise<IChatResponseModel>(r => { resolveCreated = r; });
+
+			const commitEmitter = disposables.add(new Emitter<{ original: URI; committed: URI }>());
+
+			const provider = createProviderForSendTests(disposables, model, async () => ({
+				kind: 'sent' as const,
+				data: {
+					responseCompletePromise,
+					responseCreatedPromise,
+					agent: new class extends mock<IChatAgentData>() { }(),
+				} as IChatSendRequestData,
+			}), { onDidCommitSession: commitEmitter.event });
+
+			return {
+				provider,
+				commitSession: (original, committed) => commitEmitter.fire({ original, committed }),
+				cancelRequest: () => {
+					resolveCreated({ isCanceled: true } as unknown as IChatResponseModel);
+					resolveComplete();
+				},
+			};
+		}
+
+		test('stopping a committed session keeps it in the list', async () => {
+			const { provider, commitSession, cancelRequest } = makeCommittableProvider();
+
+			const changes: ISessionChangeEvent[] = [];
+			disposables.add(provider.onDidChangeSessions(e => changes.push(e)));
+
+			const newSession = provider.createNewSession(workspace);
+			const sessionId = newSession.sessionId;
+
+			const added = waitForSessionAdded(provider);
+			const sendPromise = provider.sendAndCreateChat(sessionId, { query: 'test' });
+			await added;
+
+			assert.strictEqual(provider.getSessions().length, 1, 'session should appear while in-flight');
+
+			// Get the temp session's resource so we can fire the commit event
+			const tempSession = provider.getSessions()[0];
+			const tempResource = tempSession.resource;
+
+			// Simulate commit: the agent created the worktree, so the URI
+			// swaps from untitled to a real committed resource.
+			const committedResource = URI.from({ scheme: AgentSessionProviders.Background, path: `/committed-${Date.now()}` });
+			const committedAgentSession = createMockAgentSession(committedResource);
+			model.addSession(committedAgentSession);
+			commitSession(tempResource, committedResource);
+
+			// _sendFirstChat should complete successfully now
+			await sendPromise;
+
+			assert.strictEqual(provider.getSessions().length, 1, 'committed session should remain in list');
+
+			// Now cancel the request — session must stay
+			cancelRequest();
+
+			assert.strictEqual(provider.getSessions().length, 1, 'committed session should persist after stopping');
+		});
+
+		test('cancelling the request before commit keeps the session with completed status', async () => {
 			const { provider, cancelRequest } = makeInFlightProvider();
 
 			const changes: ISessionChangeEvent[] = [];
@@ -755,13 +830,16 @@ suite('CopilotChatSessionsProvider', () => {
 
 			// Simulate user stopping the request
 			cancelRequest();
-			await sendPromise.catch(() => { /* expected to reject */ });
+			await sendPromise;
 
-			assert.strictEqual(provider.getSessions().length, 0, 'session should be cleaned up after cancellation');
+			assert.strictEqual(provider.getSessions().length, 1, 'session should stay in list after cancellation');
 			assert.ok(
-				changes.some(e => e.removed.some(s => s.sessionId === sessionId)),
-				'removed event should have fired',
+				changes.some(e => e.changed.some(s => s.sessionId === sessionId)),
+				'changed event should have fired',
 			);
+
+			// Clean up the kept session so it doesn't leak
+			await provider.deleteSession(sessionId);
 		});
 	});
 });


### PR DESCRIPTION
## Problem

When a session was stopped before the agent committed a worktree, it was removed from the sessions list entirely. This meant the user lost access to whatever content the agent had already produced — chat messages, partial responses, etc.

## Fix

Instead of removing cancelled-before-commit sessions, keep them in the list with `Completed` status so the user can still click on them and review the chat content.

### Changes

- **`_waitForCommittedSession`** — throws `CancellationError` (instead of generic `Error`) when the response is cancelled before commit, enabling the caller to distinguish cancellation from unexpected failures.
- **`_sendFirstChat` catch block** — on `CancellationError`, keeps the temp session in the cache with `Completed` status and fires a `changed` event instead of removing it. Other errors still clean up as before.
- **`_sendSubsequentChat` catch block** — same pattern for the multi-chat path.

### Tests

- **`stopping a committed session keeps it in the list`** — verifies a session committed mid-request persists after cancellation.
- **`cancelling the request before commit keeps the session with completed status`** — verifies cancelled sessions stay in the list with a `changed` event (not `removed`).