### PR TITLE
chat: add policy for `chat.plugins.enabled`

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -163,6 +163,21 @@
             "included": true
         },
         {
+            "key": "chat.plugins.enabled",
+            "name": "ChatPluginsEnabled",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.116",
+            "localization": {
+                "description": {
+                    "key": "chat.plugins.enabled.policy",
+                    "value": "Enable agent plugin integration in chat."
+                }
+            },
+            "type": "boolean",
+            "default": true,
+            "included": true
+        },
+        {
             "key": "chat.agent.enabled",
             "name": "ChatAgentMode",
             "category": "InteractiveSession",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -169,7 +169,7 @@
             "minimumVersion": "1.116",
             "localization": {
                 "description": {
-                    "key": "chat.plugins.enabled.policy",
+                    "key": "chat.plugins.enabled",
                     "value": "Enable agent plugin integration in chat."
                 }
             },

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -730,8 +730,8 @@ configurationRegistry.registerConfiguration({
 				minimumVersion: '1.116',
 				localization: {
 					description: {
-						key: 'chat.plugins.enabled.policy',
-						value: nls.localize('chat.plugins.enabled.policy', "Enable agent plugin integration in chat."),
+						key: 'chat.plugins.enabled',
+						value: nls.localize('chat.plugins.enabled', "Enable agent plugin integration in chat."),
 					}
 				},
 			},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -724,6 +724,17 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.plugins.enabled', "Enable agent plugin integration in chat."),
 			default: true,
 			tags: ['preview'],
+			policy: {
+				name: 'ChatPluginsEnabled',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.116',
+				localization: {
+					description: {
+						key: 'chat.plugins.enabled.policy',
+						value: nls.localize('chat.plugins.enabled.policy', "Enable agent plugin integration in chat."),
+					}
+				},
+			},
 		},
 		[ChatConfiguration.PluginLocations]: {
 			type: 'object',


### PR DESCRIPTION
tracking https://github.com/microsoft/vscode-internalbacklog/issues/7245

Add a managed policy `ChatPluginsEnabled` to the `chat.plugins.enabled` setting so that organizations can control whether agent plugin integration is enabled via device management.

**Changes:**
- `src/vs/workbench/contrib/chat/browser/chat.contribution.ts` — added `policy` block with name `ChatPluginsEnabled`, category `InteractiveSession`, and `minimumVersion: '1.116'`
- `build/lib/policies/policyData.jsonc` — exported policy data entry