### PR TITLE
Add telemetry to diagnose intermittent NES model switching

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -1343,7 +1343,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		return new OffsetRange(codeToEditStart, codeToEditEndExcl);
 	}
 
-	private determineModelConfiguration(activeDocument: StatelessNextEditDocument): { promptOptions: ModelConfig; modelServiceConfig: xtabPromptOptions.ModelConfiguration } {
+	private determineModelConfiguration(activeDocument: StatelessNextEditDocument): { promptOptions: ModelConfig; modelServiceConfig: xtabPromptOptions.ModelConfiguration; modelSource: string } {
 		if (this.forceUseDefaultModel) {
 			const defaultOptions = {
 				modelName: undefined,
@@ -1352,7 +1352,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			const defaultModelConfig = this.modelService.defaultModelConfiguration();
 			return {
 				promptOptions: overrideModelConfig(defaultOptions, defaultModelConfig),
-				modelServiceConfig: defaultModelConfig
+				modelServiceConfig: defaultModelConfig,
+				modelSource: 'forceUseDefaultModel',
 			};
 		}
 

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -253,9 +253,9 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			return new NoNextEditReason.Uncategorized(new Error('NoSelection'));
 		}
 
-		const { promptOptions, modelServiceConfig } = this.determineModelConfiguration(activeDocument);
+		const { promptOptions, modelServiceConfig, modelSource } = this.determineModelConfiguration(activeDocument);
 
-		telemetry.setModelConfig(JSON.stringify(modelServiceConfig));
+		telemetry.setModelConfig(JSON.stringify({ ...modelServiceConfig, source: modelSource }));
 
 		const endpoint = this.getEndpointWithLogging(promptOptions.modelName, logContext, telemetry);
 
@@ -1394,14 +1394,15 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			includePostScript: true,
 		};
 
-		const selectedModelConfig = this.modelService.selectedModelConfiguration();
+		const { config: selectedModelConfig, source: modelSource } = this.modelService.selectedModel();
 		// proxy /models doesn't know about includeTagsInCurrentFile field as of now, so hard code it to true for CopilotNesXtab strategy
 		const modelConfig: xtabPromptOptions.ModelConfiguration = selectedModelConfig.promptingStrategy === xtabPromptOptions.PromptingStrategy.CopilotNesXtab
 			? { ...selectedModelConfig, includeTagsInCurrentFile: true }
 			: selectedModelConfig;
 		return {
 			promptOptions: overrideModelConfig(sourcedModelConfig, modelConfig),
-			modelServiceConfig: modelConfig
+			modelServiceConfig: modelConfig,
+			modelSource,
 		};
 	}
 

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -117,8 +117,8 @@ class MockInlineEditsModelService implements IInlineEditsModelService {
 
 	async setCurrentModelId(_modelId: string): Promise<void> { }
 
-	selectedModelConfiguration(): ModelConfiguration {
-		return this._selectedConfig;
+	selectedModel(): { config: ModelConfiguration; source: string } {
+		return { config: this._selectedConfig, source: 'hardCodedDefault' };
 	}
 
 	defaultModelConfiguration(): ModelConfiguration {
@@ -827,7 +827,7 @@ describe('XtabProvider integration', () => {
 			const request = createRequestWithEdit(lines, { insertionOffset: 5, insertedText: 'c' });
 
 			// Make the model service throw during config assembly
-			vi.spyOn(mockModelService, 'selectedModelConfiguration').mockImplementation(() => {
+			vi.spyOn(mockModelService, 'selectedModel').mockImplementation(() => {
 				throw new Error('test-unexpected-error');
 			});
 
@@ -955,7 +955,7 @@ describe('XtabProvider integration', () => {
 	// ========================================================================
 
 	describe('model configuration', () => {
-		it('uses selectedModelConfiguration from model service', async () => {
+		it('uses selectedModel from model service', async () => {
 			const provider = createProvider();
 
 			mockModelService.setSelectedConfig({

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditsModelService.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditsModelService.ts
@@ -8,6 +8,11 @@ import { createServiceIdentifier } from '../../../util/common/services';
 import { Event } from '../../../util/vs/base/common/event';
 import { ModelConfiguration } from './dataTypes/xtabPromptOptions';
 
+export interface SelectedModel {
+	readonly config: ModelConfiguration;
+	readonly source: string;
+}
+
 export interface IInlineEditsModelService {
 	readonly _serviceBrand: undefined;
 
@@ -17,7 +22,7 @@ export interface IInlineEditsModelService {
 
 	setCurrentModelId(modelId: string): Promise<void>;
 
-	selectedModelConfiguration(): ModelConfiguration;
+	selectedModel(): SelectedModel;
 
 	defaultModelConfiguration(): ModelConfiguration;
 }

--- a/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
+++ b/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
@@ -11,7 +11,7 @@ import { pushMany } from '../../../util/vs/base/common/arrays';
 import { assertNever, softAssert } from '../../../util/vs/base/common/assert';
 import { Emitter, Event } from '../../../util/vs/base/common/event';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
-import { derived, IObservable, observableFromEvent } from '../../../util/vs/base/common/observable';
+import { autorun, derived, IObservable, observableFromEvent } from '../../../util/vs/base/common/observable';
 import { CopilotToken } from '../../authentication/common/copilotToken';
 import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStore';
 import { ConfigKey, ExperimentBasedConfig, IConfigurationService } from '../../configuration/common/configurationService';
@@ -136,6 +136,44 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 		}).recomputeInitiallyAndOnChange(this._store);
 
 		this.onModelListUpdated = Event.fromObservableLight(this._modelInfoObs);
+
+		// Diagnostic telemetry: track model changes to diagnose intermittent switching
+		let previousModelName: string | undefined;
+		this._register(autorun(reader => {
+			const currentModel = this._currentModelObs.read(reader);
+			const models = this._modelsObs.read(reader);
+			const modelName = currentModel.modelName;
+			if (previousModelName !== undefined && previousModelName !== modelName) {
+				const fetchedNames = this._proxyModelsService.nesModels?.map(m => m.name).join(',') ?? 'undefined';
+				const copilotToken = this._tokenStore.copilotToken;
+				/* __GDPR__
+					"nesModelChanged" : {
+						"owner": "ulugbekna",
+						"comment": "Track NES model changes within a session to diagnose intermittent switching.",
+						"previousModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model name before the switch." },
+						"newModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Model name after the switch." },
+						"newModelSource": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Source of the new model (fetched, expConfig, hardCodedDefault, etc.)." },
+						"modelListNames": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "All model names in the current aggregated model list." },
+						"modelListSources": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Sources of models in the current aggregated model list." },
+						"fetchedNesModels": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "NES model names from the latest /models response." },
+						"hasCopilotToken": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether a copilot token is available.", "isMeasurement": true },
+						"isFreeUser": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the user is a free tier user.", "isMeasurement": true }
+					}
+				*/
+				this._telemetryService.sendMSFTTelemetryEvent('nesModelChanged', {
+					previousModel: previousModelName,
+					newModel: modelName,
+					newModelSource: currentModel.source,
+					modelListNames: models.map(m => m.modelName).join(','),
+					modelListSources: models.map(m => m.source).join(','),
+					fetchedNesModels: fetchedNames,
+					hasCopilotToken: copilotToken ? '1' : '0',
+					isFreeUser: copilotToken?.isFreeUser ? '1' : '0',
+				});
+				this._logger.info(`NES model changed: ${previousModelName} → ${modelName} (source: ${currentModel.source}, fetched: [${fetchedNames}])`);
+			}
+			previousModelName = modelName;
+		}));
 	}
 
 	get modelInfo(): vscode.InlineCompletionModelInfo | undefined {
@@ -283,8 +321,9 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 		return models;
 	}
 
-	public selectedModelConfiguration(): ModelConfiguration {
-		return toModelConfiguration(this._currentModelObs.get());
+	public selectedModel(): { config: ModelConfiguration; source: string } {
+		const model = this._currentModelObs.get();
+		return { config: toModelConfiguration(model), source: model.source };
 	}
 
 	public defaultModelConfiguration(): ModelConfiguration {

--- a/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
+++ b/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
@@ -167,8 +167,9 @@ export class InlineEditsModelService extends Disposable implements IInlineEditsM
 					modelListNames: models.map(m => m.modelName).join(','),
 					modelListSources: models.map(m => m.source).join(','),
 					fetchedNesModels: fetchedNames,
-					hasCopilotToken: copilotToken ? '1' : '0',
-					isFreeUser: copilotToken?.isFreeUser ? '1' : '0',
+				}, {
+					hasCopilotToken: copilotToken ? 1 : 0,
+					isFreeUser: copilotToken?.isFreeUser ? 1 : 0,
 				});
 				this._logger.info(`NES model changed: ${previousModelName} → ${modelName} (source: ${currentModel.source}, fetched: [${fetchedNames}])`);
 			}


### PR DESCRIPTION
## Problem

Investigation of `provideinlineedit` telemetry revealed that ~0.04% of sessions with successful NES fetches experience intermittent model switching — the NES model bounces between two different models (e.g., `nes-callisto-003` → `nes-callisto` → `nes-callisto-003`) mid-session.

We couldn't determine the root cause from existing telemetry because the `modelConfig` property didn't include **how** the model was selected (fetched from `/models`, experiment config, hardcoded default, etc.).

## Changes

### 1. `nesModelChanged` telemetry event
Fires whenever `_currentModelObs` produces a different model than the previous one. Captures:
- `previousModel` / `newModel` — model names before and after
- `newModelSource` — how the model was picked (`fetched`, `expConfig`, `expDefaultConfig`, `localConfig`, `hardCodedDefault`)
- `modelListNames` / `modelListSources` — full snapshot of the aggregated model list
- `fetchedNesModels` — raw NES models from latest `/models` response
- `hasCopilotToken` / `isFreeUser` — token state at switch time

### 2. `source` field in `modelConfig` JSON on every `provideInlineEdit` event
The existing `modelConfig` telemetry property now includes a `source` field, so every NES request self-documents how its model was chosen. Query via:
```kql
| extend modelSource = tostring(parse_json(Properties["modelconfig"]).source)
```

### 3. `selectedModel()` API on `IInlineEditsModelService`
Replaces the old `selectedModelConfiguration()` with `selectedModel()` returning `{ config, source }` atomically from a single observable read — avoids a race between config and source.

## Possible causes under investigation
1. Server `/models` endpoint returning different NES models across token refreshes
2. Transient loss of `/models` data falling through to hardcoded defaults
3. Experiment assignment changes mid-session

This telemetry will confirm which.