### PR TITLE
chat: remove providerApi.enabled setting and legacy code paths

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -76,8 +76,8 @@ Storage answers "where did this come from?"; harness answers "who consumes it?".
 The service is defined in `common/customizationHarnessService.ts` which also provides:
 - **`CustomizationHarnessServiceBase`** — reusable base class handling active-harness state, the observable list, and `getStorageSourceFilter` dispatch.
 - **`ISectionOverride`** — per-section UI customization: `commandId` (command invocation), `rootFile` + `label` (root-file creation), `typeLabel` (custom type name), `fileExtension` (override default), `rootFileShortcuts` (dropdown shortcuts).
-- **Factory functions** — `createVSCodeHarnessDescriptor`, `createCliHarnessDescriptor`, `createClaudeHarnessDescriptor`. The VS Code harness receives `[PromptsStorage.extension, BUILTIN_STORAGE]` as extras; CLI and Claude in core receive `[]` (no extension source). Sessions CLI receives `[BUILTIN_STORAGE]`.
-- **Well-known root helpers** — `getCliUserRoots(userHome)` and `getClaudeUserRoots(userHome)` centralize the `~/.copilot`, `~/.claude`, `~/.agents` path knowledge.
+- **Factory functions** — `createVSCodeHarnessDescriptor`, `createCliHarnessDescriptor`. The VS Code harness receives `[PromptsStorage.extension, BUILTIN_STORAGE]` as extras; Sessions CLI receives `[BUILTIN_STORAGE]`.
+- **Well-known root helpers** — `getCliUserRoots(userHome)` centralizes the `~/.copilot`, `~/.claude`, `~/.agents` path knowledge.
 - **Filter helpers** — `matchesWorkspaceSubpath()` for segment-safe subpath matching; `matchesInstructionFileFilter()` for filename/path-prefix pattern matching.
 
 Available harnesses:
@@ -86,9 +86,8 @@ Available harnesses:
 |---------|-------|-------------|
 | `vscode` | Local | Shows all storage sources (default in core) |
 | `cli` | Copilot CLI | Restricts user roots to `~/.copilot`, `~/.claude`, `~/.agents` |
-| `claude` | Claude | Restricts user roots to `~/.claude`; hides Prompts + Plugins sections |
 
-In core VS Code, all three harnesses are registered but CLI and Claude only appear when their respective agents are registered (`requiredAgentId` checked via `IChatAgentService`). VS Code is the default.
+In core VS Code, only the Local harness is registered statically. Additional harnesses (e.g. Copilot CLI) are contributed by extensions via the provider API.
 In sessions, only CLI is registered (single harness, toggle bar hidden).
 
 ### IHarnessDescriptor
@@ -97,8 +96,8 @@ Key properties on the harness descriptor:
 
 | Property | Purpose |
 |----------|--------|
-| `hiddenSections` | Sidebar sections to hide (e.g. Claude: `[Prompts, Plugins]`) |
-| `workspaceSubpaths` | Restrict file creation/display to directories (e.g. Claude: `['.claude']`) |
+| `hiddenSections` | Sidebar sections to hide |
+| `workspaceSubpaths` | Restrict file creation/display to directories |
 | `hideGenerateButton` | Replace "Generate X" sparkle button with "New X" |
 | `sectionOverrides` | Per-section `ISectionOverride` map for button behavior |
 | `requiredAgentId` | Agent ID that must be registered for harness to appear |
@@ -137,20 +136,6 @@ CLI harness (core):
 | Hooks | `[local, plugin]` | N/A |
 | Prompts | `[local, user, plugin]` | `undefined` (all roots) |
 | Agents, Skills, Instructions | `[local, user, plugin]` | `[~/.copilot, ~/.claude, ~/.agents]` |
-
-Claude harness (core):
-
-| Type | sources | includedUserFileRoots |
-|------|---------|----------------------|
-| Hooks | `[local, plugin]` | N/A |
-| Prompts | `[local, user, plugin]` | `undefined` (all roots) |
-| Agents, Skills, Instructions | `[local, user, plugin]` | `[~/.claude]` |
-
-Claude additionally applies:
-- `hiddenSections: [Prompts, Plugins]`
-- `instructionFileFilter: ['CLAUDE.md', 'CLAUDE.local.md', '.claude/rules/', 'copilot-instructions.md']`
-- `workspaceSubpaths: ['.claude']` (instruction files matching `instructionFileFilter` are exempt)
-- `sectionOverrides`: Hooks → `copilot.claude.hooks` command; Instructions → "Add CLAUDE.md" primary, "Rule" type label, `.md` file extension
 
 ### Built-in Extension Grouping (Core VS Code)
 

--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -3,13 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { basename } from '../../../../base/common/path.js';
 import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
+	IExternalCustomizationItem,
+	IExternalCustomizationItemProvider,
 	createCliHarnessDescriptor,
 	getCliUserRoots,
 } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
+import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
 
 /**
@@ -17,16 +24,65 @@ import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
  *
  * Only the CLI harness is registered because sessions always run via
  * the Copilot CLI. With a single harness the toggle bar is hidden.
+ *
+ * A built-in itemProvider wraps IPromptsService so that the management
+ * editor can display items without needing an extension-contributed provider.
  */
 export class SessionsCustomizationHarnessService extends CustomizationHarnessServiceBase {
 	constructor(
 		@IPathService pathService: IPathService,
+		@IPromptsService promptsService: IPromptsService,
 	) {
 		const userHome = pathService.userHome({ preferLocal: true });
 		const extras = [BUILTIN_STORAGE];
+
+		const emitter = new Emitter<void>();
+
+		const itemProvider: IExternalCustomizationItemProvider = {
+			onDidChange: emitter.event,
+			async provideChatSessionCustomizations(token: CancellationToken): Promise<IExternalCustomizationItem[] | undefined> {
+				const [agents, skills, instructions, prompts, hooks] = await Promise.all([
+					promptsService.getCustomAgents(token),
+					promptsService.findAgentSkills(token),
+					promptsService.listPromptFiles(PromptsType.instructions, token),
+					promptsService.listPromptFiles(PromptsType.prompt, token),
+					promptsService.listPromptFiles(PromptsType.hook, token),
+				]);
+
+				const items: IExternalCustomizationItem[] = [];
+
+				for (const agent of agents ?? []) {
+					items.push({ uri: agent.uri, type: PromptsType.agent, name: agent.name, description: agent.description });
+				}
+				for (const skill of skills ?? []) {
+					items.push({ uri: skill.uri, type: PromptsType.skill, name: skill.name, description: skill.description });
+				}
+				for (const file of instructions) {
+					items.push({ uri: file.uri, type: PromptsType.instructions, name: file.name ?? basename(file.uri.path) });
+				}
+				for (const file of prompts) {
+					items.push({ uri: file.uri, type: PromptsType.prompt, name: file.name ?? basename(file.uri.path) });
+				}
+				for (const file of hooks) {
+					items.push({ uri: file.uri, type: PromptsType.hook, name: file.name ?? basename(file.uri.path) });
+				}
+
+				return items;
+			},
+		};
+
 		super(
-			[createCliHarnessDescriptor(getCliUserRoots(userHome), extras)],
+			[{ ...createCliHarnessDescriptor(getCliUserRoots(userHome), extras), itemProvider }],
 			CustomizationHarness.CLI,
 		);
+
+		this._register(emitter);
+		this._register(Event.any(
+			promptsService.onDidChangeCustomAgents,
+			promptsService.onDidChangeSlashCommands,
+			promptsService.onDidChangeSkills,
+			promptsService.onDidChangeHooks,
+			promptsService.onDidChangeInstructions,
+		)(() => emitter.fire()));
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -48,7 +48,6 @@ import { NotebookDto } from './mainThreadNotebookDto.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../contrib/chat/common/customizationHarnessService.js';
 import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IAgentPluginService } from '../../contrib/chat/common/plugins/agentPluginService.js';
 import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 
@@ -134,23 +133,12 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		@IPromptsService private readonly _promptsService: IPromptsService,
 		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
 		@ICustomizationHarnessService private readonly _customizationHarnessService: ICustomizationHarnessService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
 		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatAgents2);
-
-		// When the provider API kill-switch is toggled off, dispose all registered providers
-		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('chat.customizations.providerApi.enabled')) {
-				if (!this._configurationService.getValue<boolean>('chat.customizations.providerApi.enabled')) {
-					this._customizationProviders.clearAndDisposeAll();
-					this._customizationProviderEmitters.clearAndDisposeAll();
-				}
-			}
-		}));
 
 		this._register(this._chatService.onDidDisposeSession(e => {
 			for (const resource of e.sessionResources) {
@@ -759,11 +747,6 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	async $registerChatSessionCustomizationProvider(handle: number, chatSessionType: string, metadata: IChatSessionCustomizationProviderMetadataDto, extensionId: ExtensionIdentifier): Promise<void> {
 		if (this._environmentService.isSessionsWindow) {
 			this._logService.trace(`[MainThreadChatAgents2] Sessions window does not use the customization provider API, ignoring registration from ${extensionId.value}`);
-			return;
-		}
-
-		if (!this._configurationService.getValue<boolean>('chat.customizations.providerApi.enabled')) {
-			this._logService.trace(`[MainThreadChatAgents2] Customization provider API is disabled, ignoring registration from ${extensionId.value}`);
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -12,10 +12,10 @@ import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { autorun } from '../../../../../base/common/observable.js';
-import { basename, dirname, isEqual, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { basename, isEqual, isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -39,7 +39,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { createActionViewItem, getContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
-import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
@@ -50,12 +50,12 @@ import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js
 import { extractExtensionIdFromPath, getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
 import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
 import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
-import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
+import { HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, matchesWorkspaceSubpath, matchesInstructionFileFilter, ICustomizationSyncProvider } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, ICustomizationSyncProvider } from '../../common/customizationHarnessService.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -109,10 +109,6 @@ export interface IAICustomizationListItem {
 	readonly badgeTooltip?: string;
 	/** When set, overrides the default prompt-type icon. */
 	readonly typeIcon?: ThemeIcon;
-	/** True when item comes from the default chat extension (grouped under Built-in). */
-	readonly isBuiltin?: boolean;
-	/** Display name of the contributing extension (for non-built-in extension items). */
-	readonly extensionLabel?: string;
 	/** Server-reported loading/sync status for remote customizations. */
 	readonly status?: 'loading' | 'loaded' | 'degraded' | 'error';
 	/** Human-readable status detail (e.g. error message or warning). */
@@ -268,19 +264,6 @@ function promptTypeToIcon(type: PromptsType): ThemeIcon {
 }
 
 /**
- * Returns the icon for a given storage type.
- */
-function storageToIcon(storage: PromptsStorage): ThemeIcon {
-	switch (storage) {
-		case PromptsStorage.local: return workspaceIcon;
-		case PromptsStorage.user: return userIcon;
-		case PromptsStorage.extension: return extensionIcon;
-		case PromptsStorage.plugin: return pluginIcon;
-		default: return instructionsIcon;
-	}
-}
-
-/**
  * Formats a name for display by stripping a trailing .md extension.
  * Names from frontmatter headers are shown as-is to stay consistent
  * with how they appear in agent dropdowns and error messages.
@@ -372,16 +355,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 
 		// Hover tooltip: name + source + badge context + plugin source
 		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.container, () => {
-			let content: string;
-			if (element.isBuiltin) {
-				content = `${element.name}\n${localize('builtinSource', "Built-in")}`;
-			} else if (element.extensionLabel) {
-				content = `${element.name}\n${localize('fromExtension', "Extension: {0}", element.extensionLabel)}`;
-			} else {
-				const isWorkspaceItem = element.storage === PromptsStorage.local;
-				const uriLabel = this.labelService.getUriLabel(element.uri, { relative: isWorkspaceItem });
-				content = `${element.name}\n${uriLabel}`;
-			}
+			const isWorkspaceItem = element.storage === PromptsStorage.local;
+			const uriLabel = this.labelService.getUriLabel(element.uri, { relative: isWorkspaceItem });
+			let content = `${element.name}\n${uriLabel}`;
 			if (element.badgeTooltip) {
 				content += `\n\n${element.badgeTooltip}`;
 			}
@@ -850,8 +826,8 @@ export class AICustomizationListWidget extends Disposable {
 
 		const { secondary } = getContextMenuActions(actions, 'inline');
 
-		// Add copy path actions (not shown for built-in items where the path is an implementation detail)
-		const copyActions = item.isBuiltin ? [] : [
+		// Add copy path actions
+		const copyActions = [
 			new Separator(),
 			new Action('copyFullPath', localize('copyFullPath', "Copy Full Path"), undefined, true, async () => {
 				await this.clipboardService.writeText(item.uri.fsPath);
@@ -1212,40 +1188,8 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Post-processes items to assign groupKey overrides for extension-sourced
-	 * items. Applies the built-in grouping consistently across all item types.
-	 *
-	 * Items that already have an explicit groupKey (e.g. instruction categories,
-	 * agent hooks) are left untouched — groupKey overrides are only applied to
-	 * items whose current groupKey is `undefined`.
-	 */
-	private applyBuiltinGroupKeys(items: IAICustomizationListItem[], extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>): IAICustomizationListItem[] {
-		return items.map(item => {
-			if (item.storage !== PromptsStorage.extension) {
-				return item;
-			}
-			const extInfo = extensionInfoByUri.get(item.uri);
-			if (!extInfo) {
-				return item;
-			}
-			const isBuiltin = this.isChatExtensionItem(extInfo.id);
-			if (isBuiltin) {
-				return {
-					...item,
-					isBuiltin: true,
-					groupKey: item.groupKey ?? BUILTIN_STORAGE,
-				};
-			}
-			return {
-				...item,
-				extensionLabel: extInfo.displayName || extInfo.id.value,
-			};
-		});
-	}
-
-	/**
 	 * Fetches and filters items for a given section.
-	 * Delegates to the provider path or core path based on the active harness.
+	 * Delegates to the provider path based on the active harness.
 	 */
 	private async fetchItemsForSection(section: AICustomizationManagementSection): Promise<IAICustomizationListItem[]> {
 		const promptType = sectionToPromptType(section);
@@ -1255,7 +1199,7 @@ export class AICustomizationListWidget extends Disposable {
 			return this.fetchProviderItemsForSection(activeDescriptor, promptType);
 		}
 
-		return this.fetchCoreItemsForSection(promptType);
+		return [];
 	}
 
 	/**
@@ -1269,375 +1213,6 @@ export class AICustomizationListWidget extends Disposable {
 		}
 		const localItems = await this.fetchLocalSyncableItems(promptType, descriptor.syncProvider);
 		return [...remoteItems, ...localItems];
-	}
-
-	/**
-	 * Fetches items from the core promptsService with full filtering pipeline.
-	 * This is the legacy path used when no external provider is active.
-	 * TODO: Remove when provider API is the sole code path.
-	 */
-	private async fetchCoreItemsForSection(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const items: IAICustomizationListItem[] = [];
-		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
-		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();
-
-
-		if (promptType === PromptsType.agent) {
-			// Use getCustomAgents which has parsed name/description from frontmatter
-			const agents = await this.promptsService.getCustomAgents(CancellationToken.None);
-			// Build extension display name lookup from raw file list
-			const allAgentFiles = await this.promptsService.listPromptFiles(PromptsType.agent, CancellationToken.None);
-			for (const file of allAgentFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			for (const agent of agents) {
-				const filename = basename(agent.uri);
-				items.push({
-					id: agent.uri.toString(),
-					uri: agent.uri,
-					name: agent.name,
-					filename,
-					description: agent.description,
-					storage: agent.source.storage,
-					promptType,
-					pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-					disabled: disabledUris.has(agent.uri),
-				});
-				// Track extension ID for built-in grouping (if not already set from file list)
-				if (agent.source.storage === PromptsStorage.extension && !extensionInfoByUri.has(agent.uri)) {
-					extensionInfoByUri.set(agent.uri, { id: agent.source.extensionId });
-				}
-			}
-		} else if (promptType === PromptsType.skill) {
-			// Use findAgentSkills for enabled skills (has parsed name/description from frontmatter)
-			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
-			// Build extension ID lookup from raw file list (like MCP builds collectionSources)
-			const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, CancellationToken.None);
-			for (const file of allSkillFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
-			const seenUris = new ResourceSet();
-			for (const skill of skills || []) {
-				const filename = basename(skill.uri);
-				const skillName = skill.name || basename(dirname(skill.uri)) || filename;
-				seenUris.add(skill.uri);
-				const skillFolderName = basename(dirname(skill.uri));
-				const uiTooltip = uiIntegrations.get(skillFolderName);
-				items.push({
-					id: skill.uri.toString(),
-					uri: skill.uri,
-					name: skillName,
-					filename,
-					description: skill.description,
-					storage: skill.storage,
-					promptType,
-					pluginUri: skill.storage === PromptsStorage.plugin ? this.findPluginUri(skill.uri) : undefined,
-					disabled: false,
-					badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-					badgeTooltip: uiTooltip,
-				});
-			}
-			// Also include disabled skills from the raw file list
-			if (disabledUris.size > 0) {
-				for (const file of allSkillFiles) {
-					if (!seenUris.has(file.uri) && disabledUris.has(file.uri)) {
-						const filename = basename(file.uri);
-						const disabledName = file.name || basename(dirname(file.uri)) || filename;
-						const disabledFolderName = basename(dirname(file.uri));
-						const uiTooltip = uiIntegrations.get(disabledFolderName);
-						items.push({
-							id: file.uri.toString(),
-							uri: file.uri,
-							name: disabledName,
-							filename,
-							description: file.description,
-							storage: file.storage,
-							promptType,
-							disabled: true,
-							badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-							badgeTooltip: uiTooltip,
-						});
-					}
-				}
-			}
-		} else if (promptType === PromptsType.prompt) {
-			// Use getPromptSlashCommands which has parsed name/description from frontmatter
-			// Filter out skills since they have their own section
-			const commands = await this.promptsService.getPromptSlashCommands(CancellationToken.None);
-			for (const command of commands) {
-				if (command.type === PromptsType.skill) {
-					continue;
-				}
-				const filename = basename(command.uri);
-				items.push({
-					id: command.uri.toString(),
-					uri: command.uri,
-					name: command.name,
-					filename,
-					description: command.description,
-					storage: command.storage,
-					promptType,
-					pluginUri: command.storage === PromptsStorage.plugin ? command.pluginUri : undefined,
-					disabled: disabledUris.has(command.uri),
-				});
-				if (command.extension) {
-					extensionInfoByUri.set(command.uri, { id: command.extension.identifier, displayName: command.extension.displayName });
-				}
-			}
-		} else if (promptType === PromptsType.hook) {
-			// Try to parse individual hooks from each file; fall back to showing the file itself
-			const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			const userHomeUri = await this.pathService.userHome();
-			const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
-
-			for (const hookFile of hookFiles) {
-				// Plugins parse their own hooks and emit them individually because they can
-				// be embedded with interpolations in the plugin manifests; don't re-parse them
-				if (hookFile.storage === PromptsStorage.plugin) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString() + ':' + hookFile.name,
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						pluginUri: hookFile.pluginUri,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-					continue;
-				}
-
-				let parsedHooks = false;
-				try {
-					const content = await this.fileService.readFile(hookFile.uri);
-					const json = parseJSONC(content.value.toString());
-					const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
-
-					if (hooks.size > 0) {
-						parsedHooks = true;
-						for (const [hookType, entry] of hooks) {
-							const hookMeta = HOOK_METADATA[hookType];
-							for (let i = 0; i < entry.hooks.length; i++) {
-								const hook = entry.hooks[i];
-								const cmdLabel = formatHookCommandLabel(hook, OS);
-								const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-								items.push({
-									id: `${hookFile.uri.toString()}#${entry.originalId}[${i}]`,
-									uri: hookFile.uri,
-									name: hookMeta?.label ?? entry.originalId,
-									filename: basename(hookFile.uri),
-									description: truncatedCmd || localize('hookUnset', "(unset)"),
-									storage: hookFile.storage,
-									promptType,
-									disabled: disabledUris.has(hookFile.uri),
-								});
-							}
-						}
-					}
-				} catch {
-					// Parse failed — fall through to show raw file
-				}
-
-				if (!parsedHooks) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString(),
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-				}
-			}
-
-			// Also include hooks defined in agent frontmatter (not in sessions window)
-			// TODO: add this back when Copilot CLI supports this
-			const agents = !this.workspaceService.isSessionsWindow ? await this.promptsService.getCustomAgents(CancellationToken.None) : [];
-			for (const agent of agents) {
-				if (!agent.hooks) {
-					continue;
-				}
-				for (const hookType of Object.values(HookType)) {
-					const hookCommands = agent.hooks[hookType];
-					if (!hookCommands || hookCommands.length === 0) {
-						continue;
-					}
-					const hookMeta = HOOK_METADATA[hookType];
-					for (let i = 0; i < hookCommands.length; i++) {
-						const hook = hookCommands[i];
-						const cmdLabel = formatHookCommandLabel(hook, OS);
-						const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-						items.push({
-							id: `${agent.uri.toString()}#hook:${hookType}[${i}]`,
-							uri: agent.uri,
-							name: hookMeta?.label ?? hookType,
-							filename: basename(agent.uri),
-							description: `${agent.name}: ${truncatedCmd || localize('hookUnset', "(unset)")}`,
-							storage: agent.source.storage,
-							groupKey: 'agents',
-							promptType,
-							pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-							disabled: disabledUris.has(agent.uri),
-						});
-					}
-				}
-			}
-		} else {
-			// For instructions, group by category: agent instructions, context instructions, on-demand instructions
-			const instructionFiles = await this.promptsService.getInstructionFiles(CancellationToken.None);
-			for (const file of instructionFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const agentInstructionFiles = await this.promptsService.listAgentInstructions(CancellationToken.None, undefined);
-			const agentInstructionUris = new ResourceSet(agentInstructionFiles.map(f => f.uri));
-
-			// Add agent instruction items
-			const workspaceFolderUris = this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			if (activeRoot) {
-				workspaceFolderUris.push(activeRoot);
-			}
-			for (const file of agentInstructionFiles) {
-				const storage = PromptsStorage.local;
-				const filename = basename(file.uri);
-				items.push({
-					id: file.uri.toString(),
-					uri: file.uri,
-					name: filename,
-					filename: this.labelService.getUriLabel(file.uri, { relative: true }),
-					displayName: filename,
-					storage,
-					promptType,
-					typeIcon: storageToIcon(storage),
-					groupKey: 'agent-instructions',
-					disabled: disabledUris.has(file.uri),
-				});
-			}
-
-			// Parse prompt files to separate into context vs on-demand
-
-			for (const { uri, pattern, name, description, storage, pluginUri } of instructionFiles) {
-				if (agentInstructionUris.has(uri)) {
-					continue; // already added as agent instruction
-				}
-
-				const friendlyName = this.getFriendlyName(name);
-
-				if (pattern !== undefined) {
-					// Context instruction
-					const badge = pattern === '**'
-						? localize('alwaysAdded', "always added")
-						: pattern;
-					const badgeTooltip = pattern === '**'
-						? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
-						: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", pattern);
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: this.labelService.getUriLabel(uri, { relative: true }),
-						displayName: friendlyName,
-						badge,
-						badgeTooltip,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'context-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				} else {
-					// On-demand instruction
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: basename(uri),
-						displayName: friendlyName,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'on-demand-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				}
-			}
-		}
-
-		// Assign built-in groupKeys — items from the default chat extension
-		// are re-grouped under "Built-in" instead of "Extensions".
-		// This is a single-pass transformation applied after all items are
-		// collected, keeping the item-building code free of grouping logic.
-		const groupedItems = this.applyBuiltinGroupKeys(items, extensionInfoByUri);
-
-		// Apply storage source filter (removes items not in visible sources or excluded user roots)
-		const filter = this.workspaceService.getStorageSourceFilter(promptType);
-		const withStorage = groupedItems.filter((item): item is IAICustomizationListItem & { readonly storage: PromptsStorage } => item.storage !== undefined);
-		const withoutStorage = groupedItems.filter(item => item.storage === undefined);
-		const filteredItems = [...applyStorageSourceFilter(withStorage, filter), ...withoutStorage];
-		items.length = 0;
-		items.push(...filteredItems);
-
-		// Apply workspace subpath filter — when the active harness specifies
-		// workspaceSubpaths, hide workspace-local items that aren't under one
-		// of the recognized sub-paths (e.g. Claude only shows .claude/ items).
-		// Exception: instruction files matched by the harness's instructionFileFilter
-		// are exempt (e.g. CLAUDE.md at workspace root is a Claude-native file
-		// even though it's not under .claude/).
-		const descriptor = this.harnessService.getActiveDescriptor();
-		const subpaths = descriptor.workspaceSubpaths;
-		const instrFilter = descriptor.instructionFileFilter;
-		if (subpaths) {
-			const projectRoot = this.workspaceService.getActiveProjectRoot();
-			for (let i = items.length - 1; i >= 0; i--) {
-				const item = items[i];
-				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
-					if (!matchesWorkspaceSubpath(item.uri.path, subpaths)) {
-						// Keep instruction files that match the harness's native patterns
-						if (instrFilter && promptType === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
-							continue;
-						}
-						// Keep agent instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md)
-						// — these live at the workspace root by design and should not be
-						// filtered out by workspace subpath restrictions.
-						if (item.groupKey === 'agent-instructions') {
-							continue;
-						}
-						items.splice(i, 1);
-					}
-				}
-			}
-		}
-
-		// Apply instruction file filter — when the active harness specifies
-		// instructionFileFilter, hide instruction files that don't match the
-		// recognized patterns (e.g. Claude doesn't support *.instructions.md).
-		if (instrFilter && promptType === PromptsType.instructions) {
-			for (let i = items.length - 1; i >= 0; i--) {
-				if (!matchesInstructionFileFilter(items[i].uri.path, instrFilter)) {
-					items.splice(i, 1);
-				}
-			}
-		}
-
-		// Sort items by name
-		items.sort((a, b) => a.name.localeCompare(b.name));
-
-		return items;
 	}
 
 	/**
@@ -2015,54 +1590,11 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Filters and groups items from the core promptsService (static harness path).
-	 * Instructions use semantic categories; other sections use storage-based groups.
-	 */
-	private filterItemsForCore(matchedItems: IAICustomizationListItem[]): void {
-		const promptType = sectionToPromptType(this.currentSection);
-		const visibleSources = new Set(this.workspaceService.getStorageSourceFilter(promptType).sources);
-
-		const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] =
-			this.currentSection === AICustomizationManagementSection.Instructions
-				? [
-					{ groupKey: 'agent-instructions', label: localize('agentInstructionsGroup', "Agent Instructions"), icon: instructionsIcon, description: localize('agentInstructionsGroupDescription', "Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md)."), items: [] },
-					{ groupKey: 'context-instructions', label: localize('contextInstructionsGroup', "Included Based on Context"), icon: instructionsIcon, description: localize('contextInstructionsGroupDescription', "Instructions automatically loaded when matching files are part of the context."), items: [] },
-					{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
-				]
-				: [
-					{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
-					{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
-					{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
-					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
-					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
-					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
-
-		for (const item of matchedItems) {
-			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
-			const group = groups.find(g => g.groupKey === key);
-			if (group) {
-				group.items.push(item);
-			}
-		}
-
-		this.buildGroupedEntries(groups);
-		this.commitDisplayEntries();
-	}
-
-	/**
 	 * Filters items based on the current search query and builds grouped display entries.
 	 */
 	private filterItems(): number {
 		const matchedItems = this.applySearchFilter(this.allItems);
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-
-		if (activeDescriptor.itemProvider) {
-			this.filterItemsForProvider(matchedItems);
-		} else {
-			this.filterItemsForCore(matchedItems);
-		}
-
+		this.filterItemsForProvider(matchedItems);
 		return matchedItems.length;
 	}
 
@@ -2119,18 +1651,6 @@ export class AICustomizationListWidget extends Disposable {
 			default:
 				return promptIcon;
 		}
-	}
-
-	/**
-	 * Finds the plugin URI for an item URI by checking the known plugins.
-	 */
-	private findPluginUri(itemUri: URI): URI | undefined {
-		for (const plugin of this.agentPluginService.plugins.get()) {
-			if (isEqualOrParent(itemUri, plugin.uri)) {
-				return plugin.uri;
-			}
-		}
-		return undefined;
 	}
 
 	private getEmptyStateInfo(): { title: string; description: string } {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -8,59 +8,22 @@ import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
 	ICustomizationHarnessService,
-	IHarnessDescriptor,
-	createCliHarnessDescriptor,
-	createClaudeHarnessDescriptor,
 	createVSCodeHarnessDescriptor,
-	getCliUserRoots,
-	getClaudeUserRoots,
 } from '../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { BUILTIN_STORAGE } from '../../common/aiCustomizationWorkspaceService.js';
-import { IPathService } from '../../../../services/path/common/pathService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { ChatConfiguration } from '../../common/constants.js';
 
 /**
  * Core implementation of the customization harness service.
  *
- * When `chat.customizations.providerApi.enabled` is true, only the Local
- * harness is registered statically. All other harnesses are contributed by
- * extensions via the provider API, so the hardcoded CLI/Claude harnesses are
- * intentionally omitted.
- *
- * When the setting is false, the full set of built-in harnesses (Local, Copilot
- * CLI, Claude) is registered for backwards compat.
+ * Only the Local harness is registered statically. All other harnesses
+ * (e.g. Copilot CLI) are contributed by extensions via the provider API.
  */
 class CustomizationHarnessService extends CustomizationHarnessServiceBase {
-	constructor(
-		@IPathService pathService: IPathService,
-		@IConfigurationService configurationService: IConfigurationService,
-	) {
-		// The Local harness includes extension-contributed and built-in customizations.
-		// Built-in items come from the default chat extension (productService.defaultChatAgent).
+	constructor() {
 		const localExtras = [PromptsStorage.extension, BUILTIN_STORAGE];
-
-		const providerApiEnabled = configurationService.getValue<boolean>(ChatConfiguration.CustomizationsProviderApi);
-
-		let allHarnesses: readonly IHarnessDescriptor[];
-		if (providerApiEnabled) {
-			// When the provider API is enabled, only expose the Local harness.
-			// CLI and Claude harnesses don't consume extension contributions.
-			// Additional harnesses are contributed entirely via the provider API.
-			allHarnesses = [createVSCodeHarnessDescriptor(localExtras)];
-		} else {
-			const userHome = pathService.userHome({ preferLocal: true });
-			const restrictedExtras: readonly string[] = [];
-			allHarnesses = [
-				createVSCodeHarnessDescriptor(localExtras),
-				createCliHarnessDescriptor(getCliUserRoots(userHome), restrictedExtras),
-				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), restrictedExtras),
-			];
-		}
-
 		super(
-			allHarnesses,
+			[createVSCodeHarnessDescriptor(localExtras)],
 			CustomizationHarness.VSCode,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1397,14 +1397,8 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.ChatCustomizationHarnessSelectorEnabled]: {
 			type: 'boolean',
 			tags: ['preview'],
-			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector (Local, Copilot CLI, Claude) is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
+			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
 			default: true,
-		},
-		[ChatConfiguration.CustomizationsProviderApi]: {
-			type: 'boolean',
-			description: nls.localize('chat.customizations.providerApi.enabled', "When enabled, the Customizations management UI reads items from the session type's customizations provider instead of built-in discovery."),
-			default: true,
-			tags: ['preview'],
 		},
 	}
 });

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -65,7 +65,6 @@ export enum ChatConfiguration {
 	ArtifactsMode = 'chat.artifacts.mode',
 	ArtifactsRulesByMimeType = 'chat.artifacts.rules.byMimeType',
 	ArtifactsRulesByFilePath = 'chat.artifacts.rules.byFilePath',
-	CustomizationsProviderApi = 'chat.customizations.providerApi.enabled',
 	ToolConfirmationCarousel = 'chat.tools.confirmationCarousel.enabled',
 	DefaultNewSessionMode = 'chat.newSession.defaultMode',
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -62,7 +62,6 @@ export interface ISectionOverride {
 export enum CustomizationHarness {
 	VSCode = 'vscode',
 	CLI = 'cli',
-	Claude = 'claude',
 }
 
 /**
@@ -275,13 +274,6 @@ export function getCliUserRoots(userHome: URI): readonly URI[] {
 	];
 }
 
-/**
- * Returns the user-home directories accessible to the Claude harness.
- */
-export function getClaudeUserRoots(userHome: URI): readonly URI[] {
-	return [joinPath(userHome, '.claude')];
-}
-
 // #endregion
 
 // #region Harness descriptor factories
@@ -319,7 +311,7 @@ export function createVSCodeHarnessDescriptor(extras: readonly string[]): IHarne
 /**
  * Creates a harness descriptor that restricts user-file roots for most
  * types (agents, skills, instructions) while leaving hooks and prompts
- * unrestricted. Used for CLI and Claude harnesses.
+ * unrestricted. Used for restricted harnesses like CLI.
  */
 interface IRestrictedHarnessOptions {
 	readonly hiddenSections?: readonly string[];
@@ -382,41 +374,6 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 					rootFileShortcuts: [AGENT_MD_FILENAME],
 				}],
 			]),
-		},
-	);
-}
-
-/**
- * Creates a "Claude" harness descriptor.
- * Claude does not support prompt files (.prompt.md), AGENTS.md, or extension-contributed plugins.
- * It supports agents (.claude/agents/), instructions (CLAUDE.md, .claude/rules/),
- * skills (.claude/skills/), and hooks (.claude/settings.json).
- */
-export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
-	return createRestrictedHarnessDescriptor(
-		CustomizationHarness.Claude,
-		localize('harness.claude', "Claude"),
-		ThemeIcon.fromId(Codicon.claude.id),
-		claudeRoots,
-		extras,
-		{
-			hiddenSections: [AICustomizationManagementSection.Prompts, AICustomizationManagementSection.Plugins],
-			workspaceSubpaths: ['.claude'],
-			hideGenerateButton: true,
-			requiredAgentId: 'claude-code',
-			sectionOverrides: new Map([
-				[AICustomizationManagementSection.Hooks, {
-					label: localize('claudeHooks', "Configure Claude Hooks"),
-					commandId: 'copilot.claude.hooks',
-				}],
-				[AICustomizationManagementSection.Instructions, {
-					label: localize('addClaudeMd', "Add CLAUDE.md"),
-					rootFile: 'CLAUDE.md',
-					typeLabel: localize('rule', "Rule"),
-					fileExtension: '.md',
-				}],
-			]),
-			instructionFileFilter: ['CLAUDE.md', 'CLAUDE.local.md', '.claude/rules/', 'copilot-instructions.md'],
 		},
 	);
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -5,7 +5,7 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
-import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -417,7 +417,7 @@ export function matchesInstructionFileFilter(filePath: string, filters: readonly
  * Concrete registrations only need to supply the list of harness
  * descriptors and a default harness id.
  */
-export class CustomizationHarnessServiceBase implements ICustomizationHarnessService {
+export class CustomizationHarnessServiceBase extends Disposable implements ICustomizationHarnessService {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _activeHarness: ISettableObservable<string>;
@@ -432,6 +432,7 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 		staticHarnesses: readonly IHarnessDescriptor[],
 		defaultHarness: string,
 	) {
+		super();
 		this._staticHarnesses = staticHarnesses;
 		this._activeHarness = observableValue<string>(this, defaultHarness);
 		this.activeHarness = this._activeHarness;

--- a/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
@@ -20,7 +20,7 @@ suite('CustomizationHarnessService', () => {
 		if (harnesses.length === 0) {
 			harnesses = [createVSCodeHarnessDescriptor([PromptsStorage.extension])];
 		}
-		return new CustomizationHarnessServiceBase(harnesses, harnesses[0].id);
+		return store.add(new CustomizationHarnessServiceBase(harnesses, harnesses[0].id));
 	}
 
 	suite('registerExternalHarness', () => {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -29,7 +29,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
 import { IWebviewService } from '../../../../contrib/webview/browser/webview.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection } from '../../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor, createClaudeHarnessDescriptor, createCliHarnessDescriptor, getCliUserRoots, getClaudeUserRoots } from '../../../../contrib/chat/common/customizationHarnessService.js';
+import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor, createCliHarnessDescriptor, getCliUserRoots } from '../../../../contrib/chat/common/customizationHarnessService.js';
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
 import { PromptsType } from '../../../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, AgentInstructionFileType, PromptsStorage, IAgentSkill, IChatPromptSlashCommand, IAgentInstructionFile } from '../../../../contrib/chat/common/promptSyntax/service/promptsService.js';
@@ -433,7 +433,6 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 	const availableHarnesses = options.availableHarnesses ?? [
 		createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]),
 		createCliHarnessDescriptor(getCliUserRoots(userHome), []),
-		createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), []),
 	];
 
 	const allMcpServers = [...mcpWorkspaceServers, ...mcpUserServers];
@@ -826,13 +825,6 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 	CliHarness: defineComponentFixture({
 		labels: { kind: 'screenshot' },
 		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.CLI, selectedSection: AICustomizationManagementSection.Agents }),
-	}),
-
-	// Full editor with Claude harness — Prompts+Plugins hidden, Agents visible,
-	// "Add CLAUDE.md" button, "New Rule" dropdown, instruction filtering, bridged MCP badge
-	ClaudeHarness: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.Claude, selectedSection: AICustomizationManagementSection.Agents }),
 	}),
 
 	// Sessions-window variant of the full editor with workspace override UX


### PR DESCRIPTION
## Summary

The provider API is now permanently enabled. This PR removes the `chat.customizations.providerApi.enabled` setting and all associated dead code paths (**616 lines removed** across 8 files).

## What was removed

| File | Change |
|---|---|
| `constants.ts` | Removed `CustomizationsProviderApi` enum value |
| `chat.contribution.ts` | Removed setting registration, fixed stale "Claude" mention in `harnessSelector.enabled` description |
| `browser/customizationHarnessService.ts` | Removed conditional harness creation (was: if providerApi → VSCode, else → CLI+Claude). Now unconditionally creates VSCode harness only. Removed `IPathService`/`IConfigurationService` deps. |
| `common/customizationHarnessService.ts` | Removed `Claude` enum value, `getClaudeUserRoots()`, `createClaudeHarnessDescriptor()` |
| `aiCustomizationListWidget.ts` | Removed ~506 lines: `fetchCoreItemsForSection`, `applyBuiltinGroupKeys`, `storageToIcon`, `findPluginUri`, `filterItemsForCore`, `isBuiltin`/`extensionLabel` interface properties and all read sites |
| `mainThreadChatAgents2.ts` | Removed kill-switch config listener and provider-API guard, `IConfigurationService` dep |
| `aiCustomizationManagementEditor.fixture.ts` | Removed Claude harness fixture and imports |
| `AI_CUSTOMIZATIONS.md` | Updated docs to remove Claude harness references |

## What was preserved

- **CLI harness code** in `common/customizationHarnessService.ts` — still used by the sessions (agents) window via `SessionsCustomizationHarnessService`
- **`HOOKS_FILTER`**, `createRestrictedHarnessDescriptor`, `createCliHarnessDescriptor`, `getCliUserRoots` — all still live via sessions window
- **`isChatExtensionItem`** — still used in the provider path for `_inferStorageAndGroup`
- **`matchesWorkspaceSubpath`/`matchesInstructionFileFilter`** — still used by editor and creator service

## Validation

- ✅ TypeScript compilation clean (`npm run compile-check-ts-native`)
- ✅ Pre-commit hygiene hooks pass
- ✅ Council review (GPT, Opus, Gemini) — no blocking issues