### PR TITLE
Remove now unused `ChatSessionChangedFile` interface

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -2132,7 +2132,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InteractiveSessionVoteDirection: extHostTypes.InteractiveSessionVoteDirection,
 			ChatCopyKind: extHostTypes.ChatCopyKind,
 			ChatSessionChangedFile: extHostTypes.ChatSessionChangedFile,
-			ChatSessionChangedFile2: extHostTypes.ChatSessionChangedFile2,
 			ChatEditingSessionActionOutcome: extHostTypes.ChatEditingSessionActionOutcome,
 			InteractiveEditorResponseFeedbackKind: extHostTypes.InteractiveEditorResponseFeedbackKind,
 			DebugStackFrame: extHostTypes.DebugStackFrame,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3791,10 +3791,6 @@ export class ChatDebugEventHookContent {
 }
 
 export class ChatSessionChangedFile {
-	constructor(public readonly modifiedUri: vscode.Uri, public readonly insertions: number, public readonly deletions: number, public readonly originalUri?: vscode.Uri) { }
-}
-
-export class ChatSessionChangedFile2 {
 	constructor(public readonly uri: vscode.Uri, public readonly originalUri: vscode.Uri | undefined, public readonly modifiedUri: vscode.Uri | undefined, public readonly insertions: number, public readonly deletions: number) { }
 }
 

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -343,7 +343,7 @@ declare module 'vscode' {
 		/**
 		 * Statistics about the chat session.
 		 */
-		changes?: readonly ChatSessionChangedFile[] | readonly ChatSessionChangedFile2[];
+		changes?: readonly ChatSessionChangedFile[];
 
 		/**
 		 * Arbitrary metadata for the chat session. Can be anything, but must be JSON-stringifyable.
@@ -353,34 +353,7 @@ declare module 'vscode' {
 		metadata?: { readonly [key: string]: any };
 	}
 
-	/**
-	 * @deprecated Use `ChatSessionChangedFile2` instead
-	 */
 	export class ChatSessionChangedFile {
-		/**
-		 * URI of the file.
-		 */
-		modifiedUri: Uri;
-
-		/**
-		 * File opened when the user takes the 'compare' action.
-		 */
-		originalUri?: Uri;
-
-		/**
-		 * Number of insertions made during the session.
-		 */
-		insertions: number;
-
-		/**
-		 * Number of deletions made during the session.
-		 */
-		deletions: number;
-
-		constructor(modifiedUri: Uri, insertions: number, deletions: number, originalUri?: Uri);
-	}
-
-	export class ChatSessionChangedFile2 {
 		/**
 		 * URI of the file.
 		 */


### PR DESCRIPTION
`ChatSessionChangedFile2` can become `ChatSessionChangedFile` and we can remove the old `ChatSessionChangedFile `