### PR TITLE
fix: Add NSLocalNetworkUsageDescription to Info.plist

### DIFF
--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -78,6 +78,9 @@ async function main(buildDir?: string): Promise<void> {
 	const appRoot = path.join(buildDir, `VSCode-darwin-${arch}`);
 	const appName = product.nameLong + '.app';
 	const infoPlistPath = path.resolve(appRoot, appName, 'Contents', 'Info.plist');
+	const embeddedInfoPlistPath = product.embedded
+		? path.resolve(appRoot, appName, 'Contents', 'Applications', `${product.embedded.nameShort}.app`, 'Contents', 'Info.plist')
+		: undefined;
 
 	const appOpts: SignOptions = {
 		app: path.join(appRoot, appName),
@@ -124,6 +127,51 @@ async function main(buildDir?: string): Promise<void> {
 			'An application in Visual Studio Code wants to use Audio Capture.',
 			`${infoPlistPath}`
 		]);
+		await spawn('plutil', [
+			'-insert',
+			'NSLocalNetworkUsageDescription',
+			'-string',
+			'The app uses your local network for DNS resolution and to connect to locally running services.',
+			`${infoPlistPath}`
+		]);
+
+		if (embeddedInfoPlistPath && fs.existsSync(embeddedInfoPlistPath)) {
+			await spawn('plutil', [
+				'-insert',
+				'NSAppleEventsUsageDescription',
+				'-string',
+				`An application in ${product.embedded.nameShort} wants to use AppleScript.`,
+				`${embeddedInfoPlistPath}`
+			]);
+			await spawn('plutil', [
+				'-replace',
+				'NSMicrophoneUsageDescription',
+				'-string',
+				`An application in ${product.embedded.nameShort} wants to use the Microphone.`,
+				`${embeddedInfoPlistPath}`
+			]);
+			await spawn('plutil', [
+				'-replace',
+				'NSCameraUsageDescription',
+				'-string',
+				`An application in ${product.embedded.nameShort} wants to use the Camera.`,
+				`${embeddedInfoPlistPath}`
+			]);
+			await spawn('plutil', [
+				'-replace',
+				'NSAudioCaptureUsageDescription',
+				'-string',
+				`An application in ${product.embedded.nameShort} wants to use Audio Capture.`,
+				`${embeddedInfoPlistPath}`
+			]);
+			await spawn('plutil', [
+				'-insert',
+				'NSLocalNetworkUsageDescription',
+				'-string',
+				`The app uses your local network for DNS resolution and to connect to locally running services.`,
+				`${embeddedInfoPlistPath}`
+			]);
+		}
 	}
 
 	await retrySignOnKeychainError(() => sign(appOpts));


### PR DESCRIPTION
macOS shows a "Local Network" privacy prompt when an app opens TCP/UDP connections to devices on the local network over Wi-Fi [per Apple TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#Local-network-operations).

Chromium's built-in DNS client (enabled by default on macOS via the kAsyncDns feature flag) sends DNS queries directly over UDP sockets to the system-configured nameservers (when DoH is not enabled or in the fallback mode) unlike the system resolver path (getaddrinfo → mDNSResponder). On most Wi-Fi networks, the DNS server is in the same-subnet address and triggers the prompt on every launch.


**Before**

<img width="282" height="273" alt="test" src="https://github.com/user-attachments/assets/544f2320-88aa-4f55-ba86-e4cb21d62cd4" />
