### PR TITLE
fix(scm): restore focus to current history item after graph refresh

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -1913,7 +1913,16 @@ export class SCMHistoryViewPane extends ViewPane {
 
 		this.updateActions();
 		this._repositoryOutdated.set(false, undefined);
-		this._tree.scrollTop = 0;
+
+		// Attempt to reveal the current history item to restore selection and focus.
+		// Fall back to scrolling to the top if there is no current item to reveal.
+		const historyProvider = this._treeViewModel.repository.get()?.provider.historyProvider.get();
+		const historyItemRef = historyProvider?.historyItemRef.get();
+		if (historyItemRef?.id && this._isCurrentHistoryItemInFilter(historyItemRef.id)) {
+			await this.revealCurrentHistoryItem();
+		} else {
+			this._tree.scrollTop = 0;
+		}
 	}
 
 	async pickRepository(): Promise<void> {


### PR DESCRIPTION
After a sync operation (push, pull, fetch) triggers a graph refresh, the SCM history tree resets its scroll position to the top and loses the current selection and focus.

This change restores the selection and focus to the current HEAD commit after each refresh by calling `revealCurrentHistoryItem()`. It falls back to the previous scroll-to-top behaviour only when there is no current item to reveal (e.g. the branch is not included in the active filter).

## Before
- User has a commit selected/focused in the SCM graph
- User runs `git pull` or `git push`
- Graph refreshes, scrolls to top, selection/focus is lost

## After
- User has a commit selected/focused in the SCM graph
- User runs `git pull` or `git push`
- Graph refreshes and scrolls to the current HEAD commit, preserving focus

Fixes microsoft/vscode#280308