### PR TITLE
fix(markdown): open file at correct line when clicking #L<n> anchor in preview

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -426,7 +426,13 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 				try {
 					const doc = await vscode.workspace.openTextDocument(vscode.Uri.from(resolved.uri));
 					if (isMarkdownFile(doc)) {
-						return this.#delegate.openPreviewLinkToMarkdownFile(doc.uri, resolved.fragment ? decodeURIComponent(resolved.fragment) : undefined);
+						const fragment = resolved.fragment ? decodeURIComponent(resolved.fragment) : undefined;
+						// Line-number anchors (e.g. #L44, #L10-L20) are not supported by the preview's
+						// fragment-based scrolling, which only handles heading anchors. Fall through to
+						// openDocumentLink so that the editor can apply the correct line selection.
+						if (!fragment || !/^L?\d+(?:,\d+)?(?:-L?\d+(?:,\d+)?)?$/i.test(fragment)) {
+							return this.#delegate.openPreviewLinkToMarkdownFile(doc.uri, fragment);
+						}
 					}
 				} catch {
 					// Noop


### PR DESCRIPTION
## Problem

When `preview.openMarkdownLinks` is `inPreview` (the default), clicking a link like `[text](other.md#L44)` in the Markdown preview opens `other.md` **in preview mode** and passes `L44` as the fragment to scroll to. Because the preview scroll logic only understands heading anchors (e.g. `#my-section`), no scrolling happens and the file is displayed from the top.

## Root cause

In `MarkdownPreview.#onDidClickPreviewLink`, when the target is a Markdown file, the code routes through `openPreviewLinkToMarkdownFile` for any fragment string. This works correctly for heading anchors but not for GitHub-style line-number anchors (`#L44`, `#L10-L20`, `#10,1-50,10`).

## Fix

Adds a check for line-number anchor patterns before deciding to open the file in preview. When the fragment matches a line-number pattern, the code falls through to `openDocumentLink()`, which uses `getSelectionFromLocationFragment` to translate the anchor into a VS Code `Range` and opens the file in the text editor at the correct line.

Fixes microsoft/vscode#304481