### PR TITLE
fix: debug console completions filtered out when adapter omits start/length

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -275,6 +275,15 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 
 							const suggestions: CompletionItem[] = [];
 							const computeRange = (length: number) => Range.fromPositions(position.delta(0, -length), position);
+
+							// When the debug adapter does not provide start/length, compute a default
+							// overlap length based on the word prefix at the cursor position. Without this,
+							// the completion range is zero-width and the suggest widget cannot properly
+							// filter completions as the user continues typing. (#278108)
+							const textBefore = text.substring(0, position.column - 1);
+							const wordMatch = textBefore.match(/[a-zA-Z_$][a-zA-Z0-9_$]*$/);
+							const defaultOverlapLength = wordMatch ? wordMatch[0].length : 0;
+
 							if (response && response.body && response.body.targets) {
 								response.body.targets.forEach(item => {
 									if (item && item.label) {
@@ -288,13 +297,14 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 											insertText = insertText.substring(0, item.selectionStart) + placeholder + insertText.substring(item.selectionStart + selectionLength);
 										}
 
+										const hasExplicitRange = typeof item.start === 'number' && typeof item.length === 'number';
 										suggestions.push({
 											label: item.label,
 											insertText,
 											detail: item.detail,
 											kind: CompletionItemKinds.fromString(item.type || 'property'),
-											filterText: (item.start && item.length) ? text.substring(item.start, item.start + item.length).concat(item.label) : undefined,
-											range: computeRange(item.length || 0),
+											filterText: hasExplicitRange ? text.substring(item.start!, item.start! + item.length!).concat(item.label) : undefined,
+											range: computeRange(hasExplicitRange ? item.length! : defaultOverlapLength),
 											sortText: item.sortText,
 											insertTextRules
 										});


### PR DESCRIPTION
## Summary

- Fixes debug console completion items from DAP adapters being incorrectly filtered out as the user continues typing, when the adapter does not provide `start`/`length` fields on `CompletionItem` (which are optional per the DAP spec)
- When `start`/`length` are omitted, the completion range was zero-width, causing the suggest widget to lose track of the typed prefix during re-filtering
- Computes a default overlap length from the word prefix at the cursor position so completions remain visible while typing
- Also fixes a subtle bug where `start === 0` (a valid position) was incorrectly treated as falsy by using `typeof` checks

Fixes #278108

## Test plan

- [ ] Start a debug session with an adapter that returns completions without `start`/`length` fields
- [ ] Type a partial word in the debug console (e.g., `m` for `myVariable`)
- [ ] Verify the completion appears and remains visible as you continue typing (`my`, `myV`, etc.)
- [ ] Verify completions from adapters that DO provide `start`/`length` still work correctly
- [ ] Verify history suggestions still appear and filter correctly