### PR TITLE
chat: remove providerApi.enabled setting and Claude harness from core

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -76,8 +76,8 @@ Storage answers "where did this come from?"; harness answers "who consumes it?".
 The service is defined in `common/customizationHarnessService.ts` which also provides:
 - **`CustomizationHarnessServiceBase`** — reusable base class handling active-harness state, the observable list, and `getStorageSourceFilter` dispatch.
 - **`ISectionOverride`** — per-section UI customization: `commandId` (command invocation), `rootFile` + `label` (root-file creation), `typeLabel` (custom type name), `fileExtension` (override default), `rootFileShortcuts` (dropdown shortcuts).
-- **Factory functions** — `createVSCodeHarnessDescriptor`, `createCliHarnessDescriptor`, `createClaudeHarnessDescriptor`. The VS Code harness receives `[PromptsStorage.extension, BUILTIN_STORAGE]` as extras; CLI and Claude in core receive `[]` (no extension source). Sessions CLI receives `[BUILTIN_STORAGE]`.
-- **Well-known root helpers** — `getCliUserRoots(userHome)` and `getClaudeUserRoots(userHome)` centralize the `~/.copilot`, `~/.claude`, `~/.agents` path knowledge.
+- **Factory functions** — `createVSCodeHarnessDescriptor`, `createCliHarnessDescriptor`. The VS Code harness receives `[PromptsStorage.extension, BUILTIN_STORAGE]` as extras; Sessions CLI receives `[BUILTIN_STORAGE]`.
+- **Well-known root helpers** — `getCliUserRoots(userHome)` centralizes the `~/.copilot`, `~/.claude`, `~/.agents` path knowledge.
 - **Filter helpers** — `matchesWorkspaceSubpath()` for segment-safe subpath matching; `matchesInstructionFileFilter()` for filename/path-prefix pattern matching.
 
 Available harnesses:
@@ -86,9 +86,8 @@ Available harnesses:
 |---------|-------|-------------|
 | `vscode` | Local | Shows all storage sources (default in core) |
 | `cli` | Copilot CLI | Restricts user roots to `~/.copilot`, `~/.claude`, `~/.agents` |
-| `claude` | Claude | Restricts user roots to `~/.claude`; hides Prompts + Plugins sections |
 
-In core VS Code, all three harnesses are registered but CLI and Claude only appear when their respective agents are registered (`requiredAgentId` checked via `IChatAgentService`). VS Code is the default.
+In core VS Code, only the Local harness is registered statically. Additional harnesses (e.g. Copilot CLI) are contributed by extensions via the provider API.
 In sessions, only CLI is registered (single harness, toggle bar hidden).
 
 ### IHarnessDescriptor
@@ -97,8 +96,8 @@ Key properties on the harness descriptor:
 
 | Property | Purpose |
 |----------|--------|
-| `hiddenSections` | Sidebar sections to hide (e.g. Claude: `[Prompts, Plugins]`) |
-| `workspaceSubpaths` | Restrict file creation/display to directories (e.g. Claude: `['.claude']`) |
+| `hiddenSections` | Sidebar sections to hide |
+| `workspaceSubpaths` | Restrict file creation/display to directories |
 | `hideGenerateButton` | Replace "Generate X" sparkle button with "New X" |
 | `sectionOverrides` | Per-section `ISectionOverride` map for button behavior |
 | `requiredAgentId` | Agent ID that must be registered for harness to appear |
@@ -137,20 +136,6 @@ CLI harness (core):
 | Hooks | `[local, plugin]` | N/A |
 | Prompts | `[local, user, plugin]` | `undefined` (all roots) |
 | Agents, Skills, Instructions | `[local, user, plugin]` | `[~/.copilot, ~/.claude, ~/.agents]` |
-
-Claude harness (core):
-
-| Type | sources | includedUserFileRoots |
-|------|---------|----------------------|
-| Hooks | `[local, plugin]` | N/A |
-| Prompts | `[local, user, plugin]` | `undefined` (all roots) |
-| Agents, Skills, Instructions | `[local, user, plugin]` | `[~/.claude]` |
-
-Claude additionally applies:
-- `hiddenSections: [Prompts, Plugins]`
-- `instructionFileFilter: ['CLAUDE.md', 'CLAUDE.local.md', '.claude/rules/', 'copilot-instructions.md']`
-- `workspaceSubpaths: ['.claude']` (instruction files matching `instructionFileFilter` are exempt)
-- `sectionOverrides`: Hooks → `copilot.claude.hooks` command; Instructions → "Add CLAUDE.md" primary, "Rule" type label, `.md` file extension
 
 ### Built-in Extension Grouping (Core VS Code)
 

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -48,7 +48,6 @@ import { NotebookDto } from './mainThreadNotebookDto.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor } from '../../contrib/chat/common/customizationHarnessService.js';
 import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { IAgentPluginService } from '../../contrib/chat/common/plugins/agentPluginService.js';
 import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 
@@ -134,23 +133,12 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		@IPromptsService private readonly _promptsService: IPromptsService,
 		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
 		@ICustomizationHarnessService private readonly _customizationHarnessService: ICustomizationHarnessService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
 		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatAgents2);
-
-		// When the provider API kill-switch is toggled off, dispose all registered providers
-		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('chat.customizations.providerApi.enabled')) {
-				if (!this._configurationService.getValue<boolean>('chat.customizations.providerApi.enabled')) {
-					this._customizationProviders.clearAndDisposeAll();
-					this._customizationProviderEmitters.clearAndDisposeAll();
-				}
-			}
-		}));
 
 		this._register(this._chatService.onDidDisposeSession(e => {
 			for (const resource of e.sessionResources) {
@@ -761,11 +749,6 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	async $registerChatSessionCustomizationProvider(handle: number, chatSessionType: string, metadata: IChatSessionCustomizationProviderMetadataDto, extensionId: ExtensionIdentifier): Promise<void> {
 		if (this._environmentService.isSessionsWindow) {
 			this._logService.trace(`[MainThreadChatAgents2] Sessions window does not use the customization provider API, ignoring registration from ${extensionId.value}`);
-			return;
-		}
-
-		if (!this._configurationService.getValue<boolean>('chat.customizations.providerApi.enabled')) {
-			this._logService.trace(`[MainThreadChatAgents2] Customization provider API is disabled, ignoring registration from ${extensionId.value}`);
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -8,59 +8,22 @@ import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
 	ICustomizationHarnessService,
-	IHarnessDescriptor,
-	createCliHarnessDescriptor,
-	createClaudeHarnessDescriptor,
 	createVSCodeHarnessDescriptor,
-	getCliUserRoots,
-	getClaudeUserRoots,
 } from '../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { BUILTIN_STORAGE } from '../../common/aiCustomizationWorkspaceService.js';
-import { IPathService } from '../../../../services/path/common/pathService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import { ChatConfiguration } from '../../common/constants.js';
 
 /**
  * Core implementation of the customization harness service.
  *
- * When `chat.customizations.providerApi.enabled` is true, only the Local
- * harness is registered statically. All other harnesses are contributed by
- * extensions via the provider API, so the hardcoded CLI/Claude harnesses are
- * intentionally omitted.
- *
- * When the setting is false, the full set of built-in harnesses (Local, Copilot
- * CLI, Claude) is registered for backwards compat.
+ * Only the Local harness is registered statically. All other harnesses
+ * (e.g. Copilot CLI) are contributed by extensions via the provider API.
  */
 class CustomizationHarnessService extends CustomizationHarnessServiceBase {
-	constructor(
-		@IPathService pathService: IPathService,
-		@IConfigurationService configurationService: IConfigurationService,
-	) {
-		// The Local harness includes extension-contributed and built-in customizations.
-		// Built-in items come from the default chat extension (productService.defaultChatAgent).
+	constructor() {
 		const localExtras = [PromptsStorage.extension, BUILTIN_STORAGE];
-
-		const providerApiEnabled = configurationService.getValue<boolean>(ChatConfiguration.CustomizationsProviderApi);
-
-		let allHarnesses: readonly IHarnessDescriptor[];
-		if (providerApiEnabled) {
-			// When the provider API is enabled, only expose the Local harness.
-			// CLI and Claude harnesses don't consume extension contributions.
-			// Additional harnesses are contributed entirely via the provider API.
-			allHarnesses = [createVSCodeHarnessDescriptor(localExtras)];
-		} else {
-			const userHome = pathService.userHome({ preferLocal: true });
-			const restrictedExtras: readonly string[] = [];
-			allHarnesses = [
-				createVSCodeHarnessDescriptor(localExtras),
-				createCliHarnessDescriptor(getCliUserRoots(userHome), restrictedExtras),
-				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), restrictedExtras),
-			];
-		}
-
 		super(
-			allHarnesses,
+			[createVSCodeHarnessDescriptor(localExtras)],
 			CustomizationHarness.VSCode,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1413,14 +1413,8 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.ChatCustomizationHarnessSelectorEnabled]: {
 			type: 'boolean',
 			tags: ['preview'],
-			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector (Local, Copilot CLI, Claude) is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
+			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
 			default: true,
-		},
-		[ChatConfiguration.CustomizationsProviderApi]: {
-			type: 'boolean',
-			description: nls.localize('chat.customizations.providerApi.enabled', "When enabled, the Customizations management UI reads items from the session type's customizations provider instead of built-in discovery."),
-			default: true,
-			tags: ['preview'],
 		},
 	}
 });

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -66,7 +66,6 @@ export enum ChatConfiguration {
 	ArtifactsRulesByMimeType = 'chat.artifacts.rules.byMimeType',
 	ArtifactsRulesByFilePath = 'chat.artifacts.rules.byFilePath',
 	ArtifactsRulesByMemoryFilePath = 'chat.artifacts.rules.byMemoryFilePath',
-	CustomizationsProviderApi = 'chat.customizations.providerApi.enabled',
 	ToolConfirmationCarousel = 'chat.tools.confirmationCarousel.enabled',
 	DefaultNewSessionMode = 'chat.newSession.defaultMode',
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -62,7 +62,6 @@ export interface ISectionOverride {
 export enum CustomizationHarness {
 	VSCode = 'vscode',
 	CLI = 'cli',
-	Claude = 'claude',
 }
 
 /**
@@ -275,13 +274,6 @@ export function getCliUserRoots(userHome: URI): readonly URI[] {
 	];
 }
 
-/**
- * Returns the user-home directories accessible to the Claude harness.
- */
-export function getClaudeUserRoots(userHome: URI): readonly URI[] {
-	return [joinPath(userHome, '.claude')];
-}
-
 // #endregion
 
 // #region Harness descriptor factories
@@ -319,7 +311,7 @@ export function createVSCodeHarnessDescriptor(extras: readonly string[]): IHarne
 /**
  * Creates a harness descriptor that restricts user-file roots for most
  * types (agents, skills, instructions) while leaving hooks and prompts
- * unrestricted. Used for CLI and Claude harnesses.
+ * unrestricted. Used for restricted harnesses like CLI.
  */
 interface IRestrictedHarnessOptions {
 	readonly hiddenSections?: readonly string[];
@@ -382,41 +374,6 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 					rootFileShortcuts: [AGENT_MD_FILENAME],
 				}],
 			]),
-		},
-	);
-}
-
-/**
- * Creates a "Claude" harness descriptor.
- * Claude does not support prompt files (.prompt.md), AGENTS.md, or extension-contributed plugins.
- * It supports agents (.claude/agents/), instructions (CLAUDE.md, .claude/rules/),
- * skills (.claude/skills/), and hooks (.claude/settings.json).
- */
-export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
-	return createRestrictedHarnessDescriptor(
-		CustomizationHarness.Claude,
-		localize('harness.claude', "Claude"),
-		ThemeIcon.fromId(Codicon.claude.id),
-		claudeRoots,
-		extras,
-		{
-			hiddenSections: [AICustomizationManagementSection.Prompts, AICustomizationManagementSection.Plugins],
-			workspaceSubpaths: ['.claude'],
-			hideGenerateButton: true,
-			requiredAgentId: 'claude-code',
-			sectionOverrides: new Map([
-				[AICustomizationManagementSection.Hooks, {
-					label: localize('claudeHooks', "Configure Claude Hooks"),
-					commandId: 'copilot.claude.hooks',
-				}],
-				[AICustomizationManagementSection.Instructions, {
-					label: localize('addClaudeMd', "Add CLAUDE.md"),
-					rootFile: 'CLAUDE.md',
-					typeLabel: localize('rule', "Rule"),
-					fileExtension: '.md',
-				}],
-			]),
-			instructionFileFilter: ['CLAUDE.md', 'CLAUDE.local.md', '.claude/rules/', 'copilot-instructions.md'],
 		},
 	);
 }

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -29,7 +29,7 @@ import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
 import { IWebviewService } from '../../../../contrib/webview/browser/webview.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection } from '../../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor, createClaudeHarnessDescriptor, createCliHarnessDescriptor, getCliUserRoots, getClaudeUserRoots } from '../../../../contrib/chat/common/customizationHarnessService.js';
+import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor, createCliHarnessDescriptor, getCliUserRoots } from '../../../../contrib/chat/common/customizationHarnessService.js';
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
 import { PromptsType } from '../../../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, AgentInstructionFileType, PromptsStorage, IAgentSkill, IChatPromptSlashCommand, IAgentInstructionFile } from '../../../../contrib/chat/common/promptSyntax/service/promptsService.js';
@@ -433,7 +433,6 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 	const availableHarnesses = options.availableHarnesses ?? [
 		createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]),
 		createCliHarnessDescriptor(getCliUserRoots(userHome), []),
-		createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), []),
 	];
 
 	const allMcpServers = [...mcpWorkspaceServers, ...mcpUserServers];
@@ -826,13 +825,6 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 	CliHarness: defineComponentFixture({
 		labels: { kind: 'screenshot' },
 		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.CLI, selectedSection: AICustomizationManagementSection.Agents }),
-	}),
-
-	// Full editor with Claude harness — Prompts+Plugins hidden, Agents visible,
-	// "Add CLAUDE.md" button, "New Rule" dropdown, instruction filtering, bridged MCP badge
-	ClaudeHarness: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: ctx => renderEditor(ctx, { harness: CustomizationHarness.Claude, selectedSection: AICustomizationManagementSection.Agents }),
 	}),
 
 	// Sessions-window variant of the full editor with workspace override UX


### PR DESCRIPTION
## Summary

Minimal cleanup that removes the `chat.customizations.providerApi.enabled` kill-switch setting and the built-in Claude harness from core VS Code. The provider API is now permanently enabled.

Re-attempt of the non-breaking parts of #308341 (reverted in #308448). The core discovery path (`fetchCoreItemsForSection`) and all its grouping/filtering logic are **preserved** — only the kill-switch and Claude harness are removed. Further cleanup will be done in follow-up PRs.

## What changed (6 files, +7 / -119 lines)

| File | Change |
|------|--------|
| `constants.ts` | Removed `CustomizationsProviderApi` enum value |
| `chat.contribution.ts` | Removed setting registration, updated harness selector description |
| `mainThreadChatAgents2.ts` | Removed `IConfigurationService` dep, kill-switch config listener, and provider registration guard |
| `common/customizationHarnessService.ts` | Removed `Claude` enum value, `getClaudeUserRoots()`, `createClaudeHarnessDescriptor()` |
| `browser/customizationHarnessService.ts` | Simplified to always register only Local harness (no conditional branching) |
| `aiCustomizationManagementEditor.fixture.ts` | Removed Claude imports, fixture, and harness descriptor |

## What was NOT changed

- Core discovery path (`fetchCoreItemsForSection`, `filterItemsForCore`, `applyBuiltinGroupKeys`) — preserved
- CLI harness descriptor factory — preserved (used by Sessions)
- All semantic instruction grouping, applyTo badges, and built-in extension grouping — preserved

## Validation

- TypeScript compilation clean
- All 15 customizationHarnessService unit tests pass
- Component explorer fixtures verified: LocalHarness, InstructionsTabWithItems both render correctly with full grouping and metadata"