### PR TITLE
Allow version bump PRs with package-lock.json changes

### DIFF
--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -22,15 +22,21 @@ jobs:
             echo "No engineering systems were modified in this PR"
           fi
       - name: Allow automated distro or version field updates
-        id: package_json_field_exception
+        id: bot_field_exception
         if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && github.event.pull_request.user.login == 'vs-code-engineering[bot]' }}
         run: |
-          # Allow the vs-code-engineering bot ONLY when package.json is the
-          # sole changed file and the diff exclusively touches the "distro"
-          # or "version" field.
+          # Allow the vs-code-engineering bot ONLY when:
+          # 1. package.json is the sole changed file and the diff exclusively
+          #    touches the "distro" or "version" field, OR
+          # 2. package.json + package-lock.json are the only changed files and
+          #    the package.json diff exclusively touches the "version" field
+          #    (lock file updates are expected from npm install after version bump).
+
           ONLY_PKG=$(jq -e '. == ["package.json"]' "$HOME/files.json" > /dev/null 2>&1 && echo true || echo false)
-          if [[ "$ONLY_PKG" != "true" ]]; then
-            echo "Bot modified files beyond package.json — not allowed"
+          PKG_AND_LOCK=$(jq -e '. | sort == ["package-lock.json", "package.json"]' "$HOME/files.json" > /dev/null 2>&1 && echo true || echo false)
+
+          if [[ "$ONLY_PKG" != "true" && "$PKG_AND_LOCK" != "true" ]]; then
+            echo "Bot modified files beyond package.json (+ package-lock.json) — not allowed"
             echo "allowed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -40,12 +46,19 @@ jobs:
             echo "allowed=false" >> $GITHUB_OUTPUT
             exit 0
           }
-          CHANGED_LINES=$(echo "$DIFF" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | wc -l)
-          DISTRO_LINES=$(echo "$DIFF" | grep -cE '^[+-][[:space:]]*"distro"[[:space:]]*:' || true)
-          VERSION_LINES=$(echo "$DIFF" | grep -cE '^[+-][[:space:]]*"version"[[:space:]]*:' || true)
 
-          if [[ "$CHANGED_LINES" -eq 2 && ("$DISTRO_LINES" -eq 2 || "$VERSION_LINES" -eq 2) ]]; then
+          # Extract only the package.json diff section (ignore package-lock.json changes)
+          PKG_DIFF=$(echo "$DIFF" | awk '/^diff --git a\/package\.json b\/package\.json/{p=1} p && /^diff --git / && !/^diff --git a\/package\.json/{exit} p{print}')
+
+          CHANGED_LINES=$(echo "$PKG_DIFF" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | wc -l)
+          DISTRO_LINES=$(echo "$PKG_DIFF" | grep -cE '^[+-][[:space:]]*"distro"[[:space:]]*:' || true)
+          VERSION_LINES=$(echo "$PKG_DIFF" | grep -cE '^[+-][[:space:]]*"version"[[:space:]]*:' || true)
+
+          if [[ "$ONLY_PKG" == "true" && "$CHANGED_LINES" -eq 2 && ("$DISTRO_LINES" -eq 2 || "$VERSION_LINES" -eq 2) ]]; then
             echo "Distro-only or version-only update by bot — allowing"
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          elif [[ "$PKG_AND_LOCK" == "true" && "$CHANGED_LINES" -eq 2 && "$VERSION_LINES" -eq 2 ]]; then
+            echo "Version bump with lock file update by bot — allowing"
             echo "allowed=true" >> $GITHUB_OUTPUT
           else
             echo "Bot changed more than a single allowed field (distro or version) — not allowed"
@@ -54,21 +67,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prevent Copilot from modifying engineering systems
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.distro_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
         run: |
           echo "Copilot is not allowed to modify .github/workflows, build folder files, or package.json files."
           echo "If you need to update engineering systems, please do so manually or through authorized means."
           exit 1
       - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: get_permissions
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.distro_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
         with:
           route: GET /repos/microsoft/vscode/collaborators/${{ github.event.pull_request.user.login }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set control output variable
         id: control
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.distro_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
         run: |
           echo "user: ${{ github.event.pull_request.user.login }}"
           echo "role: ${{ fromJson(steps.get_permissions.outputs.data).permission }}"
@@ -76,7 +89,7 @@ jobs:
           echo "should_run: ${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) }}"
           echo "should_run=${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) && github.event.pull_request.user.login != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
       - name: Check for engineering system changes
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.distro_exception.outputs.allowed != 'true' && steps.control.outputs.should_run == 'true' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.control.outputs.should_run == 'true' }}
         run: |
           echo "Changes to .github/workflows/, build/ folder files, or package.json files aren't allowed in PRs."
           exit 1


### PR DESCRIPTION
Follow-up to #308090. Extends the bot exception to also allow `package-lock.json` changes alongside `package.json` when the bot bumps the `"version"` field.

Version bump PRs run `npm install --package-lock-only` after `npm version minor`, which updates `package-lock.json`. The check now:

- **package.json only** → allow if exactly 2 lines changed matching `"distro"` OR `"version"`
- **package.json + package-lock.json** → allow if the `package.json` diff has exactly 2 lines matching `"version"` (distro changes should not need lock file updates)
- **Any other files** → blocked

Uses `awk` to extract only the `package.json` portion of the diff so `package-lock.json` line counts don't interfere with the check.