### PR TITLE
sessions: changes modal UX polish - remove twistie padding and add header

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -122,6 +122,12 @@
 	background: rgba(0, 0, 0, 0.5);
 }
 
+.agent-sessions-workbench .monaco-modal-editor-block .modal-editor-sidebar .monaco-tl-twistie.force-no-twistie {
+	width: 0 !important;
+	padding-left: 0 !important;
+	padding-right: 0 !important;
+}
+
 
 /* ---- Customization Empty State ---- */
 

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -866,7 +866,7 @@ export class ChangesViewPane extends ViewPane {
 		// Layout on resize, accounting for the header height
 		disposables.add(onDidLayout(e => {
 			const headerHeight = headerNode.offsetHeight;
-			tree.layout(e.height - headerHeight, e.width);
+			tree.layout(Math.max(0, e.height - headerHeight), e.width);
 		}));
 
 		return disposables;

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -13,6 +13,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { autorun, derived, derivedOpts, IObservable } from '../../../../base/common/observable.js';
+import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
 import { ProgressBar } from '../../../../base/browser/ui/progressbar/progressbar.js';
 import { basename, isEqual } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -39,7 +40,7 @@ import { ServiceCollection } from '../../../../platform/instantiation/common/ser
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { defaultProgressBarStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import { defaultCountBadgeStyles, defaultProgressBarStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { fillEditorsDragData } from '../../../../workbench/browser/dnd.js';
 import { ResourceLabels } from '../../../../workbench/browser/labels.js';
@@ -812,6 +813,13 @@ export class ChangesViewPane extends ViewPane {
 		const viewMode = this.viewModel.viewModeObs.get();
 		container.classList.toggle('list-mode', viewMode === ChangesViewMode.List);
 
+		// "Changes" header
+		const headerNode = dom.append(container, $('.changes-sidebar-header'));
+		const headerLabel = dom.append(headerNode, $('span'));
+		headerLabel.textContent = localize('changes', "Changes");
+		const countBadge = disposables.add(new CountBadge(headerNode, { count: items.length }, defaultCountBadgeStyles));
+		countBadge.setCount(items.length);
+
 		const tree = this.createChangesTree(container, Event.None, disposables, () => tree.getSelection().filter(item => !!item && isChangesFileItem(item)));
 
 		if (viewMode === ChangesViewMode.Tree) {
@@ -855,8 +863,11 @@ export class ChangesViewPane extends ViewPane {
 			}
 		}));
 
-		// Layout on resize
-		disposables.add(onDidLayout(e => tree.layout(e.height, e.width)));
+		// Layout on resize, accounting for the header height
+		disposables.add(onDidLayout(e => {
+			const headerHeight = headerNode.offsetHeight;
+			tree.layout(e.height - headerHeight, e.width);
+		}));
 
 		return disposables;
 	}

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -248,6 +248,18 @@
 	padding-left: 0 !important;
 }
 
+/* Modal sidebar "Changes" header */
+.changes-file-list .changes-sidebar-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 6px;
+	padding: 2px 0;
+	min-height: 22px;
+	font-weight: 500;
+	font-size: 12px;
+}
+
 /* List rows */
 .changes-view-body .chat-editing-session-container:not(.has-file-icons) .monaco-list-row .monaco-icon-label {
 	margin-left: 6px;


### PR DESCRIPTION
## Summary

Fixes #307705

Two UX polish fixes for the Changes modal sidebar in the agents window:

### 1. Remove left-padding from `force-no-twistie` in list mode
The twistie element was taking up 10px of width even when hidden, causing misaligned padding compared to the main changes list. Now set to `width: 0` — **scoped to `.agent-sessions-workbench` only**.

### 2. Add a "Changes" header with count badge
Adds a header row above the file list in the modal sidebar, displaying "Changes" with a `CountBadge` showing the file count. This improves organization and consistency with the right-panel changes list.

### Files changed
- `src/vs/sessions/browser/media/style.css` — sessions-scoped twistie override
- `src/vs/sessions/contrib/changes/browser/changesView.ts` — add header + CountBadge to `renderSidebarList()`
- `src/vs/sessions/contrib/changes/browser/media/changesView.css` — header styling