### PR TITLE
fix(git): respect core.commentChar when stripping commit message comments

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3227,17 +3227,34 @@ export class Repository {
 		return this.getBranch(result.stdout.trim());
 	}
 
-	// TODO: Support core.commentChar
-	stripCommitMessageComments(message: string): string {
-		return message.replace(/^\s*#.*$\n?/gm, '').trim();
+	stripCommitMessageComments(message: string, commentChar: string = '#'): string {
+		const escapedChar = commentChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		return message.replace(new RegExp(`^\\s*${escapedChar}.*$\\n?`, 'gm'), '').trim();
+	}
+
+	async getCommentChar(): Promise<string> {
+		try {
+			const result = await this.exec(['config', '--get', 'core.commentChar']);
+			const commentChar = result.stdout.trim();
+			// 'auto' lets Git choose a character not present in the message; fall back to '#'
+			if (!commentChar || commentChar === 'auto') {
+				return '#';
+			}
+			return commentChar[0];
+		} catch {
+			return '#';
+		}
 	}
 
 	async getSquashMessage(): Promise<string | undefined> {
 		const squashMsgPath = path.join(this.repositoryRoot, '.git', 'SQUASH_MSG');
 
 		try {
-			const raw = await fs.readFile(squashMsgPath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			const [raw, commentChar] = await Promise.all([
+				fs.readFile(squashMsgPath, 'utf8'),
+				this.getCommentChar()
+			]);
+			return this.stripCommitMessageComments(raw, commentChar);
 		} catch {
 			return undefined;
 		}
@@ -3247,8 +3264,11 @@ export class Repository {
 		const mergeMsgPath = path.join(this.repositoryRoot, '.git', 'MERGE_MSG');
 
 		try {
-			const raw = await fs.readFile(mergeMsgPath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			const [raw, commentChar] = await Promise.all([
+				fs.readFile(mergeMsgPath, 'utf8'),
+				this.getCommentChar()
+			]);
+			return this.stripCommitMessageComments(raw, commentChar);
 		} catch {
 			return undefined;
 		}
@@ -3256,15 +3276,18 @@ export class Repository {
 
 	async getCommitTemplate(): Promise<string> {
 		try {
-			const result = await this.exec(['config', '--get', 'commit.template']);
+			const [templateResult, commentChar] = await Promise.all([
+				this.exec(['config', '--get', 'commit.template']),
+				this.getCommentChar()
+			]);
 
-			if (!result.stdout) {
+			if (!templateResult.stdout) {
 				return '';
 			}
 
 			// https://github.com/git/git/blob/3a0f269e7c82aa3a87323cb7ae04ac5f129f036b/path.c#L612
 			const homedir = os.homedir();
-			let templatePath = result.stdout.trim()
+			let templatePath = templateResult.stdout.trim()
 				.replace(/^~([^\/]*)\//, (_, user) => `${user ? path.join(path.dirname(homedir), user) : homedir}/`);
 
 			if (!path.isAbsolute(templatePath)) {
@@ -3272,7 +3295,7 @@ export class Repository {
 			}
 
 			const raw = await fs.readFile(templatePath, 'utf8');
-			return this.stripCommitMessageComments(raw);
+			return this.stripCommitMessageComments(raw, commentChar);
 		} catch (err) {
 			return '';
 		}


### PR DESCRIPTION
## Problem

The Git extension strips comment lines from commit message templates and in-progress merge/squash messages before displaying them as the initial commit message. This is done by `stripCommitMessageComments()`, which always assumes the comment character is `#`.

However, Git supports configuring an alternative comment character via `core.commentChar` (e.g. `git config core.commentChar ";"`). When a user has set this, lines beginning with `;` (or whatever they chose) are comments in Git's eyes, but VS Code's extension was not stripping them — they would leak into the commit message input box.

This also means that if a user has `core.commentChar` set to something other than `#`, and their commit template or message content contains `#`, lines with `#` would be stripped even though they are not comments.

## Fix

- Add `getCommentChar()` which reads `core.commentChar` from `git config`. Handles the `auto` value (falls back to `#`) and missing/empty config (defaults to `#`).
- Update `stripCommitMessageComments()` to accept an optional `commentChar` parameter (defaults to `#` for backward compatibility) and build the regex dynamically with proper escaping.
- Update all three call sites (`getSquashMessage`, `getMergeMessage`, `getCommitTemplate`) to fetch the comment char in parallel with the file read and pass it through.

## Testing

1. Set `git config core.commentChar ";"` in a local repo
2. Create a commit template with `;`-prefixed comment lines
3. Open VS Code and start a commit — comment lines should be stripped
4. Verify that `#` lines (not comments with this config) are preserved