### PR TITLE
feat(scm): 'Open File' in graph opens current file, add 'Open File at Commit'

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -393,6 +393,38 @@ registerAction2(class extends Action2 {
 			return;
 		}
 
+		// Open the current (working tree) version of the file, rather than the
+		// historical snapshot. The historical version is shown when the user
+		// clicks the row in the graph.
+		const currentFileUri = URI.file(historyItemChange.modifiedUri.fsPath);
+		await editorService.openEditor({ resource: currentFileUri });
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.scm.action.graph.openFileAtCommit',
+			title: localize('openFileAtCommit', "Open File at Commit"),
+			icon: Codicon.history,
+			f1: false,
+			menu: [
+				{
+					id: MenuId.SCMHistoryItemChangeContext,
+					group: '0_view',
+					order: 2
+				}
+			]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor, historyItem: ISCMHistoryItem, historyItemChange: ISCMHistoryItemChange) {
+		const editorService = accessor.get(IEditorService);
+
+		if (!historyItem || !historyItemChange.modifiedUri) {
+			return;
+		}
+
 		let version: string;
 		if (historyItem.id === SCMIncomingHistoryItemId) {
 			version = localize('incomingChanges', "Incoming Changes");


### PR DESCRIPTION
## Summary

Fixes #250938.

Previously the **Open File** toolbar button in the SCM Graph history item change context opened the historical (read-only) version of the file at that commit. When a user wanted to edit or view the current working-tree version of that file, they had to use **Go to File** and type the file name manually — a slow, all-manual routine.

This PR:

- Changes the existing **Open File** action to open the **current (working tree)** version of the file, matching what users expect from a button labeled "Open File"
- Adds a new **Open File at Commit** action (context menu only) to retain access to the historical read-only snapshot view

The historical diff view for a file is still shown when the user clicks the row in the graph, so the two entry points remain:
- **Click row** → read-only diff vs parent commit (existing behavior)
- **Open File toolbar button** → current working-tree file (new behavior)
- **Open File at Commit context menu** → historical snapshot (previous toolbar behavior)

## Changes

- `src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts` — updated the `workbench.scm.action.graph.openFile` action and added a new `workbench.scm.action.graph.openFileAtCommit` action

## Test plan

- [ ] Open SCM Graph view, select a commit
- [ ] Click **Open File** toolbar button on a file — verify it opens the current working-tree version
- [ ] Right-click the file → **Open File at Commit** — verify it opens the historical snapshot with `(commit-id)` label