### PR TITLE
feat(terminal): add 'Kill Other Terminals' command

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1303,6 +1303,25 @@ export function registerTerminalActions() {
 	});
 
 	registerTerminalAction({
+		id: TerminalCommandId.KillOthers,
+		title: localize2('workbench.action.terminal.killOthers', 'Kill Other Terminals'),
+		precondition: ContextKeyExpr.or(sharedWhenClause.terminalAvailable, TerminalContextKeys.isOpen),
+		run: async (c) => {
+			const activeInstance = c.service.activeInstance;
+			if (!activeInstance) {
+				return;
+			}
+			const disposePromises: Promise<void>[] = [];
+			for (const instance of c.service.instances) {
+				if (instance !== activeInstance) {
+					disposePromises.push(c.service.safeDisposeTerminal(instance));
+				}
+			}
+			await Promise.all(disposePromises);
+		}
+	});
+
+	registerTerminalAction({
 		id: TerminalCommandId.KillEditor,
 		title: localize2('workbench.action.terminal.killEditor', 'Kill the Active Terminal in Editor Area'),
 		precondition: sharedWhenClause.terminalAvailable,

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -408,6 +408,7 @@ export const enum TerminalCommandId {
 	KillEditor = 'workbench.action.terminal.killEditor',
 	KillActiveTab = 'workbench.action.terminal.killActiveTab',
 	KillAll = 'workbench.action.terminal.killAll',
+	KillOthers = 'workbench.action.terminal.killOthers',
 	QuickKill = 'workbench.action.terminal.quickKill',
 	ConfigureTerminalSettings = 'workbench.action.terminal.openSettings',
 	ShellIntegrationLearnMore = 'workbench.action.terminal.learnMore',


### PR DESCRIPTION
## Summary

Adds a new `workbench.action.terminal.killOthers` command that kills all terminals except the currently active one, mirroring the existing **Close Others** action available in the editor tab context menu.

Fixes #295740

## Changes

- `src/vs/workbench/contrib/terminal/common/terminal.ts` — register new `TerminalCommandId.KillOthers`
- `src/vs/workbench/contrib/terminal/browser/terminalActions.ts` — implement the action (iterates `c.service.instances`, disposes all except the active one)

## Test plan

- [ ] Open 3+ terminals
- [ ] Run **Kill Other Terminals** from the command palette
- [ ] Verify only the active terminal remains open
- [ ] Verify the command is available when any terminal is open