### PR TITLE
agentHost: centralize test session helpers

### DIFF
--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IReference } from '../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+import type { IDiffComputeService, IDiffCountResult } from '../../common/diffComputeService.js';
+import type { IFileEditContent, IFileEditRecord, ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+
+export class TestSessionDatabase implements ISessionDatabase {
+	private readonly _edits: (IFileEditRecord & IFileEditContent)[] = [];
+	private readonly _metadata = new Map<string, string>();
+
+	getAllFileEditsCalls = 0;
+	getFileEditsByTurnCalls = 0;
+
+	addEdit(edit: IFileEditRecord & IFileEditContent): void {
+		this._edits.push(edit);
+	}
+
+	async createTurn(): Promise<void> { }
+
+	async deleteTurn(turnId: string): Promise<void> {
+		for (let i = this._edits.length - 1; i >= 0; i--) {
+			if (this._edits[i].turnId === turnId) {
+				this._edits.splice(i, 1);
+			}
+		}
+	}
+
+	async storeFileEdit(edit: IFileEditRecord & IFileEditContent): Promise<void> {
+		const existingIndex = this._edits.findIndex(e => e.toolCallId === edit.toolCallId && e.filePath === edit.filePath);
+		if (existingIndex >= 0) {
+			this._edits[existingIndex] = edit;
+		} else {
+			this._edits.push(edit);
+		}
+	}
+
+	async getFileEdits(toolCallIds: string[]): Promise<IFileEditRecord[]> {
+		const toolCallIdsSet = new Set(toolCallIds);
+		return this._toEditRecords(this._edits.filter(e => toolCallIdsSet.has(e.toolCallId)));
+	}
+
+	async getAllFileEdits(): Promise<IFileEditRecord[]> {
+		this.getAllFileEditsCalls++;
+		return this._toEditRecords(this._edits);
+	}
+
+	async getFileEditsByTurn(turnId: string): Promise<IFileEditRecord[]> {
+		this.getFileEditsByTurnCalls++;
+		return this._toEditRecords(this._edits.filter(e => e.turnId === turnId));
+	}
+
+	async readFileEditContent(toolCallId: string, filePath: string): Promise<IFileEditContent | undefined> {
+		return this._edits.find(e => e.toolCallId === toolCallId && e.filePath === filePath);
+	}
+
+	async getMetadata(key: string): Promise<string | undefined> {
+		return this._metadata.get(key);
+	}
+
+	async getMetadataObject<T extends Record<string, unknown>>(obj: T): Promise<{ [K in keyof T]: string | undefined }> {
+		return Object.fromEntries(Object.keys(obj).map(key => [key, this._metadata.get(key)])) as { [K in keyof T]: string | undefined };
+	}
+
+	async setMetadata(key: string, value: string): Promise<void> {
+		this._metadata.set(key, value);
+	}
+
+	async close(): Promise<void> { }
+
+	dispose(): void { }
+
+	private _toEditRecords(edits: (IFileEditRecord & IFileEditContent)[]): IFileEditRecord[] {
+		return edits.map(({ beforeContent: _, afterContent: _2, ...metadata }) => metadata);
+	}
+}
+
+export class TestDiffComputeService implements IDiffComputeService {
+	declare readonly _serviceBrand: undefined;
+
+	callCount = 0;
+
+	constructor(private readonly _result?: IDiffCountResult) { }
+
+	async computeDiffCounts(original: string, modified: string): Promise<IDiffCountResult> {
+		this.callCount++;
+		if (this._result) {
+			return this._result;
+		}
+
+		const originalLines = original ? original.split('\n') : [];
+		const modifiedLines = modified ? modified.split('\n') : [];
+		return {
+			added: Math.max(0, modifiedLines.length - originalLines.length),
+			removed: Math.max(0, originalLines.length - modifiedLines.length),
+		};
+	}
+}
+
+export function createZeroDiffComputeService(): IDiffComputeService {
+	return new TestDiffComputeService({ added: 0, removed: 0 });
+}
+
+export function createSessionDataService(database: ISessionDatabase = new TestSessionDatabase()): ISessionDataService {
+	return {
+		_serviceBrand: undefined,
+		getSessionDataDir: session => URI.from({ scheme: Schemas.inMemory, path: `/session-data${session.path}` }),
+		getSessionDataDirById: sessionId => URI.from({ scheme: Schemas.inMemory, path: `/session-data/${sessionId}` }),
+		openDatabase: () => createReference(database),
+		tryOpenDatabase: async () => createReference(database),
+		deleteSessionData: async () => { },
+		cleanupOrphanedData: async () => { },
+	};
+}
+
+export function createNullSessionDataService(): ISessionDataService {
+	return {
+		_serviceBrand: undefined,
+		getSessionDataDir: session => URI.from({ scheme: Schemas.inMemory, path: `/session-data${session.path}` }),
+		getSessionDataDirById: sessionId => URI.from({ scheme: Schemas.inMemory, path: `/session-data/${sessionId}` }),
+		openDatabase: () => { throw new Error('not implemented'); },
+		tryOpenDatabase: async () => undefined,
+		deleteSessionData: async () => { },
+		cleanupOrphanedData: async () => { },
+	};
+}
+
+export function encodeString(text: string): Uint8Array {
+	return new TextEncoder().encode(text);
+}
+
+function createReference<T>(object: T): IReference<T> {
+	return {
+		object,
+		dispose: () => { },
+	};
+}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
-import { DisposableStore, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
@@ -13,10 +13,10 @@ import { NullLogService } from '../../../log/common/log.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { AgentSession } from '../../common/agentService.js';
-import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, IActionEnvelope } from '../../common/state/sessionActions.js';
 import { ResponsePartKind, SessionLifecycle, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, type IMarkdownResponsePart, type IToolCallCompletedState, type IToolCallResponsePart } from '../../common/state/sessionState.js';
+import { createNullSessionDataService, createSessionDataService } from '../common/sessionTestHelpers.js';
 import { AgentService } from '../../node/agentService.js';
 import { MockAgent } from './mockAgent.js';
 
@@ -28,15 +28,6 @@ suite('AgentService (node dispatcher)', () => {
 	let fileService: FileService;
 
 	setup(async () => {
-		const nullSessionDataService: ISessionDataService = {
-			_serviceBrand: undefined,
-			getSessionDataDir: () => URI.parse('inmemory:/session-data'),
-			getSessionDataDirById: () => URI.parse('inmemory:/session-data'),
-			openDatabase: () => { throw new Error('not implemented'); },
-			tryOpenDatabase: async () => undefined,
-			deleteSessionData: async () => { },
-			cleanupOrphanedData: async () => { },
-		};
 		fileService = disposables.add(new FileService(new NullLogService()));
 		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
 
@@ -44,7 +35,7 @@ suite('AgentService (node dispatcher)', () => {
 		await fileService.createFolder(URI.from({ scheme: Schemas.inMemory, path: '/testDir' }));
 		await fileService.writeFile(URI.from({ scheme: Schemas.inMemory, path: '/testDir/file.txt' }), VSBuffer.fromString('hello'));
 
-		service = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService));
+		service = disposables.add(new AgentService(new NullLogService(), fileService, createNullSessionDataService()));
 		copilotAgent = new MockAgent('copilot');
 		disposables.add(toDisposable(() => copilotAgent.dispose()));
 	});
@@ -152,21 +143,7 @@ suite('AgentService (node dispatcher)', () => {
 			const sessionId = 'test-session-abc';
 			const sessionUri = AgentSession.uri('copilot', sessionId);
 
-			const sessionDataService: ISessionDataService = {
-				_serviceBrand: undefined,
-				getSessionDataDir: () => URI.parse('inmemory:/session-data'),
-				getSessionDataDirById: () => URI.parse('inmemory:/session-data'),
-				openDatabase: (): IReference<ISessionDatabase> => ({
-					object: db,
-					dispose: () => { },
-				}),
-				tryOpenDatabase: async (): Promise<IReference<ISessionDatabase> | undefined> => ({
-					object: db,
-					dispose: () => { },
-				}),
-				deleteSessionData: async () => { },
-				cleanupOrphanedData: async () => { },
-			};
+			const sessionDataService = createSessionDataService(db);
 
 			// Create a mock that returns a session with that ID
 			const agent = new MockAgent('copilot');

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
-import { DisposableStore, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -14,13 +14,14 @@ import { FileService } from '../../../files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { AgentSession, IAgent } from '../../common/agentService.js';
-import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
 import { ActionType, IActionEnvelope, ISessionAction } from '../../common/state/sessionActions.js';
 import { PendingMessageKind, SessionStatus } from '../../common/state/sessionState.js';
 import { AgentService } from '../../node/agentService.js';
 import { AgentSideEffects } from '../../node/agentSideEffects.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { AgentHostStateManager } from '../../node/agentHostStateManager.js';
+import { createNullSessionDataService, createSessionDataService } from '../common/sessionTestHelpers.js';
 import { MockAgent } from './mockAgent.js';
 
 // ---- Tests ------------------------------------------------------------------
@@ -73,15 +74,7 @@ suite('AgentSideEffects', () => {
 		sideEffects = disposables.add(new AgentSideEffects(stateManager, {
 			getAgent: () => agent,
 			agents: agentList,
-			sessionDataService: {
-				_serviceBrand: undefined,
-				getSessionDataDir: () => URI.from({ scheme: Schemas.inMemory, path: '/session-data' }),
-				getSessionDataDirById: () => URI.from({ scheme: Schemas.inMemory, path: '/session-data' }),
-				openDatabase: () => { throw new Error('not implemented'); },
-				tryOpenDatabase: async () => undefined,
-				deleteSessionData: async () => { },
-				cleanupOrphanedData: async () => { },
-			} satisfies ISessionDataService,
+			sessionDataService: createNullSessionDataService(),
 		}, new NullLogService()));
 	});
 
@@ -763,24 +756,6 @@ suite('AgentSideEffects', () => {
 
 		let sessionDb: SessionDatabase;
 
-		function createSessionDataServiceWithDb(): ISessionDataService {
-			return {
-				_serviceBrand: undefined,
-				getSessionDataDir: () => URI.from({ scheme: Schemas.inMemory, path: '/session-data' }),
-				getSessionDataDirById: () => URI.from({ scheme: Schemas.inMemory, path: '/session-data' }),
-				openDatabase: (): IReference<ISessionDatabase> => ({
-					object: sessionDb,
-					dispose: () => { },
-				}),
-				tryOpenDatabase: async (): Promise<IReference<ISessionDatabase> | undefined> => ({
-					object: sessionDb,
-					dispose: () => { },
-				}),
-				deleteSessionData: async () => { },
-				cleanupOrphanedData: async () => { },
-			};
-		}
-
 		setup(async () => {
 			sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
 		});
@@ -790,7 +765,7 @@ suite('AgentSideEffects', () => {
 		});
 
 		test('SessionTitleChanged persists to the database', async () => {
-			const sessionDataService = createSessionDataServiceWithDb();
+			const sessionDataService = createSessionDataService(sessionDb);
 			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
 			const localAgent = new MockAgent();
 			disposables.add(toDisposable(() => localAgent.dispose()));
@@ -822,7 +797,7 @@ suite('AgentSideEffects', () => {
 		});
 
 		test('handleListSessions returns persisted custom title', async () => {
-			const sessionDataService = createSessionDataServiceWithDb();
+			const sessionDataService = createSessionDataService(sessionDb);
 			const localAgent = new MockAgent();
 			disposables.add(toDisposable(() => localAgent.dispose()));
 			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService));
@@ -842,7 +817,7 @@ suite('AgentSideEffects', () => {
 		});
 
 		test('handleRestoreSession uses persisted custom title', async () => {
-			const sessionDataService = createSessionDataServiceWithDb();
+			const sessionDataService = createSessionDataService(sessionDb);
 			const localAgent = new MockAgent();
 			disposables.add(toDisposable(() => localAgent.dispose()));
 			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService));

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -13,11 +13,12 @@ import { NullLogService, ILogService } from '../../../log/common/log.js';
 import { IFileService } from '../../../files/common/files.js';
 import { AgentSession, IAgentProgressEvent } from '../../common/agentService.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
-import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
 import { CopilotAgentSession, SessionWrapperFactory } from '../../node/copilot/copilotAgentSession.js';
 import { CopilotSessionWrapper } from '../../node/copilot/copilotSessionWrapper.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { createSessionDataService, createZeroDiffComputeService } from '../common/sessionTestHelpers.js';
 
 // ---- Mock CopilotSession (SDK level) ----------------------------------------
 
@@ -62,32 +63,6 @@ class MockCopilotSession {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createMockSessionDataService(): ISessionDataService {
-	const mockDb: ISessionDatabase = {
-		createTurn: async () => { },
-		deleteTurn: async () => { },
-		storeFileEdit: async () => { },
-		getFileEdits: async () => [],
-		getAllFileEdits: async () => [],
-		readFileEditContent: async () => undefined,
-		getMetadata: async () => undefined,
-		getFileEditsByTurn: async () => [],
-		getMetadataObject: async (obj) => Object.fromEntries(Object.keys(obj).map(k => [k, undefined])) as never,
-		setMetadata: async () => { },
-		close: async () => { },
-		dispose: () => { },
-	};
-	return {
-		_serviceBrand: undefined,
-		getSessionDataDir: () => URI.from({ scheme: 'test', path: '/data' }),
-		getSessionDataDirById: () => URI.from({ scheme: 'test', path: '/data' }),
-		openDatabase: () => ({ object: mockDb, dispose: () => { } }),
-		tryOpenDatabase: async () => ({ object: mockDb, dispose: () => { } }),
-		deleteSessionData: async () => { },
-		cleanupOrphanedData: async () => { },
-	};
-}
-
 async function createAgentSession(disposables: DisposableStore, options?: { workingDirectory?: URI }): Promise<{
 	session: CopilotAgentSession;
 	mockSession: MockCopilotSession;
@@ -105,8 +80,8 @@ async function createAgentSession(disposables: DisposableStore, options?: { work
 	const services = new ServiceCollection();
 	services.set(ILogService, new NullLogService());
 	services.set(IFileService, { _serviceBrand: undefined } as IFileService);
-	services.set(ISessionDataService, createMockSessionDataService());
-	services.set(IDiffComputeService, { _serviceBrand: undefined, computeDiffCounts: async () => ({ added: 0, removed: 0 }) } as IDiffComputeService);
+	services.set(ISessionDataService, createSessionDataService());
+	services.set(IDiffComputeService, createZeroDiffComputeService());
 	const instantiationService = disposables.add(new InstantiationService(services));
 
 	const session = disposables.add(instantiationService.createInstance(

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -17,6 +17,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { IDiffComputeService } from '../../common/diffComputeService.js';
 import { ToolResultContentType } from '../../common/state/sessionState.js';
+import { createZeroDiffComputeService } from '../common/sessionTestHelpers.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { FileEditTracker, buildSessionDbUri, parseSessionDbUri } from '../../node/copilot/fileEditTracker.js';
 
@@ -38,7 +39,7 @@ suite('FileEditTracker', () => {
 		const services = new ServiceCollection();
 		services.set(ILogService, new NullLogService());
 		services.set(IFileService, fileService);
-		services.set(IDiffComputeService, { _serviceBrand: undefined, computeDiffCounts: async () => ({ added: 0, removed: 0 }) } as IDiffComputeService);
+		services.set(IDiffComputeService, createZeroDiffComputeService());
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		tracker = instantiationService.createInstance(FileEditTracker, 'copilot:/test-session', db);
 	});

--- a/src/vs/platform/agentHost/test/node/sessionDiffAggregator.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDiffAggregator.test.ts
@@ -6,66 +6,11 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import type { IDiffComputeService } from '../../common/diffComputeService.js';
-import type { IFileEditContent, IFileEditRecord, ISessionDatabase } from '../../common/sessionDataService.js';
 import { FileEditKind, type ISessionFileDiff } from '../../common/state/sessionState.js';
+import { encodeString, TestDiffComputeService, TestSessionDatabase } from '../common/sessionTestHelpers.js';
 import { computeSessionDiffs } from '../../node/sessionDiffAggregator.js';
 
-/**
- * Minimal mock of ISessionDatabase that stores file edits in memory.
- * Only implements the methods needed by computeSessionDiffs.
- */
-class MockSessionDatabase {
-	private readonly _edits: (IFileEditRecord & IFileEditContent)[] = [];
-	getAllFileEditsCalls = 0;
-	getFileEditsByTurnCalls = 0;
-
-	addEdit(edit: IFileEditRecord & IFileEditContent): void {
-		this._edits.push(edit);
-	}
-
-	async getAllFileEdits(): Promise<IFileEditRecord[]> {
-		this.getAllFileEditsCalls++;
-		return this._edits.map(({ beforeContent: _, afterContent: _2, ...meta }) => meta);
-	}
-
-	async getFileEditsByTurn(turnId: string): Promise<IFileEditRecord[]> {
-		this.getFileEditsByTurnCalls++;
-		return this._edits
-			.filter(e => e.turnId === turnId)
-			.map(({ beforeContent: _, afterContent: _2, ...meta }) => meta);
-	}
-
-	async readFileEditContent(toolCallId: string, filePath: string): Promise<IFileEditContent | undefined> {
-		return this._edits.find(e => e.toolCallId === toolCallId && e.filePath === filePath);
-	}
-}
-
-/**
- * Mock diff service that counts lines naively: each line in modified
- * not in original is "added", each line in original not in modified is
- * "removed". Good enough for testing the aggregation logic.
- */
-function createMockDiffService(): IDiffComputeService & { callCount: number } {
-	const svc = {
-		_serviceBrand: undefined as never,
-		callCount: 0,
-		async computeDiffCounts(original: string, modified: string) {
-			svc.callCount++;
-			const origLines = original ? original.split('\n') : [];
-			const modLines = modified ? modified.split('\n') : [];
-			return {
-				added: Math.max(0, modLines.length - origLines.length),
-				removed: Math.max(0, origLines.length - modLines.length),
-			};
-		},
-	};
-	return svc;
-}
-
-function enc(text: string): Uint8Array {
-	return new TextEncoder().encode(text);
-}
+const createTestDiffService = () => new TestDiffComputeService();
 
 suite('computeSessionDiffs', () => {
 
@@ -74,22 +19,22 @@ suite('computeSessionDiffs', () => {
 	// ---- Full-mode tests (no incremental options) ---------------------------
 
 	test('returns empty array for no edits', async () => {
-		const db = new MockSessionDatabase();
-		const diffService = createMockDiffService();
-		const result = await computeSessionDiffs(db as unknown as ISessionDatabase, diffService);
+		const db = new TestSessionDatabase();
+		const diffService = createTestDiffService();
+		const result = await computeSessionDiffs(db, diffService);
 		assert.deepStrictEqual(result, []);
 	});
 
 	test('computes diffs for a single edited file', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('line1\nline2'), afterContent: enc('line1\nline2\nline3'),
+			beforeContent: encodeString('line1\nline2'), afterContent: encodeString('line1\nline2\nline3'),
 		});
 
-		const diffService = createMockDiffService();
-		const result = await computeSessionDiffs(db as unknown as ISessionDatabase, diffService);
+		const diffService = createTestDiffService();
+		const result = await computeSessionDiffs(db, diffService);
 
 		assert.deepStrictEqual(result, [{
 			uri: URI.file('/a.txt').toString(),
@@ -100,20 +45,20 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('skips files with no net change', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('same'), afterContent: enc('different'),
+			beforeContent: encodeString('same'), afterContent: encodeString('different'),
 		});
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('different'), afterContent: enc('same'),
+			beforeContent: encodeString('different'), afterContent: encodeString('same'),
 		});
 
-		const diffService = createMockDiffService();
-		const result = await computeSessionDiffs(db as unknown as ISessionDatabase, diffService);
+		const diffService = createTestDiffService();
+		const result = await computeSessionDiffs(db, diffService);
 
 		// Before = tc1.before = 'same', After = tc2.after = 'same' → zero net change
 		assert.deepStrictEqual(result, []);
@@ -121,20 +66,20 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('tracks rename chains correctly', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Create,
 			addedLines: undefined, removedLines: undefined,
-			afterContent: enc('hello'),
+			afterContent: encodeString('hello'),
 		});
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/b.txt', kind: FileEditKind.Rename, originalPath: '/a.txt',
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('hello'), afterContent: enc('hello world'),
+			beforeContent: encodeString('hello'), afterContent: encodeString('hello world'),
 		});
 
-		const diffService = createMockDiffService();
-		const result = await computeSessionDiffs(db as unknown as ISessionDatabase, diffService);
+		const diffService = createTestDiffService();
+		const result = await computeSessionDiffs(db, diffService);
 
 		assert.strictEqual(result.length, 1);
 		assert.strictEqual(result[0].uri, URI.file('/b.txt').toString(), 'uses terminal path after rename');
@@ -143,27 +88,27 @@ suite('computeSessionDiffs', () => {
 	// ---- Incremental-mode tests ---------------------------------------------
 
 	test('incremental: reuses previousDiffs for untouched files', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// File A edited in turn 1 only
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('a-before'), afterContent: enc('a-after'),
+			beforeContent: encodeString('a-before'), afterContent: encodeString('a-after'),
 		});
 		// File B edited in turn 2
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/b.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('b-before'), afterContent: enc('b-after\nnew'),
+			beforeContent: encodeString('b-before'), afterContent: encodeString('b-after\nnew'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 42, removed: 7 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -180,26 +125,26 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental: recomputes file edited in current turn', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// File A edited in turn 1 and turn 2
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('original'), afterContent: enc('after-turn1'),
+			beforeContent: encodeString('original'), afterContent: encodeString('after-turn1'),
 		});
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('after-turn1'), afterContent: enc('after-turn2\nextra'),
+			beforeContent: encodeString('after-turn1'), afterContent: encodeString('after-turn2\nextra'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 100, removed: 100 }, // stale
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -214,28 +159,28 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental: rename in current turn drops old URI from previousDiffs', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// File created in turn 1
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/old.txt', kind: FileEditKind.Create,
 			addedLines: undefined, removedLines: undefined,
-			afterContent: enc('content'),
+			afterContent: encodeString('content'),
 		});
 		// Renamed in turn 2
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/new.txt', kind: FileEditKind.Rename,
 			originalPath: '/old.txt',
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('content'), afterContent: enc('content'),
+			beforeContent: encodeString('content'), afterContent: encodeString('content'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/old.txt').toString(), added: 5, removed: 0 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -246,26 +191,26 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental: file with zero net change in current turn is excluded even if in previousDiffs', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('original'), afterContent: enc('modified'),
+			beforeContent: encodeString('original'), afterContent: encodeString('modified'),
 		});
 		// Turn 2 reverts the change
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('modified'), afterContent: enc('original'),
+			beforeContent: encodeString('modified'), afterContent: encodeString('original'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 10, removed: 5 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -275,18 +220,18 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental: previousDiffs entry for file not in current identities is dropped (slow path)', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// File A was edited in turn 1 and is in previousDiffs
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('before'), afterContent: enc('after'),
+			beforeContent: encodeString('before'), afterContent: encodeString('after'),
 		});
 		// File A is edited again in turn 2 → triggers slow path (re-edit of existing file)
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('after'), afterContent: enc('latest\nline'),
+			beforeContent: encodeString('after'), afterContent: encodeString('latest\nline'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
@@ -294,9 +239,9 @@ suite('computeSessionDiffs', () => {
 			{ uri: URI.file('/orphan.txt').toString(), added: 99, removed: 99 }, // no longer in DB
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -307,20 +252,20 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('full mode recomputes all files (no incremental options)', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('a'), afterContent: enc('a\nb'),
+			beforeContent: encodeString('a'), afterContent: encodeString('a\nb'),
 		});
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc2', filePath: '/b.txt', kind: FileEditKind.Create,
 			addedLines: undefined, removedLines: undefined,
-			afterContent: enc('new'),
+			afterContent: encodeString('new'),
 		});
 
-		const diffService = createMockDiffService();
-		const result = await computeSessionDiffs(db as unknown as ISessionDatabase, diffService);
+		const diffService = createTestDiffService();
+		const result = await computeSessionDiffs(db, diffService);
 
 		assert.strictEqual(result.length, 2);
 		assert.strictEqual(diffService.callCount, 2, 'both files should be diffed in full mode');
@@ -329,27 +274,27 @@ suite('computeSessionDiffs', () => {
 	// ---- Fast-path tests (turn-scoped query optimization) -------------------
 
 	test('incremental fast path: new files only uses getFileEditsByTurn, not getAllFileEdits', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// Turn 1: existing file untouched in turn 2
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/old.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('old-before'), afterContent: enc('old-after'),
+			beforeContent: encodeString('old-before'), afterContent: encodeString('old-after'),
 		});
 		// Turn 2: creates a new file
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/new.txt', kind: FileEditKind.Create,
 			addedLines: undefined, removedLines: undefined,
-			afterContent: enc('brand new'),
+			afterContent: encodeString('brand new'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/old.txt').toString(), added: 3, removed: 1 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -366,27 +311,27 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental slow path: re-edit of existing file falls back to getAllFileEdits', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		// Turn 1: edit file A
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('original'), afterContent: enc('turn1'),
+			beforeContent: encodeString('original'), afterContent: encodeString('turn1'),
 		});
 		// Turn 2: edit file A again
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('turn1'), afterContent: enc('turn2\nextra'),
+			beforeContent: encodeString('turn1'), afterContent: encodeString('turn2\nextra'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 5, removed: 0 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -404,26 +349,26 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental slow path: rename in current turn falls back to getAllFileEdits', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Create,
 			addedLines: undefined, removedLines: undefined,
-			afterContent: enc('content'),
+			afterContent: encodeString('content'),
 		});
 		db.addEdit({
 			turnId: 't2', toolCallId: 'tc2', filePath: '/b.txt', kind: FileEditKind.Rename,
 			originalPath: '/a.txt',
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('content'), afterContent: enc('content'),
+			beforeContent: encodeString('content'), afterContent: encodeString('content'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 1, removed: 0 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);
@@ -432,20 +377,20 @@ suite('computeSessionDiffs', () => {
 	});
 
 	test('incremental: no edits in turn returns previousDiffs unchanged', async () => {
-		const db = new MockSessionDatabase();
+		const db = new TestSessionDatabase();
 		db.addEdit({
 			turnId: 't1', toolCallId: 'tc1', filePath: '/a.txt', kind: FileEditKind.Edit,
 			addedLines: undefined, removedLines: undefined,
-			beforeContent: enc('before'), afterContent: enc('after'),
+			beforeContent: encodeString('before'), afterContent: encodeString('after'),
 		});
 
 		const previousDiffs: ISessionFileDiff[] = [
 			{ uri: URI.file('/a.txt').toString(), added: 5, removed: 2 },
 		];
 
-		const diffService = createMockDiffService();
+		const diffService = createTestDiffService();
 		const result = await computeSessionDiffs(
-			db as unknown as ISessionDatabase,
+			db,
 			diffService,
 			{ changedTurnId: 't2', previousDiffs },
 		);


### PR DESCRIPTION
agentHost: centralize test session helpers

Refactors repeated session-data and diff-compute test doubles into a shared
agentHost test helper module.

- Adds reusable TestSessionDatabase and TestDiffComputeService helpers for
  tests that need in-memory file-edit metadata or deterministic diff counts.
- Adds session-data-service factories for tests that need either an injected
  database reference or an intentionally unopened/null session database.
- Updates agentHost node tests to use the common helpers instead of local
  mock database, data-service, encoder, and zero-diff implementations.

(Commit message generated by Copilot)