### PR TITLE
feat(terminal): add setting to make resize dimensions overlay optional

### DIFF
--- a/src/vs/workbench/contrib/terminal/terminalContribExports.ts
+++ b/src/vs/workbench/contrib/terminal/terminalContribExports.ts
@@ -15,6 +15,7 @@ import { TerminalDeveloperCommandId } from '../terminalContrib/developer/common/
 import { defaultTerminalFindCommandToSkipShell } from '../terminalContrib/find/common/terminal.find.js';
 import { defaultTerminalHistoryCommandsToSkipShell, terminalHistoryConfiguration } from '../terminalContrib/history/common/terminal.history.js';
 import { terminalOscNotificationsConfiguration } from '../terminalContrib/notification/common/terminalNotificationConfiguration.js';
+import { terminalResizeDimensionsOverlayConfiguration } from '../terminalContrib/resizeDimensionsOverlay/common/terminal.resizeDimensionsOverlay.js';
 import { TerminalStickyScrollSettingId, terminalStickyScrollConfiguration } from '../terminalContrib/stickyScroll/common/terminalStickyScrollConfiguration.js';
 import { defaultTerminalSuggestCommandsToSkipShell } from '../terminalContrib/suggest/common/terminal.suggest.js';
 import { TerminalSuggestSettingId, terminalSuggestConfiguration } from '../terminalContrib/suggest/common/terminalSuggestConfiguration.js';
@@ -77,6 +78,7 @@ export const terminalContribConfiguration: IConfigurationNode['properties'] = {
 	...terminalCommandGuideConfiguration,
 	...terminalHistoryConfiguration,
 	...terminalOscNotificationsConfiguration,
+	...terminalResizeDimensionsOverlayConfiguration,
 	...terminalStickyScrollConfiguration,
 	...terminalSuggestConfiguration,
 	...terminalTypeAheadConfiguration,

--- a/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts
@@ -8,7 +8,9 @@ import { Disposable, MutableDisposable, type IDisposable } from '../../../../../
 import type { ITerminalContribution, IXtermTerminal } from '../../../terminal/browser/terminal.js';
 import { registerTerminalContribution, type ITerminalContributionContext } from '../../../terminal/browser/terminalExtensions.js';
 import { timeout } from '../../../../../base/common/async.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TerminalResizeDimensionsOverlay } from './terminalResizeDimensionsOverlay.js';
+import { TerminalResizeDimensionsOverlaySettingId } from '../common/terminal.resizeDimensionsOverlay.js';
 
 class TerminalResizeDimensionsOverlayContribution extends Disposable implements ITerminalContribution {
 	static readonly ID = 'terminal.resizeDimensionsOverlay';
@@ -17,11 +19,15 @@ class TerminalResizeDimensionsOverlayContribution extends Disposable implements 
 
 	constructor(
 		private readonly _ctx: ITerminalContributionContext,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 	}
 
 	xtermOpen(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
+		if (!this._configurationService.getValue<boolean>(TerminalResizeDimensionsOverlaySettingId.Enabled)) {
+			return;
+		}
 		// Initialize resize dimensions overlay
 		this._ctx.processManager.ptyProcessReady.then(() => {
 			// Wait a second to avoid resize events during startup like when opening a terminal or

--- a/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminal.resizeDimensionsOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminal.resizeDimensionsOverlay.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IStringDictionary } from '../../../../../base/common/collections.js';
+import { localize } from '../../../../../nls.js';
+import type { IConfigurationPropertySchema } from '../../../../../platform/configuration/common/configurationRegistry.js';
+
+export const enum TerminalResizeDimensionsOverlaySettingId {
+	Enabled = 'terminal.integrated.showResizeDimensionsOverlay',
+}
+
+export const terminalResizeDimensionsOverlayConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
+	[TerminalResizeDimensionsOverlaySettingId.Enabled]: {
+		markdownDescription: localize('terminal.integrated.showResizeDimensionsOverlay', "Controls whether to show an overlay with the terminal's columns and rows when it is resized."),
+		type: 'boolean',
+		default: true
+	},
+};


### PR DESCRIPTION
## Summary

Fixes #307194.

Adds a new setting `terminal.integrated.showResizeDimensionsOverlay` (default: `true`) that controls whether to show the terminal resize dimensions overlay introduced in #284244. Users who find the overlay distracting can disable it by setting this to `false`.

## Changes

- `src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminal.resizeDimensionsOverlay.ts` (new) — defines the setting id and configuration schema
- `src/vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/browser/terminal.resizeDimensionsOverlay.contribution.ts` — reads the setting and short-circuits `xtermOpen` when disabled
- `src/vs/workbench/contrib/terminal/terminalContribExports.ts` — registers the new configuration schema

## Test plan

- [ ] Open a terminal, resize it — verify the cols/rows overlay shows (default behavior unchanged)
- [ ] Set `terminal.integrated.showResizeDimensionsOverlay: false`, open a new terminal, resize — verify no overlay
- [ ] Set it back to `true`, open a new terminal — verify overlay returns