### PR TITLE
nes: xtab: cleanup: split response format parsing implementation out of XtabProvider

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
+++ b/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
@@ -1,0 +1,240 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/documentId';
+import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { NoNextEditReason, StreamedEdit } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { ILogger } from '../../../platform/log/common/logService';
+import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
+import { LineRange } from '../../../util/vs/editor/common/core/ranges/lineRange';
+import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
+import { StringText } from '../../../util/vs/editor/common/core/text/abstractText';
+import { ResponseTags } from '../common/tags';
+import { EditIntentParseMode, parseEditIntentFromStream } from './editIntent';
+import { linesWithBackticksRemoved } from './xtabUtils';
+
+// ============================================================================
+// Result type
+// ============================================================================
+
+export namespace ResponseParseResult {
+
+	export interface EditIntentMetadata {
+		readonly intent: xtabPromptOptions.EditIntent;
+		readonly parseError?: string;
+	}
+
+	/**
+	 * The response contains edit-window lines to be fed into *ResponseProcessor.diff*.
+	 */
+	export class EditWindowLines {
+		constructor(
+			readonly lines: AsyncIterable<string>,
+			readonly editIntentMetadata?: EditIntentMetadata,
+		) { }
+	}
+
+	/**
+	 * The handler has finished — no more processing needed. Carries a {@link NoNextEditReason}.
+	 */
+	export class Done {
+		constructor(readonly reason: NoNextEditReason) { }
+	}
+
+	/**
+	 * The handler yields edits directly (e.g. INSERT or CustomDiffPatch).
+	 * The coordinator should `yield*` the stream.
+	 */
+	export class DirectEdits {
+		constructor(readonly stream: AsyncGenerator<StreamedEdit, NoNextEditReason, void>) { }
+	}
+
+	export type t = EditWindowLines | Done | DirectEdits;
+}
+
+// ============================================================================
+// Handler: EditWindowOnly
+// ============================================================================
+
+export function handleEditWindowOnly(linesStream: AsyncIterable<string>): ResponseParseResult.EditWindowLines {
+	return new ResponseParseResult.EditWindowLines(linesStream);
+}
+
+// ============================================================================
+// Handler: CodeBlock
+// ============================================================================
+
+export function handleCodeBlock(linesStream: AsyncIterable<string>): ResponseParseResult.EditWindowLines {
+	return new ResponseParseResult.EditWindowLines(linesWithBackticksRemoved(linesStream));
+}
+
+// ============================================================================
+// Handler: EditWindowWithEditIntent / EditWindowWithEditIntentShort
+// ============================================================================
+
+export async function handleEditWindowWithEditIntent(
+	linesStream: AsyncIterable<string>,
+	tracer: ILogger,
+	parseMode: EditIntentParseMode,
+	getFetchFailure: () => NoNextEditReason | undefined,
+): Promise<ResponseParseResult.EditWindowLines | ResponseParseResult.Done> {
+	const { editIntent, remainingLinesStream, parseError } = await parseEditIntentFromStream(linesStream, tracer, parseMode);
+
+	const fetchFailure = getFetchFailure();
+	if (fetchFailure) {
+		return new ResponseParseResult.Done(fetchFailure);
+	}
+
+	return new ResponseParseResult.EditWindowLines(
+		remainingLinesStream,
+		{ intent: editIntent, parseError },
+	);
+}
+
+// ============================================================================
+// Handler: UnifiedWithXml
+// ============================================================================
+
+export interface UnifiedXmlInsertContext {
+	readonly editWindowLines: string[];
+	readonly editWindowLineRange: OffsetRange;
+	readonly cursorOriginalLinesOffset: number;
+	readonly cursorColumnZeroBased: number;
+	readonly editWindow: OffsetRange;
+	readonly originalEditWindow: OffsetRange | undefined;
+	readonly targetDocument: DocumentId;
+	readonly isFromCursorJump: boolean;
+}
+
+export async function handleUnifiedWithXml(
+	linesStream: AsyncIterable<string>,
+	ctx: UnifiedXmlInsertContext,
+	documentBeforeEdits: StringText,
+	tracer: ILogger,
+	getFetchFailure: () => NoNextEditReason | undefined,
+): Promise<ResponseParseResult.t> {
+	const linesIter = linesStream[Symbol.asyncIterator]();
+	const firstLine = await linesIter.next();
+
+	{
+		const fetchFailure = getFetchFailure();
+		if (fetchFailure) {
+			return new ResponseParseResult.Done(fetchFailure);
+		}
+	}
+
+	if (firstLine.done) {
+		return new ResponseParseResult.Done(
+			new NoNextEditReason.NoSuggestions(documentBeforeEdits, ctx.editWindow),
+		);
+	}
+
+	const trimmedFirstLine = firstLine.value.trim();
+
+	if (trimmedFirstLine === ResponseTags.NO_CHANGE.start) {
+		return new ResponseParseResult.Done(
+			new NoNextEditReason.NoSuggestions(documentBeforeEdits, ctx.editWindow),
+		);
+	}
+
+	if (trimmedFirstLine === ResponseTags.INSERT.start) {
+		return new ResponseParseResult.DirectEdits(
+			generateInsertEdits(linesIter, ctx, documentBeforeEdits, getFetchFailure),
+		);
+	}
+
+	if (trimmedFirstLine === ResponseTags.EDIT.start) {
+		const editLines = generateEditLines(linesIter, getFetchFailure);
+		return new ResponseParseResult.EditWindowLines(editLines);
+	}
+
+	return new ResponseParseResult.Done(
+		new NoNextEditReason.Unexpected(new Error(`unexpected tag ${trimmedFirstLine}`)),
+	);
+}
+
+// ============================================================================
+// Internal generators for UnifiedWithXml sub-tags
+// ============================================================================
+
+async function* generateInsertEdits(
+	linesIter: AsyncIterator<string>,
+	ctx: UnifiedXmlInsertContext,
+	documentBeforeEdits: StringText,
+	getFetchFailure: () => NoNextEditReason | undefined,
+): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
+	const { editWindowLines, editWindowLineRange, cursorOriginalLinesOffset, cursorColumnZeroBased, editWindow, originalEditWindow, targetDocument, isFromCursorJump } = ctx;
+
+	const lineWithCursorContinued = await linesIter.next();
+	if (lineWithCursorContinued.done || lineWithCursorContinued.value.includes(ResponseTags.INSERT.end)) {
+		return new NoNextEditReason.NoSuggestions(documentBeforeEdits, editWindow);
+	}
+
+	{
+		const fetchFailure = getFetchFailure();
+		if (fetchFailure) {
+			return fetchFailure;
+		}
+	}
+
+	const cursorLineContent = editWindowLines[cursorOriginalLinesOffset];
+	const edit = new LineReplacement(
+		new LineRange(
+			editWindowLineRange.start + cursorOriginalLinesOffset + 1 /* 0-based to 1-based */,
+			editWindowLineRange.start + cursorOriginalLinesOffset + 2,
+		),
+		[cursorLineContent.slice(0, cursorColumnZeroBased) + lineWithCursorContinued.value + cursorLineContent.slice(cursorColumnZeroBased)],
+	);
+	yield { edit, isFromCursorJump, window: editWindow, originalWindow: originalEditWindow, targetDocument };
+
+	const lines: string[] = [];
+	let v = await linesIter.next();
+	while (!v.done) {
+		if (v.value.includes(ResponseTags.INSERT.end)) {
+			break;
+		} else {
+			lines.push(v.value);
+		}
+		v = await linesIter.next();
+	}
+
+	{
+		const fetchFailure = getFetchFailure();
+		if (fetchFailure) {
+			return fetchFailure;
+		}
+	}
+
+	const line = editWindowLineRange.start + cursorOriginalLinesOffset + 2;
+	yield {
+		edit: new LineReplacement(
+			new LineRange(line, line),
+			lines,
+		),
+		isFromCursorJump,
+		window: editWindow,
+		originalWindow: originalEditWindow,
+		targetDocument,
+	};
+
+	return new NoNextEditReason.NoSuggestions(documentBeforeEdits, editWindow);
+}
+
+async function* generateEditLines(
+	linesIter: AsyncIterator<string>,
+	getFetchFailure: () => NoNextEditReason | undefined,
+): AsyncIterable<string> {
+	let v = await linesIter.next();
+	while (!v.done) {
+		if (v.value.includes(ResponseTags.EDIT.end)) {
+			return;
+		}
+		if (getFetchFailure()) {
+			return;
+		}
+		yield v.value;
+		v = await linesIter.next();
+	}
+}

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -815,6 +815,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				logContext.setResponse(responseSoFar);
 			});
 
+		const getFetchFailure = (): NoNextEditReason | undefined =>
+			chatResponseFailure ? mapChatFetcherErrorToNoNextEditReason(chatResponseFailure) : undefined;
+
 		const llmLinesStream = AsyncIterUtilsExt.splitLines(AsyncIterUtils.map(fetchStreamSource.stream, (chunk) => chunk.delta.text));
 
 		// logging of times
@@ -847,6 +850,13 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			// Parse the edit_intent from the response
 			const { editIntent, remainingLinesStream, parseError } = await parseEditIntentFromStream(linesStream, tracer, parseMode);
 
+			{
+				const fetchFailure = getFetchFailure();
+				if (fetchFailure) {
+					return fetchFailure;
+				}
+			}
+
 			// Log the edit intent for telemetry
 			telemetry.setEditIntent(editIntent);
 
@@ -875,14 +885,17 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				activeDoc.workspaceRoot,
 				pseudoEditWindow,
 				tracer,
-				() => chatResponseFailure ? mapChatFetcherErrorToNoNextEditReason(chatResponseFailure) : undefined,
+				getFetchFailure,
 			);
 		} else if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.UnifiedWithXml) {
 			const linesIter = linesStream[Symbol.asyncIterator]();
 			const firstLine = await linesIter.next();
 
-			if (chatResponseFailure !== undefined) { // handle fetch failure
-				return new NoNextEditReason.Unexpected(ErrorUtils.fromUnknown(chatResponseFailure));
+			{
+				const fetchFailure = getFetchFailure();
+				if (fetchFailure) {
+					return fetchFailure;
+				}
 			}
 
 			if (firstLine.done) { // no lines in response -- unexpected case but take as no suggestions
@@ -900,6 +913,14 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				if (lineWithCursorContinued.done || lineWithCursorContinued.value.includes(ResponseTags.INSERT.end)) {
 					return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
 				}
+
+				{
+					const fetchFailure = getFetchFailure();
+					if (fetchFailure) {
+						return fetchFailure;
+					}
+				}
+
 				const cursorColumnOffsetZeroBased = promptPieces.currentDocument.cursorPosition.column - 1;
 				const edit = new LineReplacement(
 					new LineRange(editWindowLineRange.start + cursorOriginalLinesOffset + 1 /* 0-based to 1-based */, editWindowLineRange.start + cursorOriginalLinesOffset + 2),
@@ -916,6 +937,13 @@ export class XtabProvider implements IStatelessNextEditProvider {
 						lines.push(v.value);
 					}
 					v = await linesIter.next();
+				}
+
+				{
+					const fetchFailure = getFetchFailure();
+					if (fetchFailure) {
+						return fetchFailure;
+					}
 				}
 
 				const line = editWindowLineRange.start + cursorOriginalLinesOffset + 2;
@@ -938,6 +966,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					let v = await linesIter.next();
 					while (!v.done) {
 						if (v.value.includes(ResponseTags.EDIT.end)) {
+							return;
+						}
+						if (getFetchFailure()) {
 							return;
 						}
 						yield v.value;
@@ -1010,6 +1041,13 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					break;
 				}
 
+				{
+					const fetchFailure = getFetchFailure();
+					if (fetchFailure) {
+						return fetchFailure;
+					}
+				}
+
 				tracer.trace(`ResponseProcessor streamed edit #${i} with latency ${fetchRequestStopWatch.elapsed()} ms`);
 
 				const singleLineEdits: LineReplacement[] = [];
@@ -1042,10 +1080,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					}
 				}
 
-				if (chatResponseFailure) { // do not emit edits if chat response failed
-					break;
-				}
-
 				logContext.setResponse(responseSoFar);
 
 				for (const singleLineEdit of singleLineEdits) {
@@ -1072,8 +1106,11 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				return new NoNextEditReason.GotCancelled('cursorLineDiverged');
 			}
 
-			if (chatResponseFailure) {
-				return mapChatFetcherErrorToNoNextEditReason(chatResponseFailure);
+			{
+				const fetchFailure = getFetchFailure();
+				if (fetchFailure) {
+					return fetchFailure;
+				}
 			}
 
 			return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -62,15 +62,16 @@ import { ClippedDocument, constructTaggedFile, getUserPrompt, N_LINES_ABOVE, N_L
 import { countTokensForLines, toUniquePath } from '../common/promptCraftingUtils';
 import { ISimilarFilesContextService } from '../common/similarFilesContextService';
 import { nes41Miniv3SystemPrompt, simplifiedPrompt, systemPromptTemplate, unifiedModelSystemPrompt, xtab275SystemPrompt } from '../common/systemMessages';
-import { PromptTags, ResponseTags } from '../common/tags';
+import { PromptTags } from '../common/tags';
 import { TerminalMonitor } from '../common/terminalOutput';
 import { CurrentDocument } from '../common/xtabCurrentDocument';
 import { getCurrentCursorLine, isModelCursorLineCompatible } from './cursorLineDivergence';
-import { EditIntentParseMode, parseEditIntentFromStream } from './editIntent';
+import { EditIntentParseMode } from './editIntent';
+import { handleCodeBlock, handleEditWindowOnly, handleEditWindowWithEditIntent, handleUnifiedWithXml, ResponseParseResult } from './responseFormatHandlers';
 import { XtabCustomDiffPatchResponseHandler } from './xtabCustomDiffPatchResponseHandler';
 import { XtabEndpoint } from './xtabEndpoint';
 import { CursorJumpPrediction, XtabNextCursorPredictor } from './xtabNextCursorPredictor';
-import { charCount, constructMessages, findMergeConflictMarkersRange, linesWithBackticksRemoved } from './xtabUtils';
+import { charCount, constructMessages, findMergeConflictMarkersRange } from './xtabUtils';
 
 /**
  * Returns true if the user has made document edits since the request was created.
@@ -836,153 +837,91 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		const isFromCursorJump = retryState instanceof RetryState.Retrying && retryState.reason === 'cursorJump';
 
-		let cleanedLinesStream: AsyncIterable<string>;
+		// Dispatch to the appropriate response format handler
+		let parseResult: ResponseParseResult.t;
 
-		if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowOnly) {
-			cleanedLinesStream = linesStream;
-		} else if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntent ||
-			responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort) {
-			// Determine parse mode based on response format
-			const parseMode = responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort
-				? EditIntentParseMode.ShortName
-				: EditIntentParseMode.Tags;
-
-			// Parse the edit_intent from the response
-			const { editIntent, remainingLinesStream, parseError } = await parseEditIntentFromStream(linesStream, tracer, parseMode);
-
-			{
-				const fetchFailure = getFetchFailure();
-				if (fetchFailure) {
-					return fetchFailure;
-				}
+		switch (responseOpts.responseFormat) {
+			case xtabPromptOptions.ResponseFormat.EditWindowOnly: {
+				parseResult = handleEditWindowOnly(linesStream);
+				break;
 			}
+			case xtabPromptOptions.ResponseFormat.CodeBlock: {
+				parseResult = handleCodeBlock(linesStream);
+				break;
+			}
+			case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntent:
+			case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort: {
+				const parseMode = responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort
+					? EditIntentParseMode.ShortName
+					: EditIntentParseMode.Tags;
+				parseResult = await handleEditWindowWithEditIntent(linesStream, tracer, parseMode, getFetchFailure);
+				break;
+			}
+			case xtabPromptOptions.ResponseFormat.CustomDiffPatch: {
+				const activeDoc = request.getActiveDocument();
+				const currentDocument = promptPieces.currentDocument;
+				const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
+				const lastLineLength = lastLine.length;
+				const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
+				parseResult = new ResponseParseResult.DirectEdits(
+					XtabCustomDiffPatchResponseHandler.handleResponse(
+						linesStream,
+						currentDocument,
+						activeDoc.id,
+						activeDoc.workspaceRoot,
+						pseudoEditWindow,
+						tracer,
+						getFetchFailure,
+					),
+				);
+				break;
+			}
+			case xtabPromptOptions.ResponseFormat.UnifiedWithXml: {
+				parseResult = await handleUnifiedWithXml(
+					linesStream,
+					{
+						editWindowLines,
+						editWindowLineRange,
+						cursorOriginalLinesOffset,
+						cursorColumnZeroBased: promptPieces.currentDocument.cursorPosition.column - 1,
+						editWindow,
+						originalEditWindow,
+						targetDocument,
+						isFromCursorJump,
+					},
+					request.documentBeforeEdits,
+					tracer,
+					getFetchFailure,
+				);
+				break;
+			}
+			default:
+				assertNever(responseOpts.responseFormat);
+		}
 
-			// Log the edit intent for telemetry
-			telemetry.setEditIntent(editIntent);
+		// Handle result uniformly
+		if (parseResult instanceof ResponseParseResult.Done) {
+			return parseResult.reason;
+		}
 
-			// Log parse errors for telemetry - this helps detect malformed model output during flights
+		if (parseResult instanceof ResponseParseResult.DirectEdits) {
+			return yield* parseResult.stream;
+		}
+
+		// parseResult is EditWindowLines — log edit-intent telemetry and apply aggressiveness filter
+		if (parseResult.editIntentMetadata) {
+			const { intent, parseError } = parseResult.editIntentMetadata;
+			telemetry.setEditIntent(intent);
 			if (parseError) {
 				telemetry.setEditIntentParseError(parseError);
 			}
-
-			// Check if we should show this edit based on intent and aggressiveness
-			if (!xtabPromptOptions.EditIntent.shouldShowEdit(editIntent, promptPieces.aggressivenessLevel)) {
-				tracer.trace(`Filtered out edit due to edit intent "${editIntent}" with aggressiveness "${promptPieces.aggressivenessLevel}"`);
-				return new NoNextEditReason.FilteredOut(`editIntent:${editIntent} aggressivenessLevel:${promptPieces.aggressivenessLevel}`);
+			if (!xtabPromptOptions.EditIntent.shouldShowEdit(intent, promptPieces.aggressivenessLevel)) {
+				tracer.trace(`Filtered out edit due to edit intent "${intent}" with aggressiveness "${promptPieces.aggressivenessLevel}"`);
+				return new NoNextEditReason.FilteredOut(`editIntent:${intent} aggressivenessLevel:${promptPieces.aggressivenessLevel}`);
 			}
-
-			cleanedLinesStream = remainingLinesStream;
-		} else if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.CustomDiffPatch) {
-			const activeDoc = request.getActiveDocument();
-			const currentDocument = promptPieces.currentDocument;
-			const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
-			const lastLineLength = lastLine.length;
-			const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
-			return yield* XtabCustomDiffPatchResponseHandler.handleResponse(
-				linesStream,
-				currentDocument,
-				activeDoc.id,
-				activeDoc.workspaceRoot,
-				pseudoEditWindow,
-				tracer,
-				getFetchFailure,
-			);
-		} else if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.UnifiedWithXml) {
-			const linesIter = linesStream[Symbol.asyncIterator]();
-			const firstLine = await linesIter.next();
-
-			{
-				const fetchFailure = getFetchFailure();
-				if (fetchFailure) {
-					return fetchFailure;
-				}
-			}
-
-			if (firstLine.done) { // no lines in response -- unexpected case but take as no suggestions
-				return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
-			}
-
-			const trimmedLines = firstLine.value.trim();
-
-			if (trimmedLines === ResponseTags.NO_CHANGE.start) {
-				return yield* this.doGetNextEditsWithCursorJump(request, editStreamCtx, delaySession, tracing, cancellationToken, retryState);
-			}
-
-			if (trimmedLines === ResponseTags.INSERT.start) {
-				const lineWithCursorContinued = await linesIter.next();
-				if (lineWithCursorContinued.done || lineWithCursorContinued.value.includes(ResponseTags.INSERT.end)) {
-					return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
-				}
-
-				{
-					const fetchFailure = getFetchFailure();
-					if (fetchFailure) {
-						return fetchFailure;
-					}
-				}
-
-				const cursorColumnOffsetZeroBased = promptPieces.currentDocument.cursorPosition.column - 1;
-				const edit = new LineReplacement(
-					new LineRange(editWindowLineRange.start + cursorOriginalLinesOffset + 1 /* 0-based to 1-based */, editWindowLineRange.start + cursorOriginalLinesOffset + 2),
-					[editWindowLines[cursorOriginalLinesOffset].slice(0, cursorColumnOffsetZeroBased) + lineWithCursorContinued.value + editWindowLines[cursorOriginalLinesOffset].slice(cursorColumnOffsetZeroBased)]
-				);
-				yield { edit, isFromCursorJump, window: editWindow, originalWindow: originalEditWindow, targetDocument };
-
-				const lines: string[] = [];
-				let v = await linesIter.next();
-				while (!v.done) {
-					if (v.value.includes(ResponseTags.INSERT.end)) {
-						break;
-					} else {
-						lines.push(v.value);
-					}
-					v = await linesIter.next();
-				}
-
-				{
-					const fetchFailure = getFetchFailure();
-					if (fetchFailure) {
-						return fetchFailure;
-					}
-				}
-
-				const line = editWindowLineRange.start + cursorOriginalLinesOffset + 2;
-				yield {
-					edit: new LineReplacement(
-						new LineRange(line, line),
-						lines
-					),
-					isFromCursorJump,
-					window: editWindow,
-					originalWindow: originalEditWindow,
-					targetDocument,
-				};
-
-				return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
-			}
-
-			if (trimmedLines === ResponseTags.EDIT.start) {
-				cleanedLinesStream = (async function* () {
-					let v = await linesIter.next();
-					while (!v.done) {
-						if (v.value.includes(ResponseTags.EDIT.end)) {
-							return;
-						}
-						if (getFetchFailure()) {
-							return;
-						}
-						yield v.value;
-						v = await linesIter.next();
-					}
-				})();
-			} else {
-				return new NoNextEditReason.Unexpected(new Error(`unexpected tag ${trimmedLines}`));
-			}
-		} else if (responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.CodeBlock) {
-			cleanedLinesStream = linesWithBackticksRemoved(linesStream);
-		} else {
-			assertNever(responseOpts.responseFormat);
 		}
+
+		const cleanedLinesStream = parseResult.lines;
 
 		const diffOptions: ResponseProcessor.DiffParams = {
 			emitFastCursorLineChange: ResponseProcessor.mapEmitFastCursorLineChange(this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderEmitFastCursorLineChange, this.expService)),

--- a/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
@@ -1,0 +1,384 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
+import { EditIntent } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
+import { NoNextEditReason, StreamedEdit } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
+import { ILogger } from '../../../../platform/log/common/logService';
+import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
+import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
+import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
+import { EditIntentParseMode } from '../../node/editIntent';
+import {
+	handleCodeBlock,
+	handleEditWindowOnly,
+	handleEditWindowWithEditIntent,
+	handleUnifiedWithXml,
+	ResponseParseResult,
+	UnifiedXmlInsertContext,
+} from '../../node/responseFormatHandlers';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockLogger(): ILogger {
+	return {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		critical: vi.fn(),
+		flush: vi.fn(),
+		createSubLogger: () => createMockLogger(),
+		withContext: () => createMockLogger(),
+	} as unknown as ILogger;
+}
+
+function noFailure(): NoNextEditReason | undefined {
+	return undefined;
+}
+
+function makeInsertContext(overrides?: Partial<UnifiedXmlInsertContext>): UnifiedXmlInsertContext {
+	return {
+		editWindowLines: ['line0', 'cursor_line', 'line2'],
+		editWindowLineRange: new OffsetRange(10, 13),
+		cursorOriginalLinesOffset: 1,
+		cursorColumnZeroBased: 6,
+		editWindow: new OffsetRange(0, 100),
+		originalEditWindow: undefined,
+		targetDocument: DocumentId.create('file:///test.ts'),
+		isFromCursorJump: false,
+		...overrides,
+	};
+}
+
+function makeDocBeforeEdits(): StringText {
+	return new StringText('line0\ncursor_line\nline2');
+}
+
+async function collectLines(iter: AsyncIterable<string>): Promise<string[]> {
+	return AsyncIterUtils.toArray(iter);
+}
+
+async function consumeDirectEdits(
+	stream: AsyncGenerator<StreamedEdit, NoNextEditReason, void>,
+): Promise<{ edits: StreamedEdit[]; returnValue: NoNextEditReason }> {
+	const edits: StreamedEdit[] = [];
+	for (; ;) {
+		const result = await stream.next();
+		if (result.done) {
+			return { edits, returnValue: result.value };
+		}
+		edits.push(result.value);
+	}
+}
+
+// ============================================================================
+// handleEditWindowOnly
+// ============================================================================
+
+describe('handleEditWindowOnly', () => {
+	it('passes lines through unchanged', async () => {
+		const input = ['line1', 'line2', 'line3'];
+		const result = handleEditWindowOnly(AsyncIterUtils.fromArray(input));
+
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		expect(await collectLines(result.lines)).toEqual(input);
+		expect(result.editIntentMetadata).toBeUndefined();
+	});
+
+	it('handles empty stream', async () => {
+		const result = handleEditWindowOnly(AsyncIterUtils.fromArray([]));
+		expect(await collectLines(result.lines)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// handleCodeBlock
+// ============================================================================
+
+describe('handleCodeBlock', () => {
+	it('strips opening and closing backtick fences', async () => {
+		const input = ['```typescript', 'const x = 1;', 'const y = 2;', '```'];
+		const result = handleCodeBlock(AsyncIterUtils.fromArray(input));
+
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		expect(await collectLines(result.lines)).toEqual(['const x = 1;', 'const y = 2;']);
+	});
+
+	it('passes through when no backticks', async () => {
+		const input = ['const x = 1;', 'const y = 2;'];
+		const result = handleCodeBlock(AsyncIterUtils.fromArray(input));
+
+		expect(await collectLines(result.lines)).toEqual(input);
+	});
+
+	it('handles empty stream', async () => {
+		const result = handleCodeBlock(AsyncIterUtils.fromArray([]));
+		expect(await collectLines(result.lines)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// handleEditWindowWithEditIntent
+// ============================================================================
+
+describe('handleEditWindowWithEditIntent', () => {
+	it('parses tag-based intent and returns EditWindowLines with metadata', async () => {
+		const input = ['<|edit_intent|>high<|/edit_intent|>', 'line1', 'line2'];
+		const result = await handleEditWindowWithEditIntent(
+			AsyncIterUtils.fromArray(input),
+			createMockLogger(),
+			EditIntentParseMode.Tags,
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		const ewl = result as ResponseParseResult.EditWindowLines;
+		expect(ewl.editIntentMetadata?.intent).toBe(EditIntent.High);
+		expect(ewl.editIntentMetadata?.parseError).toBeUndefined();
+		expect(await collectLines(ewl.lines)).toEqual(['line1', 'line2']);
+	});
+
+	it('parses short-name intent', async () => {
+		const input = ['L', 'line1'];
+		const result = await handleEditWindowWithEditIntent(
+			AsyncIterUtils.fromArray(input),
+			createMockLogger(),
+			EditIntentParseMode.ShortName,
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		const ewl = result as ResponseParseResult.EditWindowLines;
+		expect(ewl.editIntentMetadata?.intent).toBe(EditIntent.Low);
+	});
+
+	it('returns Done when getFetchFailure fires', async () => {
+		const failureReason = new NoNextEditReason.GotCancelled('test');
+		const result = await handleEditWindowWithEditIntent(
+			AsyncIterUtils.fromArray(['<|edit_intent|>high<|/edit_intent|>', 'line1']),
+			createMockLogger(),
+			EditIntentParseMode.Tags,
+			() => failureReason,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.Done);
+		expect((result as ResponseParseResult.Done).reason).toBe(failureReason);
+	});
+
+	it('returns EditWindowLines with parseError on malformed intent', async () => {
+		const input = ['no intent here', 'line1'];
+		const result = await handleEditWindowWithEditIntent(
+			AsyncIterUtils.fromArray(input),
+			createMockLogger(),
+			EditIntentParseMode.Tags,
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		const ewl = result as ResponseParseResult.EditWindowLines;
+		expect(ewl.editIntentMetadata?.parseError).toBeDefined();
+		// Default to High on parse error — first line is re-emitted as content
+		expect(ewl.editIntentMetadata?.intent).toBe(EditIntent.High);
+		expect(await collectLines(ewl.lines)).toEqual(['no intent here', 'line1']);
+	});
+});
+
+// ============================================================================
+// handleUnifiedWithXml
+// ============================================================================
+
+describe('handleUnifiedWithXml', () => {
+	it('<NO_CHANGE> returns Done(NoSuggestions)', async () => {
+		const result = await handleUnifiedWithXml(
+			AsyncIterUtils.fromArray(['<NO_CHANGE>']),
+			makeInsertContext(),
+			makeDocBeforeEdits(),
+			createMockLogger(),
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.Done);
+		expect((result as ResponseParseResult.Done).reason).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+	});
+
+	it('empty response returns Done(NoSuggestions)', async () => {
+		const result = await handleUnifiedWithXml(
+			AsyncIterUtils.fromArray([]),
+			makeInsertContext(),
+			makeDocBeforeEdits(),
+			createMockLogger(),
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.Done);
+		expect((result as ResponseParseResult.Done).reason).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+	});
+
+	it('unknown tag returns Done(Unexpected)', async () => {
+		const result = await handleUnifiedWithXml(
+			AsyncIterUtils.fromArray(['<UNKNOWN_TAG>']),
+			makeInsertContext(),
+			makeDocBeforeEdits(),
+			createMockLogger(),
+			noFailure,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.Done);
+		expect((result as ResponseParseResult.Done).reason).toBeInstanceOf(NoNextEditReason.Unexpected);
+	});
+
+	it('fetch failure after first line returns Done', async () => {
+		const failureReason = new NoNextEditReason.GotCancelled('test');
+		const result = await handleUnifiedWithXml(
+			AsyncIterUtils.fromArray(['<EDIT>', 'line1', '</EDIT>']),
+			makeInsertContext(),
+			makeDocBeforeEdits(),
+			createMockLogger(),
+			() => failureReason,
+		);
+
+		expect(result).toBeInstanceOf(ResponseParseResult.Done);
+		expect((result as ResponseParseResult.Done).reason).toBe(failureReason);
+	});
+
+	describe('<EDIT>', () => {
+		it('returns EditWindowLines with correct lines, stops at </EDIT>', async () => {
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<EDIT>', 'edited_line0', 'edited_cursor_line', 'edited_line2', '</EDIT>']),
+				makeInsertContext(),
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				noFailure,
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+			const ewl = result as ResponseParseResult.EditWindowLines;
+			expect(await collectLines(ewl.lines)).toEqual(['edited_line0', 'edited_cursor_line', 'edited_line2']);
+		});
+
+		it('handles stream ending without </EDIT> tag', async () => {
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<EDIT>', 'line1', 'line2']),
+				makeInsertContext(),
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				noFailure,
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+			const ewl = result as ResponseParseResult.EditWindowLines;
+			expect(await collectLines(ewl.lines)).toEqual(['line1', 'line2']);
+		});
+
+		it('terminates early when getFetchFailure fires mid-stream', async () => {
+			let callCount = 0;
+			const failureReason = new NoNextEditReason.GotCancelled('test');
+
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<EDIT>', 'line1', 'line2', 'line3', '</EDIT>']),
+				makeInsertContext(),
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				() => {
+					callCount++;
+					// First call is from handleUnifiedWithXml (after first line read).
+					// Second call is inside generateEditLines before yielding line1 → passes.
+					// Third call is before yielding line2 → fails.
+					return callCount > 2 ? failureReason : undefined;
+				},
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+			const ewl = result as ResponseParseResult.EditWindowLines;
+			expect(await collectLines(ewl.lines)).toEqual(['line1']);
+		});
+	});
+
+	describe('<INSERT>', () => {
+		it('returns DirectEdits yielding correct edits', async () => {
+			const ctx = makeInsertContext();
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<INSERT>', 'inserted_text', '</INSERT>']),
+				ctx,
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				noFailure,
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
+			const { edits, returnValue } = await consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream);
+
+			// First edit: cursor line replacement with inserted text spliced in
+			// cursor_line with cursorColumnZeroBased=6: 'cursor' + 'inserted_text' + '_line'
+			expect(edits.length).toBeGreaterThanOrEqual(1);
+			expect(edits[0].edit.newLines).toEqual(['cursorinserted_text_line']);
+
+			// Second edit: empty insertion (no additional lines between INSERT tags)
+			expect(edits[1].edit.newLines).toEqual([]);
+
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('returns DirectEdits with multi-line insert', async () => {
+			const ctx = makeInsertContext();
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<INSERT>', 'first', 'second', 'third', '</INSERT>']),
+				ctx,
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				noFailure,
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
+			const { edits } = await consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream);
+
+			expect(edits).toHaveLength(2);
+			// First edit splices 'first' into cursor line: 'cursor' + 'first' + '_line'
+			expect(edits[0].edit.newLines).toEqual(['cursorfirst_line']);
+			// Second edit inserts remaining lines
+			expect(edits[1].edit.newLines).toEqual(['second', 'third']);
+		});
+
+		it('returns NoSuggestions when INSERT is immediately closed', async () => {
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<INSERT>', '</INSERT>']),
+				makeInsertContext(),
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				noFailure,
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
+			const { edits, returnValue } = await consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream);
+			expect(edits).toHaveLength(0);
+			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
+		});
+
+		it('returns fetch failure when it fires mid-INSERT', async () => {
+			const failureReason = new NoNextEditReason.GotCancelled('test');
+			let callCount = 0;
+
+			const result = await handleUnifiedWithXml(
+				AsyncIterUtils.fromArray(['<INSERT>', 'inserted_text', 'more_text', '</INSERT>']),
+				makeInsertContext(),
+				makeDocBeforeEdits(),
+				createMockLogger(),
+				() => {
+					callCount++;
+					return callCount > 1 ? failureReason : undefined;
+				},
+			);
+
+			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
+			const { returnValue } = await consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream);
+			expect(returnValue).toBe(failureReason);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
