### PR TITLE
sessions: fix isolation picker checked state

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -18,6 +18,11 @@ import { CopilotChatSessionsProvider } from './copilotChatSessionsProvider.js';
 
 export type IsolationMode = 'worktree' | 'workspace';
 
+interface IIsolationPickerItem {
+	readonly mode: IsolationMode;
+	readonly checked?: boolean;
+}
+
 /**
  * A self-contained widget for selecting the isolation mode.
  *
@@ -114,31 +119,32 @@ export class IsolationPicker extends Disposable {
 			return;
 		}
 
-		const items: IActionListItem<IsolationMode>[] = [
+		const currentIsolationMode = this._getSessionIsolationMode();
+		const items: IActionListItem<IIsolationPickerItem>[] = [
 			{
 				kind: ActionListItemKind.Action,
 				label: localize('isolationMode.worktree', "Worktree"),
 				group: { title: '', icon: Codicon.worktree },
-				item: 'worktree',
+				item: { mode: 'worktree', checked: currentIsolationMode === 'worktree' || undefined },
 			},
 			{
 				kind: ActionListItemKind.Action,
 				label: localize('isolationMode.folder', "Folder"),
 				group: { title: '', icon: Codicon.folder },
-				item: 'workspace',
+				item: { mode: 'workspace', checked: currentIsolationMode === 'workspace' || undefined },
 			},
 		];
 
 		const triggerElement = this._triggerElement;
-		const delegate: IActionListDelegate<IsolationMode> = {
-			onSelect: (mode) => {
+		const delegate: IActionListDelegate<IIsolationPickerItem> = {
+			onSelect: ({ mode }) => {
 				this.actionWidgetService.hide();
 				this._setModeOnSession(mode);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
 
-		this.actionWidgetService.show<IsolationMode>(
+		this.actionWidgetService.show<IIsolationPickerItem>(
 			'isolationPicker',
 			false,
 			items,

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IActionListItem } from '../../../../../platform/actionWidget/browser/actionList.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
+import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { IsolationMode, IsolationPicker } from '../../browser/isolationPicker.js';
+
+interface IIsolationActionItem {
+	readonly mode: IsolationMode;
+	readonly checked?: boolean;
+}
+
+function showPicker(container: HTMLElement): void {
+	const trigger = container.querySelector<HTMLElement>('a.action-label');
+	assert.ok(trigger);
+	trigger.click();
+}
+
+function createPicker(
+	disposables: DisposableStore,
+	mode: IsolationMode,
+	actionWidgetItems: IActionListItem<IIsolationActionItem>[],
+): IsolationPicker {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	const activeSession = {
+		providerId: 'default-copilot',
+		sessionId: 'session-id',
+		loading: observableValue('loading', false),
+	} as unknown as IActiveSession;
+	const isolationMode = observableValue<IsolationMode | undefined>('isolationMode', mode);
+	const provider = {
+		getSession: () => ({
+			gitRepository: {},
+			isolationMode,
+		}),
+	};
+
+	instantiationService.stub(IActionWidgetService, {
+		isVisible: false,
+		hide: () => { },
+		show: <T>(_id: string, _supportsPreview: boolean, items: IActionListItem<T>[]) => {
+			actionWidgetItems.splice(0, actionWidgetItems.length, ...(items as IActionListItem<IIsolationActionItem>[]));
+		},
+	});
+	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	instantiationService.stub(ISessionsManagementService, {
+		activeSession: observableValue<IActiveSession | undefined>('activeSession', activeSession),
+	} as unknown as ISessionsManagementService);
+	instantiationService.stub(ISessionsProvidersService, {
+		onDidChangeProviders: Event.None,
+		getProviders: () => [],
+		getProvider: () => provider,
+	} as unknown as ISessionsProvidersService);
+
+	return disposables.add(instantiationService.createInstance(IsolationPicker));
+}
+
+suite('IsolationPicker', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('marks folder as checked when workspace isolation is selected', () => {
+		const actionWidgetItems: IActionListItem<IIsolationActionItem>[] = [];
+		const picker = createPicker(disposables, 'workspace', actionWidgetItems);
+		const container = document.createElement('div');
+		picker.render(container);
+		showPicker(container);
+
+		assert.deepStrictEqual(
+			actionWidgetItems.map(item => ({ label: item.label, checked: item.item?.checked })),
+			[
+				{ label: 'Worktree', checked: undefined },
+				{ label: 'Folder', checked: true },
+			],
+		);
+	});
+
+	test('marks worktree as checked when worktree isolation is selected', () => {
+		const actionWidgetItems: IActionListItem<IIsolationActionItem>[] = [];
+		const picker = createPicker(disposables, 'worktree', actionWidgetItems);
+		const container = document.createElement('div');
+		picker.render(container);
+		showPicker(container);
+
+		assert.deepStrictEqual(
+			actionWidgetItems.map(item => ({ label: item.label, checked: item.item?.checked })),
+			[
+				{ label: 'Worktree', checked: true },
+				{ label: 'Folder', checked: undefined },
+			],
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fix the new chat isolation picker so the checked styling in the dropdown reflects the actual selected mode.

## What changed

- mark the active isolation mode as checked before showing the action widget menu
- keep the menu selection wired to the mode payload used by the picker delegate
- add a focused regression test covering both Folder and Worktree checked states

## Why

The picker trigger label updated correctly, but the dropdown menu always styled `Worktree` as selected because no checked item was provided to the action widget.

## Notes

- compile check passed
- layer validation passed
- the standard Electron unit-test launcher hit an environment-specific bootstrap issue while running locally, so the regression coverage was added and type-checked in-repo