### PR TITLE
Fix #143956 - Improve path distinguishability in quick open results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -12,7 +12,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { getOutOfWorkspaceEditorResources, extractRangeFromFilter, IWorkbenchSearchConfiguration } from '../common/search.js';
 import { ISearchService, ISearchComplete } from '../../../services/search/common/search.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
-import { untildify } from '../../../../base/common/labels.js';
+import { untildify, shorten } from '../../../../base/common/labels.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { toLocalResource, dirname, basenameOrAuthority } from '../../../../base/common/resources.js';
@@ -612,9 +612,22 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		// Filter excludes & convert to picks
 		const configuration = this.configuration;
-		return fileMatches
+		let picks = fileMatches
 			.filter(resource => !excludes.has(resource))
 			.map(resource => this.createAnythingPick(resource, configuration));
+
+		// Shorten paths to make them more distinguishable
+		if (picks.length > 1) {
+			const descriptions = picks.map(pick => pick.description || '');
+			const shortenedDescriptions = shorten(descriptions);
+			for (let i = 0; i < picks.length; i++) {
+				if (shortenedDescriptions[i]) {
+					picks[i].description = shortenedDescriptions[i];
+				}
+			}
+		}
+
+		return picks;
 	}
 
 	private async doFileSearch(query: IPreparedQuery, token: CancellationToken): Promise<URI[]> {


### PR DESCRIPTION
Fixes #143956

## Summary
File paths in quick open are currently displayed from the beginning, which can make it difficult to distinguish between files with similar names.

## Problem
When multiple files share the same name and similar directory structure, truncated paths appear identical in the quick open list.

Example:
- some_project/.../fruits/apples/Main.js
- some_project/.../fruits/bananas/Main.js

These entries can look very similar, making it hard for users to identify the correct file.

## Solution
Use the existing `shorten()` utility to display the most relevant (unique) end portion of each path, improving clarity and usability.

## Changes
- Imported `shorten` from the labels module
- Applied path shortening to quick open result descriptions when multiple entries are present

## Testing
- Open quick open (Ctrl+P / Cmd+P)
- Search for a filename that exists in multiple directories
- Verify that path endings are clearly distinguishable (e.g., `.../apples/Main.js` vs `.../bananas/Main.js`)

## Notes
This change improves usability by making similar file paths easier to differentiate without affecting existing functionality.