### PR TITLE
Browser: don't show a loading spinner for in-page navigation

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -236,7 +236,11 @@ export class BrowserView extends Disposable implements ICDPTarget {
 		// Loading state events
 		webContents.on('did-start-loading', () => {
 			this._lastError = undefined;
-			fireLoadingEvent(true);
+
+			// Don't fire loading events for e.g. same-document navigations
+			if (webContents.isLoadingMainFrame()) {
+				fireLoadingEvent(true);
+			}
 		});
 		webContents.on('did-stop-loading', () => fireLoadingEvent(false));
 		webContents.on('did-fail-load', (e, errorCode, errorDescription, validatedURL, isMainFrame) => {


### PR DESCRIPTION
Fixes #291218