### PR TITLE
Add scrollbar indicators for failing tests

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -770,6 +770,7 @@ const createRunTestDecoration = (
 		glyphMarginClassName: `${ThemeIcon.asClassName(primaryIcon)} ${glyphMarginClassName}`,
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
 		zIndex: 10000,
+		overviewRuler: isFailedState(computedState) ? { color: themeColorFromId(overviewRulerError), position: OverviewRulerLane.Center } : undefined,
 	};
 
 	const alternateOptions: IModelDecorationOptions = {


### PR DESCRIPTION
## Summary

- Adds overview ruler (scrollbar) markers for tests in a failed or errored state in the editor's gutter test decorations
- When a test fails, a red indicator now appears in the editor scrollbar at the line where the test is defined
- Uses the existing `overviewRulerError` theme color and `OverviewRulerLane.Center` positioning, consistent with how `TestMessageDecoration` already uses overview ruler indicators for error messages

This is a small, targeted change to `createRunTestDecoration()` in `testingDecorations.ts`. The `TestMessageDecoration` class already shows overview ruler indicators for test error messages, but the gutter decorations marking where tests are *defined* did not. This makes it easier to spot failing tests in large files without scrolling through the entire document.

Fixes #143203

## Test plan

- [ ] Open a project with tests in a large file
- [ ] Run the tests so that some fail
- [ ] Verify that red indicators appear in the scrollbar/overview ruler at the lines where failing tests are defined
- [ ] Verify that passing/unset tests do NOT show scrollbar indicators
- [ ] Verify that the indicators use the standard error color from the theme (`editorOverviewRuler.warningForeground`)