### PR TITLE
Refactor enableThinking/reasoningEffort into IModelCapabilityOptions

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -229,7 +229,7 @@ export class ClaudeLanguageModelServer extends Disposable {
 				messages: messagesForLogging,
 				finishedCb: async () => undefined,
 				location: ChatLocation.MessagesProxy,
-				enableThinking: true,
+				modelCapabilities: { enableThinking: true },
 				userInitiatedRequest: isUserInitiatedMessage
 			}, tokenSource.token);
 

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -626,7 +626,9 @@ export class CopilotLanguageModelWrapper extends Disposable {
 			requestOptions: options,
 			userInitiatedRequest: !!extensionId,
 			telemetryProperties,
-			reasoningEffort: typeof _options.modelConfiguration?.reasoningEffort === 'string' ? _options.modelConfiguration.reasoningEffort : undefined,
+			modelCapabilities: {
+				reasoningEffort: typeof _options.modelConfiguration?.reasoningEffort === 'string' ? _options.modelConfiguration.reasoningEffort : undefined,
+			},
 		}, token);
 
 		// Run request within the parent OTel context (no extra span) so chat spans in chatMLFetcher inherit the agent trace

--- a/extensions/copilot/src/extension/externalAgents/node/oaiLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/externalAgents/node/oaiLanguageModelServer.ts
@@ -205,7 +205,7 @@ export class OpenAILanguageModelServer extends Disposable {
 				messages: messagesForLogging,
 				finishedCb: async () => undefined,
 				location: ChatLocation.ResponsesProxy,
-				enableThinking: true,
+				modelCapabilities: { enableThinking: true },
 				userInitiatedRequest: isUserInitiatedMessage
 			}, tokenSource.token);
 

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -103,7 +103,7 @@ export interface IToolCallingBuiltPromptEvent {
 	tools: LanguageModelToolInformation[];
 }
 
-export type ToolCallingLoopFetchOptions = Required<Pick<IMakeChatRequestOptions, 'messages' | 'finishedCb' | 'requestOptions' | 'userInitiatedRequest' | 'turnId'>> & Pick<IMakeChatRequestOptions, 'enableThinking' | 'reasoningEffort'>;
+export type ToolCallingLoopFetchOptions = Required<Pick<IMakeChatRequestOptions, 'messages' | 'finishedCb' | 'requestOptions' | 'userInitiatedRequest' | 'turnId'>> & Pick<IMakeChatRequestOptions, 'modelCapabilities'>;
 
 interface StartHookResult {
 	/**
@@ -1415,8 +1415,6 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		let statefulMarker: string | undefined;
 		const toolCalls: IToolCall[] = [];
 		let thinkingItem: ThinkingDataItem | undefined;
-		const rawEffort = this.options.request.modelConfiguration?.reasoningEffort;
-		const reasoningEffort = typeof rawEffort === 'string' ? rawEffort : undefined;
 		const shouldDisableThinking = isContinuation && isAnthropicFamily(endpoint) && !ToolCallingLoop.messagesContainThinking(effectiveBuildPromptResult.messages);
 		const enableThinking = !shouldDisableThinking;
 		let phase: string | undefined;
@@ -1468,8 +1466,9 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 				})),
 			},
 			userInitiatedRequest: (iterationNumber === 0 && !isContinuation && !this.options.request.subAgentInvocationId && !this.options.request.isSystemInitiated) || this.stopHookUserInitiated,
-			enableThinking,
-			reasoningEffort,
+			modelCapabilities: {
+				enableThinking,
+			},
 		}, token).finally(() => {
 			this.stopHookUserInitiated = false;
 		});

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -21,7 +21,7 @@ import { IGitService } from '../../../platform/git/common/gitService';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
 import { HAS_IGNORED_FILES_MESSAGE } from '../../../platform/ignore/common/ignoreService';
 import { ILogService } from '../../../platform/log/common/logService';
-import { isAnthropicToolSearchEnabled } from '../../../platform/networking/common/anthropic';
+import { isAnthropicContextEditingEnabled, isAnthropicToolSearchEnabled } from '../../../platform/networking/common/anthropic';
 import { FilterReason } from '../../../platform/networking/common/openai';
 import { IOTelService } from '../../../platform/otel/common/otelService';
 import { CapturingToken } from '../../../platform/requestLogger/common/capturingToken';
@@ -693,9 +693,18 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 		const debugName = this._isInlineSummarizationRequest ? 'inlineSummarizeConversationHistory-full' : baseDebugName;
 		const location = this.options.overrideRequestLocation ?? this.options.location;
 		const isThinkingLocation = location === ChatLocation.Agent || location === ChatLocation.MessagesProxy;
+		const rawEffort = this.options.request.modelConfiguration?.reasoningEffort;
+		const reasoningEffort = typeof rawEffort === 'string' ? rawEffort : undefined;
+		const isSubagent = !!this.options.request.subAgentInvocationId;
 		return this.options.invocation.endpoint.makeChatRequest2({
 			...opts,
-			enableThinking: isThinkingLocation && opts.enableThinking,
+			modelCapabilities: {
+				...opts.modelCapabilities,
+				enableThinking: isThinkingLocation && opts.modelCapabilities?.enableThinking,
+				reasoningEffort,
+				enableToolSearch: !isSubagent && isAnthropicToolSearchEnabled(this.options.invocation.endpoint, this._configurationService),
+				enableContextEditing: !isSubagent && isAnthropicContextEditingEnabled(this.options.invocation.endpoint, this._configurationService, this._experimentationService),
+			},
 			debugName,
 			conversationId: this.options.conversation.sessionId,
 			turnId: opts.turnId,

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -125,15 +125,14 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		return allTools.filter(tool => allowedExecutionTools.has(tool.name as ToolName));
 	}
 
-	protected async fetch({ messages, finishedCb, requestOptions, enableThinking, reasoningEffort }: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
+	protected async fetch({ messages, finishedCb, requestOptions, modelCapabilities }: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
 		const endpoint = await this.getEndpoint();
 		return endpoint.makeChatRequest2({
 			debugName: ExecutionSubagentToolCallingLoop.ID,
 			messages,
 			finishedCb,
 			location: this.options.location,
-			enableThinking,
-			reasoningEffort,
+			modelCapabilities,
 			requestOptions: {
 				...(requestOptions ?? {}),
 				temperature: 0

--- a/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/searchSubagentToolCallingLoop.ts
@@ -139,15 +139,14 @@ export class SearchSubagentToolCallingLoop extends ToolCallingLoop<ISearchSubage
 		return allTools.filter(tool => allowedSearchTools.has(tool.name as ToolName));
 	}
 
-	protected async fetch({ messages, finishedCb, requestOptions, enableThinking, reasoningEffort }: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
+	protected async fetch({ messages, finishedCb, requestOptions, modelCapabilities }: ToolCallingLoopFetchOptions, token: CancellationToken): Promise<ChatResponse> {
 		const endpoint = await this.getEndpoint();
 		return endpoint.makeChatRequest2({
 			debugName: SearchSubagentToolCallingLoop.ID,
 			messages,
 			finishedCb,
 			location: this.options.location,
-			enableThinking,
-			reasoningEffort,
+			modelCapabilities,
 			requestOptions: {
 				...requestOptions,
 				temperature: 0

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as vscode from 'vscode';
+import { TOOL_SEARCH_SUPPORTED_MODELS } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { ILogService } from '../../../platform/log/common/logService';
-import { CUSTOM_TOOL_SEARCH_NAME, TOOL_SEARCH_SUPPORTED_MODELS } from '../../../platform/networking/common/anthropic';
+import { CUSTOM_TOOL_SEARCH_NAME } from '../../../platform/networking/common/anthropic';
 import { LanguageModelTextPart, LanguageModelToolResult } from '../../../vscodeTypes';
 import { ICopilotModelSpecificTool, ToolRegistry } from '../common/toolsRegistry';
 import { IToolsService } from '../common/toolsService';

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -379,3 +379,47 @@ export function getVerbosityForModelSync(model: IChatEndpoint): 'low' | 'medium'
 
 	return undefined;
 }
+
+/** Model ID prefixes that support the tool search tool. */
+export const TOOL_SEARCH_SUPPORTED_MODELS = [
+	'claude-sonnet-4.5',
+	'claude-sonnet-4.6',
+	'claude-opus-4.5',
+	'claude-opus-4.6',
+] as const;
+
+/**
+ * Returns true if the model supports the tool search tool.
+ * Provider-agnostic: add additional model prefixes here as other providers adopt tool search.
+ */
+export function modelSupportsToolSearch(modelId: string): boolean {
+	return TOOL_SEARCH_SUPPORTED_MODELS.some(prefix => modelId.toLowerCase().startsWith(prefix));
+}
+
+/**
+ * Context editing is supported by:
+ * - Claude Haiku 4.5 (claude-haiku-4-5-* or claude-haiku-4.5-*)
+ * - Claude Sonnet 4.6 (claude-sonnet-4-6-* or claude-sonnet-4.6-*)
+ * - Claude Sonnet 4.5 (claude-sonnet-4-5-* or claude-sonnet-4.5-*)
+ * - Claude Sonnet 4 (claude-sonnet-4-*)
+ * - Claude Opus 4.6 (claude-opus-4-6-* or claude-opus-4.6-*)
+ * - Claude Opus 4.5 (claude-opus-4-5-* or claude-opus-4.5-*)
+ * - Claude Opus 4.1 (claude-opus-4-1-* or claude-opus-4.1-*)
+ * - Claude Opus 4 (claude-opus-4-*)
+ * Provider-agnostic: add additional model prefixes here as other providers adopt context editing.
+ */
+export function modelSupportsContextEditing(modelId: string): boolean {
+	const normalized = modelId.toLowerCase().replace(/\./g, '-');
+	// The 1M context variant doesn't need context editing
+	if (normalized.includes('1m')) {
+		return false;
+	}
+	return normalized.startsWith('claude-haiku-4-5') ||
+		normalized.startsWith('claude-sonnet-4-6') ||
+		normalized.startsWith('claude-sonnet-4-5') ||
+		normalized.startsWith('claude-sonnet-4') ||
+		normalized.startsWith('claude-opus-4-6') ||
+		normalized.startsWith('claude-opus-4-5') ||
+		normalized.startsWith('claude-opus-4-1') ||
+		normalized.startsWith('claude-opus-4');
+}

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -54,6 +54,8 @@ export type IChatModelCapabilities = {
 		max_thinking_budget?: number;
 		min_thinking_budget?: number;
 		reasoning_effort?: string[];
+		tool_search?: boolean;
+		context_editing?: boolean;
 	};
 };
 

--- a/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/node/chatEndpoint.ts
@@ -30,7 +30,7 @@ import { ITelemetryService, TelemetryProperties } from '../../telemetry/common/t
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { ITokenizerProvider } from '../../tokenizer/node/tokenizer';
 import { ICAPIClientService } from '../common/capiClient';
-import { isGeminiFamily } from '../common/chatModelCapabilities';
+import { isGeminiFamily, modelSupportsContextEditing, modelSupportsToolSearch } from '../common/chatModelCapabilities';
 import { IDomainService } from '../common/domainService';
 import { CustomModel, IChatModelInformation, ModelSupportedEndpoint } from '../common/endpointProvider';
 import { createMessagesRequestBody, processResponseFromMessagesEndpoint } from './messagesApi';
@@ -129,6 +129,8 @@ export class ChatEndpoint implements IChatEndpoint {
 	public readonly minThinkingBudget?: number;
 	public readonly maxThinkingBudget?: number;
 	public readonly supportsReasoningEffort?: string[];
+	public readonly supportsToolSearch?: boolean;
+	public readonly supportsContextEditing?: boolean;
 	public readonly isPremium?: boolean | undefined;
 	public readonly multiplier?: number | undefined;
 	public readonly restrictedToSkus?: string[] | undefined;
@@ -170,6 +172,8 @@ export class ChatEndpoint implements IChatEndpoint {
 		this.minThinkingBudget = modelMetadata.capabilities.supports.min_thinking_budget;
 		this.maxThinkingBudget = modelMetadata.capabilities.supports.max_thinking_budget;
 		this.supportsReasoningEffort = modelMetadata.capabilities.supports.reasoning_effort;
+		this.supportsToolSearch = modelMetadata.capabilities.supports.tool_search ?? modelSupportsToolSearch(this.model);
+		this.supportsContextEditing = modelMetadata.capabilities.supports.context_editing ?? modelSupportsContextEditing(this.model);
 		this._supportsStreaming = !!modelMetadata.capabilities.supports.streaming;
 		this.customModel = modelMetadata.custom_model;
 		this.maxPromptImages = modelMetadata.capabilities.limits?.vision?.max_prompt_images;
@@ -179,35 +183,29 @@ export class ChatEndpoint implements IChatEndpoint {
 	// so getExtraHeaders can gate the interleaved-thinking header on whether thinking is actually enabled for the
 	// request, rather than using the location check. Once plumbed, replace isAllowedConversationAgentModel with
 	// an enableThinking check for the thinking header (keep location gate for context management / tool search).
-	public getExtraHeaders(location?: ChatLocation): Record<string, string> {
+	public getExtraHeaders(_location?: ChatLocation): Record<string, string> {
 		const headers: Record<string, string> = { ...this.modelMetadata.requestHeaders };
 
-		const isAllowedConversationAgentModel = location === ChatLocation.Agent || location === ChatLocation.MessagesProxy;
-		if (isAllowedConversationAgentModel && this.useMessagesApi) {
+		if (this.useMessagesApi) {
 
 			const modelProviderPreference = this._configurationService.getConfig(ConfigKey.TeamInternal.ModelProviderPreference);
 			if (modelProviderPreference) {
 				headers['X-Model-Provider-Preference'] = modelProviderPreference;
 			}
 
-			const betaFeatures: string[] = [];
+			const betas: string[] = [];
 
 			if (!this.supportsAdaptiveThinking) {
-				betaFeatures.push('interleaved-thinking-2025-05-14');
+				betas.push('interleaved-thinking-2025-05-14');
 			}
-
-			// Add context management beta if enabled (required for context editing)
-			if (isAnthropicContextEditingEnabled(this.model, this._configurationService, this._expService)) {
-				betaFeatures.push('context-management-2025-06-27');
+			if (isAnthropicToolSearchEnabled(this, this._configurationService)) {
+				betas.push('advanced-tool-use-2025-11-20');
 			}
-
-			// Add tool search beta if enabled
-			if (isAnthropicToolSearchEnabled(this.model, this._configurationService)) {
-				betaFeatures.push('advanced-tool-use-2025-11-20');
+			if (isAnthropicContextEditingEnabled(this, this._configurationService, this._expService)) {
+				betas.push('context-management-2025-06-27');
 			}
-
-			if (betaFeatures.length > 0) {
-				headers['anthropic-beta'] = betaFeatures.join(',');
+			if (betas.length > 0) {
+				headers['anthropic-beta'] = betas.join(',');
 			}
 		}
 

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -104,9 +104,6 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 
 	const toolSearchEnabled = isAnthropicToolSearchEnabled(endpoint, configurationService);
 	const customToolSearchEnabled = isAnthropicCustomToolSearchEnabled(endpoint, configurationService, experimentationService);
-	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
-	// TODO: Use a dedicated flag on options instead of relying on telemetry subType
-	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
 
 	// Split tools into non-deferred and deferred up front so we can build finalTools
 	// with non-deferred first. This ensures the cache_control breakpoint on the last
@@ -118,7 +115,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 			if (!tool.function.name || tool.function.name.length === 0) {
 				continue;
 			}
-			const isDeferred = toolSearchEnabled && isAllowedConversationAgent && !isSubagent && !toolDeferralService.isNonDeferredTool(tool.function.name);
+			const isDeferred = options.modelCapabilities?.enableToolSearch && toolSearchEnabled && !toolDeferralService.isNonDeferredTool(tool.function.name);
 			const anthropicTool: AnthropicMessagesTool = {
 				name: tool.function.name,
 				description: tool.function.description || '',
@@ -131,7 +128,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 
 	// Build final tools array, adding tool search tool if enabled
 	const finalTools: AnthropicMessagesTool[] = [];
-	if (isAllowedConversationAgent && !isSubagent && toolSearchEnabled && !customToolSearchEnabled) {
+	if (options.modelCapabilities?.enableToolSearch && toolSearchEnabled && !customToolSearchEnabled) {
 		// Server-side tool search: use the built-in tool_search_tool_regex
 		finalTools.push({ name: TOOL_SEARCH_TOOL_NAME, type: TOOL_SEARCH_TOOL_TYPE, defer_loading: false });
 	}
@@ -144,9 +141,9 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	// Thinking is enabled only when options.enableThinking is true, a non-zero thinking budget
 	// is configured for the model, and the model supports thinking. reasoningEffort (if present)
 	// is used only to configure the effort level when thinking is enabled, not to gate it.
-	const reasoningEffort = options.reasoningEffort;
+	const reasoningEffort = options.modelCapabilities?.reasoningEffort;
 	let thinkingConfig: { type: 'enabled' | 'adaptive'; budget_tokens?: number } | undefined;
-	if (options.enableThinking) {
+	if (options.modelCapabilities?.enableThinking) {
 		const configuredBudget = configurationService.getConfig(ConfigKey.AnthropicThinkingBudget);
 		const thinkingExplicitlyDisabled = configuredBudget === 0;
 		if (endpoint.supportsAdaptiveThinking && !thinkingExplicitlyDisabled) {
@@ -177,7 +174,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	}
 
 	// Build context management configuration
-	const contextManagement = isAllowedConversationAgent && !isSubagent && isAnthropicContextEditingEnabled(endpoint, configurationService, experimentationService)
+	const contextManagement = options.modelCapabilities?.enableContextEditing && isAnthropicContextEditingEnabled(endpoint, configurationService, experimentationService)
 		? getContextManagementFromConfig(configurationService, experimentationService, thinkingEnabled)
 		: undefined;
 

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -75,7 +75,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const shouldDisableReasoningSummary = endpoint.family === 'gpt-5.3-codex-spark-preview';
 	const effortFromSetting = configService.getConfig(ConfigKey.TeamInternal.ResponsesApiReasoningEffort);
 	const effort = endpoint.supportsReasoningEffort?.length
-		? (effortFromSetting || options.reasoningEffort || 'medium')
+		? (effortFromSetting || options.modelCapabilities?.reasoningEffort || 'medium')
 		: undefined;
 	const summary = summaryConfig === 'off' || shouldDisableReasoningSummary ? undefined : summaryConfig;
 	if (effort || summary) {

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -732,8 +732,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			supportsReasoningEffort: ['low', 'medium', 'high'],
 		});
 		const options = createMinimalOptions({
-			enableThinking: true,
-			reasoningEffort: 'high',
+			modelCapabilities: { enableThinking: true, reasoningEffort: 'high' },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
@@ -748,8 +747,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			// supportsReasoningEffort is undefined
 		});
 		const options = createMinimalOptions({
-			enableThinking: true,
-			reasoningEffort: 'high',
+			modelCapabilities: { enableThinking: true, reasoningEffort: 'high' },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
@@ -764,8 +762,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			supportsReasoningEffort: [],
 		});
 		const options = createMinimalOptions({
-			enableThinking: true,
-			reasoningEffort: 'medium',
+			modelCapabilities: { enableThinking: true, reasoningEffort: 'medium' },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
@@ -780,8 +777,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			supportsReasoningEffort: ['low', 'medium', 'high'],
 		});
 		const options = createMinimalOptions({
-			enableThinking: false,
-			reasoningEffort: 'high',
+			modelCapabilities: { enableThinking: false, reasoningEffort: 'high' },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
@@ -796,8 +792,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			supportsReasoningEffort: ['low', 'medium', 'high'],
 		});
 		const options = createMinimalOptions({
-			enableThinking: true,
-			reasoningEffort: 'xhigh' as any,
+			modelCapabilities: { enableThinking: true, reasoningEffort: 'xhigh' as any },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
@@ -815,8 +810,7 @@ describe('createMessagesRequestBody reasoning effort', () => {
 		});
 		mockConfig.setConfig(ConfigKey.AnthropicThinkingBudget, 10000);
 		const options = createMinimalOptions({
-			enableThinking: true,
-			reasoningEffort: 'low',
+			modelCapabilities: { enableThinking: true, reasoningEffort: 'low' },
 		});
 
 		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);

--- a/extensions/copilot/src/platform/networking/common/anthropic.ts
+++ b/extensions/copilot/src/platform/networking/common/anthropic.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
+import { modelSupportsContextEditing, modelSupportsToolSearch } from '../../endpoint/common/chatModelCapabilities';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { IChatEndpoint } from './networking';
 
@@ -75,14 +76,6 @@ export const TOOL_SEARCH_TOOL_TYPE = 'tool_search_tool_regex_20251119';
 /** Name for the custom client-side embeddings-based tool search tool. Must not use copilot_/vscode_ prefix — those are reserved for static package.json declarations and will be rejected by vscode.lm.registerToolDefinition. */
 export const CUSTOM_TOOL_SEARCH_NAME = 'tool_search';
 
-/** Model ID prefixes that support tool search tools. Used by isAnthropicToolSearchEnabled() and the tool registration's model selector. */
-export const TOOL_SEARCH_SUPPORTED_MODELS = [
-	'claude-sonnet-4.5',
-	'claude-sonnet-4.6',
-	'claude-opus-4.5',
-	'claude-opus-4.6',
-] as const;
-
 /**
  * Context management types for Anthropic Messages API
  * Based on https://platform.claude.com/docs/en/build-with-claude/context-editing
@@ -133,36 +126,6 @@ export interface ContextManagementResponse {
 }
 
 /**
- * Context editing is supported by:
- * - Claude Haiku 4.5 (claude-haiku-4-5-* or claude-haiku-4.5-*)
- * - Claude Sonnet 4.6 (claude-sonnet-4-6-* or claude-sonnet-4.6-*)
- * - Claude Sonnet 4.5 (claude-sonnet-4-5-* or claude-sonnet-4.5-*)
- * - Claude Sonnet 4 (claude-sonnet-4-*)
- * - Claude Opus 4.6 (claude-opus-4-6-* or claude-opus-4.6-*)
- * - Claude Opus 4.5 (claude-opus-4-5-* or claude-opus-4.5-*)
- * - Claude Opus 4.1 (claude-opus-4-1-* or claude-opus-4.1-*)
- * - Claude Opus 4 (claude-opus-4-*)
- * @param modelId The model ID to check
- * @returns true if the model supports context editing
- */
-export function modelSupportsContextEditing(modelId: string): boolean {
-	// Normalize: lowercase and replace dots with dashes so "4.5" matches "4-5"
-	const normalized = modelId.toLowerCase().replace(/\./g, '-');
-	// The 1M context variant doesn't need context editing
-	if (normalized.includes('1m')) {
-		return false;
-	}
-	return normalized.startsWith('claude-haiku-4-5') ||
-		normalized.startsWith('claude-sonnet-4-6') ||
-		normalized.startsWith('claude-sonnet-4-5') ||
-		normalized.startsWith('claude-sonnet-4') ||
-		normalized.startsWith('claude-opus-4-6') ||
-		normalized.startsWith('claude-opus-4-5') ||
-		normalized.startsWith('claude-opus-4-1') ||
-		normalized.startsWith('claude-opus-4');
-}
-
-/**
  * Interleaved thinking is supported by:
  * - Claude Sonnet 4.5 (claude-sonnet-4-5-* or claude-sonnet-4.5-*)
  * - Claude Sonnet 4 (claude-sonnet-4-*)
@@ -209,9 +172,10 @@ export function isAnthropicToolSearchEnabled(
 	endpoint: IChatEndpoint | string,
 	configurationService: IConfigurationService
 ): boolean {
-
-	const effectiveModelId = typeof endpoint === 'string' ? endpoint : endpoint.model;
-	if (!TOOL_SEARCH_SUPPORTED_MODELS.some(prefix => effectiveModelId.toLowerCase().startsWith(prefix))) {
+	const supportsIt = typeof endpoint === 'string'
+		? modelSupportsToolSearch(endpoint)
+		: endpoint.supportsToolSearch ?? modelSupportsToolSearch(endpoint.model);
+	if (!supportsIt) {
 		return false;
 	}
 
@@ -239,9 +203,10 @@ export function isAnthropicContextEditingEnabled(
 	configurationService: IConfigurationService,
 	experimentationService: IExperimentationService,
 ): boolean {
-
-	const effectiveModelId = typeof endpoint === 'string' ? endpoint : endpoint.model;
-	if (!modelSupportsContextEditing(effectiveModelId)) {
+	const supportsIt = typeof endpoint === 'string'
+		? modelSupportsContextEditing(endpoint)
+		: endpoint.supportsContextEditing ?? modelSupportsContextEditing(endpoint.model);
+	if (!supportsIt) {
 		return false;
 	}
 	const mode = configurationService.getExperimentBasedConfig(ConfigKey.AnthropicContextEditingMode, experimentationService);

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -152,6 +152,18 @@ export interface IEmbeddingsEndpoint extends IEndpoint {
 	readonly maxBatchSize: number;
 }
 
+/** Per-request model capability opt-ins. All off by default. */
+export interface IModelCapabilityOptions {
+	/** Explicitly enable thinking for this request. */
+	enableThinking?: boolean;
+	/** Reasoning effort level (e.g. 'low', 'medium', 'high'). Only used when enableThinking is true or when the model supports reasoning effort. */
+	reasoningEffort?: string;
+	/** Enable the tool search tool for this request. */
+	enableToolSearch?: boolean;
+	/** Enable context editing for this request. */
+	enableContextEditing?: boolean;
+}
+
 export interface IMakeChatRequestOptions {
 	/** The debug name for this request */
 	debugName: string;
@@ -184,10 +196,8 @@ export interface IMakeChatRequestOptions {
 	enableRetryOnError?: boolean;
 	/** Which fetcher to use, overrides the default. */
 	useFetcher?: FetcherId;
-	/** Explicitly enable thinking for this request. When not set, thinking is disabled. */
-	enableThinking?: boolean;
-	/** Reasoning effort level for this request (e.g. 'low', 'medium', 'high'). Only used when enableThinking is true or when the model supports reasoning effort. */
-	reasoningEffort?: string;
+	/** Per-request model capability opt-ins (thinking, tool search, context editing). */
+	modelCapabilities?: IModelCapabilityOptions;
 	/** Enable retrying once on simple network errors like ECONNRESET. */
 	canRetryOnceWithoutRollback?: boolean;
 	/** Custom metadata to be displayed in the log document */
@@ -234,6 +244,8 @@ export interface IChatEndpoint extends IEndpoint {
 	readonly minThinkingBudget?: number;
 	readonly maxThinkingBudget?: number;
 	readonly supportsReasoningEffort?: string[];
+	readonly supportsToolSearch?: boolean;
+	readonly supportsContextEditing?: boolean;
 	readonly supportsToolCalls: boolean;
 	readonly supportsVision: boolean;
 	readonly supportsPrediction: boolean;


### PR DESCRIPTION
Port of microsoft/vscode-copilot-chat#5026.

Refactors flat `enableThinking` and `reasoningEffort` fields on `IMakeChatRequestOptions` into a single `modelCapabilities?: IModelCapabilityOptions` object. Also moves model capability check helpers (`TOOL_SEARCH_SUPPORTED_MODELS`, `modelSupportsToolSearch`, `modelSupportsContextEditing`) from `anthropic.ts` to `chatModelCapabilities.ts`, and adds `supportsToolSearch`/`supportsContextEditing` fields to `IChatEndpoint` so they can be set from server-side metadata.