### PR TITLE
Improve path presentation in quick open window

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -287,11 +287,16 @@
 	/* separate from the separator label or scrollbar if any */
 }
 
+/* Show the end of the file path rather than the beginning when truncated.
+   direction:rtl moves the ellipsis to the left so the most-specific path
+   segments remain visible. unicode-bidi:plaintext ensures path separators
+   and Latin text still render in left-to-right order. */
 .quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label .monaco-icon-description-container > .label-description {
 	direction: rtl;
 	text-align: left;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	unicode-bidi: plaintext;
 }
 
 .quick-input-list .quick-input-list-label-meta {

--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -287,6 +287,13 @@
 	/* separate from the separator label or scrollbar if any */
 }
 
+.quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label .monaco-icon-description-container > .label-description {
+	direction: rtl;
+	text-align: left;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .quick-input-list .quick-input-list-label-meta {
 	opacity: 0.7;
 	line-height: normal;


### PR DESCRIPTION
Fixes #143956

## Description

When multiple files share the same name but reside in different directories, the Quick Open (Cmd+P) description (file path) truncates from the right, hiding the distinguishing folder names. This makes it impossible to tell files apart.

**Before:** `some_project/some_longer_path...` (ellipsis on right, distinguishing part hidden)
**After:** `...fruits/bananas/Main.js` (ellipsis on left, distinguishing part visible)

### Approach

Added a CSS rule scoped to the quick input list that applies `direction: rtl` with `text-align: left` to the path description element. This causes the browser to place the text-overflow ellipsis on the left side while keeping the text visually left-aligned, similar to how Sublime Text handles this (as referenced in the issue).

### Changes
- `src/vs/platform/quickinput/browser/media/quickInput.css` — added RTL direction rule for `.label-description` within quick input list rows

### Testing
- Verified with workspaces containing identically-named files in different directories
- The distinguishing path segments are now always visible
- No visual regression for short paths that don't trigger ellipsis