### PR TITLE
sessions: add source property to task interaction telemetry

### DIFF
--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -15,21 +15,25 @@ export type SessionsInteractionButton =
 	| 'openTerminal'
 	| 'openInVSCode';
 
+export type SessionsInteractionSource = 'menu' | 'actionWidget';
+
 type SessionsInteractionEvent = {
 	button: string;
+	source: string;
 };
 
 type SessionsInteractionClassification = {
 	owner: 'osortega';
 	comment: 'Tracks user interactions with buttons in the Agents window';
 	button: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the button that was clicked' };
+	source: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The UI surface that triggered the interaction (menu or actionWidget)' };
 };
 
 /**
  * Log a titlebar button interaction in the Agents window.
  */
-export function logSessionsInteraction(telemetryService: ITelemetryService, button: SessionsInteractionButton): void {
-	telemetryService.publicLog2<SessionsInteractionEvent, SessionsInteractionClassification>('vscodeAgents.interaction', { button });
+export function logSessionsInteraction(telemetryService: ITelemetryService, button: SessionsInteractionButton, source?: SessionsInteractionSource): void {
+	telemetryService.publicLog2<SessionsInteractionEvent, SessionsInteractionClassification>('vscodeAgents.interaction', { button, source: source ?? '' });
 }
 
 // --- Changes panel interactions ---

--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -19,21 +19,21 @@ export type SessionsInteractionSource = 'menu' | 'actionWidget';
 
 type SessionsInteractionEvent = {
 	button: string;
-	source: string;
+	source?: string;
 };
 
 type SessionsInteractionClassification = {
 	owner: 'osortega';
 	comment: 'Tracks user interactions with buttons in the Agents window';
 	button: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the button that was clicked' };
-	source: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The UI surface that triggered the interaction (menu or actionWidget)' };
+	source?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The UI surface that triggered the interaction (menu or actionWidget)' };
 };
 
 /**
  * Log a titlebar button interaction in the Agents window.
  */
 export function logSessionsInteraction(telemetryService: ITelemetryService, button: SessionsInteractionButton, source?: SessionsInteractionSource): void {
-	telemetryService.publicLog2<SessionsInteractionEvent, SessionsInteractionClassification>('vscodeAgents.interaction', { button, source: source ?? '' });
+	telemetryService.publicLog2<SessionsInteractionEvent, SessionsInteractionClassification>('vscodeAgents.interaction', source ? { button, source } : { button });
 }
 
 // --- Changes panel interactions ---

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -242,6 +242,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 				}
 
 				async run(): Promise<void> {
+					logSessionsInteraction(that._telemetryService, 'addTask', 'menu');
 					const task = await that._showConfigureQuickPick(session);
 					if (task) {
 						await that._sessionsConfigService.runTask(task, session);
@@ -265,6 +266,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 				}
 
 				async run(): Promise<void> {
+					logSessionsInteraction(that._telemetryService, 'generateNewTask', 'menu');
 					await that._sessionManagementService.sendAndCreateChat(session, { query: '/generate-run-commands' });
 				}
 			}));
@@ -681,7 +683,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			class: undefined,
 			category: tasksCategory,
 			run: async () => {
-				logSessionsInteraction(this._telemetryService, 'addTask');
+				logSessionsInteraction(this._telemetryService, 'addTask', 'actionWidget');
 				const task = await this._showConfigureQuickPick(session);
 				if (task) {
 					await this._sessionsConfigService.runTask(task, session);
@@ -703,7 +705,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			class: undefined,
 			category: tasksCategory,
 			run: async () => {
-				logSessionsInteraction(this._telemetryService, 'generateNewTask');
+				logSessionsInteraction(this._telemetryService, 'generateNewTask', 'actionWidget');
 				await this._sessionsManagementService.sendAndCreateChat(session, { query: '/generate-run-commands' });
 			},
 		});


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-internalbacklog/issues/7256
Add a `source` field (`'menu' | 'actionWidget'`) to `logSessionsInteraction` to differentiate whether `addTask` / `generateNewTask` was triggered from the standard Action2 menu path or the custom action widget dropdown.

### Changes

- **`sessionsTelemetry.ts`** — Added `SessionsInteractionSource` type and an optional `source` parameter to `logSessionsInteraction`, emitted as a new telemetry property.
- **`runScriptAction.ts`** — Added missing `logSessionsInteraction` calls to the Action2 menu registrations (`source: 'menu'`) and updated existing action widget calls with `source: 'actionWidget'`.