### PR TITLE
sessions: support worktree cleanup/recreation on archive state changes

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessions.ts
@@ -66,6 +66,7 @@ import { ChatSessionWorktreeService } from './chatSessionWorktreeServiceImpl';
 import { ClaudeChatSessionContentProvider } from './claudeChatSessionContentProvider';
 import { ClaudeCustomizationProvider } from './claudeCustomizationProvider';
 import { CopilotCLIChatSessionContentProvider, CopilotCLIChatSessionParticipant, registerCLIChatCommands } from './copilotCLIChatSessions';
+import { SessionIdForCLI } from '../copilotcli/common/utils';
 import { CopilotCLIChatSessionContentProvider as CopilotCLIChatSessionContentProviderV1, CopilotCLIChatSessionItemProvider as CopilotCLIChatSessionItemProviderV1, CopilotCLIChatSessionParticipant as CopilotCLIChatSessionParticipantV1, registerCLIChatCommands as registerCLIChatCommandsV1 } from './copilotCLIChatSessionsContribution';
 import { CopilotCLICustomizationProvider } from './copilotCLICustomizationProvider';
 import { CopilotCLITerminalIntegration, ICopilotCLITerminalIntegration } from './copilotCLITerminalIntegration';
@@ -264,7 +265,8 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 			));
 
 		const copilotcliSessionItemProvider = this._register(copilotcliAgentInstaService.createInstance(CopilotCLIChatSessionItemProviderV1));
-		this._register(vscode.chat.registerChatSessionItemProvider(this.copilotcliSessionType, copilotcliSessionItemProvider));
+		const providerRegistration = vscode.chat.registerChatSessionItemProvider(this.copilotcliSessionType, copilotcliSessionItemProvider);
+		this._register(providerRegistration);
 		this._register(copilotcliAgentInstaService.createInstance(ChatSessionRepositoryTracker, copilotcliSessionItemProvider));
 		const copilotcliChatSessionContentProvider = copilotcliAgentInstaService.createInstance(CopilotCLIChatSessionContentProviderV1, copilotcliSessionItemProvider);
 		const promptResolver = copilotcliAgentInstaService.createInstance(CopilotCLIPromptResolver);
@@ -281,6 +283,33 @@ export class ChatSessionsContrib extends Disposable implements IExtensionContrib
 		));
 		const copilotCLISessionService = copilotcliAgentInstaService.invokeFunction(accessor => accessor.get(ICopilotCLISessionService));
 		const copilotCLIWorktreeManagerService = copilotcliAgentInstaService.invokeFunction(accessor => accessor.get(IChatSessionWorktreeService));
+
+		// Handle worktree cleanup/recreation when archive state changes
+		const onDidChangeChatSessionItemState = (providerRegistration as { onDidChangeChatSessionItemState?: vscode.Event<vscode.ChatSessionItem> }).onDidChangeChatSessionItemState;
+		if (onDidChangeChatSessionItemState) {
+			this._register(onDidChangeChatSessionItemState(async (item) => {
+				const sessionId = SessionIdForCLI.parse(item.resource);
+				if (item.archived) {
+					try {
+						const result = await copilotCLIWorktreeManagerService.cleanupWorktreeOnArchive(sessionId);
+						logService.trace(`[CopilotCLI] Worktree cleanup for session ${sessionId}: ${result.cleaned ? 'cleaned' : result.reason}`);
+					} catch (error) {
+						logService.error(`[CopilotCLI] Failed to cleanup worktree for archived session ${sessionId}:`, error);
+					}
+				} else {
+					try {
+						const result = await copilotCLIWorktreeManagerService.recreateWorktreeOnUnarchive(sessionId);
+						logService.trace(`[CopilotCLI] Worktree recreation for session ${sessionId}: ${result.recreated ? 'recreated' : result.reason}`);
+						if (result.recreated) {
+							copilotcliSessionItemProvider.refreshSession({ reason: 'update', sessionId });
+						}
+					} catch (error) {
+						logService.error(`[CopilotCLI] Failed to recreate worktree for unarchived session ${sessionId}:`, error);
+					}
+				}
+			}));
+		}
+
 		const copilotCLIWorkspaceFolderSessions = copilotcliAgentInstaService.invokeFunction(accessor => accessor.get(IChatSessionWorkspaceFolderService));
 		const folderRepositoryManager = copilotcliAgentInstaService.invokeFunction(accessor => accessor.get(IFolderRepositoryManager));
 		const nativeEnvService = copilotcliAgentInstaService.invokeFunction(accessor => accessor.get(INativeEnvService));

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -253,6 +253,9 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 					try {
 						const result = await this.copilotCLIWorktreeManagerService.recreateWorktreeOnUnarchive(sessionId);
 						this.logService.trace(`[CopilotCLI] Worktree recreation for session ${sessionId}: ${result.recreated ? 'recreated' : result.reason}`);
+						if (result.recreated) {
+							await this.refreshSession({ reason: 'update', sessionId });
+						}
 					} catch (error) {
 						this.logService.error(`[CopilotCLI] Failed to recreate worktree for unarchived session ${sessionId}:`, error);
 					}

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -439,13 +439,17 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			}));
 		}
 
-		return {
+		const disposable: vscode.Disposable = {
 			dispose: () => {
 				this._chatSessionItemControllers.delete(controllerHandle);
 				disposables.dispose();
 				this._proxy.$unregisterChatSessionItemController(controllerHandle);
 			}
 		};
+
+		return Object.assign(disposable, {
+			onDidChangeChatSessionItemState: onDidChangeChatSessionItemStateEmitter.event,
+		});
 	}
 
 	createChatSessionItemController(extension: IExtensionDescription, id: string, refreshHandler: (token: vscode.CancellationToken) => Thenable<void>): vscode.ChatSessionItemController {


### PR DESCRIPTION
## Summary

Adds worktree deletion on archive and recreation on unarchive for the legacy `ChatSessionItemProvider` API (V1), matching the behavior already added to the new controller API in [vscode-copilot-chat#4889](https://github.com/microsoft/vscode-copilot-chat/pull/4889).

Also fixes a bug in the new controller API where the session item wasn't refreshed after worktree recreation, causing changes and stats to not appear in the UI after unarchiving.

## Changes

### `extHostChatSessions.ts`
- Exposes `onDidChangeChatSessionItemState` on the return value of `registerChatSessionItemProvider` via `Object.assign`, allowing consumers to listen for archive state changes without modifying the proposed API surface.

### `chatSessions.ts` (V1 registration site)
- Subscribes to the exposed `onDidChangeChatSessionItemState` event
- On archive: calls `cleanupWorktreeOnArchive()` to auto-commit and delete the worktree
- On unarchive: calls `recreateWorktreeOnUnarchive()` to restore the worktree from the preserved branch, then refreshes the session item so changes/stats are recomputed

### `copilotCLIChatSessions.ts` (V2 controller API)
- Adds `refreshSession()` call after successful worktree recreation on unarchive, fixing the missing changes/stats in the UI