### PR TITLE
Abadawi/fix automode resolution race

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -186,9 +186,14 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			return pending;
 		}
 
-		const promise = this._resolveAutoModeEndpointCore(chatRequest, conversationId, knownEndpoints);
-		this._pendingResolutions.set(conversationId, promise);
-		return promise.finally(() => this._pendingResolutions.delete(conversationId));
+		const corePromise = this._resolveAutoModeEndpointCore(chatRequest, conversationId, knownEndpoints);
+		const pendingPromise = corePromise.finally(() => {
+			if (this._pendingResolutions.get(conversationId) === pendingPromise) {
+				this._pendingResolutions.delete(conversationId);
+			}
+		});
+		this._pendingResolutions.set(conversationId, pendingPromise);
+		return pendingPromise;
 	}
 
 	private async _resolveAutoModeEndpointCore(chatRequest: ChatRequest | undefined, conversationId: string, knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint> {

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -179,21 +179,34 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 		const conversationId = chatRequest?.sessionResource?.toString() ?? chatRequest?.sessionId ?? 'unknown';
 
-		// Coalesce concurrent calls for the same conversation to avoid duplicate
-		// router calls and telemetry emissions.
-		const pending = this._pendingResolutions.get(conversationId);
-		if (pending) {
-			return pending;
-		}
+		// Coalesce concurrent calls for the same conversation so we don't fire
+		// duplicate router requests or telemetry. Concurrent callers within a
+		// single turn always share the same prompt, so reusing the result is safe.
+		return this._singleFlight(conversationId, () => this._resolveAutoModeEndpointCore(chatRequest, conversationId, knownEndpoints));
+	}
 
-		const corePromise = this._resolveAutoModeEndpointCore(chatRequest, conversationId, knownEndpoints);
-		const pendingPromise = corePromise.finally(() => {
-			if (this._pendingResolutions.get(conversationId) === pendingPromise) {
-				this._pendingResolutions.delete(conversationId);
+	/**
+	 * Single-flight coalescer: if a resolution for `key` is already in progress,
+	 * return that pending promise instead of starting a new one.
+	 *
+	 * This function MUST remain synchronous (not `async`). The atomicity of the
+	 * `get -> check -> set` sequence relies on no `await` running between them, and
+	 * keeping the function non-`async` makes that invariant structural rather than
+	 * a comment a future edit might miss.
+	 */
+	private _singleFlight(key: string, fn: () => Promise<IChatEndpoint>): Promise<IChatEndpoint> {
+		const existing = this._pendingResolutions.get(key);
+		if (existing) {
+			return existing;
+		}
+		const promise = fn().finally(() => {
+			// Reference-equality guard: only clear if this entry is still ours.
+			if (this._pendingResolutions.get(key) === promise) {
+				this._pendingResolutions.delete(key);
 			}
 		});
-		this._pendingResolutions.set(conversationId, pendingPromise);
-		return pendingPromise;
+		this._pendingResolutions.set(key, promise);
+		return promise;
 	}
 
 	private async _resolveAutoModeEndpointCore(chatRequest: ChatRequest | undefined, conversationId: string, knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint> {

--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -117,6 +117,7 @@ export interface IAutomodeService {
 export class AutomodeService extends Disposable implements IAutomodeService {
 	readonly _serviceBrand: undefined;
 	private readonly _autoModelCache: Map<string, AutoModelCacheEntry> = new Map();
+	private readonly _pendingResolutions: Map<string, Promise<IChatEndpoint>> = new Map();
 	private _reserveTokens: DisposableMap<ChatLocation, AutoModeTokenBank> = new DisposableMap();
 	private readonly _routerDecisionFetcher: RouterDecisionFetcher;
 
@@ -137,6 +138,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				entry.tokenBank.dispose();
 			}
 			this._autoModelCache.clear();
+			this._pendingResolutions.clear();
 			const keys = Array.from(this._reserveTokens.keys());
 			this._reserveTokens.clearAndDisposeAll();
 			for (const location of keys) {
@@ -152,6 +154,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			entry.tokenBank.dispose();
 		}
 		this._autoModelCache.clear();
+		this._pendingResolutions.clear();
 		this._reserveTokens.dispose();
 		super.dispose();
 	}
@@ -175,6 +178,20 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		}
 
 		const conversationId = chatRequest?.sessionResource?.toString() ?? chatRequest?.sessionId ?? 'unknown';
+
+		// Coalesce concurrent calls for the same conversation to avoid duplicate
+		// router calls and telemetry emissions.
+		const pending = this._pendingResolutions.get(conversationId);
+		if (pending) {
+			return pending;
+		}
+
+		const promise = this._resolveAutoModeEndpointCore(chatRequest, conversationId, knownEndpoints);
+		this._pendingResolutions.set(conversationId, promise);
+		return promise.finally(() => this._pendingResolutions.delete(conversationId));
+	}
+
+	private async _resolveAutoModeEndpointCore(chatRequest: ChatRequest | undefined, conversationId: string, knownEndpoints: IChatEndpoint[]): Promise<IChatEndpoint> {
 		const entry = this._autoModelCache.get(conversationId);
 		const tokenBank = this._acquireTokenBank(entry, chatRequest?.location, conversationId);
 		const token = await tokenBank.getToken();

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -916,4 +916,101 @@ describe('AutomodeService', () => {
 			);
 		});
 	});
+
+	describe('concurrent resolution coalescing', () => {
+		it('should return the same endpoint for concurrent calls with the same conversationId', async () => {
+			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-concurrent'
+			};
+
+			const [result1, result2, result3] = await Promise.all([
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+			]);
+
+			expect(result1).toBe(result2);
+			expect(result2).toBe(result3);
+		});
+
+		it('should make only one CAPI token request for concurrent calls', async () => {
+			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-concurrent-token'
+			};
+
+			await Promise.all([
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+			]);
+
+			// Only one CAPI request for the token (not two)
+			const capiCalls = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls;
+			expect(capiCalls.length).toBe(1);
+		});
+
+		it('should allow a new resolution after the first one completes', async () => {
+			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-sequential'
+			};
+
+			const result1 = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]);
+
+			// Second call after first completes should succeed (hits cache, not pending map)
+			const result2 = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]);
+			expect(result1.model).toBe(result2.model);
+		});
+
+		it('should propagate errors to all concurrent callers', async () => {
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('token fetch failed'));
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-error'
+			};
+
+			const results = await Promise.allSettled([
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
+			]);
+
+			expect(results[0].status).toBe('rejected');
+			expect(results[1].status).toBe('rejected');
+		});
+
+		it('should allow retry after a failed concurrent resolution', async () => {
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('transient failure'));
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-retry'
+			};
+
+			// First call fails
+			await expect(automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint])).rejects.toThrow();
+
+			// Pending promise should be cleared; retry should work
+			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
+			const result = await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]);
+			expect(result.model).toBeDefined();
+		});
+	});
 });

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -1015,4 +1015,170 @@ describe('AutomodeService', () => {
 			expect(result.model).toBeDefined();
 		});
 	});
+
+	/**
+	 * These tests demonstrate the duplicate telemetry bug fixed by this PR.
+	 *
+	 * Background:
+	 * In a single tool-calling round, `runOne()` in toolCallingLoop.ts calls
+	 * `getChatEndpoint(request)` up to 5 times concurrently (for getAvailableTools,
+	 * buildPrompt, buildPrompt2, tokenizer, and fetch). On the first turn of a
+	 * conversation, the cache is empty, so all 5 calls enter
+	 * `resolveAutoModeEndpoint` simultaneously and each independently performs
+	 * routing — emitting telemetry events for each redundant resolution.
+	 *
+	 * To reproduce: simulate 5 concurrent `resolveAutoModeEndpoint` calls to the
+	 * same conversation and count telemetry emissions via a spy on the telemetry
+	 * service. Without the _singleFlight fix, each concurrent call emits its own
+	 * events (5× instead of 1×). With the fix, the first caller does the work
+	 * and subsequent callers share its promise.
+	 *
+	 * Run these tests on the `main` branch to see the bug (5× emissions), then
+	 * on this branch to see the fix (1× emission).
+	 */
+	describe('telemetry duplication from concurrent resolution', () => {
+		// Helper: create an AutomodeService with a spy on sendMSFTTelemetryEvent
+		// so we can count exactly how many telemetry events are emitted.
+		function createServiceWithTelemetrySpy() {
+			const telemetryService = new NullTelemetryService();
+			const telemetrySpy = vi.spyOn(telemetryService, 'sendMSFTTelemetryEvent');
+			const service = new AutomodeService(
+				mockCAPIClientService,
+				mockAuthService,
+				mockLogService,
+				mockInstantiationService,
+				mockExpService,
+				configurationService,
+				envService,
+				telemetryService,
+				new NullRequestLogger()
+			);
+			return { service, telemetrySpy };
+		}
+
+		it('should emit automode.routerFallback exactly once for 5 concurrent calls (router fails)', async () => {
+			// When the router API is not mocked, getRouterDecision throws,
+			// causing _tryRouterSelection to return a fallbackReason.
+			// The caller in resolveAutoModeEndpoint then emits routerFallback.
+			// Without coalescing: 5 concurrent calls → 5 routerFallback events.
+			// With coalescing: only the first caller runs → 1 routerFallback event.
+			enableRouter();
+
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+			mockApiResponse(['gpt-4o', 'claude-sonnet']);
+
+			const { service, telemetrySpy } = createServiceWithTelemetrySpy();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-fallback-dup',
+			};
+
+			// Fire 5 concurrent calls, simulating what runOne() does
+			const results = await Promise.all(Array.from({ length: 5 }, () =>
+				service.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint])
+			));
+
+			// All calls should resolve to the same model
+			expect(new Set(results.map(r => r.model)).size).toBe(1);
+
+			// Exactly 1 routerFallback event (not 5)
+			const fallbackCalls = telemetrySpy.mock.calls.filter(c => c[0] === 'automode.routerFallback');
+			expect(fallbackCalls).toHaveLength(1);
+		});
+
+		it('should emit automode.routerDecision exactly once for 5 concurrent calls (router succeeds)', async () => {
+			// When the router API succeeds, RouterDecisionFetcher.getRouterDecision
+			// emits routerDecision with the predicted label and confidence.
+			// Without coalescing: 5 concurrent calls → 5 router API calls → 5 events.
+			// With coalescing: 1 resolution → 1 router API call → 1 event.
+			enableRouter();
+
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockImplementation((_body: any, opts: any) => {
+				if (opts?.type === RequestType.ModelRouter) {
+					return Promise.resolve({
+						ok: true,
+						status: 200,
+						headers: createMockHeaders(),
+						text: vi.fn().mockResolvedValue(JSON.stringify({
+							predicted_label: 'needs_reasoning',
+							confidence: 0.9,
+							latency_ms: 30,
+							chosen_model: 'gpt-4o',
+							candidate_models: ['gpt-4o', 'claude-sonnet'],
+							scores: { needs_reasoning: 0.9, no_reasoning: 0.1 },
+							sticky_override: false
+						}))
+					});
+				}
+				return Promise.resolve(makeMockTokenResponse({
+					available_models: ['gpt-4o', 'claude-sonnet'],
+					expires_at: Math.floor(Date.now() / 1000) + 3600,
+					session_token: 'test-token',
+				}));
+			});
+
+			const { service, telemetrySpy } = createServiceWithTelemetrySpy();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-decision-dup',
+			};
+
+			const results = await Promise.all(Array.from({ length: 5 }, () =>
+				service.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint])
+			));
+
+			// Router should have picked gpt-4o for all concurrent callers
+			expect(results.every(r => r.model === 'gpt-4o')).toBe(true);
+
+			// Exactly 1 routerDecision event (not 5)
+			const decisionCalls = telemetrySpy.mock.calls.filter(c => c[0] === 'automode.routerDecision');
+			expect(decisionCalls).toHaveLength(1);
+
+			// No fallback events since the router succeeded
+			const fallbackCalls = telemetrySpy.mock.calls.filter(c => c[0] === 'automode.routerFallback');
+			expect(fallbackCalls).toHaveLength(0);
+		});
+
+		it('should emit automode.routerFallback(hasImage) exactly once for 5 concurrent image calls', async () => {
+			// When the request contains an image, _tryRouterSelection returns
+			// early with fallbackReason='hasImage'. The race condition causes
+			// each concurrent caller to independently hit this early return and
+			// emit its own routerFallback event.
+			// Without coalescing: 5 concurrent calls → 5 hasImage fallback events.
+			// With coalescing: 1 resolution → 1 hasImage fallback event.
+			enableRouter();
+
+			const visionEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });
+			mockApiResponse(['gpt-4o']);
+
+			const { service, telemetrySpy } = createServiceWithTelemetrySpy();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'fix this',
+				sessionId: 'session-image-dup',
+				references: [{ id: 'img', value: { mimeType: 'image/png', data: new Uint8Array() } }] as any,
+			};
+
+			const results = await Promise.all(Array.from({ length: 5 }, () =>
+				service.resolveAutoModeEndpoint(chatRequest as ChatRequest, [visionEndpoint])
+			));
+
+			expect(new Set(results.map(r => r.model)).size).toBe(1);
+
+			// Exactly 1 hasImage fallback event (not 5)
+			const hasImageCalls = telemetrySpy.mock.calls.filter(
+				c => c[0] === 'automode.routerFallback' && (c[1] as Record<string, string>)?.reason === 'hasImage'
+			);
+			expect(hasImageCalls).toHaveLength(1);
+		});
+	});
 });

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -1180,5 +1180,38 @@ describe('AutomodeService', () => {
 			);
 			expect(hasImageCalls).toHaveLength(1);
 		});
+
+		it('should make only one CAPI token fetch for 5 concurrent calls', async () => {
+			// Each concurrent resolveAutoModeEndpoint call reaches _acquireTokenBank.
+			// When there's no cache entry (first turn), _acquireTokenBank creates a
+			// NEW AutoModeTokenBank each time (taking the reserve bank, then creating
+			// a fresh reserve). Each bank has its own FetchedValue, so FetchedValue's
+			// built-in request coalescing doesn't help — each bank fetches its own
+			// CAPI token independently.
+			//
+			// Without coalescing: 5 concurrent calls → 5 separate token banks →
+			//   5 CAPI makeRequest(AutoModels) calls.
+			// With coalescing: only the first caller enters resolveAutoModeEndpoint,
+			//   creates 1 token bank, makes 1 CAPI call. Others await the same promise.
+			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
+			automodeService = createService();
+
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'hello',
+				sessionId: 'session-capi-dup'
+			};
+
+			await Promise.all(Array.from({ length: 5 }, () =>
+				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint])
+			));
+
+			// Count CAPI token requests (AutoModels type)
+			const capiCalls = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls;
+			const autoModelsCalls = capiCalls.filter((call: any[]) => call[1]?.type === RequestType.AutoModels);
+
+			// Exactly 1 CAPI token fetch (not 5)
+			expect(autoModelsCalls).toHaveLength(1);
+		});
 	});
 });

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -954,9 +954,10 @@ describe('AutomodeService', () => {
 				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
 			]);
 
-			// Only one CAPI request for the token (not two)
+			// Only one CAPI token request for auto models should be made (not two)
 			const capiCalls = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls;
-			expect(capiCalls.length).toBe(1);
+			const autoModelsCalls = capiCalls.filter(([, requestType]: [unknown, { type?: RequestType }]) => requestType?.type === RequestType.AutoModels);
+			expect(autoModelsCalls.length).toBe(1);
 		});
 
 		it('should allow a new resolution after the first one completes', async () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -918,7 +918,7 @@ describe('AutomodeService', () => {
 	});
 
 	describe('concurrent resolution coalescing', () => {
-		it('should return the same endpoint for concurrent calls with the same conversationId', async () => {
+		it('should return consistent model selection for concurrent calls with the same conversationId', async () => {
 			mockApiResponse(['gpt-4o', 'gpt-4o-mini']);
 			automodeService = createService();
 
@@ -934,8 +934,9 @@ describe('AutomodeService', () => {
 				automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [mockChatEndpoint]),
 			]);
 
-			expect(result1).toBe(result2);
-			expect(result2).toBe(result3);
+			expect(result1.model).toBe(result2.model);
+			expect(result2.model).toBe(result3.model);
+			expect(result1.modelProvider).toBe(result2.modelProvider);
 		});
 
 		it('should make only one CAPI token request for concurrent calls', async () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -956,7 +956,7 @@ describe('AutomodeService', () => {
 
 			// Only one CAPI token request for auto models should be made (not two)
 			const capiCalls = (mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mock.calls;
-			const autoModelsCalls = capiCalls.filter(([, requestType]: [unknown, { type?: RequestType }]) => requestType?.type === RequestType.AutoModels);
+			const autoModelsCalls = capiCalls.filter(call => call[1]?.type === RequestType.AutoModels);
 			expect(autoModelsCalls.length).toBe(1);
 		});
 


### PR DESCRIPTION
## Fix duplicate telemetry from concurrent `resolveAutoModeEndpoint` calls

Concurrent calls to `resolveAutoModeEndpoint` for the same conversation race on an empty cache, causing the `automode.routerFallback` telemetry event to fire 2–5× per routing decision instead of once. This inflates telemetry counts.

### Root cause

In agent-mode, a single tool-calling round calls `getChatEndpoint(request)` multiple times (for `getAvailableTools`, `buildPrompt`, token counting, and fetch). On the first turn of a conversation, the cache entry doesn't exist yet. Since `resolveAutoModeEndpoint` is async, multiple callers read `_autoModelCache` as empty before the first caller finishes and writes the result. Each enters `_tryRouterSelection`, emits telemetry, and redundantly fetches a CAPI token.

### Fix

Add per-conversation promise coalescing via a `_pendingResolutions` map. If a resolution is already in-flight for a `conversationId`, subsequent callers await the same promise.

### Impact

- **Telemetry:** `automode.routerFallback` event count reduced ~2× to accurate levels
- **Performance:** eliminates redundant CAPI token fetches on first turn
- **User-facing:** none (same model selection behavior)

### Files changed

- `automodeService.ts` — promise coalescing wrapper
- `automodeService.spec.ts` — 5 new tests (concurrent coalescing, single CAPI call, sequential still works, error propagation, retry after failure)