### PR TITLE
fix: guard against null foldingDelegate in disposed MarkupCellViewModel

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/markupCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/markupCellViewModel.ts
@@ -73,6 +73,9 @@ export class MarkupCellViewModel extends BaseCellViewModel implements ICellViewM
 	readonly onDidChangeLayout = this._onDidChangeLayout.event;
 
 	get foldingState() {
+		if (this._store.isDisposed) {
+			return CellFoldingState.None;
+		}
 		return this.foldingDelegate.getFoldingState(this.foldingDelegate.getCellIndex(this));
 	}
 


### PR DESCRIPTION
## Summary
- Fixes a crash (`Cannot read properties of null (reading 'getFoldingState')`) that occurs when the notebook outline renderer accesses `foldingState` on a `MarkupCellViewModel` that has already been disposed
- Adds an `_store.isDisposed` guard in the `foldingState` getter to return `CellFoldingState.None` for disposed cells, preventing the null dereference on `foldingDelegate`

Fixes #283679

## Test plan
- [ ] Open a notebook with markdown cells
- [ ] Trigger rapid edits (e.g., via copilot chat log notebook) to reproduce the race condition where the outline renderer tries to read foldingState from a disposed cell
- [ ] Verify no "Cannot read properties of null" errors appear in the console