### PR TITLE
Fix Agent Debug Panel flow chart for new JSONL-based debug events

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
@@ -99,18 +99,45 @@ function truncateLabel(text: string, maxLength: number): string {
 export function buildFlowGraph(events: readonly IChatDebugEvent[]): FlowNode[] {
 	// Before filtering, extract description metadata from subagent events
 	// that will be filtered out, so we can enrich the surviving sibling events.
-	const subagentToolNames = new Set(['runSubagent', 'search_subagent']);
+	const subagentToolNames = ['runSubagent', 'search_subagent'];
 
-	// The extension emits two subagentInvocation events per subagent:
+	/**
+	 * Check whether a name matches a known subagent tool name.
+	 * Handles exact matches and names with suffixes (e.g.
+	 * "runSubagent-default", "runSubagent (agent)", "runSubagent: desc").
+	 * Callers must strip any emoji prefix before calling.
+	 */
+	function isSubagentName(name: string): boolean {
+		for (const toolName of subagentToolNames) {
+			if (name === toolName) {
+				return true;
+			}
+			if (name.startsWith(toolName)) {
+				const nextChar = name[toolName.length];
+				if (nextChar === '-' || nextChar === ' ' || nextChar === '(' || nextChar === ':') {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/** Strip the leading tool emoji prefix if present. */
+	const emojiPrefixRe = /^\u{1F6E0}\uFE0F?\s*/u;
+	function stripToolEmoji(name: string): string {
+		return name.replace(emojiPrefixRe, '');
+	}
+
+	// The extension may emit two subagentInvocation events per subagent:
 	// 1. "started" marker (agentName = descriptive name, status = running) — survives filtering
-	// 2. completion event (agentName = "runSubagent", status = completed) — filtered out
+	// 2. completion event (agentName = "runSubagent" / "runSubagent-*", status = completed) — filtered out
 	// The completion event carries the real description. When multiple subagents
 	// run under the same parent, they share a parentEventId, so we match them
 	// by order: the N-th started marker gets the N-th completion's description.
 	const completionDescsByParent = new Map<string, string[]>();
 	const startedCountByParent = new Map<string, number>();
 	for (const e of events) {
-		if (e.kind === 'subagentInvocation' && subagentToolNames.has(e.agentName) && e.description && e.parentEventId) {
+		if (e.kind === 'subagentInvocation' && isSubagentName(e.agentName) && e.description && e.parentEventId) {
 			let descs = completionDescsByParent.get(e.parentEventId);
 			if (!descs) {
 				descs = [];
@@ -133,15 +160,12 @@ export function buildFlowGraph(events: readonly IChatDebugEvent[]): FlowNode[] {
 		return descs[idx] ?? descs[0];
 	}
 
-	// Filter out redundant events:
-	// - toolCall with subagent tool names: the subagentInvocation event has richer metadata
-	// - subagentInvocation with agentName matching a tool name: these are completion
-	//   duplicates of the "SubAgent started" marker which has the proper descriptive name
+	// Filter out subagent invocation completion duplicates (events whose
+	// agentName matches a known tool name). Subagent tool calls are kept
+	// in the tree for correct parent-child linkage; they are collapsed
+	// into their subagent child in a post-processing step.
 	const filtered = events.filter(e => {
-		if (e.kind === 'toolCall' && subagentToolNames.has(e.toolName.replace(/^\u{1F6E0}\uFE0F?\s*/u, ''))) {
-			return false;
-		}
-		if (e.kind === 'subagentInvocation' && subagentToolNames.has(e.agentName)) {
+		if (e.kind === 'subagentInvocation' && isSubagentName(e.agentName)) {
 			return false;
 		}
 		return true;
@@ -185,10 +209,13 @@ export function buildFlowGraph(events: readonly IChatDebugEvent[]): FlowNode[] {
 		let description: string | undefined;
 		if (effectiveKind === 'subagentInvocation') {
 			description = getSubagentDescription(event);
+			// Strip any existing "Subagent:" prefix from the description to
+			// avoid double-prefixing (e.g. "Subagent: Subagent: name").
+			const cleanDesc = description?.replace(/^Subagent:\s*/i, '');
 			// Show "Subagent: <description>" as the label so users can identify
 			// these nodes and see what task they perform.
-			label = description
-				? localize('subagentWithDesc', "Subagent: {0}", truncateLabel(description, 30))
+			label = cleanDesc
+				? localize('subagentWithDesc', "Subagent: {0}", truncateLabel(cleanDesc, 30))
 				: localize('subagentLabel', "Subagent");
 			if (description) {
 				// Ensure description appears in tooltip if not already present
@@ -214,7 +241,80 @@ export function buildFlowGraph(events: readonly IChatDebugEvent[]): FlowNode[] {
 		};
 	}
 
-	return roots.map(toFlowNode);
+	const rawNodes = roots.map(toFlowNode);
+
+	// Post-process: collapse subagent tool call nodes into their
+	// subagent child, and flatten child_session_ref placeholder nodes.
+	// This preserves the correct parent-child hierarchy that would
+	// otherwise break when filtering events before tree construction.
+	return collapseSubagentToolCalls(rawNodes);
+
+	function collapseSubagentToolCalls(nodeList: FlowNode[]): FlowNode[] {
+		let changed = false;
+		const result: FlowNode[] = [];
+		for (const node of nodeList) {
+			if (node.kind === 'toolCall' && isSubagentName(stripToolEmoji(node.label))) {
+				changed = true;
+				// Flatten any child_session_ref intermediaries first so
+				// the subagentInvocation becomes a direct child.
+				const flatChildren = flattenChildSessionRefs(node.children);
+				const subagentChildren = flatChildren.filter(c => c.kind === 'subagentInvocation');
+				if (subagentChildren.length > 0) {
+					const otherChildren = flatChildren.filter(c => c.kind !== 'subagentInvocation');
+					// Each subagent child gets its own children; non-subagent
+					// siblings (which are rare) are added to the first subagent.
+					for (let i = 0; i < subagentChildren.length; i++) {
+						const extra = i === 0 ? otherChildren : [];
+						result.push({
+							...subagentChildren[i],
+							children: collapseSubagentToolCalls(
+								[...subagentChildren[i].children, ...extra]
+							),
+						});
+					}
+				} else {
+					// No subagent child — promote children directly
+					result.push(...collapseSubagentToolCalls(flatChildren));
+				}
+			} else {
+				const newChildren = collapseSubagentToolCalls(node.children);
+				if (newChildren !== node.children) {
+					changed = true;
+					result.push({ ...node, children: newChildren });
+				} else {
+					result.push(node);
+				}
+			}
+		}
+		return changed ? result : nodeList;
+	}
+
+	function flattenChildSessionRefs(nodeList: FlowNode[]): FlowNode[] {
+		if (!nodeList.some(n => n.kind === 'generic' && n.category === 'subagent')) {
+			return nodeList; // fast path: nothing to flatten
+		}
+		const result: FlowNode[] = [];
+		for (const node of nodeList) {
+			if (node.kind === 'generic' && node.category === 'subagent') {
+				// child_session_ref placeholder — find the subagentInvocation
+				// and move all siblings into it as children.
+				const subagentChild = node.children.find(c => c.kind === 'subagentInvocation');
+				if (subagentChild) {
+					const siblings = node.children.filter(c => c !== subagentChild);
+					result.push({
+						...subagentChild,
+						children: [...subagentChild.children, ...siblings],
+					});
+				} else {
+					// No subagent child — promote all children
+					result.push(...node.children);
+				}
+			} else {
+				result.push(node);
+			}
+		}
+		return result;
+	}
 }
 
 // ---- Flow node filtering ----

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowLayout.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowLayout.ts
@@ -347,18 +347,16 @@ function resolvePendingExpansions(
 		}
 
 		// Edge from merged node to first expanded child.
-		// Use a short downward step from the bottom of the merged node
-		// then across, so the line doesn't pass horizontally through
-		// unrelated nodes in parallel lanes.
-		const stepDownY = mergedNode.y + mergedNode.height;
-		const targetMidY = childNodes[0].y + childNodes[0].height / 2;
+		// Use a horizontal edge aligned with the first child's midpoint
+		// so the orthogonal renderer doesn't need to route upward.
+		const edgeY = childNodes[0].y + childNodes[0].height / 2;
 		result.edges.push({
 			fromId: mergedNode.id,
 			toId: childNodes[0].id,
-			fromX: mergedNode.x + mergedNode.width / 2,
-			fromY: stepDownY,
-			toX: expandX + childNodes[0].width / 2,
-			toY: targetMidY,
+			fromX: mergedNode.x + mergedNode.width,
+			fromY: edgeY,
+			toX: expandX,
+			toY: edgeY,
 		});
 
 		// Vertical edges between consecutive children

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowLayout.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowLayout.ts
@@ -346,14 +346,19 @@ function resolvePendingExpansions(
 			expandY += NODE_HEIGHT + NODE_GAP_Y;
 		}
 
-		// Horizontal edge from merged node to first child
+		// Edge from merged node to first expanded child.
+		// Use a short downward step from the bottom of the merged node
+		// then across, so the line doesn't pass horizontally through
+		// unrelated nodes in parallel lanes.
+		const stepDownY = mergedNode.y + mergedNode.height;
+		const targetMidY = childNodes[0].y + childNodes[0].height / 2;
 		result.edges.push({
 			fromId: mergedNode.id,
 			toId: childNodes[0].id,
-			fromX: mergedNode.x + mergedNode.width,
-			fromY: mergedNode.y + mergedNode.height / 2,
-			toX: expandX,
-			toY: childNodes[0].y + childNodes[0].height / 2,
+			fromX: mergedNode.x + mergedNode.width / 2,
+			fromY: stepDownY,
+			toX: expandX + childNodes[0].width / 2,
+			toY: targetMidY,
 		});
 
 		// Vertical edges between consecutive children

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -91,6 +91,11 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	private readonly _sessionBuffers = new ResourceMap<SessionEventBuffer>();
 	/** Ordered list of session URIs for LRU eviction. */
 	private readonly _sessionOrder: URI[] = [];
+	/** Per-session tracking of seen event IDs to deduplicate events
+	 *  that share the same ID (e.g. subagentInvocation + userMessage
+	 *  emitted from the same span). Stores id → event kind so we can
+	 *  keep the richer event kind on collision. */
+	private readonly _seenEventIds = new ResourceMap<Map<string, IChatDebugEvent['kind']>>();
 
 	private readonly _onDidAddEvent = this._register(new Emitter<IChatDebugEvent>());
 	readonly onDidAddEvent: Event<IChatDebugEvent> = this._onDidAddEvent.event;
@@ -111,6 +116,16 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	private readonly _importedSessionTitles = new ResourceMap<string>();
 
 	activeSessionResource: URI | undefined;
+
+	/** Priority for deduplicating events with the same ID: lower = richer. */
+	private static readonly _eventKindPriority: Record<string, number> = {
+		subagentInvocation: 0,
+		modelTurn: 1,
+		toolCall: 2,
+		agentResponse: 3,
+		userMessage: 4,
+		generic: 5,
+	};
 
 	/** Schemes eligible for debug logging and provider invocation. */
 	private static readonly _debugEligibleSchemes = new Set([
@@ -142,6 +157,28 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	}
 
 	addEvent(event: IChatDebugEvent): void {
+		// Deduplicate events that share the same ID. The extension may emit
+		// both a subagentInvocation and a userMessage from the same span;
+		// keep the richer kind and discard the duplicate.
+		if (event.id) {
+			let seen = this._seenEventIds.get(event.sessionResource);
+			if (!seen) {
+				seen = new Map();
+				this._seenEventIds.set(event.sessionResource, seen);
+			}
+			const existingKind = seen.get(event.id);
+			if (existingKind !== undefined) {
+				const priority = ChatDebugServiceImpl._eventKindPriority;
+				if ((priority[event.kind] ?? 5) >= (priority[existingKind] ?? 5)) {
+					return; // existing is richer or equal; skip this event
+				}
+				// New event is richer — we can't remove the old one from
+				// the ring buffer, but the duplicate will be filtered out
+				// in getEvents(). Update the tracked kind.
+			}
+			seen.set(event.id, event.kind);
+		}
+
 		let buffer = this._sessionBuffers.get(event.sessionResource);
 		if (!buffer) {
 			// Evict least-recently-used session if we are at the session cap.
@@ -180,7 +217,7 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			if (!buffer) {
 				return [];
 			}
-			const result = buffer.toArray();
+			let result = buffer.toArray();
 			// Sort only when the buffer is not in chronological order,
 			// which can happen when events arrive out of order (e.g.
 			// tail-first backfill). When events arrive in
@@ -188,6 +225,10 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 			if (!this._isSorted(result)) {
 				result.sort((a, b) => a.created.getTime() - b.created.getTime());
 			}
+			// Deduplicate: when multiple events share the same ID (e.g.
+			// subagentInvocation + userMessage from the same span), keep
+			// the one with the richest kind.
+			result = this._deduplicateEvents(result);
 			return result;
 		}
 
@@ -209,6 +250,29 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 		return true;
 	}
 
+	private _deduplicateEvents(events: IChatDebugEvent[]): IChatDebugEvent[] {
+		const seen = new Map<string, number>(); // id → index in result
+		const priority = ChatDebugServiceImpl._eventKindPriority;
+		const result: IChatDebugEvent[] = [];
+		for (const event of events) {
+			if (!event.id) {
+				result.push(event);
+				continue;
+			}
+			const existingIdx = seen.get(event.id);
+			if (existingIdx === undefined) {
+				seen.set(event.id, result.length);
+				result.push(event);
+			} else {
+				const existing = result[existingIdx];
+				if ((priority[event.kind] ?? 5) < (priority[existing.kind] ?? 5)) {
+					result[existingIdx] = event;
+				}
+			}
+		}
+		return result;
+	}
+
 	getSessionResources(): readonly URI[] {
 		return [...this._sessionOrder];
 	}
@@ -216,6 +280,7 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	clear(): void {
 		this._sessionBuffers.clear();
 		this._sessionOrder.length = 0;
+		this._seenEventIds.clear();
 		this._importedSessions.clear();
 		this._importedSessionTitles.clear();
 	}
@@ -223,6 +288,7 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	/** Remove all ancillary state for an evicted session. */
 	private _evictSession(sessionResource: URI): void {
 		this._sessionBuffers.delete(sessionResource);
+		this._seenEventIds.delete(sessionResource);
 		this._importedSessions.delete(sessionResource);
 		this._importedSessionTitles.delete(sessionResource);
 		const cts = this._invocationCts.get(sessionResource);
@@ -337,6 +403,8 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 				buffer.push(e);
 			}
 		}
+		// Reset dedup tracking so re-invoked provider events are accepted
+		this._seenEventIds.delete(sessionResource);
 		this._onDidClearProviderEvents.fire(sessionResource);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -177,6 +177,14 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 				// in getEvents(). Update the tracked kind.
 			}
 			seen.set(event.id, event.kind);
+			// Cap the dedup map to prevent unbounded growth in long sessions.
+			if (seen.size > ChatDebugServiceImpl.MAX_EVENTS_PER_SESSION) {
+				// Delete the oldest entry (first key in insertion order).
+				const firstKey = seen.keys().next().value;
+				if (firstKey !== undefined) {
+					seen.delete(firstKey);
+				}
+			}
 		}
 
 		let buffer = this._sessionBuffers.get(event.sessionResource);

--- a/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
@@ -659,4 +659,101 @@ suite('ChatDebugServiceImpl', () => {
 			assert.strictEqual(capturedToken.isCancellationRequested, true);
 		});
 	});
+
+	suite('event deduplication', () => {
+		test('should deduplicate events with the same ID, keeping the richer kind', () => {
+			const userMsg: IChatDebugEvent = {
+				kind: 'userMessage',
+				id: 'shared-id-1',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:00Z'),
+				message: 'hello',
+				sections: [],
+			};
+			const subagent: IChatDebugEvent = {
+				kind: 'subagentInvocation',
+				id: 'shared-id-1',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:01Z'),
+				agentName: 'Explore',
+			};
+			service.addEvent(userMsg);
+			service.addEvent(subagent);
+
+			const events = service.getEvents(session1);
+			assert.strictEqual(events.length, 1);
+			assert.strictEqual(events[0].kind, 'subagentInvocation');
+		});
+
+		test('should keep richer event when it arrives first', () => {
+			const subagent: IChatDebugEvent = {
+				kind: 'subagentInvocation',
+				id: 'shared-id-2',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:00Z'),
+				agentName: 'Explore',
+			};
+			const userMsg: IChatDebugEvent = {
+				kind: 'userMessage',
+				id: 'shared-id-2',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:01Z'),
+				message: 'hello',
+				sections: [],
+			};
+			service.addEvent(subagent);
+			service.addEvent(userMsg);
+
+			const events = service.getEvents(session1);
+			assert.strictEqual(events.length, 1);
+			assert.strictEqual(events[0].kind, 'subagentInvocation');
+		});
+
+		test('should not fire onDidAddEvent for skipped duplicates', () => {
+			const firedKinds: string[] = [];
+			disposables.add(service.onDidAddEvent(e => firedKinds.push(e.kind)));
+
+			const subagent: IChatDebugEvent = {
+				kind: 'subagentInvocation',
+				id: 'shared-id-3',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:00Z'),
+				agentName: 'Explore',
+			};
+			const userMsg: IChatDebugEvent = {
+				kind: 'userMessage',
+				id: 'shared-id-3',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:01Z'),
+				message: 'hello',
+				sections: [],
+			};
+			service.addEvent(subagent);
+			service.addEvent(userMsg); // should be skipped
+
+			assert.deepStrictEqual(firedKinds, ['subagentInvocation']);
+		});
+
+		test('should allow events without IDs to coexist', () => {
+			const event1: IChatDebugGenericEvent = {
+				kind: 'generic',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:00Z'),
+				name: 'a',
+				level: ChatDebugLogLevel.Info,
+			};
+			const event2: IChatDebugGenericEvent = {
+				kind: 'generic',
+				sessionResource: session1,
+				created: new Date('2026-01-01T00:00:01Z'),
+				name: 'b',
+				level: ChatDebugLogLevel.Info,
+			};
+			service.addEvent(event1);
+			service.addEvent(event2);
+
+			const events = service.getEvents(session1);
+			assert.strictEqual(events.length, 2);
+		});
+	});
 });


### PR DESCRIPTION
The extension recently switched from OTEL spans to JSONL entries for chat debug events. This change updates the flow chart view's subagent rendering — tool call nodes weren't filtered, child events appeared outside subagent boxes, and labels were double-prefixed.