### PR TITLE
Add promptFiles and onDidChangePromptFiles to chat namespace

### DIFF
--- a/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatPromptFiles.d.ts
@@ -181,6 +181,17 @@ declare module 'vscode' {
 		export const plugins: readonly ChatResource[];
 
 		/**
+		 * An event that fires when the list of {@link promptFiles prompt files} changes.
+		 */
+		export const onDidChangePromptFiles: Event<void>;
+
+		/**
+		 * The list of currently available prompt files. These are `.prompt.md` files
+		 * from all sources (workspace, user, and extension-provided).
+		 */
+		export const promptFiles: readonly ChatResource[];
+
+		/**
 		 * Register a provider for custom agents.
 		 * @param provider The custom agent provider.
 		 * @returns A disposable that unregisters the provider when disposed.


### PR DESCRIPTION
## Summary

Add `chat.promptFiles` and `chat.onDidChangePromptFiles` to the `vscode.chat` namespace in the `chatPromptFiles` proposed API.

## Problem

Every other resource type has both namespace-level getters/events and a provider registration function:

| Type | Namespace getter | Change event | Register function |
|------|-----------------|--------------|-------------------|
| Custom Agents | `chat.customAgents` | `chat.onDidChangeCustomAgents` | `registerCustomAgentProvider` |
| Instructions | `chat.instructions` | `chat.onDidChangeInstructions` | `registerInstructionsProvider` |
| Skills | `chat.skills` | `chat.onDidChangeSkills` | `registerSkillProvider` |
| Hooks | `chat.hooks` | `chat.onDidChangeHooks` | `registerHookProvider` |
| Plugins | `chat.plugins` | `chat.onDidChangePlugins` | _(not yet)_ |
| **Prompt Files** | ❌ **missing** | ❌ **missing** | `registerPromptFileProvider` ✅ |

Prompt files have the provider interface (`ChatPromptFileProvider`) and registration function (`registerPromptFileProvider`), but are missing the namespace-level getter and change event.

## Fix

Add `chat.promptFiles` and `chat.onDidChangePromptFiles` for parity with the other resource types. This is needed by the copilot-chat extension to report prompt files through its `ChatSessionCustomizationProvider`.