### PR TITLE
fix: support HISTTIMEFORMAT in bash shell history parsing

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
@@ -256,6 +256,12 @@ export async function fetchBashHistory(accessor: ServicesAccessor): Promise<IShe
 	let currentCommand: string | undefined = undefined;
 	let wrapChar: string | undefined = undefined;
 	for (let i = 0; i < fileLines.length; i++) {
+		// When HISTTIMEFORMAT is set, bash prepends each command in the history
+		// file with a timestamp line in the format `#<unix_epoch>`. Skip these
+		// lines so they are not treated as commands.
+		if (currentCommand === undefined && /^#\d+$/.test(fileLines[i])) {
+			continue;
+		}
 		currentLine = fileLines[i];
 		if (currentCommand === undefined) {
 			currentCommand = currentLine;

--- a/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
@@ -126,94 +126,121 @@ suite('Terminal history', () => {
 	suite('fetchBashHistory', () => {
 		let fileScheme: string;
 		let filePath: string;
-		const fileContent: string = [
-			'single line command',
-			'git commit -m "A wrapped line in pwsh history',
-			'',
-			'Some commit description',
-			'',
-			'Fixes #xyz"',
-			'git status',
-			'two "',
-			'line"'
-		].join('\n');
+		const fileContentType = [
+			{
+				type: 'simple',
+				content: [
+					'single line command',
+					'git commit -m "A wrapped line in pwsh history',
+					'',
+					'Some commit description',
+					'',
+					'Fixes #xyz"',
+					'git status',
+					'two "',
+					'line"'
+				].join('\n')
+			},
+			{
+				type: 'timestamped (HISTTIMEFORMAT)',
+				content: [
+					'#1655252330',
+					'single line command',
+					'#1655252340',
+					'git commit -m "A wrapped line in pwsh history',
+					'',
+					'Some commit description',
+					'',
+					'Fixes #xyz"',
+					'#1655252350',
+					'git status',
+					'#1655252360',
+					'two "',
+					'line"'
+				].join('\n')
+			}
+		];
 
 		let instantiationService: TestInstantiationService;
 		let remoteConnection: Pick<IRemoteAgentConnection, 'remoteAuthority'> | null = null;
 		let remoteEnvironment: Pick<IRemoteAgentEnvironment, 'os'> | null = null;
 
-		setup(() => {
-			instantiationService = new TestInstantiationService();
-			instantiationService.stub(IFileService, {
-				async readFile(resource: URI) {
-					const expected = URI.from({ scheme: fileScheme, path: filePath });
-					strictEqual(resource.scheme, expected.scheme);
-					strictEqual(resource.path, expected.path);
-					return { value: VSBuffer.fromString(fileContent) };
-				}
-			} as Pick<IFileService, 'readFile'>);
-			instantiationService.stub(IRemoteAgentService, {
-				async getEnvironment() { return remoteEnvironment; },
-				getConnection() { return remoteConnection; }
-			} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
-		});
-
-		teardown(() => {
-			instantiationService.dispose();
-		});
-
-		if (!isWindows) {
-			suite('local', () => {
-				let originalEnvValues: { HOME: string | undefined };
+		for (const { type, content } of fileContentType) {
+			suite(type, () => {
 				setup(() => {
-					originalEnvValues = { HOME: env['HOME'] };
-					env['HOME'] = '/home/user';
-					remoteConnection = { remoteAuthority: 'some-remote' };
-					fileScheme = Schemas.vscodeRemote;
-					filePath = '/home/user/.bash_history';
+					instantiationService = new TestInstantiationService();
+					instantiationService.stub(IFileService, {
+						async readFile(resource: URI) {
+							const expected = URI.from({ scheme: fileScheme, path: filePath });
+							strictEqual(resource.scheme, expected.scheme);
+							strictEqual(resource.path, expected.path);
+							return { value: VSBuffer.fromString(content) };
+						}
+					} as Pick<IFileService, 'readFile'>);
+					instantiationService.stub(IRemoteAgentService, {
+						async getEnvironment() { return remoteEnvironment; },
+						getConnection() { return remoteConnection; }
+					} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
 				});
+
 				teardown(() => {
-					if (originalEnvValues['HOME'] === undefined) {
-						delete env['HOME'];
-					} else {
-						env['HOME'] = originalEnvValues['HOME'];
-					}
+					instantiationService.dispose();
 				});
-				test('current OS', async () => {
-					filePath = '/home/user/.bash_history';
-					deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
+
+				if (!isWindows) {
+					suite('local', () => {
+						let originalEnvValues: { HOME: string | undefined };
+						setup(() => {
+							originalEnvValues = { HOME: env['HOME'] };
+							env['HOME'] = '/home/user';
+							remoteConnection = { remoteAuthority: 'some-remote' };
+							fileScheme = Schemas.vscodeRemote;
+							filePath = '/home/user/.bash_history';
+						});
+						teardown(() => {
+							if (originalEnvValues['HOME'] === undefined) {
+								delete env['HOME'];
+							} else {
+								env['HOME'] = originalEnvValues['HOME'];
+							}
+						});
+						test('current OS', async () => {
+							filePath = '/home/user/.bash_history';
+							deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
+						});
+					});
+				}
+				suite('remote', () => {
+					let originalEnvValues: { HOME: string | undefined };
+					setup(() => {
+						originalEnvValues = { HOME: env['HOME'] };
+						env['HOME'] = '/home/user';
+						remoteConnection = { remoteAuthority: 'some-remote' };
+						fileScheme = Schemas.vscodeRemote;
+						filePath = '/home/user/.bash_history';
+					});
+					teardown(() => {
+						if (originalEnvValues['HOME'] === undefined) {
+							delete env['HOME'];
+						} else {
+							env['HOME'] = originalEnvValues['HOME'];
+						}
+					});
+					test('Windows', async () => {
+						remoteEnvironment = { os: OperatingSystem.Windows };
+						strictEqual(await instantiationService.invokeFunction(fetchBashHistory), undefined);
+					});
+					test('macOS', async () => {
+						remoteEnvironment = { os: OperatingSystem.Macintosh };
+						deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
+					});
+					test('Linux', async () => {
+						remoteEnvironment = { os: OperatingSystem.Linux };
+						deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
+					});
 				});
 			});
 		}
-		suite('remote', () => {
-			let originalEnvValues: { HOME: string | undefined };
-			setup(() => {
-				originalEnvValues = { HOME: env['HOME'] };
-				env['HOME'] = '/home/user';
-				remoteConnection = { remoteAuthority: 'some-remote' };
-				fileScheme = Schemas.vscodeRemote;
-				filePath = '/home/user/.bash_history';
-			});
-			teardown(() => {
-				if (originalEnvValues['HOME'] === undefined) {
-					delete env['HOME'];
-				} else {
-					env['HOME'] = originalEnvValues['HOME'];
-				}
-			});
-			test('Windows', async () => {
-				remoteEnvironment = { os: OperatingSystem.Windows };
-				strictEqual(await instantiationService.invokeFunction(fetchBashHistory), undefined);
-			});
-			test('macOS', async () => {
-				remoteEnvironment = { os: OperatingSystem.Macintosh };
-				deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
-			});
-			test('Linux', async () => {
-				remoteEnvironment = { os: OperatingSystem.Linux };
-				deepStrictEqual((await instantiationService.invokeFunction(fetchBashHistory))!.commands, expectedCommands);
-			});
-		});
 	});
 	suite('fetchZshHistory', () => {
 		let fileScheme: string;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When HISTTIMEFORMAT is set in bash, the ~/.bash_history file contains timestamp lines in the format `#<unix_epoch>` before each command entry:

```
#1655252330
single line command
#1655252340
git status
```

The `fetchBashHistory` parser in the Run Recent Command quick pick treats these timestamp lines as commands, polluting the command history with entries like `#1655252330`.

Closes #174537

## What is the new behavior?

The parser now detects and skips timestamp lines (matching `/^#\d+$/`) when they appear at the start of a new command entry. This ensures that only actual commands are included in the history, regardless of whether HISTTIMEFORMAT is configured.

The skip only applies when `currentCommand === undefined` (i.e., we are not in the middle of parsing a multi-line command), so a line like `#1234` that legitimately appears inside a quoted multi-line command is preserved.

## Additional context

- The test suite for `fetchBashHistory` is updated to follow the same `fileContentType` pattern used by `fetchZshHistory`, testing both `simple` (without timestamps) and `timestamped (HISTTIMEFORMAT)` history file formats.
- Both test variants validate against the same `expectedCommands`, ensuring the timestamp stripping produces identical results to a plain history file.

### Files changed

- `src/vs/workbench/contrib/terminalContrib/history/common/history.ts` - Skip `#<timestamp>` lines in `fetchBashHistory`
- `src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts` - Add timestamped bash history test variant