### PR TITLE
fix: normalize icon names to lowercase in darwinBundleDocumentTypes for case-sensitive filesystems

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -96,7 +96,7 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 			role: 'Editor',
 			ostypes: ['TEXT', 'utxt', 'TUTX', '****'],
 			extensions: Array.isArray(extensions) ? extensions : [extensions],
-			iconFile: 'resources/darwin/' + icon + '.icns'
+			iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns'
 		};
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #129665

The `darwinBundleDocumentTypes` (plural) function was not calling `.toLowerCase()` on the `icon` parameter when constructing the `iconFile` path. This is inconsistent with the singular `darwinBundleDocumentType` function which correctly lowercases the icon name.

## Root Cause

In `build/lib/electron.ts`, two helper functions construct icon file paths:

- **`darwinBundleDocumentType`** (singular) — correctly uses `icon.toLowerCase()`:
  ```ts
  iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns'
  ```

- **`darwinBundleDocumentTypes`** (plural) — was **NOT** lowercasing:
  ```ts
  iconFile: 'resources/darwin/' + icon + '.icns'  // ⚠️ Missing .toLowerCase()
  ```

Since all icon files in `resources/darwin/` are lowercase (e.g., `bower.icns`, `html.icns`), this inconsistency causes builds to fail on **case-sensitive filesystems** (e.g., macOS APFS with case sensitivity enabled).

## Fix

Added `.toLowerCase()` to the icon path construction in `darwinBundleDocumentTypes` to match the behavior of `darwinBundleDocumentType`:

```diff
- iconFile: 'resources/darwin/' + icon + '.icns'
+ iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns'
```

## Testing

- Currently, all callers of the plural function pass lowercase icon names (`'c'`, `'config'`, `'html'`, `'default'`), so this change is functionally a no-op for current usage
- However, it prevents future breakage if an uppercase icon name is ever passed to the plural function
- This makes the API consistent between the two helper functions