### PR TITLE
build: fix private-to-property rewrite bugs, add syntax check

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -1027,18 +1027,19 @@ ${tslib}`,
 	// Uses esbuild.transform() as a parser since the bundles are ESM.
 	const postProcessedFiles = new Set([...mangleEdits.keys(), ...nlsEdits.keys()]);
 	if (postProcessedFiles.size > 0) {
-		const errors: string[] = [];
-		await Promise.all([...postProcessedFiles].map(async jsPath => {
+		const errors = (await Promise.all([...postProcessedFiles].map(async jsPath => {
 			try {
 				const src = await fs.promises.readFile(jsPath, 'utf-8');
 				await esbuild.transform(src, { loader: 'js', format: 'esm' });
-			} catch (e: any) {
+				return undefined;
+			} catch (e: unknown) {
 				const rel = path.relative(path.join(REPO_ROOT, outDir), jsPath);
-				errors.push(`${rel}: ${e.message}`);
+				const message = e instanceof Error ? e.message : String(e);
+				return { rel, message };
 			}
-		}));
+		}))).filter(error => error !== undefined).sort((a, b) => a.rel.localeCompare(b.rel));
 		if (errors.length > 0) {
-			throw new Error(`[bundle] Syntax errors in post-processed JS files:\n${errors.join('\n')}`);
+			throw new Error(`[bundle] Syntax errors in post-processed JS files:\n${errors.map(e => `${e.rel}: ${e.message}`).join('\n')}`);
 		}
 		console.log(`[bundle] Syntax check passed for ${postProcessedFiles.size} post-processed JS files`);
 	}

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -1021,6 +1021,28 @@ ${tslib}`,
 		}
 	}
 
+	// Syntax-check JS files that were post-processed (mangle-privates, NLS).
+	// These steps do raw string surgery on bundled JS so a bug could silently
+	// produce syntactically broken output. Catch it here at build time.
+	// Uses esbuild.transform() as a parser since the bundles are ESM.
+	const postProcessedFiles = new Set([...mangleEdits.keys(), ...nlsEdits.keys()]);
+	if (postProcessedFiles.size > 0) {
+		const errors: string[] = [];
+		await Promise.all([...postProcessedFiles].map(async jsPath => {
+			try {
+				const src = await fs.promises.readFile(jsPath, 'utf-8');
+				await esbuild.transform(src, { loader: 'js', format: 'esm' });
+			} catch (e: any) {
+				const rel = path.relative(path.join(REPO_ROOT, outDir), jsPath);
+				errors.push(`${rel}: ${e.message}`);
+			}
+		}));
+		if (errors.length > 0) {
+			throw new Error(`[bundle] Syntax errors in post-processed JS files:\n${errors.join('\n')}`);
+		}
+		console.log(`[bundle] Syntax check passed for ${postProcessedFiles.size} post-processed JS files`);
+	}
+
 	// Log mangle-privates stats
 	if (doManglePrivates && mangleStats.length > 0) {
 		let totalClasses = 0, totalFields = 0, totalEdits = 0, totalElapsed = 0;

--- a/build/next/private-to-property.ts
+++ b/build/next/private-to-property.ts
@@ -88,6 +88,7 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 
 	// Global counter for unique name generation
 	let nameCounter = 0;
+	let fieldCount = 0;
 	let classCount = 0;
 
 	// Collect all edits
@@ -114,7 +115,7 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 		lastEnd = edit.end;
 	}
 	parts.push(code.substring(lastEnd));
-	return { code: parts.join(''), classCount, fieldCount: nameCounter, editCount: edits.length, elapsed: Date.now() - t1, edits };
+return { code: parts.join(''), classCount, fieldCount: fieldCount, editCount: edits.length, elapsed: Date.now() - t1, edits };
 
 	// --- AST walking ---
 
@@ -130,8 +131,15 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 		// 1) Collect public member names so generated names don't collide
 		const publicNames = new Set<string>();
 		for (const member of node.members) {
-			if (member.name && ts.isIdentifier(member.name)) {
+			if (!member.name) {
+				continue;
+			}
+			if (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)) {
 				publicNames.add(member.name.text);
+				continue;
+			}
+			if (ts.isComputedPropertyName(member.name) && ts.isStringLiteral(member.name.expression)) {
+				publicNames.add(member.name.expression.text);
 			}
 		}
 
@@ -147,6 +155,7 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 						shortName = generateShortName(nameCounter++);
 					} while (publicNames.has(shortName));
 					scope.set(name, shortName);
+					fieldCount++;
 				}
 			}
 		}

--- a/build/next/private-to-property.ts
+++ b/build/next/private-to-property.ts
@@ -127,13 +127,26 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 	}
 
 	function visitClass(node: ts.ClassDeclaration | ts.ClassExpression): void {
-		// 1) Collect all private field/method/accessor declarations in THIS class
+		// 1) Collect public member names so generated names don't collide
+		const publicNames = new Set<string>();
+		for (const member of node.members) {
+			if (member.name && ts.isIdentifier(member.name)) {
+				publicNames.add(member.name.text);
+			}
+		}
+
+		// 2) Collect all private field/method/accessor declarations in THIS class,
+		//    skipping generated names that collide with existing public members.
 		const scope: ClassScope = new Map();
 		for (const member of node.members) {
 			if (member.name && ts.isPrivateIdentifier(member.name)) {
 				const name = member.name.text;
 				if (!scope.has(name)) {
-					scope.set(name, generateShortName(nameCounter++));
+					let shortName: string;
+					do {
+						shortName = generateShortName(nameCounter++);
+					} while (publicNames.has(shortName));
+					scope.set(name, shortName);
 				}
 			}
 		}
@@ -141,12 +154,27 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 		if (scope.size > 0) {
 			classCount++;
 		}
-		classStack.push(scope);
 
-		// 2) Walk the class body, replacing PrivateIdentifier nodes
-		ts.forEachChild(node, function walkInClass(child: ts.Node): void {
+		// 3) Walk heritage clauses BEFORE pushing this class's scope.
+		//    The `extends` expression is evaluated in the enclosing lexical scope,
+		//    so any private-field references there belong to an outer class.
+		const walkInClass = createWalkInClass(node);
+		for (const clause of node.heritageClauses ?? []) {
+			ts.forEachChild(clause, walkInClass);
+		}
+
+		// 4) Now push the scope and walk the class members
+		classStack.push(scope);
+		for (const member of node.members) {
+			ts.forEachChild(member, walkInClass);
+		}
+		classStack.pop();
+	}
+
+	function createWalkInClass(classNode: ts.ClassDeclaration | ts.ClassExpression) {
+		return function walkInClass(child: ts.Node): void {
 			// Nested class: process independently with its own scope
-			if ((ts.isClassDeclaration(child) || ts.isClassExpression(child)) && child !== node) {
+			if ((ts.isClassDeclaration(child) || ts.isClassExpression(child)) && child !== classNode) {
 				visitClass(child);
 				return;
 			}
@@ -182,9 +210,7 @@ export function convertPrivateFields(code: string, filename: string): ConvertPri
 			}
 
 			ts.forEachChild(child, walkInClass);
-		});
-
-		classStack.pop();
+		};
 	}
 
 	function resolvePrivateName(name: string): string | undefined {

--- a/build/next/test/private-to-property.test.ts
+++ b/build/next/test/private-to-property.test.ts
@@ -368,6 +368,38 @@ suite('convertPrivateFields', () => {
 			'public and private properties must remain distinct, code:\n' + result.code);
 	});
 
+	test('collision avoidance — string-literal public property name', () => {
+		const code = [
+			'class Foo {',
+			'  \'$a\' = "public";',
+			'  #x = "private";',
+			'  getPublic() { return this[\'$a\']; }',
+			'  getPrivate() { return this.#x; }',
+			'}',
+			'const f = new Foo();',
+			'return f.getPublic() + "," + f.getPrivate();',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.strictEqual(new Function(result.code)(), 'public,private',
+			'string-literal public property must not collide, code:\n' + result.code);
+	});
+
+	test('collision avoidance — computed string-literal public property name', () => {
+		const code = [
+			'class Foo {',
+			'  [\'$a\'] = "public";',
+			'  #x = "private";',
+			'  getPublic() { return this[\'$a\']; }',
+			'  getPrivate() { return this.#x; }',
+			'}',
+			'const f = new Foo();',
+			'return f.getPublic() + "," + f.getPrivate();',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.strictEqual(new Function(result.code)(), 'public,private',
+			'computed string-literal public property must not collide, code:\n' + result.code);
+	});
+
 	test('brand check in heritage clause resolves to outer scope', () => {
 		const code = [
 			'class Outer {',

--- a/build/next/test/private-to-property.test.ts
+++ b/build/next/test/private-to-property.test.ts
@@ -290,6 +290,101 @@ suite('convertPrivateFields', () => {
 		const result = convertPrivateFields(code, 'test.js');
 		assert.deepStrictEqual(result.edits, []);
 	});
+
+	test('heritage clause — extends expression resolves outer private field, not inner', () => {
+		const code = [
+			'class Outer {',
+			'  #x = "outer";',
+			'  method() {',
+			'    return class extends (this.#x, Object) {',
+			'      #x = "inner";',
+			'    };',
+			'  }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		// Outer.#x → $a (first class scanned), Inner.#x → $b (second)
+		// this.#x in the extends clause lexically refers to Outer.#x,
+		// so it must become this.$a, NOT this.$b
+		assert.ok(result.code.includes('this.$a, Object'),
+			'heritage clause should reference outer replacement ($a), got:\n' + result.code);
+	});
+
+	test('heritage clause runtime — extends uses correct outer private field', () => {
+		const code = [
+			'class Base { }',
+			'class Outer {',
+			'  #Base = Base;',
+			'  createInner() {',
+			'    return class extends this.#Base {',
+			'      #Base = null;',
+			'    };',
+			'  }',
+			'}',
+			'const o = new Outer();',
+			'const Inner = o.createInner();',
+			'const inst = new Inner();',
+			'return inst instanceof Base;',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		// With the bug, this.#Base in extends resolves to Inner's replacement
+		// ($b) instead of Outer's ($a). Since the Outer instance has no $b
+		// property, `class extends undefined` throws TypeError.
+		assert.strictEqual(new Function(result.code)(), true,
+			'inner class should extend Base via outer private field, code:\n' + result.code);
+	});
+
+	test('generated name must not collide with existing public property', () => {
+		const code = [
+			'class Foo {',
+			'  $a = "public";',
+			'  #x = "private";',
+			'  getPublic() { return this.$a; }',
+			'  getPrivate() { return this.#x; }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		// #x must not be renamed to $a since the class already has a public $a
+		const fieldDecls = result.code.match(/\$a\s*=/g);
+		assert.ok(!fieldDecls || fieldDecls.length <= 1,
+			'should not produce duplicate $a property declarations, got:\n' + result.code);
+	});
+
+	test('collision with existing property — runtime correctness', () => {
+		const code = [
+			'class Foo {',
+			'  $a = "public";',
+			'  #x = "private";',
+			'  getPublic() { return this.$a; }',
+			'  getPrivate() { return this.#x; }',
+			'}',
+			'const f = new Foo();',
+			'return f.getPublic() + "," + f.getPrivate();',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		// Original: getPublic() → "public", getPrivate() → "private"
+		// With the bug: both return "private" because $a overwrites $a
+		assert.strictEqual(new Function(result.code)(), 'public,private',
+			'public and private properties must remain distinct, code:\n' + result.code);
+	});
+
+	test('brand check in heritage clause resolves to outer scope', () => {
+		const code = [
+			'class Outer {',
+			'  #brand;',
+			'  createChecked(obj) {',
+			'    return class extends (#brand in obj ? Object : Object) {',
+			'      #brand;',
+			'    };',
+			'  }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		// #brand in the extends clause should resolve to Outer.#brand ($a),
+		// not Inner.#brand ($b)
+		assert.ok(result.code.includes('\'$a\' in obj'),
+			'brand check in heritage clause should use outer replacement, got:\n' + result.code);
+	});
 });
 
 suite('adjustSourceMap', () => {


### PR DESCRIPTION
## Summary

Fix two correctness bugs in the `convertPrivateFields` rewrite step that could produce invalid or semantically broken JavaScript output, and add a build-time syntax check as a safety net.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Test-first approach**: Tests were written first to confirm the bugs, then the logic was fixed to make them pass. Tests were not modified after the fix.
- **Heritage clause fix strategy**: Instead of a post-hoc fixup, the walk was restructured to process heritage clauses *before* pushing the inner class scope. This matches JS lexical scoping where the `extends` expression is evaluated in the enclosing scope.
- **Name collision fix strategy**: A simple `do/while` loop skips generated names (`$a`, `$b`, …) that collide with existing public member names on the same class. This avoids silent property shadowing.
- **Syntax check uses `esbuild.transform()`**: Chosen over `node --check` (which doesn't handle ESM `.js` files without `"type": "module"`) and `vm.Script` (which only parses CJS). `esbuild` is already imported, handles ESM natively, runs in-process with no child process overhead, and checks all files in parallel.
- **Syntax check scope**: Only post-processed files (those touched by mangle-privates or NLS) are checked — esbuild's own output is trusted.
</details>

## Changes

### `build/next/private-to-property.ts`
- **Heritage clause scope resolution**: Walk `extends` expressions before pushing the inner class's scope onto the stack. Previously, a nested class declaring the same `#field` as its outer class would cause `resolvePrivateName` in the heritage clause to pick the inner scope — wrong, since extends is evaluated in the enclosing lexical scope. This could cause `TypeError: Class extends value undefined` at runtime.
- **Name collision avoidance**: Collect public member names before generating replacement names. Skip any `$a`, `$b`, … that already exist as public members. Previously, a class with both `$a` (public) and `#x` (private) would get two `$a` declarations, silently breaking runtime behavior.
- Extracted `walkInClass` into `createWalkInClass()` so heritage clauses and members can be walked separately with different stack states.

### `build/next/test/private-to-property.test.ts`
- 5 new tests: heritage clause resolution (string + runtime), name collision (string + runtime), brand check in heritage clause.

### `build/next/index.ts`
- Added post-processing syntax check: after mangle-privates and NLS string surgery, all affected JS files are parsed via `esbuild.transform()` to catch any syntax corruption at build time rather than at runtime.