### PR TITLE
Handle hook messages for Claude

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
@@ -3,15 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { SDKAssistantMessage, SDKCompactBoundaryMessage, SDKMessage, SDKResultMessage, SDKUserMessage, SDKUserMessageReplay } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKAssistantMessage, SDKCompactBoundaryMessage, SDKHookProgressMessage, SDKHookResponseMessage, SDKHookStartedMessage, SDKMessage, SDKResultMessage, SDKUserMessage, SDKUserMessageReplay } from '@anthropic-ai/claude-agent-sdk';
 import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 import type Anthropic from '@anthropic-ai/sdk';
 import * as l10n from '@vscode/l10n';
 import type * as vscode from 'vscode';
+import { vBoolean, vLiteral, vObj, vString, type ValidatorType } from '../../../../platform/configuration/common/validator';
 import { ILogService } from '../../../../platform/log/common/logService';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, type ISpanHandle, SpanKind, SpanStatusCode, truncateForOTel } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, SpanKind, SpanStatusCode, truncateForOTel, type ISpanHandle } from '../../../../platform/otel/common/index';
 import { ServicesAccessor } from '../../../../util/vs/platform/instantiation/common/instantiation';
-import { ChatResponseThinkingProgressPart } from '../../../../vscodeTypes';
+import { ChatResponseThinkingProgressPart, type ChatHookType } from '../../../../vscodeTypes';
 import { ToolName } from '../../../tools/common/toolNames';
 import { IToolsService } from '../../../tools/common/toolsService';
 import { ClaudeToolNames } from './claudeTools';
@@ -30,6 +31,7 @@ export interface MessageHandlerRequestContext {
 export interface MessageHandlerState {
 	readonly unprocessedToolCalls: Map<string, Anthropic.Beta.Messages.BetaToolUseBlock>;
 	readonly otelToolSpans: Map<string, ISpanHandle>;
+	readonly otelHookSpans: Map<string, ISpanHandle>;
 }
 
 export interface MessageHandlerResult {
@@ -67,20 +69,34 @@ export const ALL_KNOWN_MESSAGE_KEYS = new Set([
 	'user',
 	'result',
 	'stream_event',
+	// TODO: Show `tool_progress` — has `tool_name` and `elapsed_time_seconds` for live tool status
+	// low pri, where would we show this?
 	'tool_progress',
+	// TODO: Show `tool_use_summary` — has `summary` text describing tool execution results
+	// low pri, where would we show this?
 	'tool_use_summary',
+	// TODO: Show `auth_status` — has `output` lines and `error` for auth failures
 	'auth_status',
+	// TODO: Show `rate_limit_event` — has `rate_limit_info.status` (allowed_warning | rejected) and reset time
 	'rate_limit_event',
+	// TODO: Show `prompt_suggestion` — has `suggestion` text for follow-up prompts
+	// low pri, follow ups are dead
 	'prompt_suggestion',
 	'system:init',
 	'system:compact_boundary',
 	'system:status',
+	// TODO: Show `system:api_retry` — has `error`, `attempt`, `max_retries` for retry visibility
+	'system:api_retry',
+	// TODO: Show `system:local_command_output` — has `content` text from local slash commands
 	'system:local_command_output',
 	'system:hook_started',
 	'system:hook_progress',
 	'system:hook_response',
+	// TODO: Show `system:task_notification` — has `summary` and `status` for subagent completion
 	'system:task_notification',
+	// TODO: Show `system:task_started` — has `description` and `prompt` for subagent launch
 	'system:task_started',
+	// TODO: Show `system:task_progress` — has `description` and `summary` for subagent progress
 	'system:task_progress',
 	'system:files_persisted',
 	'system:elicitation_complete',
@@ -274,6 +290,229 @@ export function handleCompactBoundary(
 	request.stream.markdown(`*${l10n.t('Conversation compacted')}*`);
 }
 
+export function handleHookStarted(
+	message: SDKHookStartedMessage,
+	accessor: ServicesAccessor,
+	sessionId: string,
+	state: MessageHandlerState,
+): void {
+	const otelService = accessor.get(IOTelService);
+	const span = otelService.startSpan(`user_hook ${message.hook_event}:${message.hook_name}`, {
+		kind: SpanKind.INTERNAL,
+		attributes: {
+			[GenAiAttr.OPERATION_NAME]: GenAiOperationName.EXECUTE_HOOK,
+			'copilot_chat.hook_type': message.hook_event,
+			'copilot_chat.hook_command': message.hook_name,
+			'copilot_chat.hook_id': message.hook_id,
+			[CopilotChatAttr.CHAT_SESSION_ID]: sessionId,
+		},
+	});
+	state.otelHookSpans.set(message.hook_id, span);
+}
+
+// #region Hook JSON output validator
+
+/**
+ * Validator for structured JSON output from hooks (exit code 0 only).
+ *
+ * Hooks can return JSON with these fields:
+ * - `continue`: if false, stops processing entirely
+ * - `stopReason`: message shown to user when `continue` is false
+ * - `systemMessage`: warning shown to user
+ * - `decision`: "block" to prevent the operation
+ * - `reason`: explanation when `decision` is "block"
+ *
+ * @see https://code.claude.com/docs/en/hooks.md
+ */
+const vHookJsonOutput = vObj({
+	continue: vBoolean(),
+	stopReason: vString(),
+	systemMessage: vString(),
+	decision: vLiteral('block'),
+	reason: vString(),
+});
+
+export type HookJsonOutput = ValidatorType<typeof vHookJsonOutput>;
+
+/**
+ * Parses JSON output from a hook's stdout.
+ * Returns the validated fields, or undefined if parsing/validation fails.
+ * Fields that are missing from the JSON are simply absent from the result.
+ */
+export function parseHookJsonOutput(stdout: string): Partial<HookJsonOutput> | undefined {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(stdout);
+	} catch {
+		return undefined;
+	}
+
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+		return undefined;
+	}
+
+	// Use the validator to extract known fields with type safety.
+	// vObj skips missing optional fields, so partial results are expected.
+	const result = vHookJsonOutput.validate(raw);
+	if (result.error) {
+		// Validation error means some present field had the wrong type —
+		// extract what we can by validating each field individually.
+		const obj = raw as Record<string, unknown>;
+		const partial: Partial<HookJsonOutput> = {};
+
+		const continueResult = vBoolean().validate(obj['continue']);
+		if (!continueResult.error) {
+			partial.continue = continueResult.content;
+		}
+		const stopReasonResult = vString().validate(obj['stopReason']);
+		if (!stopReasonResult.error) {
+			partial.stopReason = stopReasonResult.content;
+		}
+		const systemMessageResult = vString().validate(obj['systemMessage']);
+		if (!systemMessageResult.error) {
+			partial.systemMessage = systemMessageResult.content;
+		}
+		const decisionResult = vLiteral('block').validate(obj['decision']);
+		if (!decisionResult.error) {
+			partial.decision = decisionResult.content;
+		}
+		const reasonResult = vString().validate(obj['reason']);
+		if (!reasonResult.error) {
+			partial.reason = reasonResult.content;
+		}
+
+		return Object.keys(partial).length > 0 ? partial : undefined;
+	}
+
+	return result.content;
+}
+
+// #endregion
+
+/**
+ * Formats a localized error message for a failed hook.
+ * @param errorMessage The error message from the hook
+ * @returns A localized error message string
+ * @todo use a common function with: https://github.com/microsoft/vscode-copilot-chat/blob/9a9461734da42f28e4e2d0b975ebeae6162e9b4c/src/extension/intents/node/hookResultProcessor.ts#L142
+ */
+function formatHookErrorMessage(errorMessage: string): string {
+	if (errorMessage) {
+		return l10n.t('A hook prevented chat from continuing. Please check the GitHub Copilot Chat Hooks output channel for more details. \nError message: {0}', errorMessage);
+	}
+	return l10n.t('A hook prevented chat from continuing. Please check the GitHub Copilot Chat Hooks output channel for more details.');
+}
+
+
+export function handleHookProgress(
+	message: SDKHookProgressMessage,
+	accessor: ServicesAccessor,
+	request: MessageHandlerRequestContext,
+): void {
+	const logService = accessor.get(ILogService);
+	// TODO: can we map these types better
+	const hookType = message.hook_event as ChatHookType;
+	const progressText = message.stdout || message.stderr;
+
+	logService.trace(`[ClaudeMessageDispatch] Hook progress "${message.hook_name}" (${message.hook_event}): ${progressText}`);
+
+	if (progressText) {
+		request.stream.hookProgress(hookType, undefined, progressText);
+	}
+}
+
+export function handleHookResponse(
+	message: SDKHookResponseMessage,
+	accessor: ServicesAccessor,
+	request: MessageHandlerRequestContext,
+	state: MessageHandlerState,
+): void {
+	const logService = accessor.get(ILogService);
+	// TODO: can we map these types better
+	const hookType = message.hook_event as ChatHookType;
+
+	// #region OTel span
+	const span = state.otelHookSpans.get(message.hook_id);
+	if (span) {
+		if (message.outcome === 'error') {
+			span.setStatus(SpanStatusCode.ERROR, message.stderr || message.output);
+		} else if (message.outcome === 'cancelled') {
+			span.setStatus(SpanStatusCode.ERROR, 'cancelled');
+		} else {
+			span.setStatus(SpanStatusCode.OK);
+		}
+		if (message.exit_code !== undefined) {
+			span.setAttribute('copilot_chat.hook_exit_code', message.exit_code);
+		}
+		if (message.output) {
+			span.setAttribute('copilot_chat.hook_output', truncateForOTel(message.output));
+		}
+		span.end();
+		state.otelHookSpans.delete(message.hook_id);
+	}
+	// #endregion
+
+	// Cancelled — log only, no user-facing output
+	if (message.outcome === 'cancelled') {
+		logService.trace(`[ClaudeMessageDispatch] Hook "${message.hook_name}" (${message.hook_event}) was cancelled`);
+		return;
+	}
+
+	// Exit code 2 — blocking error (stderr is the message, JSON ignored)
+	if (message.exit_code === 2) {
+		const errorMessage = message.stderr || message.output;
+		logService.warn(`[ClaudeMessageDispatch] Hook "${message.hook_name}" (${message.hook_event}) blocking error: ${errorMessage}`);
+		request.stream.hookProgress(hookType, formatHookErrorMessage(errorMessage));
+		return;
+	}
+
+	// Other non-zero exit codes — non-blocking warning
+	if (message.exit_code !== undefined && message.exit_code !== 0) {
+		const warningMessage = message.stderr || message.output;
+		const loggedMessage = warningMessage || l10n.t('Exit Code: {0}', message.exit_code);
+		logService.warn(`[ClaudeMessageDispatch] Hook "${message.hook_name}" (${message.hook_event}) non-blocking error (exit ${message.exit_code}): ${loggedMessage}`);
+		if (warningMessage) {
+			request.stream.hookProgress(hookType, undefined, warningMessage);
+		}
+		return;
+	}
+
+	// Outcome 'error' without a specific exit code — treat as blocking error
+	if (message.outcome === 'error') {
+		const errorMessage = message.stderr || message.output;
+		logService.warn(`[ClaudeMessageDispatch] Hook "${message.hook_name}" (${message.hook_event}) failed: ${errorMessage}`);
+		request.stream.hookProgress(hookType, formatHookErrorMessage(errorMessage));
+		return;
+	}
+
+	// Exit code 0 (or undefined with success outcome) — parse JSON from stdout
+	if (!message.stdout) {
+		return;
+	}
+
+	const parsed = parseHookJsonOutput(message.stdout);
+	if (!parsed) {
+		logService.warn(`[ClaudeMessageDispatch] Hook "${message.hook_name}" returned non-JSON output`);
+		return;
+	}
+
+	// Handle `decision: "block"` with `reason`
+	if (parsed.decision === 'block') {
+		request.stream.hookProgress(hookType, formatHookErrorMessage(parsed.reason ?? ''));
+		return;
+	}
+
+	// Handle `continue: false` with optional `stopReason`
+	if (parsed.continue === false) {
+		request.stream.hookProgress(hookType, formatHookErrorMessage(parsed.stopReason ?? ''));
+		return;
+	}
+
+	// Handle `systemMessage` — shown as a warning
+	if (parsed.systemMessage) {
+		request.stream.hookProgress(hookType, undefined, parsed.systemMessage);
+	}
+}
+
 export function handleResultMessage(
 	message: SDKResultMessage,
 	request: MessageHandlerRequestContext,
@@ -322,6 +561,18 @@ export function dispatchMessage(
 		case 'system':
 			if (message.subtype === 'compact_boundary') {
 				handleCompactBoundary(message, request);
+				return;
+			}
+			if (message.subtype === 'hook_started') {
+				handleHookStarted(message, accessor, sessionId, state);
+				return;
+			}
+			if (message.subtype === 'hook_progress') {
+				handleHookProgress(message, accessor, request);
+				return;
+			}
+			if (message.subtype === 'hook_response') {
+				handleHookResponse(message, accessor, request, state);
 				return;
 			}
 			break;

--- a/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/test/claudeMessageDispatch.spec.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { NonNullableUsage, SDKAssistantMessage, SDKCompactBoundaryMessage, SDKResultError, SDKResultSuccess, SDKStatusMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { NonNullableUsage, SDKAssistantMessage, SDKCompactBoundaryMessage, SDKHookProgressMessage, SDKHookResponseMessage, SDKHookStartedMessage, SDKResultError, SDKResultSuccess, SDKStatusMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import type Anthropic from '@anthropic-ai/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as vscode from 'vscode';
@@ -18,12 +18,16 @@ import {
 	dispatchMessage,
 	handleAssistantMessage,
 	handleCompactBoundary,
+	handleHookProgress,
+	handleHookResponse,
+	handleHookStarted,
 	handleResultMessage,
 	handleUserMessage,
 	KnownClaudeError,
 	MessageHandlerRequestContext,
 	MessageHandlerState,
 	messageKey,
+	parseHookJsonOutput,
 	SYNTHETIC_MODEL_ID,
 } from '../claudeMessageDispatch';
 import { ClaudeToolNames } from '../claudeTools';
@@ -74,7 +78,8 @@ function createRequestContext(): MessageHandlerRequestContext {
 			markdown: vi.fn(),
 			push: vi.fn(),
 			progress: vi.fn(),
-		} as Pick<vscode.ChatResponseStream, 'markdown' | 'push' | 'progress'> as vscode.ChatResponseStream,
+			hookProgress: vi.fn(),
+		} as Pick<vscode.ChatResponseStream, 'markdown' | 'push' | 'progress' | 'hookProgress'> as vscode.ChatResponseStream,
 		toolInvocationToken: {} as vscode.ChatParticipantToolToken,
 		token: { isCancellationRequested: false } as vscode.CancellationToken,
 	};
@@ -84,6 +89,7 @@ function createState(): MessageHandlerState {
 	return {
 		unprocessedToolCalls: new Map(),
 		otelToolSpans: new Map(),
+		otelHookSpans: new Map(),
 	};
 }
 
@@ -219,6 +225,57 @@ function makeStatusMessage(): SDKStatusMessage {
 		type: 'system',
 		subtype: 'status',
 		status: null,
+		uuid: TEST_UUID,
+		session_id: TEST_SESSION,
+	};
+}
+
+function makeHookStarted(hookId = 'hook-1', hookName = 'my-hook', hookEvent = 'PreToolUse'): SDKHookStartedMessage {
+	return {
+		type: 'system',
+		subtype: 'hook_started',
+		hook_id: hookId,
+		hook_name: hookName,
+		hook_event: hookEvent,
+		uuid: TEST_UUID,
+		session_id: TEST_SESSION,
+	};
+}
+
+function makeHookResponse(
+	hookId = 'hook-1',
+	outcome: 'success' | 'error' | 'cancelled' = 'success',
+	overrides: Partial<Pick<SDKHookResponseMessage, 'output' | 'stderr' | 'stdout' | 'exit_code' | 'hook_name' | 'hook_event'>> = {},
+): SDKHookResponseMessage {
+	return {
+		type: 'system',
+		subtype: 'hook_response',
+		hook_id: hookId,
+		hook_name: overrides.hook_name ?? 'my-hook',
+		hook_event: overrides.hook_event ?? 'PreToolUse',
+		output: overrides.output ?? '',
+		stdout: overrides.stdout ?? '',
+		stderr: overrides.stderr ?? '',
+		exit_code: overrides.exit_code,
+		outcome,
+		uuid: TEST_UUID,
+		session_id: TEST_SESSION,
+	};
+}
+
+function makeHookProgress(
+	hookId = 'hook-1',
+	overrides: Partial<Pick<SDKHookProgressMessage, 'stdout' | 'stderr' | 'output' | 'hook_name' | 'hook_event'>> = {},
+): SDKHookProgressMessage {
+	return {
+		type: 'system',
+		subtype: 'hook_progress',
+		hook_id: hookId,
+		hook_name: overrides.hook_name ?? 'my-hook',
+		hook_event: overrides.hook_event ?? 'PreToolUse',
+		stdout: overrides.stdout ?? '',
+		stderr: overrides.stderr ?? '',
+		output: overrides.output ?? '',
 		uuid: TEST_UUID,
 		session_id: TEST_SESSION,
 	};
@@ -477,6 +534,360 @@ describe('handleCompactBoundary', () => {
 
 // #endregion
 
+// #region handleHookStarted / handleHookResponse
+
+describe('handleHookStarted', () => {
+	let services: TestServices;
+	let accessor: ServicesAccessor;
+	let state: MessageHandlerState;
+
+	beforeEach(() => {
+		services = createTestServices();
+		accessor = createAccessor(services);
+		state = createState();
+	});
+
+	it('creates an OTel span and stores it by hook_id', () => {
+		const startSpanSpy = vi.spyOn(services.otelService, 'startSpan');
+		handleHookStarted(makeHookStarted('hook-42', 'lint-check', 'PreToolUse'), accessor, TEST_SESSION_ID, state);
+
+		expect(startSpanSpy).toHaveBeenCalledWith(
+			'user_hook PreToolUse:lint-check',
+			expect.objectContaining({ attributes: expect.any(Object) }),
+		);
+		expect(state.otelHookSpans.has('hook-42')).toBe(true);
+	});
+});
+
+describe('handleHookResponse', () => {
+	let services: TestServices;
+	let accessor: ServicesAccessor;
+	let request: MessageHandlerRequestContext;
+	let state: MessageHandlerState;
+
+	beforeEach(() => {
+		services = createTestServices();
+		accessor = createAccessor(services);
+		request = createRequestContext();
+		state = createState();
+	});
+
+	it('ends the OTel span with OK on success', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+
+		handleHookResponse(makeHookResponse('hook-1', 'success'), accessor, request, state);
+
+		expect(mockSpan.setStatus).toHaveBeenCalledWith(expect.anything()); // SpanStatusCode.OK
+		expect(mockSpan.end).toHaveBeenCalled();
+		expect(state.otelHookSpans.has('hook-1')).toBe(false);
+	});
+
+	it('ends the OTel span with ERROR on failure and surfaces error via hookProgress', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', { stderr: 'lint failed', hook_name: 'lint-check', hook_event: 'PreToolUse' }),
+			accessor, request, state,
+		);
+
+		expect(mockSpan.setStatus).toHaveBeenCalledWith(expect.anything(), 'lint failed');
+		expect(mockSpan.end).toHaveBeenCalled();
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PreToolUse', expect.stringContaining('lint failed'));
+		expect(request.stream.markdown).not.toHaveBeenCalled();
+	});
+
+	it('does not surface anything to user on success with no stdout', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+
+		handleHookResponse(makeHookResponse('hook-1', 'success'), accessor, request, state);
+
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+		expect(request.stream.markdown).not.toHaveBeenCalled();
+	});
+
+	it('handles cancelled outcome — log only, no hookProgress', () => {
+		const mockSpan = createMockSpan();
+		state.otelHookSpans.set('hook-1', mockSpan);
+
+		handleHookResponse(makeHookResponse('hook-1', 'cancelled'), accessor, request, state);
+
+		expect(mockSpan.setStatus).toHaveBeenCalledWith(expect.anything(), 'cancelled');
+		expect(mockSpan.end).toHaveBeenCalled();
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	it('handles response without a matching started span gracefully', () => {
+		// No span in otelHookSpans — should not throw
+		handleHookResponse(
+			makeHookResponse('nonexistent', 'error', { stderr: 'some error', hook_name: 'my-hook', hook_event: 'PreToolUse' }),
+			accessor, request, state,
+		);
+		// Still surfaces the error via hookProgress
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PreToolUse', expect.stringContaining('some error'));
+	});
+
+	// #region Exit code handling
+
+	it('exit code 2 — blocking error via hookProgress with stderr', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', { exit_code: 2, stderr: 'blocked!', hook_event: 'Stop' }),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('Stop', expect.stringContaining('blocked!'));
+	});
+
+	it('exit code 2 — ignores JSON in stdout', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', {
+				exit_code: 2,
+				stderr: 'real error',
+				stdout: '{"decision": "block", "reason": "should be ignored"}',
+				hook_event: 'PostToolUse',
+			}),
+			accessor, request, state,
+		);
+		// Should use stderr, not JSON
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PostToolUse', expect.stringContaining('real error'));
+	});
+
+	it('other non-zero exit codes — non-blocking warning', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', { exit_code: 1, stderr: 'warning text', hook_event: 'PreToolUse' }),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PreToolUse', undefined, 'warning text');
+	});
+
+	it('other non-zero exit codes without stderr — no hookProgress', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'error', { exit_code: 1, hook_event: 'PreToolUse' }),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	// #endregion
+
+	// #region JSON output parsing (exit code 0)
+
+	it('exit code 0 — JSON with continue:false calls hookProgress with stopReason', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: JSON.stringify({ continue: false, stopReason: 'Build failed' }),
+				hook_event: 'UserPromptSubmit',
+			}),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('UserPromptSubmit', expect.stringContaining('Build failed'));
+	});
+
+	it('exit code 0 — JSON with continue:false and no stopReason uses empty string', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: JSON.stringify({ continue: false }),
+				hook_event: 'Stop',
+			}),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('Stop', expect.any(String));
+	});
+
+	it('exit code 0 — JSON with decision:block calls hookProgress with reason', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: JSON.stringify({ decision: 'block', reason: 'Tests must pass' }),
+				hook_event: 'PostToolUse',
+			}),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PostToolUse', expect.stringContaining('Tests must pass'));
+	});
+
+	it('exit code 0 — JSON with systemMessage shows warning via hookProgress', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: JSON.stringify({ systemMessage: 'Watch out for side effects' }),
+				hook_event: 'PreToolUse',
+			}),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PreToolUse', undefined, 'Watch out for side effects');
+	});
+
+	it('exit code 0 — non-JSON stdout logs warning, no hookProgress', () => {
+		const warnSpy = vi.spyOn(services.logService, 'warn');
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: 'not valid json {',
+				hook_event: 'PreToolUse',
+			}),
+			accessor, request, state,
+		);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('non-JSON output'));
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	it('exit code 0 — empty stdout means success, no hookProgress', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', { exit_code: 0, stdout: '' }),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	it('exit code 0 — JSON with continue:true and no systemMessage is silent', () => {
+		handleHookResponse(
+			makeHookResponse('hook-1', 'success', {
+				exit_code: 0,
+				stdout: JSON.stringify({ continue: true }),
+				hook_event: 'PreToolUse',
+			}),
+			accessor, request, state,
+		);
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	// #endregion
+});
+
+// #endregion
+
+// #region handleHookProgress
+
+describe('handleHookProgress', () => {
+	let services: TestServices;
+	let accessor: ServicesAccessor;
+	let request: MessageHandlerRequestContext;
+
+	beforeEach(() => {
+		services = createTestServices();
+		accessor = createAccessor(services);
+		request = createRequestContext();
+	});
+
+	it('shows stdout via hookProgress as system message', () => {
+		handleHookProgress(
+			makeHookProgress('hook-1', { stdout: 'Running lint...', hook_event: 'PreToolUse' }),
+			accessor, request,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PreToolUse', undefined, 'Running lint...');
+	});
+
+	it('falls back to stderr when stdout is empty', () => {
+		handleHookProgress(
+			makeHookProgress('hook-1', { stderr: 'warning output', hook_event: 'PostToolUse' }),
+			accessor, request,
+		);
+		expect(request.stream.hookProgress).toHaveBeenCalledWith('PostToolUse', undefined, 'warning output');
+	});
+
+	it('does not call hookProgress when both stdout and stderr are empty', () => {
+		handleHookProgress(
+			makeHookProgress('hook-1'),
+			accessor, request,
+		);
+		expect(request.stream.hookProgress).not.toHaveBeenCalled();
+	});
+
+	it('trace-logs progress output', () => {
+		const traceSpy = vi.spyOn(services.logService, 'trace');
+		handleHookProgress(
+			makeHookProgress('hook-1', { stdout: 'progress text', hook_name: 'my-hook', hook_event: 'PreToolUse' }),
+			accessor, request,
+		);
+		expect(traceSpy).toHaveBeenCalledWith(expect.stringContaining('Hook progress'));
+		expect(traceSpy).toHaveBeenCalledWith(expect.stringContaining('progress text'));
+	});
+});
+
+// #endregion
+
+// #region parseHookJsonOutput
+
+describe('parseHookJsonOutput', () => {
+	it('parses valid JSON with all fields', () => {
+		const result = parseHookJsonOutput(JSON.stringify({
+			continue: false,
+			stopReason: 'Build failed',
+			systemMessage: 'Warning',
+			decision: 'block',
+			reason: 'Not allowed',
+		}));
+		expect(result).toEqual({
+			continue: false,
+			stopReason: 'Build failed',
+			systemMessage: 'Warning',
+			decision: 'block',
+			reason: 'Not allowed',
+		});
+	});
+
+	it('parses JSON with only some fields', () => {
+		const result = parseHookJsonOutput(JSON.stringify({ continue: false }));
+		expect(result).toEqual({ continue: false });
+	});
+
+	it('returns undefined for non-JSON string', () => {
+		expect(parseHookJsonOutput('not json')).toBeUndefined();
+	});
+
+	it('returns undefined for JSON null', () => {
+		expect(parseHookJsonOutput('null')).toBeUndefined();
+	});
+
+	it('returns undefined for JSON array', () => {
+		expect(parseHookJsonOutput('[]')).toBeUndefined();
+	});
+
+	it('returns undefined for JSON primitive', () => {
+		expect(parseHookJsonOutput('"hello"')).toBeUndefined();
+	});
+
+	it('ignores fields with wrong types via fallback validation', () => {
+		const result = parseHookJsonOutput(JSON.stringify({
+			continue: 'not-a-boolean',
+			stopReason: 42,
+			systemMessage: 'valid string',
+		}));
+		expect(result).toEqual({ systemMessage: 'valid string' });
+	});
+
+	it('returns undefined when all fields have wrong types', () => {
+		const result = parseHookJsonOutput(JSON.stringify({
+			continue: 'true',
+			decision: 'allow',
+		}));
+		expect(result).toBeUndefined();
+	});
+
+	it('ignores unknown fields', () => {
+		const result = parseHookJsonOutput(JSON.stringify({
+			continue: true,
+			unknownField: 'whatever',
+		}));
+		expect(result).toEqual({ continue: true });
+	});
+
+	it('rejects decision values other than block', () => {
+		const result = parseHookJsonOutput(JSON.stringify({
+			decision: 'allow',
+			systemMessage: 'hello',
+		}));
+		// decision: 'allow' fails vLiteral('block'), but systemMessage succeeds
+		expect(result).toEqual({ systemMessage: 'hello' });
+	});
+});
+
+// #endregion
+
 // #region handleResultMessage
 
 describe('handleResultMessage', () => {
@@ -517,7 +928,7 @@ describe('ALL_KNOWN_MESSAGE_KEYS', () => {
 
 	it('contains entries for all system subtype values', () => {
 		const expectedSystemSubtypes = [
-			'init', 'compact_boundary', 'status', 'local_command_output',
+			'init', 'compact_boundary', 'status', 'api_retry', 'local_command_output',
 			'hook_started', 'hook_progress', 'hook_response',
 			'task_notification', 'task_started', 'task_progress',
 			'files_persisted', 'elicitation_complete',

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -441,6 +441,7 @@ export class ClaudeCodeSession extends Disposable {
 			// Pass the permission mode to the SDK
 			permissionMode: this._currentPermissionMode,
 			hooks: this._buildHooks(token),
+			includeHookEvents: true,
 			mcpServers,
 			settings: {
 				env: {
@@ -622,6 +623,7 @@ export class ClaudeCodeSession extends Disposable {
 	 */
 	private async _processMessages(): Promise<void> {
 		const otelToolSpans = new Map<string, ISpanHandle>();
+		const otelHookSpans = new Map<string, ISpanHandle>();
 		try {
 			const unprocessedToolCalls = new Map<string, Anthropic.Beta.Messages.BetaToolUseBlock>();
 			for await (const message of this._queryGenerator!) {
@@ -655,6 +657,7 @@ export class ClaudeCodeSession extends Disposable {
 				}, {
 					unprocessedToolCalls,
 					otelToolSpans,
+					otelHookSpans,
 				});
 
 				if (result?.requestComplete) {
@@ -680,6 +683,11 @@ export class ClaudeCodeSession extends Disposable {
 				span.end();
 			}
 			otelToolSpans.clear();
+			for (const [, span] of otelHookSpans) {
+				span.setStatus(SpanStatusCode.ERROR, 'session ended before hook completed');
+				span.end();
+			}
+			otelHookSpans.clear();
 		}
 	}
 

--- a/extensions/copilot/src/extension/chatSessions/claude/node/hooks/loggingHooks.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/hooks/loggingHooks.ts
@@ -42,30 +42,6 @@ export class NotificationLoggingHook implements HookCallbackMatcher {
 registerClaudeHook('Notification', NotificationLoggingHook);
 
 /**
- * Logging hook for UserPromptSubmit events.
- */
-export class UserPromptSubmitLoggingHook implements HookCallbackMatcher {
-	public readonly hooks: HookCallback[];
-
-	constructor(
-		@ILogService private readonly logService: ILogService,
-		@IOTelService private readonly otelService: IOTelService,
-	) {
-		this.hooks = [this._handle.bind(this)];
-	}
-
-	private async _handle(input: HookInput): Promise<HookJSONOutput> {
-		const hookInput = input as { prompt?: string; session_id: string };
-		return withHookOTelSpan(this.otelService, 'UserPromptSubmit', 'UserPromptSubmit', hookInput.session_id,
-			{ prompt: hookInput.prompt }, async () => {
-				this.logService.trace(`[ClaudeCodeSession] UserPromptSubmit Hook: prompt=${hookInput.prompt}`);
-				return { continue: true };
-			});
-	}
-}
-registerClaudeHook('UserPromptSubmit', UserPromptSubmitLoggingHook);
-
-/**
  * Logging hook for Stop events.
  */
 export class StopLoggingHook implements HookCallbackMatcher {


### PR DESCRIPTION
* Enable `includeHookEvents: true` in SDK query options to receive hook lifecycle messages (`hook_started`, `hook_progress`, `hook_response`) for all hook event types
* Forward through OTel
* Show errors to the user

Follow up from https://github.com/microsoft/vscode-copilot-chat/pull/4689

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
