### PR TITLE
git: show worktree path in branch selection dropdown

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -142,6 +142,24 @@ class BranchItem extends RefItem {
 }
 
 class CheckoutItem extends BranchItem {
+
+	override get description(): string {
+		const description = super.description;
+
+		if (this.worktreePath) {
+			const worktreeLabel = l10n.t('worktree: {0}', this.worktreePath);
+			return description.length > 0
+				? `${description}$(circle-small-filled)$(list-tree) ${worktreeLabel}`
+				: `$(list-tree) ${worktreeLabel}`;
+		}
+
+		return description;
+	}
+
+	constructor(ref: Branch, shortCommitLength: number, readonly worktreePath?: string) {
+		super(ref, shortCommitLength);
+	}
+
 	async run(repository: Repository, opts?: { detached?: boolean }): Promise<void> {
 		if (!this.ref.name) {
 			return;
@@ -159,6 +177,10 @@ class CheckoutProtectedItem extends CheckoutItem {
 
 	override get label(): string {
 		return `$(lock) ${this.ref.name ?? this.shortCommit}`;
+	}
+
+	constructor(ref: Branch, shortCommitLength: number, worktreePath?: string) {
+		super(ref, shortCommitLength, worktreePath);
 	}
 }
 
@@ -431,7 +453,18 @@ async function createCheckoutItems(repository: Repository, detached = false): Pr
 	}
 
 	const refs = await repository.getRefs({ includeCommitDetails: showRefDetails });
-	const refProcessors = checkoutTypes.map(type => getCheckoutRefProcessor(repository, type))
+
+	// Build a map of branch name -> worktree path
+	const worktreeMap = new Map<string, string>();
+	for (const worktree of repository.worktrees) {
+		if (!worktree.detached) {
+			// worktree.ref is like "refs/heads/branch-name"
+			const branchName = worktree.ref.replace(/^refs\/heads\//, '');
+			worktreeMap.set(branchName, worktree.path);
+		}
+	}
+
+	const refProcessors = checkoutTypes.map(type => getCheckoutRefProcessor(repository, type, worktreeMap))
 		.filter(p => !!p) as RefProcessor[];
 
 	const buttons = await getRemoteRefItemButtons(repository);
@@ -545,15 +578,19 @@ class RefItemsProcessor {
 
 class CheckoutRefProcessor extends RefProcessor {
 
-	constructor(private readonly repository: Repository) {
+	constructor(
+		private readonly repository: Repository,
+		private readonly worktreeMap: Map<string, string>
+	) {
 		super(RefType.Head);
 	}
 
 	override getItems(shortCommitLength: number): QuickPickItem[] {
 		const items = this.refs.map(ref => {
+			const worktreePath = ref.name ? this.worktreeMap.get(ref.name) : undefined;
 			return this.repository.isBranchProtected(ref) ?
-				new CheckoutProtectedItem(ref, shortCommitLength) :
-				new CheckoutItem(ref, shortCommitLength);
+				new CheckoutProtectedItem(ref, shortCommitLength, worktreePath) :
+				new CheckoutItem(ref, shortCommitLength, worktreePath);
 		});
 
 		return items.length === 0 ? items : [new RefItemSeparator(this.type), ...items];
@@ -625,10 +662,10 @@ class CheckoutItemsProcessor extends RefItemsProcessor {
 	}
 }
 
-function getCheckoutRefProcessor(repository: Repository, type: string): RefProcessor | undefined {
+function getCheckoutRefProcessor(repository: Repository, type: string, worktreeMap: Map<string, string>): RefProcessor | undefined {
 	switch (type) {
 		case 'local':
-			return new CheckoutRefProcessor(repository);
+			return new CheckoutRefProcessor(repository, worktreeMap);
 		case 'remote':
 			return new RefProcessor(RefType.RemoteHead, CheckoutRemoteHeadItem);
 		case 'tags':


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature enhancement

## What is the current behavior?

When using the branch picker (e.g., `Git: Checkout to...`), the dropdown lists branches with their commit info (ahead/behind counts, dates, etc.) but provides no indication of which branches are checked out in worktrees. Users have to remember or manually check which branches have associated worktrees.

Closes #258560

## What is the new behavior?

Branches that have an associated worktree now display the worktree path in their description within the branch picker dropdown. For example, a branch checked out in a worktree at `/home/user/project-wt` will show `$(list-tree) worktree: /home/user/project-wt` in the description area of the quick pick item.

This applies to both regular and protected (locked) branches. The worktree indicator uses the `$(list-tree)` icon and is appended to the existing description, separated by a `$(circle-small-filled)` dot separator when other description elements (like ahead/behind counts) are present.

### Implementation details

- `createCheckoutItems()` builds a `Map<string, string>` of branch name to worktree path from `repository.worktrees`
- The map is passed through `getCheckoutRefProcessor()` -> `CheckoutRefProcessor` -> `CheckoutItem` constructor
- `CheckoutItem` overrides `BranchItem.description` to append worktree info when available
- `CheckoutProtectedItem` passes the worktree path through to `CheckoutItem`
- Only non-detached worktrees are shown (detached worktrees don't correspond to named branches)
- The worktree path string is localized via `l10n.t()`

## Additional context

The `repository.worktrees` data is already populated during the repository status update cycle, so this change does not introduce any additional git commands or performance overhead.