### PR TITLE
fix: prevent invalid splice when removing override configuration

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -275,10 +275,18 @@ export class ConfigurationModel implements IConfigurationModel {
 		if (index === -1) {
 			return;
 		}
+
 		this.keys.splice(index, 1);
 		removeFromValueTree(this.contents, key);
+
 		if (OVERRIDE_PROPERTY_REGEX.test(key)) {
-			this.overrides.splice(this.overrides.findIndex(o => arrays.equals(o.identifiers, overrideIdentifiersFromKey(key))), 1);
+			const overrideIndex = this.overrides.findIndex(o =>
+				arrays.equals(o.identifiers, overrideIdentifiersFromKey(key))
+			);
+
+			if (overrideIndex !== -1) {
+				this.overrides.splice(overrideIndex, 1);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue in `removeValue` where `Array.splice` could be called with an invalid index when removing override configurations.

Previously, if the override was not found, `findIndex` returned -1, which could unintentionally remove the last element of the `overrides` array.

This change adds a check to ensure the override exists before removing it.

## How to test
- Call `removeValue` with a key that has no matching override
- Ensure no unintended override entries are removed