### PR TITLE
Fix terminal output last line clipping in chat terminal tool progress

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -177,7 +177,7 @@ div.chat-terminal-content-part.progress-step > div.chat-terminal-output-containe
 	background: inherit;
 }
 .chat-terminal-output-body {
-	padding: 5px 0px 1px;
+	padding: 5px 0px 3px;
 	max-width: 100%;
 	box-sizing: border-box;
 	min-height: 0;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1469,13 +1469,17 @@ class ChatTerminalToolOutputSection extends Disposable {
 		const scrollableDomNode = this._scrollableContainer.getDomNode();
 		const rowHeight = this._computeRowHeightPx();
 		const padding = this._getOutputPadding();
-		const minHeight = rowHeight * MIN_OUTPUT_ROWS + padding;
 		const maxHeight = rowHeight * MAX_OUTPUT_ROWS + padding;
 		const contentHeight = this._getOutputContentHeight(lineCount, rowHeight, padding);
 		const clampedHeight = Math.min(contentHeight, maxHeight);
-		const measuredBodyHeight = Math.max(this._outputBody.clientHeight, minHeight);
-		const appliedHeight = Math.min(clampedHeight, measuredBodyHeight);
-		scrollableDomNode.style.height = appliedHeight < maxHeight ? `${appliedHeight}px` : '';
+		// Use the line-count-based calculation directly rather than constraining by
+		// _outputBody.clientHeight. The DOM measurement races with xterm's async
+		// rendering — when new lines arrive, clientHeight reflects the stale
+		// (pre-render) size, causing the viewport to be too short and clipping the
+		// last line. The +1 buffer row in _getOutputContentHeight provides enough
+		// headroom for any mismatch between the calculated rowHeight and xterm's
+		// actual cell height.
+		scrollableDomNode.style.height = clampedHeight < maxHeight ? `${clampedHeight}px` : '';
 		this._scrollableContainer.scanDomNode();
 	}
 
@@ -1502,9 +1506,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 
 	private _getOutputContentHeight(lineCount: number, rowHeight: number, padding: number): number {
 		const contentRows = Math.max(lineCount, MIN_OUTPUT_ROWS);
-		// Always add an extra row for buffer space to prevent the last line from being cut off during streaming
-		const adjustedRows = contentRows + 1;
-		return (adjustedRows * rowHeight) + padding;
+		return (contentRows * rowHeight) + padding;
 	}
 
 	private _getOutputPadding(): number {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1476,9 +1476,9 @@ class ChatTerminalToolOutputSection extends Disposable {
 		// _outputBody.clientHeight. The DOM measurement races with xterm's async
 		// rendering — when new lines arrive, clientHeight reflects the stale
 		// (pre-render) size, causing the viewport to be too short and clipping the
-		// last line. The +1 buffer row in _getOutputContentHeight provides enough
-		// headroom for any mismatch between the calculated rowHeight and xterm's
-		// actual cell height.
+		// last line. The calculated height still has enough headroom because it
+		// includes the output padding and may round slightly differently from
+		// xterm's actual rendered cell height.
 		scrollableDomNode.style.height = clampedHeight < maxHeight ? `${clampedHeight}px` : '';
 		this._scrollableContainer.scanDomNode();
 	}


### PR DESCRIPTION
fix #307571

The scrollable viewport height was constrained by `_outputBody.clientHeight`, which races with xterm's async rendering — returning a stale pre-render size that clips the last line. Remove that constraint and use the line-count-based height directly. Also remove the +1 buffer row workaround (which was overcompensating and showing the next prompt) and bump bottom padding from 1px to 3px for sub-pixel rounding safety.

<img width="594" height="232" alt="Screenshot 2026-04-09 at 2 00 24 PM" src="https://github.com/user-attachments/assets/9d86ef40-5846-487f-aefd-02e87f58835a" />


