### PR TITLE
fix: show keyword suggestions alongside search result count

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -170,16 +170,10 @@
 	overflow-wrap: break-word;
 }
 
-.search-view .message.ai-keywords {
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
-	line-clamp: 2;
-	-webkit-line-clamp: 2;
+.search-view .message .ai-keyword-suggestions {
 	overflow: hidden;
 	text-overflow: ellipsis;
-	white-space: normal;
-	margin: 0 22px 8px;
-	padding: 0px;
+	white-space: nowrap;
 }
 
 .search-view .message p:first-child {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2010,10 +2010,26 @@ export class SearchView extends ViewPane {
 		this.inputPatternIncludes.setOnlySearchInOpenEditors(false);
 	}
 
+	private renderKeywordSuggestions(messageEl: HTMLElement) {
+		const keywordContainer = dom.append(messageEl, $('span.ai-keyword-suggestions'));
+
+		const prefix = ' - ' + nls.localize('keywordSuggestion.message', "Search instead for: ");
+		dom.append(keywordContainer, prefix);
+
+		this._cachedKeywords.forEach((kw, index) => {
+			if (index > 0) {
+				dom.append(keywordContainer, ', ');
+			}
+			const button = this.messageDisposables.add(new SearchLinkButton(
+				kw,
+				() => this.handleKeywordClick(kw, index),
+				this.hoverService
+			));
+			dom.append(keywordContainer, button.element);
+		});
+	}
+
 	private updateSearchResultCount(disregardExcludesAndIgnores?: boolean, onlyOpenEditors?: boolean, clear: boolean = false): void {
-		if (this._cachedKeywords.length > 0) {
-			return;
-		}
 		const fileCount = this.viewModel.searchResult.fileCount(this.viewModel.searchResult.aiTextSearchResult.hidden);
 		const resultCount = this.viewModel.searchResult.count(this.viewModel.searchResult.aiTextSearchResult.hidden);
 		this.hasSearchResultsKey.set(fileCount > 0);
@@ -2054,6 +2070,11 @@ export class SearchView extends ViewPane {
 				this.appendSearchWithAIButton(messageEl);
 			}
 
+			// Re-render cached keyword suggestions after the result count
+			if (this._cachedKeywords.length > 0) {
+				this.renderKeywordSuggestions(messageEl);
+			}
+
 			this.reLayout();
 		} else if (!msgWasHidden) {
 			dom.hide(this.messagesElement);
@@ -2080,36 +2101,24 @@ export class SearchView extends ViewPane {
 	}
 
 	private updateKeywordSuggestionUI(keyword: AISearchKeyword) {
-		const element = this.messagesElement.firstChild as HTMLDivElement;
-		if (this._cachedKeywords.length > 0) {
-			if (this._cachedKeywords.length >= 3) {
-				// If we already have 3 keywords, just return
-				return;
-			}
-			dom.append(element, ', ');
-			const index = this._cachedKeywords.length;
-			const button = this.messageDisposables.add(new SearchLinkButton(
-				keyword.keyword,
-				() => this.handleKeywordClick(keyword.keyword, index),
-				this.hoverService
-			));
-			dom.append(element, button.element);
-		} else {
-			const messageEl = this.clearMessage();
-			messageEl.classList.add('ai-keywords');
-
-			// Add unclickable message
-			const resultMsg = nls.localize('keywordSuggestion.message', "Search instead for: ");
-			dom.append(messageEl, resultMsg);
-
-			const button = this.messageDisposables.add(new SearchLinkButton(
-				keyword.keyword,
-				() => this.handleKeywordClick(keyword.keyword, 0),
-				this.hoverService
-			));
-			dom.append(messageEl, button.element);
+		if (this._cachedKeywords.length >= 3) {
+			// If we already have 3 keywords, just return
+			return;
 		}
+
 		this._cachedKeywords.push(keyword.keyword);
+
+		const messageEl = this.messagesElement.firstChild as HTMLDivElement;
+		if (!messageEl) {
+			return;
+		}
+
+		// Remove existing keyword suggestions container if present
+		const existingContainer = messageEl.querySelector('.ai-keyword-suggestions');
+		existingContainer?.remove();
+
+		// Re-render all keyword suggestions
+		this.renderKeywordSuggestions(messageEl);
 	}
 
 	private async getKeywordSuggestions() {


### PR DESCRIPTION
## Summary
- Fixes the bug where keyword suggestions replace the search result count message in the Search view
- Both the result count (e.g., "X results in Y files") and keyword suggestions ("Search instead for: ...") are now displayed simultaneously
- Keyword suggestions are appended after the result count using a dedicated container element

## Details

When `search.searchView.keywordSuggestions` is enabled, the keyword suggestion message ("Search instead for: ...") was completely replacing the search result count message ("X results in Y files"). This happened because:

1. `updateKeywordSuggestionUI()` called `clearMessage()` to wipe the result count before rendering keywords
2. `updateSearchResultCount()` had an early return when keywords existed, preventing the result count from ever being shown alongside keywords

### Changes:
- **Removed the early return** in `updateSearchResultCount()` that skipped rendering when cached keywords existed
- **Added `renderKeywordSuggestions()`** helper method that renders keyword suggestions into a dedicated `span.ai-keyword-suggestions` container
- **Updated `updateKeywordSuggestionUI()`** to append keywords to the existing message element rather than clearing and replacing it
- **Updated `updateSearchResultCount()`** to re-render cached keywords after the result count when they exist
- **Updated CSS** to style the new `.ai-keyword-suggestions` container instead of the old `.ai-keywords` class on the message element

Fixes #261789

## Test plan
- [ ] Enable `search.searchView.keywordSuggestions` setting
- [ ] Perform a search that triggers keyword suggestions
- [ ] Verify both the result count ("X results in Y files") and keyword suggestions ("Search instead for: ...") are visible simultaneously
- [ ] Verify keyword suggestion links are still clickable and trigger a new search
- [ ] Verify that when no keyword suggestions are available, the result count displays normally
- [ ] Verify that when results are cleared, both messages are cleared