### PR TITLE
Refine Anthropic prompt resolution and effort defaults

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -59,14 +59,17 @@ function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchem
 		return {};
 	}
 
-	// Only enable effort picker for Claude and GPT models
 	const family = endpoint.family.toLowerCase();
-	if (!family.startsWith('claude') && !family.startsWith('gpt-')) {
+	if (family.startsWith('gemini')) {
 		return {};
 	}
 
-	const preferred = family.startsWith('claude') ? 'high' : 'medium';
-	const defaultEffort = effortLevels.includes(preferred) ? preferred : undefined;
+	let defaultEffort: string | undefined;
+	if (family.startsWith('claude')) {
+		defaultEffort = effortLevels.includes('high') ? 'high' : undefined;
+	} else if (family.startsWith('gpt-')) {
+		defaultEffort = effortLevels.includes('medium') ? 'medium' : undefined;
+	}
 
 	return {
 		configurationSchema: {

--- a/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/anthropicPrompts.tsx
@@ -6,6 +6,7 @@
 import { BasePromptElementProps, PromptElement, PromptElementProps, PromptPiece, PromptSizing } from '@vscode/prompt-tsx';
 import type { LanguageModelToolInformation } from 'vscode';
 import { IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { isHiddenModelG } from '../../../../platform/endpoint/common/chatModelCapabilities';
 import { CUSTOM_TOOL_SEARCH_NAME, isAnthropicContextEditingEnabled, isAnthropicCustomToolSearchEnabled, isAnthropicToolSearchEnabled, TOOL_SEARCH_TOOL_NAME } from '../../../../platform/networking/common/anthropic';
 import { IToolDeferralService } from '../../../../platform/networking/common/toolDeferralService';
 import { IChatEndpoint } from '../../../../platform/networking/common/networking';
@@ -644,3 +645,21 @@ class AnthropicReminderInstructions extends PromptElement<ReminderInstructionsPr
 }
 
 PromptRegistry.registerPrompt(AnthropicPromptResolver);
+
+class HiddenModelGPromptResolver implements IAgentPrompt {
+	static readonly familyPrefixes: readonly string[] = [];
+
+	static matchesModel(endpoint: IChatEndpoint): boolean {
+		return isHiddenModelG(endpoint);
+	}
+
+	resolveSystemPrompt(_endpoint: IChatEndpoint): SystemPrompt | undefined {
+		return Claude46OpusPrompt;
+	}
+
+	resolveReminderInstructions(_endpoint: IChatEndpoint): ReminderInstructionsConstructor | undefined {
+		return AnthropicReminderInstructionsOptimized;
+	}
+}
+
+PromptRegistry.registerPrompt(HiddenModelGPromptResolver);

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -96,7 +96,7 @@ export function isHiddenModelF(model: LanguageModelChat | IChatEndpoint) {
 
 export function isHiddenModelG(model: LanguageModelChat | IChatEndpoint) {
 	const family_hash = getCachedSha256Hash(model.family);
-	return family_hash === '0d90e0e579352b8502fc2a46b40961ee941adc26ce67c2b1438f0e4ea97d932f';
+	return family_hash === '94e44d9d24608ae2161d0c56704f226dc89c2cd8be566abb8fbfbded5a507401';
 }
 
 export function isHiddenFamilyH(model: LanguageModelChat | IChatEndpoint) {

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -845,6 +845,26 @@ export class AnthropicMessagesProcessor {
 							encrypted: data,
 						}
 					});
+				} else if (chunk.content_block) {
+					const unknownType = (chunk.content_block as { type?: string }).type ?? 'undefined';
+					this.logService.warn(`[messagesAPI] Unknown content_block type '${unknownType}' at index ${chunk.index ?? -1} for model ${this.model}`);
+
+					/* __GDPR__
+						"messagesApi.unknownContentBlock" : {
+							"owner": "bhavyaus",
+							"comment": "Tracks unknown Anthropic content block types",
+							"requestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The request ID for correlation" },
+							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model that emitted the unknown block" },
+							"blockType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The unknown content_block.type string" }
+						}
+					*/
+					this.telemetryService.sendMSFTTelemetryEvent('messagesApi.unknownContentBlock',
+						{
+							requestId: this.requestId,
+							model: this.model,
+							blockType: unknownType,
+						}
+					);
 				}
 				return;
 			case 'content_block_delta':


### PR DESCRIPTION
Clean up prompt resolver logic and effort level defaults for Anthropic models. Add telemetry for unknown stop reasons and content block types.