### PR TITLE
Add throttling for tool stream invocations

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
+++ b/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
@@ -15,7 +15,7 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { ChatResponseClearToPreviousToolInvocationReason } from '../../../vscodeTypes';
 import { getContributedToolName } from '../../tools/common/toolNames';
 import { IResponseProcessor, IResponseProcessorContext } from './intents';
-
+console.log('@@@');
 disableErrorLogging();
 
 export interface StartStopMapping {
@@ -31,6 +31,10 @@ export class PseudoStopStartResponseProcessor implements IResponseProcessor {
 	private currentStartStop: StartStopMapping | undefined = undefined;
 	private nonReportedDeltas: IResponseDelta[] = [];
 	private thinkingActive: boolean = false;
+
+	private static readonly _toolStreamThrottleMs = 100;
+	private readonly _lastToolStreamUpdate = new Map<string, number>();
+	private readonly _pendingToolStreamUpdates = new Map<string, { id: string; arguments: string | undefined }>();
 
 	constructor(
 		private readonly stopStartMappings: readonly StartStopMapping[],
@@ -49,6 +53,15 @@ export class PseudoStopStartResponseProcessor implements IResponseProcessor {
 			}
 			this.applyDelta(delta, progress);
 		}
+		this._flushPendingToolStreamUpdates(progress);
+	}
+
+	private _flushPendingToolStreamUpdates(progress: ChatResponseStream): void {
+		for (const update of this._pendingToolStreamUpdates.values()) {
+			progress.updateToolInvocation(update.id, { partialInput: tryParsePartialToolInput(update.arguments) });
+		}
+		this._pendingToolStreamUpdates.clear();
+		this._lastToolStreamUpdate.clear();
 	}
 
 	protected applyDeltaToProgress(delta: IResponseDelta, progress: ChatResponseStream) {
@@ -79,11 +92,20 @@ export class PseudoStopStartResponseProcessor implements IResponseProcessor {
 		}
 
 		if (delta.copilotToolCallStreamUpdates?.length) {
+			const now = Date.now();
 			for (const update of delta.copilotToolCallStreamUpdates) {
 				if (!update.name) {
 					continue;
 				}
-				progress.updateToolInvocation(update.id ?? '', { partialInput: tryParsePartialToolInput(update.arguments) });
+				const toolId = update.id ?? '';
+				const lastUpdate = this._lastToolStreamUpdate.get(toolId) ?? 0;
+				if (now - lastUpdate >= PseudoStopStartResponseProcessor._toolStreamThrottleMs) {
+					this._lastToolStreamUpdate.set(toolId, now);
+					this._pendingToolStreamUpdates.delete(toolId);
+					progress.updateToolInvocation(toolId, { partialInput: tryParsePartialToolInput(update.arguments) });
+				} else {
+					this._pendingToolStreamUpdates.set(toolId, { id: toolId, arguments: update.arguments });
+				}
 			}
 		}
 	}

--- a/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
+++ b/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
@@ -15,6 +15,7 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { ChatResponseClearToPreviousToolInvocationReason } from '../../../vscodeTypes';
 import { getContributedToolName } from '../../tools/common/toolNames';
 import { IResponseProcessor, IResponseProcessorContext } from './intents';
+
 disableErrorLogging();
 
 export interface StartStopMapping {

--- a/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
+++ b/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
@@ -15,7 +15,6 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { ChatResponseClearToPreviousToolInvocationReason } from '../../../vscodeTypes';
 import { getContributedToolName } from '../../tools/common/toolNames';
 import { IResponseProcessor, IResponseProcessorContext } from './intents';
-console.log('@@@');
 disableErrorLogging();
 
 export interface StartStopMapping {

--- a/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
+++ b/extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts
@@ -47,21 +47,32 @@ export class PseudoStopStartResponseProcessor implements IResponseProcessor {
 	}
 
 	async doProcessResponse(responseStream: AsyncIterable<IResponsePart>, progress: ChatResponseStream, token: CancellationToken): Promise<void> {
-		for await (const { delta } of responseStream) {
-			if (token.isCancellationRequested) {
-				return;
+		try {
+			for await (const { delta } of responseStream) {
+				if (token.isCancellationRequested) {
+					return;
+				}
+				this.applyDelta(delta, progress);
 			}
-			this.applyDelta(delta, progress);
+		} finally {
+			if (token.isCancellationRequested) {
+				this._clearPendingToolStreamUpdates();
+			} else {
+				this._flushPendingToolStreamUpdates(progress);
+			}
 		}
-		this._flushPendingToolStreamUpdates(progress);
+	}
+
+	private _clearPendingToolStreamUpdates(): void {
+		this._pendingToolStreamUpdates.clear();
+		this._lastToolStreamUpdate.clear();
 	}
 
 	private _flushPendingToolStreamUpdates(progress: ChatResponseStream): void {
 		for (const update of this._pendingToolStreamUpdates.values()) {
 			progress.updateToolInvocation(update.id, { partialInput: tryParsePartialToolInput(update.arguments) });
 		}
-		this._pendingToolStreamUpdates.clear();
-		this._lastToolStreamUpdate.clear();
+		this._clearPendingToolStreamUpdates();
 	}
 
 	protected applyDeltaToProgress(delta: IResponseDelta, progress: ChatResponseStream) {
@@ -198,6 +209,7 @@ export class PseudoStopStartResponseProcessor implements IResponseProcessor {
 			this.currentStartStop = undefined;
 			this.nonReportedDeltas = [];
 			this.thinkingActive = false;
+			this._clearPendingToolStreamUpdates();
 			if (delta.retryReason === 'network_error' || delta.retryReason === 'server_error') {
 				progress.clearToPreviousToolInvocation(ChatResponseClearToPreviousToolInvocationReason.NoReason);
 			} else if (delta.retryReason === FilterReason.Copyright) {

--- a/extensions/copilot/src/extension/test/node/pseudoStartStopConversationCallback.spec.ts
+++ b/extensions/copilot/src/extension/test/node/pseudoStartStopConversationCallback.spec.ts
@@ -6,13 +6,14 @@
 import assert from 'assert';
 import * as sinon from 'sinon';
 import { afterEach, beforeEach, suite, test } from 'vitest';
-import type { ChatVulnerability } from 'vscode';
+import type { ChatToolInvocationStreamData, ChatVulnerability } from 'vscode';
 import { IResponsePart } from '../../../platform/chat/common/chatMLFetcher';
 import { IResponseDelta } from '../../../platform/networking/common/fetch';
 import { createPlatformServices } from '../../../platform/test/node/services';
+import { ChatResponseStreamImpl } from '../../../util/common/chatResponseStreamImpl';
 import { SpyChatResponseStream } from '../../../util/common/test/mockChatResponseStream';
 import { AsyncIterableSource } from '../../../util/vs/base/common/async';
-import { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from '../../../util/vs/base/common/cancellation';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseMarkdownPart, ChatResponseMarkdownWithVulnerabilitiesPart } from '../../../vscodeTypes';
 import { PseudoStopStartResponseProcessor } from '../../prompt/node/pseudoStartStopConversationCallback';
@@ -168,4 +169,160 @@ suite('Post Report Conversation Callback', () => {
 	});
 
 	afterEach(() => sinon.restore());
+});
+
+suite('Tool stream throttling', () => {
+	let clock: sinon.SinonFakeTimers;
+	let updateCalls: { toolCallId: string; streamData: ChatToolInvocationStreamData }[];
+	let stream: ChatResponseStreamImpl;
+
+	beforeEach(() => {
+		clock = sinon.useFakeTimers({ now: 1000, toFake: ['Date'] });
+		updateCalls = [];
+		stream = new ChatResponseStreamImpl(
+			() => { },
+			() => { },
+			undefined,
+			undefined,
+			(toolCallId, streamData) => updateCalls.push({ toolCallId, streamData }),
+		);
+	});
+
+	afterEach(() => {
+		clock.restore();
+		sinon.restore();
+	});
+
+	test('first update is emitted immediately', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, stream, CancellationToken.None);
+
+		assert.strictEqual(updateCalls.length, 1);
+		assert.strictEqual(updateCalls[0].toolCallId, 'tool1');
+	});
+
+	test('rapid updates within throttle window are throttled', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		// First update goes through immediately
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		// These arrive within the 100ms throttle window — should be buffered
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":2}' }] } });
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":3}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, stream, CancellationToken.None);
+
+		// 1 immediate + 1 flush of the last buffered update = 2 total
+		assert.strictEqual(updateCalls.length, 2);
+		assert.strictEqual(updateCalls[0].toolCallId, 'tool1');
+		assert.deepStrictEqual(updateCalls[1].streamData.partialInput, { a: 3 });
+	});
+
+	test('update after throttle window elapses is emitted immediately', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		clock.tick(100);
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":2}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, stream, CancellationToken.None);
+
+		// Both emitted immediately (no pending flush needed)
+		assert.strictEqual(updateCalls.length, 2);
+		assert.deepStrictEqual(updateCalls[0].streamData.partialInput, { a: 1 });
+		assert.deepStrictEqual(updateCalls[1].streamData.partialInput, { a: 2 });
+	});
+
+	test('different tool IDs are throttled independently', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool2', name: 'myTool', arguments: '{"b":1}' }] } });
+		// These are within the throttle window for their respective tools
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":2}' }] } });
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool2', name: 'myTool', arguments: '{"b":2}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, stream, CancellationToken.None);
+
+		// 2 immediate (one per tool) + 2 flushed (one per tool) = 4
+		assert.strictEqual(updateCalls.length, 4);
+	});
+
+	test('pending updates are not flushed on cancellation', async () => {
+		const cts = new CancellationTokenSource();
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		// Start processing, then emit items so the for-await loop consumes them
+		const promise = processor.doProcessResponse(responseSource.asyncIterable, stream, cts.token);
+
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		await new Promise(r => setTimeout(r, 0));
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":2}' }] } });
+		await new Promise(r => setTimeout(r, 0));
+
+		// Cancel after items are processed but before stream ends
+		cts.cancel();
+		responseSource.resolve();
+
+		await promise;
+
+		// Only the first immediate update — buffered update should NOT be flushed
+		assert.strictEqual(updateCalls.length, 1);
+		assert.strictEqual(updateCalls[0].toolCallId, 'tool1');
+	});
+
+	test('retry clears pending throttle state', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const clearCalls: number[] = [];
+		const clearStream = new ChatResponseStreamImpl(
+			() => { },
+			() => clearCalls.push(1),
+			undefined,
+			undefined,
+			(toolCallId, streamData) => updateCalls.push({ toolCallId, streamData }),
+		);
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		// Buffer a pending update
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":1}' }] } });
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":2}' }] } });
+		// Retry clears everything
+		responseSource.emitOne({ delta: { text: '', retryReason: 'network_error' } });
+		// New update after retry should go through immediately
+		clock.tick(100);
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: 'myTool', arguments: '{"a":3}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, clearStream, CancellationToken.None);
+
+		// 1 immediate before retry + 1 immediate after retry = 2
+		// The buffered {"a":2} should have been cleared by retry, not flushed
+		assert.strictEqual(updateCalls.length, 2);
+		assert.deepStrictEqual(updateCalls[0].streamData.partialInput, { a: 1 });
+		assert.deepStrictEqual(updateCalls[1].streamData.partialInput, { a: 3 });
+	});
+
+	test('updates without name are skipped', async () => {
+		const responseSource = new AsyncIterableSource<IResponsePart>();
+		const processor = new PseudoStopStartResponseProcessor([], undefined);
+
+		responseSource.emitOne({ delta: { text: '', copilotToolCallStreamUpdates: [{ id: 'tool1', name: undefined as any, arguments: '{"a":1}' }] } });
+		responseSource.resolve();
+
+		await processor.doProcessResponse(responseSource.asyncIterable, stream, CancellationToken.None);
+
+		assert.strictEqual(updateCalls.length, 0);
+	});
 });


### PR DESCRIPTION
# Throttle `updateToolInvocation` during tool-call streaming

## Problem

During chat streaming with tool calls, the extension host experienced **1.3–1.5s MajorGC pauses** that froze token delivery, causing visible hangs in the chat UI.

### Root cause

In `PseudoStopStartResponseProcessor.applyDeltaToProgress`, every incoming SSE token triggered:

1. **`tryParsePartialToolInput(update.arguments)`** — a recursive-descent partial JSON parse (`best-effort-json-parser`) of the **entire accumulated arguments string** from scratch
2. **`progress.updateToolInvocation()`** — an RPC call that serializes the parsed object via `JSON.stringify`, sends it over `postMessage` to the main thread, which then issues a **round-trip RPC back** to the ext host via `$handleToolStream`

For a tool call with N argument tokens, this produced:
- **O(N²) total parsing work** (re-parsing from position 0 on every token)
- **~2N RPC round-trips** (ext host → renderer → ext host per token)
- Heap growth from ~700MB to ~920MB, triggering V8 MajorGC

### Before-fix traces

The issue was reproduced across three independent traces, all showing the same pattern: ext host MajorGC pauses during tool-call streaming causing message delivery gaps.

#### Trace 1 — single hang near end of response

- Ext host (pid=10273): **1,109ms MajorGC** followed by **1,732ms RunTask** (5,444 `operator()` calls + 13 MinorGCs)
- Heap: 97MB → 303MB during chat session
- Resulted in a **1,385ms message gap** at the renderer (last message at 1255.6s, next at 1257.0s)
- User-visible: ~1.4s freeze near "What's included: Overview" before remaining text appeared

#### Trace 2 — multiple hangs throughout streaming

- Ext host (pid=19772): 3 MajorGCs during ~40s of active streaming:
  - **1,242ms** at chat+1s → 1,355ms message gap
  - **1,342ms** at chat+18s → **4,091ms** message gap (compounded with renderer GC)
  - **1,529ms** at chat+36s → 1,979ms message gap
- GC durations increased over time (1,242 → 1,342 → 1,529ms) as the heap grew

#### Trace 3 — with CPU profiling enabled

- Ext host (pid=27683): 3 MajorGCs totaling **4,086ms** (1,378ms + 1,374ms + 1,333ms)
- Heap: 759MB → 920MB
- CPU profiler confirmed the allocation sources during GC windows:

| Function | CPU samples | % of non-idle |
|---|---|---|
| `(garbage collector)` | 27,738 | 18.1% |
| `parseString` → `parseObject` (partial JSON parser) | 1,177 | 0.8% |
| `parse9` → `tryParsePartialToolInput` → `applyDeltaToProgress` | 987 | 0.6% |
| `stringify` (RPC serialization) | 572 | 0.4% |
| `deserializeRequestJSONArgs` (RPC deserialization) | 456 | 0.3% |
| `postMessage` (IPC) | 722 | 0.5% |

#### Summary of before-fix traces

| Metric | Trace 1 | Trace 2 | Trace 3 |
|---|---|---|---|
| Ext host MajorGC count | 1 | 3 | 3 |
| Ext host MajorGC total time | 1,109ms | 4,113ms | 4,086ms |
| Ext host max heap | 303MB | — | 920MB |
| Longest message gap | 1,385ms | 4,091ms | — |

## Fix

Added a 100ms throttle to `updateToolInvocation` calls in `pseudoStartStopConversationCallback.ts`. When tool stream updates arrive faster than every 100ms for the same tool call, the latest update is buffered. Pending updates are flushed when the response stream ends.

```typescript
// Before: called on every token
progress.updateToolInvocation(update.id ?? '', {
    partialInput: tryParsePartialToolInput(update.arguments)
});

// After: throttled to at most once per 100ms per tool call
const now = Date.now();
const lastUpdate = this._lastToolStreamUpdate.get(toolId) ?? 0;
if (now - lastUpdate >= PseudoStopStartResponseProcessor._toolStreamThrottleMs) {
    this._lastToolStreamUpdate.set(toolId, now);
    this._pendingToolStreamUpdates.delete(toolId);
    progress.updateToolInvocation(toolId, { partialInput: tryParsePartialToolInput(update.arguments) });
} else {
    this._pendingToolStreamUpdates.set(toolId, { id: toolId, arguments: update.arguments });
}
```

The partial input is only used for streaming UI messages (e.g., "Creating file.ts (42 lines)") — it does not need per-token precision.

## Results

Validated across two independent post-fix traces (traces 4 and 5).

| Metric | Trace 1 (before) | Trace 2 (before) | Trace 3 (before) | Trace 4 (after) | Trace 5 (after) |
|---|---|---|---|---|---|
| Ext host MajorGC count | 1 | 3 | 3 | 0 | 0 |
| Ext host MajorGC total time | 1,109ms | 4,113ms | 4,086ms | 0ms | 0ms |
| Ext host max heap | 303MB | — | 920MB | — | — |
| Longest message gap | 1,385ms | 4,091ms | — | 448ms* | — |
| `parseString` CPU samples | — | — | 1,177 | 16 | 0 |
| `tryParsePartialToolInput` CPU samples | — | — | 987 | gone | gone |
| `stringify` (RPC) CPU samples | — | — | 572 | — | — |

\* Trace 4's remaining 448ms gap was caused by the main renderer's own GC (pid=19660), not the ext host.

### Files changed

- `extensions/copilot/src/extension/prompt/node/pseudoStartStopConversationCallback.ts`

## Perfetto query:
**inclusive_samples**: The number of CPU profiler samples where that function was anywhere on the call stack — either it was the function being directly executed, OR it was a caller higher up in the chain. For example, [tryParsePartialToolInput](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) has 27 inclusive samples meaning 27 times the CPU was sampled while executing either inside [tryParsePartialToolInput](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) itself or inside any function it called (parse9, [parseObject](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [parseString](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), etc.).

**pct_of_total**: That inclusive count divided by the total number of CPU samples collected for that process (251,649 in trace 4, 406,012 in trace 3). It answers the question: "what fraction of the ext host's CPU time was spent in or under this function?" This normalizes for trace duration — a longer trace collects more samples proportionally, so the percentage is comparable across traces of different lengths.

So [tryParsePartialToolInput](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) at 0.011% in trace 4 means the ext host spent 0.011% of its total CPU time in the partial JSON parsing path, versus 0.552% in trace 3 before the fix.

`WITH RECURSIVE ancestors AS (SELECT cpss.id as sample_id, cpss.callsite_id, spc.parent_id, spf.name FROM cpu_profile_stack_sample cpss JOIN stack_profile_callsite spc ON cpss.callsite_id = spc.id JOIN stack_profile_frame spf ON spc.frame_id = spf.id JOIN thread t ON cpss.utid = t.utid JOIN process p ON t.upid = p.upid WHERE p.pid = 27683 UNION ALL SELECT a.sample_id, spc.id, spc.parent_id, spf.name FROM ancestors a JOIN stack_profile_callsite spc ON a.parent_id = spc.id JOIN stack_profile_frame spf ON spc.frame_id = spf.id), total AS (SELECT count(*) as cnt FROM cpu_profile_stack_sample cpss JOIN thread t ON cpss.utid = t.utid JOIN process p ON t.upid = p.upid WHERE p.pid = 27683) SELECT a.name, count(DISTINCT a.sample_id) as inclusive_samples, round(100.0 * count(DISTINCT a.sample_id) / total.cnt, 3) as pct_of_total FROM ancestors a, total WHERE a.name IN ('tryParsePartialToolInput', 'applyDeltaToProgress', 'parseString', 'parse9', 'parseObject', '(garbage collector)') GROUP BY a.name ORDER BY inclusive_samples DESC`

<img width="398" height="112" alt="image" src="https://github.com/user-attachments/assets/222c75f6-9574-4c96-94a7-8dcf4c5d3acd" />

vs.

`WITH RECURSIVE ancestors AS (SELECT cpss.id as sample_id, cpss.callsite_id, spc.parent_id, spf.name FROM cpu_profile_stack_sample cpss JOIN stack_profile_callsite spc ON cpss.callsite_id = spc.id JOIN stack_profile_frame spf ON spc.frame_id = spf.id JOIN thread t ON cpss.utid = t.utid JOIN process p ON t.upid = p.upid WHERE p.pid = 30297 UNION ALL SELECT a.sample_id, spc.id, spc.parent_id, spf.name FROM ancestors a JOIN stack_profile_callsite spc ON a.parent_id = spc.id JOIN stack_profile_frame spf ON spc.frame_id = spf.id), total AS (SELECT count(*) as cnt FROM cpu_profile_stack_sample cpss JOIN thread t ON cpss.utid = t.utid JOIN process p ON t.upid = p.upid WHERE p.pid = 30297) SELECT a.name, count(DISTINCT a.sample_id) as inclusive_samples, round(100.0 * count(DISTINCT a.sample_id) / total.cnt, 3) as pct_of_total FROM ancestors a, total WHERE a.name IN ('tryParsePartialToolInput', 'applyDeltaToProgress', 'parseString', 'parse9', 'parseObject', '(garbage collector)') GROUP BY a.name ORDER BY inclusive_samples DESC` (trace 4)

<img width="626" height="117" alt="image" src="https://github.com/user-attachments/assets/69f0b484-aa73-4157-b8c9-43e675c1e595" />