### PR TITLE
Fix agent-customizations typo in welcome view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -838,7 +838,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 				if (this.input) {
 					this.group.closeEditor(this.input);
 				}
-				this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customizations ', isPartialQuery: true });
+				this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customization ', isPartialQuery: true });
 			}));
 		}
 


### PR DESCRIPTION
Fix a one-character typo in the chat customizations welcome view: `/agent-customizations` → `/agent-customization`.