### PR TITLE
fix: preserve directory locality for notebook cell paths in TS server

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -99,6 +99,13 @@ export const emptyAuthority = 'ts-nul-authority';
 
 export const inMemoryResourcePrefix = '^';
 
+/**
+ * Prefix used to encode notebook cell URIs as file paths that preserve directory locality.
+ * This ensures that relative path resolution (e.g. './a.ts') in notebook cells works correctly
+ * by keeping the encoded path in the same directory as the notebook file.
+ */
+const notebookCellFilePrefix = '~vscode-notebook-cell~';
+
 interface WatchEvent {
 	updated?: Set<string>;
 	created?: Set<string>;
@@ -765,6 +772,19 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 			return resource.fsPath;
 		}
 
+		// For notebook cell URIs on desktop, encode the cell identity into the filename
+		// while keeping the path in the same directory as the notebook file.
+		// This ensures relative path resolution (e.g. ./a.ts) works correctly
+		// because the TS server resolves relative paths based on the file directory.
+		if (resource.scheme === fileSchemes.vscodeNotebookCell && !isWeb()) {
+			const dir = path.dirname(resource.fsPath);
+			const basename = path.basename(resource.fsPath);
+			return dir + path.sep
+				+ notebookCellFilePrefix + basename
+				+ '?' + encodeURIComponent(resource.authority || emptyAuthority)
+				+ (resource.fragment ? '#' + resource.fragment : '');
+		}
+
 		return (this.isProjectWideIntellisenseOnWebEnabled() ? '' : inMemoryResourcePrefix)
 			+ '/' + resource.scheme
 			+ '/' + (resource.authority || emptyAuthority)
@@ -811,6 +831,32 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 			const parts = filepath.match(/^\/([^\/]+)\/([^\/]*)\/(.+)$/);
 			if (parts) {
 				const resource = vscode.Uri.parse(parts[1] + '://' + (parts[2] === emptyAuthority ? '' : parts[2]) + '/' + parts[3]);
+				return this.bufferSyncSupport.toVsCodeResource(resource);
+			}
+		}
+
+		// Detect notebook cell paths encoded by toTsFilePath on desktop.
+		// Format: {dir}/{notebookCellFilePrefix}{basename}?{encodedAuthority}#{fragment}
+		const notebookBasename = path.basename(filepath);
+		if (notebookBasename.startsWith(notebookCellFilePrefix)) {
+			const dir = path.dirname(filepath);
+			const rest = notebookBasename.slice(notebookCellFilePrefix.length);
+			const queryIndex = rest.indexOf('?');
+			if (queryIndex !== -1) {
+				const base = rest.slice(0, queryIndex);
+				const authorityAndFragment = rest.slice(queryIndex + 1);
+				const hashIndex = authorityAndFragment.indexOf('#');
+				const encodedAuthority = hashIndex !== -1 ? authorityAndFragment.slice(0, hashIndex) : authorityAndFragment;
+				const fragment = hashIndex !== -1 ? authorityAndFragment.slice(hashIndex + 1) : '';
+				const authority = decodeURIComponent(encodedAuthority);
+				const fullPath = dir + path.sep + base;
+				const uriPath = fullPath.replace(/\\/g, '/');
+				const resource = vscode.Uri.from({
+					scheme: fileSchemes.vscodeNotebookCell,
+					authority: authority === emptyAuthority ? '' : authority,
+					path: uriPath.startsWith('/') ? uriPath : '/' + uriPath,
+					fragment: fragment,
+				});
 				return this.bufferSyncSupport.toVsCodeResource(resource);
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using TypeScript/JavaScript cells in VS Code notebooks (e.g., with the TypeScript Notebook extension), relative path imports like `import { a } from './a.ts'` fail with `TS(2307) Cannot find module`, and "Go to Definition" navigates to a nonsensical path.

This happens because the TypeScript language service client converts `vscode-notebook-cell://` URIs into virtual file paths of the form `^/vscode-notebook-cell/authority/path/to/notebook.ipynb#fragment`. The TS server sees this virtual path and resolves relative imports against its directory (`^/vscode-notebook-cell/authority/path/to/`), which does not match the actual directory of the notebook file (`/path/to/`).

Closes #196172

## What is the new behavior?

For `vscode-notebook-cell` URIs on desktop, the cell identity (authority + fragment) is now encoded into the filename while keeping the path in the same directory as the notebook file. This ensures that `path.dirname()` returns the actual notebook directory, so the TS server correctly resolves relative imports.

### Encoding format

**Before (virtual path):**
```
^/vscode-notebook-cell/ts-nul-authority/path/to/notebook.ipynb#W0sZmlsZQ
          directory: ^/vscode-notebook-cell/ts-nul-authority/path/to/  (WRONG)
```

**After (directory-preserving path):**
```
/path/to/~vscode-notebook-cell~notebook.ipynb?ts-nul-authority#W0sZmlsZQ
          directory: /path/to/  (CORRECT - matches actual notebook location)
```

The reverse conversion in `toResource` correctly parses these encoded paths back into proper `vscode-notebook-cell://` URIs.

## Additional context

- This fix only applies on desktop (non-web) environments where `fsPath` provides a real filesystem path
- The web codepath is unaffected and continues to use the existing virtual path format
- The encoding uses `~vscode-notebook-cell~` as a filename prefix, which is unlikely to collide with real filenames
- Authority is URI-encoded in the filename to handle special characters safely
- The approach was originally suggested by the issue reporter in https://github.com/microsoft/vscode/commit/bb9910b06271537ef71427f21d75a955a7594b84, adapted to the current codebase