### PR TITLE
Update Copilot dependency to version 1.0.21

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -13,7 +13,7 @@
 				"@anthropic-ai/claude-agent-sdk": "^0.2.91",
 				"@anthropic-ai/sdk": "^0.82.0",
 				"@github/blackbird-external-ingest-utils": "^0.3.0",
-				"@github/copilot": "^1.0.17",
+				"@github/copilot": "^1.0.21",
 				"@google/genai": "^1.22.0",
 				"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 				"@microsoft/tiktokenizer": "^1.0.10",
@@ -3204,26 +3204,26 @@
 			"license": "MIT"
 		},
 		"node_modules/@github/copilot": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.17.tgz",
-			"integrity": "sha512-RTJ+kEKOdidjuOs8ozsoBdz+94g7tFJIEu5kz1P2iwJhsL+iIA5rtn9/jXOF0hAI3CLSXKZoSd66cqHrn4rb1A==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.21.tgz",
+			"integrity": "sha512-P+nORjNKAtl92jYCG6Qr1Rsw2JoyScgeQSkIR6O2WB37WS5JVdA4ax1WVualMbfuc9V58CPHX6fwyNpkI89FkQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"bin": {
 				"copilot": "npm-loader.js"
 			},
 			"optionalDependencies": {
-				"@github/copilot-darwin-arm64": "1.0.17",
-				"@github/copilot-darwin-x64": "1.0.17",
-				"@github/copilot-linux-arm64": "1.0.17",
-				"@github/copilot-linux-x64": "1.0.17",
-				"@github/copilot-win32-arm64": "1.0.17",
-				"@github/copilot-win32-x64": "1.0.17"
+				"@github/copilot-darwin-arm64": "1.0.21",
+				"@github/copilot-darwin-x64": "1.0.21",
+				"@github/copilot-linux-arm64": "1.0.21",
+				"@github/copilot-linux-x64": "1.0.21",
+				"@github/copilot-win32-arm64": "1.0.21",
+				"@github/copilot-win32-x64": "1.0.21"
 			}
 		},
 		"node_modules/@github/copilot-darwin-arm64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.17.tgz",
-			"integrity": "sha512-LSv66P8611y/UjTESnaHLYqLl9kA9yBYsaocZPQoOsvMgCmktgaBgUWq+KMpLMicaFN0jBAE5F0Ve7dW6N9X3A==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.21.tgz",
+			"integrity": "sha512-aB+s9ldTwcyCOYmzjcQ4SknV6g81z92T8aUJEJZBwOXOTBeWKAJtk16ooAKangZgdwuLgO3or1JUjx1FJAm5nQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3237,9 +3237,9 @@
 			}
 		},
 		"node_modules/@github/copilot-darwin-x64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.17.tgz",
-			"integrity": "sha512-yqRS0/8kYTGl4VvfJ/QOtHTeYF+DnAWNUReZgt2U0AEP3zgj4z4hxSH7D2PsO/488L4KsBmmcnJr13HmBGiT/w==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.21.tgz",
+			"integrity": "sha512-aNad81DOGuGShmaiFNIxBUSZLwte0dXmDYkGfAF9WJIgY4qP4A8CPWFoNr8//gY+4CwaIf9V+f/OC6k2BdECbw==",
 			"cpu": [
 				"x64"
 			],
@@ -3253,9 +3253,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-arm64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.17.tgz",
-			"integrity": "sha512-TOK0ma0A24zmQJslkGxUk+KnMFpiqquWEXB5sIv/5Ci45Qi7s0BRWTnqtiJ8Vahwb/wkja6KarHkLA27+ETGUA==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.21.tgz",
+			"integrity": "sha512-FL0NsCnHax4czHVv1S8iBqPLGZDhZ28N3+6nT29xWGhmjBWTkIofxLThKUPcyyMsfPTTxIlrdwWa8qQc5z2Q+g==",
 			"cpu": [
 				"arm64"
 			],
@@ -3269,9 +3269,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-x64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.17.tgz",
-			"integrity": "sha512-4Yum3uaAuTM/SiNtzchsO/G/144Bi/Z4FEcearW6WsGDvS6cRwSJeudOM0y4aoy4BHcv8+yw7YuXH5BHC3SAiA==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.21.tgz",
+			"integrity": "sha512-S7pWVI16hesZtxYbIyfw+MHZpc5ESoGKUVr5Y+lZJNaM2340gJGPQzQwSpvKIRMLHRKI2hXLwciAnYeMFxE/Tg==",
 			"cpu": [
 				"x64"
 			],
@@ -3285,9 +3285,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-arm64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.17.tgz",
-			"integrity": "sha512-I1ferbfQ0aS149WyEUw6XS1sFixwTUUm13BPBQ3yMzD8G2SaoxTsdYdlhZpkVfkfh/rUYyvMKKi9VNxoVYOlDA==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.21.tgz",
+			"integrity": "sha512-a9qc2Ku+XbyBkXCclbIvBbIVnECACTIWnPctmXWsQeSdeapGxgfHGux7y8hAFV5j6+nhCm6cnyEMS3rkZjAhdA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3301,9 +3301,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-x64": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.17.tgz",
-			"integrity": "sha512-kjiOxY9ibS+rPp9XFpPdfdYzluEL3SHN8R5/fnA7RO+kZEJ4FDKWJjAiec3tgVkEHQT3UwNuVa/u3TdfYNF15w==",
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.21.tgz",
+			"integrity": "sha512-9klu+7NQ6tEyb8sibb0rsbimBivDrnNltZho10Bgbf1wh3o+erTjffXDjW9Zkyaw8lZA9Fz8bqhVkKntZq58Lg==",
 			"cpu": [
 				"x64"
 			],

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6365,7 +6365,7 @@
 		"@anthropic-ai/claude-agent-sdk": "^0.2.91",
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@github/blackbird-external-ingest-utils": "^0.3.0",
-		"@github/copilot": "^1.0.17",
+		"@github/copilot": "^1.0.21",
 		"@google/genai": "^1.22.0",
 		"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 		"@microsoft/tiktokenizer": "^1.0.10",

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -100,7 +100,7 @@ async function copyCopilotCliQueryFiles() {
 	await copyCopilotCLIFolders(sourceDir, targetDir);
 }
 
-async function copyCopilotCliPreBuiltFiles() {
+async function copyCopilotCliPrebuildFiles() {
 	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'prebuilds');
 	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'prebuilds');
 
@@ -113,7 +113,6 @@ async function copyCopilotCliPreBuiltFiles() {
 				if (fs.statSync(src).isFile()) {
 					return src.endsWith('computer.node');
 				}
-				console.error(`Skipping file from ${src} to ${targetDir}`);
 				return true;
 			} catch {
 				return true;
@@ -179,7 +178,7 @@ async function main() {
 	await copyCopilotCliDefinitionFiles();
 	await copyCopilotCliSkillsFiles();
 	await copyCopilotCliQueryFiles();
-	await copyCopilotCliPreBuiltFiles();
+	await copyCopilotCliPrebuildFiles();
 
 	// Check if the base cache file exists (dev-only sanity check, non-fatal in CI)
 	const baseCachePath = path.join('test', 'simulation', 'cache', 'base.sqlite');

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -86,6 +86,42 @@ async function copyCopilotCliDefinitionFiles() {
 	await copyCopilotCLIFolders(sourceDir, targetDir);
 }
 
+async function copyCopilotCliSkillsFiles() {
+	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'builtin-skills', 'customizing-copilot-cloud-agents-environment');
+	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'builtin-skills', 'customizing-copilot-cloud-agents-environment');
+
+	await copyCopilotCLIFolders(sourceDir, targetDir);
+}
+
+async function copyCopilotCliQueryFiles() {
+	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'queries');
+	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'queries');
+
+	await copyCopilotCLIFolders(sourceDir, targetDir);
+}
+
+async function copyCopilotCliPreBuiltFiles() {
+	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'prebuilds');
+	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'prebuilds');
+
+	await fs.promises.rm(targetDir, { recursive: true, force: true });
+	await fs.promises.mkdir(targetDir, { recursive: true });
+	await fs.promises.cp(sourceDir, targetDir, {
+		recursive: true, force: true, filter: (src) => {
+			try {
+				// Only copy computer.node files
+				if (fs.statSync(src).isFile()) {
+					return src.endsWith('computer.node');
+				}
+				console.error(`Skipping file from ${src} to ${targetDir}`);
+				return true;
+			} catch {
+				return true;
+			}
+		}
+	});
+}
+
 async function copyCopilotCLIFolders(sourceDir: string, targetDir: string) {
 	await fs.promises.rm(targetDir, { recursive: true, force: true });
 	await fs.promises.mkdir(targetDir, { recursive: true });
@@ -141,6 +177,9 @@ async function main() {
 	await copyCopilotCliWorkerFiles();
 	await copyCopilotCliSharpFiles();
 	await copyCopilotCliDefinitionFiles();
+	await copyCopilotCliSkillsFiles();
+	await copyCopilotCliQueryFiles();
+	await copyCopilotCliPreBuiltFiles();
 
 	// Check if the base cache file exists (dev-only sanity check, non-fatal in CI)
 	const baseCachePath = path.join('test', 'simulation', 'cache', 'base.sqlite');

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -109,9 +109,9 @@ async function copyCopilotCliPrebuildFiles() {
 	await fs.promises.cp(sourceDir, targetDir, {
 		recursive: true, force: true, filter: (src) => {
 			try {
-				// Only copy computer.node files
+				// Only copy computer.node and win_error_mode.node files
 				if (fs.statSync(src).isFile()) {
-					return src.endsWith('computer.node');
+					return src.endsWith('computer.node') || src.endsWith('win_error_mode.node');
 				}
 				return true;
 			} catch {

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLISDKUpgrade.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/copilotCLISDKUpgrade.spec.ts
@@ -49,6 +49,16 @@ describe('CopilotCLI SDK Upgrade', function () {
 			path.join('ripgrep', 'bin', 'win32-x64', 'rg.exe'),
 			path.join('prebuilds', 'darwin-arm64', 'spawn-helper'),
 			path.join('prebuilds', 'darwin-x64', 'spawn-helper'),
+			// computer use
+			path.join('prebuilds', 'darwin-arm64', 'computer.node'),
+			path.join('prebuilds', 'darwin-x64', 'computer.node'),
+			path.join('prebuilds', 'linux-arm64', 'computer.node'),
+			path.join('prebuilds', 'linux-x64', 'computer.node'),
+			path.join('prebuilds', 'win32-arm64', 'computer.node'),
+			path.join('prebuilds', 'win32-x64', 'computer.node'),
+			// win_error_mode
+			path.join('prebuilds', 'win32-arm64', 'win_error_mode.node'),
+			path.join('prebuilds', 'win32-x64', 'win_error_mode.node'),
 			path.join('ripgrep', 'bin', 'darwin-arm64', 'rg'),
 			path.join('ripgrep', 'bin', 'darwin-x64', 'rg'),
 			path.join('ripgrep', 'bin', 'linux-x64', 'rg'),


### PR DESCRIPTION
Upgrade the Copilot dependency to the latest version, ensuring compatibility and access to new features. Additionally, enhance the post-install script to copy various Copilot CLI files to the appropriate directories. This improves the setup process for users.

