### PR TITLE
git: add abort merge/rebase actions to the Branch submenu

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3103,8 +3103,18 @@
           "group": "1_merge@1"
         },
         {
+          "command": "git.mergeAbort",
+          "group": "1_merge@2",
+          "when": "gitMergeInProgress"
+        },
+        {
           "command": "git.rebase",
-          "group": "1_merge@2"
+          "group": "1_merge@3"
+        },
+        {
+          "command": "git.rebaseAbort",
+          "group": "1_merge@4",
+          "when": "gitRebaseInProgress"
         },
         {
           "command": "git.branch",


### PR DESCRIPTION
## Summary

- Adds **Abort Merge** (`git.mergeAbort`) and **Abort Rebase** (`git.rebaseAbort`) commands to the **Branch** submenu in the Source Control view
- These menu items are conditionally shown only when a merge or rebase is in progress (via `gitMergeInProgress` / `gitRebaseInProgress` context keys)
- Previously, users had to use the Command Palette to find these actions since they were not discoverable in the SCM UI where `Merge` and `Rebase` are initiated

Fixes #284362

## Test plan

- [ ] Start a merge that results in conflicts; verify "Abort Merge" appears in Source Control > Branch submenu
- [ ] Start a rebase that results in conflicts; verify "Abort Rebase" appears in Source Control > Branch submenu
- [ ] Confirm both menu items are hidden when no merge/rebase is in progress
- [ ] Confirm clicking the menu items successfully aborts the merge/rebase