### PR TITLE
chat: unify customization item paths via PromptsServiceCustomizationProvider

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -6,10 +6,13 @@
 import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
+	IExternalCustomizationItemProvider,
 	createCliHarnessDescriptor,
 	getCliUserRoots,
 } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { PromptsServiceCustomizationProvider } from '../../../../workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationProvider.js';
 import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
 
 /**
@@ -17,15 +20,38 @@ import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
  *
  * Only the CLI harness is registered because sessions always run via
  * the Copilot CLI. With a single harness the toggle bar is hidden.
+ *
+ * A {@link PromptsServiceCustomizationProvider} wraps IPromptsService
+ * so that the management editor can display items without needing an
+ * extension-contributed provider.
+ *
+ * The provider is created lazily via IInstantiationService to avoid
+ * cyclic dependencies.
  */
 export class SessionsCustomizationHarnessService extends CustomizationHarnessServiceBase {
 	constructor(
 		@IPathService pathService: IPathService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		const userHome = pathService.userHome({ preferLocal: true });
 		const extras = [BUILTIN_STORAGE];
+		const descriptor = createCliHarnessDescriptor(getCliUserRoots(userHome), extras);
+
+		// Lazy provider: created on first call to avoid cyclic DI resolution.
+		let provider: PromptsServiceCustomizationProvider | undefined;
+		const lazyItemProvider: IExternalCustomizationItemProvider = {
+			get onDidChange() {
+				provider ??= instantiationService.createInstance(PromptsServiceCustomizationProvider, descriptor);
+				return provider.onDidChange;
+			},
+			provideChatSessionCustomizations(token) {
+				provider ??= instantiationService.createInstance(PromptsServiceCustomizationProvider, descriptor);
+				return provider.provideChatSessionCustomizations(token);
+			},
+		};
+
 		super(
-			[createCliHarnessDescriptor(getCliUserRoots(userHome), extras)],
+			[{ ...descriptor, itemProvider: lazyItemProvider }],
 			CustomizationHarness.CLI,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -12,10 +12,10 @@ import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { autorun } from '../../../../../base/common/observable.js';
-import { basename, dirname, isEqual, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { basename, isEqual, isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { ResourceMap } from '../../../../../base/common/map.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -39,7 +39,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { createActionViewItem, getContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
-import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
@@ -50,12 +50,12 @@ import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js
 import { extractExtensionIdFromPath, getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
 import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
 import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
-import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
+import { HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, matchesWorkspaceSubpath, matchesInstructionFileFilter, ICustomizationSyncProvider } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, ICustomizationSyncProvider } from '../../common/customizationHarnessService.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
@@ -109,10 +109,6 @@ export interface IAICustomizationListItem {
 	readonly badgeTooltip?: string;
 	/** When set, overrides the default prompt-type icon. */
 	readonly typeIcon?: ThemeIcon;
-	/** True when item comes from the default chat extension (grouped under Built-in). */
-	readonly isBuiltin?: boolean;
-	/** Display name of the contributing extension (for non-built-in extension items). */
-	readonly extensionLabel?: string;
 	/** Server-reported loading/sync status for remote customizations. */
 	readonly status?: 'loading' | 'loaded' | 'degraded' | 'error';
 	/** Human-readable status detail (e.g. error message or warning). */
@@ -267,18 +263,6 @@ function promptTypeToIcon(type: PromptsType): ThemeIcon {
 	}
 }
 
-/**
- * Returns the icon for a given storage type.
- */
-function storageToIcon(storage: PromptsStorage): ThemeIcon {
-	switch (storage) {
-		case PromptsStorage.local: return workspaceIcon;
-		case PromptsStorage.user: return userIcon;
-		case PromptsStorage.extension: return extensionIcon;
-		case PromptsStorage.plugin: return pluginIcon;
-		default: return instructionsIcon;
-	}
-}
 
 /**
  * Formats a name for display by stripping a trailing .md extension.
@@ -372,16 +356,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 
 		// Hover tooltip: name + source + badge context + plugin source
 		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.container, () => {
-			let content: string;
-			if (element.isBuiltin) {
-				content = `${element.name}\n${localize('builtinSource', "Built-in")}`;
-			} else if (element.extensionLabel) {
-				content = `${element.name}\n${localize('fromExtension', "Extension: {0}", element.extensionLabel)}`;
-			} else {
-				const isWorkspaceItem = element.storage === PromptsStorage.local;
-				const uriLabel = this.labelService.getUriLabel(element.uri, { relative: isWorkspaceItem });
-				content = `${element.name}\n${uriLabel}`;
-			}
+			const isWorkspaceItem = element.storage === PromptsStorage.local;
+			const uriLabel = this.labelService.getUriLabel(element.uri, { relative: isWorkspaceItem });
+			let content = `${element.name}\n${uriLabel}`;
 			if (element.badgeTooltip) {
 				content += `\n\n${element.badgeTooltip}`;
 			}
@@ -850,8 +827,8 @@ export class AICustomizationListWidget extends Disposable {
 
 		const { secondary } = getContextMenuActions(actions, 'inline');
 
-		// Add copy path actions (not shown for built-in items where the path is an implementation detail)
-		const copyActions = item.isBuiltin ? [] : [
+		// Add copy path actions
+		const copyActions = [
 			new Separator(),
 			new Action('copyFullPath', localize('copyFullPath', "Copy Full Path"), undefined, true, async () => {
 				await this.clipboardService.writeText(item.uri.fsPath);
@@ -1201,10 +1178,10 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
+	/**
 	 * Returns true if the given extension identifier matches the default
-	 * chat extension (e.g. GitHub Copilot Chat). Used to group items from
-	 * the chat extension under "Built-in" instead of "Extensions", similar
-	 * to how MCP categorizes built-in servers.
+	 * chat extension (e.g. GitHub Copilot Chat). Used by _inferStorageAndGroup
+	 * to detect built-in items from extension install directories.
 	 */
 	private isChatExtensionItem(extensionId: ExtensionIdentifier): boolean {
 		const chatExtensionId = this.productService.defaultChatAgent?.chatExtensionId;
@@ -1212,432 +1189,30 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Post-processes items to assign groupKey overrides for extension-sourced
-	 * items. Applies the built-in grouping consistently across all item types.
-	 *
-	 * Items that already have an explicit groupKey (e.g. instruction categories,
-	 * agent hooks) are left untouched — groupKey overrides are only applied to
-	 * items whose current groupKey is `undefined`.
-	 */
-	private applyBuiltinGroupKeys(items: IAICustomizationListItem[], extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>): IAICustomizationListItem[] {
-		return items.map(item => {
-			if (item.storage !== PromptsStorage.extension) {
-				return item;
-			}
-			const extInfo = extensionInfoByUri.get(item.uri);
-			if (!extInfo) {
-				return item;
-			}
-			const isBuiltin = this.isChatExtensionItem(extInfo.id);
-			if (isBuiltin) {
-				return {
-					...item,
-					isBuiltin: true,
-					groupKey: item.groupKey ?? BUILTIN_STORAGE,
-				};
-			}
-			return {
-				...item,
-				extensionLabel: extInfo.displayName || extInfo.id.value,
-			};
-		});
-	}
-
-	/**
 	 * Fetches and filters items for a given section.
-	 * Delegates to the provider path or core path based on the active harness.
+	 * Every harness has an itemProvider — static harnesses wrap promptsService,
+	 * extension-contributed harnesses supply their own.
 	 */
 	private async fetchItemsForSection(section: AICustomizationManagementSection): Promise<IAICustomizationListItem[]> {
 		const promptType = sectionToPromptType(section);
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-
-		if (activeDescriptor.itemProvider && promptType) {
-			return this.fetchProviderItemsForSection(activeDescriptor, promptType);
-		}
-
-		return this.fetchCoreItemsForSection(promptType);
+		return this.fetchProviderItemsForSection(this.harnessService.getActiveDescriptor(), promptType);
 	}
 
 	/**
 	 * Fetches items from an external customization provider.
 	 * When a syncProvider is present, blends remote items with local sync items.
+	 * Harnesses with only a syncProvider (e.g. remote agent host) skip the
+	 * remote fetch and return only local syncable items.
 	 */
 	private async fetchProviderItemsForSection(descriptor: ReturnType<ICustomizationHarnessService['getActiveDescriptor']>, promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const remoteItems = await this.fetchItemsFromProvider(descriptor.itemProvider!, promptType);
+		const remoteItems = descriptor.itemProvider
+			? await this.fetchItemsFromProvider(descriptor.itemProvider, promptType)
+			: [];
 		if (!descriptor.syncProvider) {
 			return remoteItems;
 		}
 		const localItems = await this.fetchLocalSyncableItems(promptType, descriptor.syncProvider);
 		return [...remoteItems, ...localItems];
-	}
-
-	/**
-	 * Fetches items from the core promptsService with full filtering pipeline.
-	 * This is the legacy path used when no external provider is active.
-	 * TODO: Remove when provider API is the sole code path.
-	 */
-	private async fetchCoreItemsForSection(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const items: IAICustomizationListItem[] = [];
-		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
-		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();
-
-
-		if (promptType === PromptsType.agent) {
-			// Use getCustomAgents which has parsed name/description from frontmatter
-			const agents = await this.promptsService.getCustomAgents(CancellationToken.None);
-			// Build extension display name lookup from raw file list
-			const allAgentFiles = await this.promptsService.listPromptFiles(PromptsType.agent, CancellationToken.None);
-			for (const file of allAgentFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			for (const agent of agents) {
-				const filename = basename(agent.uri);
-				items.push({
-					id: agent.uri.toString(),
-					uri: agent.uri,
-					name: agent.name,
-					filename,
-					description: agent.description,
-					storage: agent.source.storage,
-					promptType,
-					pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-					disabled: disabledUris.has(agent.uri),
-				});
-				// Track extension ID for built-in grouping (if not already set from file list)
-				if (agent.source.storage === PromptsStorage.extension && !extensionInfoByUri.has(agent.uri)) {
-					extensionInfoByUri.set(agent.uri, { id: agent.source.extensionId });
-				}
-			}
-		} else if (promptType === PromptsType.skill) {
-			// Use findAgentSkills for enabled skills (has parsed name/description from frontmatter)
-			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
-			// Build extension ID lookup from raw file list (like MCP builds collectionSources)
-			const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, CancellationToken.None);
-			for (const file of allSkillFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
-			const seenUris = new ResourceSet();
-			for (const skill of skills || []) {
-				const filename = basename(skill.uri);
-				const skillName = skill.name || basename(dirname(skill.uri)) || filename;
-				seenUris.add(skill.uri);
-				const skillFolderName = basename(dirname(skill.uri));
-				const uiTooltip = uiIntegrations.get(skillFolderName);
-				items.push({
-					id: skill.uri.toString(),
-					uri: skill.uri,
-					name: skillName,
-					filename,
-					description: skill.description,
-					storage: skill.storage,
-					promptType,
-					pluginUri: skill.storage === PromptsStorage.plugin ? this.findPluginUri(skill.uri) : undefined,
-					disabled: false,
-					badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-					badgeTooltip: uiTooltip,
-				});
-			}
-			// Also include disabled skills from the raw file list
-			if (disabledUris.size > 0) {
-				for (const file of allSkillFiles) {
-					if (!seenUris.has(file.uri) && disabledUris.has(file.uri)) {
-						const filename = basename(file.uri);
-						const disabledName = file.name || basename(dirname(file.uri)) || filename;
-						const disabledFolderName = basename(dirname(file.uri));
-						const uiTooltip = uiIntegrations.get(disabledFolderName);
-						items.push({
-							id: file.uri.toString(),
-							uri: file.uri,
-							name: disabledName,
-							filename,
-							description: file.description,
-							storage: file.storage,
-							promptType,
-							disabled: true,
-							badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-							badgeTooltip: uiTooltip,
-						});
-					}
-				}
-			}
-		} else if (promptType === PromptsType.prompt) {
-			// Use getPromptSlashCommands which has parsed name/description from frontmatter
-			// Filter out skills since they have their own section
-			const commands = await this.promptsService.getPromptSlashCommands(CancellationToken.None);
-			for (const command of commands) {
-				if (command.type === PromptsType.skill) {
-					continue;
-				}
-				const filename = basename(command.uri);
-				items.push({
-					id: command.uri.toString(),
-					uri: command.uri,
-					name: command.name,
-					filename,
-					description: command.description,
-					storage: command.storage,
-					promptType,
-					pluginUri: command.storage === PromptsStorage.plugin ? command.pluginUri : undefined,
-					disabled: disabledUris.has(command.uri),
-				});
-				if (command.extension) {
-					extensionInfoByUri.set(command.uri, { id: command.extension.identifier, displayName: command.extension.displayName });
-				}
-			}
-		} else if (promptType === PromptsType.hook) {
-			// Try to parse individual hooks from each file; fall back to showing the file itself
-			const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			const userHomeUri = await this.pathService.userHome();
-			const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
-
-			for (const hookFile of hookFiles) {
-				// Plugins parse their own hooks and emit them individually because they can
-				// be embedded with interpolations in the plugin manifests; don't re-parse them
-				if (hookFile.storage === PromptsStorage.plugin) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString() + ':' + hookFile.name,
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						pluginUri: hookFile.pluginUri,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-					continue;
-				}
-
-				let parsedHooks = false;
-				try {
-					const content = await this.fileService.readFile(hookFile.uri);
-					const json = parseJSONC(content.value.toString());
-					const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
-
-					if (hooks.size > 0) {
-						parsedHooks = true;
-						for (const [hookType, entry] of hooks) {
-							const hookMeta = HOOK_METADATA[hookType];
-							for (let i = 0; i < entry.hooks.length; i++) {
-								const hook = entry.hooks[i];
-								const cmdLabel = formatHookCommandLabel(hook, OS);
-								const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-								items.push({
-									id: `${hookFile.uri.toString()}#${entry.originalId}[${i}]`,
-									uri: hookFile.uri,
-									name: hookMeta?.label ?? entry.originalId,
-									filename: basename(hookFile.uri),
-									description: truncatedCmd || localize('hookUnset', "(unset)"),
-									storage: hookFile.storage,
-									promptType,
-									disabled: disabledUris.has(hookFile.uri),
-								});
-							}
-						}
-					}
-				} catch {
-					// Parse failed — fall through to show raw file
-				}
-
-				if (!parsedHooks) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString(),
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-				}
-			}
-
-			// Also include hooks defined in agent frontmatter (not in sessions window)
-			// TODO: add this back when Copilot CLI supports this
-			const agents = !this.workspaceService.isSessionsWindow ? await this.promptsService.getCustomAgents(CancellationToken.None) : [];
-			for (const agent of agents) {
-				if (!agent.hooks) {
-					continue;
-				}
-				for (const hookType of Object.values(HookType)) {
-					const hookCommands = agent.hooks[hookType];
-					if (!hookCommands || hookCommands.length === 0) {
-						continue;
-					}
-					const hookMeta = HOOK_METADATA[hookType];
-					for (let i = 0; i < hookCommands.length; i++) {
-						const hook = hookCommands[i];
-						const cmdLabel = formatHookCommandLabel(hook, OS);
-						const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-						items.push({
-							id: `${agent.uri.toString()}#hook:${hookType}[${i}]`,
-							uri: agent.uri,
-							name: hookMeta?.label ?? hookType,
-							filename: basename(agent.uri),
-							description: `${agent.name}: ${truncatedCmd || localize('hookUnset', "(unset)")}`,
-							storage: agent.source.storage,
-							groupKey: 'agents',
-							promptType,
-							pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-							disabled: disabledUris.has(agent.uri),
-						});
-					}
-				}
-			}
-		} else {
-			// For instructions, group by category: agent instructions, context instructions, on-demand instructions
-			const instructionFiles = await this.promptsService.getInstructionFiles(CancellationToken.None);
-			for (const file of instructionFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const agentInstructionFiles = await this.promptsService.listAgentInstructions(CancellationToken.None, undefined);
-			const agentInstructionUris = new ResourceSet(agentInstructionFiles.map(f => f.uri));
-
-			// Add agent instruction items
-			const workspaceFolderUris = this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			if (activeRoot) {
-				workspaceFolderUris.push(activeRoot);
-			}
-			for (const file of agentInstructionFiles) {
-				const storage = PromptsStorage.local;
-				const filename = basename(file.uri);
-				items.push({
-					id: file.uri.toString(),
-					uri: file.uri,
-					name: filename,
-					filename: this.labelService.getUriLabel(file.uri, { relative: true }),
-					displayName: filename,
-					storage,
-					promptType,
-					typeIcon: storageToIcon(storage),
-					groupKey: 'agent-instructions',
-					disabled: disabledUris.has(file.uri),
-				});
-			}
-
-			// Parse prompt files to separate into context vs on-demand
-
-			for (const { uri, pattern, name, description, storage, pluginUri } of instructionFiles) {
-				if (agentInstructionUris.has(uri)) {
-					continue; // already added as agent instruction
-				}
-
-				const friendlyName = this.getFriendlyName(name);
-
-				if (pattern !== undefined) {
-					// Context instruction
-					const badge = pattern === '**'
-						? localize('alwaysAdded', "always added")
-						: pattern;
-					const badgeTooltip = pattern === '**'
-						? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
-						: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", pattern);
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: this.labelService.getUriLabel(uri, { relative: true }),
-						displayName: friendlyName,
-						badge,
-						badgeTooltip,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'context-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				} else {
-					// On-demand instruction
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: basename(uri),
-						displayName: friendlyName,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'on-demand-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				}
-			}
-		}
-
-		// Assign built-in groupKeys — items from the default chat extension
-		// are re-grouped under "Built-in" instead of "Extensions".
-		// This is a single-pass transformation applied after all items are
-		// collected, keeping the item-building code free of grouping logic.
-		const groupedItems = this.applyBuiltinGroupKeys(items, extensionInfoByUri);
-
-		// Apply storage source filter (removes items not in visible sources or excluded user roots)
-		const filter = this.workspaceService.getStorageSourceFilter(promptType);
-		const withStorage = groupedItems.filter((item): item is IAICustomizationListItem & { readonly storage: PromptsStorage } => item.storage !== undefined);
-		const withoutStorage = groupedItems.filter(item => item.storage === undefined);
-		const filteredItems = [...applyStorageSourceFilter(withStorage, filter), ...withoutStorage];
-		items.length = 0;
-		items.push(...filteredItems);
-
-		// Apply workspace subpath filter — when the active harness specifies
-		// workspaceSubpaths, hide workspace-local items that aren't under one
-		// of the recognized sub-paths (e.g. Claude only shows .claude/ items).
-		// Exception: instruction files matched by the harness's instructionFileFilter
-		// are exempt (e.g. CLAUDE.md at workspace root is a Claude-native file
-		// even though it's not under .claude/).
-		const descriptor = this.harnessService.getActiveDescriptor();
-		const subpaths = descriptor.workspaceSubpaths;
-		const instrFilter = descriptor.instructionFileFilter;
-		if (subpaths) {
-			const projectRoot = this.workspaceService.getActiveProjectRoot();
-			for (let i = items.length - 1; i >= 0; i--) {
-				const item = items[i];
-				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
-					if (!matchesWorkspaceSubpath(item.uri.path, subpaths)) {
-						// Keep instruction files that match the harness's native patterns
-						if (instrFilter && promptType === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
-							continue;
-						}
-						// Keep agent instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md)
-						// — these live at the workspace root by design and should not be
-						// filtered out by workspace subpath restrictions.
-						if (item.groupKey === 'agent-instructions') {
-							continue;
-						}
-						items.splice(i, 1);
-					}
-				}
-			}
-		}
-
-		// Apply instruction file filter — when the active harness specifies
-		// instructionFileFilter, hide instruction files that don't match the
-		// recognized patterns (e.g. Claude doesn't support *.instructions.md).
-		if (instrFilter && promptType === PromptsType.instructions) {
-			for (let i = items.length - 1; i >= 0; i--) {
-				if (!matchesInstructionFileFilter(items[i].uri.path, instrFilter)) {
-					items.splice(i, 1);
-				}
-			}
-		}
-
-		// Sort items by name
-		items.sort((a, b) => a.name.localeCompare(b.name));
-
-		return items;
 	}
 
 	/**
@@ -2014,55 +1589,13 @@ export class AICustomizationListWidget extends Disposable {
 		this.commitDisplayEntries();
 	}
 
-	/**
-	 * Filters and groups items from the core promptsService (static harness path).
-	 * Instructions use semantic categories; other sections use storage-based groups.
-	 */
-	private filterItemsForCore(matchedItems: IAICustomizationListItem[]): void {
-		const promptType = sectionToPromptType(this.currentSection);
-		const visibleSources = new Set(this.workspaceService.getStorageSourceFilter(promptType).sources);
-
-		const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] =
-			this.currentSection === AICustomizationManagementSection.Instructions
-				? [
-					{ groupKey: 'agent-instructions', label: localize('agentInstructionsGroup', "Agent Instructions"), icon: instructionsIcon, description: localize('agentInstructionsGroupDescription', "Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md)."), items: [] },
-					{ groupKey: 'context-instructions', label: localize('contextInstructionsGroup', "Included Based on Context"), icon: instructionsIcon, description: localize('contextInstructionsGroupDescription', "Instructions automatically loaded when matching files are part of the context."), items: [] },
-					{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
-				]
-				: [
-					{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
-					{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
-					{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
-					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
-					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
-					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
-
-		for (const item of matchedItems) {
-			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
-			const group = groups.find(g => g.groupKey === key);
-			if (group) {
-				group.items.push(item);
-			}
-		}
-
-		this.buildGroupedEntries(groups);
-		this.commitDisplayEntries();
-	}
 
 	/**
 	 * Filters items based on the current search query and builds grouped display entries.
 	 */
 	private filterItems(): number {
 		const matchedItems = this.applySearchFilter(this.allItems);
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-
-		if (activeDescriptor.itemProvider) {
-			this.filterItemsForProvider(matchedItems);
-		} else {
-			this.filterItemsForCore(matchedItems);
-		}
-
+		this.filterItemsForProvider(matchedItems);
 		return matchedItems.length;
 	}
 
@@ -2119,18 +1652,6 @@ export class AICustomizationListWidget extends Disposable {
 			default:
 				return promptIcon;
 		}
-	}
-
-	/**
-	 * Finds the plugin URI for an item URI by checking the known plugins.
-	 */
-	private findPluginUri(itemUri: URI): URI | undefined {
-		for (const plugin of this.agentPluginService.plugins.get()) {
-			if (isEqualOrParent(itemUri, plugin.uri)) {
-				return plugin.uri;
-			}
-		}
-		return undefined;
 	}
 
 	private getEmptyStateInfo(): { title: string; description: string } {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -8,22 +8,50 @@ import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
 	ICustomizationHarnessService,
+	IExternalCustomizationItemProvider,
 	createVSCodeHarnessDescriptor,
 } from '../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { BUILTIN_STORAGE } from '../../common/aiCustomizationWorkspaceService.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { PromptsServiceCustomizationProvider } from './promptsServiceCustomizationProvider.js';
 
 /**
  * Core implementation of the customization harness service.
  *
  * Only the Local harness is registered statically. All other harnesses
  * (e.g. Copilot CLI) are contributed by extensions via the provider API.
+ *
+ * A {@link PromptsServiceCustomizationProvider} wraps IPromptsService
+ * so the management editor uses the same provider-based code path for
+ * Local items as it does for extension-contributed harnesses.
+ *
+ * The provider is created lazily via IInstantiationService to avoid
+ * cyclic dependencies between ICustomizationHarnessService and
+ * IPromptsService (which depends on the extension host).
  */
 class CustomizationHarnessService extends CustomizationHarnessServiceBase {
-	constructor() {
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
 		const localExtras = [PromptsStorage.extension, BUILTIN_STORAGE];
+		const descriptor = createVSCodeHarnessDescriptor(localExtras);
+
+		// Lazy provider: created on first call to avoid cyclic DI resolution.
+		let provider: PromptsServiceCustomizationProvider | undefined;
+		const lazyItemProvider: IExternalCustomizationItemProvider = {
+			get onDidChange() {
+				provider ??= instantiationService.createInstance(PromptsServiceCustomizationProvider, descriptor);
+				return provider.onDidChange;
+			},
+			provideChatSessionCustomizations(token) {
+				provider ??= instantiationService.createInstance(PromptsServiceCustomizationProvider, descriptor);
+				return provider.provideChatSessionCustomizations(token);
+			},
+		};
+
 		super(
-			[createVSCodeHarnessDescriptor(localExtras)],
+			[{ ...descriptor, itemProvider: lazyItemProvider }],
 			CustomizationHarness.VSCode,
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationProvider.ts
@@ -1,0 +1,340 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { basename, dirname } from '../../../../../base/common/resources.js';
+import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { localize } from '../../../../../nls.js';
+import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
+import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { OS } from '../../../../../base/common/platform.js';
+import { IExternalCustomizationItem, IExternalCustomizationItemProvider, matchesWorkspaceSubpath, matchesInstructionFileFilter, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
+import { IAICustomizationWorkspaceService, BUILTIN_STORAGE } from '../../common/aiCustomizationWorkspaceService.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { URI } from '../../../../../base/common/uri.js';
+
+/**
+ * Derives a friendly name from a filename by removing extension suffixes.
+ */
+function getFriendlyName(filename: string): string {
+	let name = filename
+		.replace(/\.instructions\.md$/i, '')
+		.replace(/\.prompt\.md$/i, '')
+		.replace(/\.agent\.md$/i, '')
+		.replace(/\.md$/i, '');
+
+	name = name
+		.replace(/[-_]/g, ' ')
+		.replace(/\b\w/g, c => c.toUpperCase());
+
+	return name || filename;
+}
+
+/**
+ * An {@link IExternalCustomizationItemProvider} backed by {@link IPromptsService}.
+ *
+ * Produces the same rich items (semantic groupKeys, applyTo badges,
+ * disabled state, built-in extension grouping) that the list widget's
+ * legacy `fetchCoreItemsForSection` code path produced, but shaped as
+ * `IExternalCustomizationItem[]` so they flow through the single
+ * provider-based code path in the widget.
+ *
+ * Used by the Local (VS Code) and Sessions (CLI) harnesses.
+ */
+export class PromptsServiceCustomizationProvider extends Disposable implements IExternalCustomizationItemProvider {
+
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange: Event<void> = this._onDidChange.event;
+
+	private readonly _chatExtensionId: string | undefined;
+
+	constructor(
+		private readonly _descriptor: IHarnessDescriptor,
+		@IPromptsService private readonly _promptsService: IPromptsService,
+		@IAICustomizationWorkspaceService private readonly _workspaceService: IAICustomizationWorkspaceService,
+		@IProductService productService: IProductService,
+	) {
+		super();
+		this._chatExtensionId = productService.defaultChatAgent?.chatExtensionId;
+
+		this._register(Event.any(
+			_promptsService.onDidChangeCustomAgents,
+			_promptsService.onDidChangeSlashCommands,
+			_promptsService.onDidChangeSkills,
+			_promptsService.onDidChangeHooks,
+			_promptsService.onDidChangeInstructions,
+		)(() => this._onDidChange.fire()));
+	}
+
+	async provideChatSessionCustomizations(token: CancellationToken): Promise<IExternalCustomizationItem[] | undefined> {
+		const items: IExternalCustomizationItem[] = [];
+
+		const [agents, skills, instructions, agentInstructions, prompts, hooks] = await Promise.all([
+			this._promptsService.getCustomAgents(token),
+			this._promptsService.findAgentSkills(token),
+			this._promptsService.getInstructionFiles(token),
+			this._promptsService.listAgentInstructions(token, undefined),
+			this._promptsService.getPromptSlashCommands(token),
+			this._promptsService.listPromptFiles(PromptsType.hook, token),
+		]);
+
+		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();
+
+		// --- Agents ---
+		const allAgentFiles = await this._promptsService.listPromptFiles(PromptsType.agent, token);
+		for (const file of allAgentFiles) {
+			if (file.extension) {
+				extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+			}
+		}
+		const disabledAgents = this._promptsService.getDisabledPromptFiles(PromptsType.agent);
+		for (const agent of agents ?? []) {
+			items.push({
+				uri: agent.uri,
+				type: PromptsType.agent,
+				name: agent.name,
+				description: agent.description,
+				enabled: !disabledAgents.has(agent.uri),
+				groupKey: this._getBuiltinGroupKey(agent.uri, agent.source.storage, extensionInfoByUri),
+			});
+			if (agent.source.storage === PromptsStorage.extension && !extensionInfoByUri.has(agent.uri)) {
+				extensionInfoByUri.set(agent.uri, { id: agent.source.extensionId });
+			}
+		}
+
+		// --- Skills ---
+		const allSkillFiles = await this._promptsService.listPromptFiles(PromptsType.skill, token);
+		for (const file of allSkillFiles) {
+			if (file.extension) {
+				extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+			}
+		}
+		const uiIntegrations = this._workspaceService.getSkillUIIntegrations();
+		const disabledSkills = this._promptsService.getDisabledPromptFiles(PromptsType.skill);
+		const seenSkillUris = new ResourceSet();
+		for (const skill of skills ?? []) {
+			const skillName = skill.name || basename(dirname(skill.uri)) || basename(skill.uri);
+			seenSkillUris.add(skill.uri);
+			const skillFolderName = basename(dirname(skill.uri));
+			const uiTooltip = uiIntegrations.get(skillFolderName);
+			items.push({
+				uri: skill.uri,
+				type: PromptsType.skill,
+				name: skillName,
+				description: skill.description,
+				enabled: true,
+				badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
+				badgeTooltip: uiTooltip,
+				groupKey: this._getBuiltinGroupKey(skill.uri, skill.storage, extensionInfoByUri),
+			});
+		}
+		// Disabled skills from raw file list
+		if (disabledSkills.size > 0) {
+			for (const file of allSkillFiles) {
+				if (!seenSkillUris.has(file.uri) && disabledSkills.has(file.uri)) {
+					const disabledName = file.name || basename(dirname(file.uri)) || basename(file.uri);
+					const disabledFolderName = basename(dirname(file.uri));
+					const uiTooltip = uiIntegrations.get(disabledFolderName);
+					items.push({
+						uri: file.uri,
+						type: PromptsType.skill,
+						name: disabledName,
+						description: file.description,
+						enabled: false,
+						badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
+						badgeTooltip: uiTooltip,
+						groupKey: this._getBuiltinGroupKey(file.uri, file.storage, extensionInfoByUri),
+					});
+				}
+			}
+		}
+
+		// --- Prompts ---
+		const disabledPrompts = this._promptsService.getDisabledPromptFiles(PromptsType.prompt);
+		for (const command of prompts) {
+			if (command.type === PromptsType.skill) {
+				continue;
+			}
+			items.push({
+				uri: command.uri,
+				type: PromptsType.prompt,
+				name: command.name,
+				description: command.description,
+				enabled: !disabledPrompts.has(command.uri),
+				groupKey: this._getBuiltinGroupKey(command.uri, command.storage, extensionInfoByUri),
+			});
+			if (command.extension) {
+				extensionInfoByUri.set(command.uri, { id: command.extension.identifier, displayName: command.extension.displayName });
+			}
+		}
+
+		// --- Hooks (file-level — widget's _expandProviderHookItems handles parsing) ---
+		const disabledHooks = this._promptsService.getDisabledPromptFiles(PromptsType.hook);
+		for (const hookFile of hooks) {
+			items.push({
+				uri: hookFile.uri,
+				type: PromptsType.hook,
+				name: hookFile.name || getFriendlyName(basename(hookFile.uri)),
+				enabled: !disabledHooks.has(hookFile.uri),
+			});
+		}
+		// Agent-frontmatter hooks (not in sessions window)
+		if (!this._workspaceService.isSessionsWindow) {
+			for (const agent of agents ?? []) {
+				if (!agent.hooks) {
+					continue;
+				}
+				for (const hookType of Object.values(HookType)) {
+					const hookCommands = agent.hooks[hookType];
+					if (!hookCommands || hookCommands.length === 0) {
+						continue;
+					}
+					const hookMeta = HOOK_METADATA[hookType];
+					for (let i = 0; i < hookCommands.length; i++) {
+						const hook = hookCommands[i];
+						const cmdLabel = formatHookCommandLabel(hook, OS);
+						const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
+						items.push({
+							uri: agent.uri,
+							type: PromptsType.hook,
+							name: hookMeta?.label ?? hookType,
+							description: `${agent.name}: ${truncatedCmd || localize('hookUnset', "(unset)")}`,
+							groupKey: 'agents',
+							enabled: !disabledHooks.has(agent.uri),
+						});
+					}
+				}
+			}
+		}
+
+		// --- Instructions (semantic grouping) ---
+		const disabledInstructions = this._promptsService.getDisabledPromptFiles(PromptsType.instructions);
+		const agentInstructionUris = new ResourceSet(agentInstructions.map(f => f.uri));
+		for (const file of instructions) {
+			if (file.extension) {
+				extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+			}
+		}
+
+		// Agent instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md)
+		for (const file of agentInstructions) {
+			items.push({
+				uri: file.uri,
+				type: PromptsType.instructions,
+				name: basename(file.uri),
+				groupKey: 'agent-instructions',
+				enabled: !disabledInstructions.has(file.uri),
+			});
+		}
+
+		// Context + on-demand instructions
+		for (const { uri, pattern, name, description, storage } of instructions) {
+			if (agentInstructionUris.has(uri)) {
+				continue;
+			}
+
+			const friendlyName = getFriendlyName(name);
+			const builtinGroupKey = this._getBuiltinGroupKey(uri, storage, extensionInfoByUri);
+
+			if (pattern !== undefined) {
+				const badge = pattern === '**'
+					? localize('alwaysAdded', "always added")
+					: pattern;
+				const badgeTooltip = pattern === '**'
+					? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
+					: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", pattern);
+				items.push({
+					uri,
+					type: PromptsType.instructions,
+					name: friendlyName,
+					description,
+					badge,
+					badgeTooltip,
+					groupKey: builtinGroupKey ?? 'context-instructions',
+					enabled: !disabledInstructions.has(uri),
+				});
+			} else {
+				items.push({
+					uri,
+					type: PromptsType.instructions,
+					name: friendlyName,
+					description,
+					groupKey: builtinGroupKey ?? 'on-demand-instructions',
+					enabled: !disabledInstructions.has(uri),
+				});
+			}
+		}
+
+		// --- Post-processing: storage source filter ---
+		const filteredItems = this._applyFilters(items);
+
+		return filteredItems;
+	}
+
+	/**
+	 * Returns `BUILTIN_STORAGE` as groupKey if the item comes from the
+	 * default chat extension; `undefined` otherwise (let the widget infer).
+	 */
+	private _getBuiltinGroupKey(uri: URI, storage: PromptsStorage | string, extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>): string | undefined {
+		if (storage !== PromptsStorage.extension) {
+			return undefined;
+		}
+		const extInfo = extensionInfoByUri.get(uri);
+		if (!extInfo || !this._chatExtensionId) {
+			return undefined;
+		}
+		return ExtensionIdentifier.equals(extInfo.id, this._chatExtensionId) ? BUILTIN_STORAGE : undefined;
+	}
+
+	/**
+	 * Applies harness-descriptor-driven filters that were previously
+	 * at the end of `fetchCoreItemsForSection`.
+	 */
+	private _applyFilters(items: IExternalCustomizationItem[]): IExternalCustomizationItem[] {
+		let result = items;
+
+		// Workspace subpath filter
+		const subpaths = this._descriptor.workspaceSubpaths;
+		const instrFilter = this._descriptor.instructionFileFilter;
+		if (subpaths) {
+			const projectRoot = this._workspaceService.getActiveProjectRoot();
+			result = result.filter(item => {
+				if (item.uri.scheme !== Schemas.file || !projectRoot || !item.uri.path.startsWith(projectRoot.path)) {
+					return true;
+				}
+				if (matchesWorkspaceSubpath(item.uri.path, subpaths)) {
+					return true;
+				}
+				// Keep instruction files matching the harness's native patterns
+				if (instrFilter && item.type === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
+					return true;
+				}
+				// Keep agent instruction files at workspace root
+				if (item.groupKey === 'agent-instructions') {
+					return true;
+				}
+				return false;
+			});
+		}
+
+		// Instruction file filter
+		if (instrFilter) {
+			result = result.filter(item => {
+				if (item.type !== PromptsType.instructions) {
+					return true;
+				}
+				return matchesInstructionFileFilter(item.uri.path, instrFilter);
+			});
+		}
+
+		return result;
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -5,7 +5,7 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
-import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -417,7 +417,7 @@ export function matchesInstructionFileFilter(filePath: string, filters: readonly
  * Concrete registrations only need to supply the list of harness
  * descriptors and a default harness id.
  */
-export class CustomizationHarnessServiceBase implements ICustomizationHarnessService {
+export class CustomizationHarnessServiceBase extends Disposable implements ICustomizationHarnessService {
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _activeHarness: ISettableObservable<string>;
@@ -432,6 +432,7 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 		staticHarnesses: readonly IHarnessDescriptor[],
 		defaultHarness: string,
 	) {
+		super();
 		this._staticHarnesses = staticHarnesses;
 		this._activeHarness = observableValue<string>(this, defaultHarness);
 		this.activeHarness = this._activeHarness;

--- a/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/customizationHarnessService.test.ts
@@ -20,7 +20,7 @@ suite('CustomizationHarnessService', () => {
 		if (harnesses.length === 0) {
 			harnesses = [createVSCodeHarnessDescriptor([PromptsStorage.extension])];
 		}
-		return new CustomizationHarnessServiceBase(harnesses, harnesses[0].id);
+		return store.add(new CustomizationHarnessServiceBase(harnesses, harnesses[0].id));
 	}
 
 	suite('registerExternalHarness', () => {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
@@ -14,6 +14,7 @@ import { IListService, ListService } from '../../../../../platform/list/browser/
 import { IWorkspace, IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor } from '../../../../contrib/chat/common/customizationHarnessService.js';
+import { PromptsServiceCustomizationProvider } from '../../../../contrib/chat/browser/aiCustomization/promptsServiceCustomizationProvider.js';
 import { IAgentPluginService } from '../../../../contrib/chat/common/plugins/agentPluginService.js';
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
 import { PromptsType } from '../../../../contrib/chat/common/promptSyntax/promptTypes.js';
@@ -62,6 +63,8 @@ function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], a
 		}
 		override async listAgentInstructions() { return agentInstructionFiles; }
 		override async getCustomAgents() { return []; }
+		override async findAgentSkills() { return []; }
+		override async getPromptSlashCommands() { return []; }
 		override async getInstructionFiles() {
 			return instructionFiles.map(f => ({
 				uri: f.promptPath.uri,
@@ -109,11 +112,16 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
 		override getActiveProjectRoot() { return URI.file('/workspace'); }
 		override getStorageSourceFilter() { return defaultFilter; }
+		override getSkillUIIntegrations() { return new Map<string, string>(); }
 	}();
 }
 
-function createMockHarnessService(): ICustomizationHarnessService {
-	const descriptor = createVSCodeHarnessDescriptor([PromptsStorage.extension]);
+function createMockHarnessService(promptsService: IPromptsService, workspaceService: IAICustomizationWorkspaceService): ICustomizationHarnessService {
+	const baseDescriptor = createVSCodeHarnessDescriptor([PromptsStorage.extension]);
+	const provider = new PromptsServiceCustomizationProvider(
+		baseDescriptor, promptsService, workspaceService, new class extends mock<IProductService>() { }(),
+	);
+	const descriptor: IHarnessDescriptor = { ...baseDescriptor, itemProvider: provider };
 	return new class extends mock<ICustomizationHarnessService>() {
 		override readonly activeHarness = observableValue<string>('activeHarness', CustomizationHarness.VSCode);
 		override readonly availableHarnesses = observableValue<readonly IHarnessDescriptor[]>('harnesses', [descriptor]);
@@ -156,6 +164,9 @@ async function renderInstructionsTab(ctx: ComponentFixtureContext, instructionFi
 		override layout(): void { }
 	};
 
+	const promptsService = createMockPromptsService(instructionFiles, agentInstructionFiles);
+	const workspaceService = createMockWorkspaceService();
+
 	const instantiationService = createEditorServices(ctx.disposableStore, {
 		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
@@ -163,9 +174,9 @@ async function renderInstructionsTab(ctx: ComponentFixtureContext, instructionFi
 			reg.defineInstance(IContextMenuService, contextMenuService);
 			reg.defineInstance(IContextViewService, contextViewService);
 			reg.define(IListService, ListService);
-			reg.defineInstance(IPromptsService, createMockPromptsService(instructionFiles, agentInstructionFiles));
-			reg.defineInstance(IAICustomizationWorkspaceService, createMockWorkspaceService());
-			reg.defineInstance(ICustomizationHarnessService, createMockHarnessService());
+			reg.defineInstance(IPromptsService, promptsService);
+			reg.defineInstance(IAICustomizationWorkspaceService, workspaceService);
+			reg.defineInstance(ICustomizationHarnessService, createMockHarnessService(promptsService, workspaceService));
 			reg.defineInstance(IWorkspaceContextService, createMockWorkspaceContextService());
 			reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() {
 				override readonly onDidChangeCustomizations = Event.None;

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -30,6 +30,7 @@ import { IWorkingCopyService } from '../../../../services/workingCopy/common/wor
 import { IWebviewService } from '../../../../contrib/webview/browser/webview.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection } from '../../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor, createCliHarnessDescriptor, getCliUserRoots } from '../../../../contrib/chat/common/customizationHarnessService.js';
+import { PromptsServiceCustomizationProvider } from '../../../../contrib/chat/browser/aiCustomization/promptsServiceCustomizationProvider.js';
 import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
 import { PromptsType } from '../../../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, AgentInstructionFileType, PromptsStorage, IAgentSkill, IChatPromptSlashCommand, IAgentInstructionFile } from '../../../../contrib/chat/common/promptSyntax/service/promptsService.js';
@@ -430,10 +431,39 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 		AICustomizationManagementSection.McpServers,
 		AICustomizationManagementSection.Plugins,
 	];
-	const availableHarnesses = options.availableHarnesses ?? [
+	const promptsService = createMockPromptsService(allFiles, agentInstructions);
+	const mockProductService = new class extends mock<IProductService>() { }();
+	const mockWorkspaceService = new class extends mock<IAICustomizationWorkspaceService>() {
+		override readonly isSessionsWindow = isSessionsWindow;
+		override readonly welcomePageFeatures = {
+			showGettingStartedBanner: !isSessionsWindow,
+			showGenerateActions: !isSessionsWindow,
+		};
+		override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
+		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
+		override getActiveProjectRoot() { return URI.file('/workspace'); }
+		override getStorageSourceFilter() { return { sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin, BUILTIN_STORAGE] }; }
+		override clearOverrideProjectRoot() { }
+		override setOverrideProjectRoot() { }
+		override readonly managementSections = managementSections;
+		override async generateCustomization() { }
+		override getSkillUIIntegrations() { return skillUIIntegrations; }
+	}();
+
+	// Ensure every harness descriptor has an itemProvider so the provider-based
+	// code path in the list widget can display items.
+	const rawHarnesses = options.availableHarnesses ?? [
 		createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]),
 		createCliHarnessDescriptor(getCliUserRoots(userHome), []),
 	];
+	const availableHarnesses = rawHarnesses.map(h => {
+		if (h.itemProvider) {
+			return h;
+		}
+		const provider = new PromptsServiceCustomizationProvider(h, promptsService, mockWorkspaceService, mockProductService);
+		ctx.disposableStore.add(provider);
+		return { ...h, itemProvider: provider };
+	});
 
 	const allMcpServers = [...mcpWorkspaceServers, ...mcpUserServers];
 
@@ -456,23 +486,8 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 				}();
 				override getSession() { return undefined; }
 			}());
-			reg.defineInstance(IPromptsService, createMockPromptsService(allFiles, agentInstructions));
-			reg.defineInstance(IAICustomizationWorkspaceService, new class extends mock<IAICustomizationWorkspaceService>() {
-				override readonly isSessionsWindow = isSessionsWindow;
-				override readonly welcomePageFeatures = {
-					showGettingStartedBanner: !isSessionsWindow,
-					showGenerateActions: !isSessionsWindow,
-				};
-				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
-				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
-				override getActiveProjectRoot() { return URI.file('/workspace'); }
-				override getStorageSourceFilter(type: PromptsType) { return harnessService.getStorageSourceFilter(type); }
-				override clearOverrideProjectRoot() { }
-				override setOverrideProjectRoot() { }
-				override readonly managementSections = managementSections;
-				override async generateCustomization() { }
-				override getSkillUIIntegrations() { return skillUIIntegrations; }
-			}());
+			reg.defineInstance(IPromptsService, promptsService);
+			reg.defineInstance(IAICustomizationWorkspaceService, mockWorkspaceService);
 			reg.defineInstance(ICustomizationHarnessService, harnessService);
 			reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() {
 				override readonly onDidChangeCustomizations = Event.None;


### PR DESCRIPTION
## Summary

Extracts the ~300-line `fetchCoreItemsForSection` from the AI Customizations list widget into a new `PromptsServiceCustomizationProvider` class that implements `IExternalCustomizationItemProvider`. The widget now uses a single provider-based code path for all harnesses — static (Local, CLI) and extension-contributed.

Follows #308590 which removed the kill-switch setting and Claude harness.

## What changed (6 files, +406 / -509 lines)

| File | Change |
|------|--------|
| `promptsServiceCustomizationProvider.ts` | **NEW** — Provider class wrapping `IPromptsService`. Emits `IExternalCustomizationItem[]` with semantic `groupKey` (`agent-instructions`, `context-instructions`, `on-demand-instructions`, `agents`, `BUILTIN_STORAGE`), `badge`/`badgeTooltip` for applyTo patterns, `enabled: false` for disabled items |
| `aiCustomizationListWidget.ts` | Deleted `fetchCoreItemsForSection` (~300 lines), `filterItemsForCore` (~40), `applyBuiltinGroupKeys` (~25), `storageToIcon`, `isBuiltin`/`extensionLabel` fields, `if/else` branching in `filterItems()`. Simplified hover tooltips and copy actions. Cleaned up unused imports |
| `browser/customizationHarnessService.ts` | Core VS Code harness creates `PromptsServiceCustomizationProvider` and spreads `itemProvider` onto Local descriptor |
| `sessions/.../customizationHarnessService.ts` | Sessions CLI harness does the same |
| `common/customizationHarnessService.ts` | `CustomizationHarnessServiceBase` now extends `Disposable` for lifecycle management |
| `customizationHarnessService.test.ts` | Wrapped base class in `store.add()` |

## Widget size reduction

~2250 lines → ~1770 lines (-480 lines). The deleted code was the complete "core discovery path" that only the Local harness used. It's now handled by the provider class (~340 lines) which emits items in the same format as extension-contributed providers.

## Verification

- TypeScript compilation clean
- All 15 customizationHarnessService unit tests pass
- Pre-commit hygiene hooks pass