### PR TITLE
fix: re-evaluate active editor repository when SCM repositories change

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -278,9 +278,15 @@ export class SCMViewService implements ISCMViewService {
 			equalsFn: () => false
 		}, this.editorService.onDidActiveEditorChange, () => this.editorService.activeEditor);
 
+		const repositoriesObs = observableFromEventOpts({
+			owner: this,
+			equalsFn: () => false
+		}, Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository), () => this.scmService.repositories);
+
 		this._activeEditorRepositoryObs = derivedObservableWithCache<ISCMRepository | undefined>(this,
 			(reader, lastValue) => {
 				const activeEditor = this._activeEditorObs.read(reader);
+				repositoriesObs.read(reader);
 				const activeResource = EditorResourceAccessor.getOriginalUri(activeEditor);
 				if (!activeResource) {
 					return lastValue;


### PR DESCRIPTION
## Summary

- Fixes `${activeRepositoryName}` and `${activeRepositoryBranchName}` window title variables appearing blank in multi-root workspaces
- The `_activeEditorRepositoryObs` derived observable only tracked active editor changes but not SCM repository additions/removals. When a repository was registered after the editor was already open, the derived would cache `undefined` and never re-evaluate.
- Added a `repositoriesObs` observable that tracks `onDidAddRepository` / `onDidRemoveRepository` events and reads it inside the derived to trigger re-evaluation when repositories change.

Fixes #304129

## Test plan

- [ ] Open a multi-root workspace with multiple Git repositories
- [ ] Set `window.title` to `${rootNameShort} - ${activeRepositoryName}` or `${rootNameShort} - ${activeRepositoryBranchName}`
- [ ] Verify the active repository name and branch name appear correctly in the window title
- [ ] Open files from different repositories and verify the title updates accordingly
- [ ] Restart VS Code and verify the variables resolve correctly on startup