### PR TITLE
ChatSessionCustomizationProvider: fix groupKey, deletion refresh, section visibility, and dropdown UX

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1979,10 +1979,13 @@ export class AICustomizationListWidget extends Disposable {
 
 			for (const item of matchedItems) {
 				const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
-				const group = groups.find(g => g.groupKey === key);
-				if (group) {
-					group.items.push(item);
+				let group = groups.find(g => g.groupKey === key);
+				if (!group) {
+					// Dynamically create a group for unknown groupKeys from providers
+					group = { groupKey: key, label: formatDisplayName(key), icon: Codicon.folder, description: '', items: [] };
+					groups.push(group);
 				}
+				group.items.push(item);
 			}
 
 			this.buildGroupedEntries(groups);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1780,6 +1780,13 @@ export class AICustomizationListWidget extends Disposable {
 			}
 		}
 
+		// file: URI under an installed plugin = plugin
+		for (const plugin of this.agentPluginService.plugins.get()) {
+			if (isEqualOrParent(uri, plugin.uri)) {
+				return { storage: PromptsStorage.plugin };
+			}
+		}
+
 		// file: URI elsewhere = user directory
 		return { storage: PromptsStorage.user };
 	}
@@ -1968,11 +1975,13 @@ export class AICustomizationListWidget extends Disposable {
 						{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
 						{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
 						{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
+						{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
 						{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
 					]
 					: [
 						{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
 						{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
+						{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
 						{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
 						{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
 					];

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -285,6 +285,7 @@ registerAction2(class extends Action2 {
 		const dialogService = accessor.get(IDialogService);
 		const telemetryService = accessor.get(ITelemetryService);
 		const workspaceService = accessor.get(IAICustomizationWorkspaceService);
+		const editorService = accessor.get(IEditorService);
 
 		const uri = extractURI(context);
 		const storage = extractStorage(context);
@@ -385,6 +386,13 @@ registerAction2(class extends Action2 {
 				if (projectRoot) {
 					await workspaceService.deleteFiles(projectRoot, [deleteTarget]);
 				}
+			}
+
+			// Refresh the list to remove the deleted item immediately
+			// (provider's onDidChange may not fire if it doesn't watch the filesystem)
+			const activeEditor = editorService.activeEditorPane;
+			if (activeEditor instanceof AICustomizationManagementEditor) {
+				activeEditor.refreshList();
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -641,18 +641,17 @@ export class AICustomizationManagementEditor extends EditorPane {
 	 * unregistered).
 	 */
 	private ensureHarnessDropdown(): void {
-		const harnesses = this.harnessService.availableHarnesses.get();
-		const shouldShow = this.isHarnessSelectorEnabled && harnesses.length > 1;
-
-		if (shouldShow && !this.harnessDropdownContainer && this.sidebarContent) {
-			this.createHarnessDropdown(this.sidebarContent);
-		} else if (!shouldShow && this.harnessDropdownContainer) {
+		if (!this.isHarnessSelectorEnabled && this.harnessDropdownContainer) {
+			// Setting is off — remove the dropdown entirely
 			this.harnessDropdownContainer.remove();
 			this.harnessDropdownContainer = undefined;
 			this.harnessDropdownButton = undefined;
 			this.harnessDropdownIcon = undefined;
 			this.harnessDropdownLabel = undefined;
+		} else if (this.isHarnessSelectorEnabled && !this.harnessDropdownContainer && this.sidebarContent) {
+			this.createHarnessDropdown(this.sidebarContent);
 		}
+		// Visibility is handled by updateHarnessDropdown based on harness count
 	}
 
 	private updateHarnessDropdown(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -618,6 +618,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.harnessDropdownButton = DOM.append(container, $('button.harness-dropdown-button'));
 		this.harnessDropdownButton.setAttribute('aria-label', localize('selectHarness', "Select customization target"));
 		this.harnessDropdownButton.setAttribute('aria-haspopup', 'listbox');
+		this.editorDisposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.harnessDropdownButton, () => {
+			const descriptor = this.harnessService.availableHarnesses.get().find(h => h.id === this.harnessService.activeHarness.get());
+			return descriptor?.label ?? '';
+		}));
 
 		this.harnessDropdownIcon = DOM.append(this.harnessDropdownButton, $('span.harness-dropdown-icon'));
 		this.harnessDropdownLabel = DOM.append(this.harnessDropdownButton, $('span.harness-dropdown-label'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -301,6 +301,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private readonly editorDisposables = this._register(new DisposableStore());
 	private readonly promptsSectionCountScheduler = this._register(new RunOnceScheduler(() => this._doRefreshAllPromptsSectionCounts(), 100));
 	private _editorContentChanged = false;
+	private _previousActiveHarnessId: string | undefined;
 
 	// Folder picker (sessions window only)
 	private folderPickerContainer: HTMLElement | undefined;
@@ -573,6 +574,16 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.rebuildVisibleSections();
 			this.ensureHarnessDropdown();
 			this.updateHarnessDropdown();
+			// Reset counts to zero immediately on harness switch to prevent
+			// stale counts from the previous harness flashing before the async
+			// count refresh completes. Only reset when the active harness
+			// actually changed to avoid flicker on harness registration events.
+			if (this._previousActiveHarnessId !== undefined && this._previousActiveHarnessId !== activeId) {
+				for (const section of this.sections) {
+					this.updateSectionCount(section.id, 0);
+				}
+			}
+			this._previousActiveHarnessId = activeId;
 			this.refreshAllPromptsSectionCounts();
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -907,6 +907,8 @@
 	display: flex;
 	gap: 4px;
 	flex-shrink: 0;
+	/* Reserve space so focused button outlines do not clip against the widget's overflow:hidden */
+	padding: 1px;
 }
 
 .mcp-list-widget .list-button-group .monaco-button:focus-visible {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -228,7 +228,7 @@
 	align-items: center;
 	gap: 8px;
 	flex-shrink: 0;
-	padding: 6px 0;
+	padding: 6px 2px;
 }
 
 .ai-customization-list-widget .list-search-container,


### PR DESCRIPTION
Follow-up fixes for the `ChatSessionCustomizationProvider` API, addressing bugs found during testing (microsoft/vscode-internalbacklog#7330).

## Commits

- **Show provider items with custom groupKey** — Items with a custom `groupKey` were silently dropped because no matching group existed. Dynamically create groups for unknown keys with title-cased labels. Fixes microsoft/vscode-internalbacklog#7402
- **Refresh list after deleting a customization item** — Explicitly refresh the list after deletion so removed items disappear immediately. Fixes microsoft/vscode-internalbacklog#7401
- **Reset section counts on harness switch** — Zero-out sidebar counts on harness switch (only when the active harness actually changes) to prevent stale counts flashing. Fixes microsoft/vscode-internalbacklog#7400
- **Add tooltip to harness dropdown** — Show the provider label as a managed hover tooltip. Fixes microsoft/vscode-internalbacklog#7396
- **Prevent dropdown from jumping** — Keep the dropdown DOM in place when providers register async; toggle visibility via CSS. Fixes microsoft/vscode-internalbacklog#7398
- **Fix focus outline clipping on plugin page buttons** — Add padding to the button group container so the focus outline isn't clipped by the parent's `overflow: hidden`. Fixes microsoft/vscode-internalbacklog#7385
- **Classify plugin-sourced items correctly in provider path** — Items from installed plugins (agent-plugins directory) were showing as "User". Now checks against `IAgentPluginService.plugins` URIs and classifies as `plugin` storage. Adds "Plugins" group to the provider layout. Fixes microsoft/vscode-internalbacklog#7330