### PR TITLE
sessions: round hover/focus backgrounds in Changes panel to 4px

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/checksWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/checksWidget.ts
@@ -274,7 +274,7 @@ export class CIStatusWidget extends Disposable {
 				},
 			},
 		));
-		this._bodyNode.appendChild(this._list.getHTMLElement());
+		this._bodyNode.appendChild(listContainer);
 	}
 
 	setInput(input: ChecksViewModel): IDisposable {

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -254,7 +254,7 @@
 }
 
 .changes-view-body .chat-editing-session-container.show-file-icons .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
-	border-radius: 2px;
+	border-radius: 4px;
 }
 
 /* Action bar in list rows */

--- a/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/checksWidget.css
@@ -145,6 +145,7 @@
 }
 
 .ci-status-widget-list {
+	height: 100%;
 	background-color: transparent;
 }
 


### PR DESCRIPTION
## Summary

Rounds the hover/focus highlight backgrounds in the Changes panel (sessions app) to 4px, consistent with other rounded elements in the UI.

<img width="468" height="533" alt="Screenshot 2026-04-07 at 2 05 24 PM" src="https://github.com/user-attachments/assets/2bdedc12-b3c5-402e-8e0c-fb600f4b65f9" />

### Changes

**Fix `.ci-status-widget-list` not being in the DOM** (`checksWidget.ts`)

The `listContainer` (`.ci-status-widget-list`) element was created and passed to `WorkbenchList` as its container, but then only the inner `.monaco-list` was appended to the body node — leaving the `.ci-status-widget-list` wrapper detached. This meant all CSS rules targeting `.ci-status-widget-list` were dead code, including the existing `border-radius: 4px` rule on `.monaco-list-row`.

Fixed by appending `listContainer` itself (instead of `this._list.getHTMLElement()`) to the body node.

**Add `height: 100%` to `.ci-status-widget-list`** (`checksWidget.css`)

Required now that `.ci-status-widget-list` is a real DOM wrapper — `.monaco-list` uses `height: 100%` relative to its parent, so the wrapper needs an explicit height to fill the body.

**Update file list row border-radius from 2px → 4px** (`changesView.css`)

Updated `.changes-view-body .chat-editing-session-container.show-file-icons .monaco-scrollable-element .monaco-list-rows .monaco-list-row` to use `border-radius: 4px` to match the rest of the Changes panel.