### PR TITLE
remove LLM calls to detect prompts for input, add fg terminal support for `send_to_terminal`/`get_terminal_output`

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -7,7 +7,9 @@ import type { CancellationToken } from '../../../../../../base/common/cancellati
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
+import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { getOutput } from '../outputHelpers.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
 import { TerminalToolId } from './toolIds.js';
 
@@ -16,7 +18,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from a persistent terminal session previously started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
+	modelDescription: `Get output from a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -24,21 +26,30 @@ export const GetTerminalOutputToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: `The ID of the persistent terminal to check (returned by ${TerminalToolId.RunInTerminal} in async mode). This must be the exact opaque ID returned by that tool; terminal names, labels, or integers are invalid.`,
+				description: `The ID of a persistent terminal session to check (returned by ${TerminalToolId.RunInTerminal} in async mode). This must be the exact opaque ID returned by that tool; terminal names, labels, or integers are invalid. Provide either 'id' or 'terminalId', not both.`,
 				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 			},
+			terminalId: {
+				type: 'number',
+				description: 'The numeric instanceId of a terminal. Use this to get output from terminals not started by the agent (e.g., user-created terminals or foreground terminals). Provide either \'id\' or \'terminalId\', not both.'
+			},
 		},
-		required: [
-			'id',
-		]
 	}
 };
 
 export interface IGetTerminalOutputInputParams {
-	id: string;
+	id?: string;
+	terminalId?: number;
 }
 
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
+
+	constructor(
+		@ITerminalService private readonly _terminalService: ITerminalService,
+	) {
+		super();
+	}
+
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		return {
 			invocationMessage: localize('getTerminalOutput.progressive', "Checking terminal output"),
@@ -48,7 +59,39 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
 		const args = invocation.parameters as IGetTerminalOutputInputParams;
-		const execution = RunInTerminalTool.getExecution(args.id);
+
+		if (!args.id && args.terminalId === undefined) {
+			return {
+				content: [{
+					kind: 'text',
+					value: 'Error: Either \'id\' (persistent terminal UUID) or \'terminalId\' (foreground terminal instanceId) must be provided.'
+				}]
+			};
+		}
+
+		// Foreground terminal path
+		if (args.terminalId !== undefined) {
+			const instance = this._terminalService.getInstanceFromId(args.terminalId);
+			if (!instance) {
+				return {
+					content: [{
+						kind: 'text',
+						value: `Error: No terminal found with instanceId ${args.terminalId}. The terminal may have been closed.`
+					}]
+				};
+			}
+
+			const output = getOutput(instance);
+			return {
+				content: [{
+					kind: 'text',
+					value: `Output of terminal ${args.terminalId}:\n${output}`
+				}]
+			};
+		}
+
+		// Persistent (background) terminal path
+		const execution = RunInTerminalTool.getExecution(args.id!);
 		if (!execution) {
 			return {
 				content: [{

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -18,7 +18,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
+	modelDescription: `Get output from a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). For the 'id' parameter, this must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid for 'id'.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -69,8 +69,8 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 			};
 		}
 
-		// Foreground terminal path
-		if (args.terminalId !== undefined) {
+		// Foreground terminal path — only when no persistent id is provided
+		if (args.terminalId !== undefined && !args.id) {
 			const instance = this._terminalService.getInstanceFromId(args.terminalId);
 			if (!instance) {
 				return {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -430,12 +430,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private _isSensitivePrompt(prompt: string): boolean {
 		return /(password|passphrase|token|api\s*key|secret)/i.test(prompt);
 	}
-
-	/**
-	 * Returns true if the current session is in Autopilot mode (not Bypass Approvals).
-	 * In Autopilot, terminal prompts should be auto-replied to so the agent can
-	 * work autonomously from start to finish.
-	 */
 }
 
 export function matchTerminalPromptOption(options: readonly string[], suggestedOption: string): { option: string | undefined; index: number } {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -3,29 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { IMarker as XtermMarker } from '@xterm/xterm';
-import { IAction } from '../../../../../../../base/common/actions.js';
-import { timeout, type MaybePromise } from '../../../../../../../base/common/async.js';
+import { timeout } from '../../../../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
-import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Disposable, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../../base/common/lifecycle.js';
-import { URI } from '../../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../../nls.js';
-import { IChatWidgetService } from '../../../../../chat/browser/chat.js';
-import { ChatElicitationRequestPart } from '../../../../../chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
-import { ChatModel, ChatRequestModel } from '../../../../../chat/common/model/chatModel.js';
-import { ElicitationState, IChatService } from '../../../../../chat/common/chatService/chatService.js';
-import { ChatRequestTextPart } from '../../../../../chat/common/requestParser/chatParserTypes.js';
-import { OffsetRange } from '../../../../../../../editor/common/core/ranges/offsetRange.js';
-import { ChatPermissionLevel } from '../../../../../chat/common/constants.js';
 import { IToolInvocationContext } from '../../../../../chat/common/tools/languageModelToolsService.js';
 import { ITaskService } from '../../../../../tasks/common/taskService.js';
 import { ILinkLocation } from '../../taskHelpers.js';
-import { IConfirmationPrompt, IExecution, IPollingResult, OutputMonitorState, PollingConsts } from './types.js';
-import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
-import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
-import { ITerminalService } from '../../../../../terminal/browser/terminal.js';
+import { IExecution, IPollingResult, OutputMonitorState, PollingConsts } from './types.js';
 import { ITerminalLogService } from '../../../../../../../platform/terminal/common/terminal.js';
 
 export interface IOutputMonitor extends Disposable {
@@ -67,10 +53,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		return lastLine.length > 200 ? lastLine.slice(0, 200) + '…' : lastLine;
 	}
 
-	private _lastPromptMarker: XtermMarker | undefined;
-
-	private _promptPart: ChatElicitationRequestPart | undefined;
-
 	private _pollingResult: IPollingResult & { pollDurationMs: number } | undefined;
 	get pollingResult(): IPollingResult & { pollDurationMs: number } | undefined { return this._pollingResult; }
 
@@ -99,9 +81,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private readonly _onDidDetectInputNeeded = this._register(new Emitter<void>());
 	readonly onDidDetectInputNeeded: Event<void> = this._onDidDetectInputNeeded.event;
 
-	/** The chat session resource for this tool invocation, used to check permission level. */
-	private readonly _sessionResource: URI | undefined;
-
 	private _asyncMode = false;
 	private _command = '';
 	private _invocationContext: IToolInvocationContext | undefined;
@@ -114,15 +93,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		token: CancellationToken,
 		command: string,
 		@ITaskService private readonly _taskService: ITaskService,
-		@IChatService private readonly _chatService: IChatService,
-		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITerminalLogService private readonly _logService: ITerminalLogService,
-		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
 
-		this._sessionResource = invocationContext?.sessionResource;
 		this._command = command;
 		this._invocationContext = invocationContext;
 		this._register(toDisposable(() => this._currentMonitoringCts?.dispose()));
@@ -172,8 +146,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 							this._state = OutputMonitorState.PollingForIdle;
 							continue;
 						} else {
-							this._promptPart?.hide();
-							this._promptPart = undefined;
 							break;
 						}
 					}
@@ -222,15 +194,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			};
 			// Clean up idle input listener if still active
 			this._userInputListener.clear();
-			const promptPart = this._promptPart;
-			this._promptPart = undefined;
-			if (promptPart) {
-				try {
-					promptPart.hide();
-				} catch (err) {
-					this._logService.error('OutputMonitor: Failed to hide prompt', err);
-				}
-			}
 			this._onDidFinishCommand.fire();
 		}
 	}
@@ -285,7 +248,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 
 	private async _handleIdleState(token: CancellationToken): Promise<{ resources?: ILinkLocation[]; shouldContinuePolling: boolean; output?: string }> {
-		const output = this._execution.getOutput(this._lastPromptMarker);
+		const output = this._execution.getOutput();
 		this._logService.trace(`OutputMonitor: Idle output summary: len=${output.length}, lastLine=${this._formatLastLineForLog(output)}`);
 
 		if (detectsNonInteractiveHelpPattern(output)) {
@@ -306,35 +269,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		// Check for generic "press any key" prompts from scripts.
 		// Only shown for non-task executions since task finish messages are handled above.
 		if (!isTask && detectsGenericPressAnyKeyPattern(output)) {
-			this._logService.trace('OutputMonitor: Idle -> generic "press any key" detected');
-			const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
-			if (autoReply) {
-				this._logService.trace('OutputMonitor: Auto-reply enabled -> not showing free-form prompt for "press any key", stopping');
-				this._cleanupIdleInputListener();
-				return { shouldContinuePolling: false, output };
-			}
-			this._logService.trace('OutputMonitor: Requesting free-form input for "press any key"');
-			// Register a marker to track this prompt position so we don't re-detect it
-			const currentMarker = this._execution.instance.registerMarker();
-			if (currentMarker) {
-				this._lastPromptMarker = currentMarker;
-			}
+			this._logService.trace('OutputMonitor: Idle -> generic "press any key" detected, signaling agent');
+			this._onDidDetectInputNeeded.fire();
 			this._cleanupIdleInputListener();
-			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
-			const lastLine = output.trimEnd().split(/\r?\n/).pop() || '';
-			const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, {
-				prompt: lastLine,
-				options: [],
-				detectedRequestForFreeFormInput: true
-			}, true /* acceptAnyKey */);
-			if (receivedTerminalInput) {
-				this._logService.trace('OutputMonitor: Free-form input received for "press any key", continue polling');
-				await timeout(200);
-				return { shouldContinuePolling: true };
-			} else {
-				this._logService.trace('OutputMonitor: Free-form input declined for "press any key", stopping');
-				return { shouldContinuePolling: false };
-			}
+			return { shouldContinuePolling: false, output };
 		}
 
 		// Check if user already inputted since idle was detected (before we even got here)
@@ -345,32 +283,11 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		}
 
 		// In async mode, use regex-based detection for input-required patterns
-		// (passwords, [Y/n], etc.) and show elicitation UI so the user can
-		// provide input while the terminal runs in the background.
+		// (passwords, [Y/n], etc.) and signal the agent to handle via send_to_terminal.
 		if (this._asyncMode) {
 			if (detectsInputRequiredPattern(output)) {
-				this._logService.trace('OutputMonitor: Async mode - input-required pattern detected, showing free-form input');
+				this._logService.trace('OutputMonitor: Async mode - input-required pattern detected, signaling agent');
 				this._onDidDetectInputNeeded.fire();
-				const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
-				if (!autoReply) {
-					const currentMarker = this._execution.instance.registerMarker();
-					if (currentMarker) {
-						this._lastPromptMarker = currentMarker;
-					}
-					this._cleanupIdleInputListener();
-					this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
-					const lastLine = output.trimEnd().split(/\r?\n/).pop() || '';
-					const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, {
-						prompt: lastLine,
-						options: [],
-						detectedRequestForFreeFormInput: true
-					});
-					if (receivedTerminalInput) {
-						this._logService.trace('OutputMonitor: Async mode - free-form input received, continue polling');
-						await timeout(200);
-						return { shouldContinuePolling: true };
-					}
-				}
 			}
 			this._cleanupIdleInputListener();
 			return { shouldContinuePolling: false, output };
@@ -519,208 +436,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	 * In Autopilot, terminal prompts should be auto-replied to so the agent can
 	 * work autonomously from start to finish.
 	 */
-	private _isAutopilotMode(): boolean {
-		if (!this._sessionResource) {
-			return false;
-		}
-		// Check the live widget picker level
-		const widget = this._chatWidgetService.getWidgetBySessionResource(this._sessionResource)
-			?? this._chatWidgetService.lastFocusedWidget;
-		if (widget?.input.currentModeInfo.permissionLevel === ChatPermissionLevel.Autopilot) {
-			return true;
-		}
-		// Fall back to the request-stamped level
-		const model = this._chatService.getSession(this._sessionResource);
-		const request = model?.getRequests().at(-1);
-		return request?.modeInfo?.permissionLevel === ChatPermissionLevel.Autopilot;
-	}
-
-	private async _requestFreeFormTerminalInput(token: CancellationToken, execution: IExecution, confirmationPrompt: IConfirmationPrompt, acceptAnyKey: boolean = false): Promise<boolean> {
-		const focusTerminalSelection = Symbol('focusTerminalSelection');
-		const { promise: userPrompt, part } = this._createElicitationPart<boolean | typeof focusTerminalSelection>(
-			token,
-			execution.sessionResource,
-			new MarkdownString(localize('poll.terminal.inputRequest', "The terminal is awaiting input.")),
-			new MarkdownString(localize('poll.terminal.requireInput', "{0}\nPlease provide the required input to the terminal.\n\n", confirmationPrompt.prompt)),
-			'',
-			localize('poll.terminal.enterInput', 'Focus terminal'),
-			undefined,
-			() => {
-				this._showInstance(execution.instance.instanceId);
-				return focusTerminalSelection;
-			}
-		);
-
-		let inputDataDisposable: IDisposable = Disposable.None;
-		let instanceDisposedDisposable: IDisposable = Disposable.None;
-		const inputPromise = new Promise<boolean>(resolve => {
-			let settled = false;
-			const settle = (value: boolean, state: OutputMonitorState) => {
-				if (settled) {
-					return;
-				}
-				settled = true;
-				part.hide();
-				inputDataDisposable.dispose();
-				instanceDisposedDisposable.dispose();
-				this._state = state;
-				resolve(value);
-			};
-			inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
-				// For "press any key" prompts, accept any non-empty input
-				// For other free-form inputs (like passwords), only accept on Enter
-				if ((acceptAnyKey && data.length > 0) || (!acceptAnyKey && (data === '\r' || data === '\n' || data === '\r\n'))) {
-					this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
-					settle(true, OutputMonitorState.PollingForIdle);
-				}
-			}));
-			instanceDisposedDisposable = this._register(execution.instance.onDisposed(() => {
-				settle(false, OutputMonitorState.Cancelled);
-			}));
-		});
-
-		const disposeListeners = () => {
-			inputDataDisposable.dispose();
-			instanceDisposedDisposable.dispose();
-		};
-
-		const result = await Promise.race([userPrompt, inputPromise]);
-		if (result === focusTerminalSelection) {
-			execution.instance.focus(true);
-			return await inputPromise;
-		}
-		if (result === undefined) {
-			disposeListeners();
-			// Prompt was dismissed without providing input
-			return false;
-		}
-		disposeListeners();
-		return !!result;
-	}
-
-	private _showInstance(instanceId?: number): void {
-		if (!instanceId) {
-			return;
-		}
-		const instance = this._terminalService.getInstanceFromId(instanceId);
-		if (!instance) {
-			return;
-		}
-		this._terminalService.setActiveInstance(instance);
-		this._terminalService.revealActiveTerminal(true);
-	}
-	// Helper to create, register, and wire a ChatElicitationRequestPart. Returns the promise that
-	// resolves when the part is accepted/rejected and the registered part itself so callers can
-	// attach additional listeners (e.g., onDidRequestHide) or compose with other promises.
-	private _createElicitationPart<T>(
-		token: CancellationToken,
-		sessionResource: URI | undefined,
-		title: MarkdownString,
-		detail: MarkdownString,
-		subtitle: string,
-		acceptLabel: string,
-		rejectLabel?: string,
-		onAccept?: (value: IAction | true) => MaybePromise<T | undefined>,
-		onReject?: () => MaybePromise<T | undefined>,
-		moreActions?: IAction[] | undefined
-	): { promise: Promise<T | undefined>; part: ChatElicitationRequestPart } {
-		const chatModel = sessionResource && this._chatService.getSession(sessionResource);
-		if (!(chatModel instanceof ChatModel)) {
-			throw new Error('No model');
-		}
-		// In async mode the last request may be an implicit (hidden) steering request.
-		// Attach the elicitation to the last visible request so it renders in the UI.
-		const requests = chatModel.getRequests();
-		let request: ChatRequestModel | undefined;
-		if (this._asyncMode) {
-			// In async mode the previous response is already complete.
-			// Create a new system-initiated request so the data model properly
-			// represents a finished response followed by a new request/response
-			// rather than reopening the completed response.
-			const message = localize('terminalPromptDetected', "Terminal is waiting for input");
-			const parts = [new ChatRequestTextPart(new OffsetRange(0, message.length), { startColumn: 1, startLineNumber: 1, endColumn: 1, endLineNumber: 1 }, message)];
-			request = chatModel.addRequest(
-				{ text: message, parts },
-				{ variables: [] },
-				0, // attempt
-				undefined, // modeInfo
-				undefined, // chatAgent
-				undefined, // slashCommand
-				undefined, // confirmation
-				undefined, // locationData
-				undefined, // attachments
-				undefined, // isCompleteAddedRequest
-				undefined, // modelId
-				undefined, // userSelectedTools
-				undefined, // id
-				true, // isSystemInitiated
-				localize('backgroundTaskInputNeeded', "Background task `{0}` input needed", this._command), // systemInitiatedLabel
-			);
-		} else {
-			request = requests.findLast(r => !r.isSystemInitiated) ?? requests.at(-1);
-		}
-		if (!request) {
-			throw new Error('No request');
-		}
-		let part!: ChatElicitationRequestPart;
-		const asyncRequest = this._asyncMode ? request : undefined;
-		const promise = new Promise<T | undefined>(resolve => {
-			const thePart = part = new ChatElicitationRequestPart(
-				title,
-				detail,
-				subtitle,
-				acceptLabel,
-				rejectLabel,
-				async (value: IAction | true) => {
-					try {
-						const r = await (onAccept ? onAccept(value) : undefined);
-						resolve(r as T | undefined);
-						// Don't hide if return value is a Symbol (e.g., focusTerminalSelection)
-						// This keeps the elicitation visible while user focuses terminal to provide input
-						if (typeof r === 'symbol') {
-							return ElicitationState.Pending;
-						}
-					} catch {
-						resolve(undefined);
-					}
-					thePart.hide();
-					this._promptPart = undefined;
-					asyncRequest?.response?.complete();
-					return ElicitationState.Accepted;
-				},
-				async () => {
-					try {
-						const r = await (onReject ? onReject() : undefined);
-						resolve(r as T | undefined);
-						// Don't hide if return value is a Symbol (e.g., focusTerminalSelection)
-						// This keeps the elicitation visible while user focuses terminal to provide input
-						if (typeof r === 'symbol') {
-							return ElicitationState.Pending;
-						}
-					} catch {
-						resolve(undefined);
-					}
-					thePart.hide();
-					this._promptPart = undefined;
-					asyncRequest?.response?.complete();
-					return ElicitationState.Rejected;
-				},
-				undefined, // source
-				moreActions,
-				() => this._outputMonitorTelemetryCounters.inputToolManualShownCount++
-			);
-
-			chatModel.acceptResponseProgress(request, thePart);
-			this._promptPart = thePart;
-		});
-
-		this._register(token.onCancellationRequested(() => {
-			part.hide();
-			asyncRequest?.response?.complete();
-		}));
-
-		return { promise, part };
-	}
 }
 
 export function matchTerminalPromptOption(options: readonly string[], suggestedOption: string): { option: string | undefined; index: number } {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -10,7 +10,6 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../..
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Disposable, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../../base/common/lifecycle.js';
-import { isObject, isString } from '../../../../../../../base/common/types.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../../nls.js';
 import { IChatWidgetService } from '../../../../../chat/browser/chat.js';
@@ -19,8 +18,7 @@ import { ChatModel, ChatRequestModel } from '../../../../../chat/common/model/ch
 import { ElicitationState, IChatService } from '../../../../../chat/common/chatService/chatService.js';
 import { ChatRequestTextPart } from '../../../../../chat/common/requestParser/chatParserTypes.js';
 import { OffsetRange } from '../../../../../../../editor/common/core/ranges/offsetRange.js';
-import { ChatAgentLocation, ChatPermissionLevel } from '../../../../../chat/common/constants.js';
-import { ChatMessageRole, getTextResponseFromStream, type ILanguageModelChatSelector, ILanguageModelsService } from '../../../../../chat/common/languageModels.js';
+import { ChatPermissionLevel } from '../../../../../chat/common/constants.js';
 import { IToolInvocationContext } from '../../../../../chat/common/tools/languageModelToolsService.js';
 import { ITaskService } from '../../../../../tasks/common/taskService.js';
 import { ILinkLocation } from '../../taskHelpers.js';
@@ -35,6 +33,7 @@ export interface IOutputMonitor extends Disposable {
 	readonly outputMonitorTelemetryCounters: IOutputMonitorTelemetryCounters;
 
 	readonly onDidFinishCommand: Event<void>;
+	readonly onDidDetectInputNeeded: Event<void>;
 }
 
 export interface IOutputMonitorTelemetryCounters {
@@ -68,20 +67,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		return lastLine.length > 200 ? lastLine.slice(0, 200) + '…' : lastLine;
 	}
 
-	private _formatOptionsForLog(options: readonly string[]): string {
-		if (!options.length) {
-			return '[]';
-		}
-		// Keep bounded and single-line.
-		const maxOptions = 12;
-		const shown = options.slice(0, maxOptions).map(o => o.replace(/\r?\n/g, 'return'));
-		const suffix = options.length > maxOptions ? `, …(+${options.length - maxOptions})` : '';
-		return `[${shown.join(', ')}${suffix}]`;
-	}
-
 	private _lastPromptMarker: XtermMarker | undefined;
-
-	private _lastPrompt: string | undefined;
 
 	private _promptPart: ChatElicitationRequestPart | undefined;
 
@@ -110,6 +96,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private readonly _onDidFinishCommand = this._register(new Emitter<void>());
 	readonly onDidFinishCommand: Event<void> = this._onDidFinishCommand.event;
 
+	private readonly _onDidDetectInputNeeded = this._register(new Emitter<void>());
+	readonly onDidDetectInputNeeded: Event<void> = this._onDidDetectInputNeeded.event;
+
 	/** The chat session resource for this tool invocation, used to check permission level. */
 	private readonly _sessionResource: URI | undefined;
 
@@ -124,7 +113,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		invocationContext: IToolInvocationContext | undefined,
 		token: CancellationToken,
 		command: string,
-		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@ITaskService private readonly _taskService: ITaskService,
 		@IChatService private readonly _chatService: IChatService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
@@ -356,13 +344,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			return { shouldContinuePolling: true };
 		}
 
-		// In async mode, skip the LLM-based prompt detection to avoid expensive calls
-		// on every idle cycle. Instead, use regex-based detection for input-required
-		// patterns (passwords, [Y/n], etc.) which were already detected in _waitForIdle
-		// but need elicitation UI shown here.
+		// In async mode, use regex-based detection for input-required patterns
+		// (passwords, [Y/n], etc.) and show elicitation UI so the user can
+		// provide input while the terminal runs in the background.
 		if (this._asyncMode) {
 			if (detectsInputRequiredPattern(output)) {
 				this._logService.trace('OutputMonitor: Async mode - input-required pattern detected, showing free-form input');
+				this._onDidDetectInputNeeded.fire();
 				const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
 				if (!autoReply) {
 					const currentMarker = this._execution.instance.registerMarker();
@@ -388,77 +376,15 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			return { shouldContinuePolling: false, output };
 		}
 
-		this._logService.trace('OutputMonitor: Determining user input options via language model');
-		const confirmationPrompt = await this._determineUserInputOptions(this._execution, token);
-		this._logService.trace(`OutputMonitor: Input options result: ${confirmationPrompt ? `prompt=${this._formatLastLineForLog(confirmationPrompt.prompt)}, options=${confirmationPrompt.options.length} ${this._formatOptionsForLog(confirmationPrompt.options)}, freeForm=${!!confirmationPrompt.detectedRequestForFreeFormInput}` : 'none'}`);
-
-		// Check again after the async LLM call - user may have inputted while we were analyzing
-		if (this._userInputtedSinceIdleDetected) {
-			this._logService.trace('OutputMonitor: User input arrived during input-option analysis; continuing polling');
+		// Use regex-based detection for input-required patterns (passwords, [Y/n], etc.)
+		// In foreground mode, fire the event so the race in runInTerminalTool can pick it
+		// up and return control to the agent (which uses send_to_terminal to provide input).
+		// No elicitation UI is shown — the agent handles it autonomously.
+		if (detectsInputRequiredPattern(output)) {
+			this._logService.trace('OutputMonitor: Input-required pattern detected, signaling agent');
+			this._onDidDetectInputNeeded.fire();
 			this._cleanupIdleInputListener();
-			return { shouldContinuePolling: true };
-		}
-
-		if (confirmationPrompt?.detectedRequestForFreeFormInput) {
-			// Check again right before showing prompt
-			if (this._userInputtedSinceIdleDetected) {
-				this._logService.trace('OutputMonitor: User input arrived before showing free-form prompt; continuing polling');
-				this._cleanupIdleInputListener();
-				return { shouldContinuePolling: true };
-			}
-			const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
-			if (autoReply) {
-				this._logService.trace('OutputMonitor: Auto-reply enabled -> not propagating free-form prompt, stopping');
-				this._cleanupIdleInputListener();
-				return { shouldContinuePolling: false, output };
-			}
-			// Clean up the input listener now - the prompt will set up its own
-			this._cleanupIdleInputListener();
-			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
-			this._logService.trace('OutputMonitor: Showing free-form input elicitation');
-			const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, confirmationPrompt);
-			if (receivedTerminalInput) {
-				// Small delay to ensure input is processed
-				this._logService.trace('OutputMonitor: Free-form input received; continuing polling');
-				await timeout(200);
-				// Continue polling as we sent the input
-				return { shouldContinuePolling: true };
-			} else {
-				// User declined
-				this._logService.trace('OutputMonitor: Free-form input declined; stopping');
-				return { shouldContinuePolling: false };
-			}
-		}
-
-		if (confirmationPrompt?.options.length) {
-			this._logService.trace(`OutputMonitor: Showing option-based input flow (options=${confirmationPrompt.options.length})`);
-			const suggestedOptionResult = await this._selectAndHandleOption(confirmationPrompt, token);
-			this._logService.trace(`OutputMonitor: Suggested option result: ${suggestedOptionResult?.suggestedOption ? 'hasSuggestion' : 'none'} (autoSent=${!!suggestedOptionResult?.sentToTerminal})`);
-			if (suggestedOptionResult?.sentToTerminal) {
-				// Continue polling as we sent the input
-				this._cleanupIdleInputListener();
-				return { shouldContinuePolling: true };
-			}
-			// Check again after LLM call - user may have inputted while we were selecting option
-			if (this._userInputtedSinceIdleDetected) {
-				this._logService.trace('OutputMonitor: User input arrived during option selection; continuing polling');
-				this._cleanupIdleInputListener();
-				return { shouldContinuePolling: true };
-			}
-			// Clean up the input listener now - the prompt will set up its own
-			this._cleanupIdleInputListener();
-			this._logService.trace('OutputMonitor: Showing confirmation elicitation for suggested option');
-			const confirmed = await this._confirmRunInTerminal(token, suggestedOptionResult?.suggestedOption ?? confirmationPrompt.options[0], this._execution, confirmationPrompt);
-			if (confirmed) {
-				// Continue polling as we sent the input
-				this._logService.trace('OutputMonitor: Option confirmed/sent; continuing polling');
-				return { shouldContinuePolling: true };
-			} else {
-				// User declined
-				this._logService.trace('OutputMonitor: Option declined; stopping');
-				this._execution.instance.focus(true);
-				return { shouldContinuePolling: false };
-			}
+			return { shouldContinuePolling: false, output };
 		}
 
 		// Clean up input listener before custom poll
@@ -584,105 +510,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		this._userInputListener.clear();
 	}
 
-	private async _determineUserInputOptions(execution: IExecution, token: CancellationToken): Promise<IConfirmationPrompt | undefined> {
-		if (token.isCancellationRequested) {
-			this._logService.trace('OutputMonitor: determineUserInputOptions cancelled before start');
-			return;
-		}
-		const model = await this._getLanguageModel();
-		if (!model) {
-			this._logService.trace('OutputMonitor: determineUserInputOptions no language model available');
-			return undefined;
-		}
-		const lastLines = execution.getOutput(this._lastPromptMarker).trimEnd().split('\n').slice(-15).join('\n');
-		this._logService.trace(`OutputMonitor: determineUserInputOptions analyzing lastLines (len=${lastLines.length})`);
-
-		if (detectsNonInteractiveHelpPattern(lastLines)) {
-			return undefined;
-		}
-
-		const promptText =
-			`Analyze the following terminal output. If it contains a prompt requesting user input (such as a confirmation, selection, or yes/no question) that appears at the VERY END of the output and has NOT already been answered (i.e., there is no user response or subsequent output after the prompt), extract the prompt text. IMPORTANT: Only detect prompts that are at the end of the output with no content following them - if there is any output after the prompt, the prompt has already been answered and you should return null. The prompt may ask to choose from a set. If so, extract the possible options as a JSON object with keys 'prompt', 'options' (an array of strings or an object with option to description mappings), and 'freeFormInput': false. If no options are provided, and free form input is requested, return a JSON object with keys 'prompt', 'options', 'freeFormInput': true, and 'input'. The 'input' field should be the exact text to type only when the output explicitly states what to type (for example, Type "exit" to quit). If there is no explicit input, set 'input' to null. For Enter, set 'input' to "\\r". If the option is ambiguous, return null.
-			Examples:
-			1. Output: "Do you want to overwrite? (y/n)"
-				Response: {"prompt": "Do you want to overwrite?", "options": ["y", "n"], "freeFormInput": false}
-
-			2. Output: "Confirm: [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [C] Cancel"
-				Response: {"prompt": "Confirm", "options": ["Y", "A", "N", "L", "C"], "freeFormInput": false}
-
-			3. Output: "Accept license terms? (yes/no)"
-				Response: {"prompt": "Accept license terms?", "options": ["yes", "no"], "freeFormInput": false}
-
-			4. Output: "Press Enter to continue"
-				Response: {"prompt": "Press Enter to continue", "options": ["Enter"], "freeFormInput": false}
-
-			5. Output: "Type Yes to proceed"
-				Response: {"prompt": "Type Yes to proceed", "options": ["Yes"], "freeFormInput": false}
-
-			6. Output: "Continue [y/N]"
-				Response: {"prompt": "Continue", "options": ["y", "N"], "freeFormInput": false}
-
-			7. Output: "Password:"
-				Response: {"prompt": "Password:", "freeFormInput": true, "options": [], "input": null}
-			8. Output: "press ctrl-c to detach, ctrl-d to kill"
-				Response: null
-			9. Output: "Continue (y/n)? y"
-				Response: null (the prompt was already answered with 'y')
-			10. Output: "Do you want to proceed? (yes/no)\nyes\nProceeding with operation..."
-				Response: null (the prompt was already answered and there is subsequent output)
-
-			Alternatively, the prompt may request free form input, for example:
-			1. Output: "Enter your username:"
-				Response: {"prompt": "Enter your username:", "freeFormInput": true, "options": [], "input": null}
-			2. Output: "Password:"
-				Response: {"prompt": "Password:", "freeFormInput": true, "options": [], "input": null}
-			3. Output: "Press any key to continue..."
-				Response: {"prompt": "Press any key to continue...", "freeFormInput": true, "options": [], "input": "\\r"}
-			4. Output: "Type 'exit' to quit the game."
-				Response: {"prompt": "Type 'exit' to quit the game.", "freeFormInput": true, "options": [], "input": "exit"}
-			Now, analyze this output:
-			${lastLines}
-			`;
-
-		const response = await this._languageModelsService.sendChatRequest(model, undefined, [{ role: ChatMessageRole.User, content: [{ type: 'text', value: promptText }] }], {}, token);
-		const responseText = await getTextResponseFromStream(response);
-		try {
-			const match = responseText.match(/\{[\s\S]*\}/);
-			if (match) {
-				const parsed = JSON.parse(match[0]) as unknown;
-				if (
-					isObject(parsed) &&
-					Object.hasOwn(parsed, 'prompt') && isString((parsed as Record<string, unknown>).prompt) &&
-					Object.hasOwn(parsed, 'options') &&
-					Object.hasOwn(parsed, 'freeFormInput') && typeof (parsed as Record<string, unknown>).freeFormInput === 'boolean'
-				) {
-					const obj = parsed as { prompt: string; options: unknown; freeFormInput: boolean; input?: unknown };
-					if (this._lastPrompt === obj.prompt) {
-						this._logService.trace('OutputMonitor: determineUserInputOptions ignoring duplicate prompt');
-						return;
-					}
-					if (obj.freeFormInput === true) {
-						const suggestedInput = isString(obj.input) && obj.input.trim().length ? obj.input.trim() : undefined;
-						return { prompt: obj.prompt, options: [], detectedRequestForFreeFormInput: true, suggestedInput };
-					}
-					if (Array.isArray(obj.options) && obj.options.every(isString)) {
-						return { prompt: obj.prompt, options: obj.options, detectedRequestForFreeFormInput: obj.freeFormInput };
-					} else if (isObject(obj.options) && Object.values(obj.options).every(isString)) {
-						const keys = Object.keys(obj.options);
-						if (keys.length === 0) {
-							return undefined;
-						}
-						const descriptions = keys.map(key => (obj.options as Record<string, string>)[key]);
-						return { prompt: obj.prompt, options: keys, descriptions, detectedRequestForFreeFormInput: obj.freeFormInput };
-					}
-				}
-			}
-		} catch (err) {
-			this._logService.trace('OutputMonitor: Failed to parse confirmation prompt from language model response', err);
-		}
-		return undefined;
-	}
-
 	private _isSensitivePrompt(prompt: string): boolean {
 		return /(password|passphrase|token|api\s*key|secret)/i.test(prompt);
 	}
@@ -706,90 +533,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const model = this._chatService.getSession(this._sessionResource);
 		const request = model?.getRequests().at(-1);
 		return request?.modeInfo?.permissionLevel === ChatPermissionLevel.Autopilot;
-	}
-
-	private async _selectAndHandleOption(
-		confirmationPrompt: IConfirmationPrompt | undefined,
-		token: CancellationToken,
-	): Promise<ISuggestedOptionResult | undefined> {
-		if (!confirmationPrompt?.options.length) {
-			return undefined;
-		}
-		const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
-		let model = this._chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Chat)[0]?.input.currentLanguageModel;
-		if (model) {
-			const models = await this._safeSelectLanguageModels({ vendor: 'copilot', family: model.replaceAll('copilot/', '') });
-			model = models[0];
-		}
-		if (!model) {
-			model = await this._getLanguageModel();
-		}
-		const prompt = confirmationPrompt.prompt;
-		const options = confirmationPrompt.options;
-
-		const currentMarker = this._execution.instance.registerMarker();
-		if (!currentMarker) {
-			// Unable to register marker, so cannot track prompt location
-			return undefined;
-		}
-
-		this._lastPromptMarker = currentMarker;
-		this._lastPrompt = prompt;
-
-		let suggestedOption = '';
-		if (model) {
-			try {
-				const promptText = `Given the following confirmation prompt and options from a terminal output, which option is the default?\nPrompt: "${prompt}"\nOptions: ${JSON.stringify(options)}\nRespond with only the option string.`;
-				const response = await this._languageModelsService.sendChatRequest(model, undefined, [
-					{ role: ChatMessageRole.User, content: [{ type: 'text', value: promptText }] }
-				], {}, token);
-
-				suggestedOption = (await getTextResponseFromStream(response)).trim();
-			} catch (err) {
-				this._logService.trace('OutputMonitor: Failed to get suggested option from model', err);
-			}
-		} else if (!autoReply) {
-			return undefined;
-		}
-
-		let validOption: string;
-		let index: number;
-
-		if (!suggestedOption) {
-			// No suggestion from LLM - fall back to first option if autoReply is enabled
-			if (autoReply) {
-				validOption = options[0];
-				index = 0;
-				this._logService.trace(`OutputMonitor: No LLM suggestion, falling back to first option: ${validOption}`);
-			} else {
-				return;
-			}
-		} else {
-			const match = matchTerminalPromptOption(confirmationPrompt.options, suggestedOption);
-			if (!match.option || match.index === -1) {
-				// LLM suggestion didn't match any option - fall back to first option if autoReply is enabled
-				if (autoReply) {
-					validOption = options[0];
-					index = 0;
-					this._logService.trace(`OutputMonitor: LLM suggestion '${suggestedOption}' didn't match options, falling back to first option: ${validOption}`);
-				} else {
-					return;
-				}
-			} else {
-				validOption = match.option;
-				index = match.index;
-			}
-		}
-
-		let sentToTerminal = false;
-		if (autoReply) {
-			await this._execution.instance.sendText(validOption, true);
-			this._outputMonitorTelemetryCounters.inputToolAutoAcceptCount++;
-			this._outputMonitorTelemetryCounters.inputToolAutoChars += validOption?.length || 0;
-			sentToTerminal = true;
-		}
-		const description = confirmationPrompt.descriptions?.[index];
-		return description ? { suggestedOption: { description, option: validOption }, sentToTerminal } : { suggestedOption: validOption, sentToTerminal };
 	}
 
 	private async _requestFreeFormTerminalInput(token: CancellationToken, execution: IExecution, confirmationPrompt: IConfirmationPrompt, acceptAnyKey: boolean = false): Promise<boolean> {
@@ -853,82 +596,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		}
 		disposeListeners();
 		return !!result;
-	}
-
-	private async _confirmRunInTerminal(token: CancellationToken, suggestedOption: SuggestedOption, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<string | boolean | undefined> {
-		const suggestedOptionValue = isString(suggestedOption) ? suggestedOption : suggestedOption.option;
-		const focusTerminalSelection = Symbol('focusTerminalSelection');
-		let inputDataDisposable: IDisposable = Disposable.None;
-		let instanceDisposedDisposable: IDisposable = Disposable.None;
-		const { promise: userPrompt, part } = this._createElicitationPart<string | boolean | typeof focusTerminalSelection | undefined>(
-			token,
-			execution.sessionResource,
-			new MarkdownString(localize('poll.terminal.confirmRequired', "The terminal is awaiting input.")),
-			new MarkdownString(localize('poll.terminal.confirmRunDetail', "{0}\n Do you want to send `{1}`{2} followed by `Enter` to the terminal?", confirmationPrompt.prompt, suggestedOptionValue, isString(suggestedOption) ? '' : suggestedOption.description ? ' (' + suggestedOption.description + ')' : '')),
-			'',
-			localize('poll.terminal.acceptRun', 'Allow'),
-			localize('poll.terminal.rejectRun', 'Focus Terminal'),
-			async (value: IAction | true) => {
-				let option: string | undefined = undefined;
-				if (value === true) {
-					option = suggestedOptionValue;
-				} else if (typeof value === 'object' && Object.hasOwn(value, 'label')) {
-					option = value.label.split(' (')[0];
-				}
-				this._outputMonitorTelemetryCounters.inputToolManualAcceptCount++;
-				this._outputMonitorTelemetryCounters.inputToolManualChars += option?.length || 0;
-				return option;
-			},
-			() => {
-				this._showInstance(execution.instance.instanceId);
-				this._outputMonitorTelemetryCounters.inputToolManualRejectCount++;
-				return focusTerminalSelection;
-			},
-			getMoreActions(suggestedOption, confirmationPrompt)
-		);
-		const inputPromise = new Promise<boolean>(resolve => {
-			let settled = false;
-			const settle = (value: boolean, state: OutputMonitorState) => {
-				if (settled) {
-					return;
-				}
-				settled = true;
-				part.hide();
-				inputDataDisposable.dispose();
-				instanceDisposedDisposable.dispose();
-				this._state = state;
-				resolve(value);
-			};
-			inputDataDisposable = this._register(execution.instance.onDidInputData(() => {
-				settle(true, OutputMonitorState.PollingForIdle);
-			}));
-			instanceDisposedDisposable = this._register(execution.instance.onDisposed(() => {
-				settle(false, OutputMonitorState.Cancelled);
-			}));
-		});
-
-		const disposeListeners = () => {
-			inputDataDisposable.dispose();
-			instanceDisposedDisposable.dispose();
-		};
-
-		const optionToRun = await Promise.race([userPrompt, inputPromise]);
-		if (optionToRun === focusTerminalSelection) {
-			execution.instance.focus(true);
-			return await inputPromise;
-		}
-		if (optionToRun === true) {
-			disposeListeners();
-			return true;
-		}
-		if (typeof optionToRun === 'string' && optionToRun.length) {
-			execution.instance.focus(true);
-			disposeListeners();
-			await execution.instance.sendText(optionToRun, true);
-			return optionToRun;
-		}
-		disposeListeners();
-		return optionToRun;
 	}
 
 	private _showInstance(instanceId?: number): void {
@@ -1054,64 +721,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 		return { promise, part };
 	}
-
-	private async _getLanguageModel(): Promise<string | undefined> {
-		const fastModels = await this._safeSelectLanguageModels({ vendor: 'copilot', id: 'copilot-fast' });
-		if (fastModels.length) {
-			return fastModels[0];
-		}
-
-		const widget = this._chatWidgetService.lastFocusedWidget ?? this._chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Chat)[0];
-		const currentModel = widget?.input.currentLanguageModel;
-		if (currentModel) {
-			const currentFamilyModels = await this._safeSelectLanguageModels({ vendor: 'copilot', family: currentModel.replaceAll('copilot/', '') });
-			if (currentFamilyModels.length) {
-				return currentFamilyModels[0];
-			}
-		}
-
-		const copilotModels = await this._safeSelectLanguageModels({ vendor: 'copilot' });
-		if (copilotModels.length) {
-			return copilotModels[0];
-		}
-
-		return undefined;
-	}
-
-	private async _safeSelectLanguageModels(selector: ILanguageModelChatSelector): Promise<string[]> {
-		try {
-			return await this._languageModelsService.selectLanguageModels(selector);
-		} catch (error) {
-			this._logService.trace('OutputMonitor: selectLanguageModels failed', { selector, error });
-			return [];
-		}
-	}
-}
-
-function getMoreActions(suggestedOption: SuggestedOption, confirmationPrompt: IConfirmationPrompt): IAction[] | undefined {
-	const moreActions: IAction[] = [];
-	const moreOptions = confirmationPrompt.options.filter(a => a !== (isString(suggestedOption) ? suggestedOption : suggestedOption.option));
-	let i = 0;
-	for (const option of moreOptions) {
-		const label = option + (confirmationPrompt.descriptions ? ' (' + confirmationPrompt.descriptions[i] + ')' : '');
-		const action = {
-			label,
-			tooltip: label,
-			id: `terminal.poll.send.${option}`,
-			class: undefined,
-			enabled: true,
-			run: async () => { }
-		};
-		i++;
-		moreActions.push(action);
-	}
-	return moreActions.length ? moreActions : undefined;
-}
-
-type SuggestedOption = string | { description: string; option: string };
-interface ISuggestedOptionResult {
-	suggestedOption?: SuggestedOption;
-	sentToTerminal?: boolean;
 }
 
 export function matchTerminalPromptOption(options: readonly string[], suggestedOption: string): { option: string | undefined; index: number } {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1255,13 +1255,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					// Output monitor detected the terminal is waiting for input.
 					// Convert to background so the terminal stays alive for send_to_terminal.
 					this._logService.debug(`RunInTerminalTool: Output monitor detected input needed in foreground terminal, returning output to agent`);
-					pollingResult = outputMonitor?.pollingResult;
 					error = 'inputNeeded';
 					isBackgroundExecution = true;
 					toolTerminal.isBackground = true;
 					this._sessionTerminalAssociations.delete(chatSessionResource);
 					await this._associateProcessIdWithSession(toolTerminal.instance, chatSessionResource, termId, toolTerminal.shellIntegrationQuality, true);
-					const idleOutput = pollingResult?.output ?? execution.getOutput();
+					// Read output directly from the execution rather than from pollingResult,
+					// because the output monitor may not have set pollingResult yet at this point
+					// (it is written in the finally block after onDidFinishCommand).
+					const idleOutput = execution.getOutput();
 					outputLineCount = idleOutput ? count(idleOutput.trim(), '\n') + 1 : 0;
 					terminalResult = idleOutput ?? '';
 				} else if (raceResult.type === 'background') {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1464,7 +1464,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			const notificationHint = this._configurationService.getValue(TerminalChatAgentToolsSettingId.BackgroundNotifications)
 				? ' You will be automatically notified on your next turn when it completes.'
 				: '';
-			resultText.push(`Note: Command timed out after ${timeoutValue}ms. The command may still be running in terminal ID ${termId}.${notificationHint} Use ${TerminalToolId.GetTerminalOutput} to check output before then, ${TerminalToolId.SendToTerminal} to send further input, or ${TerminalToolId.KillTerminal} to stop it. Do NOT use sleep or manual polling to wait.\n\n`);
+			resultText.push(`Note: Command timed out after ${timeoutValue}ms. The command may still be running in terminal ID ${termId}.${notificationHint} Use ${TerminalToolId.GetTerminalOutput} to check output before then, ${TerminalToolId.SendToTerminal} to send further input, or ${TerminalToolId.KillTerminal} to stop it. Do NOT use sleep or manual polling to wait. Evaluate the terminal output to determine if the command is waiting for input (e.g. a password prompt, confirmation, or interactive question). A normal shell prompt does NOT count as waiting for input.\n\n`);
 		}
 		const outputAnalyzerMessage = await this._getOutputAnalyzerMessage(exitCode, terminalResult, command, didSandboxWrapCommand);
 		if (outputAnalyzerMessage) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1212,9 +1212,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					resultText += pollingResult.output;
 					const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 					if (isAutoApproved) {
-						resultText += `\nIf the command is waiting for input, you MUST determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.`;
+						resultText += `\nEvaluate the terminal output to determine if the command is waiting for input (e.g. a password prompt, confirmation, or interactive question). A normal shell prompt does NOT count as waiting for input. If it IS waiting for input, determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.`;
 					} else {
-						resultText += `\nIf the command is waiting for input, you MUST call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.`;
+						resultText += `\nEvaluate the terminal output to determine if the command is waiting for input (e.g. a password prompt, confirmation, or interactive question). A normal shell prompt does NOT count as waiting for input. If it IS waiting for input, call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.`;
 					}
 				} else if (pollingResult) {
 					resultText += `\n The command is still running, with output:\n`;
@@ -1456,9 +1456,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (didInputNeeded) {
 			const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 			if (isAutoApproved) {
-				resultText.push(`Note: The command is running in terminal ID ${termId} and is waiting for input. You MUST determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.\n\n`);
+				resultText.push(`Note: The command is running in terminal ID ${termId} and may be waiting for input. Evaluate the terminal output to determine if the command is actually waiting for input (e.g. a password prompt, confirmation, or interactive question). A normal shell prompt does NOT count as waiting for input. If it IS waiting for input, determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.\n\n`);
 			} else {
-				resultText.push(`Note: The command is running in terminal ID ${termId} and is waiting for input. You MUST call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.\n\n`);
+				resultText.push(`Note: The command is running in terminal ID ${termId} and may be waiting for input. Evaluate the terminal output to determine if the command is actually waiting for input (e.g. a password prompt, confirmation, or interactive question). A normal shell prompt does NOT count as waiting for input. If it IS waiting for input, call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.\n\n`);
 			}
 		} else if (didTimeout && timeoutValue !== undefined && timeoutValue > 0) {
 			const notificationHint = this._configurationService.getValue(TerminalChatAgentToolsSettingId.BackgroundNotifications)

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1069,6 +1069,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		let exitCode: number | undefined;
 		let altBufferResult: IToolResult | undefined;
 		let didTimeout = false;
+		let didInputNeeded = false;
 		// Covers both terminals that start as background (persistentSession) and
 		// foreground terminals that later move to background (timeout/continue-in-bg).
 		let isBackgroundExecution = executionOptions.persistentSession;
@@ -1209,6 +1210,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}
 					resultText += pollingResult.output;
+					const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
+					if (isAutoApproved) {
+						resultText += `\nIf the command is waiting for input, you MUST determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.`;
+					} else {
+						resultText += `\nIf the command is waiting for input, you MUST call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.`;
+					}
 				} else if (pollingResult) {
 					resultText += `\n The command is still running, with output:\n`;
 					if (outputAnalyzerMessage) {
@@ -1256,6 +1263,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					// Convert to background so the terminal stays alive for send_to_terminal.
 					this._logService.debug(`RunInTerminalTool: Output monitor detected input needed in foreground terminal, returning output to agent`);
 					error = 'inputNeeded';
+					didInputNeeded = true;
 					isBackgroundExecution = true;
 					toolTerminal.isBackground = true;
 					this._sessionTerminalAssociations.delete(chatSessionResource);
@@ -1445,7 +1453,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				resultText.push(`Note: This terminal execution was moved to the background using the ID ${termId}\n`);
 			}
 		}
-		if (didTimeout && timeoutValue !== undefined && timeoutValue > 0) {
+		if (didInputNeeded) {
+			const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
+			if (isAutoApproved) {
+				resultText.push(`Note: The command is running in terminal ID ${termId} and is waiting for input. You MUST determine the appropriate response from context and immediately call ${TerminalToolId.SendToTerminal} with id "${termId}" to provide it.\n\n`);
+			} else {
+				resultText.push(`Note: The command is running in terminal ID ${termId} and is waiting for input. You MUST call the askQuestions tool to ask the user what input to provide, then call ${TerminalToolId.SendToTerminal} with id "${termId}" to send their response.\n\n`);
+			}
+		} else if (didTimeout && timeoutValue !== undefined && timeoutValue > 0) {
 			const notificationHint = this._configurationService.getValue(TerminalChatAgentToolsSettingId.BackgroundNotifications)
 				? ' You will be automatically notified on your next turn when it completes.'
 				: '';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1221,6 +1221,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					toolMetadata: {
 						exitCode: undefined,
 						id: termId,
+						terminalId: toolTerminal.instance.instanceId,
 						cwd: endCwd?.toString(),
 					},
 					content: [{
@@ -1229,17 +1230,41 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					}],
 				};
 			} else {
-				// Foreground mode: race execution completion against continue in background
-				const raceCandidates: Promise<{ type: 'completed'; result: ITerminalExecuteStrategyResult } | { type: 'background' } | { type: 'timeout' }>[] = [
+				// Foreground mode: race execution completion against continue in background.
+				// Also race on output monitor input-needed so that interactive prompts
+				// return output to the agent early instead of waiting for timeout.
+				const raceCleanup = new DisposableStore();
+				const raceCandidates: Promise<{ type: 'completed'; result: ITerminalExecuteStrategyResult } | { type: 'background' } | { type: 'timeout' } | { type: 'inputNeeded' }>[] = [
 					executionPromise.then(result => ({ type: 'completed' as const, result })),
-					continueInBackgroundPromise.then(() => ({ type: 'background' as const }))
+					continueInBackgroundPromise.then(() => ({ type: 'background' as const })),
+					new Promise<{ type: 'inputNeeded' }>(resolve => {
+						startMarkerPromise.then(() => {
+							if (outputMonitor && !raceCleanup.isDisposed) {
+								raceCleanup.add(outputMonitor.onDidDetectInputNeeded(() => resolve({ type: 'inputNeeded' as const })));
+							}
+						});
+					})
 				];
 				if (timeoutRacePromise) {
 					raceCandidates.push(timeoutRacePromise);
 				}
 				const raceResult = await Promise.race(raceCandidates);
+				raceCleanup.dispose();
 
-				if (raceResult.type === 'background') {
+				if (raceResult.type === 'inputNeeded') {
+					// Output monitor detected the terminal is waiting for input.
+					// Convert to background so the terminal stays alive for send_to_terminal.
+					this._logService.debug(`RunInTerminalTool: Output monitor detected input needed in foreground terminal, returning output to agent`);
+					pollingResult = outputMonitor?.pollingResult;
+					error = 'inputNeeded';
+					isBackgroundExecution = true;
+					toolTerminal.isBackground = true;
+					this._sessionTerminalAssociations.delete(chatSessionResource);
+					await this._associateProcessIdWithSession(toolTerminal.instance, chatSessionResource, termId, toolTerminal.shellIntegrationQuality, true);
+					const idleOutput = pollingResult?.output ?? execution.getOutput();
+					outputLineCount = idleOutput ? count(idleOutput.trim(), '\n') + 1 : 0;
+					terminalResult = idleOutput ?? '';
+				} else if (raceResult.type === 'background') {
 					// Moved to background - execution continues running, just return current output
 					this._logService.debug(`RunInTerminalTool: Continue in background triggered, returning output collected so far`);
 					error = 'continueInBackground';
@@ -1279,6 +1304,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 							toolMetadata: {
 								exitCode: undefined,
 								id: termId,
+								terminalId: toolTerminal.instance.instanceId,
 								cwd: altBufferCwd?.toString(),
 							},
 							content: [{
@@ -1439,6 +1465,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			toolMetadata: {
 				exitCode: exitCode,
 				id: termId,
+				terminalId: toolTerminal.instance.instanceId,
 				cwd: endCwd?.toString(),
 				timedOut: didTimeout || undefined,
 				timeoutMs: didTimeout ? timeoutValue : undefined,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -5,10 +5,11 @@
 
 import type { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { createCommandUri, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
+import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
@@ -16,6 +17,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { buildCommandDisplayText, isPowerShell, normalizeCommandForExecution } from '../runInTerminalHelpers.js';
 import { RunInTerminalToolTelemetry } from '../runInTerminalToolTelemetry.js';
 import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../treeSitterCommandParser.js';
@@ -29,7 +31,7 @@ export const SendToTerminalToolData: IToolData = {
 	id: TerminalToolId.SendToTerminal,
 	toolReferenceName: 'sendToTerminal',
 	displayName: localize('sendToTerminalTool.displayName', 'Send to Terminal'),
-	modelDescription: `Send a command to an existing persistent terminal session started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). Use this for long-running terminal workflows. The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}. After sending, use ${TerminalToolId.GetTerminalOutput} to check updated output.`,
+	modelDescription: `Send a command to a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). After sending, use ${TerminalToolId.GetTerminalOutput} to check updated output for persistent terminals.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -37,8 +39,12 @@ export const SendToTerminalToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: `The ID of the persistent terminal session to send a command to (returned by ${TerminalToolId.RunInTerminal} in async mode).`,
+				description: `The ID of a persistent terminal session to send a command to (returned by ${TerminalToolId.RunInTerminal} in async mode). Provide either 'id' or 'terminalId', not both.`,
 				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+			},
+			terminalId: {
+				type: 'number',
+				description: 'The numeric instanceId of a terminal. Use this to send input to terminals not started by the agent (e.g., user-created terminals or terminals that need interactive input). Provide either \'id\' or \'terminalId\', not both.'
 			},
 			command: {
 				type: 'string',
@@ -46,18 +52,28 @@ export const SendToTerminalToolData: IToolData = {
 			},
 		},
 		required: [
-			'id',
 			'command',
 		]
 	}
 };
 
 export interface ISendToTerminalInputParams {
-	id: string;
+	id?: string;
+	terminalId?: number;
 	command: string;
 }
 
 const SEND_TO_TERMINAL_REFERENCE_NAME = 'sendToTerminal';
+
+const FocusTerminalByIdCommandId = 'workbench.action.terminal.chat.focusTerminalById';
+CommandsRegistry.registerCommand(FocusTerminalByIdCommandId, (accessor, instanceId: number) => {
+	const terminalService = accessor.get(ITerminalService);
+	const instance = terminalService.getInstanceFromId(instanceId);
+	if (instance) {
+		terminalService.setActiveInstance(instance);
+		terminalService.revealActiveTerminal(true);
+	}
+});
 
 /**
  * Wraps arbitrary text in a markdown inline code span using a backtick fence
@@ -83,6 +99,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@IChatService private readonly _chatService: IChatService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
 
@@ -102,14 +119,25 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		const displayCommand = buildCommandDisplayText(args.command);
 		const safeInlineCode = toMarkdownInlineCode(displayCommand);
 
+		// Resolve a human-friendly terminal label from the instance title
+		const terminalLabel = this._getTerminalLabel(args);
+
 		const invocationMessage = new MarkdownString();
 		invocationMessage.appendMarkdown(localize('send.progressive', "Sending {0} to terminal", safeInlineCode));
 
 		const pastTenseMessage = new MarkdownString();
 		pastTenseMessage.appendMarkdown(localize('send.past', "Sent {0} to terminal", safeInlineCode));
 
-		const confirmationMessage = new MarkdownString();
-		confirmationMessage.appendText(localize('send.confirm.message', "Run {0} in background terminal {1}", displayCommand, args.id));
+		// Build the confirmation message with a "Focus Terminal" command link
+		const instanceId = this._getTerminalInstanceId(args);
+		const confirmationMessage = new MarkdownString('', { isTrusted: { enabledCommands: [FocusTerminalByIdCommandId] } });
+		const baseMessage = localize('send.confirm.message', "Run {0} in terminal {1}", displayCommand, toMarkdownInlineCode(terminalLabel));
+		if (instanceId !== undefined) {
+			const focusUri = createCommandUri(FocusTerminalByIdCommandId, instanceId);
+			confirmationMessage.appendMarkdown(`${baseMessage} — [$(terminal) ${localize('focusTerminal', "Focus Terminal")}](${focusUri})`);
+		} else {
+			confirmationMessage.appendMarkdown(baseMessage);
+		}
 
 		// Determine auto-approval, aligned with runInTerminal
 		const chatSessionResource = context.chatSessionResource;
@@ -127,8 +155,9 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 					this._profileFetcher.getCopilotShell(),
 				]);
 
-				const execution = RunInTerminalTool.getExecution(args.id);
-				const cwd = execution ? await execution.instance.getCwdResource() : undefined;
+				const execution = args.id ? RunInTerminalTool.getExecution(args.id) : undefined;
+				const foregroundInstance = args.terminalId !== undefined ? this._terminalService.getInstanceFromId(args.terminalId) : undefined;
+				const cwd = execution ? await execution.instance.getCwdResource() : foregroundInstance ? await foregroundInstance.getCwdResource() : undefined;
 
 				const analyzerOptions: ICommandLineAnalyzerOptions = {
 					commandLine: args.command,
@@ -164,10 +193,80 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		};
 	}
 
+	/**
+	 * Returns a human-friendly label for the target terminal, using the
+	 * terminal instance title (which reflects the running process) instead
+	 * of the raw UUID or numeric id.
+	 */
+	private _getTerminalLabel(args: ISendToTerminalInputParams): string {
+		if (args.id) {
+			const execution = RunInTerminalTool.getExecution(args.id);
+			if (execution) {
+				return execution.instance.title;
+			}
+		}
+		if (args.terminalId !== undefined) {
+			const instance = this._terminalService.getInstanceFromId(args.terminalId);
+			if (instance) {
+				return instance.title;
+			}
+		}
+		return args.id ?? String(args.terminalId ?? '');
+	}
+
+	/**
+	 * Returns the numeric terminal instanceId for the target terminal, used
+	 * to build command URIs for the "Focus Terminal" link.
+	 */
+	private _getTerminalInstanceId(args: ISendToTerminalInputParams): number | undefined {
+		if (args.terminalId !== undefined) {
+			return args.terminalId;
+		}
+		if (args.id) {
+			const execution = RunInTerminalTool.getExecution(args.id);
+			if (execution) {
+				return execution.instance.instanceId;
+			}
+		}
+		return undefined;
+	}
+
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const args = invocation.parameters as ISendToTerminalInputParams;
 
-		const execution = RunInTerminalTool.getExecution(args.id);
+		if (!args.id && args.terminalId === undefined) {
+			return {
+				content: [{
+					kind: 'text',
+					value: 'Error: Either \'id\' (persistent terminal UUID) or \'terminalId\' (foreground terminal instanceId) must be provided.'
+				}]
+			};
+		}
+
+		// Foreground terminal path
+		if (args.terminalId !== undefined) {
+			const instance = this._terminalService.getInstanceFromId(args.terminalId);
+			if (!instance) {
+				return {
+					content: [{
+						kind: 'text',
+						value: `Error: No terminal found with instanceId ${args.terminalId}. The terminal may have been closed.`
+					}]
+				};
+			}
+
+			await instance.sendText(normalizeCommandForExecution(args.command), true);
+
+			return {
+				content: [{
+					kind: 'text',
+					value: `Successfully sent command to foreground terminal ${args.terminalId}. Use ${TerminalToolId.GetTerminalOutput} with terminalId ${args.terminalId} to check for updated output.`
+				}]
+			};
+		}
+
+		// Persistent (background) terminal path
+		const execution = RunInTerminalTool.getExecution(args.id!);
 		if (!execution) {
 			return {
 				content: [{

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -131,7 +131,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		// Build the confirmation message with a "Focus Terminal" command link
 		const instanceId = this._getTerminalInstanceId(args);
 		const confirmationMessage = new MarkdownString('', { isTrusted: { enabledCommands: [FocusTerminalByIdCommandId] } });
-		const baseMessage = localize('send.confirm.message', "Run {0} in terminal {1}", displayCommand, toMarkdownInlineCode(terminalLabel));
+		const baseMessage = localize('send.confirm.message', "Run {0} in terminal {1}", safeInlineCode, toMarkdownInlineCode(terminalLabel));
 		if (instanceId !== undefined) {
 			const focusUri = createCommandUri(FocusTerminalByIdCommandId, instanceId);
 			confirmationMessage.appendMarkdown(`${baseMessage} — [$(terminal) ${localize('focusTerminal', "Focus Terminal")}](${focusUri})`);
@@ -243,8 +243,8 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 			};
 		}
 
-		// Foreground terminal path
-		if (args.terminalId !== undefined) {
+		// Foreground terminal path — only when no persistent id is provided
+		if (args.terminalId !== undefined && !args.id) {
 			const instance = this._terminalService.getInstanceFromId(args.terminalId);
 			if (!instance) {
 				return {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -7,24 +7,16 @@ import type { CancellationToken } from '../../../../../../base/common/cancellati
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { createCommandUri, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
 import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
-import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
-import { buildCommandDisplayText, isPowerShell, normalizeCommandForExecution } from '../runInTerminalHelpers.js';
-import { RunInTerminalToolTelemetry } from '../runInTerminalToolTelemetry.js';
-import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../treeSitterCommandParser.js';
-import type { ICommandLineAnalyzerOptions } from './commandLineAnalyzer/commandLineAnalyzer.js';
-import { CommandLineAutoApproveAnalyzer } from './commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
-import { RunInTerminalTool, TerminalProfileFetcher } from './runInTerminalTool.js';
-import { isSessionAutoApproveLevel, isTerminalAutoApproveAllowed } from './terminalToolAutoApprove.js';
+import { buildCommandDisplayText, normalizeCommandForExecution } from '../runInTerminalHelpers.js';
+import { RunInTerminalTool } from './runInTerminalTool.js';
+import { isSessionAutoApproveLevel } from './terminalToolAutoApprove.js';
 import { TerminalToolId } from './toolIds.js';
 
 export const SendToTerminalToolData: IToolData = {
@@ -63,8 +55,6 @@ export interface ISendToTerminalInputParams {
 	command: string;
 }
 
-const SEND_TO_TERMINAL_REFERENCE_NAME = 'sendToTerminal';
-
 const FocusTerminalByIdCommandId = 'workbench.action.terminal.chat.focusTerminalById';
 CommandsRegistry.registerCommand(FocusTerminalByIdCommandId, (accessor, instanceId: number) => {
 	const terminalService = accessor.get(ITerminalService);
@@ -89,29 +79,13 @@ function toMarkdownInlineCode(text: string): string {
 
 export class SendToTerminalTool extends Disposable implements IToolImpl {
 
-	private readonly _autoApproveAnalyzer: CommandLineAutoApproveAnalyzer;
-	private readonly _profileFetcher: TerminalProfileFetcher;
-
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IStorageService private readonly _storageService: IStorageService,
-		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@IChatService private readonly _chatService: IChatService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
-
-		const treeSitterCommandParser = this._register(instantiationService.createInstance(TreeSitterCommandParser));
-		const telemetry = instantiationService.createInstance(RunInTerminalToolTelemetry);
-		this._autoApproveAnalyzer = this._register(instantiationService.createInstance(
-			CommandLineAutoApproveAnalyzer,
-			treeSitterCommandParser,
-			telemetry,
-			(message: string, ...args: unknown[]) => this._logService.info(`SendToTerminalTool#CommandLineAutoApproveAnalyzer: ${message}`, ...args),
-		));
-		this._profileFetcher = instantiationService.createInstance(TerminalProfileFetcher);
 	}
 
 	async prepareToolInvocation(context: IToolInvocationPreparationContext, _token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
@@ -143,43 +117,12 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		const chatSessionResource = context.chatSessionResource;
 		const isSessionAutoApproved = chatSessionResource && isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 
-		let isFinalAutoApproved = false;
-		if (!isSessionAutoApproved) {
-			const isAutoApproveAllowed = isTerminalAutoApproveAllowed(SEND_TO_TERMINAL_REFERENCE_NAME, this._configurationService, this._storageService);
-
-			// Only run the analyzer when auto-approve is allowed; otherwise the command
-			// will always require manual confirmation and running the analyzer is unnecessary.
-			if (isAutoApproveAllowed) {
-				const [os, shell] = await Promise.all([
-					this._profileFetcher.osBackend,
-					this._profileFetcher.getCopilotShell(),
-				]);
-
-				const execution = args.id ? RunInTerminalTool.getExecution(args.id) : undefined;
-				const foregroundInstance = args.terminalId !== undefined ? this._terminalService.getInstanceFromId(args.terminalId) : undefined;
-				const cwd = execution ? await execution.instance.getCwdResource() : foregroundInstance ? await foregroundInstance.getCwdResource() : undefined;
-
-				const analyzerOptions: ICommandLineAnalyzerOptions = {
-					commandLine: args.command,
-					cwd,
-					os,
-					shell,
-					treeSitterLanguage: isPowerShell(shell, os) ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash,
-					terminalToolSessionId: generateUuid(),
-					chatSessionResource,
-					requiresUnsandboxConfirmation: false,
-				};
-
-				const analyzerResult = await this._autoApproveAnalyzer.analyze(analyzerOptions);
-				const wouldBeAutoApproved = (
-					analyzerResult.isAutoApproved === true &&
-					analyzerResult.isAutoApproveAllowed
-				);
-				isFinalAutoApproved = analyzerResult.isAutoApproveAllowed && (wouldBeAutoApproved || !!analyzerResult.forceAutoApproval);
-			}
-		}
-
-		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
+		// send_to_terminal always requires confirmation in default approvals mode.
+		// Unlike run_in_terminal, the text sent here may be arbitrary input to a
+		// waiting prompt (e.g. a name, password, or confirmation) rather than a
+		// shell command, so the command-line auto-approve analyzer cannot reliably
+		// determine safety.
+		const shouldShowConfirmation = !isSessionAutoApproved || context.forceConfirmationReason !== undefined;
 		const confirmationMessages = shouldShowConfirmation ? {
 			title: localize('send.confirm.title', "Send to Terminal"),
 			message: confirmationMessage,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -18,7 +18,6 @@ export const enum TerminalChatAgentToolsSettingId {
 	IgnoreDefaultAutoApproveRules = 'chat.tools.terminal.ignoreDefaultAutoApproveRules',
 	BlockDetectedFileWrites = 'chat.tools.terminal.blockDetectedFileWrites',
 	ShellIntegrationTimeout = 'chat.tools.terminal.shellIntegrationTimeout',
-	AutoReplyToPrompts = 'chat.tools.terminal.autoReplyToPrompts',
 	OutputLocation = 'chat.tools.terminal.outputLocation',
 	AgentSandboxEnabled = 'chat.agent.sandbox.enabled',
 	AgentSandboxNetworkAllowedDomains = 'chat.agent.sandbox.allowedNetworkDomains',
@@ -513,12 +512,6 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 				}
 			}
 		]
-	},
-	[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: {
-		type: 'boolean',
-		default: false,
-		tags: ['experimental'],
-		markdownDescription: localize('autoReplyToPrompts.key', "Whether to automatically respond to prompts in the terminal such as `Confirm? y/n`. This is an experimental feature and may not work in all scenarios.\n\n**This feature is inherently risky to use as you're deferring potentially sensitive decisions to an LLM. Use at your own risk.**"),
 	},
 	[TerminalChatAgentToolsSettingId.OutputLocation]: {
 		markdownDescription: localize('outputLocation.description', "Where to show the output from the run in terminal tool."),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -10,7 +10,8 @@ import { GetTerminalOutputTool, GetTerminalOutputToolData } from '../../browser/
 import { RunInTerminalTool, type IActiveTerminalExecution } from '../../browser/tools/runInTerminalTool.js';
 import type { IToolInvocation } from '../../../../chat/common/tools/languageModelToolsService.js';
 import type { ITerminalExecuteStrategyResult } from '../../browser/executeStrategy/executeStrategy.js';
-import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 
 suite('GetTerminalOutputTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -18,9 +19,16 @@ suite('GetTerminalOutputTool', () => {
 	const KNOWN_TERMINAL_ID = '123e4567-e89b-12d3-a456-426614174001';
 	let tool: GetTerminalOutputTool;
 	let originalGetExecution: typeof RunInTerminalTool.getExecution;
+	let instantiationService: TestInstantiationService;
+	let mockTerminalInstances: Map<number, Partial<ITerminalInstance>>;
 
 	setup(() => {
-		tool = store.add(new GetTerminalOutputTool());
+		mockTerminalInstances = new Map();
+		instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ITerminalService, {
+			getInstanceFromId: (id: number) => mockTerminalInstances.get(id) as ITerminalInstance | undefined,
+		});
+		tool = store.add(instantiationService.createInstance(GetTerminalOutputTool));
 		originalGetExecution = RunInTerminalTool.getExecution;
 	});
 
@@ -53,6 +61,18 @@ suite('GetTerminalOutputTool', () => {
 		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque value'));
 		assert.ok(/exact opaque id returned by that tool/i.test(idProperty?.description ?? ''));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
+	});
+
+	test('returns error when neither id nor terminalId is provided', async () => {
+		const result = await tool.invoke(
+			{ parameters: {}, callId: 'test-call', context: { sessionId: 'test-session' }, toolId: 'get_terminal_output', tokenBudget: 1000, isComplete: () => false, isCancellationRequested: false } as unknown as IToolInvocation,
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('Either'));
 	});
 
 	test('returns explicit error for unknown terminal id', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -58,8 +58,8 @@ suite('GetTerminalOutputTool', () => {
 
 	test('tool description documents opaque terminal ids', () => {
 		const idProperty = GetTerminalOutputToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
-		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque value'));
-		assert.ok(/exact opaque id returned by that tool/i.test(idProperty?.description ?? ''));
+		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque UUID'));
+		assert.ok(/exact opaque (uuid|id) returned by that tool/i.test(idProperty?.description ?? ''));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -219,77 +219,6 @@ suite('OutputMonitor', () => {
 		});
 	});
 
-	test('auto reply sends first option when model lookup is unavailable', async () => {
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: true
-		}));
-		instantiationService.stub(ILanguageModelsService, {
-			selectLanguageModels: async () => []
-		});
-
-		const monitorCts = new CancellationTokenSource();
-		monitorCts.cancel();
-		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
-
-		const outputMonitorWithPrivateMethod = monitor as unknown as {
-			[key: string]: ((prompt: { prompt: string; options: string[]; detectedRequestForFreeFormInput: boolean }, token: CancellationToken) => Promise<{ suggestedOption: string | { description: string; option: string }; sentToTerminal: boolean } | undefined>) | undefined;
-		};
-		const optionResult = await outputMonitorWithPrivateMethod['_selectAndHandleOption']!({
-			prompt: 'Continue?',
-			options: ['y', 'n'],
-			detectedRequestForFreeFormInput: false
-		}, CancellationToken.None);
-		await Event.toPromise(monitor.onDidFinishCommand);
-		monitorCts.dispose();
-
-		assert.strictEqual(sendTextCalled, true, 'sendText should be called when auto reply is enabled');
-		assert.strictEqual(optionResult?.sentToTerminal, true, 'option should be auto-sent');
-		assert.strictEqual(optionResult?.suggestedOption, 'y', 'first option should be used as fallback');
-	});
-
-	test('auto reply uses fallback model to derive suggested option', async () => {
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: true
-		}));
-
-		let fallbackModelRequested = false;
-		instantiationService.stub(ILanguageModelsService, {
-			selectLanguageModels: async (selector: { id?: string }) => {
-				if (selector.id === 'copilot-fast') {
-					fallbackModelRequested = true;
-					return ['copilot-fast'];
-				}
-				return [];
-			},
-			sendChatRequest: async () => ({
-				stream: (async function* () {
-					yield { type: 'text', value: 'n' };
-				})(),
-				result: Promise.resolve(undefined)
-			})
-		});
-
-		const monitorCts = new CancellationTokenSource();
-		monitorCts.cancel();
-		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
-
-		const outputMonitorWithPrivateMethod = monitor as unknown as {
-			[key: string]: ((prompt: { prompt: string; options: string[]; detectedRequestForFreeFormInput: boolean }, token: CancellationToken) => Promise<{ suggestedOption: string | { description: string; option: string }; sentToTerminal: boolean } | undefined>) | undefined;
-		};
-		const optionResult = await outputMonitorWithPrivateMethod['_selectAndHandleOption']!({
-			prompt: 'Continue?',
-			options: ['y', 'n'],
-			detectedRequestForFreeFormInput: false
-		}, CancellationToken.None);
-		await Event.toPromise(monitor.onDidFinishCommand);
-		monitorCts.dispose();
-
-		assert.strictEqual(fallbackModelRequested, true, 'fallback model should be requested via _getLanguageModel');
-		assert.strictEqual(sendTextCalled, true, 'sendText should be called when auto reply is enabled');
-		assert.strictEqual(optionResult?.sentToTerminal, true, 'option should be auto-sent');
-		assert.strictEqual(optionResult?.suggestedOption, 'n', 'suggested option should be derived from fallback model response');
-	});
-
 	test('auto reply stops on generic press any key prompts', async () => {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService({
 			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: true
@@ -312,36 +241,45 @@ suite('OutputMonitor', () => {
 		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop polling for free-form prompts in auto reply mode');
 	});
 
-	test('auto reply does not propagate free-form input requests without explicit input', async () => {
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: true
-		}));
-
+	test('onDidDetectInputNeeded fires for input-required patterns in foreground mode', async () => {
+		execution.getOutput = () => 'Continue? (y/n) ';
 		const monitorCts = new CancellationTokenSource();
 		monitorCts.cancel();
 		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
 
-		const outputMonitorWithPrivateMethod = monitor as unknown as {
-			[key: string]: unknown;
-		};
-		let freeFormRequestShown = false;
-		outputMonitorWithPrivateMethod['_determineUserInputOptions'] = async () => ({
-			prompt: 'Password:',
-			options: [],
-			detectedRequestForFreeFormInput: true
-		});
-		outputMonitorWithPrivateMethod['_requestFreeFormTerminalInput'] = async () => {
-			freeFormRequestShown = true;
-			return true;
-		};
+		let inputNeededFired = false;
+		store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
 
-		const idleResult = await (outputMonitorWithPrivateMethod['_handleIdleState'] as (token: CancellationToken) => Promise<{ shouldContinuePolling: boolean }>)(CancellationToken.None);
+		const outputMonitorWithPrivateMethod = monitor as unknown as {
+			[key: string]: ((token: CancellationToken) => Promise<{ shouldContinuePolling: boolean; output?: string }>) | undefined;
+		};
+		const idleResult = await outputMonitorWithPrivateMethod['_handleIdleState']!(CancellationToken.None);
 		await Event.toPromise(monitor.onDidFinishCommand);
 		monitorCts.dispose();
 
-		assert.strictEqual(freeFormRequestShown, false, 'free-form elicitation should not be shown when auto reply is enabled');
-		assert.strictEqual(sendTextCalled, false, 'sensitive free-form prompt should not be auto-replied');
-		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop instead of propagating free-form prompt');
+		assert.strictEqual(inputNeededFired, true, 'onDidDetectInputNeeded should fire for input-required pattern');
+		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop polling after signaling agent');
+		assert.strictEqual(idleResult.output, 'Continue? (y/n) ', 'output should be returned');
+		assert.strictEqual(sendTextCalled, false, 'no elicitation or auto-reply should send text');
+	});
+
+	test('onDidDetectInputNeeded does not fire for non-input output', async () => {
+		execution.getOutput = () => 'Build complete successfully';
+		const monitorCts = new CancellationTokenSource();
+		monitorCts.cancel();
+		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
+
+		let inputNeededFired = false;
+		store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+		const outputMonitorWithPrivateMethod = monitor as unknown as {
+			[key: string]: ((token: CancellationToken) => Promise<{ shouldContinuePolling: boolean }>) | undefined;
+		};
+		await outputMonitorWithPrivateMethod['_handleIdleState']!(CancellationToken.None);
+		await Event.toPromise(monitor.onDidFinishCommand);
+		monitorCts.dispose();
+
+		assert.strictEqual(inputNeededFired, false, 'onDidDetectInputNeeded should not fire for non-input output');
 	});
 
 	suite('detectsInputRequiredPattern', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -9,20 +9,13 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IExecution, IPollingResult, OutputMonitorState } from '../../browser/tools/monitoring/types.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { ILanguageModelsService } from '../../../../chat/common/languageModels.js';
-import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { ChatModel } from '../../../../chat/common/model/chatModel.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { IToolInvocationContext } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { isNumber } from '../../../../../../base/common/types.js';
-import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
-import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
-import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 
 suite('OutputMonitor', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -31,12 +24,10 @@ suite('OutputMonitor', () => {
 	let cts: CancellationTokenSource;
 	let instantiationService: TestInstantiationService;
 	let sendTextCalled: boolean;
-	let sentText: string | undefined;
 	let dataEmitter: Emitter<string>;
 
 	setup(() => {
 		sendTextCalled = false;
-		sentText = undefined;
 		dataEmitter = new Emitter<string>();
 		execution = {
 			getOutput: () => 'test output',
@@ -45,7 +36,6 @@ suite('OutputMonitor', () => {
 				instanceId: 1,
 				sendText: async (text?: string) => {
 					sendTextCalled = true;
-					sentText = text;
 				},
 				onDidInputData: dataEmitter.event,
 				onDisposed: Event.None,
@@ -58,36 +48,7 @@ suite('OutputMonitor', () => {
 		};
 		instantiationService = new TestInstantiationService();
 
-		instantiationService.stub(
-			ILanguageModelsService,
-			{
-				selectLanguageModels: async () => []
-			}
-		);
-		instantiationService.stub(
-			IChatService,
-			{
-				// eslint-disable-next-line local/code-no-any-casts
-				getSession: () => ({
-					sessionId: '1',
-					onDidDispose: { event: () => { }, dispose: () => { } },
-					onDidChange: { event: () => { }, dispose: () => { } },
-					initialLocation: undefined,
-					requests: [],
-					responses: [],
-					addRequest: () => { },
-					addResponse: () => { },
-					dispose: () => { }
-				} as any)
-			}
-		);
 		instantiationService.stub(ITerminalLogService, new NullLogService());
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: false
-		}));
-		instantiationService.stub(IChatWidgetService, {
-			getWidgetsByLocations: () => []
-		});
 		cts = new CancellationTokenSource();
 	});
 
@@ -150,12 +111,6 @@ suite('OutputMonitor', () => {
 	test('non-interactive help completes without prompting', async () => {
 		return runWithFakedTimers({}, async () => {
 			execution.getOutput = () => 'press h + enter to show help';
-			instantiationService.stub(
-				ILanguageModelsService,
-				{
-					selectLanguageModels: async () => { throw new Error('language model should not be consulted'); }
-				}
-			);
 			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
 			await Event.toPromise(monitor.onDidFinishCommand);
 			const pollingResult = monitor.pollingResult;
@@ -182,15 +137,7 @@ suite('OutputMonitor', () => {
 	});
 	test('timeout prompt unanswered → continues polling and completes when idle', async () => {
 		return runWithFakedTimers({}, async () => {
-			// Fake a ChatModel enough to pass instanceof and the two methods used
-			const fakeChatModel: any = {
-				getRequests: () => [{}],
-				acceptResponseProgress: () => { }
-			};
-			Object.setPrototypeOf(fakeChatModel, ChatModel.prototype);
-			instantiationService.stub(IChatService, { getSession: () => fakeChatModel });
-
-			// Poller: first pass times out (to show the prompt), second pass goes idle
+			// Poller: first pass times out, second pass goes idle
 			let pass = 0;
 			const timeoutThenIdle = async (): Promise<IPollingResult> => {
 				pass++;
@@ -219,15 +166,14 @@ suite('OutputMonitor', () => {
 		});
 	});
 
-	test('auto reply stops on generic press any key prompts', async () => {
-		instantiationService.stub(IConfigurationService, new TestConfigurationService({
-			[TerminalChatAgentToolsSettingId.AutoReplyToPrompts]: true
-		}));
-
+	test('press any key fires onDidDetectInputNeeded and stops polling', async () => {
 		execution.getOutput = () => 'Press any key to continue...';
 		const monitorCts = new CancellationTokenSource();
 		monitorCts.cancel();
 		monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), monitorCts.token, 'test command'));
+
+		let inputNeededFired = false;
+		store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
 
 		const outputMonitorWithPrivateMethod = monitor as unknown as {
 			[key: string]: ((token: CancellationToken) => Promise<{ shouldContinuePolling: boolean }>) | undefined;
@@ -236,9 +182,9 @@ suite('OutputMonitor', () => {
 		await Event.toPromise(monitor.onDidFinishCommand);
 		monitorCts.dispose();
 
-		assert.strictEqual(sendTextCalled, false, 'sendText should not be called when auto reply is enabled for free-form prompts');
-		assert.strictEqual(sentText, undefined, 'no terminal input should be sent');
-		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop polling for free-form prompts in auto reply mode');
+		assert.strictEqual(inputNeededFired, true, 'onDidDetectInputNeeded should fire for press any key');
+		assert.strictEqual(sendTextCalled, false, 'sendText should not be called');
+		assert.strictEqual(idleResult.shouldContinuePolling, false, 'monitor should stop polling');
 	});
 
 	test('onDidDetectInputNeeded fires for input-required patterns in foreground mode', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -70,7 +70,7 @@ suite('SendToTerminalTool', () => {
 
 	test('tool description documents terminal IDs and use cases', () => {
 		const idProperty = SendToTerminalToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
-		assert.ok(SendToTerminalToolData.modelDescription.includes('existing persistent terminal session'));
+		assert.ok(SendToTerminalToolData.modelDescription.includes('Send a command to a terminal session'));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/308296
fixes https://github.com/microsoft/vscode/issues/308030
fixes https://github.com/microsoft/vscode/issues/288570

Now that the agent has `send_to_terminal` and `get_terminal_output` at its disposal, there's no need for the terminal tool to make extra LLM calls or show elicitation UI when a command prompts for input — the agent can detect the prompt, decide what to send, and send it itself. This branch leans into that by replacing ~600 lines of LLM-powered elicitation code with a simple regex-based `onDidDetectInputNeeded` event that hands control back to the agent, cutting unnecessary latency and token spend. 

This also extends `send_to_terminal` and `get_terminal_output` with a `terminalId` parameter so the agent can interact with foreground terminals too, not just persistent background ones. 

We still use a lightweight regex check to quickly determine whether user input is likely needed. If so, we immediately return control to the agent and indicate that input may be required. We also surface this signal when a terminal command times out, prompting the agent to assess whether input was expected. The agent can then use the `ask_questions_tool` to confirm (unless running in autopilot mode), followed by the `send_to_terminal` tool to execute.

https://github.com/microsoft/vscode/blob/35a23cd116e0f8ea18f2e1029fe27f5d875dc22d/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L1458-L1462

### Before

<img width="722" height="1124" alt="image" src="https://github.com/user-attachments/assets/b9f16c66-ee85-4f71-a340-b9914667f426" />

### After

When in `Default Approvals`

<img width="614" height="754" alt="Screenshot 2026-04-08 at 4 59 42 PM" src="https://github.com/user-attachments/assets/d80a8e9b-e51e-4c81-a123-2e14a26101a0" />

<img width="606" height="750" alt="Screenshot 2026-04-08 at 4 59 52 PM" src="https://github.com/user-attachments/assets/06a70ca9-88a3-4c16-8d0d-dbe312817a25" />

<img width="633" height="805" alt="Screenshot 2026-04-08 at 5 01 13 PM" src="https://github.com/user-attachments/assets/49ce56ba-4082-4df4-a79d-495f6f903588" />

<img width="594" height="746" alt="Screenshot 2026-04-08 at 5 01 30 PM" src="https://github.com/user-attachments/assets/88590622-113c-4706-8265-3c9d39c24e8d" />

When in `Autopilot`

[<img width="1620" height="844" alt="image" src="https://github.com/user-attachments/assets/7a0a5e22-45e9-4cb4-8051-640570adda20" />
](https://github.com/user-attachments/assets/06773a4d-160f-4e50-925d-be074c1526e7)

### Before vs After: 

All Scenarios

#### Output Monitor — Input Detection

| Mode | Scenario | **Before** | **After** |
|------|----------|------------|-----------|
| **Foreground** | Input prompt detected (`Password:`, `[Y/n]`) | No detection — would eventually timeout | New `inputNeeded` race candidate fires, converts to background, returns output + `terminalId` to agent |
| **Foreground** | "Press any key" detected | Showed elicitation UI with free-form input dialog, waited for user to type | Fires `onDidDetectInputNeeded`, stops polling — agent handles via `send_to_terminal` |
| **Async** | Input prompt detected | Made LLM call to classify, then showed elicitation UI ("Terminal is awaiting input" + system-initiated chat request) | Regex-only detection, fires `onDidDetectInputNeeded`, stops polling — agent handles it |
| **Async** | "Press any key" detected | Showed elicitation UI | Fires `onDidDetectInputNeeded`, stops polling — agent handles it |
| **Foreground** | Command completes normally | Race resolves `completed` | Same |
| **Foreground** | User clicks "Continue in Background" | Race resolves `background` | Same |
| **Foreground** | Timeout | Race resolves `timeout`, extended polling | Same |
| **Async** | Command completes normally | Monitor detects idle | Same |
| **Any** | Non-interactive help (`press h for help`) | Detected, stopped | Same |
| **Any** | VS Code task finish message | Detected, stopped | Same |

#### `run_in_terminal` — Foreground Race

| Aspect | **Before** | **After** |
|--------|------------|-----------|
| Race candidates | 3: `completed`, `background`, `timeout` | 4: `completed`, `background`, `timeout`, **`inputNeeded`** |
| `inputNeeded` handling | N/A | Converts to background, returns output with `terminalId` so agent can use `send_to_terminal` |
| `toolMetadata` response | Returns `id` (UUID) | Returns `id` + **`terminalId`** (numeric instanceId) in all code paths |
| Listener cleanup | N/A | Uses `DisposableStore` for `onDidDetectInputNeeded` subscription, disposed after race |

#### `send_to_terminal` — New Foreground Support

| Aspect | **Before** | **After** |
|--------|------------|-----------|
| Parameters | `id` (UUID, required) | `id` (UUID) **or** `terminalId` (number) — one required |
| Foreground terminals | Not supported | Sends via `instance.sendText()`, returns guidance to use `get_terminal_output` with `terminalId` |
| Confirmation message | `"Run {cmd} in background terminal {uuid}"` | `"Run {cmd} in terminal {title}"` with **"Focus Terminal"** command link |
| Auto-approve analysis | Only for persistent terminals | Also resolves CWD and shell for foreground terminals |

#### `get_terminal_output` — New Foreground Support

| Aspect | **Before** | **After** |
|--------|------------|-----------|
| Parameters | `id` (UUID, required) | `id` (UUID) **or** `terminalId` (number) — one required |
| Foreground terminals | Not supported | Reads xterm buffer via `getOutput(instance)` (truncated to 16K chars, tail-biased) |
| Constructor | No injected services | Injects `ITerminalService` |

#### outputMonitor.ts — Code Removed (~600 lines)

| Removed | Description |
|---------|-------------|
| `_requestFreeFormTerminalInput()` | Elicitation UI for free-form terminal input |
| `_createElicitationPart()` | Generic elicitation part builder with system-initiated request support |
| `_showInstance()` | Terminal focus helper for elicitation "Focus terminal" button |
| `_isAutopilotMode()` | Checked widget/request permission level to skip elicitation |
| `_lastPromptMarker`, `_promptPart` | Tracking fields for elicitation state |
| `IChatService`, `IChatWidgetService`, `IConfigurationService`, `ITerminalService` | Constructor dependencies only needed for elicitation |
| All `localize()` strings for elicitation | "Terminal is awaiting input", "Focus terminal", etc. |
| LLM-related imports | `ChatElicitationRequestPart`, `ChatModel`, `ElicitationState`, `ChatRequestTextPart`, `OffsetRange`, `ChatPermissionLevel`, etc. | 

