### PR TITLE
chat: Remove startup revive of chat sessions with pending edits

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1728,16 +1728,14 @@ type ChatModelsAtStartupEvent = {
 	totalModels: number;
 	modelsOpenInWidgets: number;
 	backgroundModels: number;
-	modelsKeptAliveOnlyForEdits: number;
 };
 
 type ChatModelsAtStartupClassification = {
-	totalModels: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of live chat models after startup revival.' };
+	totalModels: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Total number of live chat models at startup.' };
 	modelsOpenInWidgets: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models that are open in a chat widget or editor.' };
 	backgroundModels: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models kept alive in the background without a widget.' };
-	modelsKeptAliveOnlyForEdits: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of chat models kept alive solely because they have unaccepted edits.' };
 	owner: 'roblourens';
-	comment: 'Tracks chat model counts at startup after reviving sessions with pending edits.';
+	comment: 'Tracks chat model counts at startup.';
 };
 
 class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContribution {
@@ -1754,22 +1752,16 @@ class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContr
 	}
 
 	private async logTelemetry(): Promise<void> {
-		await this.chatService.whenSessionsRevived;
-
 		const snapshot = this.chatService.getChatModelReferenceDebugInfo();
 
 		let modelsOpenInWidgets = 0;
 		let backgroundModels = 0;
-		let modelsKeptAliveOnlyForEdits = 0;
 
 		for (const model of snapshot.models) {
 			if (this.chatWidgetService.getWidgetBySessionResource(model.sessionResource)) {
 				modelsOpenInWidgets++;
 			} else {
 				backgroundModels++;
-				if (model.hasPendingEdits && model.referenceCount === 1) {
-					modelsKeptAliveOnlyForEdits++;
-				}
 			}
 		}
 
@@ -1777,7 +1769,6 @@ class ChatModelsAtStartupTelemetry extends Disposable implements IWorkbenchContr
 			totalModels: snapshot.totalModels,
 			modelsOpenInWidgets,
 			backgroundModels,
-			modelsKeptAliveOnlyForEdits,
 		});
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1431,11 +1431,6 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionResource: URI | undefined;
 
-	/**
-	 * Promise that resolves when sessions with pending edits have been revived at startup.
-	 */
-	readonly whenSessionsRevived: Promise<void>;
-
 	readonly onDidSubmitRequest: Event<{ readonly chatSessionResource: URI; readonly message?: IParsedChatRequest }>;
 
 	readonly onDidCreateModel: Event<IChatModel>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -132,8 +132,6 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _chatServiceTelemetry: ChatServiceTelemetry;
 	private readonly _chatSessionStore: ChatSessionStore;
 
-	readonly whenSessionsRevived: Promise<void>;
-
 	readonly requestInProgressObs: IObservable<boolean>;
 
 	readonly chatModels: IObservable<Iterable<IChatModel>>;
@@ -208,10 +206,6 @@ export class ChatService extends Disposable implements IChatService {
 			this.trace('constructor', `Transferred session ${transferredData}`);
 			this._transferredSessionResource = transferredData;
 		}
-
-		this.whenSessionsRevived = this.reviveSessionsWithEdits().catch(error => {
-			this.logService.error('Failed to revive chat sessions with edits', error);
-		});
 
 		this._register(storageService.onWillSaveState(() => this.saveState()));
 
@@ -351,36 +345,6 @@ export class ChatService extends Disposable implements IChatService {
 			this.error('deserializeChats', `Malformed session data: ${err}. [${sessionData.substring(0, 20)}${sessionData.length > 20 ? '...' : ''}]`);
 			return {};
 		}
-	}
-
-	/**
-	 * todo@connor4312 This will be cleaned up with the globalization of edits.
-	 */
-	private async reviveSessionsWithEdits(): Promise<void> {
-		const idx = await this._chatSessionStore.getIndex();
-		await Promise.all(Object.values(idx).map(async session => {
-			if (!session.hasPendingEdits) {
-				return;
-			}
-
-			let sessionResource: URI;
-			// Non-local sessions store the full uri as the sessionId, so try parsing that first
-			if (session.sessionId.includes(':')) {
-				try {
-					sessionResource = URI.parse(session.sessionId, true);
-				} catch {
-					// Noop
-				}
-			}
-			sessionResource ??= LocalChatSessionUri.forSession(session.sessionId);
-
-			const sessionRef = await this.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatService#reviveSessionsWithEdits');
-			if (sessionRef?.object.editingSession) {
-				await chatEditingSessionIsReady(sessionRef.object.editingSession);
-				// the session will hold a self-reference as long as there are modified files
-				sessionRef.dispose();
-			}
-		}));
 	}
 
 	/**
@@ -627,7 +591,6 @@ export class ChatService extends Disposable implements IChatService {
 					responderUsername: '',
 					sessionId: '',
 					version: 3,
-					hasPendingEdits: undefined,
 					inputState: {
 						attachments: [],
 						contrib: {},

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1674,10 +1674,7 @@ export interface ISerializableChatData2 extends ISerializableChatData1 {
 export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 'version' | 'computedTitle'> {
 	version: 3;
 	customTitle: string | undefined;
-	/**
-	 * Whether the session had pending edits when it was stored.
-	 * todo@connor4312 This will be cleaned up with the globalization of edits.
-	 */
+	/** Whether the session had pending edits when it was stored. */
 	hasPendingEdits?: boolean;
 	/** Current draft input state (added later, fully backwards compatible) */
 	inputState?: ISerializableChatModelInputState;

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -20,7 +20,6 @@ export class MockChatService implements IChatService {
 	_serviceBrand: undefined;
 	editingSessions = [];
 	transferredSessionResource = undefined;
-	whenSessionsRevived = Promise.resolve();
 	readonly onDidSubmitRequest = Event.None;
 
 	private readonly _onDidCreateModel = new Emitter<IChatModel>();


### PR DESCRIPTION
Remove `reviveSessionsWithEdits()` and the `whenSessionsRevived` property from `IChatService`. This code eagerly loaded sessions at startup if they had pending edits, which is no longer needed.

Also removes the `modelsKeptAliveOnlyForEdits` telemetry metric that was specific to this revive path.

The `hasPendingEdits` field is kept on the serialized data and storage index so there's no data gap if it's needed again in the future.