### PR TITLE
Fix #247141: Transform actions fail on text selected in F&R widget

### DIFF
--- a/src/vs/editor/contrib/find/browser/findCommon.ts
+++ b/src/vs/editor/contrib/find/browser/findCommon.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const FIND_CONTROLLER_ID = 'editor.contrib.findController';
+
+export interface IFindInputTransformer {
+	transformFocusedInput(transform: (text: string) => string): boolean;
+}
+

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -36,6 +36,7 @@ import { FindWidgetSearchHistory } from './findWidgetSearchHistory.js';
 import { ReplaceWidgetHistory } from './replaceWidgetHistory.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { FIND_CONTROLLER_ID, IFindInputTransformer } from './findCommon.js';
 
 const SEARCH_STRING_MAX_LENGTH = 524288;
 
@@ -91,9 +92,9 @@ export interface IFindStartArguments {
 	findInSelection?: boolean;
 }
 
-export class CommonFindController extends Disposable implements IEditorContribution {
+export class CommonFindController extends Disposable implements IEditorContribution, IFindInputTransformer {
 
-	public static readonly ID = 'editor.contrib.findController';
+	public static readonly ID = FIND_CONTROLLER_ID;
 
 	protected _editor: ICodeEditor;
 	private readonly _findWidgetVisible: IContextKey<boolean>;
@@ -236,6 +237,10 @@ export class CommonFindController extends Disposable implements IEditorContribut
 	 */
 	public focusLastElement(): void {
 		// Base implementation - overridden in FindController
+	}
+
+	public transformFocusedInput(transform: (text: string) => string): boolean {
+		return false;
 	}
 
 	public getState(): FindReplaceState {
@@ -551,6 +556,10 @@ export class FindController extends CommonFindController implements IFindControl
 	 */
 	public override focusLastElement(): void {
 		this._widget?.focusLastElement();
+	}
+
+	public override transformFocusedInput(transform: (text: string) => string): boolean {
+		return this._widget?.transformFocusedInputSelection(transform) ?? false;
 	}
 
 	saveViewState(): any {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -119,6 +119,26 @@ function stopPropagationForMultiLineDownwards(event: IKeyboardEvent, value: stri
 	}
 }
 
+/**
+ * Transforms the selected text in an input element using the provided function.
+ * Returns true if the transformation was applied, false if there was no selection.
+ */
+export function transformInputSelection(
+	el: HTMLInputElement,
+	transform: (text: string) => string
+): boolean {
+	const start = el.selectionStart;
+	const end = el.selectionEnd;
+	if (start === null || end === null || start === end) {
+		return false;
+	}
+	const original = el.value;
+	const transformed = transform(original.slice(start, end));
+	el.value = original.slice(0, start) + transformed + original.slice(end);
+	el.setSelectionRange(start, start + transformed.length);
+	return true;
+}
+
 export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashLayoutProvider {
 	private static readonly ID = 'editor.contrib.findWidget';
 	private readonly _codeEditor: ICodeEditor;
@@ -148,6 +168,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	private _accessibilityHelpHintAnnounced: boolean;
 	private _labelResetTimeout: IDisposable | undefined;
 	private _lastFocusedInputWasReplace: boolean = false;
+	private _lastFocusedInput: HTMLInputElement | null = null;
 
 	private readonly _findFocusTracker: dom.IFocusTracker;
 	private readonly _findInputFocused: IContextKey<boolean>;
@@ -246,6 +267,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._register(this._findFocusTracker.onDidFocus(() => {
 			this._findInputFocused.set(true);
 			this._lastFocusedInputWasReplace = false;
+			this._lastFocusedInput = this._findInput.inputBox.inputElement;
 			this._updateSearchScope();
 		}));
 		this._register(this._findFocusTracker.onDidBlur(() => {
@@ -257,6 +279,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._register(this._replaceFocusTracker.onDidFocus(() => {
 			this._replaceInputFocused.set(true);
 			this._lastFocusedInputWasReplace = true;
+			this._lastFocusedInput = this._replaceInput.inputBox.inputElement;
 			this._updateSearchScope();
 		}));
 		this._register(this._replaceFocusTracker.onDidBlur(() => {
@@ -632,6 +655,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		if (this._isVisible) {
 			this._isVisible = false;
 			this._accessibilityHelpHintAnnounced = false;
+			this._lastFocusedInput = null;
 
 			this._updateButtons();
 
@@ -851,6 +875,22 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 
 	public highlightFindOptions(): void {
 		this._findInput.highlightFindOptions();
+	}
+
+	public transformFocusedInputSelection(transform: (text: string) => string): boolean {
+		const el = this._lastFocusedInput;
+		if (!el) {
+			return false;
+		}
+		const transformed = transformInputSelection(el, transform);
+		if (transformed) {
+			if (el === this._findInput.inputBox.inputElement) {
+				this._state.change({ searchString: el.value }, true);
+			} else {
+				this._state.change({ replaceString: el.value }, false);
+			}
+		}
+		return transformed;
 	}
 
 	private _updateSearchScope(): void {

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -23,6 +23,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { transformInputSelection } from '../../browser/findWidget.js';
 
 class TestFindController extends CommonFindController {
 
@@ -668,3 +669,98 @@ suite('FindController query options persistence', () => {
 		});
 	});
 });
+
+suite('Find Widget - Transform Actions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const serviceCollection = new ServiceCollection();
+	serviceCollection.set(IStorageService, new InMemoryStorageService());
+
+	test('issue #247141: transformInputSelection transforms selected text to uppercase', () => {
+		const input = document.createElement('input');
+		input.value = 'hello world';
+		input.selectionStart = 0;
+		input.selectionEnd = 5;
+
+		const result = transformInputSelection(input, s => s.toLocaleUpperCase());
+
+		assert.strictEqual(result, true);
+		assert.strictEqual(input.value, 'HELLO world');
+		assert.strictEqual(input.selectionStart, 0);
+		assert.strictEqual(input.selectionEnd, 5);
+	});
+
+	test('issue #247141: transformInputSelection transforms selected text to lowercase', () => {
+		const input = document.createElement('input');
+		input.value = 'HELLO WORLD';
+		input.selectionStart = 6;
+		input.selectionEnd = 11;
+
+		const result = transformInputSelection(input, s => s.toLocaleLowerCase());
+
+		assert.strictEqual(result, true);
+		assert.strictEqual(input.value, 'HELLO world');
+	});
+
+	test('issue #247141: transformInputSelection returns false and leaves input unchanged when selection is empty', () => {
+		const input = document.createElement('input');
+		input.value = 'hello world';
+		input.selectionStart = 3;
+		input.selectionEnd = 3;
+
+		const result = transformInputSelection(input, s => s.toLocaleUpperCase());
+
+		assert.strictEqual(result, false);
+		assert.strictEqual(input.value, 'hello world');
+	});
+
+	test('issue #247141: transformInputSelection returns false when selection is null', () => {
+		const input = document.createElement('input');
+		input.type = 'color';
+		input.value = '#000000';
+
+
+		assert.deepStrictEqual(
+			{ selectionStart: input.selectionStart, selectionEnd: input.selectionEnd },
+			{ selectionStart: null, selectionEnd: null }
+		);
+
+		const result = transformInputSelection(input, s => s.toLocaleUpperCase());
+
+		assert.strictEqual(result, false);
+		assert.strictEqual(input.value, '#000000');
+
+	});
+
+	test('issue #247141: transformFocusedInput returns false when no widget has been created', async () => {
+		await withAsyncTestCodeEditor([
+			'hello world'
+		], { serviceCollection: serviceCollection }, async (editor) => {
+			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
+
+			const result = findController.transformFocusedInput(s => s.toLocaleUpperCase());
+			assert.strictEqual(result, false);
+
+			findController.dispose();
+		});
+	});
+
+	test('issue #247141: transformInputSelection does not modify the editor buffer', async () => {
+		await withAsyncTestCodeEditor([
+			'hello world'
+		], { serviceCollection: serviceCollection }, async (editor) => {
+			const input = document.createElement('input');
+			input.value = 'hello world';
+			input.selectionStart = 0;
+			input.selectionEnd = 5;
+
+			transformInputSelection(input, s => s.toLocaleUpperCase());
+
+			// Editor buffer must remain unchanged
+			assert.strictEqual(editor.getModel()!.getLineContent(1), 'hello world');
+			assert.strictEqual(input.value, 'HELLO world');
+		});
+	});
+});
+

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -27,6 +27,7 @@ import { ITextModel } from '../../../common/model.js';
 import { CopyLinesCommand } from './copyLinesCommand.js';
 import { MoveLinesCommand } from './moveLinesCommand.js';
 import { SortLinesCommand } from './sortLinesCommand.js';
+import { FIND_CONTROLLER_ID, IFindInputTransformer } from '../../find/browser/findCommon.js';
 
 // copy lines
 
@@ -1114,6 +1115,12 @@ export class TransposeAction extends EditorAction {
 
 export abstract class AbstractCaseAction extends EditorAction {
 	public run(_accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const findController = editor.getContribution(FIND_CONTROLLER_ID) as IFindInputTransformer | null;
+		const findWordSeparators = editor.getOption(EditorOption.wordSeparators);
+		if (findController?.transformFocusedInput(text => this._modifyText(text, findWordSeparators))) {
+			return;
+		}
+
 		const selections = editor.getSelections();
 		if (selections === null) {
 			return;


### PR DESCRIPTION
Fixes #247141

When text is selected inside the Find & Replace widget and a transform action is run from the command palette, nothing happens.

This happens because opening the command palette moves focus away from the find input, while the browser still preserves the selection. As a result, AbstractCaseAction operates on the editor instead of the find input.

This change tracks the last focused input in FindWidget. AbstractCaseAction now checks this state and applies the transform to the find input when appropriate.

### How to test

1. Open a file and press Ctrl+F
2. Type some text in the find input
3. Select part of that text
4. Open the command palette (Ctrl+Shift+P)
5. Run "Transform to Uppercase" (or other Transform to action)
6. The selected text in the find input should be transformed
