### PR TITLE
fix: add InputFocusedContext guard to notebook output Escape keybinding

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -125,7 +125,8 @@ registerAction2(class QuitEditCellAction extends NotebookCellAction {
 					},
 					{
 						when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED,
-							NOTEBOOK_OUTPUT_FOCUSED),
+							NOTEBOOK_OUTPUT_FOCUSED,
+							InputFocusedContext.toNegated()),
 						primary: KeyCode.Escape,
 						weight: KeybindingWeight.WorkbenchContrib + 5
 					},


### PR DESCRIPTION
## Summary

Fixes #234235

The `Escape` keybinding for "Notebook: Stop Editing Cell" when notebook output is focused (`notebookEditorFocused && notebookOutputFocused`) was missing an `InputFocusedContext.toNegated()` guard. This caused the keybinding to incorrectly fire when a user pressed `Escape` to dismiss autocomplete suggestions while editing a cell, because the `NOTEBOOK_OUTPUT_FOCUSED` context key could remain stale from a previous output focus.

- Added `InputFocusedContext.toNegated()` to the output-focused `Escape` keybinding's `when` condition
- This ensures the keybinding only triggers when no input element has focus, preventing it from interfering with editor actions like dismissing the suggest widget

## Test plan

- [ ] Open a notebook and edit a code cell
- [ ] Type something to trigger the autocomplete popup
- [ ] Press `Escape` to dismiss the popup
- [ ] Verify the cell remains in edit mode (focus is not lost)
- [ ] Click on a cell output to focus it, then press `Escape`
- [ ] Verify focus properly returns to the cell container (existing behavior preserved)