### PR TITLE
actions: add WorkbenchActionBar with telemetry support

### DIFF
--- a/src/vs/platform/actions/browser/actionbar.ts
+++ b/src/vs/platform/actions/browser/actionbar.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ActionBar, IActionBarOptions } from '../../../base/browser/ui/actionbar/actionbar.js';
+import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from '../../../base/common/actions.js';
+import { ITelemetryService } from '../../telemetry/common/telemetry.js';
+
+export interface IWorkbenchActionBarOptions extends IActionBarOptions {
+	/**
+	 * When set the `workbenchActionExecuted` is automatically sent for each invoked action. The `from` property
+	 * of the event will be the passed `telemetrySource`-value.
+	 */
+	telemetrySource?: string;
+}
+
+/**
+ * A {@link ActionBar action bar} that automatically sends `workbenchActionExecuted` telemetry
+ * events for each invoked action, like {@link import('./toolbar.js').WorkbenchToolBar WorkbenchToolBar} does.
+ */
+export class WorkbenchActionBar extends ActionBar {
+
+	constructor(
+		container: HTMLElement,
+		options: IWorkbenchActionBarOptions,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super(container, options);
+
+		const telemetrySource = options.telemetrySource;
+		if (telemetrySource) {
+			this._store.add(this.onDidRun(e => telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>(
+				'workbenchActionExecuted',
+				{ id: e.action.id, from: telemetrySource })
+			));
+		}
+	}
+}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
@@ -8,7 +8,8 @@ import * as dom from '../../../../base/browser/dom.js';
 import { DEFAULT_FONT_FAMILY } from '../../../../base/browser/fonts.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { renderAsPlaintext, renderMarkdown } from '../../../../base/browser/markdownRenderer.js';
-import { ActionBar, ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
+import { ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
+import { WorkbenchActionBar } from '../../../../platform/actions/browser/actionbar.js';
 import { BaseActionViewItem } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { ActionRunner, IAction } from '../../../../base/common/actions.js';
@@ -89,9 +90,10 @@ export class InlineChatInputWidget extends Disposable {
 
 		// Create vertical actions bar below the input container
 		const actionsContainer = dom.append(this._domNode, dom.$('.inline-chat-gutter-actions'));
-		const actionBar = this._store.add(new ActionBar(actionsContainer, {
+		const actionBar = this._store.add(instantiationService.createInstance(WorkbenchActionBar, actionsContainer, {
 			orientation: ActionsOrientation.VERTICAL,
 			preventLoopNavigation: true,
+			telemetrySource: 'inlineChatInput.actionBar',
 		}));
 		const actionsMenu = this._store.add(this._menuService.createMenu(MenuId.ChatEditorInlineMenu, this._contextKeyService));
 		const updateActions = () => {


### PR DESCRIPTION
## Summary

Add a `WorkbenchActionBar` class that wraps `ActionBar` with automatic `workbenchActionExecuted` telemetry, analogous to how `WorkbenchToolBar` wraps `ToolBar`. Adopt it in the inline chat overlay widget.

Fixes #306432

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **New class instead of modifying ActionBar**: Created a new `WorkbenchActionBar` in `src/vs/platform/actions/browser/actionbar.ts` rather than modifying the base `ActionBar` class, following the existing pattern of `WorkbenchToolBar` (wraps `ToolBar`) and `WorkbenchButtonBar` (wraps `ButtonBar`).
- **Separate file**: Placed in its own file `actionbar.ts` alongside `toolbar.ts` and `buttonbar.ts`, consistent with the existing per-widget file organization.
- **Incremental adoption**: Only the inline chat overlay widget's action bar is migrated in this PR. Other `ActionBar` usages can adopt `WorkbenchActionBar` separately.

</details>

## Changes

- **New file `src/vs/platform/actions/browser/actionbar.ts`**: `WorkbenchActionBar` extends `ActionBar`, injects `ITelemetryService`, and subscribes to `onDidRun` to log `workbenchActionExecuted` when `telemetrySource` is set.
- **`src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts`**: Replaced `new ActionBar(...)` with `instantiationService.createInstance(WorkbenchActionBar, ...)` and added `telemetrySource: 'inlineChatInput.actionBar'`.
