### PR TITLE
sessions: open customizations editor to agents page from mode picker

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -16,6 +16,7 @@ import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Target } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { AICustomizationManagementCommands } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
@@ -148,7 +149,7 @@ export class ModePicker extends Disposable {
 				if (item.kind === 'mode') {
 					this._selectMode(item.mode);
 				} else {
-					this.commandService.executeCommand(AICustomizationManagementCommands.OpenEditor);
+					this.commandService.executeCommand(AICustomizationManagementCommands.OpenEditor, AICustomizationManagementSection.Agents);
 				}
 			},
 			onHide: () => { triggerElement.focus(); },


### PR DESCRIPTION
## Summary

When clicking **"Configure Custom Agents..."** in the sessions mode picker dropdown, the customizations editor now opens directly to the **Agents** page instead of whichever page was previously viewed.

## Change

In `modePicker.ts`, the `AICustomizationManagementCommands.OpenEditor` command is now called with `AICustomizationManagementSection.Agents` as the section argument. The `OpenEditor` command already supports this parameter — it calls `pane.selectSectionById(section)` when provided — so this is a one-line change plus the import.

## Testing

- Open the sessions window chat input dropdown
- Click "Configure Custom Agents..."
- Verify the customizations editor opens to the Agents section regardless of which section was last viewed