### PR TITLE
Detect extension-sourced items in provider path for correct grouping

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1770,7 +1770,7 @@ export class AICustomizationListWidget extends Disposable {
 	private _inferStorageAndGroup(uri: URI, workspaceFolders: readonly { uri: URI }[]): { storage?: PromptsStorage; groupKey?: string } {
 		// Non-file schemes are synthetic/built-in (includes vscode-userdata: for extension-contributed items)
 		if (uri.scheme !== Schemas.file) {
-			return { groupKey: BUILTIN_STORAGE };
+			return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE };
 		}
 
 		// file: URI under a workspace folder = workspace (local)
@@ -1793,7 +1793,7 @@ export class AICustomizationListWidget extends Disposable {
 		const extensionId = extractExtensionIdFromPath(uri.path);
 		if (extensionId) {
 			if (this.isChatExtensionItem(new ExtensionIdentifier(extensionId))) {
-				return { groupKey: BUILTIN_STORAGE };
+				return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE };
 			}
 			return { storage: PromptsStorage.extension };
 		}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -47,7 +47,7 @@ import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/ho
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js';
-import { getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
+import { extractExtensionIdFromPath, getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
 import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
 import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
 import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
@@ -1785,6 +1785,17 @@ export class AICustomizationListWidget extends Disposable {
 			if (isEqualOrParent(uri, plugin.uri)) {
 				return { storage: PromptsStorage.plugin };
 			}
+		}
+
+		// file: URI inside an extension install directory = extension or built-in.
+		// At this point we've already checked workspace folders and plugins, so
+		// a path containing /extensions/<id>-<version>/ is an extension directory.
+		const extensionId = extractExtensionIdFromPath(uri.path);
+		if (extensionId) {
+			if (this.isChatExtensionItem(new ExtensionIdentifier(extensionId))) {
+				return { groupKey: BUILTIN_STORAGE };
+			}
+			return { storage: PromptsStorage.extension };
 		}
 
 		// file: URI elsewhere = user directory

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidgetUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidgetUtils.ts
@@ -27,3 +27,23 @@ export function getCustomizationSecondaryText(description: string | undefined, f
 
 	return promptType === PromptsType.hook ? description : truncateToFirstLine(description);
 }
+
+/**
+ * Extracts an extension ID from a file path if the path is inside an
+ * extension install directory (e.g. `~/.vscode/extensions/<id>-<version>/...`).
+ *
+ * Returns the extension ID (e.g. `github.copilot-chat`) or `undefined`
+ * if the path is not inside an extension directory.
+ */
+export function extractExtensionIdFromPath(uriPath: string): string | undefined {
+	const segments = uriPath.split('/');
+	const extensionsIdx = segments.lastIndexOf('extensions');
+	if (extensionsIdx < 0 || extensionsIdx + 1 >= segments.length) {
+		return undefined;
+	}
+	const folderName = segments[extensionsIdx + 1];
+	// Strip version suffix: the version starts with digits after the last hyphen
+	// e.g. "github.copilot-chat-0.43.2026040602" → "github.copilot-chat"
+	const versionMatch = folderName.match(/^(.+)-\d+\./);
+	return versionMatch ? versionMatch[1] : undefined;
+}

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { getCustomizationSecondaryText, truncateToFirstLine } from '../../../browser/aiCustomization/aiCustomizationListWidgetUtils.js';
+import { extractExtensionIdFromPath, getCustomizationSecondaryText, truncateToFirstLine } from '../../../browser/aiCustomization/aiCustomizationListWidgetUtils.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 
 suite('aiCustomizationListWidget', () => {
@@ -53,6 +53,64 @@ suite('aiCustomizationListWidget', () => {
 			assert.strictEqual(
 				getCustomizationSecondaryText(undefined, 'prompt.md', PromptsType.prompt),
 				'prompt.md'
+			);
+		});
+	});
+
+	suite('extractExtensionIdFromPath', () => {
+		test('extracts extension ID from copilot-chat extension path', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/.vscode-insiders/extensions/github.copilot-chat-0.43.2026040602/assets/prompts/skills/agent-customization/SKILL.md'),
+				'github.copilot-chat'
+			);
+		});
+
+		test('extracts extension ID from PR extension path', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/.vscode-insiders/extensions/github.vscode-pull-request-github-0.135.2026040604/src/lm/skills/SKILL.md'),
+				'github.vscode-pull-request-github'
+			);
+		});
+
+		test('extracts extension ID from Code OSS dev path', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/.vscode-oss-dev/extensions/github.copilot-chat-0.43.2026040602/assets/prompts/skills/troubleshoot/SKILL.md'),
+				'github.copilot-chat'
+			);
+		});
+
+		test('extracts extension ID from Windows-style path', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('C:/Users/dev/.vscode/extensions/ms-python.python-2024.1.1/skills/SKILL.md'),
+				'ms-python.python'
+			);
+		});
+
+		test('returns undefined for workspace paths', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/git/vscode/.github/skills/accessibility/SKILL.md'),
+				undefined
+			);
+		});
+
+		test('returns undefined for user home paths', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/.copilot/skills/ios-project-setup/SKILL.md'),
+				undefined
+			);
+		});
+
+		test('returns undefined for plugin paths', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/Users/josh/.vscode-insiders/agent-plugins/github.com/microsoft/vscode-team-kit/model-council/skills/council-review/SKILL.md'),
+				undefined
+			);
+		});
+
+		test('returns undefined for bare extensions folder without version', () => {
+			assert.strictEqual(
+				extractExtensionIdFromPath('/workspace/extensions/my-extension/SKILL.md'),
+				undefined
 			);
 		});
 	});


### PR DESCRIPTION
Fixes extension-sourced items being misclassified in the Chat Customizations provider path (microsoft/vscode-internalbacklog#7330).

## Commits

- **Detect extension-sourced items in provider path for correct grouping** — Items from VS Code extensions (under `~/.vscode*/extensions/`) were classified as "User". Now uses `extractExtensionIdFromPath()` to detect extension directories by finding `extensions` in the path segments and extracting the extension ID (stripping the version suffix). Default chat extension items → Built-in; other extensions → Extensions. Includes unit tests (8 test cases). Fixes microsoft/vscode-internalbacklog#7330

- **Make built-in and extension items read-only in provider path** — Provider-path items with `groupKey: 'builtin'` had no `storage` set, so the delete action's when-clause didn't hide the delete button. Now uses `storage ?? groupKey` for the context key overlay, so built-in and extension items correctly suppress delete/modify actions. Fixes microsoft/vscode-internalbacklog#7330