### PR TITLE
sessions: fix in-progress description overflow in session list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -144,6 +144,7 @@
 		font-size: 12px;
 		line-height: 15px;
 		max-height: 15px;
+		overflow: hidden;
 		color: var(--vscode-descriptionForeground);
 
 		.session-details-icon {


### PR DESCRIPTION
Fixes #308283

## Problem

Long in-progress status descriptions from cloud sessions overflow the session list item's details row, causing visual artifacts ("screen cheese"). The `.session-details-row` has `max-height: 15px` but no overflow clipping, so rendered markdown content spills out.

## Fix

Add `overflow: hidden` to `.session-details-row` so content that exceeds the row's `max-height` is clipped. The child `.session-description` already has `text-overflow: ellipsis` and `white-space: nowrap`, so text truncates cleanly with an ellipsis.