### PR TITLE
Enable `chat.customizations.providerApi.enabled` by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1396,8 +1396,8 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.CustomizationsProviderApi]: {
 			type: 'boolean',
 			description: nls.localize('chat.customizations.providerApi.enabled', "When enabled, the Customizations management UI reads items from the session type's customizations provider instead of built-in discovery."),
-			default: false,
-			tags: ['experimental'],
+			default: true,
+			tags: ['preview'],
 		},
 	}
 });


### PR DESCRIPTION
Set the default value of `chat.customizations.providerApi.enabled` to `true` and change the tag from `experimental` to `preview`.

This graduates the Customizations provider API setting so the Customizations management UI uses the session type's customizations provider by default.