### PR TITLE
fix: reset chat mode when switching to session with customAgentTarget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -591,7 +591,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.agentSessionTypeKey.set(newSessionType);
 				this.chatSessionSupportsDelegationKey.set(this.chatSessionsService.supportsDelegationForSessionType(newSessionType));
 				this.updateWidgetLockStateFromSessionType(newSessionType);
-				this.checkModeInSessionPool();
+				this.checkModeInSessionPool(newSessionType);
 				this.refreshChatSessionPickers();
 			}));
 		}
@@ -1159,12 +1159,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	 * When the session has a customAgentTarget, only Agent mode and custom
 	 * modes matching that target are valid. Resets to Agent mode if invalid.
 	 */
-	private checkModeInSessionPool(): void {
-		const sessionResource = this._widget?.viewModel?.model.sessionResource;
-		if (!sessionResource) {
-			return;
+	private checkModeInSessionPool(sessionType?: string): void {
+		if (!sessionType) {
+			const sessionResource = this._widget?.viewModel?.model.sessionResource;
+			if (!sessionResource) {
+				return;
+			}
+			sessionType = getChatSessionType(sessionResource);
 		}
-		const customAgentTarget = this.chatSessionsService.getCustomAgentTargetForSessionType(getChatSessionType(sessionResource));
+		const customAgentTarget = this.chatSessionsService.getCustomAgentTargetForSessionType(sessionType);
 		if (!customAgentTarget || customAgentTarget === Target.Undefined) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -591,6 +591,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.agentSessionTypeKey.set(newSessionType);
 				this.chatSessionSupportsDelegationKey.set(this.chatSessionsService.supportsDelegationForSessionType(newSessionType));
 				this.updateWidgetLockStateFromSessionType(newSessionType);
+				this.checkModeInSessionPool();
 				this.refreshChatSessionPickers();
 			}));
 		}
@@ -1151,6 +1152,39 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (lm && !this.isModelValidForCurrentSession(lm)) {
 			this.setCurrentLanguageModelToDefault();
 		}
+	}
+
+	/**
+	 * Validate that the current mode is valid for the current session type.
+	 * When the session has a customAgentTarget, only Agent mode and custom
+	 * modes matching that target are valid. Resets to Agent mode if invalid.
+	 */
+	private checkModeInSessionPool(): void {
+		const sessionResource = this._widget?.viewModel?.model.sessionResource;
+		if (!sessionResource) {
+			return;
+		}
+		const customAgentTarget = this.chatSessionsService.getCustomAgentTargetForSessionType(getChatSessionType(sessionResource));
+		if (!customAgentTarget || customAgentTarget === Target.Undefined) {
+			return;
+		}
+		const currentMode = this._currentModeObservable.get();
+		// Built-in Agent mode is always valid in sessions with customAgentTarget
+		if (currentMode.id === ChatMode.Agent.id) {
+			return;
+		}
+		// Built-in Ask/Edit modes are not valid in sessions with customAgentTarget
+		if (currentMode.isBuiltin) {
+			this.setChatMode(ChatModeKind.Agent, false);
+			return;
+		}
+		// Custom modes with matching target or no target (Target.Undefined) are valid
+		const modeTarget = currentMode.target.get();
+		if (modeTarget === customAgentTarget || modeTarget === Target.Undefined) {
+			return;
+		}
+		// Current mode is not valid for this session type, reset to Agent
+		this.setChatMode(ChatModeKind.Agent, false);
 	}
 
 	/**
@@ -1921,6 +1955,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this._currentSessionType = newSessionType;
 				this.initSelectedModel();
 				this.checkModelInSessionPool();
+				this.checkModeInSessionPool();
 			}
 
 			// For contributed sessions with history, pre-select the model

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -76,8 +76,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 	) {
 		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false });
 
-		// Get custom agent target (if filtering is enabled)
-		const customAgentTarget = delegate.customAgentTarget?.() ?? Target.Undefined;
+		// Get custom agent target dynamically (may change when switching session types)
+		const getCustomAgentTarget = () => delegate.customAgentTarget?.() ?? Target.Undefined;
 
 		// Category definitions
 		const builtInCategory = { label: localize('built-in', "Built-In"), order: 0 };
@@ -160,36 +160,34 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			};
 		};
 
-		const actionProviderWithCustomAgentTarget: IActionWidgetDropdownActionProvider = {
-			getActions: () => {
-				const modes = chatModeService.getModes();
-				const currentMode = delegate.currentMode.get();
-				const filteredCustomModes = modes.custom.filter(mode => {
-					const target = mode.target.get();
-					if (target !== customAgentTarget && target !== Target.Undefined) {
-						return false;
-					}
-					if (mode.when && !this.contextKeyService.contextMatchesRules(mode.when)) {
-						return false;
-					}
-					return true;
-				});
-				const customModes = groupBy(
-					filteredCustomModes,
-					mode => isModeConsideredBuiltIn(mode, this._productService) ? 'builtin' : 'custom');
-				// Always include the default "Agent" option first
-				const checked = currentMode.id === ChatMode.Agent.id;
-				const defaultAction = { ...makeAction(ChatMode.Agent, ChatMode.Agent), checked };
-				defaultAction.category = builtInCategory;
-				const builtInActions = customModes.builtin?.map(mode => {
-					const action = makeActionFromCustomMode(mode, currentMode);
-					action.category = builtInCategory;
-					return action;
-				}) ?? [];
-				// Add filtered custom modes
-				const customActions = customModes.custom?.map(mode => makeActionFromCustomMode(mode, currentMode)) ?? [];
-				return [defaultAction, ...builtInActions, ...customActions];
-			}
+		const getActionsForCustomAgentTarget = (currentTarget: Target): IActionWidgetDropdownAction[] => {
+			const modes = chatModeService.getModes();
+			const currentMode = delegate.currentMode.get();
+			const filteredCustomModes = modes.custom.filter(mode => {
+				const target = mode.target.get();
+				if (target !== currentTarget && target !== Target.Undefined) {
+					return false;
+				}
+				if (mode.when && !this.contextKeyService.contextMatchesRules(mode.when)) {
+					return false;
+				}
+				return true;
+			});
+			const customModes = groupBy(
+				filteredCustomModes,
+				mode => isModeConsideredBuiltIn(mode, this._productService) ? 'builtin' : 'custom');
+			// Always include the default "Agent" option first
+			const checked = currentMode.id === ChatMode.Agent.id;
+			const defaultAction = { ...makeAction(ChatMode.Agent, ChatMode.Agent), checked };
+			defaultAction.category = builtInCategory;
+			const builtInActions = customModes.builtin?.map(mode => {
+				const action = makeActionFromCustomMode(mode, currentMode);
+				action.category = builtInCategory;
+				return action;
+			}) ?? [];
+			// Add filtered custom modes
+			const customActions = customModes.custom?.map(mode => makeActionFromCustomMode(mode, currentMode)) ?? [];
+			return [defaultAction, ...builtInActions, ...customActions];
 		};
 
 		const actionProvider: IActionWidgetDropdownActionProvider = {
@@ -235,8 +233,18 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			}
 		};
 
+		const dynamicActionProvider: IActionWidgetDropdownActionProvider = {
+			getActions: () => {
+				const currentTarget = getCustomAgentTarget();
+				if (currentTarget !== Target.Undefined) {
+					return getActionsForCustomAgentTarget(currentTarget);
+				}
+				return actionProvider.getActions();
+			}
+		};
+
 		const modePickerActionWidgetOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
-			actionProvider: customAgentTarget !== Target.Undefined ? actionProviderWithCustomAgentTarget : actionProvider,
+			actionProvider: dynamicActionProvider,
 			actionBarActionProvider: {
 				getActions: () => this.getModePickerActionBarActions()
 			},

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -76,8 +76,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 	) {
 		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false });
 
-		// Get custom agent target dynamically (may change when switching session types)
-		const getCustomAgentTarget = () => delegate.customAgentTarget?.() ?? Target.Undefined;
+		// Get custom agent target (if filtering is enabled)
+		const customAgentTarget = delegate.customAgentTarget?.() ?? Target.Undefined;
 
 		// Category definitions
 		const builtInCategory = { label: localize('built-in', "Built-In"), order: 0 };
@@ -162,12 +162,11 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 
 		const actionProviderWithCustomAgentTarget: IActionWidgetDropdownActionProvider = {
 			getActions: () => {
-				const currentTarget = getCustomAgentTarget();
 				const modes = chatModeService.getModes();
 				const currentMode = delegate.currentMode.get();
 				const filteredCustomModes = modes.custom.filter(mode => {
 					const target = mode.target.get();
-					if (target !== currentTarget && target !== Target.Undefined) {
+					if (target !== customAgentTarget && target !== Target.Undefined) {
 						return false;
 					}
 					if (mode.when && !this.contextKeyService.contextMatchesRules(mode.when)) {
@@ -236,18 +235,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			}
 		};
 
-		const dynamicActionProvider: IActionWidgetDropdownActionProvider = {
-			getActions: () => {
-				const currentTarget = getCustomAgentTarget();
-				if (currentTarget !== Target.Undefined) {
-					return actionProviderWithCustomAgentTarget.getActions();
-				}
-				return actionProvider.getActions();
-			}
-		};
-
 		const modePickerActionWidgetOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
-			actionProvider: dynamicActionProvider,
+			actionProvider: customAgentTarget !== Target.Undefined ? actionProviderWithCustomAgentTarget : actionProvider,
 			actionBarActionProvider: {
 				getActions: () => this.getModePickerActionBarActions()
 			},

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -76,8 +76,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 	) {
 		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false });
 
-		// Get custom agent target (if filtering is enabled)
-		const customAgentTarget = delegate.customAgentTarget?.() ?? Target.Undefined;
+		// Get custom agent target dynamically (may change when switching session types)
+		const getCustomAgentTarget = () => delegate.customAgentTarget?.() ?? Target.Undefined;
 
 		// Category definitions
 		const builtInCategory = { label: localize('built-in', "Built-In"), order: 0 };
@@ -162,11 +162,12 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 
 		const actionProviderWithCustomAgentTarget: IActionWidgetDropdownActionProvider = {
 			getActions: () => {
+				const currentTarget = getCustomAgentTarget();
 				const modes = chatModeService.getModes();
 				const currentMode = delegate.currentMode.get();
 				const filteredCustomModes = modes.custom.filter(mode => {
 					const target = mode.target.get();
-					if (target !== customAgentTarget && target !== Target.Undefined) {
+					if (target !== currentTarget && target !== Target.Undefined) {
 						return false;
 					}
 					if (mode.when && !this.contextKeyService.contextMatchesRules(mode.when)) {
@@ -235,8 +236,18 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			}
 		};
 
+		const dynamicActionProvider: IActionWidgetDropdownActionProvider = {
+			getActions: () => {
+				const currentTarget = getCustomAgentTarget();
+				if (currentTarget !== Target.Undefined) {
+					return actionProviderWithCustomAgentTarget.getActions();
+				}
+				return actionProvider.getActions();
+			}
+		};
+
 		const modePickerActionWidgetOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
-			actionProvider: customAgentTarget !== Target.Undefined ? actionProviderWithCustomAgentTarget : actionProvider,
+			actionProvider: dynamicActionProvider,
 			actionBarActionProvider: {
 				getActions: () => this.getModePickerActionBarActions()
 			},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #307118

When switching from Local to CLI, the Ask/Plan mode incorrectly persisted because the `ModePickerActionItem` captured `customAgentTarget` once at construction time and used it to statically select the action provider for the dropdown. Since the widget isn't recreated on session switch, the dropdown kept showing Local's full mode list (Ask/Edit/Agent) even in CLI. Additionally, `chatInputPart` validated the selected model on session switch but never validated the mode.

This PR makes the mode picker dynamically evaluate the `customAgentTarget` each time the dropdown is opened, and adds a `checkModeInSessionPool()` method (analogous to the existing `checkModelInSessionPool()`) that resets invalid modes to Agent when switching to a session type with a `customAgentTarget`.

**How to test:**
1. Open Copilot Chat, switch to "Local" provider
2. Select Ask or Plan mode
3. Switch to CLI provider
4. Verify the mode resets to Agent and the dropdown only shows valid modes