### PR TITLE
use backticks for sent terminal commands

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -90,10 +90,10 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		const displayCommand = buildCommandDisplayText(args.command);
 
 		const invocationMessage = new MarkdownString();
-		invocationMessage.appendText(localize('send.progressive', "Sending {0} to terminal", displayCommand));
+		invocationMessage.appendMarkdown(localize('send.progressive', "Sending `{0}` to terminal", displayCommand));
 
 		const pastTenseMessage = new MarkdownString();
-		pastTenseMessage.appendText(localize('send.past', "Sent {0} to terminal", displayCommand));
+		pastTenseMessage.appendMarkdown(localize('send.past', "Sent `{0}` to terminal", displayCommand));
 
 		const confirmationMessage = new MarkdownString();
 		confirmationMessage.appendText(localize('send.confirm.message', "Run {0} in background terminal {1}", displayCommand, args.id));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -59,6 +59,18 @@ export interface ISendToTerminalInputParams {
 
 const SEND_TO_TERMINAL_REFERENCE_NAME = 'sendToTerminal';
 
+/**
+ * Wraps arbitrary text in a markdown inline code span using a backtick fence
+ * long enough to safely contain any backtick sequences present in the text.
+ */
+function toMarkdownInlineCode(text: string): string {
+	const longestBacktickRun = Math.max(0, ...(text.match(/`+/g) ?? []).map(m => m.length));
+	const fence = '`'.repeat(longestBacktickRun + 1);
+	const needsSpace = text.startsWith('`') || text.endsWith('`');
+	const content = needsSpace ? ` ${text} ` : text;
+	return `${fence}${content}${fence}`;
+}
+
 export class SendToTerminalTool extends Disposable implements IToolImpl {
 
 	private readonly _autoApproveAnalyzer: CommandLineAutoApproveAnalyzer;
@@ -88,12 +100,13 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		const args = context.parameters as ISendToTerminalInputParams;
 		const displayCommand = buildCommandDisplayText(args.command);
+		const safeInlineCode = toMarkdownInlineCode(displayCommand);
 
 		const invocationMessage = new MarkdownString();
-		invocationMessage.appendMarkdown(localize('send.progressive', "Sending `{0}` to terminal", displayCommand));
+		invocationMessage.appendMarkdown(localize('send.progressive', "Sending {0} to terminal", safeInlineCode));
 
 		const pastTenseMessage = new MarkdownString();
-		pastTenseMessage.appendMarkdown(localize('send.past', "Sent `{0}` to terminal", displayCommand));
+		pastTenseMessage.appendMarkdown(localize('send.past', "Sent {0} to terminal", safeInlineCode));
 
 		const confirmationMessage = new MarkdownString();
 		confirmationMessage.appendText(localize('send.confirm.message', "Run {0} in background terminal {1}", displayCommand, args.id));


### PR DESCRIPTION
part of #308043

Renders the sent command as inline code in the "Sending … to terminal" and "Sent … to terminal" progress messages. Uses a `toMarkdownInlineCode` helper that dynamically sizes the backtick fence to be one longer than the longest backtick run in the command, ensuring commands containing backticks (e.g. shell command substitution like `` echo `date` ``) are always safely wrapped without breaking the inline-code span or allowing unintended markdown rendering.