### PR TITLE
sessions: add @ and # completion providers for new chat input

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
@@ -18,7 +18,6 @@ import { CommandsRegistry } from '../../../../platform/commands/common/commands.
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { FileKind } from '../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
-import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IChatAgentService } from '../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { chatAgentLeader, chatVariableLeader } from '../../../../workbench/contrib/chat/common/requestParser/chatParserTypes.js';
 import { getExcludes, ISearchConfiguration, ISearchService, QueryType } from '../../../../workbench/services/search/common/search.js';
@@ -51,11 +50,11 @@ export class ChatInputCompletions extends Disposable {
 	constructor(
 		private readonly _editor: CodeEditorWidget,
 		private readonly _contextAttachments: NewChatContextAttachments,
+		private readonly _getWorkspaceFolderUri: () => URI | undefined,
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@ILabelService private readonly labelService: ILabelService,
 		@ISearchService private readonly searchService: ISearchService,
-		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
@@ -192,32 +191,33 @@ export class ChatInputCompletions extends Disposable {
 
 		// Search workspace files
 		if (pattern) {
+			const folderUri = this._getWorkspaceFolderUri();
+			if (!folderUri) {
+				return;
+			}
+
 			const cacheKey = this._getOrCreateCacheKey();
-			const workspaces = this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
+			if (token.isCancellationRequested) {
+				return;
+			}
+			const excludePattern = getExcludes(this.configurationService.getValue<ISearchConfiguration>({ resource: folderUri }));
 
-			for (const workspace of workspaces) {
-				if (token.isCancellationRequested) {
-					return;
+			try {
+				const fileResults = await this.searchService.fileSearch({
+					folderQueries: [{ folder: folderUri, disregardIgnoreFiles: false }],
+					type: QueryType.File,
+					filePattern: pattern,
+					excludePattern,
+					sortByScore: true,
+					maxResults: 30,
+					cacheKey: cacheKey.key,
+				}, token);
+
+				for (const file of fileResults.results) {
+					result.suggestions.push(makeCompletionItem(file.resource, FileKind.FILE));
 				}
-				const excludePattern = getExcludes(this.configurationService.getValue<ISearchConfiguration>({ resource: workspace }));
-
-				try {
-					const fileResults = await this.searchService.fileSearch({
-						folderQueries: [{ folder: workspace, disregardIgnoreFiles: false }],
-						type: QueryType.File,
-						filePattern: pattern,
-						excludePattern,
-						sortByScore: true,
-						maxResults: 30,
-						cacheKey: cacheKey.key,
-					}, token);
-
-					for (const file of fileResults.results) {
-						result.suggestions.push(makeCompletionItem(file.resource, FileKind.FILE));
-					}
-				} catch {
-					// Search may fail for virtual filesystems
-				}
+			} catch {
+				// Search may fail for virtual filesystems
 			}
 		}
 	}

--- a/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
@@ -16,6 +16,7 @@ import { getWordAtText } from '../../../../editor/common/core/wordHelper.js';
 import { CompletionContext, CompletionItem, CompletionItemKind, CompletionList } from '../../../../editor/common/languages.js';
 import { ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { localize } from '../../../../nls.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { FileKind, IFileService } from '../../../../platform/files/common/files.js';
@@ -142,7 +143,7 @@ export class ChatInputCompletions extends Disposable {
 
 		this._register(this.languageFeaturesService.completionProvider.register({ scheme: uri.scheme, hasAccessToAllModels: true }, {
 			_debugDisplayName: 'sessionsFileCompletions',
-			triggerCharacters: [chatVariableLeader, chatAgentLeader],
+			triggerCharacters: [chatVariableLeader],
 			provideCompletionItems: async (model: ITextModel, position: Position, _context: CompletionContext, token: CancellationToken) => {
 				const range = this._computeCompletionRanges(model, position, FileWord);
 				if (!range) {
@@ -151,6 +152,20 @@ export class ChatInputCompletions extends Disposable {
 
 				const result: CompletionList = { suggestions: [], incomplete: true };
 				await this._addFileEntries(result, range, token);
+
+				// Always show a "browse files" fallback if no file results were found
+				if (result.suggestions.length === 0) {
+					result.suggestions.push({
+						label: { label: `${chatVariableLeader}file:`, description: localize('browseFiles', "Search workspace files") },
+						filterText: `${chatVariableLeader}file ${chatVariableLeader}`,
+						insertText: `${chatVariableLeader}file:`,
+						range,
+						kind: CompletionItemKind.Text,
+						sortText: 'z',
+						command: { id: 'editor.action.triggerSuggest', title: '' },
+					});
+				}
+
 				return result;
 			}
 		}));
@@ -166,16 +181,14 @@ export class ChatInputCompletions extends Disposable {
 			return;
 		}
 
-		const typedLeader = range.varWord?.word?.charAt(0) === chatAgentLeader ? chatAgentLeader : chatVariableLeader;
-
 		const makeCompletionItem = (resource: URI, kind: FileKind): CompletionItem => {
 			const name = this.labelService.getUriBasenameLabel(resource);
-			const text = `${typedLeader}file:${name}`;
+			const text = `${chatVariableLeader}file:${name}`;
 			const uriLabel = this.labelService.getUriLabel(resource, { relative: true });
 
 			return {
 				label: { label: name, description: uriLabel },
-				filterText: `${name} ${typedLeader}${name} ${uriLabel}`,
+				filterText: `${name} ${chatVariableLeader}${name} ${uriLabel}`,
 				insertText: range.varWord?.endColumn === range.replace.endColumn ? `${text} ` : text,
 				range,
 				kind: kind === FileKind.FILE ? CompletionItemKind.File : CompletionItemKind.Folder,
@@ -188,11 +201,11 @@ export class ChatInputCompletions extends Disposable {
 			};
 		};
 
-		// Extract search pattern from the typed word (strip leading #/@ and optional "file:" prefix)
+		// Extract search pattern from the typed word (strip leading # and optional "file:" prefix)
 		let pattern = '';
 		if (range.varWord?.word) {
 			let raw = range.varWord.word;
-			if (raw.startsWith(chatVariableLeader) || raw.startsWith(chatAgentLeader)) {
+			if (raw.startsWith(chatVariableLeader)) {
 				raw = raw.slice(1);
 			}
 			if (raw.toLowerCase().startsWith('file:')) {

--- a/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { URI } from '../../../../base/common/uri.js';
+import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { Position } from '../../../../editor/common/core/position.js';
+import { Range } from '../../../../editor/common/core/range.js';
+import { getWordAtText } from '../../../../editor/common/core/wordHelper.js';
+import { CompletionContext, CompletionItem, CompletionItemKind, CompletionList } from '../../../../editor/common/languages.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { FileKind } from '../../../../platform/files/common/files.js';
+import { ILabelService } from '../../../../platform/label/common/label.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IChatAgentService } from '../../../../workbench/contrib/chat/common/participants/chatAgents.js';
+import { chatAgentLeader, chatVariableLeader } from '../../../../workbench/contrib/chat/common/requestParser/chatParserTypes.js';
+import { getExcludes, ISearchConfiguration, ISearchService, QueryType } from '../../../../workbench/services/search/common/search.js';
+import { NewChatContextAttachments } from './newChatContextAttachments.js';
+
+/**
+ * Regex matching a `@agent` or `#variable` word.
+ */
+const LeaderWord = /[@#][\w:-]*/g;
+
+/**
+ * Regex matching a `#file:…` or `@file:…` word (allows path characters).
+ */
+const FileWord = /[@#][^\s]*/g;
+
+/**
+ * Command ID for adding a file reference as an attachment on completion accept.
+ */
+const ADD_FILE_REFERENCE_COMMAND_ID = 'sessions.chat.addFileReference';
+
+/**
+ * Registers `@` (agent) and `#` (file/context) completion providers for the
+ * sessions new-chat input editor. This is the sessions-layer counterpart of
+ * the workbench's `AgentCompletions` and `BuiltinDynamicCompletions`.
+ */
+export class ChatInputCompletions extends Disposable {
+
+	private _cacheKey?: { key: string; time: number };
+
+	constructor(
+		private readonly _editor: CodeEditorWidget,
+		private readonly _contextAttachments: NewChatContextAttachments,
+		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
+		@IChatAgentService private readonly chatAgentService: IChatAgentService,
+		@ILabelService private readonly labelService: ILabelService,
+		@ISearchService private readonly searchService: ISearchService,
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
+		this._registerAgentCompletions();
+		this._registerFileCompletions();
+	}
+
+	// --- @ Agent completions ---
+
+	private _registerAgentCompletions(): void {
+		const uri = this._editor.getModel()?.uri;
+		if (!uri) {
+			return;
+		}
+
+		this._register(this.languageFeaturesService.completionProvider.register({ scheme: uri.scheme, hasAccessToAllModels: true }, {
+			_debugDisplayName: 'sessionsAgentCompletions',
+			triggerCharacters: [chatAgentLeader],
+			provideCompletionItems: async (model: ITextModel, position: Position, _context: CompletionContext, _token: CancellationToken) => {
+				const range = this._computeCompletionRanges(model, position, LeaderWord);
+				if (!range) {
+					return null;
+				}
+
+				// Only allow agent references at the start of input
+				const textBefore = model.getValueInRange(new Range(1, 1, range.replace.startLineNumber, range.replace.startColumn));
+				if (textBefore.trim() !== '') {
+					return null;
+				}
+
+				const agents = this.chatAgentService.getAgents()
+					.filter(a => !a.isDefault);
+
+				const suggestions: CompletionItem[] = agents.map((agent, i) => {
+					const agentLabel = `${chatAgentLeader}${agent.name}`;
+					return {
+						label: { label: agentLabel, description: agent.description },
+						filterText: agentLabel,
+						insertText: `${agentLabel} `,
+						documentation: agent.description,
+						range,
+						kind: CompletionItemKind.Text,
+						sortText: `${chatAgentLeader}${agent.name}`,
+					};
+				});
+
+				// Also include agent slash commands
+				for (const agent of agents) {
+					for (const cmd of agent.slashCommands) {
+						const agentLabel = `${chatAgentLeader}${agent.name}`;
+						const label = `${agentLabel} /${cmd.name}`;
+						suggestions.push({
+							label: { label, description: cmd.description },
+							filterText: `${agentLabel}${cmd.name}`,
+							insertText: `${label} `,
+							documentation: cmd.description,
+							range,
+							kind: CompletionItemKind.Text,
+							sortText: `x${chatAgentLeader}${agent.name}${cmd.name}`,
+						});
+					}
+				}
+
+				return { suggestions };
+			}
+		}));
+	}
+
+	// --- # File/context completions ---
+
+	private _registerFileCompletions(): void {
+		const uri = this._editor.getModel()?.uri;
+		if (!uri) {
+			return;
+		}
+
+		this._register(this.languageFeaturesService.completionProvider.register({ scheme: uri.scheme, hasAccessToAllModels: true }, {
+			_debugDisplayName: 'sessionsFileCompletions',
+			triggerCharacters: [chatVariableLeader, chatAgentLeader],
+			provideCompletionItems: async (model: ITextModel, position: Position, _context: CompletionContext, token: CancellationToken) => {
+				const range = this._computeCompletionRanges(model, position, FileWord);
+				if (!range) {
+					return null;
+				}
+
+				const result: CompletionList = { suggestions: [], incomplete: true };
+				await this._addFileEntries(result, range, token);
+				return result;
+			}
+		}));
+	}
+
+	private async _addFileEntries(
+		result: CompletionList,
+		range: { insert: Range; replace: Range; varWord: { word: string; startColumn: number; endColumn: number } | null },
+		token: CancellationToken,
+	): Promise<void> {
+		const typedLeader = range.varWord?.word?.charAt(0) === chatAgentLeader ? chatAgentLeader : chatVariableLeader;
+
+		const makeCompletionItem = (resource: URI, kind: FileKind): CompletionItem => {
+			const name = this.labelService.getUriBasenameLabel(resource);
+			const text = `${typedLeader}file:${name}`;
+			const uriLabel = this.labelService.getUriLabel(resource, { relative: true });
+
+			return {
+				label: { label: name, description: uriLabel },
+				filterText: `${name} ${typedLeader}${name} ${uriLabel}`,
+				insertText: range.varWord?.endColumn === range.replace.endColumn ? `${text} ` : text,
+				range,
+				kind: kind === FileKind.FILE ? CompletionItemKind.File : CompletionItemKind.Folder,
+				sortText: '!',
+				command: {
+					id: ADD_FILE_REFERENCE_COMMAND_ID,
+					title: '',
+					arguments: [this._contextAttachments, resource, name, kind],
+				},
+			};
+		};
+
+		// Extract search pattern from the typed word (strip leading #/@ and optional "file:" prefix)
+		let pattern: string | undefined;
+		if (range.varWord?.word) {
+			let raw = range.varWord.word;
+			if (raw.startsWith(chatVariableLeader) || raw.startsWith(chatAgentLeader)) {
+				raw = raw.slice(1);
+			}
+			if (raw.toLowerCase().startsWith('file:')) {
+				raw = raw.slice(5);
+			}
+			if (raw) {
+				pattern = raw;
+			}
+		}
+
+		// Search workspace files
+		if (pattern) {
+			const cacheKey = this._getOrCreateCacheKey();
+			const workspaces = this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
+
+			for (const workspace of workspaces) {
+				if (token.isCancellationRequested) {
+					return;
+				}
+				const excludePattern = getExcludes(this.configurationService.getValue<ISearchConfiguration>({ resource: workspace }));
+
+				try {
+					const fileResults = await this.searchService.fileSearch({
+						folderQueries: [{ folder: workspace, disregardIgnoreFiles: false }],
+						type: QueryType.File,
+						filePattern: pattern,
+						excludePattern,
+						sortByScore: true,
+						maxResults: 30,
+						cacheKey: cacheKey.key,
+					}, token);
+
+					for (const file of fileResults.results) {
+						result.suggestions.push(makeCompletionItem(file.resource, FileKind.FILE));
+					}
+				} catch {
+					// Search may fail for virtual filesystems
+				}
+			}
+		}
+	}
+
+	private _getOrCreateCacheKey(): { key: string; time: number } {
+		if (this._cacheKey && Date.now() - this._cacheKey.time > 60_000) {
+			this.searchService.clearCache(this._cacheKey.key);
+			this._cacheKey = undefined;
+		}
+		if (!this._cacheKey) {
+			this._cacheKey = { key: generateUuid(), time: Date.now() };
+		}
+		this._cacheKey.time = Date.now();
+		return this._cacheKey;
+	}
+
+	// --- Shared helpers ---
+
+	private _computeCompletionRanges(model: ITextModel, position: Position, reg: RegExp): { insert: Range; replace: Range; varWord: { word: string; startColumn: number; endColumn: number } | null } | undefined {
+		const varWord = getWordAtText(position.column, reg, model.getLineContent(position.lineNumber), 0);
+		if (!varWord && model.getWordUntilPosition(position).word) {
+			return;
+		}
+
+		if (!varWord && position.column > 1) {
+			const textBefore = model.getValueInRange(new Range(position.lineNumber, position.column - 1, position.lineNumber, position.column));
+			if (textBefore !== ' ') {
+				return;
+			}
+		}
+
+		let insert: Range;
+		let replace: Range;
+		if (!varWord) {
+			insert = replace = Range.fromPositions(position);
+		} else {
+			insert = new Range(position.lineNumber, varWord.startColumn, position.lineNumber, position.column);
+			replace = new Range(position.lineNumber, varWord.startColumn, position.lineNumber, varWord.endColumn);
+		}
+
+		return { insert, replace, varWord };
+	}
+}
+
+CommandsRegistry.registerCommand(ADD_FILE_REFERENCE_COMMAND_ID, (_accessor, attachments: NewChatContextAttachments, resource: URI, name: string, kind: FileKind) => {
+	attachments.addAttachment({
+		kind: kind === FileKind.FILE ? 'file' : 'directory',
+		id: resource.toString(),
+		value: resource,
+		name,
+	});
+});

--- a/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/chatInputCompletions.ts
@@ -5,6 +5,8 @@
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { basename } from '../../../../base/common/resources.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
@@ -16,10 +18,11 @@ import { ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { FileKind } from '../../../../platform/files/common/files.js';
+import { FileKind, IFileService } from '../../../../platform/files/common/files.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IChatAgentService } from '../../../../workbench/contrib/chat/common/participants/chatAgents.js';
 import { chatAgentLeader, chatVariableLeader } from '../../../../workbench/contrib/chat/common/requestParser/chatParserTypes.js';
+import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { getExcludes, ISearchConfiguration, ISearchService, QueryType } from '../../../../workbench/services/search/common/search.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
 
@@ -53,8 +56,10 @@ export class ChatInputCompletions extends Disposable {
 		private readonly _getWorkspaceFolderUri: () => URI | undefined,
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@ILabelService private readonly labelService: ILabelService,
 		@ISearchService private readonly searchService: ISearchService,
+		@IFileService private readonly fileService: IFileService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
@@ -85,8 +90,12 @@ export class ChatInputCompletions extends Disposable {
 					return null;
 				}
 
+				const chatSessionContributions = this.chatSessionsService.getAllChatSessionContributions();
+				const chatSessionAgentIds = new Set(chatSessionContributions.map(c => c.type));
+
 				const agents = this.chatAgentService.getAgents()
-					.filter(a => !a.isDefault);
+					.filter(a => !a.isDefault)
+					.filter(a => !chatSessionAgentIds.has(a.id));
 
 				const suggestions: CompletionItem[] = agents.map((agent, i) => {
 					const agentLabel = `${chatAgentLeader}${agent.name}`;
@@ -152,6 +161,11 @@ export class ChatInputCompletions extends Disposable {
 		range: { insert: Range; replace: Range; varWord: { word: string; startColumn: number; endColumn: number } | null },
 		token: CancellationToken,
 	): Promise<void> {
+		const folderUri = this._getWorkspaceFolderUri();
+		if (!folderUri) {
+			return;
+		}
+
 		const typedLeader = range.varWord?.word?.charAt(0) === chatAgentLeader ? chatAgentLeader : chatVariableLeader;
 
 		const makeCompletionItem = (resource: URI, kind: FileKind): CompletionItem => {
@@ -175,7 +189,7 @@ export class ChatInputCompletions extends Disposable {
 		};
 
 		// Extract search pattern from the typed word (strip leading #/@ and optional "file:" prefix)
-		let pattern: string | undefined;
+		let pattern = '';
 		if (range.varWord?.word) {
 			let raw = range.varWord.word;
 			if (raw.startsWith(chatVariableLeader) || raw.startsWith(chatAgentLeader)) {
@@ -184,18 +198,11 @@ export class ChatInputCompletions extends Disposable {
 			if (raw.toLowerCase().startsWith('file:')) {
 				raw = raw.slice(5);
 			}
-			if (raw) {
-				pattern = raw;
-			}
+			pattern = raw;
 		}
 
-		// Search workspace files
-		if (pattern) {
-			const folderUri = this._getWorkspaceFolderUri();
-			if (!folderUri) {
-				return;
-			}
-
+		// For local/remote URIs, use the search service
+		if (folderUri.scheme === Schemas.file || folderUri.scheme === Schemas.vscodeRemote) {
 			const cacheKey = this._getOrCreateCacheKey();
 			if (token.isCancellationRequested) {
 				return;
@@ -217,8 +224,52 @@ export class ChatInputCompletions extends Disposable {
 					result.suggestions.push(makeCompletionItem(file.resource, FileKind.FILE));
 				}
 			} catch {
-				// Search may fail for virtual filesystems
+				// Search may fail
 			}
+		} else {
+			// For virtual filesystems (e.g. github-remote-file://), walk via IFileService
+			const patternLower = pattern.toLowerCase();
+			try {
+				await this._collectFilesViaFileService(folderUri, patternLower, result, makeCompletionItem, 30, 10, token);
+			} catch {
+				// File service walk may fail
+			}
+		}
+	}
+
+	private async _collectFilesViaFileService(
+		uri: URI,
+		pattern: string,
+		result: CompletionList,
+		makeItem: (resource: URI, kind: FileKind) => CompletionItem,
+		maxResults: number,
+		maxDepth: number,
+		token?: CancellationToken,
+		depth = 0,
+	): Promise<void> {
+		if (result.suggestions.length >= maxResults || depth > maxDepth || token?.isCancellationRequested) {
+			return;
+		}
+
+		try {
+			const stat = await this.fileService.resolve(uri);
+			if (!stat.children) {
+				return;
+			}
+			for (const child of stat.children) {
+				if (result.suggestions.length >= maxResults || token?.isCancellationRequested) {
+					return;
+				}
+				const name = basename(child.resource).toLowerCase();
+				if (!pattern || name.includes(pattern)) {
+					result.suggestions.push(makeItem(child.resource, child.isDirectory ? FileKind.FOLDER : FileKind.FILE));
+				}
+				if (child.isDirectory) {
+					await this._collectFilesViaFileService(child.resource, pattern, result, makeItem, maxResults, maxDepth, token, depth + 1);
+				}
+			}
+		} catch {
+			// Ignore errors
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
@@ -71,6 +71,14 @@ export class NewChatContextAttachments extends Disposable {
 		this._onDidChangeContext.fire();
 	}
 
+	addAttachment(entry: IChatRequestVariableEntry): void {
+		if (!this._attachedContext.some(e => e.id === entry.id)) {
+			this._attachedContext.push(entry);
+			this._updateRendering();
+			this._onDidChangeContext.fire();
+		}
+	}
+
 	private readonly _resourceLabels: ResourceLabels;
 
 	constructor(

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -48,6 +48,7 @@ import { WorkspacePicker, IWorkspaceSelection } from './sessionWorkspacePicker.j
 import { Menus } from '../../../browser/menus.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { SlashCommandHandler } from './slashCommands.js';
+import { ChatInputCompletions } from './chatInputCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
@@ -367,6 +368,9 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 		// Slash commands
 		this._slashCommandHandler = this._register(this.instantiationService.createInstance(SlashCommandHandler, this._editor));
+
+		// @ and # completions (agents, files)
+		this._register(this.instantiationService.createInstance(ChatInputCompletions, this._editor, this._contextAttachments));
 
 		this._register(this._editor.onDidChangeModelContent(() => {
 			this._updateDraftState();

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -370,7 +370,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		this._slashCommandHandler = this._register(this.instantiationService.createInstance(SlashCommandHandler, this._editor));
 
 		// @ and # completions (agents, files)
-		this._register(this.instantiationService.createInstance(ChatInputCompletions, this._editor, this._contextAttachments));
+		this._register(this.instantiationService.createInstance(ChatInputCompletions, this._editor, this._contextAttachments, () => this._getContextFolderUri()));
 
 		this._register(this._editor.onDidChangeModelContent(() => {
 			this._updateDraftState();


### PR DESCRIPTION
## Summary

Adds `@` (agent) and `#` (file) completion providers to the sessions new-chat welcome widget (`NewChatViewPane`).

## Problem

The workbench chat completions (`AgentCompletions`, `BuiltinDynamicCompletions`) register exclusively for `scheme: Schemas.vscodeChatInput`. The sessions new-chat input uses a different URI scheme (`sessions-chat`), so `@` and `#` completions never fire in the sessions window.

Since the sessions layer cannot directly depend on the workbench chat completion infrastructure, dedicated providers are needed.

## Changes

### New file: `chatInputCompletions.ts`
- **`@` agent completions** — queries `IChatAgentService.getAgents()`, shows non-default agents and their slash commands. Only allowed at the start of input (matching workbench behavior).
- **`#` file completions** — searches workspace files via `ISearchService` when the user types `#file:pattern`. On accept, adds the file as a context attachment pill via a registered command.
- Follows the established `SlashCommandHandler` pattern: registers on `uri.scheme`, uses `_computeCompletionRanges()` helper.
- All imports respect sessions layering rules (base, editor, platform, workbench — no reverse dependency).

### `newChatContextAttachments.ts`
- Added public `addAttachment(entry)` method so the file completion command can add context pills (was previously only private `_addAttachments`).

### `newChatViewPane.ts`
- Instantiates `ChatInputCompletions` alongside the existing `SlashCommandHandler`, passing the editor and context attachments.