### PR TITLE
chat: route AI customization list through item sources

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -15,6 +15,10 @@ src/vs/workbench/contrib/chat/browser/aiCustomization/
 ├── aiCustomizationManagementEditor.ts          # SplitView list/editor
 ├── aiCustomizationManagementEditorInput.ts     # Singleton input
 ├── aiCustomizationListWidget.ts                # Search + grouped list + harness toggle
+├── aiCustomizationListItem.ts                  # Browser-only list item model
+├── promptsServiceCustomizationItemProvider.ts  # promptsService -> provider-shaped item adapter
+├── providerCustomizationItemSource.ts          # Active provider/sync -> normalized list item source
+├── aiCustomizationItemNormalizer.ts            # provider-shaped item -> browser list item normalizer
 ├── aiCustomizationListWidgetUtils.ts           # List item helpers (truncation, etc.)
 ├── aiCustomizationDebugPanel.ts                # Debug diagnostics panel
 ├── aiCustomizationWorkspaceService.ts          # Core VS Code workspace service impl
@@ -167,6 +171,10 @@ This follows the same pattern as the MCP list widget, which determines grouping 
 The underlying `storage` remains `PromptsStorage.extension` — the grouping is a UI-level override via `groupKey` that keeps `applyStorageSourceFilter` working with existing storage types while visually distinguishing chat-extension items from third-party extension items.
 
 `BUILTIN_STORAGE` is defined in `aiCustomizationWorkspaceService.ts` (common layer) and re-exported by both `aiCustomizationManagement.ts` (browser) and `builtinPromptsStorage.ts` (sessions) for backward compatibility.
+
+### Management Editor Item Pipeline
+
+The management editor list widget renders one browser-only list item model, but customization discovery converges earlier on the internal provider-shaped item contract (`IExternalCustomizationItem`). Extension-contributed providers already reach that shape through the extension-host/main-thread adapter. The Local/static harness uses `PromptsServiceCustomizationItemProvider`, a thin adapter that reads `IPromptsService`, expands local-only concepts (parsed hooks, instruction buckets, UI integration badges), applies the active harness's file/storage filters, and returns the same provider-shaped rows. `ProviderCustomizationItemSource` then normalizes provider rows via `AICustomizationItemNormalizer` and adds view-only sync overlays when the active harness has an `ICustomizationSyncProvider`.
 
 ### AgenticPromptsService (Sessions)
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemNormalizer.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemNormalizer.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceMap } from '../../../../../base/common/map.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { basename, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
+import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { IExternalCustomizationItem } from '../../common/customizationHarnessService.js';
+import { BUILTIN_STORAGE } from './aiCustomizationManagement.js';
+import { extensionIcon, instructionsIcon, pluginIcon, userIcon, workspaceIcon } from './aiCustomizationIcons.js';
+import { IAICustomizationListItem } from './aiCustomizationListItem.js';
+import { extractExtensionIdFromPath } from './aiCustomizationListWidgetUtils.js';
+
+/**
+ * Returns the icon for a given storage type.
+ */
+export function storageToIcon(storage: PromptsStorage): ThemeIcon {
+	switch (storage) {
+		case PromptsStorage.local: return workspaceIcon;
+		case PromptsStorage.user: return userIcon;
+		case PromptsStorage.extension: return extensionIcon;
+		case PromptsStorage.plugin: return pluginIcon;
+		default: return instructionsIcon;
+	}
+}
+
+/**
+ * Converts provider-shaped customization rows into the rich list model used by the management UI.
+ */
+export class AICustomizationItemNormalizer {
+	constructor(
+		private readonly workspaceContextService: IWorkspaceContextService,
+		private readonly workspaceService: IAICustomizationWorkspaceService,
+		private readonly labelService: ILabelService,
+		private readonly agentPluginService: IAgentPluginService,
+		private readonly productService: IProductService,
+	) { }
+
+	normalizeItems(items: readonly IExternalCustomizationItem[], promptType: PromptsType): IAICustomizationListItem[] {
+		const uriUseCounts = new ResourceMap<number>();
+		return items
+			.filter(item => item.type === promptType)
+			.map(item => this.normalizeItem(item, promptType, uriUseCounts))
+			.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	normalizeItem(item: IExternalCustomizationItem, promptType: PromptsType, uriUseCounts = new ResourceMap<number>()): IAICustomizationListItem {
+		const { storage, groupKey, isBuiltin, extensionLabel } = this.resolveSource(item);
+		const seenCount = uriUseCounts.get(item.uri) ?? 0;
+		uriUseCounts.set(item.uri, seenCount + 1);
+		const duplicateSuffix = seenCount === 0 ? '' : `#${seenCount}`;
+		const isWorkspaceItem = storage === PromptsStorage.local;
+
+		return {
+			id: `${item.uri.toString()}${duplicateSuffix}`,
+			uri: item.uri,
+			name: item.name,
+			filename: item.uri.scheme === Schemas.file
+				? this.labelService.getUriLabel(item.uri, { relative: isWorkspaceItem })
+				: basename(item.uri),
+			description: item.description,
+			storage,
+			promptType,
+			disabled: item.enabled === false,
+			groupKey,
+			pluginUri: storage === PromptsStorage.plugin ? this.findPluginUri(item.uri) : undefined,
+			displayName: item.name,
+			badge: item.badge,
+			badgeTooltip: item.badgeTooltip,
+			typeIcon: promptType === PromptsType.instructions && storage ? storageToIcon(storage) : undefined,
+			isBuiltin,
+			extensionLabel,
+			status: item.status,
+			statusMessage: item.statusMessage,
+		};
+	}
+
+	private resolveSource(item: IExternalCustomizationItem): { storage?: PromptsStorage; groupKey?: string; isBuiltin?: boolean; extensionLabel?: string } {
+		const inferred = this.inferStorageAndGroup(item.uri);
+		if (!item.groupKey) {
+			return inferred;
+		}
+
+		switch (item.groupKey) {
+			case PromptsStorage.local:
+			case PromptsStorage.user:
+			case PromptsStorage.extension:
+			case PromptsStorage.plugin:
+				return { ...inferred, storage: item.groupKey };
+			case BUILTIN_STORAGE:
+				return { ...inferred, storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE, isBuiltin: true };
+			default:
+				return { ...inferred, groupKey: item.groupKey };
+		}
+	}
+
+	private inferStorageAndGroup(uri: URI): { storage?: PromptsStorage; groupKey?: string; isBuiltin?: boolean; extensionLabel?: string } {
+		if (uri.scheme !== Schemas.file) {
+			return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE, isBuiltin: true };
+		}
+
+		const activeProjectRoot = this.workspaceService.getActiveProjectRoot();
+		if (activeProjectRoot && isEqualOrParent(uri, activeProjectRoot)) {
+			return { storage: PromptsStorage.local };
+		}
+
+		for (const folder of this.workspaceContextService.getWorkspace().folders) {
+			if (isEqualOrParent(uri, folder.uri)) {
+				return { storage: PromptsStorage.local };
+			}
+		}
+
+		for (const plugin of this.agentPluginService.plugins.get()) {
+			if (isEqualOrParent(uri, plugin.uri)) {
+				return { storage: PromptsStorage.plugin };
+			}
+		}
+
+		const extensionId = extractExtensionIdFromPath(uri.path);
+		if (extensionId) {
+			const extensionIdentifier = new ExtensionIdentifier(extensionId);
+			if (this.isChatExtensionItem(extensionIdentifier)) {
+				return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE, isBuiltin: true };
+			}
+			return { storage: PromptsStorage.extension, extensionLabel: extensionIdentifier.value };
+		}
+
+		return { storage: PromptsStorage.user };
+	}
+
+	private isChatExtensionItem(extensionId: ExtensionIdentifier): boolean {
+		const chatExtensionId = this.productService.defaultChatAgent?.chatExtensionId;
+		return !!chatExtensionId && ExtensionIdentifier.equals(extensionId, chatExtensionId);
+	}
+
+	private findPluginUri(itemUri: URI): URI | undefined {
+		for (const plugin of this.agentPluginService.plugins.get()) {
+			if (isEqualOrParent(itemUri, plugin.uri)) {
+				return plugin.uri;
+			}
+		}
+		return undefined;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSourceUtils.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSourceUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Derives a friendly name from a filename by removing extension suffixes.
+ */
+export function getFriendlyName(filename: string): string {
+	// Remove common prompt file extensions like .instructions.md, .prompt.md, etc.
+	let name = filename
+		.replace(/\.instructions\.md$/i, '')
+		.replace(/\.prompt\.md$/i, '')
+		.replace(/\.agent\.md$/i, '')
+		.replace(/\.md$/i, '');
+
+	// Convert kebab-case or snake_case to Title Case
+	name = name
+		.replace(/[-_]/g, ' ')
+		.replace(/\b\w/g, c => c.toUpperCase());
+
+	return name || filename;
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListItem.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../base/common/event.js';
+import { IMatch } from '../../../../../base/common/filters.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+
+/**
+ * Represents an AI customization item in the list.
+ */
+export interface IAICustomizationListItem {
+	readonly id: string;
+	readonly uri: URI;
+	readonly name: string;
+	readonly filename: string;
+	readonly description?: string;
+	/** Storage origin. Set by core when items come from promptsService; omitted for external provider items. */
+	readonly storage?: PromptsStorage;
+	readonly promptType: PromptsType;
+	readonly disabled: boolean;
+	/** When set, overrides `storage` for display grouping purposes. */
+	readonly groupKey?: string;
+	/** URI of the parent plugin, when this item comes from an installed plugin. */
+	readonly pluginUri?: URI;
+	/** When set, overrides the formatted name for display. */
+	readonly displayName?: string;
+	/** When set, shows a small inline badge next to the item name. */
+	readonly badge?: string;
+	/** Tooltip shown when hovering the badge. */
+	readonly badgeTooltip?: string;
+	/** When set, overrides the default prompt-type icon. */
+	readonly typeIcon?: ThemeIcon;
+	/** True when item comes from the default chat extension (grouped under Built-in). */
+	readonly isBuiltin?: boolean;
+	/** Display name of the contributing extension (for non-built-in extension items). */
+	readonly extensionLabel?: string;
+	/** Server-reported loading/sync status for remote customizations. */
+	readonly status?: 'loading' | 'loaded' | 'degraded' | 'error';
+	/** Human-readable status detail (e.g. error message or warning). */
+	readonly statusMessage?: string;
+	/** When true, this item can be selected for syncing to a remote harness. */
+	readonly syncable?: boolean;
+	/** When true, this syncable item is currently selected for syncing. */
+	readonly synced?: boolean;
+	nameMatches?: IMatch[];
+	descriptionMatches?: IMatch[];
+}
+
+/**
+ * Browser-internal item source consumed by the list widget.
+ *
+ * Item sources fetch provider-shaped customization rows, normalize them into
+ * this browser-only list item shape, and add view-only overlays such as sync state.
+ */
+export interface IAICustomizationItemSource {
+	readonly onDidChange: Event<void>;
+	fetchItems(promptType: PromptsType): Promise<IAICustomizationListItem[]>;
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -10,12 +10,10 @@ import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { autorun } from '../../../../../base/common/observable.js';
-import { basename, dirname, isEqual, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { isEqual } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -39,7 +37,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { createActionViewItem, getContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
-import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
@@ -47,18 +45,15 @@ import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/ho
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js';
-import { extractExtensionIdFromPath, getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
-import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
-import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
-import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
-import { parse as parseJSONC } from '../../../../../base/common/json.js';
-import { Schemas } from '../../../../../base/common/network.js';
-import { OS } from '../../../../../base/common/platform.js';
+import { getCustomizationSecondaryText } from './aiCustomizationListWidgetUtils.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { ICustomizationHarnessService, IExternalCustomizationItem, IExternalCustomizationItemProvider, matchesWorkspaceSubpath, matchesInstructionFileFilter, ICustomizationSyncProvider } from '../../common/customizationHarnessService.js';
-import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { AICustomizationItemNormalizer } from './aiCustomizationItemNormalizer.js';
+import { IAICustomizationItemSource, IAICustomizationListItem } from './aiCustomizationListItem.js';
+import { ProviderCustomizationItemSource } from './providerCustomizationItemSource.js';
+import { PromptsServiceCustomizationItemProvider } from './promptsServiceCustomizationItemProvider.js';
 
 export { truncateToFirstLine } from './aiCustomizationListWidgetUtils.js';
 
@@ -83,47 +78,6 @@ type CustomizationEditorSearchClassification = {
 const ITEM_HEIGHT = 44;
 const GROUP_HEADER_HEIGHT = 36;
 const GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
-
-/**
- * Represents an AI customization item in the list.
- */
-export interface IAICustomizationListItem {
-	readonly id: string;
-	readonly uri: URI;
-	readonly name: string;
-	readonly filename: string;
-	readonly description?: string;
-	/** Storage origin. Set by core when items come from promptsService; omitted for external provider items. */
-	readonly storage?: PromptsStorage;
-	readonly promptType: PromptsType;
-	readonly disabled: boolean;
-	/** When set, overrides `storage` for display grouping purposes. */
-	readonly groupKey?: string;
-	/** URI of the parent plugin, when this item comes from an installed plugin. */
-	readonly pluginUri?: URI;
-	/** When set, overrides the formatted name for display. */
-	readonly displayName?: string;
-	/** When set, shows a small inline badge next to the item name. */
-	readonly badge?: string;
-	/** Tooltip shown when hovering the badge. */
-	readonly badgeTooltip?: string;
-	/** When set, overrides the default prompt-type icon. */
-	readonly typeIcon?: ThemeIcon;
-	/** True when item comes from the default chat extension (grouped under Built-in). */
-	readonly isBuiltin?: boolean;
-	/** Display name of the contributing extension (for non-built-in extension items). */
-	readonly extensionLabel?: string;
-	/** Server-reported loading/sync status for remote customizations. */
-	readonly status?: 'loading' | 'loaded' | 'degraded' | 'error';
-	/** Human-readable status detail (e.g. error message or warning). */
-	readonly statusMessage?: string;
-	/** When true, this item can be selected for syncing to a remote harness. */
-	readonly syncable?: boolean;
-	/** When true, this syncable item is currently selected for syncing. */
-	readonly synced?: boolean;
-	nameMatches?: IMatch[];
-	descriptionMatches?: IMatch[];
-}
 
 /**
  * Represents a collapsible group header in the list.
@@ -264,19 +218,6 @@ function promptTypeToIcon(type: PromptsType): ThemeIcon {
 		case PromptsType.prompt: return promptIcon;
 		case PromptsType.hook: return hookIcon;
 		default: return promptIcon;
-	}
-}
-
-/**
- * Returns the icon for a given storage type.
- */
-function storageToIcon(storage: PromptsStorage): ThemeIcon {
-	switch (storage) {
-		case PromptsStorage.local: return workspaceIcon;
-		case PromptsStorage.user: return userIcon;
-		case PromptsStorage.extension: return extensionIcon;
-		case PromptsStorage.plugin: return pluginIcon;
-		default: return instructionsIcon;
 	}
 }
 
@@ -590,6 +531,8 @@ export class AICustomizationListWidget extends Disposable {
 	private _loadItemsSeq = 0;
 
 	private readonly delayedFilter = new Delayer<void>(200);
+	private readonly itemNormalizer: AICustomizationItemNormalizer;
+	private readonly promptsServiceItemProvider: PromptsServiceCustomizationItemProvider;
 
 	private readonly _onDidSelectItem = this._register(new Emitter<IAICustomizationListItem>());
 	readonly onDidSelectItem: Event<IAICustomizationListItem> = this._onDidSelectItem.event;
@@ -625,6 +568,21 @@ export class AICustomizationListWidget extends Disposable {
 		@IProductService private readonly productService: IProductService,
 	) {
 		super();
+		this.itemNormalizer = new AICustomizationItemNormalizer(
+			this.workspaceContextService,
+			this.workspaceService,
+			this.labelService,
+			this.agentPluginService,
+			this.productService,
+		);
+		this.promptsServiceItemProvider = new PromptsServiceCustomizationItemProvider(
+			() => this.harnessService.getActiveDescriptor(),
+			this.promptsService,
+			this.workspaceService,
+			this.fileService,
+			this.pathService,
+			this.productService,
+		);
 		this.element = $('.ai-customization-list-widget');
 		this.create();
 
@@ -648,27 +606,17 @@ export class AICustomizationListWidget extends Disposable {
 			this.refresh();
 		}));
 
-		// Subscribe to the active provider's onDidChange event.
+		// Subscribe to the active item source's onDidChange event.
 		// Read both activeHarness and availableHarnesses so that the
 		// subscription is re-established when a new provider harness
 		// registers (availableHarnesses changes) even if activeHarness
 		// was already set to the harness id from persisted state.
-		const providerChangeDisposable = this._register(new MutableDisposable());
-		const syncChangeDisposable = this._register(new MutableDisposable());
+		const itemSourceChangeDisposable = this._register(new MutableDisposable());
 		this._register(autorun(reader => {
 			this.harnessService.activeHarness.read(reader);
 			this.harnessService.availableHarnesses.read(reader);
 			const activeDescriptor = this.harnessService.getActiveDescriptor();
-			if (activeDescriptor.itemProvider) {
-				providerChangeDisposable.value = activeDescriptor.itemProvider.onDidChange(() => this.refresh());
-			} else {
-				providerChangeDisposable.clear();
-			}
-			if (activeDescriptor.syncProvider) {
-				syncChangeDisposable.value = activeDescriptor.syncProvider.onDidChange(() => this.refresh());
-			} else {
-				syncChangeDisposable.clear();
-			}
+			itemSourceChangeDisposable.value = this.getItemSource(activeDescriptor).onDidChange(() => this.refresh());
 		}));
 
 	}
@@ -780,12 +728,6 @@ export class AICustomizationListWidget extends Disposable {
 
 		// Handle context menu
 		this._register(this.list.onContextMenu(e => this.onContextMenu(e)));
-
-		// Subscribe to prompt service changes
-		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
-		this._register(this.promptsService.onDidChangeSlashCommands(() => this.refresh()));
-		this._register(this.promptsService.onDidChangeSkills(() => this.refresh()));
-		this._register(this.promptsService.onDidChangeInstructions(() => this.refresh()));
 
 		// Refresh on file deletions so the list updates after inline delete actions
 		this._register(this.fileService.onDidFilesChange(e => {
@@ -1201,652 +1143,28 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Returns true if the given extension identifier matches the default
-	 * chat extension (e.g. GitHub Copilot Chat). Used to group items from
-	 * the chat extension under "Built-in" instead of "Extensions", similar
-	 * to how MCP categorizes built-in servers.
-	 */
-	private isChatExtensionItem(extensionId: ExtensionIdentifier): boolean {
-		const chatExtensionId = this.productService.defaultChatAgent?.chatExtensionId;
-		return !!chatExtensionId && ExtensionIdentifier.equals(extensionId, chatExtensionId);
-	}
-
-	/**
-	 * Post-processes items to assign groupKey overrides for extension-sourced
-	 * items. Applies the built-in grouping consistently across all item types.
-	 *
-	 * Items that already have an explicit groupKey (e.g. instruction categories,
-	 * agent hooks) are left untouched — groupKey overrides are only applied to
-	 * items whose current groupKey is `undefined`.
-	 */
-	private applyBuiltinGroupKeys(items: IAICustomizationListItem[], extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>): IAICustomizationListItem[] {
-		return items.map(item => {
-			if (item.storage !== PromptsStorage.extension) {
-				return item;
-			}
-			const extInfo = extensionInfoByUri.get(item.uri);
-			if (!extInfo) {
-				return item;
-			}
-			const isBuiltin = this.isChatExtensionItem(extInfo.id);
-			if (isBuiltin) {
-				return {
-					...item,
-					isBuiltin: true,
-					groupKey: item.groupKey ?? BUILTIN_STORAGE,
-				};
-			}
-			return {
-				...item,
-				extensionLabel: extInfo.displayName || extInfo.id.value,
-			};
-		});
-	}
-
-	/**
 	 * Fetches and filters items for a given section.
-	 * Delegates to the provider path or core path based on the active harness.
+	 * Delegates to the item source selected by the active harness.
 	 */
 	private async fetchItemsForSection(section: AICustomizationManagementSection): Promise<IAICustomizationListItem[]> {
 		const promptType = sectionToPromptType(section);
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-
-		if (activeDescriptor.itemProvider && promptType) {
-			return this.fetchProviderItemsForSection(activeDescriptor, promptType);
-		}
-
-		return this.fetchCoreItemsForSection(promptType);
+		return this.getItemSource(this.harnessService.getActiveDescriptor()).fetchItems(promptType);
 	}
 
 	/**
-	 * Fetches items from an external customization provider.
-	 * When a syncProvider is present, blends remote items with local sync items.
+	 * Returns the rich, browser-internal item source for a harness descriptor.
 	 */
-	private async fetchProviderItemsForSection(descriptor: ReturnType<ICustomizationHarnessService['getActiveDescriptor']>, promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const remoteItems = await this.fetchItemsFromProvider(descriptor.itemProvider!, promptType);
-		if (!descriptor.syncProvider) {
-			return remoteItems;
-		}
-		const localItems = await this.fetchLocalSyncableItems(promptType, descriptor.syncProvider);
-		return [...remoteItems, ...localItems];
-	}
-
-	/**
-	 * Fetches items from the core promptsService with full filtering pipeline.
-	 * This is the legacy path used when no external provider is active.
-	 * TODO: Remove when provider API is the sole code path.
-	 */
-	private async fetchCoreItemsForSection(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const items: IAICustomizationListItem[] = [];
-		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
-		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();
-
-
-		if (promptType === PromptsType.agent) {
-			// Use getCustomAgents which has parsed name/description from frontmatter
-			const agents = await this.promptsService.getCustomAgents(CancellationToken.None);
-			// Build extension display name lookup from raw file list
-			const allAgentFiles = await this.promptsService.listPromptFiles(PromptsType.agent, CancellationToken.None);
-			for (const file of allAgentFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			for (const agent of agents) {
-				const filename = basename(agent.uri);
-				items.push({
-					id: agent.uri.toString(),
-					uri: agent.uri,
-					name: agent.name,
-					filename,
-					description: agent.description,
-					storage: agent.source.storage,
-					promptType,
-					pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-					disabled: disabledUris.has(agent.uri),
-				});
-				// Track extension ID for built-in grouping (if not already set from file list)
-				if (agent.source.storage === PromptsStorage.extension && !extensionInfoByUri.has(agent.uri)) {
-					extensionInfoByUri.set(agent.uri, { id: agent.source.extensionId });
-				}
-			}
-		} else if (promptType === PromptsType.skill) {
-			// Use findAgentSkills for enabled skills (has parsed name/description from frontmatter)
-			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
-			// Build extension ID lookup from raw file list (like MCP builds collectionSources)
-			const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, CancellationToken.None);
-			for (const file of allSkillFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
-			const seenUris = new ResourceSet();
-			for (const skill of skills || []) {
-				const filename = basename(skill.uri);
-				const skillName = skill.name || basename(dirname(skill.uri)) || filename;
-				seenUris.add(skill.uri);
-				const skillFolderName = basename(dirname(skill.uri));
-				const uiTooltip = uiIntegrations.get(skillFolderName);
-				items.push({
-					id: skill.uri.toString(),
-					uri: skill.uri,
-					name: skillName,
-					filename,
-					description: skill.description,
-					storage: skill.storage,
-					promptType,
-					pluginUri: skill.storage === PromptsStorage.plugin ? this.findPluginUri(skill.uri) : undefined,
-					disabled: false,
-					badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-					badgeTooltip: uiTooltip,
-				});
-			}
-			// Also include disabled skills from the raw file list
-			if (disabledUris.size > 0) {
-				for (const file of allSkillFiles) {
-					if (!seenUris.has(file.uri) && disabledUris.has(file.uri)) {
-						const filename = basename(file.uri);
-						const disabledName = file.name || basename(dirname(file.uri)) || filename;
-						const disabledFolderName = basename(dirname(file.uri));
-						const uiTooltip = uiIntegrations.get(disabledFolderName);
-						items.push({
-							id: file.uri.toString(),
-							uri: file.uri,
-							name: disabledName,
-							filename,
-							description: file.description,
-							storage: file.storage,
-							promptType,
-							disabled: true,
-							badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
-							badgeTooltip: uiTooltip,
-						});
-					}
-				}
-			}
-		} else if (promptType === PromptsType.prompt) {
-			// Use getPromptSlashCommands which has parsed name/description from frontmatter
-			// Filter out skills since they have their own section
-			const commands = await this.promptsService.getPromptSlashCommands(CancellationToken.None);
-			for (const command of commands) {
-				if (command.type === PromptsType.skill) {
-					continue;
-				}
-				const filename = basename(command.uri);
-				items.push({
-					id: command.uri.toString(),
-					uri: command.uri,
-					name: command.name,
-					filename,
-					description: command.description,
-					storage: command.storage,
-					promptType,
-					pluginUri: command.storage === PromptsStorage.plugin ? command.pluginUri : undefined,
-					disabled: disabledUris.has(command.uri),
-				});
-				if (command.extension) {
-					extensionInfoByUri.set(command.uri, { id: command.extension.identifier, displayName: command.extension.displayName });
-				}
-			}
-		} else if (promptType === PromptsType.hook) {
-			// Try to parse individual hooks from each file; fall back to showing the file itself
-			const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			const userHomeUri = await this.pathService.userHome();
-			const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
-
-			for (const hookFile of hookFiles) {
-				// Plugins parse their own hooks and emit them individually because they can
-				// be embedded with interpolations in the plugin manifests; don't re-parse them
-				if (hookFile.storage === PromptsStorage.plugin) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString() + ':' + hookFile.name,
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						pluginUri: hookFile.pluginUri,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-					continue;
-				}
-
-				let parsedHooks = false;
-				try {
-					const content = await this.fileService.readFile(hookFile.uri);
-					const json = parseJSONC(content.value.toString());
-					const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
-
-					if (hooks.size > 0) {
-						parsedHooks = true;
-						for (const [hookType, entry] of hooks) {
-							const hookMeta = HOOK_METADATA[hookType];
-							for (let i = 0; i < entry.hooks.length; i++) {
-								const hook = entry.hooks[i];
-								const cmdLabel = formatHookCommandLabel(hook, OS);
-								const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-								items.push({
-									id: `${hookFile.uri.toString()}#${entry.originalId}[${i}]`,
-									uri: hookFile.uri,
-									name: hookMeta?.label ?? entry.originalId,
-									filename: basename(hookFile.uri),
-									description: truncatedCmd || localize('hookUnset', "(unset)"),
-									storage: hookFile.storage,
-									promptType,
-									disabled: disabledUris.has(hookFile.uri),
-								});
-							}
-						}
-					}
-				} catch {
-					// Parse failed — fall through to show raw file
-				}
-
-				if (!parsedHooks) {
-					const filename = basename(hookFile.uri);
-					items.push({
-						id: hookFile.uri.toString(),
-						uri: hookFile.uri,
-						name: hookFile.name || this.getFriendlyName(filename),
-						filename,
-						storage: hookFile.storage,
-						promptType,
-						disabled: disabledUris.has(hookFile.uri),
-					});
-				}
-			}
-
-			// Also include hooks defined in agent frontmatter (not in sessions window)
-			// TODO: add this back when Copilot CLI supports this
-			const agents = !this.workspaceService.isSessionsWindow ? await this.promptsService.getCustomAgents(CancellationToken.None) : [];
-			for (const agent of agents) {
-				if (!agent.hooks) {
-					continue;
-				}
-				for (const hookType of Object.values(HookType)) {
-					const hookCommands = agent.hooks[hookType];
-					if (!hookCommands || hookCommands.length === 0) {
-						continue;
-					}
-					const hookMeta = HOOK_METADATA[hookType];
-					for (let i = 0; i < hookCommands.length; i++) {
-						const hook = hookCommands[i];
-						const cmdLabel = formatHookCommandLabel(hook, OS);
-						const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-						items.push({
-							id: `${agent.uri.toString()}#hook:${hookType}[${i}]`,
-							uri: agent.uri,
-							name: hookMeta?.label ?? hookType,
-							filename: basename(agent.uri),
-							description: `${agent.name}: ${truncatedCmd || localize('hookUnset', "(unset)")}`,
-							storage: agent.source.storage,
-							groupKey: 'agents',
-							promptType,
-							pluginUri: agent.source.storage === PromptsStorage.plugin ? agent.source.pluginUri : undefined,
-							disabled: disabledUris.has(agent.uri),
-						});
-					}
-				}
-			}
-		} else {
-			// For instructions, group by category: agent instructions, context instructions, on-demand instructions
-			const instructionFiles = await this.promptsService.getInstructionFiles(CancellationToken.None);
-			for (const file of instructionFiles) {
-				if (file.extension) {
-					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
-				}
-			}
-			const agentInstructionFiles = await this.promptsService.listAgentInstructions(CancellationToken.None, undefined);
-			const agentInstructionUris = new ResourceSet(agentInstructionFiles.map(f => f.uri));
-
-			// Add agent instruction items
-			const workspaceFolderUris = this.workspaceContextService.getWorkspace().folders.map(f => f.uri);
-			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			if (activeRoot) {
-				workspaceFolderUris.push(activeRoot);
-			}
-			for (const file of agentInstructionFiles) {
-				const storage = PromptsStorage.local;
-				const filename = basename(file.uri);
-				items.push({
-					id: file.uri.toString(),
-					uri: file.uri,
-					name: filename,
-					filename: this.labelService.getUriLabel(file.uri, { relative: true }),
-					displayName: filename,
-					storage,
-					promptType,
-					typeIcon: storageToIcon(storage),
-					groupKey: 'agent-instructions',
-					disabled: disabledUris.has(file.uri),
-				});
-			}
-
-			// Parse prompt files to separate into context vs on-demand
-
-			for (const { uri, pattern, name, description, storage, pluginUri } of instructionFiles) {
-				if (agentInstructionUris.has(uri)) {
-					continue; // already added as agent instruction
-				}
-
-				const friendlyName = this.getFriendlyName(name);
-
-				if (pattern !== undefined) {
-					// Context instruction
-					const badge = pattern === '**'
-						? localize('alwaysAdded', "always added")
-						: pattern;
-					const badgeTooltip = pattern === '**'
-						? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
-						: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", pattern);
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: this.labelService.getUriLabel(uri, { relative: true }),
-						displayName: friendlyName,
-						badge,
-						badgeTooltip,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'context-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				} else {
-					// On-demand instruction
-					items.push({
-						id: uri.toString(),
-						uri,
-						name: friendlyName,
-						filename: basename(uri),
-						displayName: friendlyName,
-						description,
-						storage,
-						promptType,
-						typeIcon: storageToIcon(storage),
-						groupKey: 'on-demand-instructions',
-						pluginUri,
-						disabled: disabledUris.has(uri),
-					});
-				}
-			}
-		}
-
-		// Assign built-in groupKeys — items from the default chat extension
-		// are re-grouped under "Built-in" instead of "Extensions".
-		// This is a single-pass transformation applied after all items are
-		// collected, keeping the item-building code free of grouping logic.
-		const groupedItems = this.applyBuiltinGroupKeys(items, extensionInfoByUri);
-
-		// Apply storage source filter (removes items not in visible sources or excluded user roots)
-		const filter = this.workspaceService.getStorageSourceFilter(promptType);
-		const withStorage = groupedItems.filter((item): item is IAICustomizationListItem & { readonly storage: PromptsStorage } => item.storage !== undefined);
-		const withoutStorage = groupedItems.filter(item => item.storage === undefined);
-		const filteredItems = [...applyStorageSourceFilter(withStorage, filter), ...withoutStorage];
-		items.length = 0;
-		items.push(...filteredItems);
-
-		// Apply workspace subpath filter — when the active harness specifies
-		// workspaceSubpaths, hide workspace-local items that aren't under one
-		// of the recognized sub-paths (e.g. Claude only shows .claude/ items).
-		// Exception: instruction files matched by the harness's instructionFileFilter
-		// are exempt (e.g. CLAUDE.md at workspace root is a Claude-native file
-		// even though it's not under .claude/).
-		const descriptor = this.harnessService.getActiveDescriptor();
-		const subpaths = descriptor.workspaceSubpaths;
-		const instrFilter = descriptor.instructionFileFilter;
-		if (subpaths) {
-			const projectRoot = this.workspaceService.getActiveProjectRoot();
-			for (let i = items.length - 1; i >= 0; i--) {
-				const item = items[i];
-				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
-					if (!matchesWorkspaceSubpath(item.uri.path, subpaths)) {
-						// Keep instruction files that match the harness's native patterns
-						if (instrFilter && promptType === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
-							continue;
-						}
-						// Keep agent instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md)
-						// — these live at the workspace root by design and should not be
-						// filtered out by workspace subpath restrictions.
-						if (item.groupKey === 'agent-instructions') {
-							continue;
-						}
-						items.splice(i, 1);
-					}
-				}
-			}
-		}
-
-		// Apply instruction file filter — when the active harness specifies
-		// instructionFileFilter, hide instruction files that don't match the
-		// recognized patterns (e.g. Claude doesn't support *.instructions.md).
-		if (instrFilter && promptType === PromptsType.instructions) {
-			for (let i = items.length - 1; i >= 0; i--) {
-				if (!matchesInstructionFileFilter(items[i].uri.path, instrFilter)) {
-					items.splice(i, 1);
-				}
-			}
-		}
-
-		// Sort items by name
-		items.sort((a, b) => a.name.localeCompare(b.name));
-
-		return items;
-	}
-
-	/**
-	 * Fetches items from an external customization provider, converting
-	 * the provider's items into the list widget format.
-	 */
-	private async fetchItemsFromProvider(provider: IExternalCustomizationItemProvider, promptType: PromptsType): Promise<IAICustomizationListItem[]> {
-		const allItems = await provider.provideChatSessionCustomizations(CancellationToken.None);
-		if (!allItems) {
-			return [];
-		}
-
-		const workspaceFolders = this.workspaceContextService.getWorkspace().folders;
-
-		// Build a URI→description lookup from promptsService for items the provider
-		// doesn't supply descriptions for (e.g. skills and instructions from ChatResource).
-		const descriptionsByUri = new ResourceMap<string>();
-		if (promptType === PromptsType.skill) {
-			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
-			for (const s of skills ?? []) {
-				if (s.description) {
-					descriptionsByUri.set(s.uri, s.description);
-				}
-			}
-		}
-
-		// Hooks: expand file-level items into individual hook entries (matching core path display)
-		if (promptType === PromptsType.hook) {
-			return this._expandProviderHookItems(allItems, workspaceFolders);
-		}
-
-		return allItems
-			.filter(item => item.type === promptType)
-			.map((item: IExternalCustomizationItem) => {
-				const { storage, groupKey } = item.groupKey
-					? { storage: undefined, groupKey: item.groupKey }
-					: this._inferStorageAndGroup(item.uri, workspaceFolders);
-				return {
-					id: item.uri.toString(),
-					uri: item.uri,
-					name: item.name,
-					filename: item.uri.scheme === Schemas.file
-						? this.labelService.getUriLabel(item.uri, { relative: true })
-						: basename(item.uri),
-					description: item.description ?? descriptionsByUri.get(item.uri),
-					promptType,
-					disabled: item.enabled === false,
-					status: item.status,
-					statusMessage: item.statusMessage,
-					groupKey,
-					badge: item.badge,
-					badgeTooltip: item.badgeTooltip,
-					storage,
-				};
-			})
-			.sort((a, b) => a.name.localeCompare(b.name));
-	}
-
-	/**
-	 * Expands provider hook items (file-level) into individual hook entries
-	 * with hook type labels and command descriptions, matching the core path display.
-	 */
-	private async _expandProviderHookItems(allItems: readonly IExternalCustomizationItem[], workspaceFolders: readonly { uri: URI }[]): Promise<IAICustomizationListItem[]> {
-		const hookFileItems = allItems.filter(item => item.type === PromptsType.hook);
-		const items: IAICustomizationListItem[] = [];
-		const activeRoot = this.workspaceService.getActiveProjectRoot();
-		const userHomeUri = await this.pathService.userHome();
-		const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
-
-		for (const item of hookFileItems) {
-			const { storage } = item.groupKey
-				? { storage: undefined }
-				: this._inferStorageAndGroup(item.uri, workspaceFolders);
-
-			let parsedHooks = false;
-			try {
-				const content = await this.fileService.readFile(item.uri);
-				const json = parseJSONC(content.value.toString());
-				const { hooks } = parseHooksFromFile(item.uri, json, activeRoot, userHome);
-
-				if (hooks.size > 0) {
-					parsedHooks = true;
-					for (const [hookType, entry] of hooks) {
-						const hookMeta = HOOK_METADATA[hookType];
-						for (let i = 0; i < entry.hooks.length; i++) {
-							const hook = entry.hooks[i];
-							const cmdLabel = formatHookCommandLabel(hook, OS);
-							const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
-							items.push({
-								id: `${item.uri.toString()}#${entry.originalId}[${i}]`,
-								uri: item.uri,
-								name: hookMeta?.label ?? entry.originalId,
-								filename: basename(item.uri),
-								description: truncatedCmd || localize('hookUnset', "(unset)"),
-								storage,
-								promptType: PromptsType.hook,
-								disabled: item.enabled === false,
-							});
-						}
-					}
-				}
-			} catch {
-				// Parse failed — fall through to show raw file
-			}
-
-			if (!parsedHooks) {
-				items.push({
-					id: item.uri.toString(),
-					uri: item.uri,
-					name: item.name,
-					filename: basename(item.uri),
-					description: item.description,
-					storage,
-					promptType: PromptsType.hook,
-					disabled: item.enabled === false,
-				});
-			}
-		}
-
-		return items;
-	}
-
-	/**
-	 * Infers storage and groupKey from a URI for auto-grouping.
-	 *
-	 * - `file:` URIs under a workspace folder → storage `local` (Workspace group)
-	 * - `file:` URIs elsewhere (e.g. `~/.copilot/`) → storage `user` (User group)
-	 * - Non-file schemes (synthetic URIs, vscode-userdata:, etc.) → groupKey `builtin` (Built-in group)
-	 */
-	private _inferStorageAndGroup(uri: URI, workspaceFolders: readonly { uri: URI }[]): { storage?: PromptsStorage; groupKey?: string } {
-		// Non-file schemes are synthetic/built-in (includes vscode-userdata: for extension-contributed items)
-		if (uri.scheme !== Schemas.file) {
-			return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE };
-		}
-
-		// file: URI under a workspace folder = workspace (local)
-		for (const folder of workspaceFolders) {
-			if (isEqualOrParent(uri, folder.uri)) {
-				return { storage: PromptsStorage.local };
-			}
-		}
-
-		// file: URI under an installed plugin = plugin
-		for (const plugin of this.agentPluginService.plugins.get()) {
-			if (isEqualOrParent(uri, plugin.uri)) {
-				return { storage: PromptsStorage.plugin };
-			}
-		}
-
-		// file: URI inside an extension install directory = extension or built-in.
-		// At this point we've already checked workspace folders and plugins, so
-		// a path containing /extensions/<id>-<version>/ is an extension directory.
-		const extensionId = extractExtensionIdFromPath(uri.path);
-		if (extensionId) {
-			if (this.isChatExtensionItem(new ExtensionIdentifier(extensionId))) {
-				return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE };
-			}
-			return { storage: PromptsStorage.extension };
-		}
-
-		// file: URI elsewhere = user directory
-		return { storage: PromptsStorage.user };
-	}
-
-	/**
-	 * Fetches local customization items and marks them as syncable, using
-	 * the sync provider to determine their current selection state.
-	 * These items appear alongside remote items with sync checkboxes.
-	 */
-	private async fetchLocalSyncableItems(promptType: PromptsType, syncProvider: ICustomizationSyncProvider): Promise<IAICustomizationListItem[]> {
-		const files = await this.promptsService.listPromptFiles(promptType, CancellationToken.None);
-		if (!files.length) {
-			return [];
-		}
-
-		return files
-			.filter(f => f.storage === PromptsStorage.local || f.storage === PromptsStorage.user)
-			.map(f => ({
-				id: `sync-${f.uri.toString()}`,
-				uri: f.uri,
-				name: this.getFriendlyName(basename(f.uri)),
-				filename: basename(f.uri),
-				promptType,
-				disabled: false,
-				storage: f.storage,
-				groupKey: 'sync-local',
-				syncable: true,
-				synced: syncProvider.isSelected(f.uri),
-			}))
-			.sort((a, b) => a.name.localeCompare(b.name));
-	}
-
-	/**
-	 * Derives a friendly name from a filename by removing extension suffixes.
-	 */
-	private getFriendlyName(filename: string): string {
-		// Remove common prompt file extensions like .instructions.md, .prompt.md, etc.
-		let name = filename
-			.replace(/\.instructions\.md$/i, '')
-			.replace(/\.prompt\.md$/i, '')
-			.replace(/\.agent\.md$/i, '')
-			.replace(/\.md$/i, '');
-
-		// Convert kebab-case or snake_case to Title Case
-		name = name
-			.replace(/[-_]/g, ' ')
-			.replace(/\b\w/g, c => c.toUpperCase());
-
-		return name || filename;
+	private getItemSource(descriptor: ReturnType<ICustomizationHarnessService['getActiveDescriptor']>): IAICustomizationItemSource {
+		const itemProvider = descriptor.itemProvider ?? (descriptor.syncProvider ? undefined : this.promptsServiceItemProvider);
+		return new ProviderCustomizationItemSource(
+			itemProvider,
+			descriptor.syncProvider,
+			this.promptsService,
+			this.workspaceService,
+			this.fileService,
+			this.pathService,
+			this.itemNormalizer,
+		);
 	}
 
 	/**
@@ -1931,11 +1249,11 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Filters and groups items from an external provider.
+	 * Groups normalized list items for display.
 	 * When a syncProvider is present, shows remote items + local sync items.
-	 * Otherwise, groups items by inferred storage/groupKey.
+	 * Otherwise, groups items by normalized storage/groupKey.
 	 */
-	private filterItemsForProvider(matchedItems: IAICustomizationListItem[]): void {
+	private groupMatchedItems(matchedItems: IAICustomizationListItem[]): void {
 		const activeDescriptor = this.harnessService.getActiveDescriptor();
 
 		if (activeDescriptor.syncProvider) {
@@ -2015,53 +1333,11 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Filters and groups items from the core promptsService (static harness path).
-	 * Instructions use semantic categories; other sections use storage-based groups.
-	 */
-	private filterItemsForCore(matchedItems: IAICustomizationListItem[]): void {
-		const promptType = sectionToPromptType(this.currentSection);
-		const visibleSources = new Set(this.workspaceService.getStorageSourceFilter(promptType).sources);
-
-		const groups: { groupKey: string; label: string; icon: ThemeIcon; description: string; items: IAICustomizationListItem[] }[] =
-			this.currentSection === AICustomizationManagementSection.Instructions
-				? [
-					{ groupKey: 'agent-instructions', label: localize('agentInstructionsGroup', "Agent Instructions"), icon: instructionsIcon, description: localize('agentInstructionsGroupDescription', "Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md)."), items: [] },
-					{ groupKey: 'context-instructions', label: localize('contextInstructionsGroup', "Included Based on Context"), icon: instructionsIcon, description: localize('contextInstructionsGroupDescription', "Instructions automatically loaded when matching files are part of the context."), items: [] },
-					{ groupKey: 'on-demand-instructions', label: localize('onDemandInstructionsGroup', "Loaded on Demand"), icon: instructionsIcon, description: localize('onDemandInstructionsGroupDescription', "Instructions loaded only when explicitly referenced."), items: [] },
-				]
-				: [
-					{ groupKey: PromptsStorage.local, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "Customizations stored as files in your project folder and shared with your team via version control."), items: [] },
-					{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
-					{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
-					{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
-					{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
-					{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
-				].filter(g => g.groupKey === BUILTIN_STORAGE || g.groupKey === 'agents' || visibleSources.has(g.groupKey as PromptsStorage));
-
-		for (const item of matchedItems) {
-			const key = item.groupKey ?? item.storage ?? PromptsStorage.local;
-			const group = groups.find(g => g.groupKey === key);
-			if (group) {
-				group.items.push(item);
-			}
-		}
-
-		this.buildGroupedEntries(groups);
-		this.commitDisplayEntries();
-	}
-
-	/**
 	 * Filters items based on the current search query and builds grouped display entries.
 	 */
 	private filterItems(): number {
 		const matchedItems = this.applySearchFilter(this.allItems);
-		const activeDescriptor = this.harnessService.getActiveDescriptor();
-
-		if (activeDescriptor.itemProvider) {
-			this.filterItemsForProvider(matchedItems);
-		} else {
-			this.filterItemsForCore(matchedItems);
-		}
+		this.groupMatchedItems(matchedItems);
 
 		return matchedItems.length;
 	}
@@ -2119,18 +1395,6 @@ export class AICustomizationListWidget extends Disposable {
 			default:
 				return promptIcon;
 		}
-	}
-
-	/**
-	 * Finds the plugin URI for an item URI by checking the known plugins.
-	 */
-	private findPluginUri(itemUri: URI): URI | undefined {
-		for (const plugin of this.agentPluginService.plugins.get()) {
-			if (isEqualOrParent(itemUri, plugin.uri)) {
-				return plugin.uri;
-			}
-		}
-		return undefined;
 	}
 
 	private getEmptyStateInfo(): { title: string; description: string } {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider.ts
@@ -1,0 +1,385 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { OS } from '../../../../../base/common/platform.js';
+import { basename, dirname, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { localize } from '../../../../../nls.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
+import { HookType, HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
+import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
+import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { IExternalCustomizationItem, IExternalCustomizationItemProvider, IHarnessDescriptor, matchesInstructionFileFilter, matchesWorkspaceSubpath } from '../../common/customizationHarnessService.js';
+import { BUILTIN_STORAGE } from './aiCustomizationManagement.js';
+import { getFriendlyName } from './aiCustomizationItemSourceUtils.js';
+
+interface IPromptsServiceCustomizationItem extends IExternalCustomizationItem {
+	readonly storage?: PromptsStorage;
+}
+
+/**
+ * Adapts the rich promptsService model to the same provider-shaped items
+ * contributed by external customization providers.
+ */
+export class PromptsServiceCustomizationItemProvider implements IExternalCustomizationItemProvider {
+
+	readonly onDidChange: Event<void>;
+
+	constructor(
+		private readonly getActiveDescriptor: () => IHarnessDescriptor,
+		private readonly promptsService: IPromptsService,
+		private readonly workspaceService: IAICustomizationWorkspaceService,
+		private readonly fileService: IFileService,
+		private readonly pathService: IPathService,
+		private readonly productService: IProductService,
+	) {
+		this.onDidChange = Event.any(
+			this.promptsService.onDidChangeCustomAgents,
+			this.promptsService.onDidChangeSlashCommands,
+			this.promptsService.onDidChangeSkills,
+			this.promptsService.onDidChangeHooks,
+			this.promptsService.onDidChangeInstructions,
+		);
+	}
+
+	async provideChatSessionCustomizations(token: CancellationToken): Promise<IExternalCustomizationItem[]> {
+		const itemSets = await Promise.all([
+			this.provideCustomizations(PromptsType.agent, token),
+			this.provideCustomizations(PromptsType.skill, token),
+			this.provideCustomizations(PromptsType.instructions, token),
+			this.provideCustomizations(PromptsType.hook, token),
+			this.provideCustomizations(PromptsType.prompt, token),
+		]);
+		return itemSets.flat();
+	}
+
+	async provideCustomizations(promptType: PromptsType, token: CancellationToken = CancellationToken.None): Promise<IExternalCustomizationItem[]> {
+		const items: IPromptsServiceCustomizationItem[] = [];
+		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
+		const extensionInfoByUri = new ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>();
+
+		if (promptType === PromptsType.agent) {
+			const agents = await this.promptsService.getCustomAgents(token);
+			const allAgentFiles = await this.promptsService.listPromptFiles(PromptsType.agent, token);
+			for (const file of allAgentFiles) {
+				if (file.extension) {
+					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+				}
+			}
+			for (const agent of agents) {
+				items.push({
+					uri: agent.uri,
+					type: promptType,
+					name: agent.name,
+					description: agent.description,
+					storage: agent.source.storage,
+					enabled: !disabledUris.has(agent.uri),
+				});
+				if (agent.source.storage === PromptsStorage.extension && !extensionInfoByUri.has(agent.uri)) {
+					extensionInfoByUri.set(agent.uri, { id: agent.source.extensionId });
+				}
+			}
+		} else if (promptType === PromptsType.skill) {
+			const skills = await this.promptsService.findAgentSkills(token);
+			const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, token);
+			for (const file of allSkillFiles) {
+				if (file.extension) {
+					extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+				}
+			}
+			const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
+			const seenUris = new ResourceSet();
+			for (const skill of skills || []) {
+				const skillName = skill.name || basename(dirname(skill.uri)) || basename(skill.uri);
+				seenUris.add(skill.uri);
+				const skillFolderName = basename(dirname(skill.uri));
+				const uiTooltip = uiIntegrations.get(skillFolderName);
+				items.push({
+					uri: skill.uri,
+					type: promptType,
+					name: skillName,
+					description: skill.description,
+					storage: skill.storage,
+					enabled: true,
+					badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
+					badgeTooltip: uiTooltip,
+				});
+			}
+			if (disabledUris.size > 0) {
+				for (const file of allSkillFiles) {
+					if (!seenUris.has(file.uri) && disabledUris.has(file.uri)) {
+						const disabledName = file.name || basename(dirname(file.uri)) || basename(file.uri);
+						const disabledFolderName = basename(dirname(file.uri));
+						const uiTooltip = uiIntegrations.get(disabledFolderName);
+						items.push({
+							uri: file.uri,
+							type: promptType,
+							name: disabledName,
+							description: file.description,
+							storage: file.storage,
+							enabled: false,
+							badge: uiTooltip ? localize('uiIntegrationBadge', "UI Integration") : undefined,
+							badgeTooltip: uiTooltip,
+						});
+					}
+				}
+			}
+		} else if (promptType === PromptsType.prompt) {
+			const commands = await this.promptsService.getPromptSlashCommands(token);
+			for (const command of commands) {
+				if (command.type === PromptsType.skill) {
+					continue;
+				}
+				items.push({
+					uri: command.uri,
+					type: promptType,
+					name: command.name,
+					description: command.description,
+					storage: command.storage,
+					enabled: !disabledUris.has(command.uri),
+				});
+				if (command.extension) {
+					extensionInfoByUri.set(command.uri, { id: command.extension.identifier, displayName: command.extension.displayName });
+				}
+			}
+		} else if (promptType === PromptsType.hook) {
+			await this.fetchPromptServiceHooks(items, disabledUris, promptType);
+		} else {
+			await this.fetchPromptServiceInstructions(items, extensionInfoByUri, disabledUris, promptType);
+		}
+
+		return this.toProviderItems(this.applyLocalFilters(this.applyBuiltinGroupKeys(items, extensionInfoByUri), promptType));
+	}
+
+	private async fetchPromptServiceHooks(items: IPromptsServiceCustomizationItem[], disabledUris: ResourceSet, promptType: PromptsType): Promise<void> {
+		const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
+		const activeRoot = this.workspaceService.getActiveProjectRoot();
+		const userHomeUri = await this.pathService.userHome();
+		const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
+
+		for (const hookFile of hookFiles) {
+			if (hookFile.storage === PromptsStorage.plugin) {
+				items.push({
+					uri: hookFile.uri,
+					type: promptType,
+					name: hookFile.name || getFriendlyName(basename(hookFile.uri)),
+					storage: hookFile.storage,
+					enabled: !disabledUris.has(hookFile.uri),
+				});
+				continue;
+			}
+
+			let parsedHooks = false;
+			try {
+				const content = await this.fileService.readFile(hookFile.uri);
+				const json = parseJSONC(content.value.toString());
+				const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
+
+				if (hooks.size > 0) {
+					parsedHooks = true;
+					for (const [hookType, entry] of hooks) {
+						const hookMeta = HOOK_METADATA[hookType];
+						for (let i = 0; i < entry.hooks.length; i++) {
+							const hook = entry.hooks[i];
+							const cmdLabel = formatHookCommandLabel(hook, OS);
+							const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
+							items.push({
+								uri: hookFile.uri,
+								type: promptType,
+								name: hookMeta?.label ?? entry.originalId,
+								description: truncatedCmd || localize('hookUnset', "(unset)"),
+								storage: hookFile.storage,
+								enabled: !disabledUris.has(hookFile.uri),
+							});
+						}
+					}
+				}
+			} catch {
+				// Parse failed - fall through to show raw file.
+			}
+
+			if (!parsedHooks) {
+				items.push({
+					uri: hookFile.uri,
+					type: promptType,
+					name: hookFile.name || getFriendlyName(basename(hookFile.uri)),
+					storage: hookFile.storage,
+					enabled: !disabledUris.has(hookFile.uri),
+				});
+			}
+		}
+
+		const agents = !this.workspaceService.isSessionsWindow ? await this.promptsService.getCustomAgents(CancellationToken.None) : [];
+		for (const agent of agents) {
+			if (!agent.hooks) {
+				continue;
+			}
+			for (const hookType of Object.values(HookType)) {
+				const hookCommands = agent.hooks[hookType];
+				if (!hookCommands || hookCommands.length === 0) {
+					continue;
+				}
+				const hookMeta = HOOK_METADATA[hookType];
+				for (let i = 0; i < hookCommands.length; i++) {
+					const hook = hookCommands[i];
+					const cmdLabel = formatHookCommandLabel(hook, OS);
+					const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
+					items.push({
+						uri: agent.uri,
+						type: promptType,
+						name: hookMeta?.label ?? hookType,
+						description: `${agent.name}: ${truncatedCmd || localize('hookUnset', "(unset)")}`,
+						storage: agent.source.storage,
+						groupKey: 'agents',
+						enabled: !disabledUris.has(agent.uri),
+					});
+				}
+			}
+		}
+	}
+
+	private async fetchPromptServiceInstructions(items: IPromptsServiceCustomizationItem[], extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>, disabledUris: ResourceSet, promptType: PromptsType): Promise<void> {
+		const instructionFiles = await this.promptsService.getInstructionFiles(CancellationToken.None);
+		for (const file of instructionFiles) {
+			if (file.extension) {
+				extensionInfoByUri.set(file.uri, { id: file.extension.identifier, displayName: file.extension.displayName });
+			}
+		}
+		const agentInstructionFiles = await this.promptsService.listAgentInstructions(CancellationToken.None, undefined);
+		const agentInstructionUris = new ResourceSet(agentInstructionFiles.map(f => f.uri));
+
+		for (const file of agentInstructionFiles) {
+			const storage = PromptsStorage.local;
+			const filename = basename(file.uri);
+			items.push({
+				uri: file.uri,
+				type: promptType,
+				name: filename,
+				storage,
+				groupKey: 'agent-instructions',
+				enabled: !disabledUris.has(file.uri),
+			});
+		}
+
+		for (const { uri, pattern, name, description, storage } of instructionFiles) {
+			if (agentInstructionUris.has(uri)) {
+				continue;
+			}
+
+			const friendlyName = getFriendlyName(name);
+
+			if (pattern !== undefined) {
+				const badge = pattern === '**'
+					? localize('alwaysAdded', "always added")
+					: pattern;
+				const badgeTooltip = pattern === '**'
+					? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
+					: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", pattern);
+				items.push({
+					uri,
+					type: promptType,
+					name: friendlyName,
+					badge,
+					badgeTooltip,
+					description,
+					storage,
+					groupKey: 'context-instructions',
+					enabled: !disabledUris.has(uri),
+				});
+			} else {
+				items.push({
+					uri,
+					type: promptType,
+					name: friendlyName,
+					description,
+					storage,
+					groupKey: 'on-demand-instructions',
+					enabled: !disabledUris.has(uri),
+				});
+			}
+		}
+	}
+
+	private applyBuiltinGroupKeys(items: IPromptsServiceCustomizationItem[], extensionInfoByUri: ResourceMap<{ id: ExtensionIdentifier; displayName?: string }>): IPromptsServiceCustomizationItem[] {
+		return items.map(item => {
+			if (item.storage !== PromptsStorage.extension) {
+				return item;
+			}
+			const extInfo = extensionInfoByUri.get(item.uri);
+			if (!extInfo) {
+				return item;
+			}
+			const isBuiltin = this.isChatExtensionItem(extInfo.id);
+			if (isBuiltin) {
+				return {
+					...item,
+					groupKey: item.groupKey ?? BUILTIN_STORAGE,
+				};
+			}
+			return item;
+		});
+	}
+
+	private applyLocalFilters(groupedItems: IPromptsServiceCustomizationItem[], promptType: PromptsType): IPromptsServiceCustomizationItem[] {
+		const filter = this.workspaceService.getStorageSourceFilter(promptType);
+		const withStorage = groupedItems.filter((item): item is IPromptsServiceCustomizationItem & { readonly storage: PromptsStorage } => item.storage !== undefined);
+		const withoutStorage = groupedItems.filter(item => item.storage === undefined);
+		const items = [...applyStorageSourceFilter(withStorage, filter), ...withoutStorage];
+
+		const descriptor = this.getActiveDescriptor();
+		const subpaths = descriptor.workspaceSubpaths;
+		const instrFilter = descriptor.instructionFileFilter;
+		if (subpaths) {
+			const projectRoot = this.workspaceService.getActiveProjectRoot();
+			for (let i = items.length - 1; i >= 0; i--) {
+				const item = items[i];
+				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
+					if (!matchesWorkspaceSubpath(item.uri.path, subpaths)) {
+						if (instrFilter && promptType === PromptsType.instructions && matchesInstructionFileFilter(item.uri.path, instrFilter)) {
+							continue;
+						}
+						if (item.groupKey === 'agent-instructions') {
+							continue;
+						}
+						items.splice(i, 1);
+					}
+				}
+			}
+		}
+
+		if (instrFilter && promptType === PromptsType.instructions) {
+			for (let i = items.length - 1; i >= 0; i--) {
+				if (!matchesInstructionFileFilter(items[i].uri.path, instrFilter)) {
+					items.splice(i, 1);
+				}
+			}
+		}
+
+		return items;
+	}
+
+	private toProviderItems(items: readonly IPromptsServiceCustomizationItem[]): IExternalCustomizationItem[] {
+		return items.map(({ storage, ...item }) => ({
+			...item,
+			groupKey: item.groupKey ?? storage,
+		}));
+	}
+
+	private isChatExtensionItem(extensionId: ExtensionIdentifier): boolean {
+		const chatExtensionId = this.productService.defaultChatAgent?.chatExtensionId;
+		return !!chatExtensionId && ExtensionIdentifier.equals(extensionId, chatExtensionId);
+	}
+
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/providerCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/providerCustomizationItemSource.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
+import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { OS } from '../../../../../base/common/platform.js';
+import { basename } from '../../../../../base/common/resources.js';
+import { localize } from '../../../../../nls.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
+import { HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
+import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
+import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { ICustomizationSyncProvider, IExternalCustomizationItem, IExternalCustomizationItemProvider } from '../../common/customizationHarnessService.js';
+import { AICustomizationItemNormalizer } from './aiCustomizationItemNormalizer.js';
+import { IAICustomizationItemSource, IAICustomizationListItem } from './aiCustomizationListItem.js';
+import { getFriendlyName } from './aiCustomizationItemSourceUtils.js';
+
+interface ITypeScopedCustomizationItemProvider extends IExternalCustomizationItemProvider {
+	provideCustomizations(promptType: PromptsType, token: CancellationToken): Promise<IExternalCustomizationItem[] | undefined>;
+}
+
+function isTypeScopedCustomizationItemProvider(provider: IExternalCustomizationItemProvider): provider is ITypeScopedCustomizationItemProvider {
+	return typeof (provider as Partial<ITypeScopedCustomizationItemProvider>).provideCustomizations === 'function';
+}
+
+export class ProviderCustomizationItemSource implements IAICustomizationItemSource {
+
+	readonly onDidChange: Event<void>;
+
+	constructor(
+		private readonly itemProvider: IExternalCustomizationItemProvider | undefined,
+		private readonly syncProvider: ICustomizationSyncProvider | undefined,
+		private readonly promptsService: IPromptsService,
+		private readonly workspaceService: IAICustomizationWorkspaceService,
+		private readonly fileService: IFileService,
+		private readonly pathService: IPathService,
+		private readonly itemNormalizer: AICustomizationItemNormalizer,
+	) {
+		const onDidChangeSyncableCustomizations = this.syncProvider
+			? Event.any(
+				this.promptsService.onDidChangeCustomAgents,
+				this.promptsService.onDidChangeSlashCommands,
+				this.promptsService.onDidChangeSkills,
+				this.promptsService.onDidChangeHooks,
+				this.promptsService.onDidChangeInstructions,
+			)
+			: Event.None;
+
+		this.onDidChange = Event.any(
+			this.itemProvider?.onDidChange ?? Event.None,
+			this.syncProvider?.onDidChange ?? Event.None,
+			onDidChangeSyncableCustomizations,
+		);
+	}
+
+	async fetchItems(promptType: PromptsType): Promise<IAICustomizationListItem[]> {
+		const remoteItems = this.itemProvider
+			? await this.fetchItemsFromProvider(this.itemProvider, promptType)
+			: [];
+		if (!this.syncProvider) {
+			return remoteItems;
+		}
+		const localItems = await this.fetchLocalSyncableItems(promptType, this.syncProvider);
+		return [...remoteItems, ...localItems];
+	}
+
+	private async fetchItemsFromProvider(provider: IExternalCustomizationItemProvider, promptType: PromptsType): Promise<IAICustomizationListItem[]> {
+		let providerItems: readonly IExternalCustomizationItem[];
+		if (isTypeScopedCustomizationItemProvider(provider)) {
+			providerItems = await provider.provideCustomizations(promptType, CancellationToken.None) ?? [];
+		} else {
+			const allItems = await provider.provideChatSessionCustomizations(CancellationToken.None);
+			if (!allItems) {
+				return [];
+			}
+			providerItems = promptType === PromptsType.hook
+				? await this.expandProviderHookItems(allItems)
+				: allItems.filter(item => item.type === promptType);
+		}
+
+		if (promptType === PromptsType.skill) {
+			providerItems = await this.addSkillDescriptionFallbacks(providerItems);
+		}
+
+		return this.itemNormalizer.normalizeItems(providerItems, promptType);
+	}
+
+	private async addSkillDescriptionFallbacks(items: readonly IExternalCustomizationItem[]): Promise<readonly IExternalCustomizationItem[]> {
+		const descriptionsByUri = new Map<string, string>();
+		const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
+		for (const skill of skills ?? []) {
+			if (skill.description) {
+				descriptionsByUri.set(skill.uri.toString(), skill.description);
+			}
+		}
+
+		return items.map(item => item.description
+			? item
+			: { ...item, description: descriptionsByUri.get(item.uri.toString()) });
+	}
+
+	private async expandProviderHookItems(allItems: readonly IExternalCustomizationItem[]): Promise<IExternalCustomizationItem[]> {
+		const hookFileItems = allItems.filter(item => item.type === PromptsType.hook);
+		const items: IExternalCustomizationItem[] = [];
+		const activeRoot = this.workspaceService.getActiveProjectRoot();
+		const userHomeUri = await this.pathService.userHome();
+		const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
+
+		for (const item of hookFileItems) {
+			let parsedHooks = false;
+			try {
+				const content = await this.fileService.readFile(item.uri);
+				const json = parseJSONC(content.value.toString());
+				const { hooks } = parseHooksFromFile(item.uri, json, activeRoot, userHome);
+
+				if (hooks.size > 0) {
+					parsedHooks = true;
+					for (const [hookType, entry] of hooks) {
+						const hookMeta = HOOK_METADATA[hookType];
+						for (let i = 0; i < entry.hooks.length; i++) {
+							const hook = entry.hooks[i];
+							const cmdLabel = formatHookCommandLabel(hook, OS);
+							const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
+							items.push({
+								uri: item.uri,
+								type: PromptsType.hook,
+								name: hookMeta?.label ?? entry.originalId,
+								description: truncatedCmd || localize('hookUnset', "(unset)"),
+								enabled: item.enabled,
+								groupKey: item.groupKey,
+							});
+						}
+					}
+				}
+			} catch {
+				// Parse failed - fall through to show raw file.
+			}
+
+			if (!parsedHooks) {
+				items.push(item);
+			}
+		}
+
+		return items;
+	}
+
+	private async fetchLocalSyncableItems(promptType: PromptsType, syncProvider: ICustomizationSyncProvider): Promise<IAICustomizationListItem[]> {
+		const files = await this.promptsService.listPromptFiles(promptType, CancellationToken.None);
+		if (!files.length) {
+			return [];
+		}
+
+		const providerItems: IExternalCustomizationItem[] = files
+			.filter(file => file.storage === PromptsStorage.local || file.storage === PromptsStorage.user)
+			.map(file => ({
+				uri: file.uri,
+				type: promptType,
+				name: getFriendlyName(basename(file.uri)),
+				groupKey: 'sync-local',
+				enabled: true,
+			}));
+
+		return this.itemNormalizer.normalizeItems(providerItems, promptType)
+			.map(item => ({
+				...item,
+				id: `sync-${item.id}`,
+				syncable: true,
+				synced: syncProvider.isSelected(item.uri),
+			}));
+	}
+}


### PR DESCRIPTION
## Summary

Route the AI Customizations list widget through a small browser-internal item-source abstraction instead of branching directly between the promptsService path and extension-provider path.

This keeps Local/static harnesses on the existing rich promptsService loading pipeline (storage filtering, plugin metadata, hook parsing, built-in grouping, etc.) while adapting extension-contributed providers into the same list-item source shape.

Resolves #309627

## Notes

- No promptsService provider is attached to static harness descriptors.
- No lazy provider/proxy is used.
- The harness service remains descriptor/state-only and does not depend on IPromptsService.
- promptsService change subscriptions are owned by the widget's Local item source.

## Changes

### Commit 1: Extract AI customization item sources

Introduces a pipeline architecture where both data sources converge on `IExternalCustomizationItem` early:

```
promptsService ──→ PromptsServiceCustomizationItemProvider ──→ IExternalCustomizationItem[]
                                                                        │
External Provider ────────────────────────────────────────→ IExternalCustomizationItem[]
                                                                        │
                                                                        ▼
                                                  ProviderCustomizationItemSource → AICustomizationItemNormalizer → Widget
```

New files: `aiCustomizationListItem.ts`, `aiCustomizationItemSourceUtils.ts`, `aiCustomizationItemNormalizer.ts`, `promptsServiceCustomizationItemProvider.ts`, `providerCustomizationItemSource.ts`

### Commit 2: Clean up extraction

Council-review-driven cleanup:
- Deduplicate `isChatExtensionItem()` and hook expansion logic into shared utils
- Move `storageToIcon()` to icons file (pure function, retains `PromptsStorage` type safety)
- Replace fragile backward-index splice loops with `.filter()` chains
- Cache `ProviderCustomizationItemSource` per active harness descriptor
- Use O(n) Map lookup for hook storage recovery instead of O(n²) `.find()`

## Validation

- VS Code - Build watch: clean
- npm run precommit: passed
- npm run compile-check-ts-native: clean (only pre-existing errors in copilotAgent.ts)