### PR TITLE
Add `chat.agent.autoAccept` setting to auto-accept agent changes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -287,6 +287,11 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.implicitContext.suggestedContext', "Controls whether the new implicit context flow is shown. In Ask and Edit modes, the context will automatically be included. When using an agent, context will be suggested as an attachment. Selections are always included as context."),
 			default: true,
 		},
+		[ChatConfiguration.AutoAccept]: {
+			type: 'boolean',
+			markdownDescription: nls.localize('chat.agent.autoAccept', "When enabled, changes made by the agent are automatically accepted without showing the Keep/Undo review UI."),
+			default: false,
+		},
 		'chat.editing.autoAcceptDelay': {
 			type: 'number',
 			markdownDescription: nls.localize('chat.editing.autoAcceptDelay', "Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum."),

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -152,7 +152,7 @@ registerAction2(class AcceptAction extends WorkingSetAction {
 			title: localize2('accept.file', 'Keep'),
 			icon: Codicon.check,
 			menu: [{
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key)),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key), ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true)),
 				id: MenuId.MultiDiffEditorFileToolbar,
 				order: 0,
 				group: 'navigation',
@@ -177,7 +177,7 @@ registerAction2(class DiscardAction extends WorkingSetAction {
 			title: localize2('discard.file', 'Undo'),
 			icon: Codicon.discard,
 			menu: [{
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key)),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key), ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true)),
 				id: MenuId.MultiDiffEditorFileToolbar,
 				order: 2,
 				group: 'navigation',

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -158,7 +158,7 @@ registerAction2(class AcceptAction extends WorkingSetAction {
 				group: 'navigation',
 			}, {
 				id: MenuId.ChatEditingWidgetModifiedFilesToolbar,
-				when: ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified), ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true)),
 				order: 0,
 				group: 'navigation'
 			}],
@@ -183,7 +183,7 @@ registerAction2(class DiscardAction extends WorkingSetAction {
 				group: 'navigation',
 			}, {
 				id: MenuId.ChatEditingWidgetModifiedFilesToolbar,
-				when: ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified), ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true)),
 				order: 1,
 				group: 'navigation'
 			}],
@@ -215,7 +215,7 @@ export class ChatEditingAcceptAllAction extends EditingSessionAction {
 					id: MenuId.ChatEditingWidgetToolbar,
 					group: 'navigation',
 					order: 0,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey))
+					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), hasUndecidedChatEditingResourceContextKey, ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true))
 				}
 			]
 		});
@@ -241,7 +241,7 @@ export class ChatEditingDiscardAllAction extends EditingSessionAction {
 					id: MenuId.ChatEditingWidgetToolbar,
 					group: 'navigation',
 					order: 1,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), hasUndecidedChatEditingResourceContextKey)
+					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), hasUndecidedChatEditingResourceContextKey, ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true))
 				}
 			],
 			keybinding: {

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingEditorActions.ts
@@ -423,7 +423,7 @@ abstract class MultiDiffAcceptDiscardAction extends Action2 {
 			title: accept ? localize('accept4', 'Keep All Edits') : localize('discard4', 'Undo All Edits'),
 			icon: accept ? Codicon.check : Codicon.discard,
 			menu: {
-				when: ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notEquals(`config.${ChatConfiguration.AutoAccept}`, true)),
 				id: MenuId.EditorTitle,
 				order: accept ? 0 : 1,
 				group: 'navigation',

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -77,6 +77,11 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 	protected readonly _rewriteRatioObs = observableValue<number>(this, 0);
 	readonly rewriteRatio: IObservable<number> = this._rewriteRatioObs;
 
+	private readonly _snapshotLinesAdded = observableValue<number | undefined>(this, undefined);
+	private readonly _snapshotLinesRemoved = observableValue<number | undefined>(this, undefined);
+	readonly snapshotLinesAdded: IObservable<number | undefined> = this._snapshotLinesAdded;
+	readonly snapshotLinesRemoved: IObservable<number | undefined> = this._snapshotLinesRemoved;
+
 	private readonly _reviewModeTempObs = observableValue<true | undefined>(this, undefined);
 	readonly reviewMode: IObservable<boolean>;
 
@@ -239,6 +244,11 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 			// already accepted or rejected
 			return;
 		}
+
+		// Snapshot line counts before accept resets the diff
+		const self = this as IModifiedFileEntry;
+		this._snapshotLinesAdded.set(self.linesAdded?.get() ?? 0, undefined);
+		this._snapshotLinesRemoved.set(self.linesRemoved?.get() ?? 0, undefined);
 
 		await this._doAccept();
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedFileEntry.ts
@@ -24,6 +24,7 @@ import { IFilesConfigurationService } from '../../../../services/filesConfigurat
 import { IAiEditTelemetryService } from '../../../editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryService.js';
 import { ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatUserAction, IChatService } from '../../common/chatService/chatService.js';
+import { ChatConfiguration } from '../../common/constants.js';
 import { ChatEditKind, IModifiedEntryTelemetryInfo, IModifiedFileEntry, IModifiedFileEntryEditorIntegration, ISnapshotEntry, ModifiedFileEntryState } from '../../common/editing/chatEditingService.js';
 import { IChatResponseModel } from '../../common/model/chatModel.js';
 
@@ -128,14 +129,21 @@ export abstract class AbstractChatEditingModifiedFileEntry extends Disposable im
 		}
 
 		// review mode depends on setting and temporary override
+		const autoAcceptEnabled = observableConfigValue(ChatConfiguration.AutoAccept, false, configService);
 		const autoAcceptRaw = observableConfigValue('chat.editing.autoAcceptDelay', 0, configService);
 		this._autoAcceptTimeout = derived(r => {
+			if (autoAcceptEnabled.read(r)) {
+				return 0;
+			}
 			const value = autoAcceptRaw.read(r);
 			return clamp(value, 0, 100);
 		});
 		this.reviewMode = derived(r => {
-			const configuredValue = this._autoAcceptTimeout.read(r);
 			const tempValue = this._reviewModeTempObs.read(r);
+			if (autoAcceptEnabled.read(r)) {
+				return tempValue ?? false;
+			}
+			const configuredValue = this._autoAcceptTimeout.read(r);
 			return tempValue ?? configuredValue === 0;
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -24,7 +24,7 @@ import { Iterable } from '../../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Lazy } from '../../../../../../base/common/lazy.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { mixin } from '../../../../../../base/common/objects.js';
@@ -472,7 +472,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _chatEditsActionsDisposables: DisposableStore = this._register(new DisposableStore());
 	private readonly _chatEditsDisposables: DisposableStore = this._register(new DisposableStore());
 	private readonly _renderingChatEdits = this._register(new MutableDisposable());
-	private readonly _cachedDiffMeta = new ResourceMap<{ added: number; removed: number }>();
 
 	private _chatEditsListPool: CollapsibleListPool;
 	private _chatEditList: IDisposableReference<WorkbenchList<IChatCollapsibleListItem>> | undefined;
@@ -2840,14 +2839,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 				if (!seenEntries.has(entry.modifiedURI)) {
 					seenEntries.add(entry.modifiedURI);
-					const linesAdded = entry.linesAdded?.read(reader) ?? 0;
-					const linesRemoved = entry.linesRemoved?.read(reader) ?? 0;
-
-					// Cache diff meta while Modified so it survives auto-accept
-					if (state === ModifiedFileEntryState.Modified || !this._cachedDiffMeta.has(entry.modifiedURI)) {
-						this._cachedDiffMeta.set(entry.modifiedURI, { added: linesAdded, removed: linesRemoved });
-					}
-					const diffMeta = this._cachedDiffMeta.get(entry.modifiedURI) ?? { added: linesAdded, removed: linesRemoved };
+					const snapshotAdded = entry.snapshotLinesAdded?.read(reader);
+					const snapshotRemoved = entry.snapshotLinesRemoved?.read(reader);
+					const linesAdded = snapshotAdded ?? entry.linesAdded?.read(reader) ?? 0;
+					const linesRemoved = snapshotRemoved ?? entry.linesRemoved?.read(reader) ?? 0;
 
 					entries.push({
 						reference: entry.modifiedURI,
@@ -2855,7 +2850,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						kind: 'reference',
 						options: {
 							status: undefined,
-							diffMeta,
+							diffMeta: { added: linesAdded, removed: linesRemoved },
 							isDeletion: !!entry.isDeletion,
 							originalUri: entry.isDeletion ? entry.originalURI : undefined,
 						}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -472,6 +472,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _chatEditsActionsDisposables: DisposableStore = this._register(new DisposableStore());
 	private readonly _chatEditsDisposables: DisposableStore = this._register(new DisposableStore());
 	private readonly _renderingChatEdits = this._register(new MutableDisposable());
+	private readonly _cachedDiffMeta = new ResourceMap<{ added: number; removed: number }>();
 
 	private _chatEditsListPool: CollapsibleListPool;
 	private _chatEditList: IDisposableReference<WorkbenchList<IChatCollapsibleListItem>> | undefined;
@@ -2828,8 +2829,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			return chatEditingSession?.entries.read(r).filter(entry => entry.state.read(r) === ModifiedFileEntryState.Modified) || [];
 		});
 
-		const cachedDiffMeta = new ResourceMap<{ added: number; removed: number }>();
-
 		const editSessionEntries = derived((reader): IChatCollapsibleListItem[] => {
 			const seenEntries = new ResourceSet();
 			const entries: IChatCollapsibleListItem[] = [];
@@ -2845,10 +2844,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					const linesRemoved = entry.linesRemoved?.read(reader) ?? 0;
 
 					// Cache diff meta while Modified so it survives auto-accept
-					if (state === ModifiedFileEntryState.Modified || !cachedDiffMeta.has(entry.modifiedURI)) {
-						cachedDiffMeta.set(entry.modifiedURI, { added: linesAdded, removed: linesRemoved });
+					if (state === ModifiedFileEntryState.Modified || !this._cachedDiffMeta.has(entry.modifiedURI)) {
+						this._cachedDiffMeta.set(entry.modifiedURI, { added: linesAdded, removed: linesRemoved });
 					}
-					const diffMeta = cachedDiffMeta.get(entry.modifiedURI) ?? { added: linesAdded, removed: linesRemoved };
+					const diffMeta = this._cachedDiffMeta.get(entry.modifiedURI) ?? { added: linesAdded, removed: linesRemoved };
 
 					entries.push({
 						reference: entry.modifiedURI,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2813,6 +2813,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._lastEditingSessionResource = chatEditingSession.chatSessionResource;
 		}
 
+		const autoAcceptEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AutoAccept);
+
 		const modifiedEntries = derivedOpts<IModifiedFileEntry[]>({ equalsFn: arraysEqual }, r => {
 			// Background chat sessions render the working set based on the session files, and not the editing session
 			const sessionResource = chatEditingSession?.chatSessionResource ?? this._widget?.viewModel?.model.sessionResource;
@@ -2820,6 +2822,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				return [];
 			}
 
+			if (autoAcceptEnabled) {
+				return chatEditingSession?.entries.read(r) || [];
+			}
 			return chatEditingSession?.entries.read(r).filter(entry => entry.state.read(r) === ModifiedFileEntryState.Modified) || [];
 		});
 
@@ -2827,7 +2832,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			const seenEntries = new ResourceSet();
 			const entries: IChatCollapsibleListItem[] = [];
 			for (const entry of modifiedEntries.read(reader)) {
-				if (entry.state.read(reader) !== ModifiedFileEntryState.Modified) {
+				const state = entry.state.read(reader);
+				if (!autoAcceptEnabled && state !== ModifiedFileEntryState.Modified) {
 					continue;
 				}
 
@@ -2837,7 +2843,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					const linesRemoved = entry.linesRemoved?.read(reader);
 					entries.push({
 						reference: entry.modifiedURI,
-						state: ModifiedFileEntryState.Modified,
+						state,
 						kind: 'reference',
 						options: {
 							status: undefined,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2823,7 +2823,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 
 			if (autoAcceptEnabled) {
-				return chatEditingSession?.entries.read(r) || [];
+				return [...(chatEditingSession?.entries.read(r) || [])];
 			}
 			return chatEditingSession?.entries.read(r).filter(entry => entry.state.read(r) === ModifiedFileEntryState.Modified) || [];
 		});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -24,7 +24,7 @@ import { Iterable } from '../../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Lazy } from '../../../../../../base/common/lazy.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { ResourceSet } from '../../../../../../base/common/map.js';
+import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { MarshalledId } from '../../../../../../base/common/marshallingIds.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { mixin } from '../../../../../../base/common/objects.js';
@@ -2828,6 +2828,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			return chatEditingSession?.entries.read(r).filter(entry => entry.state.read(r) === ModifiedFileEntryState.Modified) || [];
 		});
 
+		const cachedDiffMeta = new ResourceMap<{ added: number; removed: number }>();
+
 		const editSessionEntries = derived((reader): IChatCollapsibleListItem[] => {
 			const seenEntries = new ResourceSet();
 			const entries: IChatCollapsibleListItem[] = [];
@@ -2839,15 +2841,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 				if (!seenEntries.has(entry.modifiedURI)) {
 					seenEntries.add(entry.modifiedURI);
-					const linesAdded = entry.linesAdded?.read(reader);
-					const linesRemoved = entry.linesRemoved?.read(reader);
+					const linesAdded = entry.linesAdded?.read(reader) ?? 0;
+					const linesRemoved = entry.linesRemoved?.read(reader) ?? 0;
+
+					// Cache diff meta while Modified so it survives auto-accept
+					if (state === ModifiedFileEntryState.Modified || !cachedDiffMeta.has(entry.modifiedURI)) {
+						cachedDiffMeta.set(entry.modifiedURI, { added: linesAdded, removed: linesRemoved });
+					}
+					const diffMeta = cachedDiffMeta.get(entry.modifiedURI) ?? { added: linesAdded, removed: linesRemoved };
+
 					entries.push({
 						reference: entry.modifiedURI,
 						state,
 						kind: 'reference',
 						options: {
 							status: undefined,
-							diffMeta: { added: linesAdded ?? 0, removed: linesRemoved ?? 0 },
+							diffMeta,
 							isDeletion: !!entry.isDeletion,
 							originalUri: entry.isDeletion ? entry.originalURI : undefined,
 						}

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -54,6 +54,7 @@ export enum ChatConfiguration {
 	RestoreLastPanelSession = 'chat.restoreLastPanelSession',
 	ExitAfterDelegation = 'chat.exitAfterDelegation',
 	ExplainChangesEnabled = 'chat.editing.explainChanges.enabled',
+	AutoAccept = 'chat.agent.autoAccept',
 	RevealNextChangeOnResolve = 'chat.editing.revealNextChangeOnResolve',
 	GrowthNotificationEnabled = 'chat.growthNotification.enabled',
 	SignInTitleBarEnabled = 'chat.signInTitleBar.enabled',

--- a/src/vs/workbench/contrib/chat/common/editing/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/editing/chatEditingService.ts
@@ -419,6 +419,16 @@ export interface IModifiedFileEntry {
 	 */
 	readonly linesRemoved?: IObservable<number>;
 
+	/**
+	 * Snapshot of lines added, captured before accept resets the diff.
+	 */
+	readonly snapshotLinesAdded?: IObservable<number | undefined>;
+
+	/**
+	 * Snapshot of lines removed, captured before accept resets the diff.
+	 */
+	readonly snapshotLinesRemoved?: IObservable<number | undefined>;
+
 	getEditorIntegration(editor: IEditorPane): IModifiedFileEntryEditorIntegration;
 	/**
 	 * Gets the document diff info, waiting for any ongoing promises to flush.


### PR DESCRIPTION
## Summary

Adds a new boolean setting `chat.agent.autoAccept` (default: `false`) that, when enabled, removes the Keep/Undo review UX and immediately auto-accepts all agent changes when a request completes.

Experience before/after shown here:

https://github.com/user-attachments/assets/aa02f3e3-157d-430b-b1ca-f482db8fa3e3


## Motivation

Users who trust agent changes and don't want to manually review each edit can enable this setting to streamline their workflow — changes are applied and accepted automatically without requiring interaction with the Keep/Undo UI.

## Approach

**Auto-accept logic** (`chatEditingModifiedFileEntry.ts`): When the setting is enabled, `reviewMode` is set to `false` and the auto-accept timeout is set to `0`, causing changes to be accepted immediately when the agent turn completes.

**Hide Keep/Undo buttons across all surfaces:**
- **Chat panel** (`chatEditingActions.ts`): Keep All, Undo All, and per-file Keep/Undo buttons are hidden via `config.chat.agent.autoAccept` when-clause guards
- **Editor overlay**: Already gated by `ctxReviewModeEnabled`, which becomes `false` automatically
- **Multi-diff editor** (`chatEditingEditorActions.ts`): Keep/Undo in the EditorTitle toolbar and per-file MultiDiffEditorFileToolbar are hidden

**Preserve files-changed bar** (`chatInputPart.ts`): The bar above the chat input (showing changed files + Explain button) is kept visible after auto-accept by including `Accepted` entries in the file list, not just `Modified` ones.

**Snapshot line counts** (`chatEditingModifiedFileEntry.ts`, `chatEditingService.ts`): When `accept()` fires, `_doAccept()` resets the diff (original = modified), zeroing out `linesAdded`/`linesRemoved`. To preserve accurate counts in the UI, line counts are snapshotted on the entry in `acceptDeferred()` before the diff reset. The UI reads `snapshotLinesAdded`/`snapshotLinesRemoved` as fallback values.

## How to test

1. Open Settings, search for `chat.agent.autoAccept`, enable it
2. Send an agent request that modifies files
3. Verify:
   - No Keep/Undo buttons appear in the chat panel, editor overlay, or multi-diff editor
   - Changes are auto-accepted when the agent turn completes
   - The files-changed bar persists with correct `+N -M` line counts
   - The Explain button and file list remain visible