### PR TITLE
Fix find navigation jumping wrong direction when loop is disabled

### DIFF
--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -288,13 +288,8 @@ export class FindModelBoundToEditorModel {
 
 	private _moveToPrevMatch(before: Position, isRecursed: boolean = false): void {
 		if (!this._state.canNavigateBack()) {
-			// we are beyond the first matched find result
-			// instead of doing nothing, we should refocus the first item
-			const nextMatchRange = this._decorations.matchAfterPosition(before);
-
-			if (nextMatchRange) {
-				this._setCurrentFindMatch(nextMatchRange);
-			}
+			// Loop is disabled and we are at or before the first match.
+			// Do not jump forward to refocus - just stay in place.
 			return;
 		}
 		if (this._decorations.getCount() < MATCHES_LIMIT) {
@@ -383,13 +378,8 @@ export class FindModelBoundToEditorModel {
 
 	private _moveToNextMatch(after: Position): void {
 		if (!this._state.canNavigateForward()) {
-			// we are beyond the last matched find result
-			// instead of doing nothing, we should refocus the last item
-			const prevMatchRange = this._decorations.matchBeforePosition(after);
-
-			if (prevMatchRange) {
-				this._setCurrentFindMatch(prevMatchRange);
-			}
+			// Loop is disabled and we are at or past the last match.
+			// Do not jump backward to refocus - just stay in place.
 			return;
 		}
 		if (this._decorations.getCount() < MATCHES_LIMIT) {


### PR DESCRIPTION
## Summary

- Fixes #264815
- When `editor.find.loop` is `false`, pressing **F3** (Find Next) at or past the last match would incorrectly jump **backward** to a previous match. Similarly, **Shift+F3** (Find Previous) at or before the first match would jump **forward**. This removes the "refocus" logic in the `_moveToNextMatch` / `_moveToPrevMatch` boundary guards so the cursor stays in place at the boundary, matching the expected non-looping behavior.

## Test plan

- [x] Open a file with multiple occurrences of a word
- [x] Set `"editor.find.loop": false` in settings
- [x] Open Find (Ctrl+F), search for the word
- [x] Press F3 repeatedly until reaching the last match -- verify pressing F3 again does **not** jump backward
- [x] Move cursor below the last match with arrow keys, press F3 -- verify it does **not** jump backward
- [x] Navigate to the first match, press Shift+F3 -- verify it does **not** jump forward
- [x] Move cursor above the first match, press Shift+F3 -- verify it does **not** jump forward
- [x] Re-enable `editor.find.loop` (default) and verify looping still works normally