### PR TITLE
ci: bump github runner to ubuntu-24.04 to address fontconfig crash 

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Setup system services
         run: |
           set -e
+          # Allow unprivileged user namespaces for Chromium's namespace sandbox
+          # Ubuntu 24.04 restricts this by default via AppArmor
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           # Start X server
           ./build/azure-pipelines/linux/apt-retry.sh sudo apt-get update
           ./build/azure-pipelines/linux/apt-retry.sh sudo apt-get install -y pkg-config \

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -133,6 +133,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fontconfig diagnostics and cache reset
+        run: |
+          set -e
+          echo "--- Font package versions ---"
+          dpkg -l | grep -E 'libexpat|fontconfig|libfreetype|libpango' || true
+          echo ""
+          echo "--- Installed font packages ---"
+          apt list --installed 2>/dev/null | grep -E 'fonts-|fontconfig' || true
+          echo ""
+          echo "--- Verify fonts.conf integrity ---"
+          xmllint --noout /etc/fonts/fonts.conf 2>&1 || echo "WARNING: fonts.conf is invalid or missing"
+          for f in /etc/fonts/conf.d/*.conf; do
+            xmllint --noout "$f" 2>&1 || echo "WARNING: $f is invalid"
+          done
+          echo ""
+          echo "--- Clear and rebuild font cache ---"
+          rm -rf ~/.cache/fontconfig /var/cache/fontconfig 2>/dev/null || true
+          fc-cache -f -v 2>&1 | tail -5
+          echo ""
+          echo "--- fontconfig version ---"
+          fc-cache --version 2>&1 | head -1
+        continue-on-error: true
+
       - name: Transpile client and extensions
         run: npm run gulp transpile-client-esbuild transpile-extensions
 

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -143,13 +143,22 @@ jobs:
           apt list --installed 2>/dev/null | grep -E 'fonts-|fontconfig' || true
           echo ""
           echo "--- Verify fonts.conf integrity ---"
-          xmllint --noout /etc/fonts/fonts.conf 2>&1 || echo "WARNING: fonts.conf is invalid or missing"
-          for f in /etc/fonts/conf.d/*.conf; do
-            xmllint --noout "$f" 2>&1 || echo "WARNING: $f is invalid"
-          done
+          python3 -c "
+          import xml.etree.ElementTree as ET, glob, sys
+          for f in ['/etc/fonts/fonts.conf'] + sorted(glob.glob('/etc/fonts/conf.d/*.conf')):
+              try:
+                  ET.parse(f)
+              except Exception as e:
+                  print(f'WARNING: {f} is invalid: {e}', file=sys.stderr)
+          print('Font config XML validation complete')
+          "
+          echo ""
+          echo "--- Check for symlink loops in font dirs ---"
+          find /usr/share/fonts -maxdepth 3 -type l -exec test -d {} \; -print 2>/dev/null | head -10 || true
           echo ""
           echo "--- Clear and rebuild font cache ---"
-          rm -rf ~/.cache/fontconfig /var/cache/fontconfig 2>/dev/null || true
+          sudo rm -rf /var/cache/fontconfig 2>/dev/null || true
+          rm -rf ~/.cache/fontconfig 2>/dev/null || true
           fc-cache -f -v 2>&1 | tail -5
           echo ""
           echo "--- fontconfig version ---"

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   linux-test:
     name: ${{ inputs.job_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
       NPM_ARCH: x64


### PR DESCRIPTION
For https://github.com/microsoft/vscode/actions/runs/24122759225/job/70380360453?pr=293913

```
Crash reason:  SIGSEGV /0x00000080
Crash address: 0x0
Process uptime: 1 seconds

thread_name[24]
  thread_name_rva             = 0x85d0
  thread_name                 = "[pango] FcInit"

Thread 24 (crashed)
 0  libc.so.6 + 0x44c1d
    rax = 0x0000000000000013   rdx = 0x00007f4c734ec185
    rcx = 0x00007f4c72646cbf   rbx = 0x000026180007c600
    rsi = 0x0000000000000008   rdi = 0x00007f4c734ec185
    rbp = 0x0000000000005845   rsp = 0x00007f4b5ffe34d0
     r8 = 0x0000000000000000    r9 = 0x00007f4b5ffe3520
    r10 = 0x0000000000000000   r11 = 0x0000000000000293
    r12 = 0x00cb070000000000   r13 = 0x0000000000000013
    r14 = 0x0000000000000011   r15 = 0x00007f4c734ec187
    rip = 0x00007f4c72644c1d
    Found by: given as instruction pointer in context
 1  libexpat.so.1 + 0x2288f
    rsp = 0x00007f4b5ffe3510   rip = 0x00007f4c734e588f
    Found by: stack scanning
 2  libexpat.so.1 + 0x22a49
    rsp = 0x00007f4b5ffe3540   rip = 0x00007f4c734e5a49
    Found by: stack scanning
 3  libexpat.so.1 + 0x11664
    rsp = 0x00007f4b5ffe35b0   rip = 0x00007f4c734d4664
    Found by: stack scanning
 4  libfontconfig.so.1 + 0x2e333
    rsp = 0x00007f4b5ffe35e0   rip = 0x00007f4c72138333
    Found by: stack scanning
```

**Root cause:** Chromium's `InitializeGlobalFontConfigAsync` posts `FcInit` to a thread pool worker (crbug.com/404311), while pango's pangoft2 backend independently calls `FcInit` from its own thread during GTK
initialization. Fontconfig 2.13.1 (shipped in ubuntu-22.04) lacks thread-safe initialization — concurrent first-time `FcInit` calls race and both enter `FcConfigParse`, corrupting shared global state. This causes expat (called by fontconfig to parse fonts.conf) to dereference a NULL pointer.

ubuntu-24.04 ships fontconfig 2.15.0 which includes the thread-safe initialization from 2.14+.