### PR TITLE
fix(search): align global search match decorations with local find options

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
+++ b/src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts
@@ -31,6 +31,7 @@ export class FileMatchImpl extends Disposable implements ISearchTreeFileMatch {
 		zIndex: 13,
 		className: 'currentFindMatch',
 		inlineClassName: 'currentFindMatchInline',
+		showIfCollapsed: true,
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerFindMatchForeground),
 			position: OverviewRulerLane.Center
@@ -44,8 +45,10 @@ export class FileMatchImpl extends Disposable implements ISearchTreeFileMatch {
 	private static readonly _FIND_MATCH = ModelDecorationOptions.register({
 		description: 'search-find-match',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		zIndex: 10,
 		className: 'findMatch',
 		inlineClassName: 'findMatchInline',
+		showIfCollapsed: true,
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerFindMatchForeground),
 			position: OverviewRulerLane.Center


### PR DESCRIPTION
Global search result decorations in the editor were missing two properties that the local Find widget (`Ctrl+F`) decorations already have:

- **`showIfCollapsed: true`** — without this flag, match decorations inside a collapsed folding region are not rendered at all. This means the `findMatchBorder` and `findMatchBackground` colours never appear for matches in folded code when using global search, even though they work correctly in the local Find widget.
- **`zIndex: 10`** on `_FIND_MATCH` — maintains the correct stacking order so the current-match highlight (`zIndex: 13`) always renders above regular matches, consistent with the Find widget.

The local find decorations are defined in `src/vs/editor/contrib/find/browser/findDecorations.ts`. This change brings `src/vs/workbench/contrib/search/browser/searchTreeModel/fileMatch.ts` into parity with them.

Fixes microsoft/vscode#295724