### PR TITLE
Fix: Disable button shows redundant dropdown when extension is workspace-enabled (#244138)

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1718,7 +1718,7 @@ export class DisableForWorkspaceAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier) && this.workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY)) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeWorkspaceEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
When an extension is enabled for workspace only (EnabledWorkspace state), clicking the Disable button shows a dropdown containing both "Disable" and "Disable (Workspace)" items. This is confusing because:
- Clicking "Disable" would disable the extension both globally and for workspace
- Clicking "Disable (Workspace)" would keep the extension disabled in workspace (no effective change since it's already disabled there)
The user expects that when an extension is already workspace-enabled, there should be a single "Disable" button without a dropdown.


Proposed Fix
Modified the DisableForWorkspaceAction.update() method in extensionsActions.ts to only enable when the extension is globally enabled (EnabledGlobally), not when it's workspace-enabled (EnabledWorkspace).


Changes Made
File: src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
Line 1721 - Changed the enablement check from:
&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
To:
&& this.extension.enablementState === EnablementState.EnabledGlobally


How to Test
1. Install any extension
2. Open Extensions view (Ctrl+Shift+X)
3. Right-click on the installed extension → Disable (Workspace)
4. Verify the extension shows "Enabled (Workspace)" in the extension details
5. The Disable button should now appear as a single "Disable" button without a dropdown arrow
6. Clicking it should disable the extension globally