### PR TITLE
Fix editor.find.loop not respected when matches >= MATCHES_LIMIT

### DIFF
--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -326,6 +326,10 @@ export class FindModelBoundToEditorModel {
 
 		// ...|...(----)...
 		if (before.isBefore(searchRange.getStartPosition())) {
+			if (!this._state.canNavigateInLoop()) {
+				// Loop is disabled and we are before the search range - no backward match
+				return;
+			}
 			before = searchRange.getEndPosition();
 		}
 
@@ -349,6 +353,11 @@ export class FindModelBoundToEditorModel {
 
 		if (!isRecursed && !searchRange.containsRange(prevMatch.range)) {
 			return this._moveToPrevMatch(prevMatch.range.getStartPosition(), true);
+		}
+
+		// When loop is disabled, check if the match wrapped around (found after our search position)
+		if (!this._state.canNavigateInLoop() && position.isBefore(prevMatch.range.getStartPosition())) {
+			return;
 		}
 
 		this._setCurrentFindMatch(prevMatch.range);
@@ -423,6 +432,10 @@ export class FindModelBoundToEditorModel {
 
 		// ...(----)...|...
 		if (searchRange.getEndPosition().isBefore(after)) {
+			if (!this._state.canNavigateInLoop()) {
+				// Loop is disabled and we are past the search range - no forward match
+				return null;
+			}
 			after = searchRange.getStartPosition();
 		}
 
@@ -451,6 +464,11 @@ export class FindModelBoundToEditorModel {
 
 		if (!isRecursed && !searchRange.containsRange(nextMatch.range)) {
 			return this._getNextMatch(nextMatch.range.getEndPosition(), captureMatches, forceMove, true);
+		}
+
+		// When loop is disabled, check if the match wrapped around (found before our search position)
+		if (!this._state.canNavigateInLoop() && nextMatch.range.getEndPosition().isBefore(position)) {
+			return null;
 		}
 
 		return nextMatch;

--- a/src/vs/editor/contrib/find/browser/findState.ts
+++ b/src/vs/editor/contrib/find/browser/findState.ts
@@ -6,7 +6,6 @@
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Range } from '../../../common/core/range.js';
-import { MATCHES_LIMIT } from './findModel.js';
 
 export interface FindReplaceStateChangedEvent {
 	moveCursor: boolean;
@@ -326,8 +325,8 @@ export class FindReplaceState<T extends { update: (value: T) => void } = { updat
 		return this.canNavigateInLoop() || (this.matchesPosition < this.matchesCount);
 	}
 
-	private canNavigateInLoop(): boolean {
-		return this._loop || (this.matchesCount >= MATCHES_LIMIT);
+	public canNavigateInLoop(): boolean {
+		return this._loop;
 	}
 
 }


### PR DESCRIPTION
## Summary

- Fixes `editor.find.loop` setting being ignored when a file has >= 19999 (MATCHES_LIMIT) matches
- Previously, `canNavigateInLoop()` unconditionally returned `true` when `matchesCount >= MATCHES_LIMIT`, causing the find navigation to always wrap around regardless of the loop setting
- Removes the `MATCHES_LIMIT` override from `canNavigateInLoop()` and adds wrap-around detection in the large-file code paths (`_getNextMatch` and `_moveToPrevMatch`) to prevent navigation from wrapping when loop is disabled

Fixes #277880

## Test plan

- [ ] Open a file that produces >= 19999 matches for a search term (e.g., 20000 lines each containing the word "setting")
- [ ] Set `editor.find.loop` to `false`
- [ ] Use Ctrl+F to search for the term
- [ ] Press F3 (next match) repeatedly until reaching the last match
- [ ] Verify that the search does **not** wrap around to the beginning of the file
- [ ] Press Shift+F3 (previous match) repeatedly from the first match
- [ ] Verify that the search does **not** wrap around to the end of the file
- [ ] Set `editor.find.loop` to `true` and verify wrapping still works correctly
- [ ] Test with a file below 19999 matches to ensure no regression in normal behavior