### PR TITLE
Add `clientByokEnabled` to `IChatEntitlementService`

### DIFF
--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -45,6 +45,7 @@ class MockChatEntitlementService implements Partial<IChatEntitlementService> {
 	readonly copilotTrackingId = undefined;
 	readonly quotas = {};
 	readonly previewFeaturesDisabled = false;
+	readonly clientByokEnabled = false;
 
 	get entitlement(): ChatEntitlement { return this.entitlementObs.get(); }
 	get sentiment(): IChatSentiment { return this.sentimentObs.get(); }

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -93,6 +93,7 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly entitlementObs: IObservable<ChatEntitlement> = observableValue('entitlement', ChatEntitlement.Free);
 
 	readonly previewFeaturesDisabled = false;
+	readonly clientByokEnabled = false;
 	readonly organisations: string[] | undefined = undefined;
 	readonly isInternal = false;
 	readonly sku = 'free';

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -886,11 +886,11 @@ export class ChatModelsWidget extends Disposable {
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IEditorProgressService private readonly editorProgressService: IEditorProgressService,
 		@ICommandService private readonly commandService: ICommandService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
 
-		this.searchFocusContextKey = CONTEXT_MODELS_SEARCH_FOCUS.bindTo(contextKeyService);
+		this.searchFocusContextKey = CONTEXT_MODELS_SEARCH_FOCUS.bindTo(this.contextKeyService);
 		this.delayedFiltering = this._register(new Delayer<void>(200));
 		this.viewModel = this._register(this.instantiationService.createInstance(ChatModelsViewModel));
 		this.element = DOM.$('.models-widget');
@@ -1016,6 +1016,11 @@ export class ChatModelsWidget extends Disposable {
 		this._register(this.viewModel.onDidChangeGrouping(() => this.createTable()));
 		this._register(this.chatEntitlementService.onDidChangeEntitlement(() => this.updateAddModelsButton()));
 		this._register(this.languageModelsService.onDidChangeLanguageModelVendors(() => this.updateAddModelsButton()));
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(new Set(['github.copilot.clientByokEnabled']))) {
+				this.updateAddModelsButton();
+			}
+		}));
 	}
 
 	private createTable(): void {
@@ -1307,6 +1312,7 @@ export class ChatModelsWidget extends Disposable {
 		const entitlement = this.chatEntitlementService.entitlement;
 		const isManagedEntitlement = entitlement === ChatEntitlement.Business || entitlement === ChatEntitlement.Enterprise;
 		const supportsAddingModels = this.chatEntitlementService.isInternal
+			|| (isManagedEntitlement && this.chatEntitlementService.clientByokEnabled)
 			|| (entitlement !== ChatEntitlement.Unknown
 				&& entitlement !== ChatEntitlement.Available
 				&& !isManagedEntitlement);

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -150,6 +150,7 @@ export interface IChatEntitlementService {
 	readonly entitlementObs: IObservable<ChatEntitlement>;
 
 	readonly previewFeaturesDisabled: boolean;
+	readonly clientByokEnabled: boolean;
 
 	readonly organisations: string[] | undefined;
 	readonly isInternal: boolean;
@@ -395,6 +396,10 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 
 	get previewFeaturesDisabled(): boolean {
 		return this.contextKeyService.getContextKeyValue<boolean>('github.copilot.previewFeaturesDisabled') === true;
+	}
+
+	get clientByokEnabled(): boolean {
+		return this.contextKeyService.getContextKeyValue<boolean>('github.copilot.clientByokEnabled') === true;
 	}
 
 	//#endregion

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -814,6 +814,7 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	markAnonymousRateLimited(): void { }
 
 	readonly previewFeaturesDisabled = false;
+	readonly clientByokEnabled = false;
 }
 
 export class TestLifecycleService extends Disposable implements ILifecycleService {


### PR DESCRIPTION
## Summary

Adds a `clientByokEnabled` boolean to `IChatEntitlementService` that reads the `github.copilot.clientByokEnabled` context key set by the Copilot Chat extension.

This enables the "Add Models" button in the Chat Models widget for Business/Enterprise users whose organization has the BYOK policy enabled.

## Behavior

1. **Only affects Business and Enterprise SKU users** — the `client_byok=1` claim is only present in Copilot tokens for these plans when the BYOK policy is enabled by their organization admin.
2. **Users will only be able to use BYOK if the BYOK policy is enabled** — the context key is set based on the Copilot token's `client_byok` claim, which is controlled server-side by the organization's policy settings.
3. **Availability in other plans is unchanged** — Free, Pro, and other plan users are unaffected; their tokens won't contain the `client_byok` claim, so the context key stays `undefined`/`false`.

## Changes

- **`chatEntitlementService.ts`**: Added `clientByokEnabled: boolean` to the `IChatEntitlementService` interface and a getter that reads `github.copilot.clientByokEnabled` via `contextKeyService`
- **`chatModelsWidget.ts`**: Added `|| this.chatEntitlementService.clientByokEnabled` to the `supportsAddingModels` check in `updateAddModelsButton()`
- **Test stubs**: Updated 3 test files with `readonly clientByokEnabled = false`

## Pattern

Follows the exact same pattern as `previewFeaturesDisabled` — the Copilot Chat extension sets the context key, and VS Code core reads it.

Companion PR in vscode-copilot-chat sets the `github.copilot.clientByokEnabled` context key from the Copilot token's `client_byok` claim.