### PR TITLE
Ignore file-like domain suffixes in terminal sandbox

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -135,6 +135,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	private static readonly _urlRegex = /(?:https?|wss?):\/\/[^\s'"`|&;<>]+/gi;
 	private static readonly _sshRemoteRegex = /(?:^|[\s'"`])(?:[^\s@:'"`]+@)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?::[^\s'"`|&;<>]+)(?=$|[\s'"`|&;<>])/gi;
 	private static readonly _hostRegex = /(?:^|[\s'"`(=])([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?::\d+)?(?=(?:\/[^\s'"`|&;<>]*)?(?:$|[\s'"`)\]|,;|&<>]))/gi;
+	// While the regexes above are designed to minimize false positives, we may still pick up some file paths that look like domains. To reduce noise, maintain a list of common file extensions and filter out any domain candidates that end with these extensions.
 	private static readonly _fileExtensionSuffixes = new Set([
 		'7z', 'bz2', 'cjs', 'class', 'cpp', 'cs', 'css', 'csv', 'dll', 'exe', 'gif', 'gz', 'ico', 'jar',
 		'env', 'java', 'jpeg', 'jpg', 'js', 'json', 'jsx', 'lock', 'log', 'md', 'mjs', 'pdf', 'php', 'png',
@@ -508,7 +509,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 
 		TerminalSandboxService._sshRemoteRegex.lastIndex = 0;
 		while ((match = TerminalSandboxService._sshRemoteRegex.exec(command)) !== null) {
-			const domain = this._normalizeDomain(match[1]);
+			const domain = this._normalizeDomain(match[1], true);
 			if (domain) {
 				domains.add(domain);
 			}
@@ -528,13 +529,13 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	private _extractDomainFromUrl(value: string): string | undefined {
 		try {
 			const authority = URI.parse(value).authority;
-			return this._normalizeDomain(authority);
+			return this._normalizeDomain(authority, true);
 		} catch {
 			return undefined;
 		}
 	}
 
-	private _normalizeDomain(value: string | undefined): string | undefined {
+	private _normalizeDomain(value: string | undefined, fromUrl: boolean = false): string | undefined {
 		if (!value) {
 			return undefined;
 		}
@@ -575,16 +576,18 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		}
 
 		// Disallow patterns that look like file names with common extensions, as these are unlikely to be intended as network domains and may be false positives from the regex.
-		const lastLabel = host.slice(host.lastIndexOf('.') + 1);
-		if (TerminalSandboxService._fileExtensionSuffixes.has(lastLabel)) {
-			return undefined;
+		if (!fromUrl) {
+			const lastLabel = host.slice(host.lastIndexOf('.') + 1);
+			if (TerminalSandboxService._fileExtensionSuffixes.has(lastLabel)) {
+				return undefined;
+			}
 		}
 
 		return hasWildcardPrefix ? `*.${host}` : host;
 	}
 
 	private _matchesDomainPattern(domain: string, pattern: string): boolean {
-		const normalizedPattern = this._normalizeDomain(this._extractDomainPattern(pattern));
+		const normalizedPattern = this._normalizeDomain(this._extractDomainPattern(pattern), pattern.includes('://'));
 		if (!normalizedPattern) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -135,6 +135,12 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	private static readonly _urlRegex = /(?:https?|wss?):\/\/[^\s'"`|&;<>]+/gi;
 	private static readonly _sshRemoteRegex = /(?:^|[\s'"`])(?:[^\s@:'"`]+@)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?::[^\s'"`|&;<>]+)(?=$|[\s'"`|&;<>])/gi;
 	private static readonly _hostRegex = /(?:^|[\s'"`(=])([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?::\d+)?(?=(?:\/[^\s'"`|&;<>]*)?(?:$|[\s'"`)\]|,;|&<>]))/gi;
+	private static readonly _fileExtensionSuffixes = new Set([
+		'7z', 'bz2', 'cjs', 'class', 'cpp', 'cs', 'css', 'csv', 'dll', 'exe', 'gif', 'gz', 'ico', 'jar',
+		'env', 'java', 'jpeg', 'jpg', 'js', 'json', 'jsx', 'lock', 'log', 'md', 'mjs', 'pdf', 'php', 'png',
+		'py', 'rar', 'rs', 'so', 'sql', 'svg', 'tar', 'tgz', 'toml', 'ts', 'tsx', 'txt', 'wasm', 'webp',
+		'xml', 'yaml', 'yml', 'zip'
+	]);
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -565,6 +571,12 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 
 		// Validate that the host part only contains valid hostname characters.
 		if (!/^[a-z0-9.-]+$/.test(host)) {
+			return undefined;
+		}
+
+		// Disallow patterns that look like file names with common extensions, as these are unlikely to be intended as network domains and may be false positives from the regex.
+		const lastLabel = host.slice(host.lastIndexOf('.') + 1);
+		if (TerminalSandboxService._fileExtensionSuffixes.has(lastLabel)) {
 			return undefined;
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -414,6 +414,39 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(wrapResult.blockedDomains, undefined, 'Malformed URL authorities should be ignored');
 	});
 
+	test('should ignore file-extension suffixes that look like domains', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const javascriptResult = sandboxService.wrapCommand('cat bundle.js', false, 'bash');
+		strictEqual(javascriptResult.isSandboxWrapped, true, 'File extensions such as .js should not trigger blocked-domain prompts');
+		strictEqual(javascriptResult.blockedDomains, undefined, 'File extensions such as .js should not be reported as domains');
+
+		const jsonResult = sandboxService.wrapCommand('cat package.json', false, 'bash');
+		strictEqual(jsonResult.isSandboxWrapped, true, 'File extensions such as .json should not trigger blocked-domain prompts');
+		strictEqual(jsonResult.blockedDomains, undefined, 'File extensions such as .json should not be reported as domains');
+	});
+
+	test('should not treat filenames in commands as domains', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const commands = [
+			'node server.js',
+			'php index.php',
+			'java -jar app.java',
+			'cat styles.css',
+			'cat README.md',
+			'cat .env',
+		];
+
+		for (const command of commands) {
+			const wrapResult = sandboxService.wrapCommand(command, false, 'bash');
+			strictEqual(wrapResult.isSandboxWrapped, true, `Command ${command} should remain sandboxed`);
+			strictEqual(wrapResult.blockedDomains, undefined, `Command ${command} should not report a blocked domain`);
+		}
+	});
+
 	test('should not fall back to deprecated settings outside user scope', async () => {
 		const originalInspect = configurationService.inspect.bind(configurationService);
 		configurationService.inspect = <T>(key: string) => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -427,6 +427,26 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(jsonResult.blockedDomains, undefined, 'File extensions such as .json should not be reported as domains');
 	});
 
+	test('should still treat URL authorities with file-like suffixes as domains', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const wrapResult = sandboxService.wrapCommand('curl https://example.zip/path', false, 'bash');
+
+		strictEqual(wrapResult.isSandboxWrapped, false, 'URL authorities should still trigger blocked-domain prompts even when their suffix looks like a file extension');
+		deepStrictEqual(wrapResult.blockedDomains, ['example.zip']);
+	});
+
+	test('should still treat ssh remotes with file-like suffixes as domains', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const wrapResult = sandboxService.wrapCommand('git clone git@example.zip:owner/repo.git', false, 'bash');
+
+		strictEqual(wrapResult.isSandboxWrapped, false, 'SSH remotes should still trigger blocked-domain prompts even when their suffix looks like a file extension');
+		deepStrictEqual(wrapResult.blockedDomains, ['example.zip']);
+	});
+
 	test('should not treat filenames in commands as domains', async () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 		await sandboxService.getSandboxConfigPath();


### PR DESCRIPTION
## Summary
- ignore hostname matches whose final label looks like a common file extension when normalizing candidate domains in the terminal sandbox service
- reduce false positives from commands that reference local files such as `.js`, `.json`, `.php`, `.java`, `.css`, `.md`, and `.env`
- add targeted regressions covering direct filename-like matches and commands that include filenames so they remain sandboxed

## Testing
- `./scripts/test.sh --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts`

fixes #307510 