### PR TITLE
fix: safestorage keychain for renamed agents app

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -398,10 +398,10 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 			? (product as typeof product & { embedded?: EmbeddedProductInfo }).embedded
 			: undefined;
 
-		const packageSubJsonStream = isInsiderOrExploration
+		const packageSubJsonStream = embedded
 			? gulp.src(['package.json'], { base: '.' })
 				.pipe(jsonEditor((json: Record<string, unknown>) => {
-					json.name = `sessions-${quality || 'oss-dev'}`;
+					json.name = embedded.nameShort;
 					return json;
 				}))
 				.pipe(rename('package.sub.json'))

--- a/src/vs/platform/environment/node/userDataPath.ts
+++ b/src/vs/platform/environment/node/userDataPath.ts
@@ -47,7 +47,7 @@ function doGetUserDataPath(cliArgs: NativeParsedArgs, productName: string): stri
 	// 0. Running out of sources has a fixed productName
 	if (process.env['VSCODE_DEV']) {
 		if ((process as INodeProcess).isEmbeddedApp) {
-			productName = 'sessions-oss-dev';
+			productName = 'agents-oss-dev';
 		} else {
 			productName = 'code-oss-dev';
 		}


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode-distro/pull/1380

Addresses the following
<img width="930" height="408" alt="image" src="https://github.com/user-attachments/assets/8ac3842a-4702-4caf-ab0b-97726b2865a7" />

Post rename the bundle id of the application has changed, however the keychain name is being derived from package.json `name` wasn't changed. So new bundled id attempting access keychain created by old bundle triggers the prompt, we don't want to access the old keychain post rename.
