### PR TITLE
fix: adjust .ts?esm URLs to .js?esm after transpilation

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -712,7 +712,22 @@ async function transpileFile(srcPath: string, destPath: string): Promise<void> {
 	});
 
 	await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-	await fs.promises.writeFile(destPath, result.code);
+
+	const adjustedCode = adjustEsmUrl(result.code);
+	await fs.promises.writeFile(destPath, adjustedCode);
+}
+
+/*
+ * This enables https://github.com/microsoft/esm-url-bundler-plugins to work on both original and transpiled sources.
+ * Usees regex to only replace `.ts?esm` inside quoted URL strings, avoiding false positives.
+ *
+ * E.g.:
+ * -  esmModuleLocationBundler: () => new URL("../../../api/worker/extensionHostWorkerMain.ts?esm", import.meta.url)
+ * +  esmModuleLocationBundler: () => new URL("../../../api/worker/extensionHostWorkerMain.js?esm", import.meta.url)
+ */
+function adjustEsmUrl(code: string): string {
+	const fixedCode = code.replace(/\.ts(\?esm['"])/g, '.js$1');
+	return fixedCode;
 }
 
 async function transpile(outDir: string, excludeTests: boolean): Promise<void> {


### PR DESCRIPTION
After transpilation, `.ts?esm` URL references in `new URL(...)` expressions remain pointing at `.ts` files, which breaks [esm-url-bundler-plugins](https://github.com/microsoft/esm-url-bundler-plugins) when consuming the transpiled output.

This adds an `adjustEsmUrl()` post-processing step in `build/next/index.ts` that rewrites `.ts?esm` → `.js?esm` inside quoted URL strings, so the bundler plugins work on both original and transpiled sources.

Example:
```diff
- new URL("../../../api/worker/extensionHostWorkerMain.ts?esm", import.meta.url)
+ new URL("../../../api/worker/extensionHostWorkerMain.js?esm", import.meta.url)
```