### PR TITLE
Fix terminalEditorActive incorrectly set false when panel terminal is focused

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -225,7 +225,13 @@ export class TerminalService extends Disposable implements ITerminalService {
 		this._terminalEditorActive = TerminalContextKeys.terminalEditorActive.bindTo(this._contextKeyService);
 
 		this._register(this.onDidChangeActiveInstance(instance => {
-			this._terminalEditorActive.set(!!instance?.target && instance.target === TerminalLocation.Editor);
+			// Only set the context key to true here; setting it to false is the responsibility of
+			// TerminalEditorService which tracks the active editor. Without this separation, focusing
+			// the terminal panel overwrites the key to false even when a terminal editor is still
+			// the active editor in its group. See https://github.com/microsoft/vscode/issues/182979
+			if (instance?.target === TerminalLocation.Editor) {
+				this._terminalEditorActive.set(true);
+			}
 		}));
 
 		this._register(_lifecycleService.onBeforeShutdown(async e => e.veto(this._onBeforeShutdown(e.reason), 'veto.terminal')));


### PR DESCRIPTION
Fixes microsoft/vscode#182979

## Problem

When the user has a terminal open in both an editor group (terminal editor) and the panel, focusing the panel terminal causes `terminalEditorActive` to become `false` — even though the active editor is still `terminalEditor`.

The root cause: `TerminalService.onDidChangeActiveInstance` unconditionally sets:
```ts
this._terminalEditorActive.set(!!instance?.target && instance.target === TerminalLocation.Editor);
```
When a panel terminal becomes the active instance its target is `TerminalLocation.Panel`, so the key is set to `false`. Because the active editor did not change, `TerminalEditorService.onDidActiveEditorChange` never fires to restore the value, leaving the state contradictory (`activeEditor='terminalEditor'` but `terminalEditorActive=false`).

## Fix

In `TerminalService`, only ever set `terminalEditorActive=true` (when an editor terminal becomes active). Delegate the `false` case entirely to `TerminalEditorService`, which already sets the key correctly whenever the active editor changes away from a terminal editor.

## Files changed

- `src/vs/workbench/contrib/terminal/browser/terminalService.ts` — guard the `set` call so it only fires for `TerminalLocation.Editor` instances