### PR TITLE
Prefer terminal presentation overrides in chat text

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -651,6 +651,12 @@ class AbstractResponse implements IResponse {
 	}
 
 	private getToolInvocationText(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized): { text: string; isBlock?: boolean } {
+		const getTerminalDisplayInput = (terminalData: ReturnType<typeof migrateLegacyTerminalToolSpecificData>) => terminalData.presentationOverrides?.commandLine
+			?? terminalData.commandLine.forDisplay
+			?? terminalData.commandLine.userEdited
+			?? terminalData.commandLine.toolEdited
+			?? terminalData.commandLine.original;
+
 		// Extract the message and input details
 		let message = '';
 		let input = '';
@@ -670,7 +676,7 @@ class AbstractResponse implements IResponse {
 			if (toolInvocation.toolSpecificData.kind === 'terminal') {
 				message = 'Ran terminal command';
 				const terminalData = migrateLegacyTerminalToolSpecificData(toolInvocation.toolSpecificData);
-				input = terminalData.presentationOverrides?.commandLine ?? terminalData.commandLine.forDisplay ?? terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
+				input = getTerminalDisplayInput(terminalData);
 			}
 		}
 
@@ -685,7 +691,10 @@ class AbstractResponse implements IResponse {
 			const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
 			if (resultDetails && 'input' in resultDetails) {
 				const resultPrefix = toolInvocation.kind === 'toolInvocationSerialized' || IChatToolInvocation.isComplete(toolInvocation) ? 'Completed' : 'Errored';
-				text += `\n${resultPrefix} with input: ${resultDetails.input}`;
+				const resultInput = toolInvocation.toolSpecificData?.kind === 'terminal'
+					? getTerminalDisplayInput(migrateLegacyTerminalToolSpecificData(toolInvocation.toolSpecificData))
+					: resultDetails.input;
+				text += `\n${resultPrefix} with input: ${resultInput}`;
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -679,6 +679,45 @@ suite('Response', () => {
 		assert.ok(!responseString.includes('python -c "print(1)"'));
 	});
 
+	test('response stringification uses terminal presentation override for result details', () => {
+		const response = store.add(new Response([]));
+		const sandboxWrappedCommand = `ELECTRON_RUN_AS_NODE=1 TMPDIR="/tmp/vscode" CLAUDE_TMPDIR="/tmp/vscode" "Code - Insiders" "sandbox-runtime" --settings "/tmp/settings.json" -c 'python -c "print(1)"'`;
+		const toolSpecificData: IChatTerminalToolInvocationData = {
+			kind: 'terminal',
+			language: 'python',
+			commandLine: {
+				original: 'python -c "print(1)"',
+				toolEdited: sandboxWrappedCommand,
+				forDisplay: 'python -c "print(1)"',
+				isSandboxWrapped: true,
+			},
+			presentationOverrides: {
+				commandLine: 'print(1)',
+				language: 'python',
+			},
+		};
+
+		response.updateContent({
+			kind: 'externalToolInvocationUpdate',
+			toolCallId: 'tool-call-result-details',
+			toolName: 'run_in_terminal',
+			isComplete: true,
+			pastTenseMessage: 'Ran python command',
+			toolSpecificData,
+			resultDetails: {
+				input: sandboxWrappedCommand,
+				output: [{ type: 'embed', isText: true, value: '1' }],
+				isError: true,
+			},
+		});
+
+		const responseString = response.toString();
+		assert.strictEqual(responseString, 'Ran terminal command: print(1)\nCompleted with input: print(1)');
+		assert.ok(!responseString.includes('sandbox-runtime'));
+		assert.ok(!responseString.includes('ELECTRON_RUN_AS_NODE=1'));
+		assert.ok(!responseString.includes('python -c "print(1)"'));
+	});
+
 	test('getFinalResponse returns last contiguous markdown after tool call', () => {
 		const response = store.add(new Response([]));
 		response.updateContent({ content: new MarkdownString('Early text'), kind: 'markdownContent' });


### PR DESCRIPTION
## Summary
- prefer `presentationOverrides.commandLine` when terminal tool invocations are stringified into chat response text
- reuse that same display choice for the appended `Completed with input:` line for terminal tool results
- add a regression test covering terminal result details so wrapped command text is not surfaced when a presentation override exists

Fixes #303713

## Testing
- VS Code build/watch diagnostics clean for the touched files
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/common/model/chatModel.ts src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts`
- unit test suite not run in this session