### PR TITLE
 Fix listener leak from multiple background OutputMonitors on same terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -10,7 +10,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
 import { basename, posix, win32 } from '../../../../../../base/common/path.js';
@@ -1809,22 +1809,33 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// Continue the output monitor in background mode for prompt-for-input detection.
 		// The monitor wakes only on new terminal data (not on a fixed interval), so
 		// resource cost is proportional to actual terminal activity.
-		let bgCts: CancellationTokenSource | undefined;
+		const store = new DisposableStore();
 		if (outputMonitor) {
-			bgCts = new CancellationTokenSource();
+			const bgCts = new CancellationTokenSource();
+			store.add(toDisposable(() => {
+				// Cancel before dispose so that onCancellationRequested handlers fire
+				// and pending promises (e.g. _waitForNewData) resolve properly.
+				bgCts.cancel();
+				bgCts.dispose();
+			}));
+			store.add(outputMonitor);
 			outputMonitor.continueMonitoringAsync(bgCts.token);
 		}
 
-		const listener = commandDetection.onCommandFinished(command => {
+		store.add(sessionRef);
+
+		const disposeNotification = () => this._backgroundNotifications.deleteAndDispose(termId);
+
+		store.add(commandDetection.onCommandFinished(command => {
 			const execution = RunInTerminalTool._activeExecutions.get(termId);
 			if (!execution) {
-				cleanup();
+				disposeNotification();
 				return;
 			}
 
 			// Dispose after first notification to avoid chatty repeated messages
 			// if the user runs additional commands via send_to_terminal.
-			cleanup();
+			disposeNotification();
 
 			const exitCode = command.exitCode;
 			const exitCodeText = exitCode !== undefined ? ` with exit code ${exitCode}` : '';
@@ -1841,41 +1852,28 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
 			});
-		});
+		}));
 
 		// Clean up all background resources when the terminal is disposed
 		// (e.g. user closes the terminal) to avoid leaking listeners and monitors.
-		const disposedListener = terminalInstance.onDisposed(() => {
-			cleanup();
-		});
+		store.add(terminalInstance.onDisposed(() => {
+			disposeNotification();
+		}));
 
 		// When a checkpoint is restored, requests are removed from the model.
 		// Cancel the background notification and dispose the terminal so that
 		// background processes don't outlive the rolled-back session state.
-		const modelChangeListener = sessionRef.object.onDidChange(e => {
+		store.add(sessionRef.object.onDidChange(e => {
 			if (e.kind === 'removeRequest') {
 				this._logService.debug(`RunInTerminalTool: Request removed from session, cleaning up background terminal ${termId}`);
 				RunInTerminalTool._activeExecutions.get(termId)?.dispose();
 				RunInTerminalTool._activeExecutions.delete(termId);
-				cleanup();
+				disposeNotification();
 				terminalInstance.dispose();
 			}
-		});
+		}));
 
-		const cleanup = () => {
-			this._backgroundNotifications.deleteAndLeak(termId);
-			listener.dispose();
-			disposedListener.dispose();
-			modelChangeListener.dispose();
-			// Cancel before dispose so that onCancellationRequested handlers fire
-			// and pending promises (e.g. _waitForNewData) resolve properly.
-			bgCts?.cancel();
-			bgCts?.dispose();
-			outputMonitor?.dispose();
-			sessionRef.dispose();
-		};
-
-		this._backgroundNotifications.set(termId, { dispose: cleanup });
+		this._backgroundNotifications.set(termId, store);
 	}
 	// #endregion
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -10,7 +10,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, type IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
 import { basename, posix, win32 } from '../../../../../../base/common/path.js';
@@ -431,6 +431,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	protected readonly _sessionTerminalAssociations = new ResourceMap<IToolTerminal>();
 	protected readonly _sessionTerminalInstances = new ResourceMap<Set<ITerminalInstance>>();
 	private readonly _terminalsBeingDisposedBySessionCleanup = new Set<ITerminalInstance>();
+
+	/**
+	 * Tracks active background completion notifications per terminal ID.
+	 * When a new notification is registered for a terminal that already has one,
+	 * the previous notification (and its OutputMonitor) is disposed first to
+	 * prevent listener accumulation on the terminal's onDidInputData emitter.
+	 */
+	private readonly _backgroundNotifications = new Map<string, IDisposable>();
 
 	// Immutable window state
 	protected readonly _osBackend: Promise<OperatingSystem>;
@@ -1766,6 +1774,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 * The output monitor is cancelled and disposed when a command finishes.
 	 */
 	private _registerCompletionNotification(terminalInstance: ITerminalInstance, termId: string, chatSessionResource: URI, commandName: string, outputMonitor?: OutputMonitor): void {
+		// Dispose any previous background notification for this terminal to prevent
+		// listener accumulation (e.g. multiple onDidInputData subscriptions).
+		this._backgroundNotifications.get(termId)?.dispose();
+		this._backgroundNotifications.delete(termId);
+
 		const commandDetection = terminalInstance.capabilities.get(TerminalCapability.CommandDetection);
 		if (!commandDetection) {
 			outputMonitor?.dispose();
@@ -1851,13 +1864,19 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		});
 
 		const cleanup = () => {
+			this._backgroundNotifications.delete(termId);
 			listener.dispose();
 			disposedListener.dispose();
 			modelChangeListener.dispose();
+			// Cancel before dispose so that onCancellationRequested handlers fire
+			// and pending promises (e.g. _waitForNewData) resolve properly.
+			bgCts?.cancel();
 			bgCts?.dispose();
 			outputMonitor?.dispose();
 			sessionRef.dispose();
 		};
+
+		this._backgroundNotifications.set(termId, { dispose: cleanup });
 
 		this._register(listener);
 		this._register(disposedListener);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -10,7 +10,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, type IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
 import { basename, posix, win32 } from '../../../../../../base/common/path.js';
@@ -438,7 +438,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 * the previous notification (and its OutputMonitor) is disposed first to
 	 * prevent listener accumulation on the terminal's onDidInputData emitter.
 	 */
-	private readonly _backgroundNotifications = new Map<string, IDisposable>();
+	private readonly _backgroundNotifications = this._register(new DisposableMap<string>());
 
 	// Immutable window state
 	protected readonly _osBackend: Promise<OperatingSystem>;
@@ -1776,8 +1776,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	private _registerCompletionNotification(terminalInstance: ITerminalInstance, termId: string, chatSessionResource: URI, commandName: string, outputMonitor?: OutputMonitor): void {
 		// Dispose any previous background notification for this terminal to prevent
 		// listener accumulation (e.g. multiple onDidInputData subscriptions).
-		this._backgroundNotifications.get(termId)?.dispose();
-		this._backgroundNotifications.delete(termId);
+		this._backgroundNotifications.deleteAndDispose(termId);
 
 		const commandDetection = terminalInstance.capabilities.get(TerminalCapability.CommandDetection);
 		if (!commandDetection) {
@@ -1864,7 +1863,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		});
 
 		const cleanup = () => {
-			this._backgroundNotifications.delete(termId);
+			this._backgroundNotifications.deleteAndLeak(termId);
 			listener.dispose();
 			disposedListener.dispose();
 			modelChangeListener.dispose();
@@ -1877,10 +1876,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		};
 
 		this._backgroundNotifications.set(termId, { dispose: cleanup });
-
-		this._register(listener);
-		this._register(disposedListener);
-		this._register(modelChangeListener);
 	}
 	// #endregion
 }


### PR DESCRIPTION
Fixes #308053

When commands go to background via `continueMonitoringAsync()`, the old `OutputMonitor` was only cleaned up on `onCommandFinished` — which never fires for long-running processes. This caused `onDidInputData` listeners to accumulate.

Tracks active background notifications per terminal ID so the previous monitor is disposed before registering a new one. 

