### PR TITLE
chat: fix intermittent empty code blocks in chat responses

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -601,12 +601,21 @@ export class View extends ViewEventHandler {
 				inputLatency.onRenderStart();
 
 				if (!this.domNode.domNode.isConnected) {
+					const model = this._context.viewModel.model;
+					if (model.uri.scheme === 'vscode-chat-code-block') {
+						console.warn(`[EditorView] Render dropped: isConnected=false for ${model.uri.toString()}`);
+					}
 					return null;
 				}
 
 				const viewPartsToRender = this._getViewPartsToRender();
-				if (!this._viewLines.shouldRender() && viewPartsToRender.length === 0) {
+				const viewLinesShouldRender = this._viewLines.shouldRender();
+				if (!viewLinesShouldRender && viewPartsToRender.length === 0) {
 					// Nothing to render
+					const model = this._context.viewModel.model;
+					if (model.uri.scheme === 'vscode-chat-code-block') {
+						console.warn(`[EditorView] Render dropped: nothing to render for ${model.uri.toString()}, viewLines.shouldRender=${viewLinesShouldRender}, viewParts=${viewPartsToRender.length}`);
+					}
 					return null;
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
@@ -475,6 +475,13 @@ export class CodeBlockPart extends Disposable {
 		}
 
 		this.layout();
+
+		// The editor element is typically not yet connected to the live DOM at
+		// this point (the caller still needs to attach it). Any render pass
+		// scheduled by setText/setLanguage/layout is silently dropped by the
+		// editor view when `isConnected` is false. Schedule a deferred render
+		// so the view lines are painted once the element is in the document.
+		this.editor.renderAsync(true);
 	}
 
 	reset() {


### PR DESCRIPTION
## Problem

Chat code blocks intermittently render empty — the editor container shows up with correct dimensions but no visible text or syntax highlighting. Hovering over the empty block causes the content to appear. This affects both top-level response code blocks and terminal tool confirmation editors.

## Root Cause

When `CodeBlockPart.render()` is called, the editor element is not yet attached to the live DOM (the caller still needs to insert it). The `setText()` / `setLanguage()` / `layout(postponeRendering=true)` calls schedule render passes via `requestAnimationFrame`, but when those RAFs fire, the editor view's `prepareRenderText()` bails out because `this.domNode.domNode.isConnected` is `false`. The render is silently dropped with no recovery.

Hovering later triggers `ContentHoverController` to lazily create its widget → `addContentWidget` → `_scheduleRender`, which succeeds because the element is now connected.

## Fix

Add `editor.renderAsync(true)` at the end of `CodeBlockPart.render()`. This schedules one more deferred render pass that fires after the element has been attached to the DOM by the caller. The call coalesces with existing animation frame batches so it's cheap, and `forceRedraw=true` ensures both text and tokenization are painted.

This is placed in `CodeBlockPart.render()` directly (rather than in callers) so it covers all code paths: normal chat code blocks, terminal tool confirmations, and generic tool confirmations.

## Diagnostic Logging

Adds `console.warn` logging in the editor view (`view.ts`) when a chat code block editor's render is dropped, distinguishing two bail-out paths:
- `isConnected=false` — element not in DOM
- `nothing to render` — no dirty view parts

This logging is temporary to help confirm the fix and diagnose any remaining occurrences.

Fix #307543