### PR TITLE
Fix arrow key navigation not reaching filter button in notebook find widget

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -176,25 +176,25 @@ export class FindInput extends Widget {
 			// Arrow-Key support to navigate between options
 			this.onkeydown(this.domNode, (event: IKeyboardEvent) => {
 				if (event.equals(KeyCode.LeftArrow) || event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Escape)) {
-					const indexes = this.getOptionNavigationIndexes();
-					const index = indexes.indexOf(<HTMLElement>this.domNode.ownerDocument.activeElement);
+					const elements = this.getOptionNavigationElements();
+					const index = elements.indexOf(<HTMLElement>this.domNode.ownerDocument.activeElement);
 					if (index >= 0) {
 						let newIndex: number = -1;
 						if (event.equals(KeyCode.RightArrow)) {
-							newIndex = (index + 1) % indexes.length;
+							newIndex = (index + 1) % elements.length;
 						} else if (event.equals(KeyCode.LeftArrow)) {
 							if (index === 0) {
-								newIndex = indexes.length - 1;
+								newIndex = elements.length - 1;
 							} else {
 								newIndex = index - 1;
 							}
 						}
 
 						if (event.equals(KeyCode.Escape)) {
-							indexes[index].blur();
+							elements[index].blur();
 							this.inputBox.focus();
 						} else if (newIndex >= 0) {
-							indexes[newIndex].focus();
+							elements[newIndex].focus();
 						}
 
 						dom.EventHelper.stop(event, true);
@@ -251,21 +251,21 @@ export class FindInput extends Widget {
 	 * navigation among the find input toggle buttons. Subclasses can override
 	 * this to include additional toggle-like controls.
 	 */
-	protected getOptionNavigationIndexes(): HTMLElement[] {
-		const indexes: HTMLElement[] = [];
+	protected getOptionNavigationElements(): HTMLElement[] {
+		const elements: HTMLElement[] = [];
 		if (this.caseSensitive) {
-			indexes.push(this.caseSensitive.domNode);
+			elements.push(this.caseSensitive.domNode);
 		}
 		if (this.wholeWords) {
-			indexes.push(this.wholeWords.domNode);
+			elements.push(this.wholeWords.domNode);
 		}
 		if (this.regex) {
-			indexes.push(this.regex.domNode);
+			elements.push(this.regex.domNode);
 		}
 		for (const toggle of this.additionalToggles) {
-			indexes.push(toggle.domNode);
+			elements.push(toggle.domNode);
 		}
-		return indexes;
+		return elements;
 	}
 
 	public layout(style: { collapsedFindWidget: boolean; narrowFindWidget: boolean; reducedFindWidget: boolean }) {

--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -174,9 +174,9 @@ export class FindInput extends Widget {
 			}));
 
 			// Arrow-Key support to navigate between options
-			const indexes = [this.caseSensitive.domNode, this.wholeWords.domNode, this.regex.domNode];
 			this.onkeydown(this.domNode, (event: IKeyboardEvent) => {
 				if (event.equals(KeyCode.LeftArrow) || event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Escape)) {
+					const indexes = this.getOptionNavigationIndexes();
 					const index = indexes.indexOf(<HTMLElement>this.domNode.ownerDocument.activeElement);
 					if (index >= 0) {
 						let newIndex: number = -1;
@@ -244,6 +244,28 @@ export class FindInput extends Widget {
 
 	public get onDidChange(): Event<string> {
 		return this.inputBox.onDidChange;
+	}
+
+	/**
+	 * Returns the list of DOM elements that participate in left/right arrow key
+	 * navigation among the find input toggle buttons. Subclasses can override
+	 * this to include additional toggle-like controls.
+	 */
+	protected getOptionNavigationIndexes(): HTMLElement[] {
+		const indexes: HTMLElement[] = [];
+		if (this.caseSensitive) {
+			indexes.push(this.caseSensitive.domNode);
+		}
+		if (this.wholeWords) {
+			indexes.push(this.wholeWords.domNode);
+		}
+		if (this.regex) {
+			indexes.push(this.regex.domNode);
+		}
+		for (const toggle of this.additionalToggles) {
+			indexes.push(toggle.domNode);
+		}
+		return indexes;
 	}
 
 	public layout(style: { collapsedFindWidget: boolean; narrowFindWidget: boolean; reducedFindWidget: boolean }) {

--- a/src/vs/base/test/browser/ui/findinput/findInput.test.ts
+++ b/src/vs/base/test/browser/ui/findinput/findInput.test.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mainWindow } from '../../../../browser/window.js';
+import { FindInput } from '../../../../browser/ui/findinput/findInput.js';
+import { unthemedToggleStyles } from '../../../../browser/ui/toggle/toggle.js';
+import { unthemedInboxStyles } from '../../../../browser/ui/inputbox/inputBox.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../common/utils.js';
+
+function dispatchKeydown(element: HTMLElement, keyCode: number): void {
+	const keyboardEvent = new KeyboardEvent('keydown', { bubbles: true });
+	Object.defineProperty(keyboardEvent, 'keyCode', { get: () => keyCode });
+	element.dispatchEvent(keyboardEvent);
+}
+
+// Native keyCodes consumed by StandardKeyboardEvent (see KEY_CODE_MAP in keyCodes.ts).
+const KEY_LEFT = 37;
+const KEY_RIGHT = 39;
+const KEY_ESCAPE = 27;
+
+suite('FindInput', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let container: HTMLElement;
+
+	setup(() => {
+		container = document.createElement('div');
+		mainWindow.document.body.appendChild(container);
+	});
+
+	teardown(() => {
+		container.remove();
+	});
+
+	/**
+	 * Exposes the protected option-navigation hook and mirrors the override
+	 * pattern used by `NotebookFindInput`: non-focusable toggles are skipped and
+	 * an extra focusable control (modelling the filter button) can be appended.
+	 */
+	class TestFindInput extends FindInput {
+		public extraControl: HTMLElement | undefined;
+
+		public navigationElements(): HTMLElement[] {
+			return this.getOptionNavigationElements();
+		}
+
+		public toggles() {
+			return { caseSensitive: this.caseSensitive!, wholeWords: this.wholeWords!, regex: this.regex! };
+		}
+
+		public get controlsContainer(): HTMLElement {
+			return this.controls;
+		}
+
+		protected override getOptionNavigationElements(): HTMLElement[] {
+			const elements = super.getOptionNavigationElements().filter(element => this.isFocusable(element));
+			if (this.extraControl && this.isFocusable(this.extraControl)) {
+				elements.push(this.extraControl);
+			}
+			return elements;
+		}
+
+		private isFocusable(element: HTMLElement): boolean {
+			return element.tabIndex >= 0 && element.getAttribute('aria-disabled') !== 'true';
+		}
+	}
+
+	function createInput(): TestFindInput {
+		const input = store.add(new TestFindInput(container, undefined, {
+			label: 'test',
+			showCommonFindToggles: true,
+			toggleStyles: unthemedToggleStyles,
+			inputBoxStyles: unthemedInboxStyles
+		}));
+		return input;
+	}
+
+	test('getOptionNavigationElements() returns the common toggles in order', () => {
+		const input = createInput();
+		const { caseSensitive, wholeWords, regex } = input.toggles();
+
+		assert.deepStrictEqual(input.navigationElements(), [
+			caseSensitive.domNode,
+			wholeWords.domNode,
+			regex.domNode
+		]);
+	});
+
+	test('right arrow cycles focus forward through the toggles and wraps around', () => {
+		const input = createInput();
+		const { caseSensitive, wholeWords, regex } = input.toggles();
+
+		caseSensitive.domNode.focus();
+		assert.strictEqual(mainWindow.document.activeElement, caseSensitive.domNode);
+
+		dispatchKeydown(caseSensitive.domNode, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, wholeWords.domNode);
+
+		dispatchKeydown(wholeWords.domNode, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, regex.domNode);
+
+		// wraps back to the first toggle
+		dispatchKeydown(regex.domNode, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, caseSensitive.domNode);
+	});
+
+	test('left arrow cycles focus backward through the toggles and wraps around', () => {
+		const input = createInput();
+		const { caseSensitive, wholeWords, regex } = input.toggles();
+
+		caseSensitive.domNode.focus();
+
+		// wraps to the last toggle
+		dispatchKeydown(caseSensitive.domNode, KEY_LEFT);
+		assert.strictEqual(mainWindow.document.activeElement, regex.domNode);
+
+		dispatchKeydown(regex.domNode, KEY_LEFT);
+		assert.strictEqual(mainWindow.document.activeElement, wholeWords.domNode);
+	});
+
+	test('escape blurs the focused toggle and returns focus to the input box', () => {
+		const input = createInput();
+		const { wholeWords } = input.toggles();
+
+		wholeWords.domNode.focus();
+		assert.strictEqual(mainWindow.document.activeElement, wholeWords.domNode);
+
+		dispatchKeydown(wholeWords.domNode, KEY_ESCAPE);
+		assert.strictEqual(mainWindow.document.activeElement, input.inputBox.inputElement);
+	});
+
+	test('arrow navigation reaches an additional focusable control appended by a subclass', () => {
+		const input = createInput();
+		const { caseSensitive, wholeWords, regex } = input.toggles();
+
+		// Model the notebook find widget's filter button: an extra focusable
+		// control that the override adds to the navigation order.
+		const filterButton = document.createElement('a');
+		filterButton.tabIndex = 0;
+		input.controlsContainer.appendChild(filterButton);
+		input.extraControl = filterButton;
+
+		assert.deepStrictEqual(input.navigationElements(), [
+			caseSensitive.domNode,
+			wholeWords.domNode,
+			regex.domNode,
+			filterButton
+		]);
+
+		// Right arrow from the last toggle now lands on the filter button.
+		regex.domNode.focus();
+		dispatchKeydown(regex.domNode, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, filterButton);
+
+		// And it is part of the cycle: another right arrow wraps to the first toggle.
+		dispatchKeydown(filterButton, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, caseSensitive.domNode);
+	});
+
+	test('arrow navigation skips a toggle that has been removed from the tab order', () => {
+		const input = createInput();
+		const { caseSensitive, wholeWords, regex } = input.toggles();
+
+		// The notebook widget sets regex.domNode.tabIndex = -1 when filters are
+		// active; such non-focusable controls must be skipped.
+		regex.domNode.tabIndex = -1;
+
+		assert.deepStrictEqual(input.navigationElements(), [
+			caseSensitive.domNode,
+			wholeWords.domNode
+		]);
+
+		// Right arrow from the last focusable toggle wraps directly to the first,
+		// never landing on the non-focusable regex toggle.
+		wholeWords.domNode.focus();
+		dispatchKeydown(wholeWords.domNode, KEY_RIGHT);
+		assert.strictEqual(mainWindow.document.activeElement, caseSensitive.domNode);
+	});
+});

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -257,6 +257,17 @@ export class NotebookFindInput extends FindInput {
 		this.controls.appendChild(this._findFilter.container);
 	}
 
+	protected override getOptionNavigationIndexes(): HTMLElement[] {
+		const indexes = super.getOptionNavigationIndexes();
+		// Include the filter button's focusable element in arrow-key navigation
+		// so users can reach it with left/right arrow keys in addition to Tab.
+		const filterFocusable = this._findFilter.container.querySelector<HTMLElement>('a.action-label');
+		if (filterFocusable) {
+			indexes.push(filterFocusable);
+		}
+		return indexes;
+	}
+
 	override setEnabled(enabled: boolean) {
 		super.setEnabled(enabled);
 		if (enabled && !this._filterChecked) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -257,15 +257,31 @@ export class NotebookFindInput extends FindInput {
 		this.controls.appendChild(this._findFilter.container);
 	}
 
-	protected override getOptionNavigationIndexes(): HTMLElement[] {
-		const indexes = super.getOptionNavigationIndexes();
+	private isOptionNavigationFocusable(element: HTMLElement | null): element is HTMLElement {
+		if (!element) {
+			return false;
+		}
+
+		if (element.tabIndex < 0 || element.getAttribute('aria-disabled') === 'true') {
+			return false;
+		}
+
+		return dom.getWindow(element).getComputedStyle(element).display !== 'none';
+	}
+
+	protected override getOptionNavigationElements(): HTMLElement[] {
+		// Filter out the regex toggle (and any other ancestor toggle) when it has
+		// been removed from the tab order — e.g. when filters are active the
+		// notebook sets `regex.domNode.tabIndex = -1` and we don't want arrow
+		// keys to land on a non-focusable control.
+		const elements = super.getOptionNavigationElements().filter(element => this.isOptionNavigationFocusable(element));
 		// Include the filter button's focusable element in arrow-key navigation
 		// so users can reach it with left/right arrow keys in addition to Tab.
 		const filterFocusable = this._findFilter.container.querySelector<HTMLElement>('a.action-label');
-		if (filterFocusable) {
-			indexes.push(filterFocusable);
+		if (this.isOptionNavigationFocusable(filterFocusable)) {
+			elements.push(filterFocusable);
 		}
-		return indexes;
+		return elements;
 	}
 
 	override setEnabled(enabled: boolean) {


### PR DESCRIPTION
Fixes microsoft/vscode#207765

## Problem

In the notebook find widget, arrow key navigation among the toggle buttons only cycles through the three standard toggles (case sensitive, whole words, regex) but skips the filter (funnel) button added by `NotebookFindInput`.

The root cause was that `FindInput` hardcoded its arrow-key navigation index list as a local constant captured in a closure during the constructor, making it impossible for subclasses to extend the list with additional controls.

## Solution

Extract the index computation into a protected `getOptionNavigationIndexes()` method that is called dynamically on each keydown event. The default implementation returns the standard toggles plus any `additionalToggles`.

`NotebookFindInput` overrides this method to also include the filter button's focusable anchor element, so left/right arrow keys now correctly cycle through all four toggle buttons.

## Files changed

- `src/vs/base/browser/ui/findinput/findInput.ts` — add protected `getOptionNavigationIndexes()` method
- `src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts` — override to include filter button