### PR TITLE
feat: add CP857 (Turkish DOS) to supported document encodings

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -693,85 +693,90 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelShort: 'ISO 8859-9',
 		order: 33
 	},
+	cp857: {
+		labelLong: 'Turkish (CP 857)',
+		labelShort: 'CP 857',
+		order: 34
+	},
 	windows1258: {
 		labelLong: 'Vietnamese (Windows 1258)',
 		labelShort: 'Windows 1258',
-		order: 34
+		order: 35
 	},
 	gbk: {
 		labelLong: 'Simplified Chinese (GBK)',
 		labelShort: 'GBK',
-		order: 35
+		order: 36
 	},
 	gb18030: {
 		labelLong: 'Simplified Chinese (GB18030)',
 		labelShort: 'GB18030',
-		order: 36
+		order: 37
 	},
 	cp950: {
 		labelLong: 'Traditional Chinese (Big5)',
 		labelShort: 'Big5',
-		order: 37,
+		order: 38,
 		guessableName: 'Big5'
 	},
 	big5hkscs: {
 		labelLong: 'Traditional Chinese (Big5-HKSCS)',
 		labelShort: 'Big5-HKSCS',
-		order: 38
+		order: 39
 	},
 	shiftjis: {
 		labelLong: 'Japanese (Shift JIS)',
 		labelShort: 'Shift JIS',
-		order: 39,
+		order: 40,
 		guessableName: 'SHIFT_JIS'
 	},
 	eucjp: {
 		labelLong: 'Japanese (EUC-JP)',
 		labelShort: 'EUC-JP',
-		order: 40,
+		order: 41,
 		guessableName: 'EUC-JP'
 	},
 	euckr: {
 		labelLong: 'Korean (EUC-KR)',
 		labelShort: 'EUC-KR',
-		order: 41,
+		order: 42,
 		guessableName: 'EUC-KR'
 	},
 	windows874: {
 		labelLong: 'Thai (Windows 874)',
 		labelShort: 'Windows 874',
-		order: 42
+		order: 43
 	},
 	iso885911: {
 		labelLong: 'Latin/Thai (ISO 8859-11)',
 		labelShort: 'ISO 8859-11',
-		order: 43
+		order: 44
 	},
 	koi8ru: {
 		labelLong: 'Cyrillic (KOI8-RU)',
 		labelShort: 'KOI8-RU',
-		order: 44
+		order: 45
 	},
 	koi8t: {
 		labelLong: 'Tajik (KOI8-T)',
 		labelShort: 'KOI8-T',
-		order: 45
+		order: 46
 	},
 	gb2312: {
 		labelLong: 'Simplified Chinese (GB 2312)',
 		labelShort: 'GB 2312',
-		order: 46,
+		order: 47,
 		guessableName: 'GB2312'
 	},
 	cp865: {
 		labelLong: 'Nordic DOS (CP 865)',
 		labelShort: 'CP 865',
-		order: 47
+		order: 48
 	},
 	cp850: {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
-		order: 48
+		order: 49
 	}
 };
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -130,7 +130,7 @@ declare module 'vscode' {
 		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
 		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
 		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
-		 * 'cp865', 'cp850'.
+		 * 'cp865', 'cp850', 'cp857'.
 		 */
 		readonly encoding: string;
 


### PR DESCRIPTION
## Summary

This PR adds **CP857 (Turkish DOS)** to VS Code's supported document encodings, resolving the long-standing request in #300041 (160+ upvotes).

## Problem

CP857 (Code Page 857) was the dominant encoding used in Turkey until the 2000s. Many legacy Turkish projects, government databases, and archived files still use this encoding. Currently, VS Code users working with CP857-encoded files cannot select this encoding from the encoding picker, forcing them to use workarounds or external tools.

While CP857 is already recognized in VS Code's terminal encoding detection (`src/vs/base/node/terminalEncoding.ts`), it was missing from the document encoding picker (`SUPPORTED_ENCODINGS`).

## Changes

**`src/vs/workbench/services/textfile/common/encoding.ts`**:
- Added `cp857` entry to the `SUPPORTED_ENCODINGS` map
- Grouped it with the existing Turkish encodings (Windows 1254 at order 32, ISO 8859-9 at order 33)
- Assigned order 34, shifting subsequent encodings by +1
- Labels follow existing conventions: `'Turkish (CP 857)'` (long) / `'CP 857'` (short)

## Why this works without further changes

- **`@vscode/iconv-lite-umd`** already supports CP857 natively — no dependency updates needed
- The encoding picker UI automatically picks up any entry in `SUPPORTED_ENCODINGS`
- The `toNodeEncoding()` and `encodingExists()` functions handle CP857 correctly via iconv-lite's normalization

## Testing

- Verified that `@vscode/iconv-lite-umd` recognizes `'cp857'` as a valid encoding
- The change follows the exact same pattern as all other DOS code page entries (CP 437, CP 850, CP 852, CP 865, CP 866)
- No breaking changes — this is purely additive

## Before / After

| Before | After |
|--------|-------|
| Turkish section shows only Windows 1254 and ISO 8859-9 | Turkish section now also shows CP 857 |
| CP857 files cannot be opened with correct encoding | CP857 files can be properly decoded and re-encoded |

Fixes #300041