### PR TITLE
fix(scm): support Delete key to drop stash in Repositories view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -9,7 +9,7 @@ import { IWorkbenchContributionsRegistry, registerWorkbenchContribution2, Extens
 import { QuickDiffWorkbenchController } from './quickDiffDecorator.js';
 import { VIEWLET_ID, ISCMService, VIEW_PANE_ID, ISCMProvider, ISCMViewService, REPOSITORIES_VIEW_PANE_ID, HISTORY_VIEW_PANE_ID } from '../common/scm.js';
 import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
-import { MenuRegistry, MenuId, registerAction2, Action2 } from '../../../../platform/actions/common/actions.js';
+import { MenuRegistry, MenuId, registerAction2, Action2, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { SCMActiveResourceContextKeyController, SCMActiveRepositoryController } from './activity.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -42,7 +42,7 @@ import { SCMHistoryViewPane } from './scmHistoryViewPane.js';
 import { QuickDiffModelService, IQuickDiffModelService } from './quickDiffModel.js';
 import { QuickDiffEditorController } from './quickDiffWidget.js';
 import { EditorContributionInstantiation, registerEditorContribution } from '../../../../editor/browser/editorExtensions.js';
-import { RemoteNameContext, ResourceContextKey } from '../../../common/contextkeys.js';
+import { FocusedViewContext, RemoteNameContext, ResourceContextKey } from '../../../common/contextkeys.js';
 import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { SCMAccessibilityHelp } from './scmAccessibilityHelp.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
@@ -678,6 +678,59 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const scmView = await viewsService.openView<SCMViewPane>(VIEW_PANE_ID);
 		if (scmView) {
 			scmView.focusNextResourceGroup();
+		}
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'workbench.scm.repositories.dropArtifact',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(FocusedViewContext.key, REPOSITORIES_VIEW_PANE_ID),
+		ContextKeys.SCMRepositoryFocusedArtifactGroupId.notEqualsTo('')
+	),
+	primary: KeyCode.Delete,
+	mac: {
+		primary: KeyMod.CtrlCmd | KeyCode.Backspace,
+		secondary: [KeyCode.Delete]
+	},
+	handler: async accessor => {
+		const viewsService = accessor.get(IViewsService);
+		const commandService = accessor.get(ICommandService);
+		const view = viewsService.getActiveViewWithId<SCMRepositoriesViewPane>(REPOSITORIES_VIEW_PANE_ID);
+		if (!view) {
+			return;
+		}
+
+		const focusedArtifact = view.getFocusedArtifact();
+		if (!focusedArtifact) {
+			return;
+		}
+
+		const { repository, artifact, groupId } = focusedArtifact;
+		const provider = repository.provider;
+
+		// Get the artifact context menu and find a delete/drop action
+		const menus = accessor.get(ISCMViewService).menus.getRepositoryMenus(provider);
+		const artifactGroups = await provider.artifactProvider.get()?.provideArtifactGroups();
+		const artifactGroup = artifactGroups?.find(g => g.id === groupId);
+		if (!artifactGroup) {
+			return;
+		}
+
+		const menu = menus.getArtifactMenu(artifactGroup, artifact);
+		const actions = menu.getActions({ arg: provider, shouldForwardArgs: true });
+
+		for (const [, groupActions] of actions) {
+			for (const action of groupActions) {
+				if (action instanceof MenuItemAction) {
+					const id = action.item.id.toLowerCase();
+					if (id.includes('drop') || id.includes('delete')) {
+						await commandService.executeCommand(action.item.id, provider, artifact);
+						return;
+					}
+				}
+			}
 		}
 	}
 });

--- a/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmRepositoriesViewPane.ts
@@ -47,6 +47,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IActionViewItemProvider } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { fromNow } from '../../../../base/common/date.js';
+import { ContextKeys } from './scmViewPane.js';
 
 type TreeElement = ISCMRepository | SCMArtifactGroupTreeElement | SCMArtifactTreeElement | IResourceNode<SCMArtifactTreeElement, SCMArtifactGroupTreeElement>;
 
@@ -439,6 +440,7 @@ export class SCMRepositoriesViewPane extends ViewPane {
 
 	private readonly visibilityDisposables = new DisposableStore();
 	private readonly repositoryDisposables = new DisposableMap<ISCMRepository>();
+	private readonly focusedArtifactGroupIdContextKey;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -457,6 +459,8 @@ export class SCMRepositoriesViewPane extends ViewPane {
 		@IStorageService private readonly storageService: IStorageService
 	) {
 		super({ ...options, titleMenuId: MenuId.SCMSourceControlTitle }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
+
+		this.focusedArtifactGroupIdContextKey = ContextKeys.SCMRepositoryFocusedArtifactGroupId.bindTo(contextKeyService);
 
 		this.visibleCountObs = observableConfigValue('scm.repositories.visible', 10, this.configurationService);
 		this.providerCountBadgeObs = observableConfigValue<'hidden' | 'auto' | 'visible'>('scm.providerCountBadge', 'hidden', this.configurationService);
@@ -549,6 +553,24 @@ export class SCMRepositoriesViewPane extends ViewPane {
 	override focus(): void {
 		super.focus();
 		this.tree.domFocus();
+	}
+
+	getFocusedArtifact(): { repository: ISCMRepository; artifact: { id: string; name: string; description?: string }; groupId: string } | undefined {
+		const focused = this.tree.getFocus();
+		if (focused.length === 0 || !focused[0]) {
+			return undefined;
+		}
+
+		const element = focused[0];
+		if (isSCMArtifactTreeElement(element)) {
+			return {
+				repository: element.repository,
+				artifact: element.artifact,
+				groupId: element.group.id
+			};
+		}
+
+		return undefined;
 	}
 
 	private createTree(container: HTMLElement, viewState?: IAsyncDataTreeViewState): void {
@@ -736,6 +758,23 @@ export class SCMRepositoriesViewPane extends ViewPane {
 				this.scmViewService.focus(e.elements[0]);
 			}
 		}
+
+		// Update artifact group context key
+		this.updateFocusedArtifactGroupId(e.elements);
+	}
+
+	private updateFocusedArtifactGroupId(elements: (TreeElement | null)[]): void {
+		if (elements.length > 0 && elements[0]) {
+			const element = elements[0];
+			if (isSCMArtifactTreeElement(element)) {
+				this.focusedArtifactGroupIdContextKey.set(element.group.id);
+				return;
+			} else if (isSCMArtifactNode(element)) {
+				this.focusedArtifactGroupIdContextKey.set(element.context.artifactGroup.id);
+				return;
+			}
+		}
+		this.focusedArtifactGroupIdContextKey.reset();
 	}
 
 	private onDidTreeFocus(): void {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -947,7 +947,8 @@ export const ContextKeys = {
 	RepositoryVisibilityCount: new RawContextKey<number>('scmRepositoryVisibleCount', 0),
 	RepositoryVisibility(repository: ISCMRepository) {
 		return new RawContextKey<boolean>(`scmRepositoryVisible:${repository.provider.id}`, false);
-	}
+	},
+	SCMRepositoryFocusedArtifactGroupId: new RawContextKey<string | undefined>('scmRepositoryFocusedArtifactGroupId', undefined),
 };
 
 MenuRegistry.appendMenuItem(MenuId.SCMTitle, {


### PR DESCRIPTION
## Summary

- Fixes #280604 - Pressing `Delete` key on a stash in the SCM Repositories tree now drops the stash
- Adds a `scmRepositoryFocusedArtifactGroupId` context key that tracks which artifact group (stashes, branches, tags, worktrees) the focused tree element belongs to
- Registers a `Delete` keybinding (`Cmd+Backspace` on macOS) when the Repositories view is focused and an artifact is selected
- The handler generically discovers the appropriate delete/drop action from the artifact's context menu, so this also works for branch deletion, tag deletion, and worktree deletion

## Implementation

Three files are changed:

1. **`scmViewPane.ts`** - Added `SCMRepositoryFocusedArtifactGroupId` to the exported `ContextKeys` object
2. **`scmRepositoriesViewPane.ts`** - Binds and updates the context key when tree focus changes; exposes `getFocusedArtifact()` to retrieve the currently focused artifact
3. **`scm.contribution.ts`** - Registers the `Delete` keybinding that finds and executes the appropriate drop/delete `MenuItemAction` from the artifact's context menu

## Test plan

- [ ] Open a Git repository in VS Code
- [ ] Create at least one stash (`git stash`)
- [ ] In the Source Control Repositories view, expand the repository and the "Stashes" group
- [ ] Select a stash in the tree
- [ ] Press `Delete` (or `Cmd+Backspace` on macOS)
- [ ] Verify the stash drop confirmation dialog appears
- [ ] Confirm the stash is dropped
- [ ] Verify that pressing `Delete` on a branch artifact shows the delete branch dialog
- [ ] Verify that pressing `Delete` on a non-artifact element (e.g., repository) does nothing