### PR TITLE
fix(server): handle quoted ID values in /etc/os-release

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
## Problem

The devcontainer setup script `check-requirements-linux.sh` fails to parse `/etc/os-release` on Rocky Linux 8.5 because it uses ad-hoc grep/sed parsing that doesn't handle quoted values.

On Rocky 8.5, the file contains:
```
ID="rocky"
```

The current regex pattern `ID=([^"]+)` fails to match this format, causing `OS_ID` to be empty and the script to exit with code 1.

## Solution

Replace the ad-hoc parsing with proper shell variable sourcing:
```bash
OS_ID=$(source /etc/os-release && echo $ID)
```

This approach:
- ✅ Handles both quoted and unquoted values correctly
- ✅ Runs in a subshell to prevent environment pollution
- ✅ Follows the official `/etc/os-release` spec (shell-style variable assignments)
- ✅ More robust and maintainable

## Files Changed
- `resources/server/bin/helpers/check-requirements-linux.sh`

Closes #232159