### PR TITLE
sessions: return to sign-in screen after sign out (#307660)

### DIFF
--- a/src/vs/sessions/common/welcome.ts
+++ b/src/vs/sessions/common/welcome.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const WELCOME_COMPLETE_KEY = 'workbench.agentsession.welcomeComplete';

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -9,6 +9,7 @@ import './media/accountTitleBarWidget.css';
 import '../../../../workbench/contrib/chat/browser/chatStatus/media/chatStatus.css';
 import Severity from '../../../../base/common/severity.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Event } from '../../../../base/common/event.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -29,11 +30,12 @@ import { IUpdateService, State, StateType } from '../../../../platform/update/co
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 import { URI } from '../../../../base/common/uri.js';
 import { UpdateHoverWidget } from './updateHoverWidget.js';
-import { ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
+import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ChatStatusDashboard } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -149,6 +151,17 @@ async function runSessionsUpdateAction(
 	}
 }
 
+export async function showSessionsWelcomeAfterSignOut(
+	chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'>,
+	commandService: Pick<ICommandService, 'executeCommand'>,
+): Promise<void> {
+	if (chatEntitlementService.entitlement !== ChatEntitlement.Unknown) {
+		await Event.toPromise(Event.filter(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.entitlement === ChatEntitlement.Unknown));
+	}
+
+	await commandService.executeCommand('workbench.action.resetSessionsWelcome');
+}
+
 // Sign In (shown when signed out)
 registerAction2(class extends Action2 {
 	constructor() {
@@ -189,6 +202,8 @@ registerAction2(class extends Action2 {
 		const authenticationService = accessor.get(IAuthenticationService);
 		const authenticationUsageService = accessor.get(IAuthenticationUsageService);
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
+		const chatEntitlementService = accessor.get(IChatEntitlementService);
+		const commandService = accessor.get(ICommandService);
 		const defaultAccount = await defaultAccountService.getDefaultAccount();
 		if (!defaultAccount) {
 			return;
@@ -212,6 +227,7 @@ registerAction2(class extends Action2 {
 		await Promise.all(sessions.map(session => authenticationService.removeSession(providerId, session.id)));
 		authenticationUsageService.removeAccountUsage(providerId, accountLabel);
 		authenticationAccessService.removeAllowedExtensions(providerId, accountLabel);
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
 	}
 });
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -155,8 +155,13 @@ export async function showSessionsWelcomeAfterSignOut(
 	chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'>,
 	commandService: Pick<ICommandService, 'executeCommand'>,
 ): Promise<void> {
-	if (chatEntitlementService.entitlement !== ChatEntitlement.Unknown) {
-		await Event.toPromise(Event.filter(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.entitlement === ChatEntitlement.Unknown));
+	const waitForUnknownEntitlement = Event.toPromise(Event.filter(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.entitlement === ChatEntitlement.Unknown));
+	try {
+		if (chatEntitlementService.entitlement !== ChatEntitlement.Unknown) {
+			await waitForUnknownEntitlement;
+		}
+	} finally {
+		waitForUnknownEntitlement.cancel();
 	}
 
 	await commandService.executeCommand('workbench.action.resetSessionsWelcome');

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -30,7 +30,6 @@ import { IUpdateService, State, StateType } from '../../../../platform/update/co
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -45,6 +44,11 @@ import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextke
 import { IAuthenticationAccessService } from '../../../../workbench/services/authentication/browser/authenticationAccessService.js';
 import { IAuthenticationUsageService } from '../../../../workbench/services/authentication/browser/authenticationUsageService.js';
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
+import { resetSessionsWelcome } from '../../welcome/browser/welcome.contribution.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
+import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 
 // --- Account Menu Items --- //
 const AccountMenu = new MenuId('SessionsAccountMenu');
@@ -153,7 +157,7 @@ async function runSessionsUpdateAction(
 
 export async function showSessionsWelcomeAfterSignOut(
 	chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'>,
-	commandService: Pick<ICommandService, 'executeCommand'>,
+	resetWelcome: () => void,
 ): Promise<void> {
 	const waitForUnknownEntitlement = Event.toPromise(Event.filter(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.entitlement === ChatEntitlement.Unknown));
 	try {
@@ -164,7 +168,7 @@ export async function showSessionsWelcomeAfterSignOut(
 		waitForUnknownEntitlement.cancel();
 	}
 
-	await commandService.executeCommand('workbench.action.resetSessionsWelcome');
+	resetWelcome();
 }
 
 // Sign In (shown when signed out)
@@ -208,7 +212,12 @@ registerAction2(class extends Action2 {
 		const authenticationUsageService = accessor.get(IAuthenticationUsageService);
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
 		const chatEntitlementService = accessor.get(IChatEntitlementService);
-		const commandService = accessor.get(ICommandService);
+		const storageService = accessor.get(IStorageService);
+		const instantiationService = accessor.get(IInstantiationService);
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+		const contextKeyService = accessor.get(IContextKeyService);
+		const environmentService = accessor.get(IWorkbenchEnvironmentService);
+		const logService = accessor.get(ILogService);
 		const defaultAccount = await defaultAccountService.getDefaultAccount();
 		if (!defaultAccount) {
 			return;
@@ -232,7 +241,7 @@ registerAction2(class extends Action2 {
 		await Promise.all(sessions.map(session => authenticationService.removeSession(providerId, session.id)));
 		authenticationUsageService.removeAccountUsage(providerId, accountLabel);
 		authenticationAccessService.removeAllowedExtensions(providerId, accountLabel);
-		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, () => resetSessionsWelcome(storageService, instantiationService, layoutService, chatEntitlementService, contextKeyService, environmentService, logService));
 	}
 });
 

--- a/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ChatEntitlement, IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
+import { showSessionsWelcomeAfterSignOut } from '../../browser/account.contribution.js';
+
+suite('Sessions - Account Contribution', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('shows welcome after sign out once entitlement becomes unknown', async () => {
+		const order: string[] = [];
+		const entitlementChangeEmitter = disposables.add(new Emitter<void>());
+		let entitlement = ChatEntitlement.Free;
+
+		const chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'> = {
+			get entitlement() {
+				return entitlement;
+			},
+			onDidChangeEntitlement: entitlementChangeEmitter.event,
+		};
+		const commandService: Pick<ICommandService, 'executeCommand'> = {
+			async executeCommand(commandId) {
+				order.push(`command:${commandId}`);
+				return undefined;
+			},
+		};
+
+		const showWelcomePromise = showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
+		order.push('signOut');
+		entitlement = ChatEntitlement.Unknown;
+		entitlementChangeEmitter.fire();
+		order.push('entitlementChanged');
+		await showWelcomePromise;
+
+		assert.deepStrictEqual(order, [
+			'signOut',
+			'entitlementChanged',
+			'command:workbench.action.resetSessionsWelcome',
+		]);
+	});
+
+	test('shows welcome immediately when entitlement is already unknown', async () => {
+		const order: string[] = [];
+		const chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'> = {
+			entitlement: ChatEntitlement.Unknown,
+			onDidChangeEntitlement: disposables.add(new Emitter<void>()).event,
+		};
+		const commandService: Pick<ICommandService, 'executeCommand'> = {
+			async executeCommand(commandId) {
+				order.push(`command:${commandId}`);
+				return undefined;
+			},
+		};
+
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
+
+		assert.deepStrictEqual(order, ['command:workbench.action.resetSessionsWelcome']);
+	});
+});

--- a/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
@@ -70,4 +70,30 @@ suite('Sessions - Account Contribution', () => {
 
 		assert.deepStrictEqual(order, ['command:workbench.action.resetSessionsWelcome']);
 	});
+
+	test('handles entitlement becoming unknown while the listener is being attached', async () => {
+		const order: string[] = [];
+		let entitlement = ChatEntitlement.Free;
+		const onDidChangeEntitlement: IChatEntitlementService['onDidChangeEntitlement'] = listener => {
+			entitlement = ChatEntitlement.Unknown;
+			listener();
+			return { dispose() { } };
+		};
+		const chatEntitlementService: Pick<IChatEntitlementService, 'entitlement' | 'onDidChangeEntitlement'> = {
+			get entitlement() {
+				return entitlement;
+			},
+			onDidChangeEntitlement,
+		};
+		const commandService: Pick<ICommandService, 'executeCommand'> = {
+			async executeCommand(commandId) {
+				order.push(`command:${commandId}`);
+				return undefined;
+			},
+		};
+
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
+
+		assert.deepStrictEqual(order, ['command:workbench.action.resetSessionsWelcome']);
+	});
 });

--- a/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts
@@ -7,7 +7,6 @@ import assert from 'assert';
 import { Emitter } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { showSessionsWelcomeAfterSignOut } from '../../browser/account.contribution.js';
 
@@ -32,14 +31,7 @@ suite('Sessions - Account Contribution', () => {
 			},
 			onDidChangeEntitlement: entitlementChangeEmitter.event,
 		};
-		const commandService: Pick<ICommandService, 'executeCommand'> = {
-			async executeCommand(commandId) {
-				order.push(`command:${commandId}`);
-				return undefined;
-			},
-		};
-
-		const showWelcomePromise = showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
+		const showWelcomePromise = showSessionsWelcomeAfterSignOut(chatEntitlementService, () => order.push('resetWelcome'));
 		order.push('signOut');
 		entitlement = ChatEntitlement.Unknown;
 		entitlementChangeEmitter.fire();
@@ -49,7 +41,7 @@ suite('Sessions - Account Contribution', () => {
 		assert.deepStrictEqual(order, [
 			'signOut',
 			'entitlementChanged',
-			'command:workbench.action.resetSessionsWelcome',
+			'resetWelcome',
 		]);
 	});
 
@@ -59,16 +51,9 @@ suite('Sessions - Account Contribution', () => {
 			entitlement: ChatEntitlement.Unknown,
 			onDidChangeEntitlement: disposables.add(new Emitter<void>()).event,
 		};
-		const commandService: Pick<ICommandService, 'executeCommand'> = {
-			async executeCommand(commandId) {
-				order.push(`command:${commandId}`);
-				return undefined;
-			},
-		};
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, () => order.push('resetWelcome'));
 
-		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
-
-		assert.deepStrictEqual(order, ['command:workbench.action.resetSessionsWelcome']);
+		assert.deepStrictEqual(order, ['resetWelcome']);
 	});
 
 	test('handles entitlement becoming unknown while the listener is being attached', async () => {
@@ -85,15 +70,8 @@ suite('Sessions - Account Contribution', () => {
 			},
 			onDidChangeEntitlement,
 		};
-		const commandService: Pick<ICommandService, 'executeCommand'> = {
-			async executeCommand(commandId) {
-				order.push(`command:${commandId}`);
-				return undefined;
-			},
-		};
+		await showSessionsWelcomeAfterSignOut(chatEntitlementService, () => order.push('resetWelcome'));
 
-		await showSessionsWelcomeAfterSignOut(chatEntitlementService, commandService);
-
-		assert.deepStrictEqual(order, ['command:workbench.action.resetSessionsWelcome']);
+		assert.deepStrictEqual(order, ['resetWelcome']);
 	});
 });

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -19,8 +19,16 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
 import { SessionsWalkthroughOverlay, WalkthroughOutcome } from './sessionsWalkthrough.js';
+import { WELCOME_COMPLETE_KEY } from '../../../common/welcome.js';
 
-const WELCOME_COMPLETE_KEY = 'workbench.agentsession.welcomeComplete';
+function shouldSkipSessionsWelcome(environmentService: IWorkbenchEnvironmentService): boolean {
+	const envArgs = (environmentService as IWorkbenchEnvironmentService & { args?: Record<string, unknown> }).args;
+	if (envArgs?.['skip-sessions-welcome']) {
+		return true;
+	}
+
+	return typeof globalThis.location !== 'undefined' && new URLSearchParams(globalThis.location.search).has('skip-sessions-welcome');
+}
 
 function needsChatSetup(chatEntitlementService: Pick<IChatEntitlementService, 'sentiment' | 'entitlement' | 'anonymous'>, includeUnknown: boolean = true): boolean {
 	const { sentiment, entitlement } = chatEntitlementService;
@@ -65,11 +73,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		// Allow automated tests to skip the welcome overlay entirely.
 		// Desktop: --skip-sessions-welcome CLI flag
 		// Web: ?skip-sessions-welcome query parameter
-		const envArgs = (this.environmentService as IWorkbenchEnvironmentService & { args?: Record<string, unknown> }).args;
-		if (envArgs?.['skip-sessions-welcome']) {
-			return;
-		}
-		if (typeof globalThis.location !== 'undefined' && new URLSearchParams(globalThis.location.search).has('skip-sessions-welcome')) {
+		if (shouldSkipSessionsWelcome(this.environmentService)) {
 			return;
 		}
 
@@ -94,10 +98,11 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 	 * completed. If the user's state changes such that setup is needed again
 	 * (e.g. extension uninstalled/disabled), shows the welcome overlay.
 	 *
-	 * {@link ChatEntitlement.Unknown} is intentionally ignored here: it is
-	 * almost always a transient state caused by a stale OAuth token being
-	 * refreshed after an update. A genuine sign-out will be caught on the
-	 * next app launch via the initial {@link showWalkthroughIfNeeded} check.
+	 * {@link ChatEntitlement.Unknown} is intentionally ignored here while the
+	 * welcome completion marker remains set: it is almost always a transient
+	 * state caused by a stale OAuth token being refreshed after an update.
+	 * Explicit sign-out clears that marker first so the next Unknown transition
+	 * immediately returns the user to the sign-in walkthrough.
 	 */
 	private watchEntitlementState(): void {
 		let setupComplete = !this._needsChatSetup(false);
@@ -105,7 +110,8 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			this.chatEntitlementService.sentimentObs.read(reader);
 			this.chatEntitlementService.entitlementObs.read(reader);
 
-			const needsSetup = this._needsChatSetup(false);
+			const includeUnknown = !this.storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false);
+			const needsSetup = this._needsChatSetup(includeUnknown);
 			if (setupComplete && needsSetup) {
 				this.showWalkthrough();
 			}
@@ -179,10 +185,15 @@ registerAction2(class extends Action2 {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const chatEntitlementService = accessor.get(IChatEntitlementService);
 		const contextKeyService = accessor.get(IContextKeyService);
+		const environmentService = accessor.get(IWorkbenchEnvironmentService);
 		const logService = accessor.get(ILogService);
 
 		// Clear completion marker
 		storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
+
+		if (shouldSkipSessionsWelcome(environmentService)) {
+			return;
+		}
 
 		// Immediately show the walkthrough overlay
 		const store = new DisposableStore();

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -47,6 +47,57 @@ function needsChatSetup(chatEntitlementService: Pick<IChatEntitlementService, 's
 function shouldPersistWelcomeCompletion(outcome: WalkthroughOutcome, chatEntitlementService: Pick<IChatEntitlementService, 'sentiment' | 'entitlement' | 'anonymous'>): boolean {
 	return outcome === 'completed' || !needsChatSetup(chatEntitlementService);
 }
+
+export function resetSessionsWelcome(
+	storageService: Pick<IStorageService, 'remove' | 'store'>,
+	instantiationService: IInstantiationService,
+	layoutService: IWorkbenchLayoutService,
+	chatEntitlementService: Pick<IChatEntitlementService, 'sentimentObs' | 'entitlementObs' | 'sentiment' | 'entitlement' | 'anonymous'>,
+	contextKeyService: IContextKeyService,
+	environmentService: IWorkbenchEnvironmentService,
+	logService: ILogService,
+): void {
+	// Clear completion marker
+	storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
+
+	if (shouldSkipSessionsWelcome(environmentService)) {
+		return;
+	}
+
+	// Immediately show the walkthrough overlay
+	const store = new DisposableStore();
+	const welcomeVisibleKey = SessionsWelcomeVisibleContext.bindTo(contextKeyService);
+	welcomeVisibleKey.set(true);
+	store.add(toDisposable(() => welcomeVisibleKey.reset()));
+
+	const walkthrough = store.add(instantiationService.createInstance(
+		SessionsWalkthroughOverlay,
+		layoutService.mainContainer,
+	));
+
+	store.add(autorun(reader => {
+		chatEntitlementService.sentimentObs.read(reader);
+		chatEntitlementService.entitlementObs.read(reader);
+
+		if (!needsChatSetup(chatEntitlementService)) {
+			storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			walkthrough.complete();
+			store.dispose();
+		}
+	}));
+
+	walkthrough.outcome
+		.then(outcome => {
+			logService.info(`[sessions welcome] Developer reset walkthrough finished with outcome: ${outcome}`);
+			if (shouldPersistWelcomeCompletion(outcome, chatEntitlementService)) {
+				storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			}
+		})
+		.finally(() => {
+			store.dispose();
+		});
+}
+
 export class SessionsWelcomeContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsWelcome';
@@ -187,45 +238,6 @@ registerAction2(class extends Action2 {
 		const contextKeyService = accessor.get(IContextKeyService);
 		const environmentService = accessor.get(IWorkbenchEnvironmentService);
 		const logService = accessor.get(ILogService);
-
-		// Clear completion marker
-		storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
-
-		if (shouldSkipSessionsWelcome(environmentService)) {
-			return;
-		}
-
-		// Immediately show the walkthrough overlay
-		const store = new DisposableStore();
-		const welcomeVisibleKey = SessionsWelcomeVisibleContext.bindTo(contextKeyService);
-		welcomeVisibleKey.set(true);
-		store.add(toDisposable(() => welcomeVisibleKey.reset()));
-
-		const walkthrough = store.add(instantiationService.createInstance(
-			SessionsWalkthroughOverlay,
-			layoutService.mainContainer,
-		));
-
-		store.add(autorun(reader => {
-			chatEntitlementService.sentimentObs.read(reader);
-			chatEntitlementService.entitlementObs.read(reader);
-
-			if (!needsChatSetup(chatEntitlementService)) {
-				storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
-				walkthrough.complete();
-				store.dispose();
-			}
-		}));
-
-		walkthrough.outcome
-			.then(outcome => {
-				logService.info(`[sessions welcome] Developer reset walkthrough finished with outcome: ${outcome}`);
-				if (shouldPersistWelcomeCompletion(outcome, chatEntitlementService)) {
-					storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
-				}
-			})
-			.finally(() => {
-				store.dispose();
-			});
+		resetSessionsWelcome(storageService, instantiationService, layoutService, chatEntitlementService, contextKeyService, environmentService, logService);
 	}
 });

--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -17,13 +17,13 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IExtensionService } from '../../../../../workbench/services/extensions/common/extensions.js';
 import { ChatEntitlement, IChatEntitlementService, IChatSentiment } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ChatSetupStrategy } from '../../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
+import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
 import { workbenchInstantiationService } from '../../../../../workbench/test/browser/workbenchTestServices.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
+import { WELCOME_COMPLETE_KEY } from '../../../../common/welcome.js';
 import { SessionsWelcomeContribution } from '../../browser/welcome.contribution.js';
 import { SessionsWalkthroughOverlay, WalkthroughOutcome } from '../../browser/sessionsWalkthrough.js';
-
-const WELCOME_COMPLETE_KEY = 'workbench.agentsession.welcomeComplete';
 
 class MockChatEntitlementService implements Partial<IChatEntitlementService> {
 
@@ -148,6 +148,50 @@ suite('SessionsWelcomeContribution', () => {
 		});
 
 		assert.strictEqual(isOverlayVisible(), false, 'should remain hidden after recovery');
+	});
+
+	test('returning user: sign out clears welcome completion and shows overlay on Unknown entitlement', async () => {
+		markReturningUser();
+		mockEntitlementService.entitlementObs.set(ChatEntitlement.Pro, undefined);
+		mockEntitlementService.sentimentObs.set({ completed: true, installed: true } as IChatSentiment, undefined);
+
+		const contribution = disposables.add(instantiationService.createInstance(SessionsWelcomeContribution));
+		assert.ok(contribution);
+		assert.strictEqual(isOverlayVisible(), false, 'should not show initially');
+
+		const storageService = instantiationService.get(IStorageService);
+		storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
+
+		transaction(tx => {
+			mockEntitlementService.entitlementObs.set(ChatEntitlement.Unknown, tx);
+		});
+
+		assert.strictEqual(isOverlayVisible(), true, 'should show overlay after explicit sign out');
+
+		transaction(tx => {
+			mockEntitlementService.entitlementObs.set(ChatEntitlement.Free, tx);
+		});
+		await flushMicrotasks();
+
+		assert.strictEqual(isOverlayVisible(), false, 'should hide overlay after signing back in');
+		assert.strictEqual(storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false), true);
+	});
+
+	test('reset welcome respects skip-sessions-welcome while still clearing completion state', async () => {
+		markReturningUser();
+
+		const environmentService = instantiationService.get(IWorkbenchEnvironmentService);
+		instantiationService.stub(IWorkbenchEnvironmentService, {
+			...environmentService,
+			args: { ...(environmentService as IWorkbenchEnvironmentService & { args?: Record<string, unknown> }).args, 'skip-sessions-welcome': true },
+		} as IWorkbenchEnvironmentService);
+
+		const commandService = instantiationService.get(ICommandService);
+		await commandService.executeCommand('workbench.action.resetSessionsWelcome');
+
+		const storageService = instantiationService.get(IStorageService);
+		assert.strictEqual(storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false), false, 'should clear completion state');
+		assert.strictEqual(isOverlayVisible(), false, 'should not show overlay when skip flag is set');
 	});
 
 	test('returning user: transient Unresolved entitlement does NOT show overlay', () => {

--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -18,11 +18,12 @@ import { IExtensionService } from '../../../../../workbench/services/extensions/
 import { ChatEntitlement, IChatEntitlementService, IChatSentiment } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ChatSetupStrategy } from '../../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
 import { IWorkbenchEnvironmentService } from '../../../../../workbench/services/environment/common/environmentService.js';
+import { IWorkbenchLayoutService } from '../../../../../workbench/services/layout/browser/layoutService.js';
 import { workbenchInstantiationService } from '../../../../../workbench/test/browser/workbenchTestServices.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
 import { WELCOME_COMPLETE_KEY } from '../../../../common/welcome.js';
-import { SessionsWelcomeContribution } from '../../browser/welcome.contribution.js';
+import { resetSessionsWelcome, SessionsWelcomeContribution } from '../../browser/welcome.contribution.js';
 import { SessionsWalkthroughOverlay, WalkthroughOutcome } from '../../browser/sessionsWalkthrough.js';
 
 class MockChatEntitlementService implements Partial<IChatEntitlementService> {
@@ -180,16 +181,18 @@ suite('SessionsWelcomeContribution', () => {
 	test('reset welcome respects skip-sessions-welcome while still clearing completion state', async () => {
 		markReturningUser();
 
+		const storageService = instantiationService.get(IStorageService);
+		const layoutService = instantiationService.get(IWorkbenchLayoutService);
+		const contextKeyService = instantiationService.get(IContextKeyService);
+		const logService = instantiationService.get(ILogService);
 		const environmentService = instantiationService.get(IWorkbenchEnvironmentService);
 		instantiationService.stub(IWorkbenchEnvironmentService, {
 			...environmentService,
 			args: { ...(environmentService as IWorkbenchEnvironmentService & { args?: Record<string, unknown> }).args, 'skip-sessions-welcome': true },
 		} as IWorkbenchEnvironmentService);
 
-		const commandService = instantiationService.get(ICommandService);
-		await commandService.executeCommand('workbench.action.resetSessionsWelcome');
+		resetSessionsWelcome(storageService, instantiationService, layoutService, mockEntitlementService, contextKeyService, instantiationService.get(IWorkbenchEnvironmentService), logService);
 
-		const storageService = instantiationService.get(IStorageService);
 		assert.strictEqual(storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false), false, 'should clear completion state');
 		assert.strictEqual(isOverlayVisible(), false, 'should not show overlay when skip flag is set');
 	});

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -907,7 +907,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		if (!this.defaultAccount) {
 			return;
 		}
-		this.commandService.executeCommand('_signOutOfAccount', { providerId: this.defaultAccount.authenticationProvider.id, accountLabel: this.defaultAccount.accountName });
+		await this.commandService.executeCommand('_signOutOfAccount', { providerId: this.defaultAccount.authenticationProvider.id, accountLabel: this.defaultAccount.accountName });
 	}
 
 }


### PR DESCRIPTION
Fixes #307660

## Summary
- wait for the default account sign-out flow to complete before resetting the sessions welcome state
- reopen the sessions welcome/sign-in walkthrough after entitlement falls back to `Unknown`
- keep transient `Unknown` entitlement handling unchanged for token refreshes and add regression coverage for the sign-out path

## Testing
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/common/welcome.ts src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts src/vs/sessions/contrib/accountMenu/test/browser/account.contribution.test.ts src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts src/vs/workbench/services/accounts/browser/defaultAccount.ts`

## Notes
- Targeted unit tests could not be run locally because the Electron test harness in this environment crashes before loading tests (`test/unit/electron/index.js` sees `app` as `undefined`).