### PR TITLE
Git - warn that changes will be LOST when force deleting worktree

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2125,7 +2125,8 @@ export class Repository implements Disposable {
 				if (err.gitErrorCode === GitErrorCodes.WorktreeContainsChanges) {
 					const forceDelete = l10n.t('Force Delete');
 					const message = l10n.t('The worktree contains modified or untracked files. Do you want to force delete?');
-					const choice = await window.showWarningMessage(message, { modal: true }, forceDelete);
+					const detail = l10n.t('This is IRREVERSIBLE!\nYour changes will be FOREVER LOST if you proceed.');
+					const choice = await window.showWarningMessage(message, { modal: true, detail }, forceDelete);
 					if (choice === forceDelete) {
 						await deleteWorktree({ ...options, force: true });
 					}


### PR DESCRIPTION
## What does this PR do?

Make the force-delete confirmation for a worktree with modified or untracked files explicit about data loss.

Fixes #286100

## Current behavior

When attempting to delete a worktree that contains modified or untracked files, the user sees:

> The worktree contains modified or untracked files. Do you want to force delete?

This does not clearly communicate that the user's uncommitted work will be permanently lost if they proceed.

## New behavior

The dialog now includes an explicit detail message, matching the `IRREVERSIBLE` / `FOREVER LOST` language already used in the discard-changes flow (`_cleanTrackedChanges` / `getDiscardUntrackedChangesDialogDetails` in `extensions/git/src/commands.ts`):

> **The worktree contains modified or untracked files. Do you want to force delete?**
>
> This is IRREVERSIBLE!
> Your changes will be FOREVER LOST if you proceed.

## Notes

- Localized via `l10n.t`.
- Single file touched: `extensions/git/src/repository.ts`.
- No behavior change beyond the updated copy on the modal warning.