### PR TITLE
fix: strip ANSI escape codes from inline test output messages

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -1288,7 +1288,8 @@ class TestMessageDecoration implements ITestDecoration {
 		const message = testMessage.message;
 
 		const options = editorService.resolveDecorationOptions(TestMessageDecoration.decorationId, true);
-		options.hoverMessage = typeof message === 'string' ? new MarkdownString().appendText(message) : message;
+		const hoverText = renderTestMessageAsText(message);
+		options.hoverMessage = new MarkdownString().appendText(hoverText);
 		options.zIndex = 10; // todo: in spite of the z-index, this appears behind gitlens
 		options.className = `testing-inline-message-severity-${severity}`;
 		options.isWholeLine = true;

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -11,6 +11,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue } from '../../../../base/common/observable.js';
 import { language } from '../../../../base/common/platform.js';
 import { WellDefinedPrefixTree } from '../../../../base/common/prefixTree.js';
+import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import { localize } from '../../../../nls.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -357,7 +358,8 @@ export class LiveTestResult extends Disposable implements ITestResult {
 	 * Appends output that occurred during the test run.
 	 */
 	public appendOutput(output: VSBuffer, taskId: string, location?: IRichLocation, testId?: string): void {
-		const preview = output.byteLength > 100 ? output.slice(0, 100).toString() + '…' : output.toString();
+		const rawPreview = output.byteLength > 100 ? output.slice(0, 100).toString() + '…' : output.toString();
+		const preview = removeAnsiEscapeCodes(rawPreview);
 		let marker: number | undefined;
 
 		// currently, the UI only exposes jump-to-message from tests or locations,


### PR DESCRIPTION
Fixes #305615

## Summary

- When `testRun.appendOutput()` is called with a `Location`, the output preview stored in `ITestOutputMessage.message` retains raw ANSI escape codes. This causes escape sequences to appear as garbled text in inline test decorations and their hover tooltips.
- **`testResult.ts`**: Strip ANSI codes from the preview string at creation time via `removeAnsiEscapeCodes()`, so all downstream consumers get clean text
- **`testingDecorations.ts`**: Strip ANSI codes from the hover message using `renderTestMessageAsText()` instead of passing raw message text
- The terminal-based "Test Results" view is unaffected — it reads from the raw `VSBuffer` output directly via xterm, which natively interprets ANSI codes

## Test plan

- [ ] Create a test extension that calls `testRun.appendOutput('\x1b[33mcolored text\x1b[39m', location)` with a Location
- [ ] Verify inline decoration shows clean text ("colored text") without ANSI escape sequences
- [ ] Verify hovering over the inline decoration shows clean text in the tooltip
- [ ] Verify the "Test Results" terminal still renders colors correctly
- [ ] Verify test error messages (assertions) still work correctly with markdown formatting