### PR TITLE
fix: respect chat.promptFilesLocations ordering for file discovery

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -359,14 +359,19 @@ export class PromptsService extends Disposable implements IPromptsService {
 	}
 
 	private async computeListPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]> {
-		const prompts = await Promise.all([
-			this.fileLocator.listFiles(type, PromptsStorage.user, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath))),
-			this.fileLocator.listFiles(type, PromptsStorage.local, token).then(uris => uris.map(uri => ({ uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath))),
+		const [orderedFiles, extensionPrompts, pluginPrompts] = await Promise.all([
+			this.fileLocator.listAllFilesInOrder(type, token),
 			this.getExtensionPromptFiles(type, token),
 			this._pluginPromptFilesByType.get(type) ?? [],
 		]);
 
-		return prompts.flat();
+		const prompts: IPromptPath[] = orderedFiles.map(({ uri, storage }) =>
+			storage === PromptsStorage.user
+				? { uri, storage: PromptsStorage.user, type } satisfies IUserPromptPath
+				: { uri, storage: PromptsStorage.local, type } satisfies ILocalPromptPath
+		);
+
+		return [...prompts, ...extensionPrompts, ...pluginPrompts];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -177,6 +177,39 @@ export class PromptFilesLocator {
 		return [...paths];
 	}
 
+	/**
+	 * List all prompt files in the order configured by `chat.promptFilesLocations`.
+	 * Unlike {@link listFiles}, this method returns files from all storage types
+	 * in their configured order with storage metadata attached.
+	 */
+	public async listAllFilesInOrder(type: PromptsType, token: CancellationToken): Promise<readonly { uri: URI; storage: PromptsStorage }[]> {
+		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations);
+
+		if (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt) {
+			absoluteLocations.push(this.userDataFolder);
+		}
+
+		const seen = new ResourceSet();
+		const result: { uri: URI; storage: PromptsStorage }[] = [];
+
+		for (const location of absoluteLocations) {
+			const files = (location.filePattern === undefined)
+				? await this.resolveFilesAtLocation(location.parent, type, token)
+				: await this.searchFilesInLocation(location.parent, location.filePattern, token);
+			for (const file of files) {
+				if (getPromptFileType(file) === type && !seen.has(file)) {
+					seen.add(file);
+					result.push({ uri: file, storage: location.storage });
+				}
+			}
+			if (token.isCancellationRequested) {
+				return [];
+			}
+		}
+		return result;
+	}
+
 	public createFilesUpdatedEvent(type: PromptsType): { readonly event: Event<void>; dispose: () => void } {
 		const disposables = new DisposableStore();
 		const eventEmitter = disposables.add(new Emitter<void>());
@@ -347,16 +380,13 @@ export class PromptFilesLocator {
 	}
 
 	/**
-	 * Gets all resolved source folders in the same order that file discovery
-	 * searches them (user folders first, then local/workspace folders).
-	 * This matches the order used by {@link listFiles} and should be used
-	 * for debug/diagnostic output so the displayed order is accurate.
+	 * Gets all resolved source folders in the order they are configured
+	 * in `chat.promptFilesLocations`. This preserves the user's intended
+	 * precedence order for file discovery and deduplication.
 	 */
 	public async getSourceFoldersInDiscoveryOrder(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
 		const absoluteLocations = await this.getLocalStorageFolders(type);
-		const userFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.user);
-		const localFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.local);
-		return this.dedupeSourceFolders([...userFolders, ...localFolders]);
+		return this.dedupeSourceFolders(absoluteLocations);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Fixed `getSourceFoldersInDiscoveryOrder()` to preserve the user's configured ordering in `chat.promptFilesLocations` instead of hardcoding user-before-local
- Added `listAllFilesInOrder()` method to `PromptFilesLocator` that returns files with storage metadata in their configured order
- Updated `computeListPromptFiles()` in `promptsServiceImpl.ts` to use the new ordered listing instead of making separate user/local calls that always put user first

## Test plan

- [ ] Configure `chat.promptFilesLocations` with local paths before user paths (e.g., `{ ".prompts": true, "~/prompts": true }`)
- [ ] Verify that prompt files from `.prompts` appear before those from `~/prompts` in the prompt file picker
- [ ] Verify the reverse ordering also works when user paths are configured first
- [ ] Verify default behavior (no custom ordering) still works correctly
- [ ] Verify the debug panel source folder diagnostics reflect the configured order

Fixes #305876