### PR TITLE
sessions: rename `inSessions` to `inAgents` and fix updateTask duplication bug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -277,14 +277,14 @@
 			"label": "Run and Compile Agents - OSS",
 			"dependsOn": ["Transpile Client", "Run Dev Agents"],
 			"dependsOrder": "sequence",
-			"inSessions": true,
+			"inAgents": true,
 			"problemMatcher": []
 		},
 		{
 			"label": "Run and Compile Code - OSS",
 			"dependsOn": ["Transpile Client", "Run Dev"],
 			"dependsOrder": "sequence",
-			"inSessions": true,
+			"inAgents": true,
 			"problemMatcher": []
 		},
 		{
@@ -423,7 +423,7 @@
 			"type": "shell",
 			"command": "npx component-explorer serve -p ./test/componentFixtures/component-explorer.json -vv --kill-if-running",
 			"isBackground": true,
-			"inSessions": true,
+			"inAgents": true,
 			"problemMatcher": {
 				"owner": "component-explorer",
 				"fileLocation": "absolute",
@@ -447,7 +447,7 @@
 			"windows": {
 				"command": "cmd /c \"npm ci && npm run watch\""
 			},
-			"inSessions": true,
+			"inAgents": true,
 			"runOptions": {
 				"runOn": "worktreeCreated"
 			},

--- a/extensions/copilot/.vscode/tasks.json
+++ b/extensions/copilot/.vscode/tasks.json
@@ -5,20 +5,20 @@
 			"label": "Install dependencies",
 			"type": "shell",
 			"command": "npm ci",
-			"inSessions": true,
+			"inAgents": true,
 			"runOptions": { "runOn": "worktreeCreated" }
 		},
 		{
 			"label": "Compile & Launch Extension Host",
 			"type": "shell",
 			"command": "npm run compile && COPILOT_LOG_TELEMETRY=true VSCODE_DEV_DEBUG=1 code-insiders --extensionDevelopmentPath=$(pwd)",
-			"inSessions": true
+			"inAgents": true
 		},
 		{
 			"label": "Typecheck",
 			"type": "shell",
 			"command": "npm run typecheck",
-			"inSessions": true
+			"inAgents": true
 		},
 		{
 			"label": "compile",

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -338,7 +338,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 				let updatedTask: ITaskEntry = {
 					...existingTask.task,
 					label: newLabel,
-					inSessions: true,
+					inAgents: true,
 				};
 
 				if (taskConfiguration.command && existingTask.task.command !== undefined) {
@@ -365,7 +365,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 			await this._sessionsConfigService.addTaskToSessions(existingTask.task, session, existingTask.target, { runOn: taskConfiguration.runOn ?? 'default' });
 			return {
 				...existingTask.task,
-				inSessions: true,
+				inAgents: true,
 				...(taskConfiguration.runOn ? { runOptions: { runOn: taskConfiguration.runOn } } : {}),
 			};
 		}

--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -36,7 +36,7 @@ export interface ITaskEntry {
 	readonly type?: string;
 	readonly command?: string;
 	readonly args?: CommandString[];
-	readonly inSessions?: boolean;
+	readonly inAgents?: boolean;
 	readonly runOptions?: ITaskRunOptions;
 	readonly windows?: { command?: string; args?: CommandString[] };
 	readonly osx?: { command?: string; args?: CommandString[] };
@@ -66,26 +66,26 @@ export interface ISessionsConfigurationService {
 	readonly _serviceBrand: undefined;
 
 	/**
-	 * Observable list of tasks with `inSessions: true`, automatically
+	 * Observable list of tasks with `inAgents: true`, automatically
 	 * updated when the tasks.json file changes. Each entry includes the
 	 * storage target the task was loaded from.
 	 */
 	getSessionTasks(session: ISession): IObservable<readonly ISessionTaskWithTarget[]>;
 
 	/**
-	 * Returns tasks that do NOT have `inSessions: true` — used as
+	 * Returns tasks that do NOT have `inAgents: true` — used as
 	 * suggestions in the "Add Run Action" picker.
 	 */
 	getNonSessionTasks(session: ISession): Promise<readonly INonSessionTaskEntry[]>;
 
 	/**
-	 * Sets `inSessions: true` on an existing task (identified by label),
+	 * Sets `inAgents: true` on an existing task (identified by label),
 	 * updating it in place in its tasks.json.
 	 */
 	addTaskToSessions(task: ITaskEntry, session: ISession, target: TaskStorageTarget, options?: ITaskRunOptions): Promise<void>;
 
 	/**
-	 * Creates a new shell task with `inSessions: true` and writes it to
+	 * Creates a new shell task with `inAgents: true` and writes it to
 	 * the appropriate tasks.json (user or workspace).
 	 */
 	createAndAddTask(label: string | undefined, command: string, session: ISession, target: TaskStorageTarget, options?: ITaskRunOptions): Promise<ITaskEntry | undefined>;
@@ -166,7 +166,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		if (workspaceUri) {
 			const workspaceJson = await this._readTasksJson(workspaceUri);
 			for (const task of workspaceJson.tasks ?? []) {
-				if (!task.inSessions && this._isSupportedTask(task)) {
+				if (!task.inAgents && this._isSupportedTask(task)) {
 					result.push({ task, target: 'workspace' });
 				}
 			}
@@ -176,7 +176,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		if (userUri) {
 			const userJson = await this._readTasksJson(userUri);
 			for (const task of userJson.tasks ?? []) {
-				if (!task.inSessions && this._isSupportedTask(task)) {
+				if (!task.inAgents && this._isSupportedTask(task)) {
 					result.push({ task, target: 'user' });
 				}
 			}
@@ -199,7 +199,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		}
 
 		const edits: { path: (string | number)[]; value: unknown }[] = [
-			{ path: ['tasks', index, 'inSessions'], value: true },
+			{ path: ['tasks', index, 'inAgents'], value: true },
 		];
 
 		if (options) {
@@ -225,7 +225,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			label: resolvedLabel,
 			type: 'shell',
 			command,
-			inSessions: true,
+			inAgents: true,
 			...(options?.runOn && options.runOn !== 'default' ? { runOptions: { runOn: options.runOn } } : {}),
 		};
 
@@ -252,8 +252,9 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		}
 
 		if (currentTasksJsonUri.toString() === newTasksJsonUri.toString()) {
+			const updatedTasks = currentTasks.map((task, i) => i === currentIndex ? updatedTask : task);
 			await this._jsonEditingService.write(currentTasksJsonUri, [
-				{ path: ['tasks', currentIndex], value: updatedTask },
+				{ path: ['tasks'], value: updatedTasks },
 			], true);
 		} else {
 			const newTasksJson = await this._readTasksJson(newTasksJsonUri);
@@ -408,14 +409,14 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		const tasksUri = joinPath(folder, '.vscode', 'tasks.json');
 		const tasksJson = await this._readTasksJson(tasksUri);
 		const sessionTasks: ISessionTaskWithTarget[] = (tasksJson.tasks ?? [])
-			.filter(t => t.inSessions && this._isSupportedTask(t))
+			.filter(t => t.inAgents && this._isSupportedTask(t))
 			.map(t => ({ task: t, target: 'workspace' as TaskStorageTarget }));
 
 		// Also include user-level session tasks
 		const userUri = joinPath(dirname(this._preferencesService.userSettingsResource), 'tasks.json');
 		const userJson = await this._readTasksJson(userUri);
 		const userSessionTasks: ISessionTaskWithTarget[] = (userJson.tasks ?? [])
-			.filter(t => t.inSessions && this._isSupportedTask(t))
+			.filter(t => t.inAgents && this._isSupportedTask(t))
 			.map(t => ({ task: t, target: 'user' as TaskStorageTarget }));
 
 		transaction(tx => this._sessionTasks.set([...sessionTasks, ...userSessionTasks], tx));

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -76,16 +76,16 @@ function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISession 
 	return session;
 }
 
-function makeTask(label: string, command?: string, inSessions?: boolean): ITaskEntry {
-	return { label, type: 'shell', command: command ?? label, inSessions };
+function makeTask(label: string, command?: string, inAgents?: boolean): ITaskEntry {
+	return { label, type: 'shell', command: command ?? label, inAgents };
 }
 
-function makeNpmTask(label: string, script: string, inSessions?: boolean): ITaskEntry {
-	return { label, type: 'npm', script, inSessions };
+function makeNpmTask(label: string, script: string, inAgents?: boolean): ITaskEntry {
+	return { label, type: 'npm', script, inAgents };
 }
 
-function makeUnsupportedTask(label: string, inSessions?: boolean): ITaskEntry {
-	return { label, type: 'gulp', command: label, inSessions };
+function makeUnsupportedTask(label: string, inAgents?: boolean): ITaskEntry {
+	return { label, type: 'gulp', command: label, inAgents };
 }
 
 function tasksJsonContent(tasks: ITaskEntry[]): string {
@@ -180,7 +180,7 @@ suite('SessionsConfigurationService', () => {
 
 	// --- getSessionTasks ---
 
-	test('getSessionTasks returns tasks with inSessions: true from worktree', async () => {
+	test('getSessionTasks returns tasks with inAgents: true from worktree', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('build', 'npm run build', true),
@@ -251,7 +251,7 @@ suite('SessionsConfigurationService', () => {
 
 	// --- getNonSessionTasks ---
 
-	test('getNonSessionTasks returns only tasks without inSessions', async () => {
+	test('getNonSessionTasks returns only tasks without inAgents', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('build', 'npm run build', true),
@@ -305,7 +305,7 @@ suite('SessionsConfigurationService', () => {
 
 	// --- addTaskToSessions ---
 
-	test('addTaskToSessions writes inSessions: true to the matching task index', async () => {
+	test('addTaskToSessions writes inAgents: true to the matching task index', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('build', 'npm run build'),
@@ -317,7 +317,7 @@ suite('SessionsConfigurationService', () => {
 		await service.addTaskToSessions(task, session, 'workspace');
 
 		assert.strictEqual(jsonEdits.length, 1);
-		assert.deepStrictEqual(jsonEdits[0].values, [{ path: ['tasks', 1, 'inSessions'], value: true }]);
+		assert.deepStrictEqual(jsonEdits[0].values, [{ path: ['tasks', 1, 'inAgents'], value: true }]);
 	});
 
 	test('addTaskToSessions does nothing when task label not found', async () => {
@@ -344,7 +344,7 @@ suite('SessionsConfigurationService', () => {
 
 		assert.strictEqual(jsonEdits.length, 1);
 		assert.strictEqual(jsonEdits[0].uri.toString(), repoTasksUri.toString());
-		assert.deepStrictEqual(jsonEdits[0].values, [{ path: ['tasks', 1, 'inSessions'], value: true }]);
+		assert.deepStrictEqual(jsonEdits[0].values, [{ path: ['tasks', 1, 'inAgents'], value: true }]);
 	});
 
 	test('addTaskToSessions updates runOptions when provided', async () => {
@@ -357,7 +357,7 @@ suite('SessionsConfigurationService', () => {
 		await service.addTaskToSessions(makeTask('build', 'npm run build'), session, 'workspace', { runOn: 'worktreeCreated' });
 
 		assert.deepStrictEqual(jsonEdits[0].values, [
-			{ path: ['tasks', 0, 'inSessions'], value: true },
+			{ path: ['tasks', 0, 'inAgents'], value: true },
 			{ path: ['tasks', 0, 'runOptions'], value: { runOn: 'worktreeCreated' } },
 		]);
 	});
@@ -372,14 +372,14 @@ suite('SessionsConfigurationService', () => {
 		await service.addTaskToSessions(makeTask('build', 'npm run build'), session, 'workspace', { runOn: 'default' });
 
 		assert.deepStrictEqual(jsonEdits[0].values, [
-			{ path: ['tasks', 0, 'inSessions'], value: true },
+			{ path: ['tasks', 0, 'inAgents'], value: true },
 			{ path: ['tasks', 0, 'runOptions'], value: undefined },
 		]);
 	});
 
 	// --- createAndAddTask ---
 
-	test('createAndAddTask writes new task with inSessions: true', async () => {
+	test('createAndAddTask writes new task with inAgents: true', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('existing', 'echo hi'),
@@ -396,7 +396,7 @@ suite('SessionsConfigurationService', () => {
 		const tasks = tasksValue!.value as ITaskEntry[];
 		assert.strictEqual(tasks.length, 2);
 		assert.strictEqual(tasks[1].label, 'npm run dev');
-		assert.strictEqual(tasks[1].inSessions, true);
+		assert.strictEqual(tasks[1].inAgents, true);
 	});
 
 	test('createAndAddTask writes to repository and does not commit when no worktree', async () => {
@@ -415,7 +415,7 @@ suite('SessionsConfigurationService', () => {
 		const tasks = tasksValue!.value as ITaskEntry[];
 		assert.strictEqual(tasks.length, 2);
 		assert.strictEqual(tasks[1].label, 'npm run dev');
-		assert.strictEqual(tasks[1].inSessions, true);
+		assert.strictEqual(tasks[1].inAgents, true);
 	});
 
 	test('createAndAddTask writes worktreeCreated run option when requested', async () => {
@@ -484,20 +484,23 @@ suite('SessionsConfigurationService', () => {
 			label: 'Test Changed',
 			type: 'shell',
 			command: 'pnpm test',
-			inSessions: true,
+			inAgents: true,
 			runOptions: { runOn: 'worktreeCreated' }
 		}, session, 'workspace', 'workspace');
 
 		assert.strictEqual(jsonEdits.length, 1);
 		assert.deepStrictEqual(jsonEdits[0].values, [{
-			path: ['tasks', 1],
-			value: {
-				label: 'Test Changed',
-				type: 'shell',
-				command: 'pnpm test',
-				inSessions: true,
-				runOptions: { runOn: 'worktreeCreated' }
-			}
+			path: ['tasks'],
+			value: [
+				makeTask('build', 'npm run build', true),
+				{
+					label: 'Test Changed',
+					type: 'shell',
+					command: 'pnpm test',
+					inAgents: true,
+					runOptions: { runOn: 'worktreeCreated' }
+				}
+			]
 		}]);
 	});
 
@@ -516,7 +519,7 @@ suite('SessionsConfigurationService', () => {
 			label: 'Build Changed',
 			type: 'shell',
 			command: 'pnpm build',
-			inSessions: true,
+			inAgents: true,
 		}, session, 'workspace', 'user');
 
 		assert.strictEqual(jsonEdits.length, 2);
@@ -539,7 +542,7 @@ suite('SessionsConfigurationService', () => {
 							label: 'Build Changed',
 							type: 'shell',
 							command: 'pnpm build',
-							inSessions: true,
+							inAgents: true,
 						}
 					]
 				}
@@ -576,7 +579,7 @@ suite('SessionsConfigurationService', () => {
 			label: 'build:watch',
 			type: 'shell',
 			command: 'npm run watch',
-			inSessions: true,
+			inAgents: true,
 		}, session, 'workspace', 'workspace');
 
 		assert.strictEqual(service.getPinnedTaskLabel(repoUri).get(), 'build:watch');

--- a/src/vs/sessions/skills/generate-run-commands/SKILL.md
+++ b/src/vs/sessions/skills/generate-run-commands/SKILL.md
@@ -11,7 +11,7 @@ Help the user set up run commands for the current Agent Session workspace. Run c
 ## Understanding the task schema
 
 A run command is a `tasks.json` task with:
-- `"inSessions": true` — required: makes the task appear in the Sessions run button
+- `"inAgents": true` — required: makes the task appear in the Agents run button
 - `"runOptions": { "runOn": "worktreeCreated" }` — optional: auto-runs the task whenever a new worktree is created (use for setup/install commands)
 
 ```json
@@ -21,14 +21,14 @@ A run command is a `tasks.json` task with:
       "label": "Install dependencies",
       "type": "shell",
       "command": "npm install",
-      "inSessions": true,
+      "inAgents": true,
       "runOptions": { "runOn": "worktreeCreated" }
     },
     {
       "label": "Start dev server",
       "type": "shell",
       "command": "npm run dev",
-      "inSessions": true
+      "inAgents": true
     }
   ]
 }
@@ -36,14 +36,14 @@ A run command is a `tasks.json` task with:
 
 ## Decision logic
 
-**First, read the existing `.vscode/tasks.json`** to check for existing run commands (`inSessions: true` tasks).
+**First, read the existing `.vscode/tasks.json`** to check for existing run commands (`inAgents: true` tasks).
 
 **If run commands already exist:** treat this as a modify request — ask the user what they'd like to change (add, remove, or update a command).
 
 **If no run commands exist:** try to infer the right commands from the workspace:
 - Check `package.json`, `Makefile`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `.nvmrc`, or other project files to understand the stack and common commands.
 - If it's clear what the setup command is (e.g., `npm install`, `pip install -r requirements.txt`), add it with `"runOptions": { "runOn": "worktreeCreated" }` — no need to ask.
-- If it's clear what the primary run/dev command is (e.g., `npm run dev`, `cargo run`), add it with just `"inSessions": true`.
+- If it's clear what the primary run/dev command is (e.g., `npm run dev`, `cargo run`), add it with just `"inAgents": true`.
 - **Only ask the user** if the commands are ambiguous (e.g., multiple equally valid options, no recognizable project structure, or the project uses a non-standard setup).
 
 ## Writing the file

--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -56,9 +56,9 @@ const hide: IJSONSchema = {
 	default: true
 };
 
-const inSessions: IJSONSchema = {
+const inAgents: IJSONSchema = {
 	type: 'boolean',
-	description: nls.localize('JsonSchema.inSessions', 'Show this task in the Agent Sessions run action dropdown'),
+	description: nls.localize('JsonSchema.inAgents', 'Show this task in the Agents run action dropdown'),
 	default: false
 };
 
@@ -443,7 +443,7 @@ const taskConfiguration: IJSONSchema = {
 		presentation: Objects.deepClone(presentation),
 		icon: Objects.deepClone(icon),
 		hide: Objects.deepClone(hide),
-		inSessions: Objects.deepClone(inSessions),
+		inAgents: Objects.deepClone(inAgents),
 		options: options,
 		problemMatcher: {
 			$ref: '#/definitions/problemMatcherType',
@@ -517,7 +517,7 @@ taskDescriptionProperties.args = Objects.deepClone(args);
 taskDescriptionProperties.isShellCommand = Objects.deepClone(shellCommand);
 taskDescriptionProperties.dependsOn = dependsOn;
 taskDescriptionProperties.hide = Objects.deepClone(hide);
-taskDescriptionProperties.inSessions = Objects.deepClone(inSessions);
+taskDescriptionProperties.inAgents = Objects.deepClone(inAgents);
 taskDescriptionProperties.dependsOrder = dependsOrder;
 taskDescriptionProperties.identifier = Objects.deepClone(identifier);
 taskDescriptionProperties.type = Objects.deepClone(taskType);

--- a/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
@@ -376,9 +376,9 @@ export interface IConfigurationProperties {
 	hide?: boolean;
 
 	/**
-	 * Show this task in the Agent Sessions run action dropdown
+	 * Show this task in the Agents run action dropdown
 	 */
-	inSessions?: boolean;
+	inAgents?: boolean;
 }
 
 export interface ICustomTask extends ICommandProperties, IConfigurationProperties {
@@ -1371,7 +1371,7 @@ namespace ConfigurationProperties {
 		{ property: 'options' },
 		{ property: 'icon' },
 		{ property: 'hide' },
-		{ property: 'inSessions' }
+		{ property: 'inAgents' }
 	];
 
 	export function from(this: void, external: IConfigurationProperties & { [key: string]: unknown }, context: IParseContext,
@@ -1400,7 +1400,7 @@ namespace ConfigurationProperties {
 		}
 		result.icon = external.icon;
 		result.hide = external.hide;
-		result.inSessions = external.inSessions;
+		result.inAgents = external.inAgents;
 		if (external.isBackground !== undefined) {
 			result.isBackground = !!external.isBackground;
 		}
@@ -1534,7 +1534,7 @@ namespace ConfiguringTask {
 			type,
 			taskIdentifier,
 			RunOptions.fromConfiguration(external.runOptions),
-			{ hide: external.hide, inSessions: external.inSessions }
+			{ hide: external.hide, inAgents: external.inAgents }
 		);
 		const configuration = ConfigurationProperties.from(external as IConfigurationProperties & { [key: string]: unknown }, context, true, source, typeDeclaration.properties);
 		result.addTaskLoadMessages(configuration.errors);
@@ -1688,7 +1688,7 @@ namespace CustomTask {
 				identifier: configuredProps.configurationProperties.identifier || contributedTask.configurationProperties.identifier,
 				icon: configuredProps.configurationProperties.icon,
 				hide: configuredProps.configurationProperties.hide,
-				inSessions: configuredProps.configurationProperties.inSessions
+				inAgents: configuredProps.configurationProperties.inAgents
 			},
 
 		);

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -42,7 +42,7 @@ export interface ICustomizationProperties {
 	isBackground?: boolean;
 	color?: string;
 	icon?: string;
-	inSessions?: boolean;
+	inAgents?: boolean;
 }
 
 export interface ITaskFilter {

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -579,9 +579,9 @@ export interface IConfigurationProperties {
 	hide?: boolean;
 
 	/**
-	 * Show this task in the Agent Sessions run action dropdown
+	 * Show this task in the Agents run action dropdown
 	 */
-	inSessions?: boolean;
+	inAgents?: boolean;
 }
 
 export enum RunOnOptions {


### PR DESCRIPTION
## Summary
Fixes: https://github.com/microsoft/vscode/issues/308801
Two changes in this PR:

### 1. Rename `inSessions` → `inAgents`

Renames the `inSessions` task property to `inAgents` across the entire codebase to align with the "Agents" branding. This touches:

- **Task infrastructure** — `tasks.ts`, `jsonSchema_v2.ts`, `taskService.ts`, `taskConfiguration.ts`
- **Sessions layer** — `sessionsConfigurationService.ts`, `runScriptAction.ts`
- **Tests** — `sessionsConfigurationService.test.ts`
- **JSON configs** — `.vscode/tasks.json`, `extensions/copilot/.vscode/tasks.json`
- **Docs** — `generate-run-commands/SKILL.md`

### 2. Fix `updateTask` duplicating entries instead of replacing

`setProperty` from `jsonEdit.ts` treats numeric array indices as **insert positions**, not replacement indices. So `{ path: ['tasks', currentIndex], value: updatedTask }` was inserting a duplicate entry instead of replacing the existing one when using the configure gear action.

**Fix**: Replace the entire `tasks` array with the updated entry mapped in at the correct index (consistent with how `removeTask` already works):

```ts
const updatedTasks = currentTasks.map((task, i) => i === currentIndex ? updatedTask : task);
await this._jsonEditingService.write(uri, [{ path: ['tasks'], value: updatedTasks }], true);
```