### PR TITLE
fix: exempt agent instructions from workspace subpath filter

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -19,6 +19,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
@@ -171,6 +172,17 @@ export class AICustomizationOverviewView extends ViewPane {
 			} else {
 				const allItems = await this.promptsService.listPromptFiles(type, CancellationToken.None);
 				count = allItems.length;
+
+				// For instructions, also count agent instructions (AGENTS.md, copilot-instructions.md, CLAUDE.md, etc.)
+				if (type === PromptsType.instructions) {
+					const existingUris = new ResourceSet(allItems.map(item => item.uri));
+					const agentInstructions = await this.promptsService.listAgentInstructions(CancellationToken.None);
+					for (const file of agentInstructions) {
+						if (!existingUris.has(file.uri)) {
+							count++;
+						}
+					}
+				}
 			}
 
 			const sectionData = this.sections.find(s => s.id === section);

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -27,6 +27,7 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon, builtinIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
@@ -446,7 +447,19 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 
 		// For other types, fetch once and cache grouped by storage
 		if (!cached.files) {
-			const allItems = await this.promptsService.listPromptFiles(promptType, CancellationToken.None);
+			const allItems: IPromptPath[] = [...await this.promptsService.listPromptFiles(promptType, CancellationToken.None)];
+
+			// For instructions, also include agent instructions (AGENTS.md, copilot-instructions.md, CLAUDE.md, etc.)
+			if (promptType === PromptsType.instructions) {
+				const existingUris = new ResourceSet(allItems.map(item => item.uri));
+				const agentInstructions = await this.promptsService.listAgentInstructions(CancellationToken.None);
+				for (const file of agentInstructions) {
+					if (!existingUris.has(file.uri)) {
+						allItems.push({ uri: file.uri, storage: PromptsStorage.local, type: PromptsType.instructions });
+					}
+				}
+			}
+
 			const workspaceItems = allItems.filter(item => item.storage === PromptsStorage.local);
 			const userItems = allItems.filter(item => item.storage === PromptsStorage.user);
 			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1609,6 +1609,12 @@ export class AICustomizationListWidget extends Disposable {
 						if (instrFilter && promptType === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
 							continue;
 						}
+						// Keep agent instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md)
+						// — these live at the workspace root by design and should not be
+						// filtered out by workspace subpath restrictions.
+						if (item.groupKey === 'agent-instructions') {
+							continue;
+						}
 						items.splice(i, 1);
 					}
 				}


### PR DESCRIPTION
Follow-up to #307745.

AGENTS.md, CLAUDE.md, and copilot-instructions.md live at the workspace root by design. The CLI harness restricts items to `workspaceSubpaths` (`.github`, `.copilot`, `.agents`, `.claude`), which filtered out these root-level agent instruction files in the core path (used by the Sessions window where `providerApi.enabled` is false).

Items with `groupKey: 'agent-instructions'` are now exempt from the workspace subpath filter, matching the existing exemption pattern for `instructionFileFilter`.

Sessions window → Customizations → Instructions → [AGENTS.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) should appear under "Agent Instructions" (it was filtered out by the workspace subpath check)
Sessions window → Sidebar tree → Instructions section should list [AGENTS.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Sessions window → Overview badge count for Instructions should include [AGENTS.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (e.g. 13 not 10)