### PR TITLE
Fix typos

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -335,7 +335,7 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	app.commandLine.appendSwitch('disable-features', featuresToDisable);
 
 	// Blink features to configure.
-	// `FontMatchingCTMigration` - Siwtch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
+	// `FontMatchingCTMigration` - Switch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
 	// `StandardizedBrowserZoom` - Disable zoom adjustment for bounding box (https://github.com/microsoft/vscode/issues/232750#issuecomment-2459495394)
 	const blinkFeaturesToDisable =
 		`FontMatchingCTMigration,StandardizedBrowserZoom,${app.commandLine.getSwitchValue('disable-blink-features')}`;

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1983,7 +1983,7 @@ export class DragAndDropObserver extends Disposable {
 	// A helper to fix issues with repeated DRAG_ENTER / DRAG_LEAVE
 	// calls see https://github.com/microsoft/vscode/issues/14470
 	// when the element has child elements where the events are fired
-	// repeadedly.
+	// repeatedly.
 	private counter: number = 0;
 
 	// Allows to measure the duration of the drag operation.

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -1026,7 +1026,7 @@ export type GridLocation = number[];
  * flex-like layout algorithm for a collection of {@link IView} instances, which
  * are mostly HTMLElement instances with size constraints. A {@link GridView} is a
  * tree composition of multiple {@link SplitView} instances, orthogonal between
- * one another. It will respect view's size contraints, just like the SplitView.
+ * one another. It will respect view's size constraints, just like the SplitView.
  *
  * It has a low-level index based API, allowing for fine grain performant operations.
  * Look into the {@link Grid} widget for a higher-level API.

--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -264,7 +264,7 @@ export interface IHoverLifecycleOptions {
 	 * showDelayedHover({ content: 'Button 2', target: someElement2 }, { groupId });
 	 * ```
 	 *
-	 * @example Use a feature-specific string to set a unqiue `groupId` for related hovers
+	 * @example Use a feature-specific string to set a unique `groupId` for related hovers
 	 *
 	 * ```typescript
 	 * showDelayedHover({ content: 'Button 1', target: someElement1 }, { groupId: 'my-feature-items' });

--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -230,7 +230,7 @@ export class IconLabel extends Disposable {
 		let hoverTarget = htmlElement;
 		if (this.creationOptions?.hoverTargetOverride) {
 			if (!dom.isAncestor(htmlElement, this.creationOptions.hoverTargetOverride)) {
-				throw new Error('hoverTargetOverrride must be an ancestor of the htmlElement');
+				throw new Error('hoverTargetOverride must be an ancestor of the htmlElement');
 			}
 			hoverTarget = this.creationOptions.hoverTargetOverride;
 		}

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -581,7 +581,7 @@ class TypeNavigationController<T> implements IDisposable {
 
 					if (fuzzy) {
 						const fuzzyScore = fuzzy[0].end - fuzzy[0].start;
-						// ensures that when fuzzy matching, doesn't clash with prefix matching (1 input vs 1+ should be prefix and fuzzy respecitvely). Also makes sure that exact matches are prioritized.
+						// ensures that when fuzzy matching, doesn't clash with prefix matching (1 input vs 1+ should be prefix and fuzzy respectively). Also makes sure that exact matches are prioritized.
 						if (fuzzyScore > 1 && fuzzy.length === 1) {
 							this.previouslyFocused = start;
 							this.list.setFocus([index]);

--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -508,7 +508,7 @@ export class MenuBar extends Disposable {
 		}
 
 
-		// If below minimium menu threshold, show the overflow menu only as hamburger menu
+		// If below minimum menu threshold, show the overflow menu only as hamburger menu
 		if (this.numMenusShown - 1 <= showableMenus.length / 4) {
 			for (const menuBarMenu of showableMenus) {
 				menuBarMenu.buttonElement.style.visibility = 'hidden';

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -182,7 +182,7 @@ export interface ISplitViewOptions<TLayoutContext = undefined, TView extends IVi
 
 	/**
 	 * An initial description of this {@link SplitView} instance, allowing
-	 * to initialze all views within the ctor.
+	 * to initialize all views within the ctor.
 	 */
 	readonly descriptor?: ISplitViewDescriptor<TLayoutContext, TView>;
 
@@ -682,7 +682,7 @@ export class SplitView<TLayoutContext = undefined, TView extends IView<TLayoutCo
 				}
 			}
 
-			// Save referene view, in case of `split` sizing
+			// Save reference view, in case of `split` sizing
 			const referenceViewItem = sizing?.type === 'split' ? this.viewItems[sizing.index] : undefined;
 
 			// Remove view

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1468,8 +1468,8 @@ class StickyScrollController<T, TFilterData, TRef> extends Disposable {
 			nextStickyNode = this.getNextStickyNode(firstVisibleNodeUnderWidget, nextStickyNode.node, stickyNodesHeight);
 		}
 
-		const contrainedStickyNodes = this.constrainStickyNodes(stickyNodes);
-		return contrainedStickyNodes.length ? new StickyScrollState(contrainedStickyNodes) : undefined;
+		const constrainedStickyNodes = this.constrainStickyNodes(stickyNodes);
+		return constrainedStickyNodes.length ? new StickyScrollState(contrainedStickyNodes) : undefined;
 	}
 
 	private getNextVisibleNode(previousStickyNode: StickyScrollNode<T, TFilterData>): ITreeNode<T, TFilterData> | undefined {

--- a/src/vs/base/common/color.ts
+++ b/src/vs/base/common/color.ts
@@ -321,7 +321,7 @@ export class Color {
 	}
 
 	/**
-	 * Reduces the "foreground" color on this "background" color unti it is
+	 * Reduces the "foreground" color on this "background" color until it is
 	 * below the relative luminace ratio.
 	 * @returns the new foreground color
 	 * @see https://github.com/xtermjs/xterm.js/blob/44f9fa39ae03e2ca6d28354d88a399608686770e/src/common/Color.ts#L315
@@ -641,7 +641,7 @@ export namespace Color {
 
 			/**
 			 * Formats the color as #RRGGBBAA
-			 * If 'compact' is set, colors without transparancy will be printed as #RRGGBB
+			 * If 'compact' is set, colors without transparency will be printed as #RRGGBB
 			 */
 			export function formatHexA(color: Color, compact = false): string {
 				if (compact && color.rgba.a === 1) {

--- a/src/vs/base/common/jsonSchema.ts
+++ b/src/vs/base/common/jsonSchema.ts
@@ -247,7 +247,7 @@ export function getCompressedContent(schema: IJSONSchema): string {
 	// this will add new items to the definitions array
 	const str = stringify(schema);
 
-	// now stringify the definitions. Each invication of stringify cann add new items to the definitions array, so the length can grow while we iterate
+	// now stringify the definitions. Each invocation of stringify can add new items to the definitions array, so the length can grow while we iterate
 	const defStrings: string[] = [];
 	for (let i = 0; i < definitions.length; i++) {
 		defStrings.push(`"_${i}":${stringify(definitions[i])}`);
@@ -317,8 +317,8 @@ function traverseNodes(root: IJSONSchema, visit: (schema: IJSONSchema) => boolea
 
 	let next = toWalk.pop();
 	while (next) {
-		const visitChildern = visit(next);
-		if (visitChildern) {
+		const visitChildren = visit(next);
+		if (visitChildren) {
 			collectEntries(next.additionalItems, next.additionalProperties, next.not, next.contains, next.propertyNames, next.if, next.then, next.else, next.unevaluatedItems, next.unevaluatedProperties);
 			collectMapEntries(next.definitions, next.$defs, next.properties, next.patternProperties, <IJSONSchemaMap>next.dependencies, next.dependentSchemas);
 			collectArrayEntries(next.anyOf, next.allOf, next.oneOf, next.prefixItems);

--- a/src/vs/base/common/observableInternal/observables/derivedImpl.ts
+++ b/src/vs/base/common/observableInternal/observables/derivedImpl.ts
@@ -136,7 +136,7 @@ export class Derived<T, TChangeSummary = any, TChange = void> extends BaseObserv
 		} else {
 			do {
 				// We might not get a notification for a dependency that changed while it is updating,
-				// thus we also have to ask all our depedencies if they changed in this case.
+				// thus we also have to ask all our dependencies if they changed in this case.
 				if (this._state === DerivedState.dependenciesMightHaveChanged) {
 					for (const d of this._dependencies) {
 						/** might call {@link handleChange} indirectly, which could make us stale */

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -861,7 +861,7 @@ export function* forAnsiStringParts(str: string) {
 
 /**
  * Strips ANSI escape sequences from a string.
- * @param str The dastringa stringo strip the ANSI escape sequences from.
+ * @param str The string to strip the ANSI escape sequences from.
  *
  * @example
  * removeAnsiEscapeCodes('\u001b[31mHello, World!\u001b[0m');

--- a/src/vs/base/common/tfIdf.ts
+++ b/src/vs/base/common/tfIdf.ts
@@ -216,7 +216,7 @@ export class TfIdfCalculator {
 }
 
 /**
- * Normalize the scores to be between 0 and 1 and sort them decending.
+ * Normalize the scores to be between 0 and 1 and sort them descending.
  * @param scores array of scores from {@link TfIdfCalculator.calculateScores}
  * @returns normalized scores
  */

--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -32,7 +32,7 @@ export function isArrayOf<T>(value: unknown, check: (item: unknown) => item is T
  */
 export function isObject(obj: unknown): obj is Object {
 	// The method can't do a type cast since there are type (like strings) which
-	// are subclasses of any put not positvely matched by the function. Hence type
+	// are subclasses of any put not positively matched by the function. Hence type
 	// narrowing results in wrong results.
 	return typeof obj === 'object'
 		&& obj !== null
@@ -42,7 +42,7 @@ export function isObject(obj: unknown): obj is Object {
 }
 
 /**
- * @returns whether the provided parameter is of type `Buffer` or Uint8Array dervived type
+ * @returns whether the provided parameter is of type `Buffer` or Uint8Array derived type
  */
 export function isTypedArray(obj: unknown): obj is Object {
 	const TypedArray = Object.getPrototypeOf(Uint8Array);

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -98,7 +98,7 @@ export interface IDirent {
 
 /**
  * Drop-in replacement of `fs.readdir` with support
- * for converting from macOS NFD unicon form to NFC
+ * for converting from macOS NFD unicode form to NFC
  * (https://github.com/nodejs/node/issues/2165)
  */
 async function readdir(path: string): Promise<string[]>;

--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -50,13 +50,13 @@ suite('Arrays', () => {
 
 	test('quickSelect', () => {
 
-		function assertMedian(expexted: number, data: number[], nth: number = Math.floor(data.length / 2)) {
+		function assertMedian(expected: number, data: number[], nth: number = Math.floor(data.length / 2)) {
 			const compare = (a: number, b: number) => a - b;
 			const actual1 = arrays.quickSelect(nth, data, compare);
-			assert.strictEqual(actual1, expexted);
+			assert.strictEqual(actual1, expected);
 
 			const actual2 = data.slice().sort(compare)[nth];
-			assert.strictEqual(actual2, expexted);
+			assert.strictEqual(actual2, expected);
 		}
 
 		assertMedian(5, [9, 1, 0, 2, 3, 4, 6, 8, 7, 10, 5]);

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -549,7 +549,7 @@ suite('Filters', () => {
 		assertMatches('cno', 'co_new', '^c^o_^new', fuzzyScoreGracefulAggressive);
 	});
 
-	test('List highlight filter: Not all characters from match are highlighterd #66923', () => {
+	test('List highlight filter: Not all characters from match are highlighted #66923', () => {
 		assertMatches('foo', 'barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar_foo', 'barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar_^f^o^o', fuzzyScore);
 	});
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -445,7 +445,7 @@ export class CodeApplication extends Disposable {
 			// For all other URLs, delegate to the OS.
 			contents.setWindowOpenHandler(details => {
 
-				// about:blank windows can open as window witho our default options
+				// about:blank windows can open as window without our default options
 				if (details.url === 'about:blank') {
 					this.logService.trace('[aux window] webContents#setWindowOpenHandler: Allowing auxiliary window to open on about:blank');
 
@@ -655,7 +655,7 @@ export class CodeApplication extends Disposable {
 		const nativeHostMainService = this.nativeHostMainService = accessor.get(INativeHostMainService);
 		const dialogMainService = accessor.get(IDialogMainService);
 
-		// Install URL handlers that deal with protocl URLs either
+		// Install URL handlers that deal with protocol URLs either
 		// from this process by opening windows and/or by forwarding
 		// the URLs into a window process to be handled there.
 

--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -73,7 +73,7 @@ function getDataToCopy(viewModel: IViewModel, modelSelections: Range[], emptySel
 
 /**
  * Every time we write to the clipboard, we record a bit of extra metadata here.
- * Every time we read from the cipboard, if the text matches our last written text,
+ * Every time we read from the clipboard, if the text matches our last written text,
  * we can fetch the previous metadata.
  */
 export class InMemoryClipboardMetadataManager {

--- a/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
@@ -162,7 +162,7 @@ export class TextureAtlas extends Disposable {
 
 	/**
 	 * Warms up the atlas by rasterizing all printable ASCII characters for each token color. This
-	 * is distrubuted over multiple idle callbacks to avoid blocking the main thread.
+	 * is distributed over multiple idle callbacks to avoid blocking the main thread.
 	 */
 	private _warmUpAtlas(rasterizer: IGlyphRasterizer): void {
 		const colorMap = this._colorMap;

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2236,7 +2236,7 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, IGo
 					...jsonSubset,
 				},
 				'editor.gotoLocation.multipleImplementations': {
-					description: nls.localize('editor.editor.gotoLocation.multipleImplemenattions', "Controls the behavior the 'Go to Implementations'-command when multiple target locations exist."),
+					description: nls.localize('editor.editor.gotoLocation.multipleImplementations', "Controls the behavior the 'Go to Implementations'-command when multiple target locations exist."),
 					...jsonSubset,
 				},
 				'editor.gotoLocation.multipleReferences': {
@@ -5245,7 +5245,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 				'editor.suggest.showClasses': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showClasss', "When enabled IntelliSense shows `class`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showClasses', "When enabled IntelliSense shows `class`-suggestions.")
 				},
 				'editor.suggest.showStructs': {
 					type: 'boolean',
@@ -5265,7 +5265,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 				'editor.suggest.showProperties': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showPropertys', "When enabled IntelliSense shows `property`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showProperties', "When enabled IntelliSense shows `property`-suggestions.")
 				},
 				'editor.suggest.showEvents': {
 					type: 'boolean',
@@ -6619,7 +6619,7 @@ export const EditorOptions = {
 	selectionHighlightMaxLength: register(new EditorIntOption(
 		EditorOption.selectionHighlightMaxLength, 'selectionHighlightMaxLength',
 		200, 0, Constants.MAX_SAFE_SMALL_INTEGER,
-		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similiar matches are not highlighted. Set to zero for unlimited.") }
+		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similar matches are not highlighted. Set to zero for unlimited.") }
 	)),
 	selectionHighlightMultiline: register(new EditorBooleanOption(
 		EditorOption.selectionHighlightMultiline, 'selectionHighlightMultiline', false,

--- a/src/vs/editor/common/core/edits/lineEdit.ts
+++ b/src/vs/editor/common/core/edits/lineEdit.ts
@@ -147,7 +147,7 @@ export class LineEdit {
 			result.push(`${specialChar} ${origLn} ${modLn} ${content}`);
 		}
 
-		function pushSeperator() {
+		function pushSeparator() {
 			result.push('---');
 		}
 
@@ -156,7 +156,7 @@ export class LineEdit {
 
 		for (const edits of groupAdjacentBy(this.replacements, (e1, e2) => e1.lineRange.distanceToRange(e2.lineRange) <= 5)) {
 			if (!first) {
-				pushSeperator();
+				pushSeparator();
 			} else {
 				first = false;
 			}

--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -138,7 +138,7 @@ export function getInheritIndentForLine(
 		// it doesn't increase indent of following lines
 		// it doesn't increase just next line
 		// so current line is not affect by precedingUnIgnoredLine
-		// and then we should get a correct inheritted indentation from above lines
+		// and then we should get a correct inherited indentation from above lines
 		if (precedingUnIgnoredLine === 1) {
 			return {
 				indentation: strings.getLeadingWhitespace(model.getLineContent(precedingUnIgnoredLine)),

--- a/src/vs/editor/common/languages/supports/richEditBrackets.ts
+++ b/src/vs/editor/common/languages/supports/richEditBrackets.ts
@@ -71,7 +71,7 @@ export class RichEditBracket {
 	 * This regular expression is built in a way that it is aware of the other bracket
 	 * pairs defined for the language, so it might match brackets from other groups.
 	 *
-	 * See the fine defails in `getReversedRegexForBracketPair`.
+	 * See the fine details in `getReversedRegexForBracketPair`.
 	 */
 	readonly reversedRegex: RegExp;
 	private readonly _openSet: Set<string>;
@@ -300,7 +300,7 @@ function unique(arr: string[]): string[] {
  * The two bracket pairs do not collide because no open or close brackets are equal.
  * So the function getRegexForBracketPair is called twice, once with
  * the ['begin'], ['end'] group consisting of one bracket pair, and once with
- * the ['if'], ['end if'] group consiting of the other bracket pair.
+ * the ['if'], ['end if'] group consisting of the other bracket pair.
  *
  * But there could be a situation where an occurrence of 'end if' is mistaken
  * for an occurrence of 'end'.

--- a/src/vs/editor/common/viewLayout/viewLineRenderer.ts
+++ b/src/vs/editor/common/viewLayout/viewLineRenderer.ts
@@ -1183,7 +1183,7 @@ function _renderLine(input: ResolvedRenderLineInput, sb: StringBuilder): RenderL
 
 	if (!lastCharacterMappingDefined) {
 		// When getting client rects for the last character, we will position the
-		// text range at the end of the span, insteaf of at the beginning of next span
+		// text range at the end of the span, instead of at the beginning of next span
 		characterMapping.setColumnInfo(len + 1, parts.length - 1, charOffsetInPart, charHorizontalOffset);
 	}
 

--- a/src/vs/editor/common/viewModel/inlineDecorations.ts
+++ b/src/vs/editor/common/viewModel/inlineDecorations.ts
@@ -193,7 +193,7 @@ export interface IInjectedTextInlineDecorationsComputerContext {
 	 */
 	getInjectionOffsets(modelLineNumber: number): number[] | null;
 	/**
-	 * Get the break offets for a model line number
+	 * Get the break offsets for a model line number
 	 */
 	getBreakOffsets(modelLineNumber: number): number[];
 	/**


### PR DESCRIPTION
This is done via a script I wrote to report typos and after I checked them multiple times manually, I applied the correct ones.

This includes many parts, from documentation to variable names to translatable strings.

This is all done manually so if there is a mistake, my apologies.
