### PR TITLE
fix: prevent flash of white theme on VS Code startup

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench.ts
+++ b/src/vs/code/electron-browser/workbench/workbench.ts
@@ -75,6 +75,19 @@
 				shellBackground = '#FFFFFF';
 				shellForeground = '#000000';
 			}
+		} else {
+			// Use stored theme data from main process
+			const storedTheme = configuration.storedThemeData;
+			if (storedTheme) {
+				baseTheme = storedTheme.baseTheme;
+				shellBackground = storedTheme.background;
+				shellForeground = storedTheme.foreground;
+			} else {
+				// Ultimate fallback: dark theme
+				baseTheme = 'vs-dark';
+				shellBackground = '#1F1F1F';
+				shellForeground = '#CCCCCC';
+			}
 		}
 
 		const style = document.createElement('style');

--- a/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
+++ b/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
@@ -219,6 +219,38 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 		}
 	}
 
+	getStoredThemeData(): { baseTheme: string; background: string; foreground: string } {
+		const baseTheme = this.getStoredBaseTheme();
+		let background = '#1F1F1F';  // default Dark
+		let foreground = '#CCCCCC';
+
+		switch (baseTheme) {
+			case ThemeTypeSelector.VS:
+				background = '#FFFFFF';
+				foreground = '#000000';
+				break;
+			case ThemeTypeSelector.HC_BLACK:
+				background = '#000000';
+				foreground = '#FFFFFF';
+				break;
+			case ThemeTypeSelector.HC_LIGHT:
+				background = '#FFFFFF';
+				foreground = '#000000';
+				break;
+			case ThemeTypeSelector.VS_DARK:
+			default:
+				background = '#1F1F1F';
+				foreground = '#CCCCCC';
+				break;
+		}
+
+		return {
+			baseTheme: baseTheme === ThemeTypeSelector.VS ? 'vs' : baseTheme,
+			background,
+			foreground
+		};
+	}
+
 	saveWindowSplash(windowId: number | undefined, workspace: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | undefined, splash: IPartsSplash): void {
 
 		// Update override as needed

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -444,6 +444,7 @@ export interface INativeWindowConfiguration extends IWindowConfiguration, Native
 	userDataDir: string;
 
 	partsSplash?: IPartsSplash;
+	storedThemeData?: { baseTheme: string; background: string; foreground: string };
 
 	workspace?: IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier;
 

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -1279,6 +1279,7 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		configuration.fullscreen = this.isFullScreen;
 		configuration.maximized = this._win.isMaximized();
 		configuration.partsSplash = this.themeMainService.getWindowSplash(configuration.workspace);
+		configuration.storedThemeData = this.themeMainService.getStoredThemeData();
 		configuration.zoomLevel = this.getZoomLevel();
 		configuration.isCustomZoomLevel = typeof this.customZoomLevel === 'number';
 		if (configuration.isCustomZoomLevel && configuration.partsSplash) {


### PR DESCRIPTION
Problem:
When opening VS Code, a brief white/light theme flash (FOUC - Flash of Unstyled Content) occurs during the splash screen loading phase. This is especially jarring for users with dark theme preferences, as they see a bright white screen for a second before the workbench loads the correct theme.

Cause:
The initial shell colors in the renderer process were defaulting to white because the stored user theme data (background/foreground) wasn't available early enough in the configuration or was being ignored if auto-detection was disabled.

Solution:
Synchronized the stored theme preference from the Main process to the Renderer process during window initialization.

Changes:

[themeMainServiceImpl.ts](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added [getStoredThemeData()](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to retrieve the last used theme's colors from the state service.
[window.ts](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Extended [INativeWindowConfiguration](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include [storedThemeData](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[windowImpl.ts](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Populated the window configuration with the stored theme colors before launching the renderer.
[workbench.ts](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Updated the splash screen logic to use the [storedThemeData](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as a reliable fallback, ensuring the correct background color is applied to the [body](vscode-file://vscode-app/c:/Users/yousseflap/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) immediately.
Result:
The splash screen now correctly matches the user's saved theme (Dark, Light, or High Contrast) from the very first millisecond of startup.