### PR TITLE
sessions: disable chat tips in agents window

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -24,6 +24,7 @@ import { Menus } from '../../../browser/menus.js';
 import { BranchChatSessionAction } from './branchChatSessionAction.js';
 import { RunScriptContribution } from './runScriptAction.js';
 import './nullInlineChatSessionService.js';
+import './nullChatTipService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { AgenticPromptsService } from './promptsService.js';

--- a/src/vs/sessions/contrib/chat/browser/nullChatTipService.ts
+++ b/src/vs/sessions/contrib/chat/browser/nullChatTipService.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../base/common/event.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IChatTip, IChatTipService } from '../../../../workbench/contrib/chat/browser/chatTipService.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+
+class NullChatTipService implements IChatTipService {
+	declare _serviceBrand: undefined;
+
+	readonly onDidDismissTip: Event<void> = Event.None;
+	readonly onDidNavigateTip: Event<IChatTip> = Event.None;
+	readonly onDidHideTip: Event<void> = Event.None;
+	readonly onDidDisableTips: Event<void> = Event.None;
+
+	getWelcomeTip(_contextKeyService: IContextKeyService): IChatTip | undefined { return undefined; }
+	resetSession(): void { }
+	dismissTip(): void { }
+	dismissTipForSession(): void { }
+	hideTip(): void { }
+	hideTipsForSession(): void { }
+	async disableTips(): Promise<void> { }
+	navigateToNextTip(): IChatTip | undefined { return undefined; }
+	navigateToPreviousTip(): IChatTip | undefined { return undefined; }
+	getNextEligibleTip(): IChatTip | undefined { return undefined; }
+	hasMultipleTips(): boolean { return false; }
+	recordSlashCommandUsage(_command: string): void { }
+	clearDismissedTips(): void { }
+}
+
+registerSingleton(IChatTipService, NullChatTipService, InstantiationType.Delayed);


### PR DESCRIPTION
## Summary

Registers a `NullChatTipService` in the sessions layer to suppress getting-started tips in the agents window.

## Problem

When switching between sessions in the agents window, the "Tip: Try the Plan agent..." message briefly flashes above the chat input. This happens because the chat widget temporarily has zero items while session messages are loading, and `updateChatViewVisibility()` treats that as an empty/new session — rendering the tip. Once messages arrive, the tip disappears.

## Solution

Follow the existing pattern used by `NullInlineChatSessionService` — register a no-op `IChatTipService` implementation in the sessions layer (`src/vs/sessions/`) that always returns `undefined` from `getWelcomeTip()`. This completely suppresses tips in the agents window without modifying any core workbench code.

## Changes

- **New**: `src/vs/sessions/contrib/chat/browser/nullChatTipService.ts` — null implementation of `IChatTipService`
- **Modified**: `src/vs/sessions/contrib/chat/browser/chat.contribution.ts` — import the null service registration