### PR TITLE
Fix debug console DAP completion highlight matching

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -275,6 +275,9 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 
 							const suggestions: CompletionItem[] = [];
 							const computeRange = (length: number) => Range.fromPositions(position.delta(0, -length), position);
+							// When the debug adapter doesn't provide start/length, use the word at cursor
+							// as the default replacement range so the suggest widget can highlight matching characters (#278109)
+							const defaultWordLength = model.getWordUntilPosition(position).word.length;
 							if (response && response.body && response.body.targets) {
 								response.body.targets.forEach(item => {
 									if (item && item.label) {
@@ -294,7 +297,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 											detail: item.detail,
 											kind: CompletionItemKinds.fromString(item.type || 'property'),
 											filterText: (item.start && item.length) ? text.substring(item.start, item.start + item.length).concat(item.label) : undefined,
-											range: computeRange(item.length || 0),
+											range: computeRange(item.length || defaultWordLength),
 											sortText: item.sortText,
 											insertTextRules
 										});


### PR DESCRIPTION
## Summary
- Fix debug console completions from the debug adapter not highlighting matching characters in the suggest widget
- When the DAP does not provide `start`/`length` on completion items, the replacement range defaults to zero length, which prevents the suggest widget from identifying the typed prefix and highlighting it
- Use `model.getWordUntilPosition()` to compute a default word length, so the suggest widget can properly highlight matching characters (consistent with history suggestions)

Fixes #278109

## Test plan
- [ ] Start a debug session with a debug adapter that returns completions (e.g., Dart, Python, Node.js)
- [ ] Type a partial identifier in the debug console (e.g., `my`)
- [ ] Verify that DAP-provided completions (e.g., `myVariable`) now highlight the matching prefix `my`, just like history suggestions do
- [ ] Verify that completions where the DAP explicitly provides `start`/`length` still work correctly (no behavior change)