### PR TITLE
fix(markdown): offer to create file when clicking link to non-existent file

### DIFF
--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -66,6 +66,23 @@ export class MdLinkOpener {
 					}
 				}
 
+				// Check if the file exists before opening. If not, offer to create it.
+				try {
+					await vscode.workspace.fs.stat(uri.with({ fragment: '' }));
+				} catch {
+					const fileName = uri.path.split('/').pop() ?? uri.fsPath;
+					const create = vscode.l10n.t('Create File');
+					const choice = await vscode.window.showInformationMessage(
+						vscode.l10n.t("The file '{0}' does not exist.", fileName),
+						{ modal: false },
+						create
+					);
+					if (choice !== create) {
+						return;
+					}
+					await vscode.workspace.fs.writeFile(uri.with({ fragment: '' }), new Uint8Array(0));
+				}
+
 				return vscode.commands.executeCommand('vscode.open', uri, {
 					selection: resolved.position
 						? new vscode.Range(resolved.position.line, resolved.position.character, resolved.position.line, resolved.position.character)


### PR DESCRIPTION
When a markdown link points to a file that does not exist, clicking the link in the preview now prompts the user with an option to create the file rather than silently failing or opening an error editor.

Before this fix, clicking a markdown preview link to a non-existent file would open an error placeholder editor ("file not found"). After this fix, the user gets an informational message offering to create the missing file. If they accept, an empty file is created and then opened.

This mirrors the behaviour already present in `TextFileEditor.handleSetInputError()` where a "Create File" action is offered.

Fixes microsoft/vscode#188338