### PR TITLE
sessions: show branch in active session title

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -82,7 +82,7 @@ The Agent Sessions titlebar includes a command center with a custom title bar wi
 
 The widget:
 - Extends `BaseActionViewItem` and renders a clickable label showing the active session title
-- Shows kind icon (provider type icon), session title, repository folder name, and changes summary (+insertions -deletions)
+- Shows kind icon (provider type icon), session title, repository folder name, and the active git branch/worktree name in parentheses when available, plus the changes summary (+insertions -deletions)
 - On click, opens the `AgentSessionsPicker` quick pick to switch between sessions
 - Gets the active session label from `IActiveSessionService.getActiveSession()` and the live model title from `IChatService`, falling back to "New Session" if no active session is found
 - Re-renders automatically when the active session changes via `autorun` on `IActiveSessionService.activeSession`, and when session data changes via `IAgentSessionsService.model.onDidChangeSessions`
@@ -644,6 +644,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-03 | Updated `SessionsTitleBarWidget` to format active session titles as `{Title} · {repo name} ({git branch/worktree name})` when repository detail metadata is available, falling back to the worktree folder name when needed. |
 | 2026-03-30 | Adjusted `.agent-sessions-titlebar-container` padding so it sits flush when the sidebar is visible and restores 16px left padding when the sidebar is hidden |
 | 2026-03-26 | Updated the sessions sidebar appear animation so only the body content (`.part.sidebar > .content`) slides/fades in during reveal while the sidebar title/header and footer remain fixed |
 | 2026-03-24 | Polished the sessions task configuration quick input modal to use stronger modal-style header chrome, increased horizontal padding in the quick input/form content, and added an explicit close action in the modal header |

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -33,6 +33,7 @@ import { SHOW_SESSIONS_PICKER_COMMAND_ID } from './sessionsActions.js';
 import { IsSessionArchivedContext, IsSessionPinnedContext, IsSessionReadContext, SessionItemContextMenuId } from './views/sessionsList.js';
 import { SessionsView, SessionsViewId } from './views/sessionsView.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
+import { basename } from '../../../../base/common/resources.js';
 
 /**
  * Sessions Title Bar Widget - renders the active chat session title
@@ -41,7 +42,7 @@ import { IViewsService } from '../../../../workbench/services/views/common/views
  * Shows the current chat session label as a clickable pill with:
  * - Kind icon at the beginning (provider type icon)
  * - Session title
- * - Repository folder name
+ * - Repository folder name and active branch/worktree name when available
  *
  * Session actions (changes, terminal, etc.) are rendered via the
  * SessionTitleActions menu toolbar next to the session title.
@@ -79,6 +80,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			if (sessionData) {
 				sessionData.title.read(reader);
 				sessionData.status.read(reader);
+				sessionData.workspace.read(reader);
 			}
 			this.sessionsManagementService.activeProviderId.read(reader);
 			this._lastRenderState = undefined;
@@ -132,8 +134,10 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			const label = this._getActiveSessionLabel();
 			const icon = this._getActiveSessionIcon();
 			const repoLabel = this._getRepositoryLabel();
+			const repoDetailLabel = this._getRepositoryDetailLabel();
+			const pillLabel = repoLabel ? `${label} \u00B7 ${repoLabel}${repoDetailLabel ? ` (${repoDetailLabel})` : ''}` : label;
 			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}`;
+			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}|${repoDetailLabel ?? ''}`;
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
@@ -174,7 +178,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				centerGroup.appendChild(separator1);
 
 				const repoEl = $('span.agent-sessions-titlebar-repo');
-				repoEl.textContent = repoLabel;
+				repoEl.textContent = repoDetailLabel ? `${repoLabel} (${repoDetailLabel})` : repoLabel;
 				centerGroup.appendChild(repoEl);
 			}
 
@@ -202,7 +206,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			this._dynamicDisposables.add(this.hoverService.setupManagedHover(
 				getDefaultHoverDelegate('mouse'),
 				sessionPill,
-				label
+				pillLabel
 			));
 
 			// Keyboard handler
@@ -252,6 +256,35 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			}
 		}
 		return undefined;
+	}
+
+	private _getRepositoryDetailLabel(): string | undefined {
+		const sessionData = this.sessionsManagementService.activeSession.get();
+		const workspace = sessionData?.workspace.get();
+		const repository = workspace?.repositories[0];
+		if (!workspace || !repository) {
+			return undefined;
+		}
+
+		if (repository.detail && !workspace.label.includes(`[${repository.detail}]`)) {
+			return repository.detail;
+		}
+
+		if (!repository.workingDirectory) {
+			return undefined;
+		}
+
+		const worktreeName = basename(repository.workingDirectory);
+		if (!worktreeName) {
+			return undefined;
+		}
+
+		const repositoryName = basename(repository.uri);
+		if (worktreeName === workspace.label || worktreeName === repositoryName) {
+			return undefined;
+		}
+
+		return worktreeName;
 	}
 
 	private _showContextMenu(e: MouseEvent): void {


### PR DESCRIPTION
## Summary

Updates the sessions titlebar widget so active session titles render as:

`{Title} · {repo name} ({git branch/worktree name})`

when branch/worktree metadata is available.

## What changed

- append repository detail metadata to the active session title in `SessionsTitleBarWidget`
- fall back to the worktree folder name when explicit repository detail metadata is not available
- include workspace changes in the widget rerender tracking so the title stays up to date
- update the hover text to match the visible title
- document the new title format in `src/vs/sessions/LAYOUT.md`

## Validation

- `npm run compile-check-ts-native --silent`
- `npm run valid-layers-check --silent`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts src/vs/sessions/LAYOUT.md`

## Notes

This keeps the existing title format for sessions without repository detail/worktree metadata and only appends the extra suffix when it is available.