### PR TITLE
nes: fix: ensure request log tree entries always have icons

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -420,6 +420,8 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 				telemetryBuilder.setStatus('emptyEditsButHasNextCursorPosition');
 				return new NextEditResult(logContext.requestId, req, { jumpToPosition: error.nextCursorPosition, targetDocumentId: error.nextCursorDocumentId, documentBeforeEdits: documentAtInvocationTime, isFromCursorJump: false, isSubsequentEdit: false });
 			}
+		} else if (error instanceof NoNextEditReason.GotCancelled) {
+			logContext.setIsSkipped();
 		}
 
 		const emptyResult = new NextEditResult(logContext.requestId, req, undefined);
@@ -1279,10 +1281,13 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const capturingToken = new CapturingToken(label, undefined);
 
 		void this._requestLogger.captureInvocation(capturingToken, async () => {
+			this._addLiveLogContextEntry(logContext, label);
 			try {
 				await this._runSpeculativeProviderCall(nextEditRequest, projectedDocuments, curDocId, req, logger);
+			} catch (e) {
+				logContext.setError(e);
 			} finally {
-				this._addLogContextEntry(logContext, label);
+				logContext.markCompleted();
 			}
 		});
 
@@ -1324,6 +1329,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 					Result.error(res.value.v),
 					res.value.telemetryBuilder
 				));
+				logContext.markAsNoSuggestions();
 				logger.trace('speculative request completed with no edits');
 			} else {
 
@@ -1372,6 +1378,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 										res.value.telemetryBuilder
 									)
 								);
+								logContext.setResponseResults([nextEditReplacement]);
 							}
 
 							logger.trace(`cached speculative edit ${ithEdit}`);
@@ -1390,6 +1397,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 								res.value.telemetryBuilder
 							)
 						);
+						logContext.markAsNoSuggestions();
 					}
 				});
 			}
@@ -1468,16 +1476,15 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		this._snippyService.handlePostInsertion(docId.toUri(), suggestion.result.documentBeforeEdits, suggestion.result.edit);
 	}
 
-	private _addLogContextEntry(logContext: InlineEditRequestLogContext, debugNameOverride?: string): void {
-		if (!logContext.includeInLogTree) {
-			return;
-		}
+	private _addLiveLogContextEntry(logContext: InlineEditRequestLogContext, debugNameOverride?: string): void {
 		this._requestLogger.addEntry({
 			type: LoggedRequestKind.MarkdownContentRequest,
 			debugName: debugNameOverride ?? logContext.getDebugName(),
-			icon: logContext.getIcon(),
+			icon: () => logContext.getIcon(),
 			startTimeMs: logContext.time,
-			markdownContent: logContext.toLogDocument(),
+			markdownContent: () => logContext.toLogDocument(),
+			onDidChange: logContext.onDidChange,
+			isVisible: () => logContext.includeInLogTree,
 		});
 	}
 

--- a/extensions/copilot/src/extension/log/vscode-node/requestLogTree.ts
+++ b/extensions/copilot/src/extension/log/vscode-node/requestLogTree.ts
@@ -619,16 +619,12 @@ class ChatRequestProvider extends Disposable implements vscode.TreeDataProvider<
 				// whose debugName matches the token label), associate it directly with the
 				// parent ChatPromptItem — don't add it as a child. The entry stays in the
 				// request logger for virtual document serving; only tree nesting changes.
-				// Only wire the main entry if it is visible — for live NES/Ghost entries,
-				// isVisible() can be false (e.g. skipped/cancelled); wiring a hidden entry
-				// would make it visible again via the parent's icon and click command.
+				// Always wire the main entry so the parent node is clickable and shows the
+				// current icon (e.g. loading, lightbulb, skipped, circleSlash, etc.).
 				if (currReq.kind === LoggedInfoKind.Request &&
 					currReq.entry.type === LoggedRequestKind.MarkdownContentRequest &&
 					currReq.entry.debugName === currReq.token.label) {
-					const isHidden = currReq.entry.isVisible && !currReq.entry.isVisible();
-					if (!isHidden) {
-						prompt.setMainEntry(currReq);
-					}
+					prompt.setMainEntry(currReq);
 					continue;
 				}
 

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -357,8 +357,12 @@ export class InlineEditRequestLogContext {
 
 	private _icon: Icon.t | undefined;
 
-	getIcon(): ThemeIcon | undefined {
-		return this._icon?.themeIcon;
+	private _resolveIcon(): Icon.t {
+		return this._icon ?? (this._isCompleted ? Icon.check : Icon.loading);
+	}
+
+	getIcon(): ThemeIcon {
+		return this._resolveIcon().themeIcon;
 	}
 
 	public setIsSkipped() {
@@ -460,8 +464,8 @@ export class InlineEditRequestLogContext {
 	}
 
 	getMarkdownTitle(): string {
-		const icon: string = this._icon ? `${this._icon.svg} ` : '';
-		return (icon) + this.getDebugName();
+		const icon = this._resolveIcon();
+		return `${icon.svg} ` + this.getDebugName();
 	}
 
 	protected _recentEdit: HistoryContext | undefined = undefined;

--- a/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
@@ -53,6 +53,16 @@ export namespace Icon {
 		themeIcon: ThemeIcon.fromId('database'),
 		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M13 3.5C13 2.119 10.761 1 8 1S3 2.119 3 3.5c0 .04.02.077.024.117H3v8.872l.056.357C3.336 14.056 5.429 15 8 15s4.664-.944 4.944-2.154l.056-.357V3.617h-.024c.004-.04.024-.077.024-.117M8 2.032c2.442 0 4 .964 4 1.468s-1.558 1.468-4 1.468S4 4 4 3.5s1.558-1.468 4-1.468m4 10.458l-.03.131C11.855 13.116 10.431 14 8 14s-3.855-.884-3.97-1.379L4 12.49v-7.5A7.4 7.4 0 0 0 8 6a7.4 7.4 0 0 0 4-1.014z"/></svg>`,
 	};
+
+	export const loading: t = {
+		themeIcon: ThemeIcon.fromId('loading~spin'),
+		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M13.917 7A6.002 6.002 0 0 0 2.083 7H1.071a7.002 7.002 0 0 1 13.858 0zm0 2a6.002 6.002 0 0 1-11.834 0H1.071a7.002 7.002 0 0 0 13.858 0z" clip-rule="evenodd"/></svg>`,
+	};
+
+	export const check: t = {
+		themeIcon: ThemeIcon.fromId('check'),
+		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="m14.431 3.323l-8.47 10l-.79-.036l-3.35-4.77l.818-.574l2.978 4.24l8.051-9.506z" clip-rule="evenodd"/></svg>`,
+	};
 }
 
 export function shortenOpportunityId(opportunityId: string): string {


### PR DESCRIPTION
## Summary

**edit**: perhaps descirption should've been changed after code review comments were addressed

NES and speculative NES entries in the Chat Debug request log tree could appear without icons (showing the default `copilot` robot icon or spinning endlessly).

### Changes

**`inlineEditLogContext.ts`**
- `getIcon()` now always returns a `ThemeIcon` (never `undefined`): `loading~spin` while in-progress, `lightbulbFull` when completed without an explicit icon
- `getMarkdownTitle()` always renders an icon SVG in the markdown document title

**`utils.ts`**
- Added `Icon.loading` with `ThemeIcon.fromId('loading~spin')` for in-progress state

**`nextEditProvider.ts`**
- Speculative requests now use a live log entry (`_addLiveLogContextEntry`) registered inside `captureInvocation` so the entry is associated with the correct `CapturingToken` and shows dynamic icons
- `_runSpeculativeProviderCall` now sets icons on `logContext`: `markAsNoSuggestions()` when no edits, `setResponseResults()` when edits produced
- `logContext.markCompleted()` called in the `finally` block so the spinner stops