### PR TITLE
fix: properly cancel tasks when command input returns undefined

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -340,8 +340,11 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 						missingAttribute('command');
 					}
 					return this.userInputAccessQueue.queue(() => this.commandService.executeCommand<string>(info.command, info.args)).then(result => {
-						if (typeof result === 'string' || Types.isUndefinedOrNull(result)) {
+						if (typeof result === 'string') {
 							return { value: result, input: info };
+						}
+						if (Types.isUndefinedOrNull(result)) {
+							return undefined;
 						}
 						throw new VariableError(VariableKind.Input, localize('inputVariable.command.noStringType', "Cannot substitute input variable '{0}' because command '{1}' did not return a result of type string.", variable, info.command));
 					});

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -783,6 +783,24 @@ suite('Configuration Resolver Service', () => {
 		const result = await configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks');
 		assert.strictEqual(result, undefined);
 	});
+
+	test('canceled command input', async () => {
+		// Simulate a command that returns undefined (user cancelled the input)
+		stub(mockCommandService, 'executeCommand').resolves(undefined);
+
+		const configuration = {
+			'name': 'Attach to Process',
+			'type': 'node',
+			'request': 'attach',
+			'processId': '${input:input4}',
+			'port': 5858,
+			'sourceMaps': false,
+			'outDir': null
+		};
+
+		const result = await configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks');
+		assert.strictEqual(result, undefined);
+	});
 });
 
 


### PR DESCRIPTION
## Summary

Fixes #255503

**Bug:** Tasks using `${input}` variables with `type: command` could not be cancelled when the user pressed Escape, because the task continued to execute with an undefined value instead of being abandoned.

**Root Cause:** In `baseConfigurationResolverService.ts`, when a command-type input returned `undefined` (indicating the user cancelled), it was wrapped in a `{ value: undefined }` object and treated as a valid result instead of signaling cancellation.

**Fix:** Return `undefined` directly when the command result is `undefined` or `null`, so the upstream resolution logic correctly interprets this as a cancellation and abandons the task.

## Changes

- `src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts`: Separated the handling of `undefined`/`null` command results from string results. Now returns `undefined` instead of `{ value: result }` when the command returns no value, allowing task cancellation to propagate correctly.
- `src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts`: Added regression test `canceled command input` that stubs `executeCommand` to return `undefined` and verifies that `resolveWithInteractionReplace` returns `undefined` (task abandoned).

## Testing

- Added regression test that verifies command-type input cancellation correctly abandons task resolution
- All existing tests pass