### PR TITLE
NES: refactor InlineEditRequestLogContext state management

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/vscodeInlineCompletionItemProvider.ts
@@ -119,6 +119,7 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 		return await this.requestLogger.captureInvocation(capturingToken, async () => {
 
 			const logContext = new GhostTextLogContext(doc.uri.toString(), doc.version, context);
+			this.inlineEditLogger.addLive(logContext);
 
 			const logger = this.logger.createSubLogger('provideInlineCompletionItems').withExtraTarget(LogTarget.fromCallback((_level, msg) => {
 				logContext.trace(`[${Math.floor(sw.elapsed()).toString().padStart(4, ' ')}ms] ${msg}`);
@@ -136,8 +137,7 @@ export class CopilotInlineCompletionItemProvider extends Disposable implements I
 				const emptyList = { items: [], telemetryBuilder }; // we need to return an empty list, such that vscode invokes endOfLife on it and we send telemetry
 				return emptyList;
 			} finally {
-				this.inlineEditLogger.add(logContext);
-
+				logContext.markCompleted();
 				telemetryBuilder.nesBuilder.markEndTime();
 			}
 		});

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -480,7 +480,6 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 		} finally {
 			logContext.markCompleted();
 			requestCancellationTokenSource.dispose();
-			this.logger.add(logContext);
 		}
 	}
 

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/parts/inlineEditLogger.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/parts/inlineEditLogger.ts
@@ -9,7 +9,6 @@ import { Disposable } from '../../../../util/vs/base/common/lifecycle';
 
 export class InlineEditLogger extends Disposable {
 	private readonly _requests: InlineEditRequestLogContext[] = [];
-	private readonly _liveRequestIds = new Set<number>();
 
 	constructor(
 		@IRequestLogger private readonly _requestLogger: IRequestLogger,
@@ -23,7 +22,6 @@ export class InlineEditLogger extends Disposable {
 	 * refreshes automatically as the logContext state changes.
 	 */
 	addLive(request: InlineEditRequestLogContext): void {
-		this._liveRequestIds.add(request.requestId);
 		this._requestLogger.addEntry({
 			type: LoggedRequestKind.MarkdownContentRequest,
 			debugName: request.getDebugName(),
@@ -36,32 +34,10 @@ export class InlineEditLogger extends Disposable {
 		this._pushRequest(request);
 	}
 
-	add(request: InlineEditRequestLogContext): void {
-		if (this._liveRequestIds.has(request.requestId)) {
-			return; // already added as a live entry
-		}
-
-		if (!request.includeInLogTree) {
-			return;
-		}
-
-		this._requestLogger.addEntry({
-			type: LoggedRequestKind.MarkdownContentRequest,
-			debugName: request.getDebugName(),
-			icon: request.getIcon(),
-			startTimeMs: request.time,
-			markdownContent: request.toLogDocument(),
-		});
-		this._pushRequest(request);
-	}
-
 	private _pushRequest(request: InlineEditRequestLogContext): void {
 		this._requests.push(request);
 		if (this._requests.length > 100) {
-			const evicted = this._requests.shift();
-			if (evicted) {
-				this._liveRequestIds.delete(evicted.requestId);
-			}
+			this._requests.shift();
 		}
 	}
 

--- a/extensions/copilot/src/extension/log/vscode-node/requestLogTree.ts
+++ b/extensions/copilot/src/extension/log/vscode-node/requestLogTree.ts
@@ -698,6 +698,13 @@ class ChatPromptItem extends vscode.TreeItem {
 	}
 
 	/**
+	 * The main entry associated with this parent node. Stored so that
+	 * `withFilteredChildren` can re-resolve the icon freshly from the entry
+	 * rather than copying a potentially stale `iconPath` snapshot.
+	 */
+	private _mainEntryRef: ILoggedRequestInfo | undefined;
+
+	/**
 	 * Associate a main entry directly with this parent item.
 	 * The main entry's icon and click command are shown on the parent node.
 	 * The entry is NOT added as a child — it stays in the request logger
@@ -707,10 +714,9 @@ class ChatPromptItem extends vscode.TreeItem {
 		if (info.entry.type !== LoggedRequestKind.MarkdownContentRequest) {
 			return;
 		}
+		this._mainEntryRef = info;
 		const resolvedIcon = resolveMarkdownIcon(info.entry);
-		if (resolvedIcon !== undefined) {
-			this.iconPath = new vscode.ThemeIcon(resolvedIcon.id);
-		}
+		this.iconPath = resolvedIcon !== undefined ? new vscode.ThemeIcon(resolvedIcon.id) : undefined;
 		this.command = {
 			command: 'vscode.open',
 			title: '',
@@ -722,8 +728,12 @@ class ChatPromptItem extends vscode.TreeItem {
 		const item = new ChatPromptItem(this.token);
 		item.children = this.children.filter(filter);
 		item.id = this.id;
-		item.iconPath = this.iconPath;
-		item.command = this.command;
+		if (this._mainEntryRef) {
+			item.setMainEntry(this._mainEntryRef);
+		} else {
+			item.iconPath = this.iconPath;
+			item.command = this.command;
+		}
 		item.collapsibleState = item.children.length > 0
 			? vscode.TreeItemCollapsibleState.Expanded
 			: vscode.TreeItemCollapsibleState.None;

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -25,6 +25,19 @@ export interface MarkdownLoggable {
 	toMarkdown(): string;
 }
 
+/**
+ * The outcome of a log context request. Determines the icon shown in the log tree.
+ * - `pending`: no outcome yet (shows spinner or check depending on completion)
+ * - `succeeded`: model returned suggestions
+ * - `noSuggestions`: model returned no suggestions
+ * - `cached`: result is from NES cache
+ * - `cachedFromGhostText`: result is from ghost text cache
+ * - `skipped`: request was skipped or fetch-cancelled
+ * - `cancelled`: request was cancelled via CancellationToken
+ * - `errored`: an error occurred
+ */
+type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored';
+
 export class InlineEditRequestLogContext {
 
 	private static _id = 0;
@@ -44,6 +57,9 @@ export class InlineEditRequestLogContext {
 
 	/** Mark this request as completed (no longer in progress). */
 	markCompleted(): void {
+		if (this._isCompleted) {
+			console.warn(`[InlineEditRequestLogContext] markCompleted called twice (request #${this.requestId})`);
+		}
 		this._isCompleted = true;
 		this.fireDidChange();
 	}
@@ -269,47 +285,29 @@ export class InlineEditRequestLogContext {
 	private _logContextOfCachedEdit: InlineEditRequestLogContext | undefined = undefined;
 
 	setIsCachedResult(logContextOfCachedEdit: InlineEditRequestLogContext): void {
-
 		this._logContextOfCachedEdit = logContextOfCachedEdit;
 
-		{ // inherit stateless provider state from cached log context
-			this.recordingBookmark = logContextOfCachedEdit.recordingBookmark;
-
-			if (logContextOfCachedEdit._nextEditRequest) {
-				this._nextEditRequest = logContextOfCachedEdit._nextEditRequest;
-
-			}
-			if (logContextOfCachedEdit._resultEdit) {
-				this.setResult(logContextOfCachedEdit._resultEdit);
-			}
-			if (logContextOfCachedEdit._diagnosticsResultEdit) {
-				this.setDiagnosticsResult(logContextOfCachedEdit._diagnosticsResultEdit);
-			}
-			if (logContextOfCachedEdit._endpointInfo) {
-				this.setEndpointInfo(logContextOfCachedEdit._endpointInfo.url, logContextOfCachedEdit._endpointInfo.modelName);
-			}
-			if (logContextOfCachedEdit.headerRequestId) {
-				this.setHeaderRequestId(logContextOfCachedEdit.headerRequestId);
-			}
-			if (logContextOfCachedEdit.prompt) {
-				this.setPrompt(logContextOfCachedEdit.prompt);
-			}
-			if (logContextOfCachedEdit.response) {
-				this.setResponse(logContextOfCachedEdit.response);
-			}
-			if (logContextOfCachedEdit.responseResults) {
-				this.setResponseResults(logContextOfCachedEdit.responseResults);
-			}
-			if (logContextOfCachedEdit.fullResponsePromise) {
-				this.setFullResponse(logContextOfCachedEdit.fullResponsePromise);
-			}
-			if (logContextOfCachedEdit.error) {
-				this.setError(logContextOfCachedEdit.error);
-			}
+		// Direct field copy — avoids triggering outcome transitions from the
+		// public setters (e.g. setResponseResults -> succeeded, setError -> errored).
+		// The final outcome is always 'cached'.
+		this.recordingBookmark = logContextOfCachedEdit.recordingBookmark;
+		this._nextEditRequest = logContextOfCachedEdit._nextEditRequest ?? this._nextEditRequest;
+		this._resultEdit = logContextOfCachedEdit._resultEdit ?? this._resultEdit;
+		this._diagnosticsResultEdit = logContextOfCachedEdit._diagnosticsResultEdit ?? this._diagnosticsResultEdit;
+		this._endpointInfo = logContextOfCachedEdit._endpointInfo ?? this._endpointInfo;
+		this._headerRequestId = logContextOfCachedEdit._headerRequestId ?? this._headerRequestId;
+		if (logContextOfCachedEdit._prompt) {
+			this._prompt = logContextOfCachedEdit._prompt;
 		}
+		this.response = logContextOfCachedEdit.response ?? this.response;
+		this._responseResults = logContextOfCachedEdit._responseResults ?? this._responseResults;
+		if (logContextOfCachedEdit.fullResponsePromise) {
+			this.setFullResponse(logContextOfCachedEdit.fullResponsePromise);
+		}
+		this._error = logContextOfCachedEdit._error ?? this._error;
 
 		this._isVisible = true;
-		this._icon = Icon.database;
+		this._outcome = 'cached';
 		this.fireDidChange();
 	}
 
@@ -355,10 +353,31 @@ export class InlineEditRequestLogContext {
 		this.fireDidChange();
 	}
 
-	private _icon: Icon.t | undefined;
+	private _outcome: LogContextOutcome = 'pending';
+
+	/**
+	 * Sets the outcome, warning if already set (i.e., not `pending`).
+	 * Use direct `this._outcome = ...` assignment to bypass the guard
+	 * (e.g., in `setIsCachedResult` which intentionally overrides any inherited outcome).
+	 */
+	private _setOutcome(outcome: LogContextOutcome): void {
+		if (this._outcome !== 'pending') {
+			console.warn(`[InlineEditRequestLogContext] outcome transition from '${this._outcome}' to '${outcome}' (request #${this.requestId})`);
+		}
+		this._outcome = outcome;
+	}
 
 	private _resolveIcon(): Icon.t {
-		return this._icon ?? (this._isCompleted ? Icon.check : Icon.loading);
+		switch (this._outcome) {
+			case 'pending': return this._isCompleted ? Icon.check : Icon.loading;
+			case 'succeeded': return Icon.lightbulbFull;
+			case 'noSuggestions': return Icon.circleSlash;
+			case 'cached':
+			case 'cachedFromGhostText': return Icon.database;
+			case 'skipped': return Icon.skipped;
+			case 'cancelled': return Icon.loading;
+			case 'errored': return Icon.error;
+		}
 	}
 
 	getIcon(): ThemeIcon {
@@ -366,34 +385,40 @@ export class InlineEditRequestLogContext {
 	}
 
 	public setIsSkipped() {
+		this._setOutcome('skipped');
 		this._isVisible = false;
-		this._icon = Icon.skipped;
 		this.fireDidChange();
 	}
 
 	public markAsFromCache() {
+		this._setOutcome('cachedFromGhostText');
 		this._isVisible = true;
-		this._icon = Icon.database;
 		this.fireDidChange();
 	}
 
 	public markAsNoSuggestions() {
+		this._setOutcome('noSuggestions');
 		this._isVisible = true;
-		this._icon = Icon.circleSlash;
 		this.fireDidChange();
 	}
 
-	private error: unknown | undefined = undefined;
+	private _error: unknown | undefined = undefined;
+
+	get error(): unknown | undefined {
+		return this._error;
+	}
+
 	setError(e: unknown): void {
 		this._isVisible = true;
-		this.error = e;
+		this._error = e;
 
-		if (this.error instanceof FetchCancellationError) {
-			this._icon = Icon.skipped;
-		} else if (isCancellationError(this.error)) {
+		if (this._error instanceof FetchCancellationError) {
+			this._setOutcome('skipped');
+		} else if (isCancellationError(this._error)) {
+			this._setOutcome('cancelled');
 			this._isVisible = false;
 		} else {
-			this._icon = Icon.error;
+			this._setOutcome('errored');
 		}
 		this.fireDidChange();
 	}
@@ -455,7 +480,9 @@ export class InlineEditRequestLogContext {
 	setResponseResults(v: readonly unknown[]): void {
 		this._isVisible = true;
 		this._responseResults = v;
-		this._icon ??= Icon.lightbulbFull;
+		if (this._outcome === 'pending') {
+			this._outcome = 'succeeded';
+		}
 		this.fireDidChange();
 	}
 

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -33,7 +33,7 @@ export interface MarkdownLoggable {
  * - `cached`: result is from NES cache
  * - `cachedFromGhostText`: result is from ghost text cache
  * - `skipped`: request was skipped or fetch-cancelled
- * - `cancelled`: request was cancelled via CancellationToken
+ * - `cancelled`: request was cancelled via CancellationToken (shown as skipped)
  * - `errored`: an error occurred
  */
 type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored';
@@ -374,8 +374,8 @@ export class InlineEditRequestLogContext {
 			case 'noSuggestions': return Icon.circleSlash;
 			case 'cached':
 			case 'cachedFromGhostText': return Icon.database;
-			case 'skipped': return Icon.skipped;
-			case 'cancelled': return Icon.loading;
+			case 'skipped':
+			case 'cancelled': return Icon.skipped;
 			case 'errored': return Icon.error;
 		}
 	}


### PR DESCRIPTION
## Summary

Refactors `InlineEditRequestLogContext` state management to eliminate implicit icon state, unify logging paths, fix stale icon caching, and enforce lifecycle.

Fixes #308719, fixes #308720, fixes #308721, fixes #308722

## Changes

### 1. Replace implicit `_icon` with explicit outcome state machine (#308719)

Replace the implicit `_icon: Icon.t | undefined` field with an explicit `_outcome: LogContextOutcome` discriminated union (8 states: `pending`, `succeeded`, `noSuggestions`, `cached`, `cachedFromGhostText`, `skipped`, `cancelled`, `errored`).

- `_resolveIcon()` is now a switch on `_outcome` — every state maps to exactly one icon
- `_isCompleted` stays orthogonal (lifecycle flag controlling spinner text + `Icon.check` fallback)
- `_setOutcome()` warns on invalid re-transitions
- `setIsCachedResult()` refactored to direct field copy — avoids triggering cascading outcome transitions
- No caller changes required — public method signatures unchanged

### 2. Unify live and static log entry paths (#308720, #308722)

Remove the static `add()` path from `InlineEditLogger` — all entries now use the live pattern with callbacks.

- Ghost text provider now uses `addLive()` + `markCompleted()` in `finally` block, ensuring lifecycle is always closed
- Remove redundant `add()` call in NES `inlineCompletionProvider` (was already a no-op)
- Eliminates the static snapshot path that was the source of frozen spinner bugs

### 3. Fix stale icon caching in ChatPromptItem (#308721)

Store the main entry reference in `ChatPromptItem` and always resolve the icon from it.

- `setMainEntry()` always sets `iconPath` (even to `undefined`), clearing any stale value
- `withFilteredChildren()` re-resolves from the entry ref via `setMainEntry()` instead of copying a potentially stale `iconPath` snapshot
- Makes stale icons structurally impossible

## Testing

- All 7731 copilot unit tests pass (vitest)
- All hygiene checks pass
- TypeScript compilation clean (only pre-existing unrelated error in `copilotcliSessionService.ts`)
