### PR TITLE
fix: preserve special characters in terminal drag-drop paths

### DIFF
--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -7,9 +7,9 @@ import { OperatingSystem, OS } from '../../../base/common/platform.js';
 import { IShellLaunchConfig, TerminalShellType, PosixShellType, WindowsShellType, GeneralShellType } from './terminal.js';
 
 /**
- * Aggressively escape non-windows paths to prepare for being sent to a shell. This will do some
- * escaping inaccurately to be careful about possible script injection via the file path. For
- * example, we're trying to prevent this sort of attack: `/foo/file$(echo evil)`.
+ * Escape non-windows paths to prepare for being sent to a shell. The path is wrapped in
+ * shell-appropriate quotes to prevent interpretation of special characters like `~`, `$`, etc.
+ * This also prevents script injection attacks like `/foo/file$(echo evil)`.
  */
 export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType): string {
 	let newPath = path;
@@ -41,7 +41,7 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			break;
 		case PosixShellType.Fish:
 			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '\\"')}"`,
+				bothQuotes: (path) => `"${path.replace(/[\\"$]/g, '\\$&')}"`,
 				singleQuotes: (path) => `'${path.replace(/'/g, '\\\'')}'`,
 				noSingleQuotes: (path) => `'${path}'`
 			};
@@ -50,7 +50,7 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			// PowerShell should be handled separately in preparePathForShell
 			// but if we get here, use PowerShell escaping
 			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '`"')}"`,
+				bothQuotes: (path) => `"${path.replace(/[`"$]/g, '`$&')}"`,
 				singleQuotes: (path) => `'${path.replace(/'/g, '\'\'')}'`,
 				noSingleQuotes: (path) => `'${path}'`
 			};
@@ -64,10 +64,6 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			};
 			break;
 	}
-
-	// Remove dangerous characters except single and double quotes, which we'll escape properly
-	const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
-	newPath = newPath.replace(bannedChars, '');
 
 	// Apply shell-specific escaping based on quote content
 	if (newPath.includes('\'') && newPath.includes('"')) {

--- a/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
@@ -91,9 +91,31 @@ suite('terminalEnvironment', () => {
 			strictEqual(escapeNonWindowsPath('/foo/bar\'baz'), '\'/foo/bar\\\'baz\'');
 		});
 
-		test('should remove dangerous characters', () => {
-			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar(echo evil)\'');
-			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/barwhoami\'');
+		test('should preserve special characters safely inside single quotes', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar$(echo evil)\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/bar`whoami`\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar~baz', PosixShellType.Bash), '\'/foo/bar~baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar#comment', PosixShellType.Bash), '\'/foo/bar#comment\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar!cmd', PosixShellType.Bash), '\'/foo/bar!cmd\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar&bg', PosixShellType.Bash), '\'/foo/bar&bg\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar|pipe', PosixShellType.Bash), '\'/foo/bar|pipe\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar;next', PosixShellType.Bash), '\'/foo/bar;next\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar>out', PosixShellType.Bash), '\'/foo/bar>out\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar<in', PosixShellType.Bash), '\'/foo/bar<in\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar^caret', PosixShellType.Bash), '\'/foo/bar^caret\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar*glob', PosixShellType.Bash), '\'/foo/bar*glob\'');
+		});
+
+		test('should preserve special characters in paths with both quotes (bash)', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar~baz\'"qux', PosixShellType.Bash), '$\'/foo/bar~baz\\\'\"qux\'');
+		});
+
+		test('should escape $ inside double quotes for fish bothQuotes path', () => {
+			strictEqual(escapeNonWindowsPath('/foo/$bar\'"baz', PosixShellType.Fish), '"/foo/\\$bar\'\\\"baz"');
+		});
+
+		test('should escape $ and ` inside double quotes for PowerShell bothQuotes path', () => {
+			strictEqual(escapeNonWindowsPath('/foo/$bar`cmd\'"baz', GeneralShellType.PowerShell), '"/foo/`$bar``cmd\'`"baz"');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #276999

**Bug:** Dragging and dropping a file with a tilde (`~`) or other special characters (`$`, `#`, `&`, etc.) in its name into the terminal silently stripped those characters from the path.

**Root Cause:** `escapeNonWindowsPath()` contained a `bannedChars` regex that removed `~`, `$`, `#`, `!`, `&`, `|`, `;`, `>`, `<`, `^`, `*`, and backticks from paths. This was overly aggressive since the paths are already wrapped in single quotes, which prevent shell expansion of these characters.

**Fix:** Removed the `bannedChars` regex entirely, relying on single-quote wrapping for safety. Added proper escaping of `$`, backticks, and `"` in the Fish and PowerShell double-quote fallback paths (used only when a path contains both single and double quotes).

## Changes

- `src/vs/platform/terminal/common/terminalEnvironment.ts`: Removed the `bannedChars` regex that stripped special characters. Fixed Fish `bothQuotes` handler to escape `\`, `"`, and `$`. Fixed PowerShell `bothQuotes` handler to escape backtick, `"`, and `$`.
- `src/vs/platform/terminal/test/common/terminalEnvironment.test.ts`: Replaced the "should remove dangerous characters" test with comprehensive tests verifying that special characters are preserved inside single quotes. Added tests for Fish and PowerShell `bothQuotes` code paths.

## Testing

- Added regression tests verifying `~`, `$`, `#`, `!`, `&`, `|`, `;`, `>`, `<`, `^`, `*`, and backticks are preserved in paths
- Added tests for Fish and PowerShell double-quote fallback escaping
- All existing tests pass