### PR TITLE
fix: add left padding to SCM file tree items (#234083)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -19,6 +19,7 @@
 }
 
 .scm-view .monaco-tl-contents > div {
+	padding-left: 2px;
 	padding-right: 12px;
 	overflow: hidden;
 }


### PR DESCRIPTION
## Summary

- Adds 2px of left padding to SCM tree content elements (`.scm-view .monaco-tl-contents > div`) so file names have breathing room from the tree indent guide vertical lines
- Previously, file tree items in the SCM Changes view were rendered flush against the indent guides, which looked aesthetically off (as reported in the issue)
- The fix is a minimal CSS change that improves the visual spacing without affecting layout or functionality

Fixes #234083

## Test plan

- [ ] Open a Git repository in VS Code
- [ ] Open the Source Control view and ensure changes are visible in tree view mode
- [ ] Verify file names in the tree have a small gap from the indent guide vertical lines
- [ ] Compare with the explorer tree view to confirm similar visual spacing