### PR TITLE
Focus active terminal on single-click in empty tab list space

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -179,6 +179,15 @@ export class TerminalTabList extends WorkbenchList<ITerminalInstance> {
 				return;
 			}
 
+			if (!e.element) {
+				// Clicking on empty space in the tab list should focus the active terminal
+				const activeInstance = this._terminalGroupService.activeInstance;
+				if (activeInstance) {
+					await activeInstance.focusWhenReady();
+				}
+				return;
+			}
+
 			if (e.browserEvent.altKey && e.element) {
 				await this._terminalService.createTerminal({ location: { parentTerminal: e.element } });
 			} else if (this._getFocusMode() === 'singleClick') {


### PR DESCRIPTION
## Summary
- When single-clicking on the empty space (below the last tab) in the terminal tabs sidebar, the active terminal is now focused instead of entering a "focus limbo" state where neither the terminal input nor the tab list is properly focused.
- This is consistent with how double-click on empty space already has a handler (creating a new terminal), showing the area is interactive and capable of receiving click events.
- Especially useful when managing multiple terminal sessions (e.g., AI coding assistants, dev servers) where efficient terminal panel navigation is critical.

Fixes #305527

## Test plan
- [ ] Open VS Code with the terminal panel visible and terminal tabs sidebar enabled
- [ ] Create at least one terminal
- [ ] Single-click on the empty space below the last tab in the terminal tabs sidebar
- [ ] Verify that the active terminal receives keyboard focus (you can start typing immediately)
- [ ] Verify that double-click on empty space still creates a new terminal (existing behavior preserved)
- [ ] Verify that single-click on a tab still works as before (selects/focuses the terminal)