### PR TITLE
Migrate terminal shell integration to AsyncIterableProducer

### DIFF
--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -12,7 +12,7 @@ import { IExtHostRpcService } from './extHostRpcService.js';
 import { IExtHostTerminalService } from './extHostTerminalService.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
 import { URI } from '../../../base/common/uri.js';
-import { AsyncIterableObject, Barrier, type AsyncIterableEmitter } from '../../../base/common/async.js';
+import { AsyncIterableProducer, Barrier, DeferredPromise, type AsyncIterableEmitter } from '../../../base/common/async.js';
 
 export interface IExtHostTerminalShellIntegration extends ExtHostTerminalShellIntegrationShape {
 	readonly _serviceBrand: undefined;
@@ -400,7 +400,7 @@ class InternalTerminalShellExecution {
 	private _createDataStream(): AsyncIterable<string> {
 		if (!this._dataStream) {
 			if (this._isEnded) {
-				return AsyncIterableObject.EMPTY;
+				return AsyncIterableProducer.EMPTY;
 			}
 			this._dataStream = new ShellExecutionDataStream();
 		}
@@ -432,7 +432,7 @@ class InternalTerminalShellExecution {
 
 class ShellExecutionDataStream extends Disposable {
 	private _barrier: Barrier | undefined;
-	private _iterables: AsyncIterableObject<string>[] = [];
+	private _completionPromises: DeferredPromise<void>[] = [];
 	private _emitters: AsyncIterableEmitter<string>[] = [];
 
 	createIterable(): AsyncIterable<string> {
@@ -440,11 +440,13 @@ class ShellExecutionDataStream extends Disposable {
 			this._barrier = new Barrier();
 		}
 		const barrier = this._barrier;
-		const iterable = new AsyncIterableObject<string>(async emitter => {
+		const completionPromise = new DeferredPromise<void>();
+		this._completionPromises.push(completionPromise);
+		const iterable = new AsyncIterableProducer<string>(async emitter => {
 			this._emitters.push(emitter);
 			await barrier.wait();
+			completionPromise.complete(undefined);
 		});
-		this._iterables.push(iterable);
 		return iterable;
 	}
 
@@ -459,7 +461,7 @@ class ShellExecutionDataStream extends Disposable {
 	}
 
 	async flush(): Promise<void> {
-		await Promise.all(this._iterables.map(e => e.toPromise()));
+		await Promise.all(this._completionPromises.map(p => p.p));
 	}
 }
 

--- a/src/vs/workbench/api/test/common/extHostTerminalShellIntegration.test.ts
+++ b/src/vs/workbench/api/test/common/extHostTerminalShellIntegration.test.ts
@@ -64,7 +64,7 @@ suite('InternalTerminalShellIntegration', () => {
 	}
 
 	async function emitData(data: string): Promise<void> {
-		// AsyncIterableObjects are initialized in a microtask, this doesn't matter in practice
+		// AsyncIterableProducers are initialized in a microtask, this doesn't matter in practice
 		// since the events will always come through in different events.
 		await new Promise<void>(r => queueMicrotask(r));
 		si.emitData(data);


### PR DESCRIPTION
## Summary
- Migrates `AsyncIterableObject` → `AsyncIterableProducer` in `extHostTerminalShellIntegration.ts`, addressing part of #256854
- `ShellExecutionDataStream` was retaining all emitted terminal output in `AsyncIterableObject._results`, causing a potential memory leak for long-running sessions
- Replaced `toPromise()`-based flush (which re-iterated the stream) with `DeferredPromise` completion tracking — simpler and avoids the need for multi-iteration support

## Changes
- `AsyncIterableObject.EMPTY` → `AsyncIterableProducer.EMPTY` for the empty data stream case
- `ShellExecutionDataStream.createIterable()` now uses `AsyncIterableProducer` + `DeferredPromise` for completion signaling
- `flush()` awaits the deferred promises instead of re-iterating via `toPromise()`
- Updated comment in test file

## Test plan
- [ ] Existing `extHostTerminalShellIntegration.test.ts` tests pass
- [ ] Manual: run commands in the integrated terminal and verify output streaming works
- [ ] Manual: verify terminal shell execution end events fire correctly after flush

cc @Tyriar

🤖 Generated with [Claude Code](https://claude.com/claude-code)