### PR TITLE
Use provider ordering in chat model picker

### DIFF
--- a/product.json
+++ b/product.json
@@ -155,5 +155,11 @@
 		"github-enterprise": [
 			"GitHub.copilot-chat"
 		]
+	},
+	"extensionsGallery": {
+		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
+		"itemUrl": "https://marketplace.visualstudio.com/items",
+		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
+		"controlUrl": ""
 	}
 }

--- a/product.json
+++ b/product.json
@@ -155,11 +155,5 @@
 		"github-enterprise": [
 			"GitHub.copilot-chat"
 		]
-	},
-	"extensionsGallery": {
-		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
-		"itemUrl": "https://marketplace.visualstudio.com/items",
-		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
-		"controlUrl": ""
 	}
 }

--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -232,6 +232,7 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 					targetChatSessionType: m.targetChatSessionType,
 					configurationSchema: m.configurationSchema as IJSONSchema | undefined,
 					modelPickerCategory: m.category ?? DEFAULT_MODEL_PICKER_CATEGORY,
+					vendorPriority: m.vendorPriority,
 					capabilities: m.capabilities ? {
 						vision: m.capabilities.imageInput,
 						editTools: m.capabilities.editTools,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -339,6 +339,19 @@ export function buildModelPickerItems(
 				}
 			}
 
+			// Vendor-priority-based promotion: models with vendorPriority are auto-promoted
+			for (const model of models) {
+				if (model.metadata.vendorPriority !== undefined && !placed.has(model.identifier) && !placed.has(model.metadata.id)) {
+					markPlaced(model.identifier, model.metadata.id);
+					const entry = controlModels[model.metadata.id];
+					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+						promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
+					} else {
+						promotedItems.push({ kind: 'available', model });
+					}
+				}
+			}
+
 			// Render promoted section: available first, then by vendor priority, then alphabetically by name
 			if (promotedItems.length > 0) {
 				promotedItems.sort((a, b) => {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -339,19 +339,6 @@ export function buildModelPickerItems(
 				}
 			}
 
-			// Vendor-priority-based promotion: models with vendorPriority are auto-promoted
-			for (const model of models) {
-				if (model.metadata.vendorPriority !== undefined && !placed.has(model.identifier) && !placed.has(model.metadata.id)) {
-					markPlaced(model.identifier, model.metadata.id);
-					const entry = controlModels[model.metadata.id];
-					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-						promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
-					} else {
-						promotedItems.push({ kind: 'available', model });
-					}
-				}
-			}
-
 			// Render promoted section: available first, then by vendor priority, then alphabetically by name
 			if (promotedItems.length > 0) {
 				promotedItems.sort((a, b) => {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -339,13 +339,23 @@ export function buildModelPickerItems(
 				}
 			}
 
-			// Render promoted section: available first, then sorted alphabetically by name
+			// Render promoted section: available first, then by vendor priority, then alphabetically by name
 			if (promotedItems.length > 0) {
 				promotedItems.sort((a, b) => {
 					const aAvail = a.kind === 'available' ? 0 : 1;
 					const bAvail = b.kind === 'available' ? 0 : 1;
 					if (aAvail !== bAvail) {
 						return aAvail - bAvail;
+					}
+					// Use vendorPriority if available
+					const aVP = a.kind === 'available' ? a.model.metadata.vendorPriority : undefined;
+					const bVP = b.kind === 'available' ? b.model.metadata.vendorPriority : undefined;
+					if (aVP !== undefined || bVP !== undefined) {
+						const aPrio = aVP ?? Number.MAX_SAFE_INTEGER;
+						const bPrio = bVP ?? Number.MAX_SAFE_INTEGER;
+						if (aPrio !== bPrio) {
+							return aPrio - bPrio;
+						}
 					}
 					const aName = a.kind === 'available' ? a.model.metadata.name : a.entry.label;
 					const bName = b.kind === 'available' ? b.model.metadata.name : b.entry.label;
@@ -371,6 +381,16 @@ export function buildModelPickerItems(
 					const bAvail = bEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, bEntry.minVSCodeVersion) ? 1 : 0;
 					if (aAvail !== bAvail) {
 						return aAvail - bAvail;
+					}
+					// Use vendorPriority if available on either model
+					const aVP = a.metadata.vendorPriority;
+					const bVP = b.metadata.vendorPriority;
+					if (aVP !== undefined || bVP !== undefined) {
+						const aPrio = aVP ?? Number.MAX_SAFE_INTEGER;
+						const bPrio = bVP ?? Number.MAX_SAFE_INTEGER;
+						if (aPrio !== bPrio) {
+							return aPrio - bPrio;
+						}
 					}
 					const aCopilot = a.metadata.vendor === 'copilot' ? 0 : 1;
 					const bCopilot = b.metadata.vendor === 'copilot' ? 0 : 1;
@@ -434,6 +454,16 @@ export function buildModelPickerItems(
 		const sortedModels = models
 			.filter(m => m !== autoModel)
 			.sort((a, b) => {
+				// Use vendorPriority if available on either model
+				const aVP = a.metadata.vendorPriority;
+				const bVP = b.metadata.vendorPriority;
+				if (aVP !== undefined || bVP !== undefined) {
+					const aPrio = aVP ?? Number.MAX_SAFE_INTEGER;
+					const bPrio = bVP ?? Number.MAX_SAFE_INTEGER;
+					if (aPrio !== bPrio) {
+						return aPrio - bPrio;
+					}
+				}
 				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
 				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
 			});

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -221,6 +221,11 @@ export interface ILanguageModelChatMetadata {
 	 * Used to validate user-provided per-model configuration in `chatLanguageModels.json`.
 	 */
 	readonly configurationSchema?: ILanguageModelConfigurationSchema;
+	/**
+	 * Optional vendor priority for ordering models in the model picker.
+	 * Lower values appear higher in the list.
+	 */
+	readonly vendorPriority?: number;
 }
 
 export namespace ILanguageModelChatMetadata {

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -92,6 +92,13 @@ declare module 'vscode' {
 		 * The value must match a `type` declared in a `chatSessions` extension contribution.
 		 */
 		readonly targetChatSessionType?: string;
+
+		/**
+		 * Optional vendor priority for ordering models in the model picker.
+		 * Lower values appear higher in the list. When set, models are sorted
+		 * by this priority before falling back to alphabetical vendor/name ordering.
+		 */
+		readonly vendorPriority?: number;
 	}
 
 	export interface LanguageModelChatCapabilities {


### PR DESCRIPTION
## Summary
- add `vendorPriority` to the proposed chat provider model metadata and plumb it through the extension host
- use `vendorPriority` when sorting promoted and other models in the chat model picker
- keep top-level promotion manifest-driven so featured models still come from the existing models control manifest

## Testing
- built OSS dev locally with Copilot Chat from source and verified provider ordering in the picker while manifest-featured models stayed at the top level