### PR TITLE
fix(markdown-math): prevent single $ with trailing space from starting math block

### DIFF
--- a/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
@@ -48,7 +48,7 @@
 		"single_dollar_math_block": {
 			"name": "markup.math.block.markdown",
 			"contentName": "meta.embedded.math.markdown",
-			"begin": "(?<=^\\s*)(\\$)(?![^$]*\\$|\\d)",
+			"begin": "(?<=^\\s*)(\\$)(?![^$]*\\$|\\d|\\s)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.math.begin.markdown"


### PR DESCRIPTION
## Summary

Fixes #277285

A lone `$` followed by a space (e.g. `$ b`) at the start of a line was incorrectly treated as the beginning of a block math expression, causing all subsequent content to be highlighted as math until the next `$` was found.

**Before:**
```md
# a

$ b

# c
```
The `$ b` line would open a math block, swallowing `# c` into math highlighting.

**After:**
The `$` followed by whitespace is no longer recognized as a math block opener. The `# c` heading renders correctly.

## Changes

- Added `\s` to the negative lookahead in the `single_dollar_math_block` begin pattern in `md-math-block.tmLanguage.json`
- The begin pattern now rejects `$` followed by whitespace, digits, or another `$` on the same line

## Test plan

- [ ] Open a `.md` file containing `$ b` on its own line — verify it is NOT highlighted as math
- [ ] Verify `$x+y$` inline math still highlights correctly
- [ ] Verify `$$` block math still works
- [ ] Verify `$` immediately followed by a non-space character (e.g. `$x`) on its own line still starts a math block