### PR TITLE
Fix #297799: color picker in private fields

### DIFF
--- a/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
+++ b/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
@@ -101,7 +101,7 @@ function _findMatches(model: IDocumentColorComputerTarget | string, regex: RegEx
 function computeColors(model: IDocumentColorComputerTarget): IColorInformation[] {
 	const result: IColorInformation[] = [];
 	// Early validation for RGB and HSL (including CSS Level 4 syntax with / separator)
-	const initialValidationRegex = /\b(rgb|rgba|hsl|hsla)(\([0-9\s,.\%\/]*\))|^(#)([A-Fa-f0-9]{3})\b|^(#)([A-Fa-f0-9]{4})\b|^(#)([A-Fa-f0-9]{6})\b|^(#)([A-Fa-f0-9]{8})\b|(?<=['"\s])(#)([A-Fa-f0-9]{3})\b|(?<=['"\s])(#)([A-Fa-f0-9]{4})\b|(?<=['"\s])(#)([A-Fa-f0-9]{6})\b|(?<=['"\s])(#)([A-Fa-f0-9]{8})\b/gm;
+	const initialValidationRegex = /\b(rgb|rgba|hsl|hsla)(\([0-9\s,.\%\/]*\))|^(#)([A-Fa-f0-9]{3})\b|^(#)([A-Fa-f0-9]{4})\b|^(#)([A-Fa-f0-9]{6})\b|^(#)([A-Fa-f0-9]{8})\b|(?<=['"][ ]*)(#)([A-Fa-f0-9]{3})\b|(?<=['"][ ]*)(#)([A-Fa-f0-9]{4})\b|(?<=['"][ ]*)(#)([A-Fa-f0-9]{6})\b|(?<=['"][ ]*)(#)([A-Fa-f0-9]{8})\b/gm;
 	const initialValidationMatches = _findMatches(model, initialValidationRegex);
 
 	// Potential colors have been found, validate the parameters

--- a/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
+++ b/src/vs/editor/test/common/languages/defaultDocumentColorsComputer.test.ts
@@ -79,7 +79,6 @@ suite('Default Document Colors Computer', () => {
 		const testCases = [
 			{ content: `const color = ' #ff0000';`, name: 'hex with space before' },
 			{ content: '#ff0000', name: 'hex at start of line' },
-			{ content: '  #ff0000', name: 'hex with whitespace before' }
 		];
 
 		testCases.forEach(testCase => {
@@ -186,6 +185,20 @@ suite('Default Document Colors Computer', () => {
 			const model = new TestDocumentModel(`const color = ${testCase.content};`);
 			const colors = computeDefaultDocumentColors(model);
 			assert.strictEqual(colors.length, 1, `Should detect rgb/rgba color with ${testCase.name}: ${testCase.content}`);
+		});
+	});
+
+	test('JavaScript private fields with # should not be recognized as colors', () => {
+		// Test case from issue #297799
+		const testCases = [
+			{ content: 'class Foo {\n\t#facade\n}', name: 'private field #facade should not be a color' },
+			{ content: 'class Component {\n\treadonly #facade = inject(Facade);\n}', name: 'private field #facade with injection should not be a color' },
+		];
+
+		testCases.forEach(testCase => {
+			const model = new TestDocumentModel(testCase.content);
+			const colors = computeDefaultDocumentColors(model);
+			assert.strictEqual(colors.length, 0, `Should not detect color with ${testCase.name}: ${testCase.content}`);
 		});
 	});
 });


### PR DESCRIPTION
### Fix false positives in default color detection regex

Fixes #297799

This PR updates the default color detection regex to avoid incorrectly matching JavaScript/TypeScript private fields (e.g., `#foo`) as hex colors.

The default color provider applies to all languages, which caused incorrect matches in JS/TS. Since short hex colors like `#fff` are mainly relevant for CSS (which has its own color picker), removing this behavior improves accuracy without affecting common use cases like `"#000000"` in strings.

### Changes
- Prevent matching hex patterns outside strings  
- Avoid false positives for private fields  
- Remove outdated unit test for hex outside strings (`{ content: '  #ff0000', name: 'hex with whitespace before' }`)  

### How to test
- `#foo` → not detected  
- `"#000000"` → detected  