### PR TITLE
Add welcome page to Chat Customizations editor

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -112,6 +112,11 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 
 	readonly isSessionsWindow = true;
 
+	readonly welcomePageFeatures = {
+		showGettingStartedBanner: false,
+		showGenerateActions: false,
+	};
+
 	/**
 	 * Commits customization files. Always commits to the main repository
 	 * so the change persists across worktrees. When a worktree is active

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -6,6 +6,7 @@
 import { toAction } from '../../../../../base/common/actions.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ResourceSet } from '../../../../../base/common/map.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
@@ -142,6 +143,12 @@ function createMockPromptsServiceWithCounts(counts?: ICustomizationCounts): IPro
 	return new class extends mock<IPromptsService>() {
 		override readonly onDidChangeCustomAgents = Event.None;
 		override readonly onDidChangeSlashCommands = Event.None;
+		override readonly onDidChangeSkills = Event.None;
+		override readonly onDidChangeInstructions = Event.None;
+		override readonly onDidChangeHooks = Event.None;
+		override getDisabledPromptFiles(): ResourceSet { return new ResourceSet(); }
+		override async getInstructionFiles() { return instructions as never[]; }
+		override getPromptLocationLabel() { return ''; }
 		override async getCustomAgents() { return agents as never[]; }
 		override async findAgentSkills() { return skills as never[]; }
 		override async getPromptSlashCommands() { return prompts as never[]; }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -296,7 +296,13 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private dimension: DOM.Dimension | undefined;
 	private readonly sections: ISectionItem[] = [];
 	private readonly allSections: ISectionItem[] = [];
-	private selectedSection: AICustomizationManagementSection = AICustomizationManagementSection.Agents;
+	private selectedSection: AICustomizationManagementSection | undefined;
+
+	// Welcome page
+	private welcomeContentContainer: HTMLElement | undefined;
+	private welcomeCardsContainer: HTMLElement | undefined;
+	private welcomeGettingStartedButton: HTMLElement | undefined;
+	private readonly welcomeCardDisposables = this._register(new DisposableStore());
 
 	private readonly editorDisposables = this._register(new DisposableStore());
 	private readonly promptsSectionCountScheduler = this._register(new RunOnceScheduler(() => this._doRefreshAllPromptsSectionCounts(), 100));
@@ -380,12 +386,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 		this.rebuildVisibleSections();
 
-		// Restore selected section from storage, falling back to first available
+		// Restore selected section from storage, falling back to welcome page
 		const savedSection = this.storageService.get(AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY, StorageScope.PROFILE);
 		if (savedSection && this.sections.some(s => s.id === savedSection)) {
 			this.selectedSection = savedSection as AICustomizationManagementSection;
-		} else if (this.sections.length > 0) {
-			this.selectedSection = this.sections[0].id;
+		} else {
+			this.selectedSection = undefined; // Show welcome page
 		}
 	}
 
@@ -509,9 +515,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.sectionsList.splice(0, this.sectionsList.length, this.sections);
 		}
 
-		// If the current selection is hidden, fall back to first visible
-		if (!this.sections.some(s => s.id === this.selectedSection) && this.sections.length > 0) {
-			this.selectSection(this.sections[0].id);
+		// Rebuild welcome cards to reflect new visible sections
+		this.rebuildWelcomeCards();
+
+		// If the current selection is hidden, fall back to welcome page
+		if (this.selectedSection !== undefined && !this.sections.some(s => s.id === this.selectedSection) && this.sections.length > 0) {
+			this.showWelcomePage();
 		} else {
 			this.ensureSectionsListReflectsActiveSection();
 		}
@@ -552,7 +561,9 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		this.editorDisposables.add(this.sectionsList.onDidChangeSelection(e => {
 			if (e.elements.length === 0) {
-				this.ensureSectionsListReflectsActiveSection();
+				if (this.selectedSection !== undefined) {
+					this.showWelcomePage();
+				}
 				return;
 			}
 			this.selectSection(e.elements[0].id);
@@ -754,8 +765,158 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 	}
 
+	private readonly categoryDescriptions: { id: AICustomizationManagementSection; label: string; icon: ThemeIcon; description: string; promptType?: PromptsType }[] = [
+		{
+			id: AICustomizationManagementSection.Agents,
+			label: localize('agents', "Agents"),
+			icon: agentIcon,
+			description: localize('agentsDesc', "Define custom agents with specialized personas, tool access, and instructions for specific tasks."),
+			promptType: PromptsType.agent,
+		},
+		{
+			id: AICustomizationManagementSection.Skills,
+			label: localize('skills', "Skills"),
+			icon: skillIcon,
+			description: localize('skillsDesc', "Create reusable skill files that provide domain-specific knowledge and workflows."),
+			promptType: PromptsType.skill,
+		},
+		{
+			id: AICustomizationManagementSection.Instructions,
+			label: localize('instructions', "Instructions"),
+			icon: instructionsIcon,
+			description: localize('instructionsDesc', "Set always-on instructions that guide AI behavior across your workspace or user profile."),
+			promptType: PromptsType.instructions,
+		},
+		{
+			id: AICustomizationManagementSection.Hooks,
+			label: localize('hooks', "Hooks"),
+			icon: hookIcon,
+			description: localize('hooksDesc', "Configure automated actions triggered by events like saving files or running tasks."),
+			promptType: PromptsType.hook,
+		},
+		{
+			id: AICustomizationManagementSection.McpServers,
+			label: localize('mcpServers', "MCP Servers"),
+			icon: Codicon.server,
+			description: localize('mcpServersDesc', "Connect external tool servers that extend AI capabilities with custom tools and data sources."),
+		},
+		{
+			id: AICustomizationManagementSection.Plugins,
+			label: localize('plugins', "Plugins"),
+			icon: pluginIcon,
+			description: localize('pluginsDesc', "Install and manage agent plugins that add additional tools, skills, and integrations."),
+		},
+	];
+
+	private createWelcomePage(parent: HTMLElement): void {
+		this.welcomeContentContainer = DOM.append(parent, $('.welcome-content-container'));
+
+		const welcomeInner = DOM.append(this.welcomeContentContainer, $('.welcome-inner'));
+
+		const heading = DOM.append(welcomeInner, $('h2.welcome-heading'));
+		heading.textContent = localize('welcomeHeading', "Chat Customizations");
+
+		const subtitle = DOM.append(welcomeInner, $('p.welcome-subtitle'));
+		subtitle.textContent = localize('welcomeSubtitle', "Tailor how AI agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.");
+
+		const welcomePageFeatures = this.workspaceService.welcomePageFeatures;
+
+		// Getting Started banner
+		if (welcomePageFeatures?.showGettingStartedBanner !== false) {
+			const gettingStarted = DOM.append(welcomeInner, $('button.welcome-getting-started'));
+			this.welcomeGettingStartedButton = gettingStarted;
+			const gettingStartedIcon = DOM.append(gettingStarted, $('span.welcome-getting-started-icon.codicon.codicon-sparkle'));
+			gettingStartedIcon.setAttribute('aria-hidden', 'true');
+			const gettingStartedText = DOM.append(gettingStarted, $('.welcome-getting-started-text'));
+			const gettingStartedTitle = DOM.append(gettingStartedText, $('span.welcome-getting-started-title'));
+			gettingStartedTitle.textContent = localize('gettingStartedTitle', "Configure Your AI");
+			const gettingStartedDesc = DOM.append(gettingStartedText, $('span.welcome-getting-started-desc'));
+			gettingStartedDesc.textContent = localize('gettingStartedDesc', "Describe your project and coding patterns. Copilot will generate agents, skills, and instructions tailored to your workflow.");
+			const gettingStartedChevron = DOM.append(gettingStarted, $('span.welcome-getting-started-chevron.codicon.codicon-chevron-right'));
+			gettingStartedChevron.setAttribute('aria-hidden', 'true');
+			this.editorDisposables.add(DOM.addDisposableListener(gettingStarted, 'click', () => {
+				if (this.input) {
+					this.group.closeEditor(this.input);
+				}
+				this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customizations ', isPartialQuery: true });
+			}));
+		}
+
+		this.welcomeCardsContainer = DOM.append(welcomeInner, $('.welcome-cards'));
+		this.rebuildWelcomeCards();
+	}
+
+	private rebuildWelcomeCards(): void {
+		if (!this.welcomeCardsContainer) {
+			return;
+		}
+		this.welcomeCardDisposables.clear();
+		DOM.clearNode(this.welcomeCardsContainer);
+
+		const visibleSections = new Set(this.sections.map(s => s.id));
+
+		for (const category of this.categoryDescriptions) {
+			if (!visibleSections.has(category.id)) {
+				continue;
+			}
+
+			const card = DOM.append(this.welcomeCardsContainer, $('.welcome-card'));
+			card.setAttribute('tabindex', '0');
+			card.setAttribute('role', 'button');
+
+			const cardHeader = DOM.append(card, $('.welcome-card-header'));
+			const iconEl = DOM.append(cardHeader, $('.welcome-card-icon'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(category.icon));
+			const labelEl = DOM.append(cardHeader, $('span.welcome-card-label'));
+			labelEl.textContent = category.label;
+
+			const descEl = DOM.append(card, $('p.welcome-card-description'));
+			descEl.textContent = category.description;
+
+			const cardFooter = DOM.append(card, $('.welcome-card-footer'));
+
+			// "Browse" button navigates to the section
+			const browseBtn = DOM.append(cardFooter, $('button.welcome-card-browse'));
+			browseBtn.textContent = localize('browse', "Browse");
+			this.welcomeCardDisposables.add(DOM.addDisposableListener(browseBtn, 'click', (e) => {
+				e.stopPropagation();
+				this.selectSection(category.id);
+			}));
+
+			// "Generate with AI" button (only for prompt-based sections when enabled)
+			if (category.promptType && this.workspaceService.welcomePageFeatures?.showGenerateActions !== false) {
+				const generateBtn = DOM.append(cardFooter, $('button.welcome-card-generate'));
+				DOM.append(generateBtn, $('span.codicon.codicon-sparkle'));
+				const generateLabel = DOM.append(generateBtn, $('span'));
+				generateLabel.textContent = localize('generateWithAI', "Generate with AI");
+				const promptType = category.promptType;
+				this.welcomeCardDisposables.add(DOM.addDisposableListener(generateBtn, 'click', (e) => {
+					e.stopPropagation();
+					if (this.input) {
+						this.group.closeEditor(this.input);
+					}
+					this.workspaceService.generateCustomization(promptType);
+				}));
+			}
+
+			// Clicking the card itself navigates to the section
+			this.welcomeCardDisposables.add(DOM.addDisposableListener(card, 'click', () => {
+				this.selectSection(category.id);
+			}));
+			this.welcomeCardDisposables.add(DOM.addDisposableListener(card, 'keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					this.selectSection(category.id);
+				}
+			}));
+		}
+	}
+
 	private createContent(): void {
 		const contentInner = DOM.append(this.contentContainer, $('.content-inner'));
+
+		// Welcome page (shown when no section is selected)
+		this.createWelcomePage(contentInner);
 
 		// Container for prompts-based content (Agents, Skills, Instructions, Prompts)
 		this.promptsContentContainer = DOM.append(contentInner, $('.prompts-content-container'));
@@ -765,7 +926,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Handle item selection
 		this.editorDisposables.add(this.listWidget.onDidSelectItem(item => {
 			this.telemetryService.publicLog2<CustomizationEditorItemSelectedEvent, CustomizationEditorItemSelectedClassification>('chatCustomizationEditor.itemSelected', {
-				section: this.selectedSection,
+				section: this.selectedSection ?? 'welcome',
 				promptType: item.promptType,
 				storage: item.storage ?? 'external',
 			});
@@ -888,7 +1049,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 	}
 
-	private isPromptsSection(section: AICustomizationManagementSection): boolean {
+	private isPromptsSection(section: AICustomizationManagementSection | undefined): section is AICustomizationManagementSection {
 		return section === AICustomizationManagementSection.Agents ||
 			section === AICustomizationManagementSection.Skills ||
 			section === AICustomizationManagementSection.Instructions ||
@@ -936,6 +1097,30 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 	//#endregion
 
+	/**
+	 * Navigates to the welcome page (no section selected).
+	 */
+	private showWelcomePage(): void {
+		if (this.viewMode === 'editor') {
+			this.goBackToList();
+		}
+		if (this.viewMode === 'mcpDetail') {
+			this.goBackFromMcpDetail();
+		}
+		if (this.viewMode === 'pluginDetail') {
+			this.goBackFromPluginDetail();
+		}
+
+		this.selectedSection = undefined;
+		this.sectionContextKey.set('');
+
+		// Clear persisted section so welcome shows next time
+		this.storageService.remove(AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY, StorageScope.PROFILE);
+
+		this.updateContentVisibility();
+		this.ensureSectionsListReflectsActiveSection(undefined);
+	}
+
 	private selectSection(section: AICustomizationManagementSection): void {
 		if (this.selectedSection === section) {
 			this.ensureSectionsListReflectsActiveSection(section);
@@ -973,8 +1158,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.ensureSectionsListReflectsActiveSection(section);
 	}
 
-	private ensureSectionsListReflectsActiveSection(section: AICustomizationManagementSection = this.selectedSection): void {
+	private ensureSectionsListReflectsActiveSection(section: AICustomizationManagementSection | undefined = this.selectedSection): void {
 		if (!this.sectionsList) {
+			return;
+		}
+
+		if (section === undefined) {
+			// Welcome page — deselect all
+			this.sectionsList.setSelection([]);
+			this.sectionsList.setFocus([]);
 			return;
 		}
 
@@ -999,11 +1191,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 		const isMcpDetailMode = this.viewMode === 'mcpDetail';
 		const isPluginDetailMode = this.viewMode === 'pluginDetail';
 		const isDetailMode = isMcpDetailMode || isPluginDetailMode;
-		const isPromptsSection = this.isPromptsSection(this.selectedSection);
+		const isWelcome = this.selectedSection === undefined;
+		const isPromptsSection = this.selectedSection !== undefined && this.isPromptsSection(this.selectedSection);
 		const isModelsSection = this.selectedSection === AICustomizationManagementSection.Models;
 		const isMcpSection = this.selectedSection === AICustomizationManagementSection.McpServers;
 		const isPluginsSection = this.selectedSection === AICustomizationManagementSection.Plugins;
 
+		if (this.welcomeContentContainer) {
+			this.welcomeContentContainer.style.display = isWelcome && !isEditorMode && !isDetailMode ? '' : 'none';
+		}
 		if (this.promptsContentContainer) {
 			this.promptsContentContainer.style.display = !isEditorMode && !isDetailMode && isPromptsSection ? '' : 'none';
 		}
@@ -1040,7 +1236,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	 */
 	private async createNewItemWithAI(type: PromptsType): Promise<void> {
 		this.telemetryService.publicLog2<CustomizationEditorCreateItemEvent, CustomizationEditorCreateItemClassification>('chatCustomizationEditor.createItem', {
-			section: this.selectedSection,
+			section: this.selectedSection ?? 'welcome',
 			promptType: type,
 			creationMode: 'ai',
 			target: 'workspace',
@@ -1056,7 +1252,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	 */
 	private async createNewItemManual(type: PromptsType, target: 'workspace' | 'user' | 'workspace-root', rootFileName?: string): Promise<void> {
 		this.telemetryService.publicLog2<CustomizationEditorCreateItemEvent, CustomizationEditorCreateItemClassification>('chatCustomizationEditor.createItem', {
-			section: this.selectedSection,
+			section: this.selectedSection ?? 'welcome',
 			promptType: type,
 			creationMode: 'manual',
 			target: target === 'workspace-root' ? 'workspace' : target,
@@ -1070,7 +1266,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			if (!projectRoot) {
 				return;
 			}
-			const override = this.harnessService.getActiveDescriptor().sectionOverrides?.get(this.selectedSection);
+			const override = this.selectedSection ? this.harnessService.getActiveDescriptor().sectionOverrides?.get(this.selectedSection) : undefined;
 			const fileName = rootFileName ?? override?.rootFile ?? AGENT_MD_FILENAME;
 			const fileUri = URI.joinPath(projectRoot, fileName);
 			if (await this.fileService.exists(fileUri)) {
@@ -1118,7 +1314,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// When the active harness overrides the file extension (e.g. Claude
 		// rules use .md instead of .instructions.md), pass it through so the
 		// name picker and file creation use the correct extension.
-		const override = this.harnessService.getActiveDescriptor().sectionOverrides?.get(this.selectedSection);
+		const override = this.selectedSection ? this.harnessService.getActiveDescriptor().sectionOverrides?.get(this.selectedSection) : undefined;
 
 		const options: INewPromptOptions = {
 			targetFolder: targetDir,
@@ -1242,12 +1438,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.workspaceService.clearOverrideProjectRoot();
 
 		this.inEditorContextKey.set(true);
-		this.sectionContextKey.set(this.selectedSection);
+		this.sectionContextKey.set(this.selectedSection ?? '');
 
 		input.setSaveHandler(() => this.handleBuiltinSave());
 
 		this.telemetryService.publicLog2<CustomizationEditorOpenedEvent, CustomizationEditorOpenedClassification>('chatCustomizationEditor.opened', {
-			section: this.selectedSection,
+			section: this.selectedSection ?? 'welcome',
 		});
 
 		await super.setInput(input, options, context, token);
@@ -1293,6 +1489,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		super.focus();
 		if (this.viewMode === 'editor') {
 			this.embeddedEditor?.focus();
+			return;
+		}
+		if (this.selectedSection === undefined) {
+			this.welcomeGettingStartedButton?.focus();
 			return;
 		}
 		if (this.selectedSection === AICustomizationManagementSection.McpServers) {
@@ -1918,7 +2118,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	 */
 	public async showPluginDetail(item: IAgentPluginItem): Promise<void> {
 		if (this.selectedSection !== AICustomizationManagementSection.Plugins) {
-			this.pluginDetailReturnSection = this.selectedSection;
+			this.pluginDetailReturnSection = this.selectedSection ?? AICustomizationManagementSection.Agents;
 		}
 		await this.showEmbeddedPluginDetail(item);
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -64,6 +64,11 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 
 	readonly isSessionsWindow = false;
 
+	readonly welcomePageFeatures = {
+		showGettingStartedBanner: true,
+		showGenerateActions: true,
+	};
+
 	readonly hasOverrideProjectRoot = constObservable(false);
 	setOverrideProjectRoot(_root: URI): void { }
 	clearOverrideProjectRoot(): void { }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1086,3 +1086,170 @@
 .ai-customization-management-editor .embedded-editor-container .monaco-editor {
 	border-radius: 4px;
 }
+
+/* Welcome Page */
+.ai-customization-management-editor .welcome-content-container {
+	height: 100%;
+	overflow-y: auto;
+	padding: 24px;
+	box-sizing: border-box;
+}
+
+.ai-customization-management-editor .welcome-inner {
+	max-width: 800px;
+	margin: 0 auto;
+	padding-top: 16px;
+}
+
+.ai-customization-management-editor .welcome-heading {
+	font-size: 18px;
+	font-weight: 400;
+	letter-spacing: -0.01em;
+	margin: 0 0 6px;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-management-editor .welcome-subtitle {
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 20px;
+	line-height: 1.6;
+}
+
+/* Getting Started banner */
+.ai-customization-management-editor .welcome-getting-started {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+	padding: 12px 16px;
+	margin-bottom: 20px;
+	border: 1px solid var(--vscode-button-background, #007acc);
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--vscode-button-background, #007acc) 8%, transparent);
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+	text-align: left;
+	outline: none;
+}
+
+.ai-customization-management-editor .welcome-getting-started:hover {
+	background: color-mix(in srgb, var(--vscode-button-background, #007acc) 14%, transparent);
+}
+
+.ai-customization-management-editor .welcome-getting-started:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.ai-customization-management-editor .welcome-getting-started-icon {
+	font-size: 20px;
+	color: var(--vscode-button-background);
+	flex-shrink: 0;
+}
+
+.ai-customization-management-editor .welcome-getting-started-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.ai-customization-management-editor .welcome-getting-started-title {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-management-editor .welcome-getting-started-desc {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.ai-customization-management-editor .welcome-getting-started-chevron {
+	margin-left: auto;
+	font-size: 16px;
+	color: var(--vscode-descriptionForeground);
+	flex-shrink: 0;
+}
+
+.ai-customization-management-editor .welcome-cards {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 10px;
+}
+
+.ai-customization-management-editor .welcome-card {
+	display: flex;
+	flex-direction: column;
+	padding: 16px;
+	border: 1px solid var(--vscode-widget-border);
+	border-radius: 6px;
+	background: var(--vscode-sideBar-background);
+	cursor: pointer;
+	transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.ai-customization-management-editor .welcome-card:hover {
+	border-color: var(--vscode-focusBorder);
+	background: var(--vscode-list-hoverBackground);
+}
+
+.ai-customization-management-editor .welcome-card:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.ai-customization-management-editor .welcome-card-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.ai-customization-management-editor .welcome-card-icon {
+	font-size: 16px;
+	color: var(--vscode-icon-foreground);
+}
+
+.ai-customization-management-editor .welcome-card-label {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-management-editor .welcome-card-description {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.5;
+	margin: 0 0 12px;
+	flex: 1;
+}
+
+.ai-customization-management-editor .welcome-card-footer {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.ai-customization-management-editor .welcome-card-browse,
+.ai-customization-management-editor .welcome-card-generate {
+	font-size: 11px;
+	color: var(--vscode-foreground);
+	text-decoration: none;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 3px 8px;
+	border-radius: 4px;
+	background: var(--vscode-button-secondaryBackground);
+	border: none;
+}
+
+.ai-customization-management-editor .welcome-card-browse:hover,
+.ai-customization-management-editor .welcome-card-generate:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}

--- a/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
@@ -58,6 +58,17 @@ export interface IStorageSourceFilter {
 }
 
 /**
+ * Controls which features are shown on the welcome page of the
+ * AI Customization Management Editor.
+ */
+export interface IWelcomePageFeatures {
+	/** Show the "Configure Your AI" getting-started banner. */
+	readonly showGettingStartedBanner: boolean;
+	/** Show "Generate with AI" actions on category cards. */
+	readonly showGenerateActions: boolean;
+}
+
+/**
  * Applies a storage source filter to an array of items that have uri and storage.
  * Removes items whose storage is not in the filter's source list,
  * and for user-storage items, removes those not under an allowed root.
@@ -106,6 +117,11 @@ export interface IAICustomizationWorkspaceService {
 	 * Whether this is a sessions window (vs core VS Code).
 	 */
 	readonly isSessionsWindow: boolean;
+
+	/**
+	 * Controls which features are displayed on the welcome page.
+	 */
+	readonly welcomePageFeatures: IWelcomePageFeatures;
 
 	/**
 	 * Commits files in the active project.

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
@@ -52,6 +52,7 @@ function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], a
 		override readonly onDidChangeSlashCommands = Event.None;
 		override readonly onDidChangeSkills = Event.None;
 		override readonly onDidChangeInstructions = Event.None;
+		override readonly onDidChangeHooks = Event.None;
 		override getDisabledPromptFiles(): ResourceSet { return new ResourceSet(); }
 		override async listPromptFiles(type: PromptsType) {
 			if (type === PromptsType.instructions) {
@@ -100,6 +101,10 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 	const activeProjectRoot = observableValue<URI | undefined>('mockActiveProjectRoot', URI.file('/workspace'));
 	return new class extends mock<IAICustomizationWorkspaceService>() {
 		override readonly isSessionsWindow = false;
+		override readonly welcomePageFeatures = {
+			showGettingStartedBanner: true,
+			showGenerateActions: true,
+		};
 		override readonly activeProjectRoot = activeProjectRoot;
 		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 		override getActiveProjectRoot() { return URI.file('/workspace'); }

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -105,7 +105,9 @@ function createMockPromptsService(files: IFixtureFile[], agentInstructions: IAge
 		override readonly onDidChangeSlashCommands = Event.None;
 		override readonly onDidChangeSkills = Event.None;
 		override readonly onDidChangeInstructions = Event.None;
+		override readonly onDidChangeHooks = Event.None;
 		override getDisabledPromptFiles(): ResourceSet { return new ResourceSet(); }
+		override getPromptLocationLabel() { return ''; }
 		override async listPromptFiles(type: PromptsType, _token: CancellationToken) {
 			return files.filter(f => f.type === type).map(f => ({
 				uri: f.uri,
@@ -458,6 +460,10 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 			reg.defineInstance(IPromptsService, createMockPromptsService(allFiles, agentInstructions));
 			reg.defineInstance(IAICustomizationWorkspaceService, new class extends mock<IAICustomizationWorkspaceService>() {
 				override readonly isSessionsWindow = isSessionsWindow;
+				override readonly welcomePageFeatures = {
+					showGettingStartedBanner: !isSessionsWindow,
+					showGenerateActions: !isSessionsWindow,
+				};
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 				override getActiveProjectRoot() { return URI.file('/workspace'); }
@@ -632,6 +638,10 @@ async function renderMcpBrowseMode(ctx: ComponentFixtureContext): Promise<void> 
 			reg.defineInstance(IDialogService, new class extends mock<IDialogService>() { }());
 			reg.defineInstance(IAICustomizationWorkspaceService, new class extends mock<IAICustomizationWorkspaceService>() {
 				override readonly isSessionsWindow = false;
+				override readonly welcomePageFeatures = {
+					showGettingStartedBanner: true,
+					showGenerateActions: true,
+				};
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 				override getActiveProjectRoot() { return URI.file('/workspace'); }
@@ -798,25 +808,31 @@ async function renderPluginBrowseMode(ctx: ComponentFixtureContext): Promise<voi
 
 export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 
+	// Welcome page — default state with no section selected
+	WelcomePage: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.VSCode }),
+	}),
+
 	// Full editor with Local (VS Code) harness — all sections visible, harness dropdown,
 	// Generate buttons, AGENTS.md shortcut, all storage groups
 	LocalHarness: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.VSCode }),
+		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.VSCode, selectedSection: AICustomizationManagementSection.Agents }),
 	}),
 
 	// Full editor with Copilot CLI harness — no prompts section, CLI-specific
 	// root files and instruction filtering under .github/.copilot paths.
 	CliHarness: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.CLI }),
+		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.CLI, selectedSection: AICustomizationManagementSection.Agents }),
 	}),
 
 	// Full editor with Claude harness — Prompts+Plugins hidden, Agents visible,
 	// "Add CLAUDE.md" button, "New Rule" dropdown, instruction filtering, bridged MCP badge
 	ClaudeHarness: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.Claude }),
+		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.Claude, selectedSection: AICustomizationManagementSection.Agents }),
 	}),
 
 	// Sessions-window variant of the full editor with workspace override UX
@@ -826,6 +842,7 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 		render: ctx => renderEditor(ctx, {
 			harness: CustomizationHarness.CLI,
 			isSessionsWindow: true,
+			selectedSection: AICustomizationManagementSection.Agents,
 			availableHarnesses: [
 				createCliHarnessDescriptor(getCliUserRoots(userHome), [BUILTIN_STORAGE]),
 			],


### PR DESCRIPTION
## Summary

Adds a default welcome page to the Chat Customizations editor that shows when no section is selected (the new default state).

## Welcome Page Contents

- **Heading & subtitle** — "Chat Customizations" with a brief description
- **Getting Started banner** — Accent-colored CTA with sparkle icon that pre-fills `/agent-customizations` into chat (without sending)
- **Category card grid** — Cards for Agents, Skills, Instructions, Hooks, MCP Servers, and Plugins, each with:
  - Category icon and description
  - **Browse** button → navigates to that section
  - **Generate with AI** button → closes editor and triggers AI generation (prompt-based sections only)

## Design Details

- `selectedSection` is now nullable (`undefined` = welcome page)
- All interactive elements are proper `<button>` elements for keyboard accessibility
- Cards rebuild dynamically when visible sections change (e.g., harness switch from VS Code to Claude)
- Welcome container has `tabindex="-1"` for programmatic focus support
- Getting Started banner has `focus-visible` outline styling
- Telemetry calls use `?? 'welcome'` fallback for the nullable section

## Testing

- Added `WelcomePage` component fixture for screenshot testing
- Updated `LocalHarness` fixture to explicitly select Agents tab (since default is now welcome page)
- TypeScript compilation: clean
- Layering check: clean
- Hygiene: clean