### PR TITLE
fix: use glob matching for cached file search results

### DIFF
--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -223,7 +223,7 @@ export class SearchService implements IRawSearchService {
 			return undefined;
 		}
 
-		const cached = this.getResultsFromCache(cache, config.filePattern || '', progressCallback, token);
+		const cached = this.getResultsFromCache(cache, config.filePattern || '', progressCallback, token, config.shouldGlobMatchFilePattern, config.ignoreGlobCase);
 		if (cached) {
 			return cached.then(([result, results, cacheStats]) => {
 				const sortSW = StopWatch.create(false);
@@ -275,7 +275,7 @@ export class SearchService implements IRawSearchService {
 		}
 	}
 
-	private getResultsFromCache(cache: Cache, searchValue: string, progressCallback: IFileProgressCallback, token?: CancellationToken): Promise<[ISearchEngineSuccess, IRawFileMatch[], ICachedSearchStats]> | null {
+	private getResultsFromCache(cache: Cache, searchValue: string, progressCallback: IFileProgressCallback, token?: CancellationToken, shouldGlobMatch?: boolean, ignoreGlobCase?: boolean): Promise<[ISearchEngineSuccess, IRawFileMatch[], ICachedSearchStats]> | null {
 		const cacheLookupSW = StopWatch.create(false);
 
 		// Find cache entries by prefix of search value
@@ -319,12 +319,20 @@ export class SearchService implements IRawSearchService {
 
 			// Pattern match on results
 			const results: IRawFileMatch[] = [];
-			const normalizedSearchValueLowercase = prepareQuery(searchValue).normalizedLowercase;
+			const normalizedSearchValueLowercase = shouldGlobMatch ? null : prepareQuery(searchValue).normalizedLowercase;
 			for (const entry of cachedEntries) {
 
 				// Check if this entry is a match for the search value
-				if (!isFilePatternMatch(entry, normalizedSearchValueLowercase)) {
-					continue;
+				// When glob matching is requested, use glob matching with the raw pattern
+				// instead of fuzzy matching with the normalized pattern (which strips wildcards)
+				if (normalizedSearchValueLowercase) {
+					if (!isFilePatternMatch(entry, normalizedSearchValueLowercase)) {
+						continue;
+					}
+				} else if (searchValue) {
+					if (searchValue !== '*' && !isFilePatternMatch(entry, searchValue, false, ignoreGlobCase)) {
+						continue;
+					}
 				}
 
 				results.push(entry);


### PR DESCRIPTION
## Summary

Fixes #265630

When `shouldGlobMatchFilePattern` is true (used by chat file completions via `#` mentions and explorer find), the initial file walk in `FileWalker` correctly uses glob matching via `isFilePatternMatch` with `fuzzy=false`. However, when the same query is served from cache via `getResultsFromCache`, the code always:

1. Normalizes the search pattern through `prepareQuery()`, which strips wildcard characters (`*`, etc.)
2. Uses fuzzy matching instead of glob matching

This causes the cache path to return 0 results on repeated queries, because the stripped pattern no longer matches any files.

## Fix

- Pass `shouldGlobMatchFilePattern` and `ignoreGlobCase` from the query config into `getResultsFromCache`
- When glob matching is requested, skip the `prepareQuery` normalization (which strips wildcards) and use `isFilePatternMatch` with `fuzzy=false` and the raw pattern -- matching the behavior in `FileWalker.isFileMatch()`
- Handle the `*` wildcard as an all-matching pattern, consistent with `FileWalker`

## Test plan

- [ ] Open chat view, type `#f`, observe file results appear
- [ ] Press backspace to get `#`, then type `f` again to get `#f`
- [ ] Verify the same file results appear (previously returned 0 results)
- [ ] Verify normal file search (Quick Open) still works correctly with caching
- [ ] Verify explorer find filter still works with repeated queries