### PR TITLE
sessions: round layout sashes

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -429,6 +429,8 @@ Parts manage their own border and background styling via the `updateStyles()` me
 | Auxiliary Bar | Card appearance via CSS variables `--part-background` / `--part-border-color`, with a light-theme-only CSS border-color override | Uses `sessionsAuxiliaryBarBackground` / `PANEL_BORDER`; default light themes map this card to `editorBackground` and darken the outline with `editorWidget.border`, while dark and high-contrast themes keep the existing sidebar-style surface; margins create card offset |
 | Panel | Card appearance via CSS variables `--part-background` / `--part-border-color`, with a light-theme-only CSS border-color override | Uses `sessionsPanelBackground` / `PANEL_BORDER`; default light themes map this card to `editorBackground` and darken the outline with `editorWidget.border`, while dark and high-contrast themes keep the existing sidebar-style surface; margins create card offset |
 
+The sessions workbench also scopes its resize sash styling in `browser/media/style.css`, rounding the sash hover indicator and orthogonal drag handles so the layout chrome matches the card surfaces.
+
 ---
 
 ### 9.6 Auxiliary Bar Run Script Dropdown
@@ -647,6 +649,7 @@ interface IPartVisibilityState {
 | Date | Change |
 |------|--------|
 | 2026-04-08 | Darkened the light-theme-only chat, auxiliary bar, and panel card borders with a sessions-specific CSS `border-color` override that uses `editorWidget.border`; dark and high-contrast themes continue using the existing part border tokens. |
+| 2026-04-08 | Rounded the sessions workbench sash hover indicators and orthogonal drag handles via `browser/media/style.css` so resize handles use rounded corners instead of square edges. |
 | 2026-04-04 | Inverted the default light-theme surface mapping so the sessions window background uses the off-white workbench/sidebar surface while the chat, changes, and panel cards use the brighter editor background; dark and high-contrast mappings remain unchanged. |
 | 2026-04-03 | Updated `SessionsTitleBarWidget` to format active session titles as `{Title} · {repo name} ({git branch/worktree name})` when repository detail metadata is available, falling back to the worktree folder name when needed. |
 | 2026-04-03 | Reduced the sessions left sidebar minimum resizable width from 270px to 170px so it can shrink significantly more while keeping the default 300px width unchanged |

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -64,6 +64,14 @@
 	background-color: var(--vscode-sessionsSidebar-background);
 }
 
+.agent-sessions-workbench .monaco-sash:before {
+	border-radius: calc(var(--vscode-sash-hover-size) / 2);
+}
+
+.agent-sessions-workbench .monaco-sash:not(.disabled) > .orthogonal-drag-handle {
+	border-radius: var(--vscode-sash-size);
+}
+
 .monaco-workbench.vs.agent-sessions-workbench .part.chatbar,
 .monaco-workbench.vs.agent-sessions-workbench .part.auxiliarybar,
 .monaco-workbench.vs.agent-sessions-workbench .part.panel {


### PR DESCRIPTION
## Summary
- round the sessions workbench sash hover indicator and orthogonal drag handles
- keep the change scoped to the sessions app so shared sash styling is unchanged
- document the sessions-specific sash styling in `src/vs/sessions/LAYOUT.md`

<img width="1820" height="1176" alt="Screenshot 2026-04-09 at 2 57 06 PM" src="https://github.com/user-attachments/assets/8274f405-94b9-4cfa-b073-77f95ec14951" />

## Testing
- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/browser/media/style.css src/vs/sessions/LAYOUT.md`