### PR TITLE
sessions: polish light theme surfaces

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -420,14 +420,14 @@ Each agent session part uses separate storage keys to avoid conflicts with regul
 
 ### 9.5 Part Borders and Card Appearance
 
-Parts manage their own border and background styling via the `updateStyles()` method. The auxiliary bar and panel use a **card appearance** with CSS variables for background and border:
+Parts manage their own border and background styling via the `updateStyles()` method. In the default light theme, the sessions workbench surface uses the off-white workbench/sidebar background while the card-like chat, auxiliary bar, and panel surfaces use the brighter editor background; dark and high-contrast mappings remain unchanged. The auxiliary bar and panel use a **card appearance** with CSS variables for background and border:
 
 | Part | Styling | Notes |
 |------|---------|-------|
 | Sidebar | Right border via `SIDE_BAR_BORDER` / `contrastBorder` | Flush appearance, no card styling |
 | Chat Bar | Background only, no borders | `borderWidth` returns `0` |
-| Auxiliary Bar | Card appearance via CSS variables `--part-background` / `--part-border-color` | Uses `SIDE_BAR_BACKGROUND` / `SIDE_BAR_BORDER`; transparent background on container; margins create card offset |
-| Panel | Card appearance via CSS variables `--part-background` / `--part-border-color` | Uses `PANEL_BACKGROUND` / `PANEL_BORDER`; transparent background on container; margins create card offset |
+| Auxiliary Bar | Card appearance via CSS variables `--part-background` / `--part-border-color` | Uses `sessionsAuxiliaryBarBackground` / `SIDE_BAR_BORDER`; default light themes map this card to `editorBackground`, while dark and high-contrast themes keep the existing sidebar-style surface; margins create card offset |
+| Panel | Card appearance via CSS variables `--part-background` / `--part-border-color` | Uses `sessionsPanelBackground` / `PANEL_BORDER`; default light themes map this card to `editorBackground`, while dark and high-contrast themes keep the existing sidebar-style surface; margins create card offset |
 
 ---
 
@@ -646,6 +646,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-04 | Inverted the default light-theme surface mapping so the sessions window background uses the off-white workbench/sidebar surface while the chat, changes, and panel cards use the brighter editor background; dark and high-contrast mappings remain unchanged. |
 | 2026-04-03 | Updated `SessionsTitleBarWidget` to format active session titles as `{Title} · {repo name} ({git branch/worktree name})` when repository detail metadata is available, falling back to the worktree folder name when needed. |
 | 2026-04-03 | Reduced the sessions left sidebar minimum resizable width from 270px to 170px so it can shrink significantly more while keeping the default 300px width unchanged |
 | 2026-03-30 | Adjusted `.agent-sessions-titlebar-container` padding so it sits flush when the sidebar is visible and restores 16px left padding when the sidebar is hidden |

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -43,6 +43,10 @@
 	box-sizing: border-box;
 }
 
+.agent-sessions-workbench .part.auxiliarybar > .content .pane-body {
+	background-color: var(--vscode-sessionsAuxiliaryBar-background);
+}
+
 .agent-sessions-workbench .part.panel {
 	margin: 0 10px 10px 10px;
 	background: var(--part-background);
@@ -65,6 +69,19 @@
 /* Remove max-width from the session container so the scrollbar extends full width */
 .agent-sessions-workbench .interactive-session {
 	max-width: none;
+}
+
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows {
+	background: transparent !important;
+}
+
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.request:hover,
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.response:hover,
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.focused.request,
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.focused.response,
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.selected.request,
+.monaco-workbench.vs.agent-sessions-workbench .part.chatbar .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.selected.response {
+	background: transparent !important;
 }
 
 /* Constrain content items to the same max-width, centered */
@@ -105,6 +122,7 @@
 
 .agent-sessions-workbench .interactive-session .chat-input-container {
 	border-radius: var(--vscode-cornerRadius-large);
+	border-color: var(--vscode-editorWidget-border, var(--vscode-widget-border)) !important;
 }
 .agent-sessions-workbench .interactive-session .interactive-input-part {
 	width: 100%;
@@ -116,6 +134,54 @@
 	box-sizing: border-box;
 }
 
+/* Hide shared chat-session option-group pickers in the sessions app active chat UI.
+ * The sessions workbench provides its own new-session configuration controls and
+ * should not surface the shared workbench chat session pickers here. */
+.agent-sessions-workbench .interactive-session .chat-input-toolbars .chat-sessionPicker-container {
+	display: none;
+}
+
+/* ---- Sessions Action Widget Pickers ---- */
+
+.agent-sessions-workbench .action-widget {
+	background-color: var(--vscode-sessionsPanel-background);
+}
+
+.agent-sessions-workbench .action-widget .action-widget-action-bar,
+.agent-sessions-workbench .action-widget .action-list-filter {
+	background-color: var(--vscode-sessionsPanel-background);
+}
+
+.agent-sessions-workbench .action-widget .monaco-scrollable-element > .monaco-list-rows {
+	background-color: var(--vscode-sessionsPanel-background) !important;
+}
+
+/* ---- Sessions Quick Picks ---- */
+
+.agent-sessions-workbench .quick-input-widget,
+.agent-sessions-workbench .quick-input-titlebar {
+	background-color: var(--vscode-sessionsPanel-background) !important;
+}
+
+.agent-sessions-workbench .quick-input-header,
+.agent-sessions-workbench .quick-input-html-widget,
+.agent-sessions-workbench .quick-input-list .monaco-scrollable-element > .monaco-list-rows,
+.agent-sessions-workbench .quick-input-tree .monaco-scrollable-element > .monaco-list-rows {
+	background-color: var(--vscode-sessionsPanel-background) !important;
+}
+
+/* ---- Sessions Context Menus ---- */
+
+.agent-sessions-workbench .context-view.monaco-menu-container,
+.agent-sessions-workbench .context-view.monaco-menu-container .monaco-menu,
+.agent-sessions-workbench .context-view.monaco-menu-container .monaco-scrollable-element {
+	background-color: var(--vscode-sessionsPanel-background) !important;
+}
+
+/* Keep code block backgrounds stable across themes; add separation in older light themes via border only */
+.agent-sessions-workbench .interactive-session .interactive-response .interactive-result-code-block {
+	border-color: var(--vscode-editorWidget-border, var(--vscode-widget-border));
+}
 /* ---- Modal Editor Block ---- */
 
 .agent-sessions-workbench .monaco-modal-editor-block {

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -45,6 +45,23 @@
 	background-color: var(--vscode-sessionsPanel-background);
 }
 
+.agent-sessions-workbench .part.panel > .content .pane-body,
+.agent-sessions-workbench .part.panel > .content .chat-debug-editor,
+.agent-sessions-workbench .part.panel > .content .chat-debug-home,
+.agent-sessions-workbench .part.panel > .content .chat-debug-home-content,
+.agent-sessions-workbench .part.panel > .content .chat-debug-overview,
+.agent-sessions-workbench .part.panel > .content .chat-debug-overview-content {
+	background-color: var(--vscode-sessionsPanel-background);
+}
+
+.monaco-workbench.vs.agent-sessions-workbench .part.panel > .content #workbench\.sessions\.panel\.chatDebugContainer {
+	--vscode-panel-background: var(--vscode-sessionsPanel-background);
+}
+
+.monaco-workbench.vs.agent-sessions-workbench .part.panel > .content #workbench\.sessions\.panel\.chatDebugContainer .monaco-list-rows {
+	background: var(--vscode-sessionsPanel-background) !important;
+}
+
 /* Terminal body background */
 .agent-sessions-workbench .part.panel .terminal-wrapper {
 	background-color: var(--vscode-sessionsPanel-background);

--- a/src/vs/sessions/browser/parts/sessionCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/sessionCompositeBar.ts
@@ -16,11 +16,8 @@ import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { localize } from '../../../nls.js';
 import { IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
 import { sessionsChatBarBackground } from '../../common/theme.js';
-// TODO: we should move the sessions management service to a more core location so that we don't have to depend on the entire sessions contrib in this common/browser component
-// eslint-disable-next-line local/code-import-patterns
-import { ISessionsManagementService } from '../../contrib/sessions/browser/sessionsManagementService.js';
-// eslint-disable-next-line local/code-import-patterns
-import { IChat } from '../../contrib/sessions/common/sessionData.js';
+import { IChat } from '../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
 
 interface ISessionTab {
 	readonly chat: IChat;

--- a/src/vs/sessions/browser/parts/sessionCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/sessionCompositeBar.ts
@@ -9,14 +9,18 @@ import { Emitter, Event } from '../../../base/common/event.js';
 import { $, addDisposableListener, EventType, getWindow, reset } from '../../../base/browser/dom.js';
 import { autorun } from '../../../base/common/observable.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
-import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND, SIDE_BAR_BACKGROUND } from '../../../workbench/common/theme.js';
+import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND } from '../../../workbench/common/theme.js';
 import { Action } from '../../../base/common/actions.js';
 import { IContextMenuService } from '../../../platform/contextview/browser/contextView.js';
 import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { localize } from '../../../nls.js';
 import { IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
-import { IChat } from '../../services/sessions/common/session.js';
-import { ISessionsManagementService } from '../../services/sessions/common/sessionsManagement.js';
+import { sessionsChatBarBackground } from '../../common/theme.js';
+// TODO: we should move the sessions management service to a more core location so that we don't have to depend on the entire sessions contrib in this common/browser component
+// eslint-disable-next-line local/code-import-patterns
+import { ISessionsManagementService } from '../../contrib/sessions/browser/sessionsManagementService.js';
+// eslint-disable-next-line local/code-import-patterns
+import { IChat } from '../../contrib/sessions/common/sessionData.js';
 
 interface ISessionTab {
 	readonly chat: IChat;
@@ -185,7 +189,7 @@ export class SessionCompositeBar extends Disposable {
 	private _updateStyles(): void {
 		const theme = this._themeService.getColorTheme();
 
-		const bg = theme.getColor(SIDE_BAR_BACKGROUND);
+		const bg = theme.getColor(sessionsChatBarBackground);
 		const activeFg = theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND);
 		const inactiveFg = theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND);
 		const activeBorder = theme.getColor(PANEL_ACTIVE_TITLE_BORDER);

--- a/src/vs/sessions/common/theme.ts
+++ b/src/vs/sessions/common/theme.ts
@@ -8,33 +8,53 @@ import { getColorRegistry, registerColor, transparent } from '../../platform/the
 import { contrastBorder } from '../../platform/theme/common/colorRegistry.js';
 import { editorWidgetBorder, editorBackground } from '../../platform/theme/common/colors/editorColors.js';
 import { buttonBackground } from '../../platform/theme/common/colors/inputColors.js';
-import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from '../../workbench/common/theme.js';
+import { SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from '../../workbench/common/theme.js';
 
 // Sessions sidebar background color
 export const sessionsSidebarBackground = registerColor(
 	'sessionsSidebar.background',
-	editorBackground,
+	{
+		dark: editorBackground,
+		light: SIDE_BAR_BACKGROUND,
+		hcDark: editorBackground,
+		hcLight: editorBackground,
+	},
 	localize('sessionsSidebar.background', 'Background color of the sidebar view in the agent sessions window.')
 );
 
 // Sessions auxiliary bar background color
 export const sessionsAuxiliaryBarBackground = registerColor(
 	'sessionsAuxiliaryBar.background',
-	SIDE_BAR_BACKGROUND,
+	{
+		dark: SIDE_BAR_BACKGROUND,
+		light: editorBackground,
+		hcDark: SIDE_BAR_BACKGROUND,
+		hcLight: SIDE_BAR_BACKGROUND,
+	},
 	localize('sessionsAuxiliaryBar.background', 'Background color of the auxiliary bar in the agent sessions window.')
 );
 
 // Sessions panel background color
 export const sessionsPanelBackground = registerColor(
 	'sessionsPanel.background',
-	SIDE_BAR_BACKGROUND,
+	{
+		dark: SIDE_BAR_BACKGROUND,
+		light: editorBackground,
+		hcDark: SIDE_BAR_BACKGROUND,
+		hcLight: SIDE_BAR_BACKGROUND,
+	},
 	localize('sessionsPanel.background', 'Background color of the panel in the agent sessions window.')
 );
 
 // Sessions chat bar background color
 export const sessionsChatBarBackground = registerColor(
 	'sessionsChatBar.background',
-	SIDE_BAR_BACKGROUND,
+	{
+		dark: SIDE_BAR_BACKGROUND,
+		light: editorBackground,
+		hcDark: SIDE_BAR_BACKGROUND,
+		hcLight: SIDE_BAR_BACKGROUND,
+	},
 	localize('sessionsChatBar.background', 'Background color of the chat bar in the agent sessions window.')
 );
 
@@ -83,8 +103,3 @@ export const sessionsUpdateButtonDownloadedBackground = registerColor(
 	transparent(buttonBackground, 0.7),
 	localize('sessionsUpdateButton.downloadedBackground', 'Background color of the update button when download is complete in the agent sessions window.')
 );
-
-const colorRegistry = getColorRegistry();
-
-// Override panel background to use editor background in sessions window
-colorRegistry.updateDefaultColor(PANEL_BACKGROUND, editorBackground);

--- a/src/vs/sessions/common/theme.ts
+++ b/src/vs/sessions/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../nls.js';
-import { getColorRegistry, registerColor, transparent } from '../../platform/theme/common/colorUtils.js';
+import { registerColor, transparent } from '../../platform/theme/common/colorUtils.js';
 import { contrastBorder } from '../../platform/theme/common/colorRegistry.js';
 import { editorWidgetBorder, editorBackground } from '../../platform/theme/common/colors/editorColors.js';
 import { buttonBackground } from '../../platform/theme/common/colors/inputColors.js';

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -26,7 +26,7 @@
 	width: 100%;
 	max-width: 800px;
 	box-sizing: border-box;
-	border: 1px solid var(--vscode-input-border, var(--vscode-contrastBorder, transparent));
+	border: 1px solid var(--vscode-editorWidget-border, var(--vscode-widget-border, var(--vscode-contrastBorder, transparent)));
 	border-radius: 8px;
 	background-color: var(--vscode-input-background);
 	overflow: hidden;
@@ -35,7 +35,7 @@
 }
 
 .sessions-chat-input-area:focus-within {
-	border-color: var(--vscode-input-border, var(--vscode-contrastBorder, transparent));
+	border-color: var(--vscode-editorWidget-border, var(--vscode-widget-border, var(--vscode-contrastBorder, transparent)));
 }
 
 /* Editor */

--- a/src/vs/sessions/contrib/files/browser/files.contribution.ts
+++ b/src/vs/sessions/contrib/files/browser/files.contribution.ts
@@ -17,11 +17,27 @@ import { WorkspaceFolderCountContext } from '../../../../workbench/common/contex
 import { ExplorerView } from '../../../../workbench/contrib/files/browser/views/explorerView.js';
 import { ViewPaneContainer } from '../../../../workbench/browser/parts/views/viewPaneContainer.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
+import type { IViewPaneLocationColors } from '../../../../workbench/browser/parts/views/viewPane.js';
+import { sessionsAuxiliaryBarBackground } from '../../../common/theme.js';
 
 const SESSIONS_FILES_CONTAINER_ID = 'workbench.sessions.auxiliaryBar.filesContainer';
 const SESSIONS_FILES_VIEW_ID = 'sessions.files.explorer';
 
 const filesViewIcon = registerIcon('sessions-files-view-icon', Codicon.files, localize2('sessionsFilesViewIcon', 'View icon of the files view in the sessions window.').value);
+
+class SessionsExplorerView extends ExplorerView {
+	protected override getLocationBasedColors(): IViewPaneLocationColors {
+		const colors = super.getLocationBasedColors();
+		return {
+			...colors,
+			background: sessionsAuxiliaryBarBackground,
+			listOverrideStyles: {
+				...colors.listOverrideStyles,
+				listBackground: sessionsAuxiliaryBarBackground,
+			}
+		};
+	}
+}
 
 class RegisterFilesViewContribution implements IWorkbenchContribution {
 
@@ -48,7 +64,7 @@ class RegisterFilesViewContribution implements IWorkbenchContribution {
 			id: SESSIONS_FILES_VIEW_ID,
 			name: localize2('files', "Files"),
 			containerIcon: filesViewIcon,
-			ctorDescriptor: new SyncDescriptor(ExplorerView),
+			ctorDescriptor: new SyncDescriptor(SessionsExplorerView),
 			canToggleVisibility: true,
 			canMoveView: false,
 			when: WorkspaceFolderCountContext.notEqualsTo('0'),

--- a/src/vs/sessions/electron-browser/sessions.ts
+++ b/src/vs/sessions/electron-browser/sessions.ts
@@ -44,7 +44,9 @@
 		let shellForeground = '#CCCCCC';
 		if (data) {
 			baseTheme = data.baseTheme;
-			shellBackground = data.colorInfo.editorBackground ?? data.colorInfo.background;
+			shellBackground = data.baseTheme === 'vs'
+				? (data.colorInfo.background ?? data.colorInfo.editorBackground)
+				: (data.colorInfo.editorBackground ?? data.colorInfo.background);
 			shellForeground = data.colorInfo.foreground ?? shellForeground;
 		} else if (configuration.autoDetectHighContrast && configuration.colorScheme.highContrast) {
 			if (configuration.colorScheme.dark) {
@@ -63,7 +65,7 @@
 				shellForeground = '#CCCCCC';
 			} else {
 				baseTheme = 'vs';
-				shellBackground = '#FFFFFF';
+				shellBackground = '#F3F3F3';
 				shellForeground = '#000000';
 			}
 		}

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -6,9 +6,16 @@
 //#region --- editor/workbench core
 
 import '../editor/editor.all.js';
+import { getColorRegistry } from '../platform/theme/common/colorUtils.js';
+import { PANEL_BACKGROUND } from '../workbench/common/theme.js';
+import { TERMINAL_BACKGROUND_COLOR } from '../workbench/contrib/terminal/common/terminalColorRegistry.js';
 
 import '../workbench/api/browser/extensionHost.contribution.js';
 import '../workbench/browser/workbench.contribution.js';
+import { sessionsPanelBackground } from './common/theme.js';
+
+getColorRegistry().updateDefaultColor(PANEL_BACKGROUND, sessionsPanelBackground);
+getColorRegistry().updateDefaultColor(TERMINAL_BACKGROUND_COLOR, sessionsPanelBackground);
 
 //#endregion
 


### PR DESCRIPTION
## Summary
- invert the sessions light-theme surface mapping so the app window uses the off-white workbench surface while chat, panel, and auxiliary cards use the brighter surface
- apply sessions-only background fixes for nested menus, quick picks, files, terminal, and Chat Debug surfaces
- add sessions-local border fallbacks for chat inputs and response code blocks in older light themes

<img width="1969" height="1162" alt="Screenshot 2026-04-07 at 6 25 03 PM" src="https://github.com/user-attachments/assets/ba78f514-92fd-459d-810b-b031bd0f755d" />

## Why
Ensure that the content in panels gets the highest contrast applied between background and foreground content.

## Notes for reviewers
- dark and high-contrast theme mappings are intentionally left unchanged
- the account/profile menu still renders through a separate custom hover panel path, so this PR does not try to force it to match the standard menu popup path
- the fixes rely on sessions-local token mappings and scoped CSS overrides rather than global theme token changes