### PR TITLE
Allow BYOK for business/enterprise users with client_byok policy

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -160,7 +160,7 @@ export function isBYOKEnabled(copilotToken: Omit<CopilotToken, 'token'>, capiCli
 	}
 
 	const isGHE = capiClientService.dotcomAPIURL !== 'https://api.github.com';
-	const byokAllowed = (copilotToken.isInternal || copilotToken.isIndividual) && !isGHE;
+	const byokAllowed = (copilotToken.isInternal || copilotToken.isIndividual || copilotToken.isClientBYOKEnabled()) && !isGHE;
 	return byokAllowed;
 }
 

--- a/extensions/copilot/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
+++ b/extensions/copilot/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
@@ -35,6 +35,8 @@ const debugReportFeedbackContextKey = 'github.copilot.debugReportFeedback';
 
 const previewFeaturesDisabledContextKey = 'github.copilot.previewFeaturesDisabled';
 
+const clientByokEnabledContextKey = 'github.copilot.clientByokEnabled';
+
 const debugContextKey = 'github.copilot.chat.debug';
 
 const missingPermissiveSessionContextKey = 'github.copilot.auth.missingPermissiveSession';
@@ -197,6 +199,15 @@ export class ContextKeysContribution extends Disposable {
 		}
 	}
 
+	private async _updateClientByokEnabledContext() {
+		try {
+			const copilotToken = await this._authenticationService.getCopilotToken();
+			commands.executeCommand('setContext', clientByokEnabledContextKey, copilotToken.isClientBYOKEnabled());
+		} catch (e) {
+			commands.executeCommand('setContext', clientByokEnabledContextKey, undefined);
+		}
+	}
+
 	private _updateShowLogViewContext() {
 		if (this._showLogView) {
 			return;
@@ -221,6 +232,7 @@ export class ContextKeysContribution extends Disposable {
 		this._inspectContext();
 		this._updateQuotaExceededContext();
 		this._updatePreviewFeaturesDisabledContext();
+		this._updateClientByokEnabledContext();
 		this._updateShowLogViewContext();
 		this._updatePermissiveSessionContext();
 	}

--- a/extensions/copilot/src/platform/authentication/common/copilotToken.ts
+++ b/extensions/copilot/src/platform/authentication/common/copilotToken.ts
@@ -217,6 +217,10 @@ export class CopilotToken {
 		return this.getTokenValue('mcp') !== '0';
 	}
 
+	isClientBYOKEnabled(): boolean {
+		return this.getTokenValue('client_byok') === '1';
+	}
+
 	getTokenValue(key: string): string | undefined {
 		return this.tokenMap.get(key);
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

BYOK (Bring Your Own Key) is currently gated to internal and individual Copilot users. Business and enterprise users should also be able to use BYOK when their organization has opted in via the `client_byok` policy (token field `client_byok=1`).

## Approach

Three changes in the copilot extension, mirroring what's already wired up on the VS Code core side (`chatEntitlementService`, `chatModelsWidget`):

1. **`CopilotToken.isClientBYOKEnabled()`** — New method that reads `client_byok` from the token, following the same pattern as `isMcpEnabled()` / `isEditorPreviewFeaturesEnabled()`.

2. **`isBYOKEnabled()` update** — Adds `copilotToken.isClientBYOKEnabled()` to the allowlist so business/enterprise users with the policy can use BYOK providers.

3. **`github.copilot.clientByokEnabled` context key** — Set from `contextKeys.contribution.ts` on auth change, following the exact `previewFeaturesDisabledContextKey` pattern. This context key is already read by `chatEntitlementService.clientByokEnabled` in VS Code core to gate the "Add Models" button for managed entitlements.

## Testing

- A business/enterprise user with `client_byok=1` in their token should see BYOK providers enabled and the "Add Models" button active in the model picker.
- Users without the flag should see no change in behavior.
- Individual and internal users remain unaffected (already allowed).