### PR TITLE
Fix AI customization count misalignment for plugin-storage items

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -96,6 +96,26 @@ export class AICustomizationOverviewView extends ViewPane {
 			this.loadCounts();
 		}));
 
+		// Reactively track MCP server count (register once, not per-loadCounts call)
+		const mcpSection = this.sections.find(s => s.id === AICustomizationManagementSection.McpServers);
+		if (mcpSection) {
+			this._register(autorun(reader => {
+				const servers = this.mcpService.servers.read(reader);
+				mcpSection.count = servers.length;
+				this.updateCountElements();
+			}));
+		}
+
+		// Reactively track plugin count (register once, not per-loadCounts call)
+		const pluginSection = this.sections.find(s => s.id === AICustomizationManagementSection.Plugins);
+		if (pluginSection) {
+			this._register(autorun(reader => {
+				const plugins = this.agentPluginService.plugins.read(reader);
+				pluginSection.count = plugins.length;
+				this.updateCountElements();
+			}));
+		}
+
 	}
 
 	protected override renderBody(container: HTMLElement): void {
@@ -190,26 +210,6 @@ export class AICustomizationOverviewView extends ViewPane {
 				sectionData.count = count;
 			}
 		}));
-
-		// Update MCP server count reactively
-		const mcpSection = this.sections.find(s => s.id === AICustomizationManagementSection.McpServers);
-		if (mcpSection) {
-			this._register(autorun(reader => {
-				const servers = this.mcpService.servers.read(reader);
-				mcpSection.count = servers.length;
-				this.updateCountElements();
-			}));
-		}
-
-		// Update plugin count reactively
-		const pluginSection = this.sections.find(s => s.id === AICustomizationManagementSection.Plugins);
-		if (pluginSection) {
-			this._register(autorun(reader => {
-				const plugins = this.agentPluginService.plugins.read(reader);
-				pluginSection.count = plugins.length;
-				this.updateCountElements();
-			}));
-		}
 
 		this.updateCountElements();
 	}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -306,7 +306,7 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
  */
 interface ICachedTypeData {
 	skills?: IAgentSkill[];
-	files?: Map<string, readonly IPromptPath[]>;
+	files?: Map<AICustomizationPromptsStorage, readonly IPromptPath[]>;
 }
 
 /**
@@ -403,11 +403,45 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 	}
 
 	/**
+	 * Groups items by storage type, returning group items for all
+	 * non-empty storage types in a stable display order.
+	 */
+	private static readonly STORAGE_ORDER: readonly AICustomizationPromptsStorage[] = [
+		PromptsStorage.local,
+		PromptsStorage.user,
+		PromptsStorage.plugin,
+		PromptsStorage.extension,
+		BUILTIN_STORAGE,
+	];
+
+	private groupByStorage<T extends { readonly storage: AICustomizationPromptsStorage }>(items: readonly T[]): Map<AICustomizationPromptsStorage, readonly T[]> {
+		const grouped = new Map<AICustomizationPromptsStorage, T[]>();
+		for (const item of items) {
+			let bucket = grouped.get(item.storage);
+			if (!bucket) {
+				bucket = [];
+				grouped.set(item.storage, bucket);
+			}
+			bucket.push(item);
+		}
+		return grouped;
+	}
+
+	private buildGroupItems(promptType: PromptsType, grouped: ReadonlyMap<AICustomizationPromptsStorage, { readonly length: number }>): IAICustomizationGroupItem[] {
+		const groups: IAICustomizationGroupItem[] = [];
+		for (const storage of UnifiedAICustomizationDataSource.STORAGE_ORDER) {
+			const items = grouped.get(storage);
+			if (items && items.length > 0) {
+				groups.push(this.createGroupItem(promptType, storage, items.length));
+			}
+		}
+		return groups;
+	}
+
+	/**
 	 * Fetches and caches data for a prompt type, returning storage groups with items.
 	 */
 	private async getStorageGroups(promptType: PromptsType): Promise<IAICustomizationGroupItem[]> {
-		const groups: IAICustomizationGroupItem[] = [];
-
 		// Check cache first
 		let cached = this.cache.get(promptType);
 		if (!cached) {
@@ -424,25 +458,8 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 				this.onItemCountChanged(this.totalItemCount);
 			}
 
-			const workspaceSkills = cached.skills.filter(s => s.storage === PromptsStorage.local);
-			const userSkills = cached.skills.filter(s => s.storage === PromptsStorage.user);
-			const extensionSkills = cached.skills.filter(s => s.storage === PromptsStorage.extension);
-			const builtinSkills = cached.skills.filter(s => s.storage === BUILTIN_STORAGE);
-
-			if (workspaceSkills.length > 0) {
-				groups.push(this.createGroupItem(promptType, PromptsStorage.local, workspaceSkills.length));
-			}
-			if (userSkills.length > 0) {
-				groups.push(this.createGroupItem(promptType, PromptsStorage.user, userSkills.length));
-			}
-			if (extensionSkills.length > 0) {
-				groups.push(this.createGroupItem(promptType, PromptsStorage.extension, extensionSkills.length));
-			}
-			if (builtinSkills.length > 0) {
-				groups.push(this.createGroupItem(promptType, BUILTIN_STORAGE, builtinSkills.length));
-			}
-
-			return groups;
+			const grouped = this.groupByStorage(cached.skills);
+			return this.buildGroupItems(promptType, grouped);
 		}
 
 		// For other types, fetch once and cache grouped by storage
@@ -460,42 +477,12 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 				}
 			}
 
-			const workspaceItems = allItems.filter(item => item.storage === PromptsStorage.local);
-			const userItems = allItems.filter(item => item.storage === PromptsStorage.user);
-			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);
-			const builtinItems = allItems.filter(item => item.storage === BUILTIN_STORAGE);
-
-			cached.files = new Map<string, readonly IPromptPath[]>([
-				[PromptsStorage.local, workspaceItems],
-				[PromptsStorage.user, userItems],
-				[PromptsStorage.extension, extensionItems],
-				[BUILTIN_STORAGE, builtinItems],
-			]);
-
-			const itemCount = allItems.length;
-			this.totalItemCount += itemCount;
+			cached.files = this.groupByStorage(allItems);
+			this.totalItemCount += allItems.length;
 			this.onItemCountChanged(this.totalItemCount);
 		}
 
-		const workspaceItems = cached.files!.get(PromptsStorage.local) || [];
-		const userItems = cached.files!.get(PromptsStorage.user) || [];
-		const extensionItems = cached.files!.get(PromptsStorage.extension) || [];
-		const builtinItems = cached.files!.get(BUILTIN_STORAGE) || [];
-
-		if (workspaceItems.length > 0) {
-			groups.push(this.createGroupItem(promptType, PromptsStorage.local, workspaceItems.length));
-		}
-		if (userItems.length > 0) {
-			groups.push(this.createGroupItem(promptType, PromptsStorage.user, userItems.length));
-		}
-		if (extensionItems.length > 0) {
-			groups.push(this.createGroupItem(promptType, PromptsStorage.extension, extensionItems.length));
-		}
-		if (builtinItems.length > 0) {
-			groups.push(this.createGroupItem(promptType, BUILTIN_STORAGE, builtinItems.length));
-		}
-
-		return groups;
+		return this.buildGroupItems(promptType, cached.files);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes count misalignment in the Sessions app's AI Customization views where plugin-storage items were not correctly represented.

## Bugs Fixed

### 1. Tree view dropped plugin-storage items
`UnifiedAICustomizationDataSource.getStorageGroups()` manually filtered for `local`, `user`, `extension`, and `builtin` storage types — but never `plugin`. Items with `storage === PromptsStorage.plugin` were included in `totalItemCount` (affecting the empty-state context key) but never displayed as groups in the tree.

**Fix**: Replaced brittle per-storage-type filtering with dynamic `groupByStorage()` + `buildGroupItems()` helpers that handle all storage types via a single `STORAGE_ORDER` array. Adding a new storage type now requires one line.

### 2. Overview view leaked autorun subscriptions
`loadCounts()` registered new `autorun` subscriptions for MCP and plugin counts on every call. Since `loadCounts()` is triggered by workspace/agent/command change events, this accumulated duplicate autoruns — a memory leak producing redundant work.

**Fix**: Moved MCP and plugin autorun registrations into the constructor so they register exactly once.

### 3. Net simplification
Removed ~75 lines of repetitive per-storage-type filter/push code, replaced with 2 reusable helpers.