### PR TITLE
inline chat: skip normalizeToolSchema for internal tools

### DIFF
--- a/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
@@ -49,7 +49,6 @@ import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
 import { ICompletedToolCallRound, InlineChat2Prompt, LARGE_FILE_LINE_THRESHOLD } from '../../prompts/node/inline/inlineChat2Prompt';
 import { InlineChatEditCodePrompt } from '../../prompts/node/inline/inlineChatEditCodePrompt';
 import { ToolName } from '../../tools/common/toolNames';
-import { normalizeToolSchema } from '../../tools/common/toolSchemaNormalizer';
 import { CopilotToolMode } from '../../tools/common/toolsRegistry';
 import { isToolValidationError, isValidatedToolInput, IToolsService } from '../../tools/common/toolsService';
 import { InlineChatProgressMessages } from './progressMessages';
@@ -432,20 +431,16 @@ class InlineChatEditToolsStrategy implements IInlineChatEditStrategy {
 
 		const requestOptions: IMakeChatRequestOptions['requestOptions'] = {
 			tool_choice: 'auto',
-			tools: normalizeToolSchema(
-				endpoint.family,
-				inlineChatTools.map(tool => ({
-					type: 'function',
-					function: {
-						name: tool.name,
-						description: tool.description,
-						parameters: tool.inputSchema && Object.keys(tool.inputSchema).length ? tool.inputSchema : undefined
-					},
-				})),
-				(tool, rule) => {
-					this._logService.warn(`Tool ${tool} failed validation: ${rule}`);
+			// Inline chat only uses internal tools with known-good schemas,
+			// skip expensive normalizeToolSchema validation
+			tools: inlineChatTools.map(tool => ({
+				type: 'function' as const,
+				function: {
+					name: tool.name,
+					description: tool.description,
+					parameters: tool.inputSchema && Object.keys(tool.inputSchema).length ? tool.inputSchema : undefined
 				},
-			)
+			})),
 		};
 
 		const toolCalls: IToolCall[] = [];


### PR DESCRIPTION
## Summary

Skip the expensive `normalizeToolSchema` call in inline chat's new world path (`_makeRequestAndRunTools`). Inline chat only uses internal tools with hardcoded, well-formed schemas so the defensive AJV validation is unnecessary.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **CPU profile analysis confirmed the cost**: Profiling both old and new world inline chat paths showed ~23ms spent in AJV `compileSchema`/`normalizeToolSchema` during the new world flow. This is a synchronous cost on every inline chat request.
- **Internal tool schemas are already valid**: The tools used by inline chat (`apply_patch`, `insert_edit_into_file`, `replace_string_in_file`, `multi_replace_string_in_file`, `read_file`) all have simple, well-formed JSON schemas with basic types, proper `type: "object"` wrappers, and no unsupported keywords. None of the `normalizeToolSchema` fixups apply.
- **Skip entirely rather than conditionally**: Rather than adding a flag to `normalizeToolSchema`, we remove the call entirely since inline chat's contract guarantees only internal tools with known-good schemas.

</details>

## Changes

- Remove `normalizeToolSchema` call in `InlineChatEditToolsStrategy._makeRequestAndRunTools`, replacing it with a direct tool-to-schema mapping
- Remove unused `normalizeToolSchema` import