### PR TITLE
sessions: include AGENTS.md in instructions listing

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -19,6 +19,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
@@ -171,6 +172,17 @@ export class AICustomizationOverviewView extends ViewPane {
 			} else {
 				const allItems = await this.promptsService.listPromptFiles(type, CancellationToken.None);
 				count = allItems.length;
+
+				// For instructions, also count agent instructions (AGENTS.md, copilot-instructions.md, CLAUDE.md, etc.)
+				if (type === PromptsType.instructions) {
+					const existingUris = new ResourceSet(allItems.map(item => item.uri));
+					const agentInstructions = await this.promptsService.listAgentInstructions(CancellationToken.None);
+					for (const file of agentInstructions) {
+						if (!existingUris.has(file.uri)) {
+							count++;
+						}
+					}
+				}
 			}
 
 			const sectionData = this.sections.find(s => s.id === section);

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -27,6 +27,7 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon, builtinIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
@@ -446,7 +447,19 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 
 		// For other types, fetch once and cache grouped by storage
 		if (!cached.files) {
-			const allItems = await this.promptsService.listPromptFiles(promptType, CancellationToken.None);
+			const allItems: IPromptPath[] = [...await this.promptsService.listPromptFiles(promptType, CancellationToken.None)];
+
+			// For instructions, also include agent instructions (AGENTS.md, copilot-instructions.md, CLAUDE.md, etc.)
+			if (promptType === PromptsType.instructions) {
+				const existingUris = new ResourceSet(allItems.map(item => item.uri));
+				const agentInstructions = await this.promptsService.listAgentInstructions(CancellationToken.None);
+				for (const file of agentInstructions) {
+					if (!existingUris.has(file.uri)) {
+						allItems.push({ uri: file.uri, storage: PromptsStorage.local, type: PromptsType.instructions });
+					}
+				}
+			}
+
 			const workspaceItems = allItems.filter(item => item.storage === PromptsStorage.local);
 			const userItems = allItems.filter(item => item.storage === PromptsStorage.user);
 			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);


### PR DESCRIPTION
The sessions AI customization tree view and overview were only calling `listPromptFiles(PromptsType.instructions)` to discover instruction files. However, `AGENTS.md` (along with `CLAUDE.md` and `copilot-instructions.md`) is classified as an agent type by `getPromptFileType()`, so it was never returned by that call — making these files invisible in the Instructions section.

## Fix

Call `listAgentInstructions()` alongside `listPromptFiles()` and merge the results (deduplicating by URI). This matches the pattern already used by the workbench customization editor in `aiCustomizationListWidget.ts`.

### Changed files

- **`aiCustomizationTreeViewViews.ts`** — `getStorageGroups()` now merges agent instruction files into the instructions list
- **`aiCustomizationOverviewView.ts`** — `loadCounts()` now includes agent instruction files in the instructions count badge