### PR TITLE
Post Update Widget Polish

### DIFF
--- a/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
@@ -94,23 +94,27 @@
 	white-space: nowrap;
 }
 
-.update-tooltip .release-notes-button {
+.update-tooltip .update-button-secondary {
 	background-color: var(--vscode-button-secondaryBackground);
 	color: var(--vscode-button-secondaryForeground);
 	border: 1px solid var(--vscode-button-border, transparent);
 }
 
-.update-tooltip .release-notes-button:hover {
+.update-tooltip .update-button-secondary:hover {
 	background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
-.update-tooltip .action-button {
+.update-tooltip .update-button-leading-secondary {
+	margin-right: auto;
+}
+
+.update-tooltip .update-button-primary {
 	background-color: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
 	border: 1px solid var(--vscode-button-border, transparent);
 }
 
-.update-tooltip .action-button:hover {
+.update-tooltip .update-button-primary:hover {
 	background-color: var(--vscode-button-hoverBackground);
 }
 

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -258,7 +258,7 @@ registerAction2(class ShowUpdateInfoAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const commandService = accessor.get(ICommandService);
 		const quickInputService = accessor.get(IQuickInputService);
-		const markdown = await quickInputService.input({ prompt: localize('showUpdateInfo.prompt', "Enter markdown to render (leave empty to load from URL)") });
+		const markdown = await quickInputService.input({ prompt: localize('showUpdateInfo.prompt', "Enter markdown to render, or JSON with markdown/buttons (leave empty to load from URL)") });
 		if (markdown === undefined) {
 			return; // cancelled
 		}

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -28,6 +28,7 @@ import { IChatService } from '../../chat/common/chatService/chatService.js';
 import { computeProgressPercent, isMajorMinorVersionChange } from '../common/updateUtils.js';
 import { waitForState } from '../../../../base/common/observable.js';
 import './media/updateTitleBarEntry.css';
+import { IUpdateInfoButton } from '../common/updateInfoParser.js';
 import { UpdateTooltip } from './updateTooltip.js';
 
 const UPDATE_TITLE_BAR_ACTION_ID = 'workbench.actions.updateIndicator';
@@ -77,6 +78,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 		@IChatService private readonly chatService: IChatService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@IHoverService private readonly hoverService: IHoverService,
 		@IHostService private readonly hostService: IHostService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IProductService private readonly productService: IProductService,
@@ -115,17 +117,35 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 			}
 		));
 
-		this._register(CommandsRegistry.registerCommand('_update.showUpdateInfo', (_accessor, markdown?: string) => this.showUpdateInfo(markdown)));
+		this._register(CommandsRegistry.registerCommand('_update.showUpdateInfo', (_accessor, markdown?: string, options?: { buttons?: IUpdateInfoButton[] }) => this.showUpdateInfo(markdown, options)));
 
 		void this.onStateChange(true);
 	}
 
-	private async showUpdateInfo(markdown?: string) {
-		const rendered = await this.tooltip.renderPostInstall(markdown);
+	private async showUpdateInfo(markdown?: string, options?: { buttons?: IUpdateInfoButton[] }) {
+		const rendered = await this.tooltip.renderPostInstall(markdown, options?.buttons);
 		if (rendered) {
 			this.tooltipVisible = true;
-			this.context.set(true);
-			this.entry?.showTooltip(true);
+
+			const targetWindow = dom.getActiveWindow();
+			const targetElement = targetWindow.document.body ?? targetWindow.document.documentElement;
+			const width = Math.min(640, Math.max(targetWindow.innerWidth - 32, 320));
+			const x = Math.max(targetWindow.innerWidth - width - 80, 16);
+			const y = 40;
+
+			this.hoverService.showInstantHover({
+				content: this.tooltip.domNode,
+				target: {
+					targetElements: [targetElement],
+					x,
+					y,
+					dispose: () => {
+						this.tooltipVisible = false;
+					}
+				},
+				persistence: { sticky: true },
+				appearance: { showPointer: false, compact: true, maxHeightRatio: 0.8 },
+			}, true);
 		}
 	}
 
@@ -223,6 +243,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 export class UpdateTitleBarEntry extends BaseActionViewItem {
 	private content: HTMLElement | undefined;
 	private showTooltipOnRender = false;
+	private pendingTooltipOptions: { showPointer?: boolean; hideLabel?: boolean } | undefined;
 
 	constructor(
 		action: IAction,
@@ -249,14 +270,21 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 
 		if (this.showTooltipOnRender) {
 			this.showTooltipOnRender = false;
-			dom.scheduleAtNextAnimationFrame(dom.getWindow(container), () => this.showTooltip());
+			const opts = this.pendingTooltipOptions;
+			this.pendingTooltipOptions = undefined;
+			dom.scheduleAtNextAnimationFrame(dom.getWindow(container), () => this.showTooltip(false, opts));
 		}
 	}
 
-	public showTooltip(focus = false) {
+	public showTooltip(focus = false, options?: { showPointer?: boolean; hideLabel?: boolean }) {
 		if (!this.element?.isConnected) {
 			this.showTooltipOnRender = true;
+			this.pendingTooltipOptions = options;
 			return;
+		}
+
+		if (options?.hideLabel && this.element) {
+			this.element.style.visibility = 'hidden';
 		}
 
 		this.hoverService.showInstantHover({
@@ -264,13 +292,16 @@ export class UpdateTitleBarEntry extends BaseActionViewItem {
 			target: {
 				targetElements: [this.element],
 				dispose: () => {
+					if (this.element) {
+						this.element.style.visibility = '';
+					}
 					if (!!this.element?.isConnected) {
 						this.onUserDismissedTooltip();
 					}
 				}
 			},
 			persistence: { sticky: true },
-			appearance: { showPointer: true, compact: true },
+			appearance: { showPointer: options?.showPointer ?? true, compact: true },
 		}, focus);
 	}
 

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
+import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -19,10 +20,14 @@ import { IMeteredConnectionService } from '../../../../platform/meteredConnectio
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { asTextOrError, IRequestService } from '../../../../platform/request/common/request.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { AvailableForDownload, Disabled, DisablementReason, Downloaded, Downloading, Idle, IUpdate, Overwriting, Ready, Restarting, State, StateType, Updating } from '../../../../platform/update/common/update.js';
+import { IUpdateInfoButton, parseUpdateInfoInput, UpdateInfoButtonStyle } from '../common/updateInfoParser.js';
 import { ShowCurrentReleaseNotesActionId } from '../common/update.js';
 import { computeDownloadSpeed, computeDownloadTimeRemaining, computeProgressPercent, formatBytes, formatDate, formatTimeRemaining, getUpdateInfoUrl, tryParseDate } from '../common/updateUtils.js';
 import './media/updateTooltip.css';
+
+const UPDATE_INFO_TELEMETRY_SOURCE = 'updateinfo';
 
 /**
  * A stateful tooltip control for the update status.
@@ -64,8 +69,11 @@ export class UpdateTooltip extends Disposable {
 	private readonly buttonBar: HTMLElement;
 	private readonly releaseNotesButton: HTMLButtonElement;
 	private readonly actionButton: HTMLButtonElement;
+	private readonly customButtonListeners = this._register(new DisposableStore());
+	private customButtons: HTMLButtonElement[] = [];
 
 	private releaseNotesVersion: string | undefined;
+	private commandTelemetrySource: string | undefined;
 
 	constructor(
 		@IClipboardService private readonly clipboardService: IClipboardService,
@@ -77,6 +85,7 @@ export class UpdateTooltip extends Disposable {
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 		@IRequestService private readonly requestService: IRequestService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -131,7 +140,7 @@ export class UpdateTooltip extends Disposable {
 		// Button bar
 		this.buttonBar = dom.append(this.domNode, dom.$('.button-bar'));
 
-		this.releaseNotesButton = dom.append(this.buttonBar, dom.$('button.release-notes-button')) as HTMLButtonElement;
+		this.releaseNotesButton = dom.append(this.buttonBar, dom.$('button.update-button-secondary')) as HTMLButtonElement;
 		this.releaseNotesButton.textContent = localize('updateTooltip.viewReleaseNotes', "Release Notes");
 		this._register(dom.addDisposableListener(this.releaseNotesButton, 'click', () => {
 			if (this.releaseNotesVersion) {
@@ -139,7 +148,7 @@ export class UpdateTooltip extends Disposable {
 			}
 		}));
 
-		this.actionButton = dom.append(this.buttonBar, dom.$('button.action-button')) as HTMLButtonElement;
+		this.actionButton = dom.append(this.buttonBar, dom.$('button.update-button-primary')) as HTMLButtonElement;
 		this._register(dom.addDisposableListener(this.actionButton, 'click', () => {
 			const commandId = this.actionButton.dataset.commandId;
 			if (commandId) {
@@ -175,7 +184,14 @@ export class UpdateTooltip extends Disposable {
 		this.markdown.clear();
 		this.actionButton.style.display = 'none';
 		this.actionButton.dataset.commandId = '';
+		this.releaseNotesButton.style.display = '';
 		this.releaseNotesButton.style.marginRight = '';
+		this.commandTelemetrySource = undefined;
+		this.customButtonListeners.clear();
+		for (const btn of this.customButtons) {
+			btn.remove();
+		}
+		this.customButtons = [];
 	}
 
 	public renderState(state: State) {
@@ -382,7 +398,7 @@ export class UpdateTooltip extends Disposable {
 		this.renderMessage(localize('updateTooltip.restartingPleaseWait', "Restarting to update, please wait..."));
 	}
 
-	public async renderPostInstall(markdown?: string): Promise<boolean> {
+	public async renderPostInstall(markdown?: string, buttons?: IUpdateInfoButton[]): Promise<boolean> {
 		this.hideAll();
 		this.renderTitleAndInfo(localize('updateTooltip.installedDefaultTitle', "New Update Installed"));
 		this.renderMessage(
@@ -401,6 +417,15 @@ export class UpdateTooltip extends Disposable {
 		if (!text) {
 			return false;
 		}
+
+		// Parse buttons from the markdown payload if no explicit buttons were provided.
+		if (!buttons?.length) {
+			const parsed = parseUpdateInfoInput(text);
+			text = parsed.markdown;
+			buttons = parsed.buttons;
+		}
+
+		this.commandTelemetrySource = UPDATE_INFO_TELEMETRY_SOURCE;
 
 		this.titleNode.textContent = localize('updateTooltip.installedTitle', "New in {0}", this.productService.version);
 		this.productInfoNode.style.display = 'none';
@@ -424,7 +449,43 @@ export class UpdateTooltip extends Disposable {
 		this.markdownContainer.appendChild(rendered.element);
 		this.markdownContainer.style.display = '';
 
+		// Render custom buttons if provided
+		if (buttons?.length) {
+			this.renderCustomButtons(buttons);
+		}
+
 		return true;
+	}
+
+	private renderCustomButtons(buttons: IUpdateInfoButton[]) {
+		this.customButtonListeners.clear();
+		for (const btn of this.customButtons) {
+			btn.remove();
+		}
+		this.customButtons = [];
+
+		// Hide both default buttons when custom buttons are provided
+		this.actionButton.style.display = 'none';
+		this.releaseNotesButton.style.display = 'none';
+
+		for (const button of buttons) {
+			const btn = dom.append(this.buttonBar, dom.$('button')) as HTMLButtonElement;
+			btn.textContent = button.label;
+			btn.classList.add(this.getButtonClass(button.style));
+			if (button.style === 'secondary' && buttons.length > 1) {
+				btn.classList.add('update-button-leading-secondary');
+			}
+			this.customButtons.push(btn);
+			this.customButtonListeners.add(dom.addDisposableListener(btn, 'click', () => {
+				this.runCommandAndClose(button.commandId, ...(button.args ?? []));
+			}));
+		}
+
+		this.buttonBar.style.display = '';
+	}
+
+	private getButtonClass(style: UpdateInfoButtonStyle | undefined): string {
+		return style === 'secondary' ? 'update-button-secondary' : 'update-button-primary';
 	}
 
 	private renderTitleAndInfo(title: string, update?: IUpdate) {
@@ -501,6 +562,10 @@ export class UpdateTooltip extends Disposable {
 	}
 
 	private runCommandAndClose(command: string, ...args: unknown[]) {
+		if (this.commandTelemetrySource) {
+			this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: command, from: this.commandTelemetrySource });
+		}
+
 		this.commandService.executeCommand(command, ...args);
 		this.hoverService.hideHover(true);
 	}

--- a/src/vs/workbench/contrib/update/common/updateInfoParser.ts
+++ b/src/vs/workbench/contrib/update/common/updateInfoParser.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { hasKey } from '../../../../base/common/types.js';
+
+export type UpdateInfoButtonStyle = 'primary' | 'secondary';
+
+export interface IUpdateInfoButton {
+	readonly label: string;
+	readonly commandId: string;
+	readonly args?: unknown[];
+	readonly style?: UpdateInfoButtonStyle;
+}
+
+export interface IParsedUpdateInfoInput {
+	readonly markdown: string;
+	readonly buttons?: IUpdateInfoButton[];
+}
+
+/**
+ * Parses optional metadata from update info input.
+ *
+ * Supported formats:
+ * ```
+ * {"markdown":"$(info) **Feature**<br>Description...","buttons":[{"label":"Release Notes","commandId":"update.showCurrentReleaseNotes","style":"secondary"},{"label":"Open Sessions","commandId":"workbench.action.chat.open","style":"primary"}]}
+ * ```
+ * ```
+ * ---
+ * {"buttons":[{"label":"Release Notes","commandId":"update.showCurrentReleaseNotes","style":"secondary"},{"label":"Open Sessions","commandId":"workbench.action.chat.open","style":"primary"}]}
+ * ---
+ * $(info) **Feature**<br>Description...
+ * ```
+ * ```
+ * --- {"buttons":[{"label":"Release Notes","commandId":"update.showCurrentReleaseNotes","style":"secondary"},{"label":"Open Sessions","commandId":"workbench.action.chat.open","style":"primary"}]} ---
+ * $(info) **Feature**<br>Description...
+ * ```
+ */
+export function parseUpdateInfoInput(text: string): IParsedUpdateInfoInput {
+	const normalized = text.replace(/^\uFEFF/, '');
+	return tryParseUpdateInfoEnvelope(normalized) ?? parseUpdateInfoFrontmatter(normalized);
+}
+
+function tryParseUpdateInfoEnvelope(text: string): IParsedUpdateInfoInput | undefined {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+		return undefined;
+	}
+
+	try {
+		const value = JSON.parse(trimmed) as { markdown?: string; buttons?: unknown };
+		if (typeof value.markdown !== 'string') {
+			return undefined;
+		}
+
+		return {
+			markdown: value.markdown,
+			buttons: parseUpdateInfoButtons(value.buttons),
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function parseUpdateInfoFrontmatter(text: string): IParsedUpdateInfoInput {
+	const blockMatch = text.match(/^---[ \t]*\r?\n(?<json>[\s\S]*?)\r?\n---[ \t]*(?:\r?\n(?<body>[\s\S]*))?$/);
+	if (blockMatch?.groups) {
+		return parseUpdateInfoFrontmatterMatch(text, blockMatch.groups['json'], blockMatch.groups['body'] ?? '');
+	}
+
+	const inlineMatch = text.match(/^---[ \t]*(?<json>\{[\s\S]*?\})[ \t]*---[ \t]*(?<body>[\s\S]*)$/);
+	if (inlineMatch?.groups) {
+		return parseUpdateInfoFrontmatterMatch(text, inlineMatch.groups['json'], inlineMatch.groups['body']);
+	}
+
+	return { markdown: text };
+}
+
+function parseUpdateInfoFrontmatterMatch(text: string, jsonText: string, markdown: string): IParsedUpdateInfoInput {
+	try {
+		const meta = JSON.parse(jsonText) as { buttons?: unknown };
+		return {
+			markdown,
+			buttons: parseUpdateInfoButtons(meta.buttons),
+		};
+	} catch {
+		return { markdown: text };
+	}
+}
+
+function parseUpdateInfoButtons(buttons: unknown): IUpdateInfoButton[] | undefined {
+	if (!Array.isArray(buttons)) {
+		return undefined;
+	}
+
+	const parsedButtons: IUpdateInfoButton[] = [];
+	for (const button of buttons) {
+		if (typeof button !== 'object' || button === null) {
+			continue;
+		}
+
+		if (!hasKey(button, { label: true, commandId: true }) || typeof button.label !== 'string' || typeof button.commandId !== 'string') {
+			continue;
+		}
+
+		const style = hasKey(button, { style: true }) && (button.style === 'primary' || button.style === 'secondary') ? button.style : undefined;
+		const args = hasKey(button, { args: true }) && Array.isArray(button.args) ? button.args : undefined;
+		parsedButtons.push({
+			label: button.label,
+			commandId: button.commandId,
+			args,
+			style,
+		});
+	}
+
+	return parsedButtons.length ? parsedButtons : undefined;
+}


### PR DESCRIPTION
**Support for custom update info and buttons:**

* Added a new `parseUpdateInfoInput` utility in `updateInfoParser.ts` to parse JSON or frontmatter metadata from update info payloads, supporting custom markdown and button definitions.
* Updated the tooltip rendering logic in `updateTooltip.ts` to use parsed buttons, render custom buttons with primary/secondary styling, and hide default buttons when custom ones are present. [[1]](diffhunk://#diff-525e16e92c56eb6b46cab22bbe4206d45a651b43492b5e597d042d74f6489047L385-R401) [[2]](diffhunk://#diff-525e16e92c56eb6b46cab22bbe4206d45a651b43492b5e597d042d74f6489047R452-R490)
* Modified the update title bar and tooltip APIs to accept and propagate button definitions, enabling dynamic UI updates based on parsed payloads. [[1]](diffhunk://#diff-5188fdfb146ea20c810fd2fb5523cb2c4c996a4644877cb7c8988e947ee4be78L118-R148) [[2]](diffhunk://#diff-5188fdfb146ea20c810fd2fb5523cb2c4c996a4644877cb7c8988e947ee4be78R81) [[3]](diffhunk://#diff-525e16e92c56eb6b46cab22bbe4206d45a651b43492b5e597d042d74f6489047R421-R429)

**UI and styling improvements:**

* Refactored CSS classes and button styles in `updateTooltip.css` to support new button types and layouts for primary, secondary, and leading secondary buttons.
* Updated DOM construction in `updateTooltip.ts` to use the new CSS classes and button structure, ensuring consistent appearance for both default and custom buttons.

**Telemetry and command execution:**

* Added telemetry logging for custom button actions in the tooltip, capturing the source of the command for analytics. [[1]](diffhunk://#diff-525e16e92c56eb6b46cab22bbe4206d45a651b43492b5e597d042d74f6489047R565-R568) [[2]](diffhunk://#diff-525e16e92c56eb6b46cab22bbe4206d45a651b43492b5e597d042d74f6489047R23-R31)

These changes collectively enable a more flexible and interactive update notification experience, supporting richer content and actionable buttons in the update tooltip.

<img width="2251" height="1419" alt="image" src="https://github.com/user-attachments/assets/56147140-f13e-4d51-890d-3467d7c0f8c6" />

