### PR TITLE
fix: prevent comment continuation when '//' appears inside strings

### DIFF
--- a/src/vs/editor/common/languages/supports/indentationLineProcessor.ts
+++ b/src/vs/editor/common/languages/supports/indentationLineProcessor.ts
@@ -198,6 +198,8 @@ class IndentationLineProcessor {
 
 	/**
 	 * Process the line with the given tokens, remove the language configuration brackets from the regex, string and comment tokens.
+	 * Additionally, remove comment markers from string and regex tokens so that comment-like
+	 * sequences inside strings (e.g. '//text') do not trigger comment continuation on Enter.
 	 */
 	getProcessedTokens(tokens: IViewLineTokens): IViewLineTokens {
 
@@ -207,9 +209,16 @@ class IndentationLineProcessor {
 				|| tokenType === StandardTokenType.Comment;
 		};
 
+		const shouldRemoveCommentMarkersFromTokenType = (tokenType: StandardTokenType): boolean => {
+			return tokenType === StandardTokenType.String
+				|| tokenType === StandardTokenType.RegEx;
+		};
+
 		const languageId = tokens.getLanguageId(0);
-		const bracketsConfiguration = this.languageConfigurationService.getLanguageConfiguration(languageId).bracketsNew;
+		const languageConfiguration = this.languageConfigurationService.getLanguageConfiguration(languageId);
+		const bracketsConfiguration = languageConfiguration.bracketsNew;
 		const bracketsRegExp = bracketsConfiguration.getBracketRegExp({ global: true });
+		const commentMarkerRegExp = IndentationLineProcessor._getCommentMarkerRegExp(languageConfiguration);
 		const textAndMetadata: { text: string; metadata: number }[] = [];
 		tokens.forEach((tokenIndex: number) => {
 			const tokenType = tokens.getStandardTokenType(tokenIndex);
@@ -217,11 +226,35 @@ class IndentationLineProcessor {
 			if (shouldRemoveBracketsFromTokenType(tokenType)) {
 				text = text.replace(bracketsRegExp, '');
 			}
+			if (shouldRemoveCommentMarkersFromTokenType(tokenType) && commentMarkerRegExp) {
+				text = text.replace(commentMarkerRegExp, '');
+			}
 			const metadata = tokens.getMetadata(tokenIndex);
 			textAndMetadata.push({ text, metadata });
 		});
 		const processedLineTokens = LineTokens.createFromTextAndMetadata(textAndMetadata, tokens.languageIdCodec);
 		return processedLineTokens;
+	}
+
+	private static _getCommentMarkerRegExp(languageConfiguration: ReturnType<ILanguageConfigurationService['getLanguageConfiguration']>): RegExp | null {
+		const comments = languageConfiguration.comments;
+		if (!comments) {
+			return null;
+		}
+		const markers: string[] = [];
+		if (comments.lineCommentToken) {
+			markers.push(strings.escapeRegExpCharacters(comments.lineCommentToken));
+		}
+		if (comments.blockCommentStartToken) {
+			markers.push(strings.escapeRegExpCharacters(comments.blockCommentStartToken));
+		}
+		if (comments.blockCommentEndToken) {
+			markers.push(strings.escapeRegExpCharacters(comments.blockCommentEndToken));
+		}
+		if (markers.length === 0) {
+			return null;
+		}
+		return new RegExp(markers.join('|'), 'g');
 	}
 }
 

--- a/src/vs/editor/contrib/indentation/test/browser/indentationLineProcessor.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentationLineProcessor.test.ts
@@ -126,6 +126,54 @@ suite('Indentation Context Processor - TypeScript/JavaScript', () => {
 			assert.strictEqual(processedContext.previousLineProcessedTokens.getLineContent(), '');
 		});
 	});
+
+	test('comment markers inside of string - issue #241802', () => {
+
+		const model = createTextModel([
+			"let string = '//this is a string'.charAt(0)",
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel, instantiationService) => {
+			const tokens: StandardTokenTypeData[][] = [[
+				{ startIndex: 0, standardTokenType: StandardTokenType.Other },
+				{ startIndex: 13, standardTokenType: StandardTokenType.String },
+				{ startIndex: 33, standardTokenType: StandardTokenType.Other }
+			]];
+			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
+			const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
+			const indentationContextProcessor = new IndentationContextProcessor(model, languageConfigurationService);
+			const processedContext = indentationContextProcessor.getProcessedTokenContextAroundRange(new Range(1, 44, 1, 44));
+			// The '//' inside the string should be removed so it does not trigger comment continuation
+			assert.strictEqual(processedContext.beforeRangeProcessedTokens.getLineContent(), "let string = 'this is a string'.charAt(0)");
+			assert.strictEqual(processedContext.afterRangeProcessedTokens.getLineContent(), '');
+			assert.strictEqual(processedContext.previousLineProcessedTokens.getLineContent(), '');
+		});
+	});
+
+	test('URL inside of string should not trigger comment continuation - issue #241802', () => {
+
+		const model = createTextModel([
+			'axios.get("http://localhost/index").then()',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel, instantiationService) => {
+			const tokens: StandardTokenTypeData[][] = [[
+				{ startIndex: 0, standardTokenType: StandardTokenType.Other },
+				{ startIndex: 10, standardTokenType: StandardTokenType.String },
+				{ startIndex: 34, standardTokenType: StandardTokenType.Other }
+			]];
+			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
+			const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
+			const indentationContextProcessor = new IndentationContextProcessor(model, languageConfigurationService);
+			const processedContext = indentationContextProcessor.getProcessedTokenContextAroundRange(new Range(1, 43, 1, 43));
+			// The '//' inside the URL string should be removed
+			assert.strictEqual(processedContext.beforeRangeProcessedTokens.getLineContent(), 'axios.get("httplocalhost/index").then()');
+			assert.strictEqual(processedContext.afterRangeProcessedTokens.getLineContent(), '');
+			assert.strictEqual(processedContext.previousLineProcessedTokens.getLineContent(), '');
+		});
+	});
 });
 
 suite('Processed Indent Rules Support - TypeScript/JavaScript', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When pressing Enter on a line containing `//` inside a string literal (e.g. `'//this is a string'` or `"http://localhost"`), VS Code incorrectly treats it as a line comment and adds `//` on the next line.

For example:
```js
let string = '//this is a string'.charAt(0)
// Pressing Enter after '.charAt(0)' produces:
let string = '//this is a string'.charAt(0)
// <-- unwanted comment continuation
```

Similarly with URLs:
```js
axios.get("http://localhost/index").then()
// Pressing Enter produces:
axios.get("http://localhost/index").then()
// <-- unwanted comment continuation
```

Closes #241802

## What is the new behavior?

Comment markers (`//`, `/*`, `*/`) are now stripped from string and regex tokens during indentation context processing, just like brackets already are. This prevents the onEnter comment continuation rule from matching `//` that appears inside string literals, while preserving correct comment continuation behavior for actual line comments.

## Additional context

**Root cause:** The `IndentationLineProcessor.getProcessedTokens` method already removes brackets from string/regex/comment tokens to prevent bracket-based indentation rules from being triggered by brackets inside strings. However, it did not remove comment markers from string/regex tokens, so the regex-based onEnter comment continuation rule could match `//` that appeared inside string content.

**Fix approach:** Added comment marker stripping (line comment token, block comment start/end tokens from the language configuration) for string and regex tokens, alongside the existing bracket stripping. This is a minimal, targeted fix that follows the same architectural pattern already used for brackets.

**Files changed:**
- `src/vs/editor/common/languages/supports/indentationLineProcessor.ts` — Strip comment markers from string/regex tokens
- `src/vs/editor/contrib/indentation/test/browser/indentationLineProcessor.test.ts` — Added tests for the fix