### PR TITLE
Fix diff overview ruler ignoring scrollByPage setting

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/features/overviewRulerFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/overviewRulerFeature.ts
@@ -56,7 +56,26 @@ export class OverviewRulerFeature extends Disposable {
 		}).root;
 		this._register(appendRemoveOnDispose(diffOverviewRoot, viewportDomElement.domNode));
 		this._register(addStandardDisposableListener(diffOverviewRoot, EventType.POINTER_DOWN, (e) => {
-			this._editors.modified.delegateVerticalScrollbarPointerDown(e);
+			// Calculate the click's vertical offset relative to the overview ruler element.
+			// Using page coordinates and element position for reliability, since
+			// e.browserEvent.offsetY can be relative to a child element rather than diffOverviewRoot.
+			const elementTop = diffOverviewRoot.getBoundingClientRect().top
+				+ diffOverviewRoot.ownerDocument.defaultView!.scrollY;
+			const offsetY = e.posy - elementTop;
+			const totalHeight = diffOverviewRoot.clientHeight;
+			if (totalHeight === 0) {
+				return;
+			}
+			const scrollHeight = this._editors.modified.getScrollHeight();
+			const layoutInfo = this._editors.modified.getLayoutInfo();
+			const viewportHeight = layoutInfo.height;
+
+			// Calculate scroll position proportional to click position in the overview ruler,
+			// centering the viewport on the clicked location. This avoids delegating to the
+			// scrollbar which would respect the scrollByPage setting (fixes #276862).
+			const ratio = offsetY / totalHeight;
+			const targetScrollTop = Math.max(0, ratio * scrollHeight - viewportHeight / 2);
+			this._editors.modified.setScrollTop(targetScrollTop);
 		}));
 		this._register(addDisposableListener(diffOverviewRoot, EventType.MOUSE_WHEEL, (e: IMouseWheelEvent) => {
 			this._editors.modified.delegateScrollFromMouseWheelEvent(e);


### PR DESCRIPTION
## Summary
- When `editor.scrollbar.scrollByPage` is enabled, clicking on the diff editor overview ruler (the colored bar to the right showing diff locations) incorrectly scrolls by one page instead of jumping directly to the clicked position
- The fix replaces the `delegateVerticalScrollbarPointerDown` call (which respects `scrollByPage`) with direct proportional scroll position calculation, making the overview ruler behave consistently with the minimap
- The viewport is now centered on the clicked position in the overview ruler

Fixes #276862

## Test plan
- [ ] Set `"editor.scrollbar.scrollByPage": true` in settings
- [ ] Open a diff view for a file with several screen-lengths of content
- [ ] Click on the vertical scrollbar gutter -- should scroll by one page (existing behavior, unchanged)
- [ ] Click on a specific colored region in the diff overview ruler (the bar to the right of the scrollbar) -- should jump directly to that diff location (fixed behavior)
- [ ] Verify the minimap click behavior remains unchanged (should always jump to clicked position)
- [ ] Verify mouse wheel scrolling on the overview ruler still works normally