### PR TITLE
Skip the builtinCG for extensions without a repo

### DIFF
--- a/build/lib/builtInExtensionsCG.ts
+++ b/build/lib/builtInExtensionsCG.ts
@@ -21,9 +21,14 @@ const contentFileNames = ['package.json', 'package-lock.json'];
 
 async function downloadExtensionDetails(extension: IExtensionDefinition): Promise<void> {
 	const extensionLabel = `${extension.name}@${extension.version}`;
+
+	if (!extension.repo) {
+		console.log(`Skipping CG for ${extensionLabel} because no repository is defined`);
+		return;
+	}
+
 	const repository = url.parse(extension.repo).path!.substr(1);
 	const repositoryContentBaseUrl = `https://${token ? `${token}@` : ''}${contentBasePath}/${repository}/v${extension.version}`;
-
 
 	async function getContent(fileName: string): Promise<{ fileName: string; body: Buffer | undefined | null }> {
 		try {


### PR DESCRIPTION
If an built-in extension does not have a repo, we assume that it's being maintained by another team

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
