### PR TITLE
fix(markdown): refresh preview when panel becomes visible again

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -169,6 +169,15 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			}
 		}));
 
+		// Refresh when the panel becomes visible so that externally-changed files
+		// (e.g. via git checkout or an outside editor) are reflected even when no
+		// text document change event was fired while the preview was hidden.
+		this._register(this.#webviewPanel.onDidChangeViewState(() => {
+			if (this.#webviewPanel.visible) {
+				this.refresh();
+			}
+		}));
+
 		this.refresh();
 	}
 


### PR DESCRIPTION
## Problem

When the user switches away from a Markdown preview panel and then switches back, the preview can show stale content if the underlying file was changed by an external tool (e.g. `git checkout`, an outside editor, or another file-system watcher) while the panel was hidden.

This happened because `MarkdownPreview` only listened for `onDidChangeTextDocument` and file-system watcher events to trigger a re-render. Neither of these events fires for changes that happen outside of VS Code while the preview tab is not visible.

## Fix

Adds an `onDidChangeViewState` listener to `MarkdownPreview` that calls `refresh()` whenever the panel becomes visible. The existing early-exit path in `#updatePreview` (which checks `currentVersion.equals(pendingVersion)`) ensures that no unnecessary work is done when the document has not actually changed — making the fix cheap for the common case.

Fixes microsoft/vscode#271233