### PR TITLE
Git: use consistent worktree open label in repositories view

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -11,7 +11,7 @@
 	"command.close": "Close Repository",
 	"command.closeOtherRepositories": "Close Other Repositories",
 	"command.openWorktree": "Open Worktree in Current Window",
-	"command.openWorktree2": "Open",
+	"command.openWorktree2": "Open in Current Window",
 	"command.openWorktreeInNewWindow": "Open Worktree in New Window",
 	"command.openWorktreeInNewWindow2": "Open in New Window",
 	"command.refresh": "Refresh",


### PR DESCRIPTION
## Summary
- Changes the label for the `git.repositories.openWorktree` command from "Open" to "Open in Current Window" in the SCM Repositories view
- This makes the worktree sub-node context menu label consistent with the top-level `git.openWorktree` command ("Open Worktree in Current Window") and the companion "Open in New Window" action

## Details
In the SCM Repositories view, right-clicking a worktree sub-node shows:
- **Before:** "Open" and "Open in New Window"  
- **After:** "Open in Current Window" and "Open in New Window"

The inline action tooltip also now explicitly says "Open in Current Window" instead of just "Open", matching the explicit qualifier used by its sibling action.

Fixes #286094