### PR TITLE
Add support for code page 857 (Turkish DOS)

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -772,6 +772,11 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
 		order: 48
+	},
+	cp857: {
+		labelLong: 'Turkish DOS (CP 857)',
+		labelShort: 'CP 857',
+		order: 49
 	}
 };
 


### PR DESCRIPTION
## Summary

Adds CP 857 (Turkish DOS) to the list of supported document encodings in `SUPPORTED_ENCODINGS`.

CP 857 was widely used for Turkish text in legacy DOS/Windows environments and is still present in many legacy projects today. It was already supported in the integrated terminal (`terminalEncoding.ts`) but was missing from the document encoding list, which appears to have been an unintentional omission.

Fixes #300041

## Test plan

- [ ] Open a file saved with CP 857 encoding
- [ ] Use "Change File Encoding" / "Reopen with Encoding" command and verify "Turkish DOS (CP 857)" appears in the encoding picker
- [ ] Verify selecting CP 857 correctly decodes Turkish characters in the file