### PR TITLE
Sessions: derive PR icon from live GitHubPullRequestModel

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -10,7 +10,7 @@ import { CancellationError } from '../../../../base/common/errors.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, IObservable, IReader, observableFromEvent, observableValue, transaction } from '../../../../base/common/observable.js';
-import { themeColorFromId, ThemeIcon } from '../../../../base/common/themables.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
@@ -42,6 +42,8 @@ import { SessionsGroupModel } from '../../sessions/browser/sessionsGroupModel.js
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IGitHubService } from '../../github/browser/githubService.js';
+import { computePullRequestIcon, GitHubPullRequestState } from '../../github/common/types.js';
 
 export interface ICopilotChatSession {
 	/** Globally unique session ID (`providerId:localId`). */
@@ -387,7 +389,7 @@ class CopilotCLISession extends Disposable implements ICopilotChatSession {
 	}
 
 	update(agentSession: IAgentSession): void {
-		const session = new AgentSessionAdapter(agentSession, this.providerId);
+		const session = new AgentSessionAdapter(agentSession, this.providerId, undefined);
 		this._workspaceData.set(session.workspace.get(), undefined);
 		this._title.set(session.title.get(), undefined);
 		this._status.set(session.status.get(), undefined);
@@ -703,7 +705,7 @@ class AgentSessionAdapter implements ICopilotChatSession {
 	private readonly _lastTurnEnd: ReturnType<typeof observableValue<Date | undefined>>;
 	readonly lastTurnEnd: IObservable<Date | undefined>;
 
-	private readonly _gitHubInfo: ReturnType<typeof observableValue<IGitHubInfo | undefined>>;
+	private readonly _baseGitHubInfo: ReturnType<typeof observableValue<IGitHubInfo | undefined>>;
 	readonly gitHubInfo: IObservable<IGitHubInfo | undefined>;
 
 	readonly permissionLevel: IObservable<ChatPermissionLevel> = constObservable(ChatPermissionLevel.Default);
@@ -715,6 +717,7 @@ class AgentSessionAdapter implements ICopilotChatSession {
 	constructor(
 		session: IAgentSession,
 		providerId: string,
+		private readonly _gitHubService: IGitHubService | undefined,
 	) {
 		this.id = `${providerId}:${session.resource.toString()}`;
 		this.resource = session.resource;
@@ -750,8 +753,21 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		this.description = this._description;
 		this._lastTurnEnd = observableValue(this, session.timing.lastRequestEnded ? new Date(session.timing.lastRequestEnded) : undefined);
 		this.lastTurnEnd = this._lastTurnEnd;
-		this._gitHubInfo = observableValue(this, this._extractGitHubInfo(session));
-		this.gitHubInfo = this._gitHubInfo;
+		this._baseGitHubInfo = observableValue(this, this._extractGitHubInfo(session));
+		this.gitHubInfo = this._gitHubService
+			? derived(this, reader => {
+				const base = this._baseGitHubInfo.read(reader);
+				if (!base?.pullRequest || !this._gitHubService) {
+					return base;
+				}
+				const prModel = this._gitHubService.getPullRequest(base.owner, base.repo, base.pullRequest.number);
+				const livePR = prModel.pullRequest.read(reader);
+				if (!livePR) {
+					return base;
+				}
+				return { ...base, pullRequest: { ...base.pullRequest, icon: computePullRequestIcon(livePR.isDraft ? 'draft' : livePR.state) } };
+			})
+			: this._baseGitHubInfo;
 	}
 
 	setPermissionLevel(level: ChatPermissionLevel): void {
@@ -784,7 +800,7 @@ class AgentSessionAdapter implements ICopilotChatSession {
 			this._isRead.set(session.isRead(), tx);
 			this._description.set(this._extractDescription(session), tx);
 			this._lastTurnEnd.set(session.timing.lastRequestEnded ? new Date(session.timing.lastRequestEnded) : undefined, tx);
-			this._gitHubInfo.set(this._extractGitHubInfo(session), tx);
+			this._baseGitHubInfo.set(this._extractGitHubInfo(session), tx);
 		});
 	}
 
@@ -884,17 +900,8 @@ class AgentSessionAdapter implements ICopilotChatSession {
 	private _extractPullRequestStateIcon(session: IAgentSession): ThemeIcon | undefined {
 		const metadata = session.metadata;
 		const state = metadata?.pullRequestState;
-		if (state) {
-			switch (state) {
-				case 'merged':
-					return { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') };
-				case 'closed':
-					return { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') };
-				case 'draft':
-					return { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') };
-				default:
-					return { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') };
-			}
+		if (typeof state === 'string') {
+			return computePullRequestIcon(state as GitHubPullRequestState | 'draft');
 		}
 		return undefined;
 	}
@@ -1059,6 +1066,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
+		@IGitHubService private readonly gitHubService: IGitHubService,
 	) {
 		super();
 
@@ -1818,7 +1826,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 				existing.update(session);
 				changedData.push(existing);
 			} else {
-				const adapter = new AgentSessionAdapter(session, this.id);
+				const adapter = new AgentSessionAdapter(session, this.id, this.gitHubService);
 				this._sessionCache.set(key, adapter);
 				addedData.push(adapter);
 			}

--- a/src/vs/sessions/contrib/github/common/types.ts
+++ b/src/vs/sessions/contrib/github/common/types.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../base/common/codicons.js';
+import { themeColorFromId, ThemeIcon } from '../../../../base/common/themables.js';
+
 //#region Session Context
 
 /**
@@ -85,6 +88,24 @@ export interface IMergeBlocker {
 export interface IGitHubPullRequestMergeability {
 	readonly canMerge: boolean;
 	readonly blockers: readonly IMergeBlocker[];
+}
+
+/**
+ * Compute the PR status icon from a state value.
+ * Accepts both the `GitHubPullRequestState` enum values and the
+ * metadata-only `'draft'` value the extension writes to session metadata.
+ */
+export function computePullRequestIcon(state: GitHubPullRequestState | 'draft'): ThemeIcon {
+	switch (state) {
+		case GitHubPullRequestState.Merged:
+			return { ...Codicon.gitPullRequestDone, color: themeColorFromId('charts.purple') };
+		case GitHubPullRequestState.Closed:
+			return { ...Codicon.gitPullRequestClosed, color: themeColorFromId('charts.red') };
+		case 'draft':
+			return { ...Codicon.gitPullRequestDraft, color: themeColorFromId('descriptionForeground') };
+		case GitHubPullRequestState.Open:
+			return { ...Codicon.gitPullRequest, color: themeColorFromId('charts.green') };
+	}
 }
 
 //#endregion


### PR DESCRIPTION
## Summary

Fixes: https://github.com/microsoft/vscode/issues/308242

Migrates PR state detection from static extension metadata to a reactive core feature. Session card PR icons now update automatically when the `GitHubPullRequestModel` polling detects state changes (e.g. merged, closed, draft) — no extension round-trip needed.

## Changes

### `src/vs/sessions/contrib/github/common/types.ts`
- Added `computePullRequestIcon(state, isDraft?)` — single source of truth for PR state → icon mapping
- Handles both `GitHubPullRequestState` enum values and the string states the extension writes to metadata (including `'draft'`)

### `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
- `AgentSessionAdapter.gitHubInfo` is now a `derived()` observable that combines:
  - **Base info** from extension metadata (owner, repo, prNumber, URL) — same as before
  - **Live PR model** from `IGitHubService` — reads `prModel.pullRequest` reactively
- Falls back to metadata-based icon if the PR model hasn't loaded yet
- Replaced inline icon switch in `_extractPullRequestStateIcon` with a call to the shared `computePullRequestIcon` helper
- Injected `IGitHubService` into `CopilotChatSessionsProvider` and passed to adapters

### Architecture

```
Extension writes metadata (pullRequestUrl, pullRequestState)
    ↓ (initial seed — owner, repo, prNumber, URL)
AgentSessionAdapter._extractGitHubInfo(session)
    ↓
derived(reader => {
    base = _baseGitHubInfo.read(reader)     // from metadata
    livePR = prModel.pullRequest.read(reader) // reactive, from polling
    icon = computePullRequestIcon(livePR.state, livePR.isDraft)
    return { ...base, pullRequest: { ...base.pullRequest, icon } }
})
    ↓
ISession.gitHubInfo (observable, auto-updates)
    ↓
sessionsList.ts autorun → re-renders icon ✓
```

## Notes
- No changes to polling behavior — existing `GitHubActiveSessionRefreshContribution` triggers refresh on session open, and existing polling handles the rest
- Extension still writes metadata for backward compat and initial state before the model loads
- PR model is cached by `IGitHubService` (keyed by owner/repo/prNumber), so multiple sessions for the same PR share a model