### PR TITLE
fix: use outline instead of border for diff text decorations

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/src/vs/editor/browser/widget/diffEditor/style.css
@@ -253,22 +253,20 @@
 
 .monaco-editor .line-insert,
 .monaco-editor .char-insert {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-insertedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-insertedTextBorder);
 }
 .monaco-editor.hc-black .line-insert, .monaco-editor.hc-light .line-insert,
 .monaco-editor.hc-black .char-insert, .monaco-editor.hc-light .char-insert {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .line-delete,
 .monaco-editor .char-delete {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-removedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-removedTextBorder);
 }
 .monaco-editor.hc-black .line-delete, .monaco-editor.hc-light .line-delete,
 .monaco-editor.hc-black .char-delete, .monaco-editor.hc-light .char-delete {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .inline-added-margin-view-zone,


### PR DESCRIPTION
## Summary

Fixes #277259

**Bug:** `diffEditor.removedTextBorder` and `diffEditor.insertedTextBorder` settings cause lines to be displaced because CSS `border` adds to the element's layout size.

**Root Cause:** The diff text decorations (`.line-insert`, `.char-insert`, `.line-delete`, `.char-delete`) used CSS `border` which participates in the box model and increases the element's dimensions, shifting surrounding content.

**Fix:** Replaced `border` with `outline` which is drawn outside the element's box model and does not affect layout. Also removed the now-unnecessary `box-sizing: border-box` declarations and updated high-contrast theme overrides from `border-style` to `outline-style`.

## Changes

- `src/vs/editor/browser/widget/diffEditor/style.css`: Replaced `border` with `outline` for `.line-insert`, `.char-insert`, `.line-delete`, and `.char-delete` classes. Removed `box-sizing: border-box`. Updated high-contrast theme overrides to use `outline-style: dashed` instead of `border-style: dashed`.

## Testing

- Visual regression: diff editor borders no longer displace lines when `diffEditor.removedTextBorder` or `diffEditor.insertedTextBorder` are set
- All existing tests pass