### PR TITLE
fix: reduce /enabled endpoint traffic and surface unexpected status codes

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/common/test/ttlCache.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/test/ttlCache.spec.ts
@@ -89,6 +89,23 @@ describe('TtlCache', () => {
 		vi.advanceTimersByTime(1000);
 		expect(cache.has('key')).toBe(false);
 	});
+
+	it('supports per-entry TTL override', () => {
+		const cache = new TtlCache<string>(5000);
+		cache.set('default', 'value1');
+		cache.set('short', 'value2', 1000);
+
+		vi.advanceTimersByTime(999);
+		expect(cache.get('default')).toBe('value1');
+		expect(cache.get('short')).toBe('value2');
+
+		vi.advanceTimersByTime(1);
+		expect(cache.get('default')).toBe('value1');
+		expect(cache.get('short')).toBeUndefined(); // expired at 1000ms
+
+		vi.advanceTimersByTime(4000);
+		expect(cache.get('default')).toBeUndefined(); // expired at 5000ms
+	});
 });
 
 describe('SingleSlotTtlCache', () => {

--- a/extensions/copilot/src/extension/chatSessions/common/ttlCache.ts
+++ b/extensions/copilot/src/extension/chatSessions/common/ttlCache.ts
@@ -8,7 +8,7 @@
  * Entries are evicted lazily on access when their TTL has elapsed.
  */
 export class TtlCache<V> {
-	private readonly _entries = new Map<string, { value: V; timestamp: number }>();
+	private readonly _entries = new Map<string, { value: V; timestamp: number; ttlMs?: number }>();
 
 	/**
 	 * @param _ttlMs The time-to-live in milliseconds for cache entries.
@@ -23,7 +23,8 @@ export class TtlCache<V> {
 		if (!entry) {
 			return undefined;
 		}
-		if (Date.now() - entry.timestamp >= this._ttlMs) {
+		const ttl = entry.ttlMs ?? this._ttlMs;
+		if (Date.now() - entry.timestamp >= ttl) {
 			this._entries.delete(key);
 			return undefined;
 		}
@@ -32,9 +33,10 @@ export class TtlCache<V> {
 
 	/**
 	 * Stores a value in the cache with the current timestamp.
+	 * @param ttlMs Optional per-entry TTL override in milliseconds. If not provided, the cache-wide TTL is used.
 	 */
-	set(key: string, value: V): void {
-		this._entries.set(key, { value, timestamp: Date.now() });
+	set(key: string, value: V, ttlMs?: number): void {
+		this._entries.set(key, { value, timestamp: Date.now(), ttlMs });
 	}
 
 	/**

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -163,6 +163,8 @@ const CCA_ENABLED_CACHE_TTL_MS = 30 * 60 * 1_000; // 30 minutes
 // Shorter TTL for caching /enabled responses when CCA is disabled or undetermined,
 // so users aren't stuck but we don't hammer the endpoint on every options query
 const CCA_DISABLED_CACHE_TTL_MS = 5 * 60 * 1_000; // 5 minutes
+// Status codes that are expected/handled by isCCAEnabled; anything else is unexpected
+const CCA_KNOWN_STATUS_CODES = new Set([401, 403, 422]);
 // TTL for caching session provider options (custom agents, models, partner agents, etc.)
 const OPTIONS_CACHE_TTL_MS = 15 * 60 * 1_000; // 15 minutes
 
@@ -636,8 +638,15 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		});
 
 		// Track unexpected status codes (429 rate-limit, 5xx, etc.) as errors so they surface in dashboards
-		const knownStatusCodes = new Set([401, 403, 422]);
-		if (result.statusCode !== undefined && !knownStatusCodes.has(result.statusCode)) {
+		if (result.statusCode !== undefined && !CCA_KNOWN_STATUS_CODES.has(result.statusCode)) {
+			/* __GDPR__
+				"copilot.codingAgent.CCAIsEnabledUnexpectedStatus" : {
+					"owner": "joshspicer",
+					"comment": "Fired when the /enabled endpoint returns an unexpected HTTP status code (e.g. 429 rate-limit or 5xx).",
+					"statusCode": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "The unexpected HTTP status code returned by the /enabled endpoint." },
+					"isRateLimited": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "True if the status code is 429 (rate limited)." }
+				}
+			*/
 			this.telemetry.sendTelemetryErrorEvent('copilot.codingAgent.CCAIsEnabledUnexpectedStatus', { microsoft: true, github: false }, {
 				statusCode: String(result.statusCode),
 				isRateLimited: String(result.statusCode === 429),

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -635,6 +635,15 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 			cacheHit: 'false',
 		});
 
+		// Track unexpected status codes (429 rate-limit, 5xx, etc.) as errors so they surface in dashboards
+		const knownStatusCodes = new Set([401, 403, 422]);
+		if (result.statusCode !== undefined && !knownStatusCodes.has(result.statusCode)) {
+			this.telemetry.sendTelemetryErrorEvent('copilot.codingAgent.CCAIsEnabledUnexpectedStatus', { microsoft: true, github: false }, {
+				statusCode: String(result.statusCode),
+				isRateLimited: String(result.statusCode === 429),
+			});
+		}
+
 		this.logService.trace(`copilotCloudSessionsProvider#checkCCAEnabled: fetched CCA enabled status for ${owner}/${repo}: ${result.enabled}`);
 		return result;
 	}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider.ts
@@ -158,8 +158,11 @@ const CLEAR_CACHES_COMMAND_ID = 'github.copilot.chat.cloudSessions.clearCaches';
 const USER_SELECTED_REPOS_KEY = 'userSelectedRepositories';
 const USER_SELECTED_REPOS_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 
-// TTL for caching /enabled responses (only caches enabled=true; disabled results always re-fetch)
+// TTL for caching /enabled responses when CCA is enabled
 const CCA_ENABLED_CACHE_TTL_MS = 30 * 60 * 1_000; // 30 minutes
+// Shorter TTL for caching /enabled responses when CCA is disabled or undetermined,
+// so users aren't stuck but we don't hammer the endpoint on every options query
+const CCA_DISABLED_CACHE_TTL_MS = 5 * 60 * 1_000; // 5 minutes
 // TTL for caching session provider options (custom agents, models, partner agents, etc.)
 const OPTIONS_CACHE_TTL_MS = 15 * 60 * 1_000; // 15 minutes
 
@@ -273,7 +276,7 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	private readonly gitOperationsManager = new CopilotCloudGitOperationsManager(this.logService, this._gitService, this._gitExtensionService);
 
 	// TTL cache for CCA enabled status per repository (key: "owner/repo")
-	// Only caches enabled=true results; disabled results always re-fetch to avoid stuck states
+	// enabled=true cached for 30 min; disabled/undetermined cached for 5 min to reduce traffic
 	private _ccaEnabledCache = new TtlCache<CCAEnabledResult>(CCA_ENABLED_CACHE_TTL_MS);
 
 	// Single-slot TTL cache for the full session provider options result (custom agents, models, partner agents, etc.)
@@ -600,8 +603,8 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 	/**
 	 * Checks if the Copilot cloud agent is enabled for a repository.
 	 * Results are cached with a TTL: enabled=true results are cached for {@link CCA_ENABLED_CACHE_TTL_MS},
-	 * while enabled=false results are never cached (always re-fetched) so users who just
-	 * enabled CCA are not stuck in a disabled state.
+	 * while disabled/undetermined results are cached for a shorter {@link CCA_DISABLED_CACHE_TTL_MS}
+	 * to balance responsiveness with reducing endpoint traffic.
 	 * @param owner Repository owner
 	 * @param repo Repository name
 	 * @returns CCAEnabledResult with enabled status and optional status code
@@ -610,19 +613,20 @@ export class CopilotCloudSessionsProvider extends Disposable implements vscode.C
 		const cacheKey = `${owner}/${repo}`;
 
 		const cached = this._ccaEnabledCache.get(cacheKey);
-		if (cached !== undefined && cached.enabled === true) {
+		if (cached !== undefined) {
 			this.logService.trace(`copilotCloudSessionsProvider#checkCCAEnabled: using cached CCA enabled status for ${owner}/${repo}: ${cached.enabled}`);
 			return cached;
 		}
 
 		const result = await this._octoKitService.isCCAEnabled(owner, repo, {});
 
-		// Only cache enabled=true results with a TTL; disabled results should always re-fetch
+		// Cache all results: enabled=true uses the default 30 min TTL,
+		// disabled/undetermined uses a shorter 5 min TTL so users who just
+		// enabled CCA aren't stuck for too long
 		if (result.enabled === true) {
 			this._ccaEnabledCache.set(cacheKey, result);
 		} else {
-			// Remove any stale positive cache entry
-			this._ccaEnabledCache.delete(cacheKey);
+			this._ccaEnabledCache.set(cacheKey, result, CCA_DISABLED_CACHE_TTL_MS);
 		}
 
 		this.telemetry.sendTelemetryEvent('copilot.codingAgent.CCAIsEnabledCheck', { microsoft: true, github: false }, {

--- a/extensions/copilot/src/platform/github/common/githubService.ts
+++ b/extensions/copilot/src/platform/github/common/githubService.ts
@@ -97,9 +97,10 @@ export interface CCAEnabledResult {
 	 */
 	enabled: boolean | undefined;
 	/**
-	 * The HTTP status code when the cloud agent is disabled (401, 403, or 422).
+	 * The HTTP status code from the /enabled response. Known values: 401, 403, 422.
+	 * Unexpected values (e.g. 429 rate-limit, 5xx) are also propagated for telemetry.
 	 */
-	statusCode?: 401 | 403 | 422;
+	statusCode?: number;
 }
 
 export interface IOctoKitSessionInfo {

--- a/extensions/copilot/src/platform/github/common/octoKitServiceImpl.ts
+++ b/extensions/copilot/src/platform/github/common/octoKitServiceImpl.ts
@@ -530,7 +530,7 @@ export class OctoKitService extends BaseOctoKitService implements IOctoKitServic
 					return { enabled: false, statusCode: 422 };
 				default:
 					this._logService.trace(`Unexpected status code for isCCAEnabled: ${response.status}`);
-					return { enabled: undefined };
+					return { enabled: undefined, statusCode: response.status };
 			}
 		} catch (e) {
 			this._logService.error(`Error checking if CCA is enabled: ${e}`);


### PR DESCRIPTION
## Problem

The `jobs/:owner/:repo/enabled` (CCA /enabled) endpoint was seeing unexpectedly increased traffic. Two root causes:

1. **No caching for disabled repos**: `checkCCAEnabled()` only cached `enabled=true` results. For repos where CCA is disabled, every `provideChatSessionProviderOptions()` call (invoked on every chat session start) made a fresh network request.

2. **Unexpected status codes swallowed**: The `isCCAEnabled` implementation returned `{ enabled: undefined }` with no status code for unexpected responses (429, 5xx etc.), so they were invisible in telemetry.

## Changes

### Caching fix
- `enabled=true` results: cached for 30 min (unchanged)
- `enabled=false` / undetermined results: now cached for 5 min (`CCA_DISABLED_CACHE_TTL_MS`)
- Added per-entry TTL override to `TtlCache.set()` to support two TTLs in one cache instance

### Telemetry fix
- Widened `CCAEnabledResult.statusCode` from `401 | 403 | 422` to `number`
- `isCCAEnabled` default case now propagates `response.status` instead of dropping it
- `checkCCAEnabled` fires a dedicated `sendTelemetryErrorEvent('copilot.codingAgent.CCAIsEnabledUnexpectedStatus')` for any code outside `{401, 403, 422}`, with an `isRateLimited` flag for easy 429 filtering

## Files changed

- `extensions/copilot/src/extension/chatSessions/common/ttlCache. per-entry TTL override on `set()`ts` 
- `extensions/copilot/src/extension/chatSessions/common/test/ttlCache.spec. test for per-entry TTLts` 
- `extensions/copilot/src/extension/chatSessions/vscode-node/copilotCloudSessionsProvider. cache disabled results, fire error telemetry for unexpected codests` 
- `extensions/copilot/src/platform/github/common/githubService. widen `statusCode` typets` 
- `extensions/copilot/src/platform/github/common/octoKitServiceImpl. propagate unexpected status codests`