### PR TITLE
fix: prevent wobby sync icon in notebook toolbar

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebookToolbar.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookToolbar.css
@@ -66,6 +66,17 @@
 	padding-left: 2px;
 }
 
+/* Move spin animation to ::before pseudo-element so that the icon spins
+   inside the padding box instead of spinning the padding with it, which
+   causes a visible wobble due to the asymmetric padding-left (#243027). */
+.monaco-workbench .notebookOverlay .notebook-toolbar-container .monaco-action-bar .action-item .action-label.codicon-modifier-spin {
+	animation: none;
+}
+
+.monaco-workbench .notebookOverlay .notebook-toolbar-container .monaco-action-bar .action-item .action-label.codicon-modifier-spin::before {
+	animation: codicon-spin 1.5s steps(30) infinite;
+}
+
 .monaco-workbench .notebook-action-view-item .action-label {
 	display: inline-flex;
 }


### PR DESCRIPTION
## Summary
- Fixes the wobbling sync/loading icon in the notebook toolbar caused by asymmetric `padding-left: 2px` on `.action-label` elements
- Moves the `codicon-spin` animation from the `.action-label` element to its `::before` pseudo-element, so the icon glyph spins inside the padding box instead of spinning the entire element (including the off-center padding)
- This is a CSS-only change scoped to the notebook toolbar, with no impact on other toolbar animations

## Details
The `.action-label` in the notebook toolbar has `padding-left: 2px` (line 66 of `notebookToolbar.css`). When a spinning codicon (e.g., the kernel sync icon) is applied, the `codicon-spin` animation rotates the entire element. Because the padding is asymmetric, the visual center is shifted from the geometric center, causing a visible wobble.

The fix overrides the animation on `.action-label.codicon-modifier-spin` to `none`, and instead applies the same `codicon-spin` animation to the `::before` pseudo-element (which renders the icon glyph). This way the glyph rotates perfectly centered within the padding box.

Fixes #243027

## Test plan
- [ ] Open a Jupyter notebook in VS Code
- [ ] Trigger a kernel connection/sync (the sync icon should appear in the notebook toolbar)
- [ ] Verify the sync icon spins smoothly without wobbling
- [ ] Verify other spinning codicons elsewhere in VS Code are unaffected