### PR TITLE
Fix initial option values not getting passed down

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -441,6 +441,7 @@ export class ClaudeChatSessionItemController extends Disposable {
 				permissionMode,
 				cwd: folder,
 			};
+			this._controller.items.add(item);
 			return item;
 		};
 


### PR DESCRIPTION
Without this, `this._controller.items.get(uri)` returns undefined... but the metadata is stored on the item so that is needed to resolve.

FYI @mjbvz as an interesting quirk of the API.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
