### PR TITLE
fix: clamp HTML completion ranges for unclosed string literals

### DIFF
--- a/extensions/html-language-features/server/src/modes/htmlMode.ts
+++ b/extensions/html-language-features/server/src/modes/htmlMode.ts
@@ -20,14 +20,45 @@ export function getHTMLMode(htmlLanguageService: HTMLLanguageService, workspace:
 		async getSelectionRange(document: TextDocument, position: Position): Promise<SelectionRange> {
 			return htmlLanguageService.getSelectionRanges(document, [position])[0];
 		},
-		doComplete(document: TextDocument, position: Position, documentContext: DocumentContext, settings = workspace.settings) {
+		async doComplete(document: TextDocument, position: Position, documentContext: DocumentContext, settings = workspace.settings) {
 			const htmlSettings = settings?.html;
 			const options = merge(htmlSettings?.suggest, {});
 			options.hideAutoCompleteProposals = htmlSettings?.autoClosingTags === true;
 			options.attributeDefaultValue = htmlSettings?.completion?.attributeDefaultValue ?? 'doublequotes';
 
 			const htmlDocument = htmlDocuments.get(document);
-			const completionList = htmlLanguageService.doComplete2(document, position, htmlDocument, documentContext, options);
+			const completionList = await htmlLanguageService.doComplete2(document, position, htmlDocument, documentContext, options);
+
+			// Fix completion ranges for unclosed string literals (issue #273226).
+			// When an attribute value has an opening quote but no closing quote,
+			// the parser treats everything after the quote as the attribute value,
+			// causing the replacement range to extend too far (e.g., into subsequent tags).
+			// We clamp the replacement range to end before the next '<' character after the cursor.
+			const text = document.getText();
+			const offset = document.offsetAt(position);
+			for (const item of completionList.items) {
+				if (!item.textEdit) {
+					continue;
+				}
+				const editRange = 'range' in item.textEdit ? item.textEdit.range : item.textEdit.replace;
+				const editEndOffset = document.offsetAt(editRange.end);
+				if (editEndOffset <= offset) {
+					continue;
+				}
+				// Check if the text between cursor and end of range contains a '<',
+				// which indicates the range leaked into subsequent HTML tags
+				const textAfterCursor = text.substring(offset, editEndOffset);
+				const angleBracketIndex = textAfterCursor.indexOf('<');
+				if (angleBracketIndex !== -1) {
+					const clampedEnd = document.positionAt(offset + angleBracketIndex);
+					if ('range' in item.textEdit) {
+						item.textEdit.range = Range.create(editRange.start, clampedEnd);
+					} else {
+						item.textEdit.replace = Range.create(editRange.start, clampedEnd);
+					}
+				}
+			}
+
 			return completionList;
 		},
 		async doHover(document: TextDocument, position: Position, settings?: Settings) {

--- a/extensions/html-language-features/server/src/test/completions.test.ts
+++ b/extensions/html-language-features/server/src/test/completions.test.ts
@@ -94,6 +94,34 @@ suite('HTML Completion', () => {
 	});
 });
 
+suite('HTML Unclosed String Completions', () => {
+	test('Completion should not replace content after cursor when attribute value has unclosed quote', async () => {
+		// Issue #273226: When an attribute value has an opening quote but no closing quote,
+		// the replacement range should not extend into subsequent HTML tags.
+		await testCompletionFor('<th><input type="che|</th>', {
+			items: [
+				{ label: 'checkbox', resultText: '<th><input type="checkbox</th>' },
+			]
+		});
+	});
+
+	test('Completion should not replace content after cursor with space before closing tag', async () => {
+		await testCompletionFor('<th><input type="che| </th>', {
+			items: [
+				{ label: 'checkbox', resultText: '<th><input type="checkbox </th>' },
+			]
+		});
+	});
+
+	test('Completion with properly closed quotes should still work normally', async () => {
+		await testCompletionFor('<input type="che|">', {
+			items: [
+				{ label: 'checkbox', resultText: '<input type="checkbox">' },
+			]
+		});
+	});
+});
+
 suite('HTML Path Completion', () => {
 	const triggerSuggestCommand = {
 		title: 'Suggest',


### PR DESCRIPTION
Fixes #273226

## Summary

**Bug:** When an HTML attribute value has an unclosed quote (e.g., `<input type="che`), selecting a completion replaces content beyond the cursor, deleting subsequent HTML tags.

**Root Cause:** The HTML parser treats everything after an unclosed quote as part of the attribute value string, so the completion replacement range extends into subsequent tags like `</th>`.

**Fix:** Post-process completion items in `htmlMode.ts` to clamp their text edit ranges before any `<` character found after the cursor position, preventing the replacement from leaking into subsequent HTML content.

## Changes

- `extensions/html-language-features/server/src/modes/htmlMode.ts`: Added range clamping logic after `doComplete2` that scans for `<` between the cursor and the edit range end, and clamps the range to stop before it.
- `extensions/html-language-features/server/src/test/completions.test.ts`: Added 3 regression tests covering unclosed quote completions, unclosed quote with trailing space, and properly closed quotes (to ensure no regression).

## Test Plan

- [x] Added regression test: completion for `<th><input type="che|</th>` produces `checkbox` without replacing `</th>`
- [x] Added regression test: completion for `<th><input type="che| </th>` works correctly with space before closing tag
- [x] Added regression test: completion for `<input type="che|">` still works normally with properly closed quotes
- [x] All existing HTML completion tests continue to pass