### PR TITLE
fix(markdown-math): prevent angle bracket auto-close inside inline math ($...$)

### DIFF
--- a/extensions/markdown-math/syntaxes/md-math-inline.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math-inline.tmLanguage.json
@@ -15,23 +15,24 @@
 	"repository": {
 		"math_inline_single": {
 			"name": "markup.math.inline.markdown",
-			"match": "(?<=\\s|\\W|^)(?<!\\$)(\\$)(.+?)(\\$)(?!\\$)(?=\\s|\\W|$)",
-			"captures": {
+			"contentName": "meta.embedded.math.markdown",
+			"begin": "(?<=\\s|\\W|^)(?<!\\$)(\\$)(?![\\s\\d$])",
+			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.math.begin.markdown"
-				},
-				"2": {
-					"name": "meta.embedded.math.markdown",
-					"patterns": [
-						{
-							"include": "text.html.markdown.math#math"
-						}
-					]
-				},
-				"3": {
+				}
+			},
+			"end": "(\\$)(?!\\$)(?=\\s|\\W|$)|(?=$)",
+			"endCaptures": {
+				"1": {
 					"name": "punctuation.definition.math.end.markdown"
 				}
-			}
+			},
+			"patterns": [
+				{
+					"include": "text.html.markdown.math#math"
+				}
+			]
 		},
 		"math_inline_double": {
 			"name": "markup.math.inline.markdown",


### PR DESCRIPTION
Fixes #272922

## Problem

When typing `<` inside `$...$` (inline LaTeX math) in a Markdown file, VS Code auto-closes it to `<>`. This is incorrect — in LaTeX, `<` is a less-than operator, not an HTML tag delimiter, so the auto-close is unwanted and disruptive.

## Root Cause

The `math_inline_single` pattern in `md-math-inline.tmLanguage.json` used a TextMate `match` rule. Match rules are applied retroactively after the full pattern is recognized — they cannot signal the embedded language to the editor while the user is still typing.

As a result, during editing VS Code has no way to know the cursor is inside embedded LaTeX, and falls back to the Markdown host language configuration. The Markdown language config includes `<`/`>` as an auto-closing pair (with `notIn: ["string"]`), which fires unconditionally inside math content.

By contrast, the block math pattern (`math_inline_block`) already uses a `begin`/`end` rule and works correctly — the editor switches to the embedded `latex` language in real-time, and since `latex-language-configuration.json` does not include `<`/`>` as an auto-closing pair, angle brackets are not auto-closed there.

## Fix

Convert `math_inline_single` from a `match` rule to a `begin`/`end` rule with `contentName: "meta.embedded.math.markdown"`. This mirrors the approach used by `math_inline_block` and allows VS Code to correctly detect the embedded LaTeX context while the user types inside `$...$`.

The `end` pattern includes `|(?=$)` to terminate at end-of-line, preserving the single-line semantics of the original match rule.

## Testing

1. Open a `.md` file
2. Type `$ ` (dollar space)
3. Type `<` — it should **not** be auto-closed to `<>`
4. Verify that `$a < b$` renders correctly in the preview