### PR TITLE
terminal: fix unreliable middle-click paste on Linux

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
@@ -120,6 +120,15 @@ export class TerminalClipboardContribution extends Disposable implements ITermin
 					this.paste();
 					return { handled: true };
 				}
+				// On Linux with 'default' middle click behavior, explicitly paste the
+				// primary selection clipboard. Relying on the browser to handle the
+				// middle-click paste is unreliable when the click occurs over a word
+				// because xterm.js intercepts the mouse event to select the word before
+				// the browser can perform the paste.
+				if (isLinux && this._terminalConfigurationService.config.middleClickBehavior === 'default') {
+					this.pasteSelection();
+					return { handled: true };
+				}
 				break;
 			}
 			case 2: { // Right click


### PR DESCRIPTION
## Summary
- On Linux the middle-click paste in the integrated terminal was unreliable when the click occurred over a word
- xterm.js intercepts the mouse event to select the word before the browser can perform the primary-selection paste
- This change explicitly pastes the primary selection clipboard when `middleClickBehavior` is `default` on Linux

Fixes #272927

## Test plan
- [ ] Open a terminal on Linux
- [ ] Select text somewhere (in terminal or another X app)
- [ ] Middle-click on a word in the terminal, verify the selection is pasted
- [ ] Middle-click on whitespace in the terminal, verify the selection is pasted
- [ ] Verify `middleClickBehavior: paste` continues to work (pastes regular clipboard)
- [ ] Verify macOS/Windows behavior is unchanged