### PR TITLE
Fix cropped install button outline in plugin list

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -285,10 +285,9 @@ class McpGalleryItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpG
 		const header = DOM.append(headerContainer, $('.header'));
 		const name = DOM.append(header, $('span.name'));
 		const description = DOM.append(details, $('.description.ellipsis'));
-		const footer = DOM.append(details, $('.footer'));
-		const publisherContainer = DOM.append(footer, $('.publisher-container'));
-		const publisher = DOM.append(publisherContainer, $('span.publisher-name'));
-		const actionContainer = DOM.append(footer, $('.mcp-gallery-action'));
+		const publisherContainer = DOM.append(details, $('.publisher-container'));
+		const publisher = DOM.append(publisherContainer, $('span.publisher-name.mcp-gallery-publisher'));
+		const actionContainer = DOM.append(container, $('.mcp-gallery-action'));
 		const installButton = new Button(actionContainer, { ...defaultButtonStyles, supportIcons: true });
 		installButton.element.classList.add('mcp-gallery-install-button');
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -960,22 +960,31 @@
 }
 
 .mcp-gallery-item.extension-list-item {
-	padding: 6px 8px 6px 16px;
+	padding: 6px 16px;
 }
 
-.mcp-gallery-item.extension-list-item > .details > .footer {
-	display: flex;
-	align-items: center;
-	padding-bottom: 4px;
+.mcp-gallery-item.extension-list-item > .details {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
 }
 
-.mcp-gallery-item.extension-list-item .mcp-gallery-action {
-	margin-left: auto;
+.mcp-gallery-item.extension-list-item > .details > .description {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	line-height: 16px;
 }
 
 .mcp-gallery-item .mcp-gallery-install-button {
 	font-size: 11px;
 	padding: 2px 10px;
+}
+
+.mcp-gallery-item .mcp-gallery-install-button:focus-visible {
+	outline-offset: -1px;
 }
 
 /* Embedded Editor View */

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -217,10 +217,9 @@ class PluginMarketplaceItemRenderer implements IListRenderer<IPluginMarketplaceI
 		const header = DOM.append(headerContainer, $('.header'));
 		const name = DOM.append(header, $('span.name'));
 		const description = DOM.append(details, $('.description.ellipsis'));
-		const footer = DOM.append(details, $('.footer'));
-		const publisherContainer = DOM.append(footer, $('.publisher-container'));
-		const publisher = DOM.append(publisherContainer, $('span.publisher-name'));
-		const actionContainer = DOM.append(footer, $('.mcp-gallery-action'));
+		const publisherContainer = DOM.append(details, $('.publisher-container'));
+		const publisher = DOM.append(publisherContainer, $('span.publisher-name.mcp-gallery-publisher'));
+		const actionContainer = DOM.append(container, $('.mcp-gallery-action'));
 		const installButton = new Button(actionContainer, { ...defaultButtonStyles, supportIcons: true });
 		installButton.element.classList.add('mcp-gallery-install-button');
 


### PR DESCRIPTION
Add `outline-offset: -1px` to the gallery install button's `:focus-visible` state, matching the existing pattern used for `.list-button-group` buttons. This prevents the focus outline from being clipped by `overflow: hidden` on ancestor containers (list rows, `.mcp-list-widget`).

Fixes https://github.com/microsoft/vscode/issues/308206