### PR TITLE
feat: Expose ViewColumn.Modal in API

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -64,7 +64,7 @@ import { TestId } from '../../contrib/testing/common/testId.js';
 import { CoverageDetails, DetailType, ICoverageCount, IFileCoverage, ISerializedTestResults, ITestErrorMessage, ITestItem, ITestRunProfileReference, ITestTag, TestMessageType, TestResultItem, TestRunProfileBitset, denamespaceTestTag, namespaceTestTag } from '../../contrib/testing/common/testTypes.js';
 import { AiSettingsSearchResult, AiSettingsSearchResultKind } from '../../services/aiSettingsSearch/common/aiSettingsSearch.js';
 import { EditorGroupColumn } from '../../services/editor/common/editorGroupColumn.js';
-import { ACTIVE_GROUP, SIDE_GROUP } from '../../services/editor/common/editorService.js';
+import { ACTIVE_GROUP, MODAL_GROUP, SIDE_GROUP } from '../../services/editor/common/editorService.js';
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
 import { Dto, SerializableObjectWithBuffers } from '../../services/extensions/common/proxyIdentifier.js';
 import * as extHostProtocol from './extHost.protocol.js';
@@ -326,6 +326,10 @@ export namespace ViewColumn {
 
 		if (column === types.ViewColumn.Beside) {
 			return SIDE_GROUP;
+		}
+
+		if (column === types.ViewColumn.Modal) {
+			return MODAL_GROUP;
 		}
 
 		return ACTIVE_GROUP; // default is always the active group

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -647,6 +647,7 @@ export enum InlineCompletionDisplayLocationKind {
 export enum ViewColumn {
 	Active = -1,
 	Beside = -2,
+	Modal = -4,
 	One = 1,
 	Two = 2,
 	Three = 3,

--- a/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
+++ b/src/vs/workbench/api/test/common/extHostTypeConverters.test.ts
@@ -7,8 +7,9 @@ import assert from 'assert';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IconPathDto } from '../../common/extHost.protocol.js';
-import { ChatRequestModeInstructions, IconPath } from '../../common/extHostTypeConverters.js';
-import { ThemeColor, ThemeIcon } from '../../common/extHostTypes.js';
+import { ChatRequestModeInstructions, IconPath, ViewColumn } from '../../common/extHostTypeConverters.js';
+import { ThemeColor, ThemeIcon, ViewColumn as ViewColumnEnum } from '../../common/extHostTypes.js';
+import { ACTIVE_GROUP, MODAL_GROUP, SIDE_GROUP } from '../../../../workbench/services/editor/common/editorService.js';
 import { IChatRequestModeInstructions } from '../../../contrib/chat/common/model/chatModel.js';
 import { Dto } from '../../../services/extensions/common/proxyIdentifier.js';
 
@@ -241,6 +242,44 @@ suite('extHostTypeConverters', function () {
 			assert.strictEqual(backToApi.toolReferences?.[0].range, undefined);
 			assert.strictEqual(backToApi.toolReferences?.[1].name, 'tool2');
 			assert.deepStrictEqual(backToApi.toolReferences?.[1].range, [10, 20]);
+		});
+	});
+
+	suite('ViewColumn', function () {
+		suite('from', function () {
+			test('undefined defaults to Active group', function () {
+				assert.strictEqual(ViewColumn.from(undefined), ACTIVE_GROUP);
+			});
+
+			test('Active resolves to Active group', function () {
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.Active), ACTIVE_GROUP);
+			});
+
+			test('Beside resolves to Side group', function () {
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.Beside), SIDE_GROUP);
+			});
+
+			test('Modal resolves to Modal group', function () {
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.Modal), MODAL_GROUP);
+			});
+
+			test('numbered columns are zero-indexed', function () {
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.One), 0);
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.Two), 1);
+				assert.strictEqual(ViewColumn.from(ViewColumnEnum.Nine), 8);
+			});
+		});
+
+		suite('to', function () {
+			test('zero-indexed positions map to numbered columns', function () {
+				assert.strictEqual(ViewColumn.to(0), ViewColumnEnum.One);
+				assert.strictEqual(ViewColumn.to(1), ViewColumnEnum.Two);
+				assert.strictEqual(ViewColumn.to(8), ViewColumnEnum.Nine);
+			});
+
+			test('negative positions throw', function () {
+				assert.throws(() => ViewColumn.to(-1));
+			});
 		});
 	});
 });

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -7349,6 +7349,12 @@ declare module 'vscode' {
 		 */
 		Beside = -2,
 		/**
+		 * A *symbolic* editor column representing a modal overlay on top of the workbench. This value
+		 * can be used when opening editors, but the *resolved* {@link TextEditor.viewColumn viewColumn}-value
+		 * of editors will always be `One`, `Two`, `Three`,... or `undefined` but never `Modal`.
+		 */
+		Modal = -4,
+		/**
 		 * The first editor column.
 		 */
 		One = 1,


### PR DESCRIPTION
## Summary

Fixes #307835

- Add `ViewColumn.Modal` (`-4`) to the API enum
- Map it to `MODAL_GROUP` in `extHostTypeConverters`
- Add unit tests for the new ViewColumn value

## Test Plan
- [x] Unit tests pass (`extHostTypeConverters.test.ts`)
- [x] TypeScript compilation clean
- [x] Manual: test extension using `ViewColumn.Modal` opens editor in modal overlay

https://github.com/user-attachments/assets/6d54db26-bc92-427d-9e8a-47a278991233