### PR TITLE
inlineChat: bypass zone widget in hover mode, use direct sendRequest

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -42,10 +42,10 @@ import { IChatWidgetLocationOptions } from '../../chat/browser/widget/chatWidget
 import { IChatEditingService, ModifiedFileEntryState } from '../../chat/common/editing/chatEditingService.js';
 import { ChatModel } from '../../chat/common/model/chatModel.js';
 import { ChatMode } from '../../chat/common/chatModes.js';
-import { IChatService } from '../../chat/common/chatService/chatService.js';
+import { IChatLocationData, IChatService } from '../../chat/common/chatService/chatService.js';
 import { IChatRequestVariableEntry, IDiagnosticVariableEntryFilterData } from '../../chat/common/attachments/chatVariableEntries.js';
 import { isResponseVM } from '../../chat/common/model/chatViewModel.js';
-import { ChatAgentLocation } from '../../chat/common/constants.js';
+import { ChatAgentLocation, ChatModeKind } from '../../chat/common/constants.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatSelector, ILanguageModelsService, isILanguageModelChatSelector } from '../../chat/common/languageModels.js';
 import { isNotebookContainingCellEditor as isNotebookWithCellEditor } from '../../notebook/browser/notebookEditor.js';
 import { INotebookEditorService } from '../../notebook/browser/services/notebookEditorService.js';
@@ -339,9 +339,7 @@ export class InlineChatController implements IEditorContribution {
 				_editor.focus();
 				ctxInlineChatVisible.reset();
 			} else if (renderMode === 'hover') {
-				// hover mode: set model but don't show zone, keep focus in editor
-				this._zone.value.widget.chatWidget.setModel(session.chatModel);
-				this._zone.rawValue?.hide();
+				// hover mode: no zone widget needed, keep focus in editor
 				ctxInlineChatVisible.set(true);
 			} else {
 				ctxInlineChatVisible.set(true);
@@ -479,13 +477,13 @@ export class InlineChatController implements IEditorContribution {
 			}
 
 			// make sure the ZONE isn't inbetween a diff and move above if so
-			if (entry?.diffInfo && this._zone.value.position) {
-				const { position } = this._zone.value;
+			if (entry?.diffInfo && this._zone.rawValue?.position) {
+				const { position } = this._zone.rawValue;
 				const diff = entry.diffInfo.read(r);
 
 				for (const change of diff.changes) {
 					if (change.modified.contains(position.lineNumber)) {
-						this._zone.value.updatePositionAndHeight(new Position(change.modified.startLineNumber - 1, 1));
+						this._zone.rawValue?.updatePositionAndHeight(new Position(change.modified.startLineNumber - 1, 1));
 						break;
 					}
 				}
@@ -519,6 +517,99 @@ export class InlineChatController implements IEditorContribution {
 
 		const session = this._inlineChatSessionService.createSession(this._editor);
 
+		if (this._renderMode.get() === 'hover') {
+			return this._runHover(session, arg);
+		} else {
+			return this._runZone(session, arg);
+		}
+	}
+
+	/**
+	 * Hover mode: submit requests directly via IChatService.sendRequest without
+	 * instantiating the zone widget.
+	 */
+	private async _runHover(session: IInlineChatSession2, arg?: InlineChatRunOptions): Promise<boolean> {
+		assertType(this._editor.hasModel());
+		const uri = this._editor.getModel().uri;
+
+
+		// Apply editor adjustments from args
+		if (arg && InlineChatRunOptions.isInlineChatRunOptions(arg)) {
+			if (arg.initialRange) {
+				this._editor.revealRange(arg.initialRange);
+			}
+			if (arg.initialSelection) {
+				this._editor.setSelection(arg.initialSelection);
+			}
+		}
+
+		// Build location data (after selection adjustments)
+		const { location, locationData } = this._buildLocationData();
+
+		// Resolve model
+		let userSelectedModelId: string | undefined;
+		if (arg?.modelSelector) {
+			userSelectedModelId = (await this._languageModelService.selectLanguageModels(arg.modelSelector)).sort().at(0);
+			if (!userSelectedModelId) {
+				throw new Error(`No language models found matching selector: ${JSON.stringify(arg.modelSelector)}.`);
+			}
+		} else {
+			userSelectedModelId = await this._resolveModelId(location);
+		}
+
+		// Collect attachments
+		const attachedContext: IChatRequestVariableEntry[] = [];
+		if (arg?.attachments) {
+			for (const attachment of arg.attachments) {
+				const resolved = await this._chatAttachmentResolveService.resolveImageEditorAttachContext(attachment);
+				if (resolved) {
+					attachedContext.push(resolved);
+				}
+			}
+		}
+
+		// Send the request directly
+		if (arg?.message && arg.autoSend) {
+			await this._chatService.sendRequest(
+				session.chatModel.sessionResource,
+				arg.message,
+				{
+					userSelectedModelId,
+					location,
+					locationData,
+					attachedContext: attachedContext.length > 0 ? attachedContext : undefined,
+					modeInfo: {
+						kind: ChatModeKind.Ask,
+						isBuiltin: true,
+						modeInstructions: undefined,
+						modeId: 'ask',
+						applyCodeBlockSuggestionId: undefined,
+					},
+				}
+			);
+		}
+
+		if (!arg?.resolveOnResponse) {
+			await Event.toPromise(session.editingSession.onDidDispose);
+			const rejected = session.editingSession.getEntry(uri)?.state.get() === ModifiedFileEntryState.Rejected;
+			return !rejected;
+		} else {
+			const modifiedObs = derived(r => {
+				const entry = session.editingSession.readEntry(uri, r);
+				return entry?.state.read(r) === ModifiedFileEntryState.Modified && !entry?.isCurrentlyBeingModifiedBy.read(r);
+			});
+			await waitForState(modifiedObs, state => state === true);
+			return true;
+		}
+	}
+
+	/**
+	 * Zone mode: use the full zone widget and chat widget for request submission.
+	 */
+	private async _runZone(session: IInlineChatSession2, arg?: InlineChatRunOptions): Promise<boolean> {
+		assertType(this._editor.hasModel());
+		const uri = this._editor.getModel().uri;
+
 		// Store for tracking model changes during this session
 		const sessionStore = new DisposableStore();
 
@@ -526,7 +617,7 @@ export class InlineChatController implements IEditorContribution {
 			await this._applyModelDefaults(session, sessionStore);
 
 			if (arg) {
-				arg.attachDiagnostics ??= this._configurationService.getValue(InlineChatConfigKeys.RenderMode) === 'zone';
+				arg.attachDiagnostics ??= true;
 			}
 
 			// ADD diagnostics (only when explicitly requested)
@@ -662,6 +753,75 @@ export class InlineChatController implements IEditorContribution {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Resolves the language model identifier without going through the zone widget.
+	 * Used in hover mode to avoid instantiating the zone widget.
+	 *
+	 * Priority: user session choice > inlineChat.defaultModel setting > vendor default for location
+	 */
+	private async _resolveModelId(location: ChatAgentLocation): Promise<string | undefined> {
+		const userSelectedModel = InlineChatController._userSelectedModel;
+		const defaultModelSetting = this._configurationService.getValue<string>(InlineChatConfigKeys.DefaultModel);
+
+		// 1. Try user's explicitly chosen model from a previous inline chat
+		if (userSelectedModel) {
+			const match = this._languageModelService.lookupLanguageModelByQualifiedName(userSelectedModel);
+			if (match) {
+				return match.identifier;
+			}
+			// Previously selected model is no longer available
+			InlineChatController._userSelectedModel = undefined;
+		}
+
+		// 2. Try inlineChat.defaultModel setting
+		if (defaultModelSetting) {
+			const match = this._languageModelService.lookupLanguageModelByQualifiedName(defaultModelSetting);
+			if (match) {
+				return match.identifier;
+			}
+			this._logService.warn(`inlineChat.defaultModel setting value '${defaultModelSetting}' did not match any available model. Falling back to vendor default.`);
+		}
+
+		// 3. Fall back to vendor default for the given location
+		for (const id of this._languageModelService.getLanguageModelIds()) {
+			const metadata = this._languageModelService.lookupLanguageModel(id);
+			if (metadata?.isDefaultForLocation[location]) {
+				return id;
+			}
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Builds location data for chat requests without going through the zone widget.
+	 */
+	private _buildLocationData(): { location: ChatAgentLocation; locationData: IChatLocationData } {
+		assertType(this._editor.hasModel());
+
+		const notebookEditor = this._notebookEditorService.getNotebookForPossibleCell(this._editor);
+		if (notebookEditor) {
+			return {
+				location: ChatAgentLocation.Notebook,
+				locationData: {
+					type: ChatAgentLocation.Notebook,
+					sessionInputUri: this._editor.getModel().uri,
+				}
+			};
+		}
+
+		return {
+			location: ChatAgentLocation.EditorInline,
+			locationData: {
+				type: ChatAgentLocation.EditorInline,
+				id: getEditorId(this._editor, this._editor.getModel()),
+				selection: this._editor.getSelection(),
+				document: this._editor.getModel().uri,
+				wholeRange: this._editor.getSelection(),
+			}
+		};
 	}
 
 	/**

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -803,11 +803,26 @@ export class InlineChatController implements IEditorContribution {
 
 		const notebookEditor = this._notebookEditorService.getNotebookForPossibleCell(this._editor);
 		if (notebookEditor) {
+			const useNotebookAgent = this._configurationService.getValue<boolean>(InlineChatConfigKeys.notebookAgent);
+			if (useNotebookAgent) {
+				return {
+					location: ChatAgentLocation.Notebook,
+					locationData: {
+						type: ChatAgentLocation.Notebook,
+						sessionInputUri: this._editor.getModel().uri,
+					}
+				};
+			}
+			// Notebook cell but notebookAgent config is off: use Notebook location
+			// but with EditorInline-shaped locationData (matches zone widget behavior)
 			return {
 				location: ChatAgentLocation.Notebook,
 				locationData: {
-					type: ChatAgentLocation.Notebook,
-					sessionInputUri: this._editor.getModel().uri,
+					type: ChatAgentLocation.EditorInline,
+					id: getEditorId(this._editor, this._editor.getModel()),
+					selection: this._editor.getSelection(),
+					document: this._editor.getModel().uri,
+					wholeRange: this._editor.getSelection(),
 				}
 			};
 		}

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Selection } from '../../../../../editor/common/core/selection.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { ITestCodeEditor, instantiateTestCodeEditor } from '../../../../../editor/test/browser/testCodeEditor.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { InlineChatConfigKeys } from '../../common/inlineChat.js';
+import { IChatSendRequestOptions, IChatService } from '../../../chat/common/chatService/chatService.js';
+import { IInlineChatSession2, IInlineChatSessionService } from '../../browser/inlineChatSessionService.js';
+import { InlineChatController } from '../../browser/inlineChatController.js';
+import { ChatAgentLocation, ChatModeKind } from '../../../chat/common/constants.js';
+import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../chat/common/languageModels.js';
+import { IChatAgentData } from '../../../chat/common/participants/chatAgents.js';
+import { IChatModel, IChatResponseModel } from '../../../chat/common/model/chatModel.js';
+import { Range } from '../../../../../editor/common/core/range.js';
+import { IChatEditingService, IChatEditingSession, IModifiedFileEntry } from '../../../chat/common/editing/chatEditingService.js';
+import { Position } from '../../../../../editor/common/core/position.js';
+import { CursorChangeReason } from '../../../../../editor/common/cursorEvents.js';
+import { CursorState } from '../../../../../editor/common/cursorCommon.js';
+import { IUserInteractionService, MockUserInteractionService } from '../../../../../platform/userInteraction/browser/userInteractionService.js';
+import { INotebookEditorService } from '../../../notebook/browser/services/notebookEditorService.js';
+
+suite('InlineChatController - Request Parity', () => {
+
+	const store = new DisposableStore();
+	let editor: ITestCodeEditor;
+	let model: ITextModel;
+	let instantiationService: TestInstantiationService;
+	let configurationService: TestConfigurationService;
+
+	/** Captured sendRequest calls: [sessionResource, message, options] */
+	let sendRequestCalls: { sessionResource: URI; message: string; options?: IChatSendRequestOptions }[];
+	/** Emitter to signal session dispose */
+	let sessionDisposedEmitter: Emitter<void>;
+
+	const testModelId = 'test-model-id';
+	const testModelQualifiedName = 'Test Model (TestVendor)';
+	const testSessionResource = URI.parse('chat-session:test-session');
+
+	setup(() => {
+		sendRequestCalls = [];
+		sessionDisposedEmitter = store.add(new Emitter<void>());
+
+		instantiationService = workbenchInstantiationService({
+			configurationService: () => new TestConfigurationService({
+				[InlineChatConfigKeys.RenderMode]: 'hover',
+			}),
+		}, store);
+
+		configurationService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+
+		// Mock IUserInteractionService — needed for InlineChatInputWidget's internal code editor
+		instantiationService.stub(IUserInteractionService, new MockUserInteractionService());
+
+		// Mock INotebookEditorService
+		instantiationService.stub(INotebookEditorService, new class extends mock<INotebookEditorService>() {
+			override getNotebookForPossibleCell() { return undefined; }
+		});
+
+		// Mock IChatService — capture sendRequest calls
+		instantiationService.stub(IChatService, new class extends mock<IChatService>() {
+			override async sendRequest(sessionResource: URI, message: string, options?: IChatSendRequestOptions) {
+				sendRequestCalls.push({ sessionResource, message, options });
+				return { kind: 'sent' as const, data: { agent: {} as Partial<IChatAgentData> as IChatAgentData, responseCreatedPromise: Promise.resolve({} as Partial<IChatResponseModel> as IChatResponseModel), responseCompletePromise: Promise.resolve() } };
+			}
+			override async cancelCurrentRequestForSession() { }
+		});
+
+		// Mock ILanguageModelsService
+		const testMetadata: ILanguageModelChatMetadata = {
+			vendor: 'TestVendor',
+			name: 'Test Model',
+			family: 'test',
+			version: '1',
+			id: testModelId,
+			maxInputTokens: 1000,
+			maxOutputTokens: 1000,
+			auth: undefined,
+			capabilities: {},
+			isDefaultForLocation: { [ChatAgentLocation.EditorInline]: true },
+			targetEntitlements: [],
+		} as Partial<ILanguageModelChatMetadata> as ILanguageModelChatMetadata;
+
+		instantiationService.stub(ILanguageModelsService, new class extends mock<ILanguageModelsService>() {
+			override getLanguageModelIds() { return [testModelId]; }
+			override lookupLanguageModel(id: string) { return id === testModelId ? testMetadata : undefined; }
+			override lookupLanguageModelByQualifiedName(name: string) {
+				if (name === testModelQualifiedName) {
+					return { metadata: testMetadata, identifier: testModelId };
+				}
+				return undefined;
+			}
+			override async selectLanguageModels() { return [testModelId]; }
+		});
+
+		// Mock IChatEditingService
+		instantiationService.stub(IChatEditingService, new class extends mock<IChatEditingService>() {
+			override readonly editingSessionsObs = observableValue('sessions', []);
+		});
+
+		// Mock IInlineChatSessionService
+		const onDidChangeSessionsEmitter = store.add(new Emitter<any>());
+		const sessionStateObs = observableValue<undefined>('terminationState', undefined);
+		const entriesObs = observableValue<readonly IModifiedFileEntry[]>('entries', []);
+
+		instantiationService.stub(IInlineChatSessionService, new class extends mock<IInlineChatSessionService>() {
+			override readonly onWillStartSession = Event.None;
+			override readonly onDidChangeSessions = onDidChangeSessionsEmitter.event;
+			override getSessionByTextModel() { return undefined; }
+			override getSessionBySessionUri() { return undefined; }
+			override createSession(_editor: any): IInlineChatSession2 {
+				const session: IInlineChatSession2 = {
+					initialPosition: new Position(1, 1),
+					initialSelection: _editor.getSelection() ?? new Selection(1, 1, 1, 6),
+					uri: _editor.getModel()!.uri,
+					chatModel: {
+						sessionResource: testSessionResource,
+						initialLocation: ChatAgentLocation.EditorInline,
+						hasRequests: false,
+						inputModel: { state: observableValue('state', undefined), setState: () => { }, clearState: () => { }, toJSON: () => ({}) },
+						getRequests: () => [],
+						lastRequestObs: observableValue('lastReq', undefined),
+						onDidChange: Event.None,
+					} as unknown as IChatModel,
+					editingSession: {
+						onDidDispose: sessionDisposedEmitter.event,
+						entries: entriesObs,
+						readEntry: () => undefined,
+						getEntry: () => undefined,
+						accept: async () => { },
+						reject: async () => { },
+						dispose: () => { },
+					} as Partial<IChatEditingSession> as IChatEditingSession,
+					terminationState: sessionStateObs,
+					setTerminationState: () => { },
+					dispose: () => {
+						onDidChangeSessionsEmitter.fire(undefined);
+					},
+				};
+				onDidChangeSessionsEmitter.fire(undefined);
+				return session;
+			}
+		});
+
+		model = store.add(createTextModel('hello world\nfoo bar\nbaz qux'));
+		editor = store.add(instantiateTestCodeEditor(instantiationService, model));
+	});
+
+	teardown(() => {
+		store.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setExplicitSelection(sel: Selection): void {
+		editor.getViewModel()!.setCursorStates(
+			'test',
+			CursorChangeReason.Explicit,
+			[CursorState.fromModelSelection(sel)]
+		);
+	}
+
+	test('hover mode sendRequest has correct location and locationData', async () => {
+		setExplicitSelection(new Selection(1, 1, 1, 6));
+
+		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
+
+		// Don't await — run will wait for session dispose. We'll settle it after checking.
+		const runPromise = controller.run({ message: 'test message', autoSend: true });
+
+		// Let microtasks settle so sendRequest is called
+		await new Promise(r => setTimeout(r, 50));
+
+		// Settle the session so run() can return
+		sessionDisposedEmitter.fire();
+		await runPromise;
+
+		assert.strictEqual(sendRequestCalls.length, 1, 'should have exactly one sendRequest call');
+		const call = sendRequestCalls[0];
+
+		// Verify session resource
+		assert.ok(call.sessionResource.toString() === testSessionResource.toString());
+
+		// Verify message
+		assert.strictEqual(call.message, 'test message');
+
+		// Verify location
+		assert.strictEqual(call.options?.location, ChatAgentLocation.EditorInline);
+
+		// Verify locationData
+		const locData = call.options?.locationData;
+		assert.ok(locData);
+		assert.strictEqual(locData.type, ChatAgentLocation.EditorInline);
+		if (locData.type === ChatAgentLocation.EditorInline) {
+			assert.ok(locData.document.toString() === model.uri.toString());
+			assert.deepStrictEqual(Selection.liftSelection(locData.selection), new Selection(1, 1, 1, 6));
+		}
+
+		// Verify model selection
+		assert.strictEqual(call.options?.userSelectedModelId, testModelId);
+
+		// Verify modeInfo
+		assert.strictEqual(call.options?.modeInfo?.kind, ChatModeKind.Ask);
+		assert.strictEqual(call.options?.modeInfo?.modeId, 'ask');
+		assert.strictEqual(call.options?.modeInfo?.isBuiltin, true);
+	});
+
+	test('hover mode sendRequest locationData matches what zone widget resolveData would produce', async () => {
+		setExplicitSelection(new Selection(2, 1, 2, 4));
+
+		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
+
+		const runPromise = controller.run({ message: 'edit code', autoSend: true });
+		await new Promise(r => setTimeout(r, 50));
+		sessionDisposedEmitter.fire();
+		await runPromise;
+
+		assert.strictEqual(sendRequestCalls.length, 1);
+		const locData = sendRequestCalls[0].options?.locationData;
+		assert.ok(locData);
+
+		// The zone widget's resolveData builds the same shape:
+		// { type: ChatAgentLocation.EditorInline, id: getEditorId(editor, model), selection, document, wholeRange }
+		if (locData.type === ChatAgentLocation.EditorInline) {
+			// id should be `${editorId},${modelId}`
+			assert.ok(typeof locData.id === 'string');
+			assert.ok(locData.id.length > 0);
+			// document should match the editor's model URI
+			assert.ok(locData.document.toString() === model.uri.toString());
+			// selection should match what we set
+			assert.deepStrictEqual(Selection.liftSelection(locData.selection), new Selection(2, 1, 2, 4));
+			// wholeRange should equal the selection (same as zone widget behavior)
+			assert.deepStrictEqual(Range.lift(locData.wholeRange), new Range(2, 1, 2, 4));
+		} else {
+			assert.fail('Expected EditorInline location data');
+		}
+	});
+
+	test('hover mode resolves model via defaultModel setting', async () => {
+		// Reset _userSelectedModel static
+		// @ts-ignore accessing private static for test reset
+		InlineChatController._userSelectedModel = undefined;
+
+		// Set a default model config
+		configurationService.setUserConfiguration(InlineChatConfigKeys.DefaultModel, testModelQualifiedName);
+		configurationService.onDidChangeConfigurationEmitter.fire(new class extends mock<IConfigurationChangeEvent>() {
+			override affectsConfiguration() { return true; }
+		});
+
+		setExplicitSelection(new Selection(1, 1, 1, 6));
+		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
+
+		const runPromise = controller.run({ message: 'hello', autoSend: true });
+		await new Promise(r => setTimeout(r, 50));
+		sessionDisposedEmitter.fire();
+		await runPromise;
+
+		assert.strictEqual(sendRequestCalls.length, 1);
+		assert.strictEqual(sendRequestCalls[0].options?.userSelectedModelId, testModelId);
+	});
+
+	test('hover mode does not send request when autoSend is false', async () => {
+		setExplicitSelection(new Selection(1, 1, 1, 6));
+		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
+
+		const runPromise = controller.run({ message: 'hello', autoSend: false });
+		await new Promise(r => setTimeout(r, 50));
+		sessionDisposedEmitter.fire();
+		await runPromise;
+
+		assert.strictEqual(sendRequestCalls.length, 0, 'should not call sendRequest when autoSend is false');
+	});
+
+	test('hover mode does not send request when message is missing', async () => {
+		setExplicitSelection(new Selection(1, 1, 1, 6));
+		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
+
+		const runPromise = controller.run({ autoSend: true });
+		await new Promise(r => setTimeout(r, 50));
+		sessionDisposedEmitter.fire();
+		await runPromise;
+
+		assert.strictEqual(sendRequestCalls.length, 0, 'should not call sendRequest when message is missing');
+	});
+});

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../base/common/observable.js';
@@ -33,6 +34,7 @@ import { CursorChangeReason } from '../../../../../editor/common/cursorEvents.js
 import { CursorState } from '../../../../../editor/common/cursorCommon.js';
 import { IUserInteractionService, MockUserInteractionService } from '../../../../../platform/userInteraction/browser/userInteractionService.js';
 import { INotebookEditorService } from '../../../notebook/browser/services/notebookEditorService.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 
 suite('InlineChatController - Request Parity', () => {
 
@@ -174,16 +176,13 @@ suite('InlineChatController - Request Parity', () => {
 		);
 	}
 
-	test('hover mode sendRequest has correct location and locationData', async () => {
+	test('hover mode sendRequest has correct location and locationData', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		setExplicitSelection(new Selection(1, 1, 1, 6));
 
 		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
 
-		// Don't await — run will wait for session dispose. We'll settle it after checking.
 		const runPromise = controller.run({ message: 'test message', autoSend: true });
-
-		// Let microtasks settle so sendRequest is called
-		await new Promise(r => setTimeout(r, 50));
+		await timeout(0);
 
 		// Settle the session so run() can return
 		sessionDisposedEmitter.fire();
@@ -217,15 +216,15 @@ suite('InlineChatController - Request Parity', () => {
 		assert.strictEqual(call.options?.modeInfo?.kind, ChatModeKind.Ask);
 		assert.strictEqual(call.options?.modeInfo?.modeId, 'ask');
 		assert.strictEqual(call.options?.modeInfo?.isBuiltin, true);
-	});
+	}));
 
-	test('hover mode sendRequest locationData matches what zone widget resolveData would produce', async () => {
+	test('hover mode sendRequest locationData matches what zone widget resolveData would produce', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		setExplicitSelection(new Selection(2, 1, 2, 4));
 
 		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
 
 		const runPromise = controller.run({ message: 'edit code', autoSend: true });
-		await new Promise(r => setTimeout(r, 50));
+		await timeout(0);
 		sessionDisposedEmitter.fire();
 		await runPromise;
 
@@ -248,9 +247,9 @@ suite('InlineChatController - Request Parity', () => {
 		} else {
 			assert.fail('Expected EditorInline location data');
 		}
-	});
+	}));
 
-	test('hover mode resolves model via defaultModel setting', async () => {
+	test('hover mode resolves model via defaultModel setting', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		// Reset _userSelectedModel static
 		// @ts-ignore accessing private static for test reset
 		InlineChatController._userSelectedModel = undefined;
@@ -265,35 +264,35 @@ suite('InlineChatController - Request Parity', () => {
 		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
 
 		const runPromise = controller.run({ message: 'hello', autoSend: true });
-		await new Promise(r => setTimeout(r, 50));
+		await timeout(0);
 		sessionDisposedEmitter.fire();
 		await runPromise;
 
 		assert.strictEqual(sendRequestCalls.length, 1);
 		assert.strictEqual(sendRequestCalls[0].options?.userSelectedModelId, testModelId);
-	});
+	}));
 
-	test('hover mode does not send request when autoSend is false', async () => {
+	test('hover mode does not send request when autoSend is false', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		setExplicitSelection(new Selection(1, 1, 1, 6));
 		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
 
 		const runPromise = controller.run({ message: 'hello', autoSend: false });
-		await new Promise(r => setTimeout(r, 50));
+		await timeout(0);
 		sessionDisposedEmitter.fire();
 		await runPromise;
 
 		assert.strictEqual(sendRequestCalls.length, 0, 'should not call sendRequest when autoSend is false');
-	});
+	}));
 
-	test('hover mode does not send request when message is missing', async () => {
+	test('hover mode does not send request when message is missing', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		setExplicitSelection(new Selection(1, 1, 1, 6));
 		const controller = store.add(instantiationService.createInstance(InlineChatController, editor));
 
 		const runPromise = controller.run({ autoSend: true });
-		await new Promise(r => setTimeout(r, 50));
+		await timeout(0);
 		sessionDisposedEmitter.fire();
 		await runPromise;
 
 		assert.strictEqual(sendRequestCalls.length, 0, 'should not call sendRequest when message is missing');
-	});
+	}));
 });


### PR DESCRIPTION
## Summary

In hover mode, the `InlineChatZoneWidget` was being lazily instantiated, fully configured (model, attachments, input text), used to submit requests via `chatWidget.acceptInput()`, then immediately hidden. This PR eliminates that intermediary by calling `IChatService.sendRequest()` directly on the session's `ChatModel`, so the zone widget is never instantiated in hover mode.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Direct `sendRequest` over `addRequest`**: Uses the high-level `IChatService.sendRequest()` which handles parsing, instruction collection, and agent invocation - not the low-level `ChatModel.addRequest()`.
- **Zone mode untouched**: All changes are scoped to hover mode. The `_runZone()` codepath is the original `run()` logic, completely unchanged (except `attachDiagnostics` defaulting to `true` since it's always zone mode).
- **`_resolveModelId()` uses `lookupLanguageModelByQualifiedName`**: Same 3-tier priority as `_applyModelDefaults` (user session choice > `inlineChat.defaultModel` setting > vendor default for location), but queries `ILanguageModelsService` directly instead of going through `chatWidget.input.switchModelByQualifiedName()`.
- **`_buildLocationData()` replicates zone widget's `resolveData`**: Produces identical `IChatLocationData` shape, handling both regular editors and notebook cells.
- **Constructor autoruns guarded**: The HIDE/SHOW autorun no longer calls `this._zone.value` in hover mode (which would force instantiation). The diff-adjustment autorun uses `rawValue?.` so it only acts when the zone already exists.
- **`InlineChatRunOptions` API unchanged**: External callers (extensions, actions) don't need changes.
- **`as unknown as T` used in test mocks**: `Partial<T> as T` was insufficient for deeply-nested mock objects; `unknown` intermediary was chosen over `any` to satisfy lint rules.

</details>

## Changes

- **`run()` split into `_runHover()` and `_runZone()`** - dispatches based on `_renderMode`
- **New `_resolveModelId(location)`** - resolves language model ID without zone widget
- **New `_buildLocationData()`** - builds `IChatLocationData` from editor state without zone widget
- **Constructor autoruns guarded** - `_zone.value` -> `_zone.rawValue?.` where appropriate for hover mode
- **New test file** `inlineChatController.test.ts` - verifies sendRequest options (location, locationData, modelId, modeInfo) match expected values in hover mode
