### PR TITLE
Add inline YAML prompt override debug setting

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4011,6 +4011,18 @@
 						],
 						"description": "%github.copilot.config.projectSetupInfoSkill.enabled%"
 					},
+					"github.copilot.chat.debug.promptOverrideString": {
+						"type": [
+							"string",
+							"null"
+						],
+						"default": null,
+						"markdownDescription": "YAML string that overrides the system prompt and/or tool descriptions sent to the model. When both this setting and `github.copilot.chat.debug.promptOverrideFile` are configured, this setting takes precedence.\n\n**Note**: This is an advanced debugging setting.",
+						"tags": [
+							"advanced",
+							"experimental"
+						]
+					},
 					"github.copilot.chat.debug.promptOverrideFile": {
 						"type": [
 							"string",

--- a/extensions/copilot/src/extension/intents/node/promptOverride.ts
+++ b/extensions/copilot/src/extension/intents/node/promptOverride.ts
@@ -8,14 +8,48 @@ import * as yaml from 'js-yaml';
 import type { LanguageModelToolInformation, Uri } from 'vscode';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { ILogService } from '../../../platform/log/common/logService';
+import { URI } from '../../../util/vs/base/common/uri';
 
 interface PromptOverrideConfig {
 	readonly systemPrompt?: string;
 	readonly toolDescriptions?: Record<string, { readonly description: string }>;
 }
 
-/** Tracks which file URIs have already had a warning logged, to avoid spamming. */
-const warnedFiles = new Set<string>();
+interface PromptOverrideResult {
+	readonly messages: Raw.ChatMessage[];
+	readonly tools: LanguageModelToolInformation[];
+}
+
+const INLINE_PROMPT_OVERRIDE_SOURCE = 'github.copilot.chat.debug.promptOverrideString';
+
+/** Tracks which override sources have already had a warning logged, to avoid spamming. */
+const warnedSources = new Set<string>();
+
+export async function applyConfiguredPromptOverrides(
+	inlinePromptOverride: string | null,
+	promptOverrideFile: string | null,
+	messages: readonly Raw.ChatMessage[],
+	tools: readonly LanguageModelToolInformation[],
+	fileSystemService: IFileSystemService,
+	logService: ILogService,
+): Promise<PromptOverrideResult> {
+	const normalizedInlinePromptOverride = inlinePromptOverride?.trim();
+	const normalizedPromptOverrideFile = promptOverrideFile?.trim();
+
+	if (normalizedInlinePromptOverride) {
+		if (normalizedPromptOverrideFile) {
+			logService.trace('[PromptOverride] Both inline prompt override text and prompt override file are configured; using inline prompt override text');
+		}
+
+		return applyPromptOverridesFromString(normalizedInlinePromptOverride, messages, tools, logService);
+	}
+
+	if (normalizedPromptOverrideFile) {
+		return applyPromptOverrides(URI.file(normalizedPromptOverrideFile), messages, tools, fileSystemService, logService);
+	}
+
+	return clonePromptOverrideResult(messages, tools);
+}
 
 /**
  * Applies debug prompt overrides from a YAML file.
@@ -28,30 +62,70 @@ export async function applyPromptOverrides(
 	tools: readonly LanguageModelToolInformation[],
 	fileSystemService: IFileSystemService,
 	logService: ILogService,
-): Promise<{ messages: Raw.ChatMessage[]; tools: LanguageModelToolInformation[] }> {
-	let config: PromptOverrideConfig;
+	): Promise<PromptOverrideResult> {
+	const key = fileUri.toString();
+	let content: string;
 	try {
 		const buffer = await fileSystemService.readFile(fileUri);
-		const content = new TextDecoder().decode(buffer);
+		content = new TextDecoder().decode(buffer);
+	} catch (err) {
+		logPromptOverrideFailure(logService, key, `Failed to read prompt override file "${key}"`, err);
+		return clonePromptOverrideResult(messages, tools);
+	}
+
+	const config = parsePromptOverrideConfig(content, key, `prompt override file "${key}"`, logService);
+	if (!config) {
+		return clonePromptOverrideResult(messages, tools);
+	}
+
+	return applyPromptOverrideConfig(config, messages, tools, logService);
+}
+
+
+export function applyPromptOverridesFromString(
+	content: string,
+	messages: readonly Raw.ChatMessage[],
+	tools: readonly LanguageModelToolInformation[],
+	logService: ILogService,
+): PromptOverrideResult {
+	const config = parsePromptOverrideConfig(content, INLINE_PROMPT_OVERRIDE_SOURCE, `inline prompt override setting "${INLINE_PROMPT_OVERRIDE_SOURCE}"`, logService);
+	if (!config) {
+		return clonePromptOverrideResult(messages, tools);
+	}
+
+	return applyPromptOverrideConfig(config, messages, tools, logService);
+}
+
+function parsePromptOverrideConfig(
+	content: string,
+	sourceKey: string,
+	sourceDescription: string,
+	logService: ILogService,
+): PromptOverrideConfig | undefined {
+	let config: PromptOverrideConfig;
+	try {
 		config = yaml.load(content) as PromptOverrideConfig;
 	} catch (err) {
-		const key = fileUri.toString();
-		if (!warnedFiles.has(key)) {
-			warnedFiles.add(key);
-			logService.warn(`[PromptOverride] Failed to read or parse YAML file "${key}": ${err}`);
-		} else {
-			logService.trace(`[PromptOverride] Failed to read or parse YAML file "${key}": ${err}`);
-		}
-		return { messages: [...messages], tools: [...tools] };
+		logPromptOverrideFailure(logService, sourceKey, `Failed to parse prompt override from ${sourceDescription}`, err);
+		return undefined;
 	}
 
-	// On successful read, clear any previous warning so a new error is re-surfaced as warn
-	warnedFiles.delete(fileUri.toString());
+	// On successful parsing, clear any previous warning so a new error is re-surfaced as warn.
+	warnedSources.delete(sourceKey);
 
 	if (!config || typeof config !== 'object') {
-		return { messages: [...messages], tools: [...tools] };
+		return undefined;
 	}
 
+	return config;
+}
+
+function applyPromptOverrideConfig(
+	config: PromptOverrideConfig,
+	messages: readonly Raw.ChatMessage[],
+	tools: readonly LanguageModelToolInformation[],
+	logService: ILogService,
+): PromptOverrideResult {
 	let resultMessages = [...messages];
 	let resultTools = [...tools];
 
@@ -68,12 +142,28 @@ export async function applyPromptOverrides(
 	return { messages: resultMessages, tools: resultTools };
 }
 
+function clonePromptOverrideResult(
+	messages: readonly Raw.ChatMessage[],
+	tools: readonly LanguageModelToolInformation[],
+): PromptOverrideResult {
+	return { messages: [...messages], tools: [...tools] };
+}
+
+function logPromptOverrideFailure(logService: ILogService, sourceKey: string, message: string, err: unknown): void {
+	if (!warnedSources.has(sourceKey)) {
+		warnedSources.add(sourceKey);
+		logService.warn(`[PromptOverride] ${message}: ${err}`);
+	} else {
+		logService.trace(`[PromptOverride] ${message}: ${err}`);
+	}
+}
+
 /**
  * Resets the internal warning deduplication state.
  * Exported for testing only.
  */
 export function resetPromptOverrideWarnings(): void {
-	warnedFiles.clear();
+	warnedSources.clear();
 }
 
 function applySystemPromptOverride(messages: Raw.ChatMessage[], systemPrompt: string): Raw.ChatMessage[] {

--- a/extensions/copilot/src/extension/intents/node/promptOverride.ts
+++ b/extensions/copilot/src/extension/intents/node/promptOverride.ts
@@ -20,7 +20,7 @@ interface PromptOverrideResult {
 	readonly tools: LanguageModelToolInformation[];
 }
 
-const INLINE_PROMPT_OVERRIDE_SOURCE = 'github.copilot.chat.debug.promptOverrideString';
+const INLINE_PROMPT_OVERRIDE_SOURCE = 'inlinePromptOverrideString';
 
 /** Tracks which override sources have already had a warning logged, to avoid spamming. */
 const warnedSources = new Set<string>();

--- a/extensions/copilot/src/extension/intents/node/promptOverride.ts
+++ b/extensions/copilot/src/extension/intents/node/promptOverride.ts
@@ -62,7 +62,7 @@ export async function applyPromptOverrides(
 	tools: readonly LanguageModelToolInformation[],
 	fileSystemService: IFileSystemService,
 	logService: ILogService,
-	): Promise<PromptOverrideResult> {
+): Promise<PromptOverrideResult> {
 	const key = fileUri.toString();
 	let content: string;
 	try {

--- a/extensions/copilot/src/extension/intents/node/test/promptOverride.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/promptOverride.spec.ts
@@ -9,7 +9,7 @@ import type { LanguageModelToolInformation } from 'vscode';
 import { MockFileSystemService } from '../../../../platform/filesystem/node/test/mockFileSystemService';
 import { TestLogService } from '../../../../platform/testing/common/testLogService';
 import { URI } from '../../../../util/vs/base/common/uri';
-import { applyPromptOverrides, resetPromptOverrideWarnings } from '../promptOverride';
+import { applyConfiguredPromptOverrides, applyPromptOverrides, applyPromptOverridesFromString, resetPromptOverrideWarnings } from '../promptOverride';
 
 function makeMessages(...specs: Array<{ role: Raw.ChatRole; content: string }>): Raw.ChatMessage[] {
 	return specs.map(s => ({
@@ -108,6 +108,43 @@ describe('applyPromptOverrides', () => {
 		expect(result.tools[1].description).toBe('Default description for tool_b');
 	});
 
+	test('applies inline system prompt override', () => {
+		const result = applyPromptOverridesFromString(
+			'systemPrompt: "Inline system prompt"',
+			makeMessages(
+				{ role: Raw.ChatRole.System, content: 'Old system' },
+				{ role: Raw.ChatRole.User, content: 'Hello' },
+			),
+			makeTools('tool_a'),
+			logService,
+		);
+
+		expect(result.messages[0]).toEqual({
+			role: Raw.ChatRole.System,
+			content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Inline system prompt' }],
+		});
+		expect(result.messages[1]).toEqual({
+			role: Raw.ChatRole.User,
+			content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }],
+		});
+	});
+
+	test('applies inline tool description overrides', () => {
+		const result = applyPromptOverridesFromString(
+			[
+				'toolDescriptions:',
+				'  tool_a:',
+				'    description: "Inline description"',
+			].join('\n'),
+			makeMessages(),
+			makeTools('tool_a', 'tool_b'),
+			logService,
+		);
+
+		expect(result.tools[0].description).toBe('Inline description');
+		expect(result.tools[1].description).toBe('Default description for tool_b');
+	});
+
 	test('applies both system prompt and tool description overrides', async () => {
 		const fileUri = URI.file('/override.yaml');
 		fileSystemService.mockFile(fileUri, [
@@ -147,6 +184,18 @@ describe('applyPromptOverrides', () => {
 
 		expect(result.messages).toEqual(messages);
 		expect(result.tools).toEqual(tools);
+	});
+
+	test('returns unchanged and logs warning on invalid inline YAML', () => {
+		const warnSpy = vi.spyOn(logService, 'warn');
+		const messages = makeMessages({ role: Raw.ChatRole.System, content: 'original' });
+		const tools = makeTools('tool_a');
+
+		const result = applyPromptOverridesFromString('{{{{not valid yaml', messages, tools, logService);
+
+		expect(result.messages).toEqual(messages);
+		expect(result.tools).toEqual(tools);
+		expect(warnSpy).toHaveBeenCalledOnce();
 	});
 
 	test('silently ignores tool names not found in available tools', async () => {
@@ -201,5 +250,29 @@ describe('applyPromptOverrides', () => {
 		fileSystemService.mockError(fileUri, new Error('ENOENT'));
 		await applyPromptOverrides(fileUri, messages, tools, fileSystemService, logService);
 		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	test('prefers inline prompt override text over prompt override file', async () => {
+		const fileUri = URI.file('/override.yaml');
+		fileSystemService.mockFile(fileUri, 'systemPrompt: "From file"');
+		const traceSpy = vi.spyOn(logService, 'trace');
+
+		const result = await applyConfiguredPromptOverrides(
+			'systemPrompt: "From inline"',
+			fileUri.fsPath,
+			makeMessages(
+				{ role: Raw.ChatRole.System, content: 'Old system' },
+				{ role: Raw.ChatRole.User, content: 'Hello' },
+			),
+			makeTools('tool_a'),
+			fileSystemService,
+			logService,
+		);
+
+		expect(result.messages[0]).toEqual({
+			role: Raw.ChatRole.System,
+			content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'From inline' }],
+		});
+		expect(traceSpy).toHaveBeenCalledWith('[PromptOverride] Both inline prompt override text and prompt override file are configured; using inline prompt override text');
 	});
 });

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -54,7 +54,7 @@ import { ToolName } from '../../tools/common/toolNames';
 import { IToolsService, ToolCallCancelledError } from '../../tools/common/toolsService';
 import { ReadFileParams } from '../../tools/node/readFileTool';
 import { isHookAbortError, processHookResults } from './hookResultProcessor';
-import { applyPromptOverrides } from './promptOverride';
+import { applyConfiguredPromptOverrides } from './promptOverride';
 
 export const enum ToolCallLimitBehavior {
 	Confirm,
@@ -1300,12 +1300,14 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		// Possible the tool call resulted in new tools getting added.
 		availableTools = await this.getAvailableTools(outputStream, token);
 
-		// Apply debug prompt/tool overrides from YAML file, only when the setting is explicitly configured
+		// Apply debug prompt/tool overrides from either inline YAML text or a YAML file.
+		const promptOverride = this._configurationService.getConfig(ConfigKey.Advanced.DebugPromptOverrideString);
 		const promptOverrideFile = this._configurationService.getConfig(ConfigKey.Advanced.DebugPromptOverrideFile);
 		let effectiveBuildPromptResult: IBuildPromptResult = buildPromptResult;
-		if (promptOverrideFile) {
-			const overrideResult = await applyPromptOverrides(
-				URI.file(promptOverrideFile),
+		if (promptOverride || promptOverrideFile) {
+			const overrideResult = await applyConfiguredPromptOverrides(
+				promptOverride,
+				promptOverrideFile,
 				buildPromptResult.messages,
 				availableTools,
 				this._fileSystemService,

--- a/extensions/copilot/src/extension/test/node/configurations.spec.ts
+++ b/extensions/copilot/src/extension/test/node/configurations.spec.ts
@@ -108,6 +108,15 @@ describe('Configurations', () => {
 		});
 	});
 
+	it('prompt override string setting uses camelCase', () => {
+		const advancedSection = packageJson.contributes.configuration.find(section => section.id === 'advanced')!;
+		const promptOverrideStringKey = ConfigKey.Advanced.DebugPromptOverrideString;
+
+		expect(promptOverrideStringKey.fullyQualifiedId).toBe('github.copilot.chat.debug.promptOverrideString');
+		expect(promptOverrideStringKey.fullyQualifiedOldId).toBeUndefined();
+		expect(Object.keys(advancedSection.properties)).toContain(promptOverrideStringKey.fullyQualifiedId);
+	});
+
 	it('all localization strings in package.json are present in package.nls.json', async () => {
 		// Get all keys from package.nls.json
 		const packageJsonPath = path.join(__dirname, '../../../../package.json');

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -591,6 +591,7 @@ export namespace ConfigKey {
 		 * Note: this should not be used while self-hosting because it might lead to
 		 * a fundamental different experience compared to our end-users.
 		*/
+		export const DebugPromptOverrideString = defineSetting<string | null>('chat.debug.promptOverrideString', ConfigType.Simple, null);
 		export const DebugPromptOverrideFile = defineSetting<string | null>('chat.debug.promptOverrideFile', ConfigType.Simple, null);
 		export const WorkspacePrototypeAdoCodeSearchEndpointOverride = defineAndMigrateSetting<string>('chat.advanced.workspace.prototypeAdoCodeSearchEndpointOverride', 'chat.workspace.prototypeAdoCodeSearchEndpointOverride', '');
 		export const FeedbackOnChange = defineAndMigrateSetting('chat.advanced.feedback.onChange', 'chat.feedback.onChange', false);


### PR DESCRIPTION
## Summary

Adds a new advanced debug configuration option to override the agent prompt/tool YAML inline in settings as an alternative to providing a YAML file, and wires this into the tool-calling loop so inline overrides take precedence when both are set.

## Changes

- Introduces `github.copilot.chat.debug.promptOverrideString` in the Copilot Chat advanced settings.
- Updates prompt override application to support inline YAML or a YAML file, preferring the inline value when both are configured.
- Clarifies in the setting description that `github.copilot.chat.debug.promptOverrideString` takes precedence over `github.copilot.chat.debug.promptOverrideFile`.
- Adds tests covering the new configuration key and the inline prompt override behavior.

## Testing

- `npm run typecheck`

## Example

```json
"github.copilot.chat.debug.promptOverrideString": "systemPrompt: \"You are a concise coding assistant. Always explain tool choices briefly.\"\ntoolDescriptions:\n  read_file:\n    description: \"Read a file from the workspace when exact file content is needed.\"\n  grep_search:\n    description: \"Search the workspace for exact text or regex matches before reading files.\""
```