### PR TITLE
Simple Browser: add Focus Content command

### DIFF
--- a/extensions/simple-browser/package.json
+++ b/extensions/simple-browser/package.json
@@ -24,6 +24,7 @@
   ],
   "activationEvents": [
     "onCommand:simpleBrowser.api.open",
+    "onCommand:simpleBrowser.focusContent",
     "onOpenExternalUri:http",
     "onOpenExternalUri:https",
     "onWebviewPanel:simpleBrowser.view"
@@ -40,6 +41,11 @@
         "command": "simpleBrowser.show",
         "title": "Show",
         "category": "Simple Browser"
+      },
+      {
+        "command": "simpleBrowser.focusContent",
+        "title": "%command.focusContent.title%",
+        "category": "Simple Browser"
       }
     ],
     "menus": {
@@ -47,6 +53,10 @@
         {
           "command": "simpleBrowser.show",
           "when": "isWeb"
+        },
+        {
+          "command": "simpleBrowser.focusContent",
+          "when": "activeWebviewPanelId == 'simpleBrowser.view'"
         }
       ]
     },

--- a/extensions/simple-browser/package.nls.json
+++ b/extensions/simple-browser/package.nls.json
@@ -1,5 +1,6 @@
 {
 	"displayName": "Simple Browser",
 	"description": "A very basic built-in webview for displaying web content.",
+	"command.focusContent.title": "Focus Content",
 	"configuration.focusLockIndicator.enabled.description": "Enable/disable the floating indicator that shows when focused in the simple browser."
 }

--- a/extensions/simple-browser/src/extension.ts
+++ b/extensions/simple-browser/src/extension.ts
@@ -14,6 +14,7 @@ declare class URL {
 
 const openApiCommand = 'simpleBrowser.api.open';
 const showCommand = 'simpleBrowser.show';
+const focusContentCommand = 'simpleBrowser.focusContent';
 const integratedBrowserCommand = 'workbench.action.browser.open';
 
 const enabledHosts = new Set<string>([
@@ -73,6 +74,10 @@ export function activate(context: vscode.ExtensionContext) {
 		if (url) {
 			manager.show(url);
 		}
+	}));
+
+	context.subscriptions.push(vscode.commands.registerCommand(focusContentCommand, () => {
+		manager.focusContent();
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand(openApiCommand, async (url: vscode.Uri, showOptions?: {

--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -38,6 +38,10 @@ export class SimpleBrowserManager {
 		this._activeView ??= view;
 	}
 
+	public focusContent(): void {
+		this._activeView?.focusContent();
+	}
+
 	private registerWebviewListeners(view: SimpleBrowserView) {
 		view.onDispose(() => {
 			if (this._activeView === view) {

--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -110,6 +110,11 @@ export class SimpleBrowserView extends Disposable {
 		this._webviewPanel.reveal(options?.viewColumn, options?.preserveFocus);
 	}
 
+	public focusContent() {
+		this._webviewPanel.reveal(undefined, false);
+		this._webviewPanel.webview.postMessage({ type: 'focus' });
+	}
+
 	private getHtml(url: string) {
 		const configuration = vscode.workspace.getConfiguration('simpleBrowser');
 


### PR DESCRIPTION
## Summary

Adds a new `Simple Browser: Focus Content` command that moves focus directly to the browser content (iframe), bypassing the URL bar. This improves accessibility for screen reader users who need a more efficient way to navigate into the browser content.

The webview already had a `focus` message handler in `preview-src/index.ts` that calls `iframe.focus()`, but there was no command exposed to trigger it. This PR wires up the existing handler to a new command, activation event, and command palette entry (gated by `activeWebviewPanelId == 'simpleBrowser.view'`).

## Test plan

- [ ] Open Simple Browser (via `Simple Browser: Show` on web, or an external URL)
- [ ] Focus the URL bar by clicking it
- [ ] Run `Simple Browser: Focus Content` from the command palette
- [ ] Verify focus moves to the iframe content
- [ ] Verify the command only appears in the palette when the Simple Browser panel is active

Fixes #305717