### PR TITLE
Update terminal image setting description to document kitty z-index limitation

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -654,7 +654,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	},
 	[TerminalSettingId.EnableImages]: {
 		restricted: true,
-		markdownDescription: localize('terminal.integrated.enableImages', "Enables image support in the terminal, this will only work when {0} is enabled. Sixel and iTerm's inline image protocol are supported on Linux and macOS. The kitty graphics protocol is supported on all platforms. On Windows, all image protocols will only work for versions of ConPTY >= v2 which is shipped with Windows itself, see also {1}. Images will currently not be restored between window reloads/reconnects. When enabled, transparency mode is also turned on in the terminal.", `\`#${TerminalSettingId.GpuAcceleration}#\``, `\`#${TerminalSettingId.WindowsUseConptyDll}#\``),
+		markdownDescription: localize('terminal.integrated.enableImages', "Enables image support in the terminal, this will only work when {0} is enabled. Sixel and iTerm's inline image protocol are supported on Linux and macOS. The kitty graphics protocol is supported on all platforms. On Windows, all image protocols will only work for versions of ConPTY >= v2 which is shipped with Windows itself, see also {1}. Kitty graphics z-index support (rendering images behind text with a negative z-index) requires {0} to be set to {2}. Images will currently not be restored between window reloads/reconnects. When enabled, transparency mode is also turned on in the terminal to allow images to render correctly.", `\`#${TerminalSettingId.GpuAcceleration}#\``, `\`#${TerminalSettingId.WindowsUseConptyDll}#\``, `\`off\``),
 		type: 'boolean',
 		default: false
 	},


### PR DESCRIPTION
## Summary

- Document that kitty graphics z-index support (rendering images behind text with a negative z-index) requires GPU acceleration to be set to `off` in the `terminal.integrated.enableImages` setting description
- Clarify that transparency mode is automatically enabled to allow images to render correctly

Fixes #295634