### PR TITLE
Fix --prof-startup never being able to profile renderer/extension host

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -386,8 +386,8 @@ export async function main(argv: string[]): Promise<void> {
 			const filenamePrefix = randomPath(homedir(), 'prof');
 
 			addArg(argv, `--inspect-brk=${profileHost}:${portMain}`);
-			addArg(argv, `--remote-debugging-port=${profileHost}:${portRenderer}`);
-			addArg(argv, `--inspect-brk-extensions=${profileHost}:${portExthost}`);
+			addArg(argv, `--remote-debugging-port=${portRenderer}`);
+			addArg(argv, `--inspect-brk-extensions=${portExthost}`);
 			addArg(argv, `--prof-startup-prefix`, filenamePrefix);
 			addArg(argv, `--no-cached-data`);
 

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -385,7 +385,7 @@ export async function main(argv: string[]): Promise<void> {
 
 			const filenamePrefix = randomPath(homedir(), 'prof');
 
-			addArg(argv, `--inspect-brk=${profileHost}:${portMain}`);
+			addArg(argv, `--inspect-brk=${portMain}`);
 			addArg(argv, `--remote-debugging-port=${portRenderer}`);
 			addArg(argv, `--inspect-brk-extensions=${portExthost}`);
 			addArg(argv, `--prof-startup-prefix`, filenamePrefix);


### PR DESCRIPTION
`--remote-debugging-port` is [documented](https://www.electronjs.org/docs/latest/api/command-line-switches#--remote-debugging-portport) as only accepting a port.
Similarly, `--inspect-brk-extensions` runs through `parseDebugParams`, which directly tries to convert the argument into a number.

So, remove the host from both arguments.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
