### PR TITLE
fix: update modelId replacement character in telemetry data

### DIFF
--- a/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/telemetry/aiEditTelemetry/aiEditTelemetryServiceImpl.ts
@@ -84,7 +84,7 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			editLinesDeleted: data.editDeltaInfo?.linesRemoved,
 
 			modeId: data.modeId,
-			modelId: data.modelId?.replace(/[\/\\]/g, '_'),
+			modelId: data.modelId?.replace(/[\/\\]/g, '|'),
 			applyCodeBlockSuggestionId: data.applyCodeBlockSuggestionId as unknown as string,
 
 			...forwardToChannelIf(isCopilotLikeExtension(data.source?.extensionId)),
@@ -165,7 +165,7 @@ export class AiEditTelemetryServiceImpl implements IAiEditTelemetryService {
 			editLinesDeleted: data.editDeltaInfo?.linesRemoved,
 
 			modeId: data.modeId,
-			modelId: data.modelId?.replace(/[\/\\]/g, '_'),
+			modelId: data.modelId?.replace(/[\/\\]/g, '|'),
 			applyCodeBlockSuggestionId: data.applyCodeBlockSuggestionId as unknown as string,
 			acceptanceMethod: data.acceptanceMethod,
 


### PR DESCRIPTION
In the past, model ids with slash (e.g. `copilot/gpt4`) were sent as `copilot/gpt4`.
However, for that, we had to mark these model ids as trusted telemetry value to avoid path escaping.
Unfortunately, we cannot mark these model ids as trusted value anymore, so we need to escape the value again.
In the far past, we escaped them with `|`. When we disabled trusted telemetry values for model ids, we used `_` as escaping character.
This PR aligns these characters and uses `|` for both.
The reason we use `|` instead of `_` is that the many model ids contain `_`.