### PR TITLE
fix: check message location visibility for failureInVisibleDocument peek

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -310,6 +310,13 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 				if (!Iterable.some(resultItemParents(evt.result, evt.item), i => i.item.uri && editorUris.has(i.item.uri.toString()))) {
 					return;
 				}
+				// Also check that the message location itself is in a visible
+				// document. The message may point to a different file (e.g. a
+				// utility) than where the test is defined, and opening a non-
+				// visible file just to show a peek would be disruptive.
+				if (!editorUris.has(candidate.location.uri.toString())) {
+					return;
+				}
 				break; //continue
 			}
 			case AutoOpenPeekViewWhen.FailureAnywhere:


### PR DESCRIPTION
## Summary

- Fixes an issue where `testing.automaticallyOpenPeekView` set to `failureInVisibleDocument` would still open peek views in non-visible documents
- When a test in a visible file fails with an error located in a different file (e.g. a utility module), VS Code previously opened that non-visible file just to show the peek, contradicting the setting's intent
- Now both the test item's URI **and** the message location URI must be in visible editors for the peek to auto-open

Fixes #230881

## Test plan

- [ ] Set `"testing.automaticallyOpenPeekView": "failureInVisibleDocument"`
- [ ] Create a test file (`example.spec.ts`) that calls a utility function in a separate file (`util.ts`) which throws an error
- [ ] Open only `example.spec.ts` in the editor (ensure `util.ts` is NOT open)
- [ ] Run the failing test
- [ ] Verify the peek view does **not** auto-open (since the error location `util.ts` is not visible)
- [ ] Now open both `example.spec.ts` and `util.ts` side by side
- [ ] Re-run the failing test
- [ ] Verify the peek view **does** auto-open (since both the test and message location are visible)