### PR TITLE
Fix: Request ID changes over lifetime of WebSocket connection

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -1065,7 +1065,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 		if (request.messages?.some((m: CAPIChatMessage) => Array.isArray(m.content) ? m.content.some(c => 'image_url' in c) : false) && chatEndpointInfo.supportsVision) {
 			additionalHeaders['Copilot-Vision-Request'] = 'true';
 		}
-		const connection = this._webSocketManager.getOrCreateConnection(conversationId, additionalHeaders);
+		const connection = this._webSocketManager.getOrCreateConnection(conversationId, additionalHeaders, ourRequestId);
 		try {
 			await connection.connect();
 		} catch (err) {
@@ -1087,8 +1087,8 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 		});
 
 		const modelRequestId = getRequestId(connection.responseHeaders);
-		// Preserve ourRequestId as headerRequestId if the server didn't echo x-request-id
-		modelRequestId.headerRequestId = modelRequestId.headerRequestId || ourRequestId;
+		// Request id changes over the lifetime of the connection.
+		modelRequestId.headerRequestId = ourRequestId;
 		telemetryData.extendWithRequestId(modelRequestId);
 
 		for (const [key, value] of Object.entries(request)) {
@@ -1100,7 +1100,7 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 		this._telemetryService.sendGHTelemetryEvent('request.sent', telemetryData.properties, telemetryData.measurements);
 
 		const requestStart = Date.now();
-		const handle = connection.sendRequest(request, { userInitiated: !!userInitiatedRequest, turnId }, cancellationToken);
+		const handle = connection.sendRequest(request, { userInitiated: !!userInitiatedRequest, turnId, requestId: ourRequestId }, cancellationToken);
 
 		const extendedBaseTelemetryData = baseTelemetryData.extendedBy({ modelCallId });
 		const processor = this._instantiationService.createInstance(OpenAIResponsesProcessor, extendedBaseTelemetryData, modelRequestId.headerRequestId, modelRequestId.gitHubRequestId);

--- a/extensions/copilot/src/platform/networking/node/chatWebSocketManager.ts
+++ b/extensions/copilot/src/platform/networking/node/chatWebSocketManager.ts
@@ -29,7 +29,7 @@ export interface IChatWebSocketManager {
 	 * The connection is shared across turns and tool call rounds within
 	 * the same conversation, keeping server-side context alive.
 	 */
-	getOrCreateConnection(conversationId: string, headers: Record<string, string>): IChatWebSocketConnection;
+	getOrCreateConnection(conversationId: string, headers: Record<string, string>, initiatingRequestId: string): IChatWebSocketConnection;
 
 	/**
 	 * Returns true if there is an open WebSocket connection for the given
@@ -54,7 +54,7 @@ export interface IChatWebSocketManager {
  */
 export class NullChatWebSocketManager implements IChatWebSocketManager {
 	declare readonly _serviceBrand: undefined;
-	getOrCreateConnection(_conversationId: string, _headers?: Record<string, string>): IChatWebSocketConnection {
+	getOrCreateConnection(_conversationId: string, _headers?: Record<string, string>, _initiatingRequestId?: string): IChatWebSocketConnection {
 		throw new Error('WebSocket not available');
 	}
 	hasActiveConnection(_conversationId: string): boolean { return false; }
@@ -65,6 +65,7 @@ export class NullChatWebSocketManager implements IChatWebSocketManager {
 export interface IChatWebSocketRequestOptions {
 	userInitiated: boolean;
 	turnId: string;
+	requestId: string;
 }
 
 export interface IChatWebSocketConnection extends IDisposable {
@@ -89,9 +90,6 @@ export interface IChatWebSocketConnection extends IDisposable {
 
 	/** Response status text from the WebSocket connection handshake. */
 	readonly responseStatusText: string | undefined;
-
-	/** The request ID from response headers or the outgoing X-Request-Id header. */
-	readonly requestId: string;
 
 	/** The GitHub request ID from response headers. */
 	readonly gitHubRequestId: string;
@@ -169,7 +167,7 @@ export class ChatWebSocketManager extends Disposable implements IChatWebSocketMa
 		super();
 	}
 
-	getOrCreateConnection(conversationId: string, headers: Record<string, string>): IChatWebSocketConnection {
+	getOrCreateConnection(conversationId: string, headers: Record<string, string>, initiatingRequestId: string): IChatWebSocketConnection {
 		const existing = this._connections.get(conversationId);
 
 		// Reuse the connection if it's still open, even across turns.
@@ -183,7 +181,7 @@ export class ChatWebSocketManager extends Disposable implements IChatWebSocketMa
 			this._connections.delete(conversationId);
 		}
 
-		const connection = new ChatWebSocketConnection(this._capiClientService, this._logService, this._telemetryService, this._configurationService, conversationId, headers);
+		const connection = new ChatWebSocketConnection(this._capiClientService, this._logService, this._telemetryService, this._configurationService, conversationId, headers, initiatingRequestId);
 		this._logService.debug(`[ChatWebSocketManager] Creating new connection for conversation ${conversationId}`);
 		this._connections.set(conversationId, connection);
 
@@ -286,6 +284,7 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 		private readonly _configurationService: IConfigurationService,
 		private readonly _conversationId: string,
 		private readonly _headers: Record<string, string>,
+		private readonly _initiatingRequestId: string,
 	) {
 		super();
 	}
@@ -316,10 +315,6 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 
 	get responseStatusText(): string | undefined {
 		return this._responseStatusText;
-	}
-
-	get requestId(): string {
-		return this._responseHeaders.get('x-request-id') || Object.entries(this._headers).find(([k]) => k.toLowerCase() === 'x-request-id')?.[1] || '';
 	}
 
 	get gitHubRequestId(): string {
@@ -355,7 +350,7 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 				this._logService.debug(`[ChatWebSocketManager] Connected for conversation ${this._conversationId}`);
 				ChatWebSocketTelemetrySender.sendConnectedTelemetry(this._telemetryService, {
 					conversationId: this._conversationId,
-					requestId: this.requestId,
+					initiatingRequestId: this._initiatingRequestId,
 					gitHubRequestId: this.gitHubRequestId,
 					connectDurationMs,
 				});
@@ -375,7 +370,7 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 				this._logService.error(`[ChatWebSocketManager] Connection error for conversation ${this._conversationId}: ${errorMessage}${networkErrorMessage ? ` (cause: ${networkErrorMessage})` : ''}`);
 				ChatWebSocketTelemetrySender.sendConnectErrorTelemetry(this._telemetryService, {
 					conversationId: this._conversationId,
-					requestId: this.requestId,
+					initiatingRequestId: this._initiatingRequestId,
 					gitHubRequestId: this.gitHubRequestId,
 					error: errorMessage,
 					connectDurationMs,
@@ -397,7 +392,7 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 				this._logService.debug(`[ChatWebSocketManager] Connection closed during setup for conversation ${this._conversationId} (code: ${event.code} ${closeCodeDescription}, reason: ${event.reason || '<empty>'}, wasClean: ${event.wasClean})`);
 				ChatWebSocketTelemetrySender.sendCloseDuringSetupTelemetry(this._telemetryService, {
 					conversationId: this._conversationId,
-					requestId: this.requestId,
+					initiatingRequestId: this._initiatingRequestId,
 					gitHubRequestId: this.gitHubRequestId,
 					closeCode: event.code,
 					closeReason: closeCodeDescription,
@@ -439,10 +434,11 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 				this._logService.error(`[ChatWebSocketManager] Failed to parse message for conversation ${this._conversationId} turn ${this._turnId}: ${parseErrorMessage}`);
 				ChatWebSocketTelemetrySender.sendMessageParseErrorTelemetry(this._telemetryService, {
 					conversationId: this._conversationId,
+					initiatingRequestId: this._initiatingRequestId,
 					turnId: this._turnId,
 					previousTurnId: this._previousTurnId,
 					hadActiveRequest: this._hadActiveRequest,
-					requestId: this.requestId,
+					requestId: this._activeRequest?.requestId,
 					gitHubRequestId: this.gitHubRequestId,
 					error: parseErrorMessage,
 					connectionDurationMs,
@@ -469,10 +465,11 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 			this._logService.debug(`[ChatWebSocketManager] Connection closed for conversation ${this._conversationId} turn ${this._turnId} (code: ${event.code} ${closeCodeDescription}, reason: ${event.reason || '<empty>'}, wasClean: ${event.wasClean})`);
 			ChatWebSocketTelemetrySender.sendCloseTelemetry(this._telemetryService, {
 				conversationId: this._conversationId,
+				initiatingRequestId: this._initiatingRequestId,
 				turnId: this._turnId,
 				previousTurnId: this._previousTurnId,
 				hadActiveRequest: this._hadActiveRequest,
-				requestId: this.requestId,
+				requestId: this._activeRequest?.requestId,
 				gitHubRequestId: this.gitHubRequestId,
 				closeCode: event.code,
 				closeReason: closeCodeDescription,
@@ -496,10 +493,11 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 			this._logService.error(`[ChatWebSocketManager] Error for conversation ${this._conversationId} turn ${this._turnId}: ${errorMessage}`);
 			ChatWebSocketTelemetrySender.sendErrorTelemetry(this._telemetryService, {
 				conversationId: this._conversationId,
+				initiatingRequestId: this._initiatingRequestId,
 				turnId: this._turnId,
 				previousTurnId: this._previousTurnId,
 				hadActiveRequest: this._hadActiveRequest,
-				requestId: this.requestId,
+				requestId: this._activeRequest?.requestId,
 				gitHubRequestId: this.gitHubRequestId,
 				error: errorMessage,
 				connectionDurationMs,
@@ -546,12 +544,14 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 		this._turnId = turnId;
 		this._hadActiveRequest = hadActiveRequest;
 
+		const requestId = options.requestId;
+
 		const requestStartTime = Date.now();
 		const requestStartSentMessageCount = this._totalSentMessageCount;
 		const requestStartReceivedMessageCount = this._totalReceivedMessageCount;
 		const requestStartSentCharacters = this._totalSentCharacters;
 		const requestStartReceivedCharacters = this._totalReceivedCharacters;
-		const request = new ChatWebSocketActiveRequest(this._configurationService, this._logService);
+		const request = new ChatWebSocketActiveRequest(requestId, this._configurationService, this._logService);
 		request.onDidSettle(({ outcome, closeCode, closeReason, serverErrorMessage, serverErrorCode }) => {
 			if (this._activeRequest === request) {
 				this._activeRequest = undefined;
@@ -564,10 +564,11 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 			const requestReceivedCharacters = this._totalReceivedCharacters - requestStartReceivedCharacters;
 			ChatWebSocketTelemetrySender.sendRequestOutcomeTelemetry(this._telemetryService, {
 				conversationId: this._conversationId,
+				initiatingRequestId: this._initiatingRequestId,
 				turnId,
 				previousTurnId,
 				hadActiveRequest,
-				requestId: this.requestId,
+				requestId,
 				gitHubRequestId: this.gitHubRequestId,
 				requestOutcome: outcome,
 				statefulMarkerMatched,
@@ -615,10 +616,11 @@ class ChatWebSocketConnection extends Disposable implements IChatWebSocketConnec
 		this._logService.debug(`[ChatWebSocketManager] Sending request for conversation ${this._conversationId} turn ${this._turnId} (totalSentMessageCount: ${this._totalSentMessageCount}, sentMessageCharacters: ${sentMessageCharacters})`);
 		ChatWebSocketTelemetrySender.sendRequestSentTelemetry(this._telemetryService, {
 			conversationId: this._conversationId,
+			initiatingRequestId: this._initiatingRequestId,
 			turnId,
 			previousTurnId,
 			hadActiveRequest,
-			requestId: this.requestId,
+			requestId,
 			gitHubRequestId: this.gitHubRequestId,
 			statefulMarkerMatched,
 			previousResponseIdUnset,
@@ -672,6 +674,7 @@ class ChatWebSocketActiveRequest implements IChatWebSocketRequestHandle {
 	readonly done: Promise<void>;
 
 	constructor(
+		readonly requestId: string,
 		private readonly _configurationService: IConfigurationService,
 		private readonly _logService: ILogService,
 	) {

--- a/extensions/copilot/src/platform/networking/node/chatWebSocketTelemetry.ts
+++ b/extensions/copilot/src/platform/networking/node/chatWebSocketTelemetry.ts
@@ -7,11 +7,12 @@ import { ITelemetryService } from '../../telemetry/common/telemetry';
 
 interface IChatWebSocketConnectionTelemetryProperties {
 	conversationId: string;
-	requestId: string;
+	initiatingRequestId: string;
 	gitHubRequestId: string;
 }
 
 interface IChatWebSocketRequestTelemetryProperties extends IChatWebSocketConnectionTelemetryProperties {
+	requestId: string | undefined;
 	turnId: string | undefined;
 	previousTurnId: string | undefined;
 	hadActiveRequest: boolean;
@@ -114,14 +115,14 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report a successful WebSocket connection.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
-				"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the current turn request" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub request id if available" },
 				"connectDurationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time to establish the WebSocket connection in milliseconds", "isMeasurement": true }
 			}
 		*/
 		telemetryService.sendTelemetryEvent('websocket.connected', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
-			requestId: properties.requestId,
+			initiatingRequestId: properties.initiatingRequestId,
 			gitHubRequestId: properties.gitHubRequestId,
 		}, {
 			connectDurationMs: properties.connectDurationMs,
@@ -137,7 +138,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report a failed WebSocket connection attempt.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
-				"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the current turn request" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub request id if available" },
 				"error": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Error message for the failed connection" },
 				"connectDurationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Time until the connection error in milliseconds", "isMeasurement": true },
@@ -148,7 +149,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryErrorEvent('websocket.connectError', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
-			requestId: properties.requestId,
+			initiatingRequestId: properties.initiatingRequestId,
 			gitHubRequestId: properties.gitHubRequestId,
 			error: properties.error,
 			responseStatusText: properties.responseStatusText,
@@ -168,6 +169,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report a WebSocket connection close event.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"turnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the turn" },
 				"previousTurnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Turn id of the previous request on this connection" },
 				"hadActiveRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the previous request was still active when the new one began", "isMeasurement": true },
@@ -186,6 +188,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryEvent('websocket.close', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
+			initiatingRequestId: properties.initiatingRequestId,
 			turnId: properties.turnId,
 			previousTurnId: properties.previousTurnId,
 			requestId: properties.requestId,
@@ -213,6 +216,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report a runtime error on an established WebSocket connection.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"turnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the turn" },
 				"previousTurnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Turn id of the previous request on this connection" },
 				"hadActiveRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the previous request was still active when the new one began", "isMeasurement": true },
@@ -228,6 +232,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryErrorEvent('websocket.error', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
+			initiatingRequestId: properties.initiatingRequestId,
 			turnId: properties.turnId,
 			previousTurnId: properties.previousTurnId,
 			requestId: properties.requestId,
@@ -252,7 +257,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report when a WebSocket connection is closed during setup before fully opening.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
-				"requestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the current turn request" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"gitHubRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "GitHub request id if available" },
 				"closeReason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Human-readable description of the close code" },
 				"closeEventReason": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Close event reason string from server" },
@@ -263,7 +268,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryErrorEvent('websocket.closeDuringSetup', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
-			requestId: properties.requestId,
+			initiatingRequestId: properties.initiatingRequestId,
 			gitHubRequestId: properties.gitHubRequestId,
 			closeReason: properties.closeReason,
 			closeEventReason: properties.closeEventReason,
@@ -283,6 +288,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report when a request is sent over the WebSocket connection.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"turnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the turn" },
 				"previousTurnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Turn id of the previous request on this connection" },
 				"hadActiveRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the previous request was still active when the new one began", "isMeasurement": true },
@@ -301,6 +307,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryEvent('websocket.requestSent', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
+			initiatingRequestId: properties.initiatingRequestId,
 			turnId: properties.turnId,
 			previousTurnId: properties.previousTurnId,
 			requestId: properties.requestId,
@@ -328,6 +335,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report when a received websocket message fails JSON parsing.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"turnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the turn" },
 				"previousTurnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Turn id of the previous request on this connection" },
 				"hadActiveRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the previous request was still active when the new one began", "isMeasurement": true },
@@ -344,6 +352,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryErrorEvent('websocket.messageParseError', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
+			initiatingRequestId: properties.initiatingRequestId,
 			turnId: properties.turnId,
 			previousTurnId: properties.previousTurnId,
 			requestId: properties.requestId,
@@ -369,6 +378,7 @@ export class ChatWebSocketTelemetrySender {
 				"owner": "chrmarti",
 				"comment": "Report terminal outcome for a websocket request.",
 				"conversationId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the conversation" },
+				"initiatingRequestId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the request that initiated the connection" },
 				"turnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Id of the turn" },
 				"previousTurnId": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Turn id of the previous request on this connection" },
 				"hadActiveRequest": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Whether the previous request was still active when the new one began", "isMeasurement": true },
@@ -396,6 +406,7 @@ export class ChatWebSocketTelemetrySender {
 		*/
 		telemetryService.sendTelemetryEvent('websocket.requestOutcome', { github: true, microsoft: true }, {
 			conversationId: properties.conversationId,
+			initiatingRequestId: properties.initiatingRequestId,
 			turnId: properties.turnId,
 			previousTurnId: properties.previousTurnId,
 			requestId: properties.requestId,

--- a/extensions/copilot/src/platform/networking/node/test/chatWebSocketManager.spec.ts
+++ b/extensions/copilot/src/platform/networking/node/test/chatWebSocketManager.spec.ts
@@ -78,7 +78,7 @@ describe('ChatWebSocketManager', () => {
 			{ getConfig: () => undefined } as unknown as IConfigurationService,
 		);
 		disposables.add(manager);
-		const connection = manager.getOrCreateConnection('conv-1', headers);
+		const connection = manager.getOrCreateConnection('conv-1', headers, 'req-conn');
 		const connectPromise = connection.connect();
 		// Defer open event to allow connect() to attach listeners first
 		await Promise.resolve();
@@ -94,7 +94,7 @@ describe('ChatWebSocketManager', () => {
 			const connection = await getConnection();
 
 			// Request a connection for a new turn — should return the same object
-			const connection2 = manager.getOrCreateConnection('conv-1', {});
+			const connection2 = manager.getOrCreateConnection('conv-1', {}, 'req-conn-2');
 			expect(connection2).toBe(connection);
 			expect(manager.hasActiveConnection('conv-1')).toBe(true);
 		});
@@ -104,7 +104,7 @@ describe('ChatWebSocketManager', () => {
 			connection.dispose();
 
 			// Same manager, new getOrCreateConnection call should replace the disposed one
-			const connection2 = manager.getOrCreateConnection('conv-1', {});
+			const connection2 = manager.getOrCreateConnection('conv-1', {}, 'req-conn-2');
 			expect(connection2).not.toBe(connection);
 		});
 
@@ -126,7 +126,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -144,7 +144,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: false, turnId: 'turn-1' },
+				{ userInitiated: false, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -161,7 +161,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -180,7 +180,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -200,7 +200,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -221,7 +221,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -240,7 +240,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -263,7 +263,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -283,7 +283,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -320,7 +320,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -335,7 +335,7 @@ describe('ChatWebSocketManager', () => {
 			const cts = disposables.add(new CancellationTokenSource());
 			const handle = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts.token,
 			);
 
@@ -355,7 +355,7 @@ describe('ChatWebSocketManager', () => {
 			const cts1 = disposables.add(new CancellationTokenSource());
 			const handle1 = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts1.token,
 			);
 
@@ -365,7 +365,7 @@ describe('ChatWebSocketManager', () => {
 			const cts2 = disposables.add(new CancellationTokenSource());
 			const handle2 = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: false, turnId: 'turn-2' },
+				{ userInitiated: false, turnId: 'turn-2', requestId: 'req-2' },
 				cts2.token,
 			);
 
@@ -382,7 +382,7 @@ describe('ChatWebSocketManager', () => {
 			const cts1 = disposables.add(new CancellationTokenSource());
 			const handle1 = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: true, turnId: 'turn-1' },
+				{ userInitiated: true, turnId: 'turn-1', requestId: 'req-1' },
 				cts1.token,
 			);
 
@@ -394,7 +394,7 @@ describe('ChatWebSocketManager', () => {
 			const cts2 = disposables.add(new CancellationTokenSource());
 			const handle2 = connection.sendRequest(
 				{ model: 'test-model', messages: [], stream: true },
-				{ userInitiated: false, turnId: 'turn-2' },
+				{ userInitiated: false, turnId: 'turn-2', requestId: 'req-2' },
 				cts2.token,
 			);
 


### PR DESCRIPTION
Separate connection-level and request-level request IDs in WebSocket telemetry.

- `initiatingRequestId`: the request that opened the connection, used in connection-level telemetry
- `requestId`: per-turn request ID, stored on the active request object, used in request/turn-level telemetry
- Removed the `requestId` getter from the connection (it was stale after the first turn)