### PR TITLE
Fix customization directory picker not being multiroot-aware

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -88,6 +88,11 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 		return root;
 	}
 
+	getAllProjectRoots(): readonly URI[] {
+		const root = this.getActiveProjectRoot();
+		return root ? [root] : [];
+	}
+
 	setOverrideProjectRoot(root: URI): void {
 		this._overrideRoot.set(root, undefined);
 	}

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -165,6 +165,7 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 	return new class extends mock<IAICustomizationWorkspaceService>() {
 		override readonly activeProjectRoot = activeProjectRoot;
 		override getActiveProjectRoot() { return undefined; }
+		override getAllProjectRoots() { return []; }
 		override getStorageSourceFilter() { return defaultFilter; }
 	}();
 }

--- a/src/vs/sessions/contrib/sessions/test/browser/customizationCounts.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/customizationCounts.test.ts
@@ -103,6 +103,7 @@ function createMockWorkspaceService(opts: {
 		_serviceBrand: undefined,
 		activeProjectRoot: observableValue('test', opts.activeRoot),
 		getActiveProjectRoot: () => opts.activeRoot,
+		getAllProjectRoots: () => opts.activeRoot ? [opts.activeRoot] : [],
 		managementSections: [],
 		getStorageSourceFilter: () => defaultFilter,
 		preferManualCreation: false,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1154,19 +1154,21 @@ export class AICustomizationManagementEditor extends EditorPane {
 	 */
 	private async resolveTargetDirectoryWithPicker(type: PromptsType, target: 'workspace' | 'user'): Promise<URI | undefined | null> {
 		const allFolders = await this.promptsService.getSourceFolders(type);
-		const projectRoot = this.workspaceService.getActiveProjectRoot();
+		const projectRoots = this.workspaceService.getAllProjectRoots();
 		const descriptor = this.harnessService.getActiveDescriptor();
 		const subpaths = descriptor.workspaceSubpaths;
 
-		// Partition folders by whether they're under the active project root.
+		const isUnderAnyRoot = (uri: URI) => projectRoots.some(root => isEqualOrParent(uri, root));
+
+		// Partition folders by whether they're under any project root.
 		// The storage tags from getSourceFolders() are unreliable (tilde-expanded
 		// user paths like ~/.copilot/skills get tagged PromptsStorage.local),
-		// so we use the project root as the authoritative boundary.
+		// so we use the project roots as the authoritative boundary.
 		let matchingFolders;
 		if (target === 'workspace') {
-			matchingFolders = projectRoot
+			matchingFolders = projectRoots.length > 0
 				? allFolders.filter(f => {
-					if (!isEqualOrParent(f.uri, projectRoot)) {
+					if (!isUnderAnyRoot(f.uri)) {
 						return false;
 					}
 					// When the active harness specifies workspaceSubpaths, only offer
@@ -1178,8 +1180,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 				})
 				: [];
 		} else {
-			matchingFolders = projectRoot
-				? allFolders.filter(f => !isEqualOrParent(f.uri, projectRoot))
+			matchingFolders = projectRoots.length > 0
+				? allFolders.filter(f => !isUnderAnyRoot(f.uri))
 				: allFolders;
 
 			// When the active harness restricts user roots, only offer

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -48,6 +48,10 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 		return folders[0]?.uri;
 	}
 
+	getAllProjectRoots(): readonly URI[] {
+		return this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
+	}
+
 	readonly managementSections: readonly AICustomizationManagementSection[] = [
 		AICustomizationManagementSection.Agents,
 		AICustomizationManagementSection.Skills,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
@@ -110,19 +110,21 @@ export class CustomizationCreatorService {
 	 */
 	private async resolveTargetDirectoryWithPicker(type: PromptsType): Promise<URI | undefined | null> {
 		const allFolders = await this.promptsService.getSourceFolders(type);
-		const projectRoot = this.workspaceService.getActiveProjectRoot();
+		const projectRoots = this.workspaceService.getAllProjectRoots();
 		const descriptor = this.harnessService.getActiveDescriptor();
 		const subpaths = descriptor.workspaceSubpaths;
 
-		// Filter to only workspace-scoped folders (under the active project root).
+		const isUnderAnyRoot = (uri: URI) => projectRoots.some(root => isEqualOrParent(uri, root));
+
+		// Filter to only workspace-scoped folders (under any project root).
 		// Don't rely on storage tags — tilde-expanded user paths can be tagged local.
 		// Deduplicate by URI to avoid inflated counts and duplicate picker entries.
 		// When the active harness specifies workspaceSubpaths, further restrict to
 		// directories whose path includes one of those sub-paths (e.g. `.claude`).
 		const seen = new Set<string>();
-		const workspaceFolders = projectRoot
+		const workspaceFolders = projectRoots.length > 0
 			? allFolders.filter(f => {
-				if (!isEqualOrParent(f.uri, projectRoot)) {
+				if (!isUnderAnyRoot(f.uri)) {
 					return false;
 				}
 				const key = f.uri.toString();

--- a/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
@@ -92,6 +92,13 @@ export interface IAICustomizationWorkspaceService {
 	getActiveProjectRoot(): URI | undefined;
 
 	/**
+	 * Returns all project roots for the current workspace.
+	 * In a multiroot workspace this returns all workspace folder roots.
+	 * In a sessions window this returns the active session's repository root.
+	 */
+	getAllProjectRoots(): readonly URI[];
+
+	/**
 	 * The sections to show in the AI Customization Management Editor sidebar.
 	 */
 	readonly managementSections: readonly AICustomizationManagementSection[];

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
@@ -103,6 +103,7 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 		override readonly activeProjectRoot = activeProjectRoot;
 		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 		override getActiveProjectRoot() { return URI.file('/workspace'); }
+		override getAllProjectRoots() { return [URI.file('/workspace')]; }
 		override getStorageSourceFilter() { return defaultFilter; }
 	}();
 }

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -461,6 +461,7 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 				override getActiveProjectRoot() { return URI.file('/workspace'); }
+				override getAllProjectRoots() { return [URI.file('/workspace')]; }
 				override getStorageSourceFilter(type: PromptsType) { return harnessService.getStorageSourceFilter(type); }
 				override clearOverrideProjectRoot() { }
 				override setOverrideProjectRoot() { }
@@ -635,6 +636,7 @@ async function renderMcpBrowseMode(ctx: ComponentFixtureContext): Promise<void> 
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 				override getActiveProjectRoot() { return URI.file('/workspace'); }
+				override getAllProjectRoots() { return [URI.file('/workspace')]; }
 				override getStorageSourceFilter() {
 					return { sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin] };
 				}


### PR DESCRIPTION
## Summary

Fixes #297397

The "New X (workspace)" and "New X (User)" actions in the AI Customization view used `getActiveProjectRoot()` which only returns the first workspace folder (`folders[0]`). In a multiroot workspace this caused:
- **Workspace creation** silently picking the first folder without asking
- **User creation** incorrectly showing folders from other workspace roots as user folders

## Changes

- Added `getAllProjectRoots()` to `IAICustomizationWorkspaceService` interface — returns all workspace folder URIs (multiroot-aware in core, single-root in sessions)
- Updated both `resolveTargetDirectoryWithPicker` methods (in `customizationCreatorService.ts` and `aiCustomizationManagementEditor.ts`) to filter against all roots using `isUnderAnyRoot()` instead of just the first root
- Updated all test fixtures/mocks to implement the new method