### PR TITLE
fix: agents app not closing for update on macOS

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -128,7 +128,7 @@ async function runSessionsUpdateAction(
 				scheme: productService.urlProtocol,
 				query: 'windowId=_blank',
 			}), { openExternal: true });
-			await hostService.close();
+			await hostService.shutdown();
 		}
 
 		return;

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -636,6 +636,10 @@ export class BrowserHostService extends Disposable implements IHostService {
 		mainWindow.close();
 	}
 
+	async shutdown(): Promise<void> {
+		return this.close();
+	}
+
 	async withExpectedShutdown<T>(expectedShutdownTask: () => Promise<T>): Promise<T> {
 		const previousShutdownReason = this.shutdownReason;
 		try {

--- a/src/vs/workbench/services/host/browser/host.ts
+++ b/src/vs/workbench/services/host/browser/host.ts
@@ -142,6 +142,13 @@ export interface IHostService {
 	close(): Promise<void>;
 
 	/**
+	 * Quit the entire application. Unlike {@link close}, this will
+	 * terminate the process even on macOS where closing the last
+	 * window normally keeps the app running.
+	 */
+	shutdown(): Promise<void>;
+
+	/**
 	 * Execute an asynchronous `expectedShutdownTask`. While this task is
 	 * in progress, attempts to quit the application will not be vetoed with a dialog.
 	 */

--- a/src/vs/workbench/services/host/electron-browser/nativeHostService.ts
+++ b/src/vs/workbench/services/host/electron-browser/nativeHostService.ts
@@ -214,6 +214,10 @@ class WorkbenchHostService extends Disposable implements IHostService {
 		return this.nativeHostService.closeWindow();
 	}
 
+	shutdown(): Promise<void> {
+		return this.nativeHostService.quit();
+	}
+
 	async withExpectedShutdown<T>(expectedShutdownTask: () => Promise<T>): Promise<T> {
 		return await expectedShutdownTask();
 	}

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1360,6 +1360,7 @@ export class TestHostService implements IHostService {
 	async restart(): Promise<void> { }
 	async reload(): Promise<void> { }
 	async close(): Promise<void> { }
+	async shutdown(): Promise<void> { }
 	async withExpectedShutdown<T>(expectedShutdownTask: () => Promise<T>): Promise<T> {
 		return await expectedShutdownTask();
 	}


### PR DESCRIPTION
Prevents blank windows of agents app after update via the host app on macOS