### PR TITLE
Allow background notifs setting to be controlled via exp

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -661,6 +661,9 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],
+		experiment: {
+			mode: 'auto'
+		},
 		markdownDescription: localize('backgroundNotifications.description', "Whether to automatically notify the agent when a background terminal command completes or needs input. When enabled, a steering message is sent to the chat session with the exit code and terminal output, and the output monitor continues running to detect prompts for input."),
 	}
 };


### PR DESCRIPTION
Configuration update:

* Added an `experiment` property with `mode: 'auto'` to the `backgroundNotifications` configuration option in `terminalChatAgentToolsConfiguration`, enabling experimental rollout of automatic agent notifications for background terminal commands.
