### PR TITLE
sessions: disable release notes on update

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -58,6 +58,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',
 		'workbench.editor.restoreEditors': false,
+		'update.showReleaseNotes': false,
 		'workbench.startupEditor': 'none',
 		'workbench.tips.enabled': false,
 		'workbench.layoutControl.type': 'toggles',


### PR DESCRIPTION
## Summary
Fixes: https://github.com/microsoft/vscode/issues/308809
Prevents release notes from auto-opening in the agent sessions app after a version update.

## Change

Adds `'update.showReleaseNotes': false` to the sessions app configuration defaults in `configuration.contribution.ts`. This follows the same pattern used to suppress the welcome page (`'workbench.startupEditor': 'none'`) — a targeted config override that disables the behavior while keeping the rest of the update machinery (notifications, quality switching, etc.) intact.

`ProductContribution` already checks this setting before opening release notes, so no additional code changes are needed.