### PR TITLE
Reserve badge space in panel tabs to prevent layout shift

### DIFF
--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -143,6 +143,7 @@ export interface ICompositeBarOptions {
 	readonly orientation: ActionsOrientation;
 	readonly colors: (theme: IColorTheme) => ICompositeBarColors;
 	readonly compact?: boolean;
+	readonly reserveBadgeSpace?: boolean;
 	readonly compositeSize: number;
 	readonly overflowActionSize: number;
 	readonly dndHandler: ICompositeDragAndDrop;
@@ -293,7 +294,7 @@ export class CompositeBar extends Widget implements ICompositeBar {
 				const item = this.model.findItem(action.id);
 				return item && this.instantiationService.createInstance(
 					CompositeActionViewItem,
-					{ ...options, draggable: true, colors: this.options.colors, icon: this.options.icon, hoverOptions: this.options.activityHoverOptions, compact: this.options.compact },
+					{ ...options, draggable: true, colors: this.options.colors, icon: this.options.icon, hoverOptions: this.options.activityHoverOptions, compact: this.options.compact, reserveBadgeSpace: this.options.reserveBadgeSpace },
 					action as CompositeBarAction,
 					item.pinnedAction,
 					item.toggleBadgeAction,

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -150,6 +150,7 @@ export interface ICompositeBarActionViewItemOptions extends IActionViewItemOptio
 	readonly hoverOptions: IActivityHoverOptions;
 	readonly hasPopup?: boolean;
 	readonly compact?: boolean;
+	readonly reserveBadgeSpace?: boolean;
 }
 
 export class CompositeBarActionViewItem extends BaseActionViewItem {
@@ -280,7 +281,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 		// pane composite bar active border + background
 		append(container, $('.active-item-indicator'));
 
-		hide(this.badge);
+		this.hideBadge();
 
 		this.update();
 		this.updateStyles();
@@ -315,7 +316,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 		this.badgeDisposable.value = new DisposableStore();
 
 		clearNode(this.badgeContent);
-		hide(this.badge);
+		this.hideBadge();
 
 		const shouldRenderBadges = this.badgesEnabled(this.compositeBarActionItem.id);
 
@@ -329,7 +330,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 
 			// Progress
 			if (type === 'progress') {
-				show(this.badge);
+				this.showBadge();
 				classes.push('progress-badge');
 			}
 
@@ -347,7 +348,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 						classes.push('compact-content');
 					}
 					this.badgeContent.textContent = badgeNumber;
-					show(this.badge);
+					this.showBadge();
 				}
 			}
 
@@ -357,7 +358,7 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 				const badgeContentClassess = ['icon-overlay', ...ThemeIcon.asClassNameArray((badges[0] as IconBadge).icon)];
 				this.badgeContent.classList.add(...badgeContentClassess);
 				this.badgeDisposable.value.add(toDisposable(() => this.badgeContent?.classList.remove(...badgeContentClassess)));
-				show(this.badge);
+				this.showBadge();
 			}
 
 			if (classes.length) {
@@ -369,6 +370,32 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 
 		this.updateTitle();
 		this.updateStyles();
+	}
+
+	/**
+	 * Hides the badge. When `reserveBadgeSpace` is enabled, uses visibility
+	 * instead of display to keep the badge's space reserved in the layout,
+	 * preventing adjacent tabs from shifting when the badge appears/disappears.
+	 */
+	private hideBadge(): void {
+		if (this.options.reserveBadgeSpace) {
+			this.badge.style.visibility = 'hidden';
+			this.badge.setAttribute('aria-hidden', 'true');
+		} else {
+			hide(this.badge);
+		}
+	}
+
+	/**
+	 * Shows the badge. Restores visibility when `reserveBadgeSpace` is enabled.
+	 */
+	private showBadge(): void {
+		if (this.options.reserveBadgeSpace) {
+			this.badge.style.visibility = 'visible';
+			this.badge.removeAttribute('aria-hidden');
+		} else {
+			show(this.badge);
+		}
 	}
 
 	private getVisibleBadges(activities: IActivity[]): { badges: IBadge[]; type: 'progress' | 'icon' | 'number' | undefined } {

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -74,6 +74,7 @@ export interface IPaneCompositeBarOptions {
 	readonly viewContainersWorkspaceStateKey: string;
 	readonly icon: boolean;
 	readonly compact?: boolean;
+	readonly reserveBadgeSpace?: boolean;
 	readonly iconSize: number;
 	readonly recomputeSizes: boolean;
 	readonly orientation: ActionsOrientation;
@@ -134,6 +135,7 @@ export class PaneCompositeBar extends Disposable {
 		return this._register(this.instantiationService.createInstance(CompositeBar, cachedItems, {
 			icon: this.options.icon,
 			compact: this.options.compact,
+			reserveBadgeSpace: this.options.reserveBadgeSpace,
 			orientation: this.options.orientation,
 			activityHoverOptions: this.options.activityHoverOptions,
 			preventLoopNavigation: this.options.preventLoopNavigation,

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -149,6 +149,7 @@ export class PanelPart extends AbstractPaneCompositePart {
 			compositeSize: 0,
 			iconSize: 16,
 			compact: true, // Only applies to icons, not labels
+			reserveBadgeSpace: true,
 			overflowActionSize: 44,
 			colors: theme => ({
 				activeBackgroundColor: theme.getColor(PANEL_BACKGROUND), // Background color for overflow action


### PR DESCRIPTION
## Summary
- Fixes #249973
- When the Problems badge appears or disappears in the panel title bar, adjacent tabs (Output, Debug Console, Terminal, etc.) shift left and right, which is distracting during typing
- Adds a `reserveBadgeSpace` option that uses CSS `visibility: hidden` instead of `display: none` to hide badges, so the badge's layout space is always reserved in the panel even when no badge is shown
- The option is enabled for the panel part only; other composite bars (sidebar, auxiliary bar) retain the existing behavior

## Approach
Instead of toggling `display: none` (which removes the badge from the layout flow), the new `reserveBadgeSpace` option on `CompositeBarActionViewItem` toggles `visibility: hidden` (which hides the badge visually but preserves its space). The existing `.badge-content` CSS already defines `min-width: 16px`, so the reserved space matches a single-digit badge width, preventing the most common source of shifting (0 problems to non-zero and back).

### Changed files
- `compositeBarActions.ts` - Added `reserveBadgeSpace` to options interface; added `hideBadge()`/`showBadge()` helpers that choose between `display:none` and `visibility:hidden`
- `compositeBar.ts` - Added `reserveBadgeSpace` to `ICompositeBarOptions` and pass it through to action view items
- `paneCompositeBar.ts` - Added `reserveBadgeSpace` to `IPaneCompositeBarOptions` and pass it through
- `panelPart.ts` - Set `reserveBadgeSpace: true` for the panel

## Test plan
- [ ] Open a project with some problems, observe the panel tab bar (Problems, Output, Debug Console, Terminal)
- [ ] Fix all problems so the badge disappears - verify the Output/Debug Console/Terminal tabs do not shift
- [ ] Introduce a problem so the badge reappears - verify tabs remain stable
- [ ] Verify sidebar and auxiliary bar badges still toggle with `display: none` (no behavior change)