### PR TITLE
scm: remember worktree visibility across restarts

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -405,6 +405,17 @@ export class SCMViewService implements ISCMViewService {
 					this.didSelectRepository = true;
 				}
 			}
+		} else if (this.previousState && this.didFinishLoadingRepositories.get()) {
+			// Even after the initial loading phase has ended, repositories
+			// that are discovered later (e.g. git worktrees) should respect
+			// the previously persisted hidden state so that the user does
+			// not have to hide them again on every restart.
+			const index = this.previousState.all.indexOf(getProviderStorageKey(repository.provider));
+			if (index !== -1 && this.previousState.visible.indexOf(index) === -1) {
+				this.insertRepositoryView(this._repositories, repositoryView);
+				this._onDidChangeRepositories.fire({ added: Iterable.empty(), removed: Iterable.empty() });
+				return;
+			}
 		}
 
 		if (this.selectionModeConfig.get() === ISCMRepositorySelectionMode.Multiple || !this._repositories.find(r => r.selectionIndex !== -1)) {


### PR DESCRIPTION
## Summary
- When a repository is discovered after the initial loading phase (5s debounce) has ended (e.g. git worktrees detected by `git.detectWorktrees`), the SCM view service was ignoring the persisted visibility state and making the repository visible by default
- This forced users to re-hide any worktrees they had previously deselected on every restart
- This change keeps consulting the persisted state for repositories added after loading finished: if the repository was explicitly hidden in the previous session, it stays hidden when it is re-discovered

Fixes #271554

## Test plan
- [ ] Open a workspace with a git repository and worktrees with `git.detectWorktrees: true`
- [ ] Hide one or more worktrees via checkbox in the Source Control view
- [ ] Restart VS Code
- [ ] Verify the hidden worktrees remain hidden after restart
- [ ] Verify the visible worktrees remain visible