### PR TITLE
agentHost: Simplify SSH relay reconnect with dispose-and-recreate pattern

### DIFF
--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -51,6 +51,8 @@ interface SSHClient {
 	on(event: 'ready', listener: () => void): SSHClient;
 	on(event: 'error', listener: (err: Error) => void): SSHClient;
 	on(event: 'close', listener: () => void): SSHClient;
+	removeListener(event: 'close', listener: () => void): SSHClient;
+	removeListener(event: 'error', listener: (err: Error) => void): SSHClient;
 	connect(config: Record<string, unknown>): void;
 	exec(command: string, callback: (err: Error | undefined, stream: SSHChannel) => void): SSHClient;
 	forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number, callback: (err: Error | undefined, channel: SSHChannel) => void): SSHClient;
@@ -256,12 +258,21 @@ function sanitizeConfig(config: ISSHAgentHostConfig): ISSHAgentHostConfigSanitiz
 	return sanitized;
 }
 
+/**
+ * State for a single active SSH relay connection.
+ * Immutable and dispose-once — follows the same pattern as TunnelConnection.
+ * On reconnect, the old SSHConnection is disposed and a fresh one is created;
+ * the SSH client can be detached first so only the WebSocket relay is torn down.
+ */
 class SSHConnection extends Disposable {
 	private readonly _onDidClose = new Emitter<void>();
 	readonly onDidClose = this._onDidClose.event;
 
 	readonly config: ISSHAgentHostConfigSanitized;
 	private _closed = false;
+	private _sshClientDetached = false;
+	private readonly _sshCloseListener = () => { this.dispose(); };
+	private readonly _sshErrorListener = () => { this.dispose(); };
 
 	constructor(
 		fullConfig: ISSHAgentHostConfig,
@@ -269,9 +280,10 @@ class SSHConnection extends Disposable {
 		readonly address: string,
 		readonly name: string,
 		readonly connectionToken: string | undefined,
-		sshClient: SSHClient,
+		readonly remotePort: number,
+		readonly sshClient: SSHClient,
 		private readonly _relay: { send: (data: string) => void; close: () => void },
-		remoteStream: SSHChannel | undefined,
+		private readonly _remoteStream: SSHChannel | undefined,
 	) {
 		super();
 
@@ -284,20 +296,29 @@ class SSHConnection extends Disposable {
 			}
 			this._closed = true;
 			this._relay.close();
-			remoteStream?.close();
-			sshClient.end();
+			if (!this._sshClientDetached) {
+				this._remoteStream?.close();
+				sshClient.end();
+			}
 			this._onDidClose.fire();
 		}));
 
 		this._register(this._onDidClose);
 
-		sshClient.on('close', () => {
-			this.dispose();
-		});
+		sshClient.on('close', this._sshCloseListener);
+		sshClient.on('error', this._sshErrorListener);
+	}
 
-		sshClient.on('error', () => {
-			this.dispose();
-		});
+	/**
+	 * Detach the SSH client from this connection so that `dispose()`
+	 * only closes the WebSocket relay without ending the SSH session.
+	 * Also removes event listeners from the SSH client so the old
+	 * connection object is not retained by the shared client.
+	 */
+	detachSshClient(): void {
+		this._sshClientDetached = true;
+		this.sshClient.removeListener('close', this._sshCloseListener);
+		this.sshClient.removeListener('error', this._sshErrorListener);
 	}
 
 	relaySend(data: string): void {
@@ -350,13 +371,70 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		return this._nativeRequire;
 	}
 
-	async connect(config: ISSHAgentHostConfig): Promise<ISSHConnectResult> {
+	async connect(config: ISSHAgentHostConfig, replaceRelay?: boolean): Promise<ISSHConnectResult> {
 		const connectionKey = config.sshConfigHost
 			? `ssh:${config.sshConfigHost}`
 			: `${config.username}@${config.host}:${config.port ?? 22}`;
 
 		const existing = this._connections.get(connectionKey);
 		if (existing) {
+			if (replaceRelay) {
+				// Tear down the old relay and create a fresh one, following
+				// the same dispose-and-recreate pattern as TunnelAgentHostMainService.
+				// The SSH client is detached so only the WebSocket relay is closed.
+				this._logService.info(`${LOG_PREFIX} Reconnecting relay for existing SSH tunnel ${connectionKey}`);
+				const { sshClient, remotePort, connectionToken } = existing;
+
+				// Remove from map and detach SSH client before disposing so
+				// the old relay's close handler (conn?.dispose()) is a no-op.
+				this._connections.deleteAndLeak(connectionKey);
+				existing.detachSshClient();
+				existing.dispose();
+
+				// Create fresh relay and connection. If relay creation fails,
+				// clean up the detached SSH client so it doesn't leak.
+				const connectionId = connectionKey;
+				try {
+					let conn: SSHConnection | undefined; // eslint-disable-line prefer-const
+					const relay = await this._createWebSocketRelay(
+						sshClient, '127.0.0.1', remotePort, connectionToken,
+						(data: string) => this._onDidRelayMessage.fire({ connectionId, data }),
+						() => { conn?.dispose(); },
+					);
+
+					conn = new SSHConnection(
+						config, connectionId, connectionKey, config.name,
+						connectionToken, remotePort, sshClient, relay, undefined,
+					);
+
+					Event.once(conn.onDidClose)(() => {
+						if (this._connections.get(connectionKey) === conn) {
+							this._connections.deleteAndDispose(connectionKey);
+							this._onDidRelayClose.fire(connectionId);
+							this._onDidCloseConnection.fire(connectionId);
+							this._onDidChangeConnections.fire();
+						}
+					});
+
+					this._connections.set(connectionKey, conn);
+
+					return {
+						connectionId: conn.connectionId,
+						address: conn.address,
+						name: conn.name,
+						connectionToken: conn.connectionToken,
+						config: conn.config,
+						sshConfigHost: config.sshConfigHost,
+					};
+				} catch (err) {
+					sshClient.end();
+					this._onDidRelayClose.fire(connectionId);
+					this._onDidCloseConnection.fire(connectionId);
+					this._onDidChangeConnections.fire();
+					throw err;
+				}
+			}
+
 			return {
 				connectionId: existing.connectionId,
 				address: existing.address,
@@ -428,12 +506,13 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			// 6. Connect to remote agent host via WebSocket relay (no local TCP port)
 			reportProgress(localize('sshProgressForwarding', "Connecting to remote agent host..."));
 			const connectionId = connectionKey;
+			let conn: SSHConnection | undefined; // eslint-disable-line prefer-const
 			let relay: { send: (data: string) => void; close: () => void };
 			try {
 				relay = await this._createWebSocketRelay(
 					sshClient, '127.0.0.1', remotePort, connectionToken,
 					(data: string) => this._onDidRelayMessage.fire({ connectionId, data }),
-					() => this._onDidRelayClose.fire(connectionId),
+					() => { conn?.dispose(); },
 				);
 			} catch (relayErr) {
 				if (!existingAH) {
@@ -455,27 +534,31 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				relay = await this._createWebSocketRelay(
 					sshClient, '127.0.0.1', remotePort, connectionToken,
 					(data: string) => this._onDidRelayMessage.fire({ connectionId, data }),
-					() => this._onDidRelayClose.fire(connectionId),
+					() => { conn?.dispose(); },
 				);
 			}
 
 			// 7. Create connection object
 			const address = connectionKey;
-			const conn = new SSHConnection(
+			conn = new SSHConnection(
 				config,
 				connectionId,
 				address,
 				config.name,
 				connectionToken,
+				remotePort,
 				sshClient,
 				relay,
 				agentStream,
 			);
 
 			Event.once(conn.onDidClose)(() => {
-				this._connections.deleteAndDispose(connectionKey);
-				this._onDidCloseConnection.fire(connectionId);
-				this._onDidChangeConnections.fire();
+				if (this._connections.get(connectionKey) === conn) {
+					this._connections.deleteAndDispose(connectionKey);
+					this._onDidRelayClose.fire(connectionId);
+					this._onDidCloseConnection.fire(connectionId);
+					this._onDidChangeConnections.fire();
+				}
 			});
 
 			this._connections.set(connectionKey, conn);
@@ -537,7 +620,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			name,
 			sshConfigHost,
 			remoteAgentHostCommand,
-		});
+		}, /* replaceRelay */ true);
 	}
 
 	async listSSHConfigHosts(): Promise<string[]> {

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -8,7 +8,7 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { SSHAuthMethod, type ISSHAgentHostConfig } from '../../common/sshRemoteAgentHost.js';
+import { SSHAuthMethod, type ISSHAgentHostConfig, type ISSHConnectProgress } from '../../common/sshRemoteAgentHost.js';
 import { SSHRemoteAgentHostMainService } from '../../node/sshRemoteAgentHostService.js';
 
 /** Minimal mock SSHChannel for testing. */
@@ -28,6 +28,7 @@ class MockSSHClient {
 
 	private readonly _execResponses: Array<{ stdout: string; code: number }>;
 	private readonly _closeListeners: Array<() => void> = [];
+	private readonly _errorListeners: Array<() => void> = [];
 
 	constructor(execResponses: Array<{ stdout: string; code: number }> = []) {
 		this._execResponses = execResponses;
@@ -36,6 +37,19 @@ class MockSSHClient {
 	on(event: string, listener: (...args: never[]) => void): this {
 		if (event === 'close') {
 			this._closeListeners.push(listener as () => void);
+		} else if (event === 'error') {
+			this._errorListeners.push(listener as () => void);
+		}
+		return this;
+	}
+
+	removeListener(event: string, listener: (...args: unknown[]) => void): this {
+		const list = event === 'close' ? this._closeListeners : event === 'error' ? this._errorListeners : undefined;
+		if (list) {
+			const idx = list.indexOf(listener as () => void);
+			if (idx >= 0) {
+				list.splice(idx, 1);
+			}
 		}
 		return this;
 	}
@@ -44,6 +58,14 @@ class MockSSHClient {
 		for (const listener of this._closeListeners) {
 			listener();
 		}
+	}
+
+	get closeListenerCount(): number {
+		return this._closeListeners.length;
+	}
+
+	get errorListenerCount(): number {
+		return this._errorListeners.length;
 	}
 
 	connect(): void { /* no-op */ }
@@ -144,6 +166,13 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 	/** Override to intercept relay creation in specific tests. */
 	relayHook: ((call: number) => { send: (data: string) => void; close: () => void } | Error | undefined) | undefined;
 
+	/** Stored onMessage callbacks from relays, most recent last. */
+	private readonly _relayMessageCallbacks: Array<(data: string) => void> = [];
+	/** Stored onClose callbacks from relays, most recent last. */
+	private readonly _relayCloseCallbacks: Array<() => void> = [];
+	/** Stored relay result objects, most recent last (for makePreviousRelaySyncClose). */
+	private readonly _relayResults: Array<{ send: (data: string) => void; close: () => void }> = [];
+
 	protected override async _connectSSH(
 		_config: ISSHAgentHostConfig,
 	) {
@@ -161,15 +190,78 @@ class TestableSSHRemoteAgentHostMainService extends SSHRemoteAgentHostMainServic
 
 	protected override async _createWebSocketRelay(
 		_client: unknown, _dstHost: string, _dstPort: number, _connectionToken: string | undefined,
-		_onMessage: (data: string) => void, _onClose: () => void,
+		onMessage: (data: string) => void, onClose: () => void,
 	) {
 		this.relayCalled++;
+		this._relayMessageCallbacks.push(onMessage);
+		this._relayCloseCallbacks.push(onClose);
 		const hookResult = this.relayHook?.(this.relayCalled);
-		const result = hookResult ?? this.relayResult;
+		if (hookResult !== undefined) {
+			if (hookResult instanceof Error) {
+				throw hookResult;
+			}
+			this._relayResults.push(hookResult);
+			return hookResult;
+		}
+		const result = this.relayResult;
 		if (result instanceof Error) {
 			throw result;
 		}
-		return result;
+		// Return a distinct object per call so each SSHConnection gets its own relay
+		const relayObj = { send: result.send, close: result.close };
+		this._relayResults.push(relayObj);
+		return relayObj;
+	}
+
+	override async resolveSSHConfig(_host: string): ReturnType<SSHRemoteAgentHostMainService['resolveSSHConfig']> {
+		return {
+			hostname: '10.0.0.1',
+			port: 22,
+			user: 'testuser',
+			identityFile: [],
+			forwardAgent: false,
+		};
+	}
+
+	/**
+	 * Simulate the old (superseded) relay's WebSocket close event firing.
+	 * This calls the onClose callback of the second-to-last relay.
+	 */
+	simulateOldRelayClose(): void {
+		if (this._relayCloseCallbacks.length >= 2) {
+			this._relayCloseCallbacks[this._relayCloseCallbacks.length - 2]();
+		}
+	}
+
+	/**
+	 * Modify the most recently created relay so that calling close()
+	 * synchronously fires its onClose callback. This simulates a WebSocket
+	 * implementation that fires the 'close' event inline during ws.close().
+	 */
+	makePreviousRelaySyncClose(): void {
+		const idx = this._relayResults.length - 1;
+		if (idx >= 0 && this._relayCloseCallbacks.length > idx) {
+			const onClose = this._relayCloseCallbacks[idx];
+			this._relayResults[idx].close = () => { onClose(); };
+		}
+	}
+
+	/**
+	 * Simulate a message arriving on a specific relay (0-indexed).
+	 * Defaults to the most recent relay.
+	 */
+	simulateRelayMessage(data: string, relayIndex?: number): void {
+		const idx = relayIndex ?? this._relayMessageCallbacks.length - 1;
+		this._relayMessageCallbacks[idx]?.(data);
+	}
+
+	/**
+	 * Simulate the current (active) relay's WebSocket close event firing.
+	 */
+	simulateCurrentRelayClose(): void {
+		if (this._relayCloseCallbacks.length > 0) {
+			this._relayCloseCallbacks[this._relayCloseCallbacks.length - 1]();
+		}
 	}
 }
 
@@ -195,9 +287,8 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('returns existing connection on duplicate connect', async () => {
-		// First connect: provide exec responses for uname -s, uname -m, CLI --version check,
-		// and the findRunningAgentHost state file check (cat fails = no existing)
+	test('returns existing connection on duplicate connect without replacing relay', async () => {
+		// First connect: uname, CLI check, findRunningAgentHost (no state), write state
 		service.execResponses = [
 			{ stdout: 'Linux\n', code: 0 },      // uname -s
 			{ stdout: 'x86_64\n', code: 0 },      // uname -m
@@ -211,14 +302,86 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(result1.connectionId, 'ssh:myalias');
 		assert.strictEqual(result1.sshConfigHost, 'myalias');
 		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1);
 
-		// Second connect with same config — should return the cached connection
+		// Second connect without replaceRelay — returns existing info
+		// without creating a new relay or restarting the agent
 		const result2 = await service.connect(config);
 		assert.strictEqual(result2.connectionId, result1.connectionId);
 		assert.strictEqual(result2.connectionToken, result1.connectionToken);
 		assert.strictEqual(result2.sshConfigHost, 'myalias');
-		// Should NOT have started a second agent host
 		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1); // no new relay
+	});
+
+	test('creates fresh relay on reconnect without restarting agent', async () => {
+		// First connect: uname, CLI check, findRunningAgentHost (no state), write state
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },      // uname -s
+			{ stdout: 'x86_64\n', code: 0 },      // uname -m
+			{ stdout: '1.0.0\n', code: 0 },       // CLI --version (already installed)
+			{ stdout: '', code: 1 },               // cat state file (not found)
+			{ stdout: '', code: 0 },               // echo state file (write)
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		const result1 = await service.connect(config);
+		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1);
+
+		// Reconnect — creates fresh relay on existing SSH tunnel
+		const result2 = await service.reconnect('myalias', 'test-agent');
+		assert.strictEqual(result2.connectionId, result1.connectionId);
+		assert.strictEqual(result2.connectionToken, result1.connectionToken);
+		assert.strictEqual(service.startCalled, 1); // no restart
+		assert.strictEqual(service.relayCalled, 2); // fresh relay
+	});
+
+	test('reconnect does not fire onDidRelayClose for superseded relay', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		await service.connect(config);
+
+		const closeEvents: string[] = [];
+		disposables.add(service.onDidRelayClose(id => closeEvents.push(id)));
+
+		// Reconnect replaces the relay — old relay close should be suppressed
+		await service.reconnect('myalias', 'test-agent');
+
+		// Simulate the old relay's close event firing asynchronously
+		service.simulateOldRelayClose();
+
+		assert.deepStrictEqual(closeEvents, []);
+	});
+
+	test('reconnect suppresses synchronous close from old relay during replacement', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		await service.connect(config);
+
+		const closeEvents: string[] = [];
+		disposables.add(service.onDidRelayClose(id => closeEvents.push(id)));
+
+		// Make the first relay's close() synchronously fire its onClose callback,
+		// simulating a WebSocket that fires 'close' synchronously on ws.close().
+		service.makePreviousRelaySyncClose();
+
+		await service.reconnect('myalias', 'test-agent');
+		assert.deepStrictEqual(closeEvents, []);
 	});
 
 	test('uses sshConfigHost as connection key when present', async () => {
@@ -259,8 +422,8 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 			{ stdout: 'Linux\n', code: 0 },       // uname -s
 			{ stdout: 'x86_64\n', code: 0 },      // uname -m
 			{ stdout: '1.0.0\n', code: 0 },       // CLI --version
-			{ stdout: existingState, code: 0 },   // cat state file (found)
-			{ stdout: '', code: 0 },              // kill -0 (PID alive)
+			{ stdout: existingState, code: 0 },    // cat state file (found)
+			{ stdout: '', code: 0 },               // kill -0 (PID alive)
 		];
 
 		const result = await service.connect(makeConfig());
@@ -299,8 +462,8 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 			{ stdout: 'Linux\n', code: 0 },       // uname -s
 			{ stdout: 'x86_64\n', code: 0 },      // uname -m
 			{ stdout: '1.0.0\n', code: 0 },       // CLI --version
-			{ stdout: existingState, code: 0 },   // cat state file (found)
-			{ stdout: '', code: 0 },              // kill -0 (PID alive)
+			{ stdout: existingState, code: 0 },    // cat state file (found)
+			{ stdout: '', code: 0 },               // kill -0 (PID alive)
 			// cleanup: cat state file, kill PID, rm state file
 			{ stdout: existingState, code: 0 },
 			{ stdout: '', code: 0 },
@@ -424,8 +587,425 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(events[0], 'changed');
 
 		await service.disconnect(result.connectionId);
-		// disconnect fires both closed and changed
-		assert.ok(events.includes(`closed:${result.connectionId}`));
-		assert.strictEqual(events.filter(e => e === 'changed').length, 2);
+		// disconnect fires close before change
+		assert.deepStrictEqual(events, [
+			'changed',
+			`closed:${result.connectionId}`,
+			'changed',
+		]);
+	});
+
+	// --- Relay message routing ---
+
+	test('relay messages fire onDidRelayMessage with correct connectionId', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({
+			remoteAgentHostCommand: '/agent',
+		}));
+
+		const messages: Array<{ connectionId: string; data: string }> = [];
+		disposables.add(service.onDidRelayMessage(msg => messages.push(msg)));
+
+		service.simulateRelayMessage('{"jsonrpc":"2.0","id":1}');
+		service.simulateRelayMessage('{"jsonrpc":"2.0","id":2}');
+
+		assert.deepStrictEqual(messages, [
+			{ connectionId: result.connectionId, data: '{"jsonrpc":"2.0","id":1}' },
+			{ connectionId: result.connectionId, data: '{"jsonrpc":"2.0","id":2}' },
+		]);
+	});
+
+	test('relay close fires onDidRelayClose with correct connectionId', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({
+			remoteAgentHostCommand: '/agent',
+		}));
+
+		const closes: string[] = [];
+		disposables.add(service.onDidRelayClose(id => closes.push(id)));
+
+		service.simulateCurrentRelayClose();
+
+		assert.deepStrictEqual(closes, [result.connectionId]);
+	});
+
+	test('relaySend delivers data to the correct connection', async () => {
+		const sentData: string[] = [];
+		service.relayResult = {
+			send: (data: string) => sentData.push(data),
+			close: () => { },
+		};
+
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const result = await service.connect(makeConfig({
+			remoteAgentHostCommand: '/agent',
+		}));
+
+		await service.relaySend(result.connectionId, 'hello');
+		await service.relaySend(result.connectionId, 'world');
+
+		assert.deepStrictEqual(sentData, ['hello', 'world']);
+	});
+
+	test('relaySend to unknown connectionId is a no-op', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		await service.connect(makeConfig({ remoteAgentHostCommand: '/agent' }));
+
+		// Should not throw
+		await service.relaySend('nonexistent', 'data');
+	});
+
+	// --- Multiple independent connections ---
+
+	test('connects to two different hosts independently', async () => {
+		// First host
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r1 = await service.connect(makeConfig({
+			host: '10.0.0.1', remoteAgentHostCommand: '/agent',
+		}));
+
+		// Second host
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r2 = await service.connect(makeConfig({
+			host: '10.0.0.2', remoteAgentHostCommand: '/agent',
+		}));
+
+		assert.notStrictEqual(r1.connectionId, r2.connectionId);
+		assert.strictEqual(service.startCalled, 2);
+		assert.strictEqual(service.relayCalled, 2);
+	});
+
+	test('disconnect one host does not affect the other', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r1 = await service.connect(makeConfig({
+			host: '10.0.0.1', remoteAgentHostCommand: '/agent',
+		}));
+
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r2 = await service.connect(makeConfig({
+			host: '10.0.0.2', remoteAgentHostCommand: '/agent',
+		}));
+
+		await service.disconnect(r1.connectionId);
+
+		// r2 should still be live — duplicate connect returns existing info
+		const r2Again = await service.connect(makeConfig({
+			host: '10.0.0.2', remoteAgentHostCommand: '/agent',
+		}));
+		assert.strictEqual(r2Again.connectionId, r2.connectionId);
+		// No new start or relay was needed
+		assert.strictEqual(service.startCalled, 2);
+		assert.strictEqual(service.relayCalled, 2);
+	});
+
+	// --- Relay messages route to correct connection when multiple exist ---
+
+	test('relay messages from two connections are distinguished by connectionId', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r1 = await service.connect(makeConfig({
+			host: '10.0.0.1', remoteAgentHostCommand: '/agent',
+		}));
+
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r2 = await service.connect(makeConfig({
+			host: '10.0.0.2', remoteAgentHostCommand: '/agent',
+		}));
+
+		const messages: Array<{ connectionId: string; data: string }> = [];
+		disposables.add(service.onDidRelayMessage(msg => messages.push(msg)));
+
+		// Message on first connection's relay (index 0)
+		service.simulateRelayMessage('msg-from-host1', 0);
+		// Message on second connection's relay (index 1)
+		service.simulateRelayMessage('msg-from-host2', 1);
+
+		assert.deepStrictEqual(messages, [
+			{ connectionId: r1.connectionId, data: 'msg-from-host1' },
+			{ connectionId: r2.connectionId, data: 'msg-from-host2' },
+		]);
+	});
+
+	// --- Reconnect creates fresh SSH connection after disconnect ---
+
+	test('reconnect after disconnect establishes a new SSH connection', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+		const r1 = await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+		assert.strictEqual(service.mockClients.length, 1);
+
+		await service.disconnect(r1.connectionId);
+
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const r2 = await service.reconnect('myhost', 'test-host');
+		// Should have created a fresh SSH client (not reused the old one)
+		assert.strictEqual(service.mockClients.length, 2);
+		assert.strictEqual(r2.connectionId, r1.connectionId);
+	});
+
+	// --- Progress events ---
+
+	test('fires progress events during connect', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const progress: ISSHConnectProgress[] = [];
+		disposables.add(service.onDidReportConnectProgress(p => progress.push(p)));
+
+		await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+
+		// Expect at least: SSH connecting, platform detection, CLI check, start agent, relay
+		assert.ok(progress.length >= 3, `expected at least 3 progress events, got ${progress.length}`);
+		assert.ok(progress.every(p => p.connectionKey === 'ssh:myhost'));
+		assert.ok(progress.every(p => p.message.length > 0), 'all progress messages should be non-empty');
+	});
+
+	// --- SSH client close triggers connection disposal ---
+
+	test('SSH client close event disposes the connection', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({
+			remoteAgentHostCommand: '/agent',
+		}));
+
+		const closeEvents: string[] = [];
+		disposables.add(service.onDidCloseConnection(id => closeEvents.push(id)));
+
+		// Simulate the SSH client closing (e.g. network drop)
+		service.mockClients[0].fireClose();
+
+		assert.deepStrictEqual(closeEvents, [result.connectionId]);
+	});
+
+	// --- CLI install flow ---
+
+	test('skips CLI download when CLI is already installed', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },       // uname -s
+			{ stdout: 'x86_64\n', code: 0 },      // uname -m
+			{ stdout: '1.0.0\n', code: 0 },       // CLI --version succeeds
+			{ stdout: '', code: 1 },               // cat state file (not found)
+			{ stdout: '', code: 0 },               // echo state file (write)
+		];
+
+		await service.connect(makeConfig());
+
+		// The exec calls should NOT include any curl/tar/install commands
+		const execCalls = service.mockClients[0].execCalls;
+		assert.ok(!execCalls.some(c => c.includes('curl') || c.includes('tar')),
+			'should not download CLI when already installed');
+	});
+
+	test('downloads CLI when version check fails', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },       // uname -s
+			{ stdout: 'x86_64\n', code: 0 },      // uname -m
+			{ stdout: '', code: 127 },             // CLI --version fails (not found)
+			{ stdout: '', code: 0 },               // curl | tar install
+			{ stdout: '', code: 1 },               // cat state file (not found)
+			{ stdout: '', code: 0 },               // echo state file (write)
+		];
+
+		await service.connect(makeConfig());
+
+		const execCalls = service.mockClients[0].execCalls;
+		assert.ok(execCalls.some(c => c.includes('curl')),
+			'should download CLI when not installed');
+	});
+
+	// --- Connection key formats ---
+
+	test('uses host:port as connection key without sshConfigHost', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({
+			host: '192.168.1.1',
+			port: 2222,
+			remoteAgentHostCommand: '/agent',
+		}));
+		assert.strictEqual(result.connectionId, 'testuser@192.168.1.1:2222');
+	});
+
+	test('defaults to port 22 in connection key', async () => {
+		service.execResponses = [
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({
+			host: '192.168.1.1',
+			remoteAgentHostCommand: '/agent',
+		}));
+		assert.strictEqual(result.connectionId, 'testuser@192.168.1.1:22');
+	});
+
+	// --- Reconnect preserves connection token from initial connect ---
+
+	test('reconnect preserves connection token and address', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const original = await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+
+		const reconnected = await service.reconnect('myhost', 'new-name');
+		assert.strictEqual(reconnected.connectionToken, original.connectionToken);
+		assert.strictEqual(reconnected.address, original.address);
+		assert.strictEqual(reconnected.connectionId, original.connectionId);
+	});
+
+	// --- Relay messages from superseded relay are still routed (not gated) ---
+
+	test('messages from superseded relay still arrive (only close is suppressed)', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		const result = await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+
+		const messages: Array<{ connectionId: string; data: string }> = [];
+		disposables.add(service.onDidRelayMessage(msg => messages.push(msg)));
+
+		// Reconnect replaces the relay
+		await service.reconnect('myhost', 'test-host');
+
+		// Simulate a message arriving from the OLD relay (index 0)
+		service.simulateRelayMessage('stale-message', 0);
+		// And from the NEW relay (index 1)
+		service.simulateRelayMessage('fresh-message', 1);
+
+		// Both messages arrive — message suppression is deliberately NOT done
+		assert.deepStrictEqual(messages, [
+			{ connectionId: result.connectionId, data: 'stale-message' },
+			{ connectionId: result.connectionId, data: 'fresh-message' },
+		]);
+	});
+
+	// --- Reconnect failure cleans up detached SSH client ---
+
+	test('reconnect cleans up SSH client when relay recreation fails', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+		const originalClient = service.mockClients[0];
+		assert.strictEqual(originalClient.ended, false);
+
+		// Make relay creation fail on the next call (the reconnect attempt)
+		service.relayHook = (call) => {
+			if (call === 2) {
+				return new Error('relay failed');
+			}
+			return undefined;
+		};
+
+		const closeEvents: string[] = [];
+		disposables.add(service.onDidCloseConnection(id => closeEvents.push(id)));
+
+		await assert.rejects(
+			() => service.reconnect('myhost', 'test-host'),
+			/relay failed/,
+		);
+
+		// SSH client should have been cleaned up despite the failure
+		assert.strictEqual(originalClient.ended, true);
+		// Close event should have fired to notify the renderer
+		assert.deepStrictEqual(closeEvents, ['ssh:myhost']);
+	});
+
+	// --- Reconnect cleans up old SSH client listeners ---
+
+	test('reconnect removes old close/error listeners from shared SSH client', async () => {
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },
+			{ stdout: 'x86_64\n', code: 0 },
+			{ stdout: '1.0.0\n', code: 0 },
+			{ stdout: '', code: 1 },
+			{ stdout: '', code: 0 },
+		];
+
+		await service.connect(makeConfig({ sshConfigHost: 'myhost' }));
+		const client = service.mockClients[0];
+
+		// After initial connect, the SSH client has close/error listeners from SSHConnection
+		const closeListenersBefore = client.closeListenerCount;
+		const errorListenersBefore = client.errorListenerCount;
+		assert.ok(closeListenersBefore > 0, 'should have close listeners after connect');
+		assert.ok(errorListenersBefore > 0, 'should have error listeners after connect');
+
+		// Reconnect replaces the SSHConnection — old listeners should be removed
+		await service.reconnect('myhost', 'test-host');
+
+		// Listener count should not grow — old ones removed, new ones added
+		assert.strictEqual(client.closeListenerCount, closeListenersBefore);
+		assert.strictEqual(client.errorListenerCount, errorListenersBefore);
 	});
 });


### PR DESCRIPTION
Refactor `SSHConnection` to use the same immutable dispose-and-recreate pattern as `TunnelConnection` instead of the more complex `isActiveRelay()`/`replaceRelay()` approach.

## Problem

When a window reloads, we need to replace the WebSocket relay (for a fresh `initialize` handshake) while keeping the SSH session alive. The previous implementation mutated `_relay` inside a living `SSHConnection` and required every relay close handler to check `isActiveRelay()` to suppress stale close events. This was subtle and error-prone.

## Solution

Adopt the pattern from `TunnelConnection`: connections are immutable, dispose-once objects. On reconnect, the old `SSHConnection` is disposed and a new one is created reusing the same SSH client.

### Key changes
- **Remove `isActiveRelay()` and `replaceRelay()`** — `SSHConnection._relay` is now `readonly`
- **Add `detachSshClient()`** — prevents `dispose()` from ending the SSH session during ownership transfer; also removes event listeners from the shared SSH client
- **Add `removeListener` to `SSHClient` interface** — enables proper listener cleanup on detach
- **Simplify relay close handlers** — from `if (conn?.isActiveRelay(relay)) { ... }` to `() => { conn?.dispose(); }`
- **Add error handling** — try/catch in reconnect cleans up the detached SSH client if relay creation fails

### Test coverage
18 new unit tests (33 total, up from 15):
- Event lifecycle ordering
- Relay message routing and multi-connection discrimination
- `relaySend` delivery and unknown-connectionId no-op
- Multi-host isolation (disconnect one doesn't affect other)
- Reconnect after disconnect creates fresh SSH client
- Progress events during connect
- SSH client close triggers connection disposal
- CLI install flow (skip/download)
- Connection key formats
- Reconnect preserves token/address
- **Reconnect failure cleanup** (SSH client not leaked)
- **Listener cleanup across reconnects** (close + error listener counts stable)

(Written by Copilot)