### PR TITLE
perf: fix expensive git commands in GVFS repos (chat sessions)

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorkspaceFolderServiceImpl.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorkspaceFolderServiceImpl.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 import * as vscode from 'vscode';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IGitService } from '../../../platform/git/common/gitService';
-import { parseGitChangesRaw } from '../../../platform/git/vscode-node/utils';
+import { buildTempIndexEnv, getChangedFilePaths, isGvfsRepository, parseGitChangesRaw, stageChangedFiles } from '../../../platform/git/vscode-node/utils';
 import { DiffChange } from '../../../platform/git/vscode/git';
 import { ILogService } from '../../../platform/log/common/logService';
 import { SequencerByKey } from '../../../util/vs/base/common/async';
@@ -119,43 +119,60 @@ export class ChatSessionWorkspaceFolderService extends Disposable implements ICh
 			if (hasUntrackedChanges) {
 				// Tracked + untracked changes
 				const tmpDirName = `vscode-sessions-${generateUuid()}`;
-				const diffIndexFile = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName, 'diff.index');
+				const tmpDir = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName);
+				const diffIndexFile = path.join(tmpDir, 'diff.index');
+				const pathspecFile = path.join(tmpDir, 'pathspec.txt');
+				const env = buildTempIndexEnv(diffIndexFile);
 
 				try {
-					// Create temp index file directory
-					await fs.mkdir(path.dirname(diffIndexFile), { recursive: true });
+					// Create temp directory
+					await fs.mkdir(tmpDir, { recursive: true });
 
 					try {
 						// Populate temp index from HEAD, fall back to empty tree if no commits exist
-						await this.gitService.exec(repository.rootUri, ['read-tree', 'HEAD'], { GIT_INDEX_FILE: diffIndexFile });
+						await this.gitService.exec(repository.rootUri, ['read-tree', 'HEAD'], env);
 					} catch {
 						// Fall back to empty tree for repositories with no commits
-						await this.gitService.exec(repository.rootUri, ['read-tree', ChatSessionWorkspaceFolderService.EMPTY_TREE_OBJECT], { GIT_INDEX_FILE: diffIndexFile });
+						await this.gitService.exec(repository.rootUri, ['read-tree', ChatSessionWorkspaceFolderService.EMPTY_TREE_OBJECT], env);
 					}
 
-					// Stage entire working directory into temp index
-					await this.gitService.exec(repository.rootUri, ['add', '-A', '--', '.'], { GIT_INDEX_FILE: diffIndexFile });
+					// Stage only changed files into temp index instead of the entire working
+					// directory. `git add -A -- .` scans all directories, which in GVFS repos
+					// hydrates every placeholder directory (>10min on large repos). Using the
+					// git extension's already-computed change list and --pathspec-from-file
+					// limits staging to only modified files (~0.5s).
+					const changedFiles = getChangedFilePaths(repository);
+					await stageChangedFiles(this.gitService, repository.rootUri, changedFiles, env, pathspecFile);
 
-					// Diff the temp index with the base branch
+					// Diff the temp index with the base branch.
+					// --no-renames is added for GVFS repos because rename detection downloads
+					// blob content for similarity analysis, which is extremely expensive.
+					// Renames will appear as delete+add pairs instead.
+					const gvfs = await isGvfsRepository(this.gitService, repository.rootUri);
+					const noRenamesArg = gvfs ? ['--no-renames'] : [];
 					const result = repositoryProperties.baseBranchName
-						? await this.gitService.exec(repository.rootUri, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--merge-base', repositoryProperties.baseBranchName, '--'], { GIT_INDEX_FILE: diffIndexFile })
-						: await this.gitService.exec(repository.rootUri, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--'], { GIT_INDEX_FILE: diffIndexFile });
+						? await this.gitService.exec(repository.rootUri, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--merge-base', repositoryProperties.baseBranchName, '--'], env)
+						: await this.gitService.exec(repository.rootUri, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--'], env);
 					diffChanges.push(...parseGitChangesRaw(repository.rootUri.fsPath, result));
 				} catch (error) {
 					this.logService.error(`[ChatSessionWorkspaceFolderService][getWorkspaceChanges] Error while processing workspace changes: ${error}`);
 					return [];
 				} finally {
 					try {
-						await fs.rm(path.dirname(diffIndexFile), { recursive: true, force: true });
+						await fs.rm(tmpDir, { recursive: true, force: true });
 					} catch (error) {
 						this.logService.error(`[ChatSessionWorkspaceFolderService][getWorkspaceChanges] Error while cleaning up temp index file: ${error}`);
 					}
 				}
 			} else {
-				// Tracked changes
+				// Tracked changes only (no untracked files).
+				// --no-renames added for GVFS repos to avoid expensive blob hydration
+				// for similarity analysis during rename detection.
+				const gvfs = await isGvfsRepository(this.gitService, repository.rootUri);
+				const noRenamesArg = gvfs ? ['--no-renames'] : [];
 				const result = repositoryProperties.baseBranchName
-					? await this.gitService.exec(repository.rootUri, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--merge-base', repositoryProperties.baseBranchName, '--'])
-					: await this.gitService.exec(repository.rootUri, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--']);
+					? await this.gitService.exec(repository.rootUri, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--merge-base', repositoryProperties.baseBranchName, '--'])
+					: await this.gitService.exec(repository.rootUri, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--']);
 				diffChanges.push(...parseGitChangesRaw(repository.rootUri.fsPath, result));
 			}
 

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorktreeCheckpointServiceImpl.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorktreeCheckpointServiceImpl.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'fs';
 import { Uri } from 'vscode';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IGitService } from '../../../platform/git/common/gitService';
+import { buildTempIndexEnv, getChangedFilePaths, stageChangedFiles } from '../../../platform/git/vscode-node/utils';
 import { ILogService } from '../../../platform/log/common/logService';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import * as path from '../../../util/vs/base/common/path';
@@ -206,25 +207,36 @@ export class ChatSessionWorktreeCheckpointService extends Disposable implements 
 
 	private async _createCheckpoint(sessionId: string, repositoryUri: Uri, turnNumber: number, parentCheckpointRef?: string): Promise<string | undefined> {
 		const tmpDirName = `vscode-sessions-${sessionId}-${generateUuid()}`;
-		const checkpointIndexFile = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName, `checkpoint.index`);
+		const tmpDir = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName);
+		const checkpointIndexFile = path.join(tmpDir, 'checkpoint.index');
+		const pathspecFile = path.join(tmpDir, 'pathspec.txt');
+		const env = buildTempIndexEnv(checkpointIndexFile);
 
 		try {
-			// Create temp index file directory
-			await fs.mkdir(path.dirname(checkpointIndexFile), { recursive: true });
+			// Create temp directory
+			await fs.mkdir(tmpDir, { recursive: true });
 
 			// Resolve parent checkpoint ref
 			const parentCommitOid = parentCheckpointRef
 				? await this.gitService.exec(repositoryUri, ['rev-parse', parentCheckpointRef])
 				: undefined;
 
-			// Populate temp index from previous checkpoint tree (or HEAD for the baseline)
-			await this.gitService.exec(repositoryUri, ['read-tree', parentCommitOid ?? 'HEAD'], { GIT_INDEX_FILE: checkpointIndexFile });
+			// Populate temp index from HEAD so that repository.changes (which is
+			// relative to HEAD) is the correct delta to apply on top.
+			// NOTE: Previously this used `read-tree <parentCommitOid ?? 'HEAD'>`. We
+			// always use HEAD now because getChangedFilePaths() returns changes
+			// relative to HEAD. The parent checkpoint linkage is preserved via -p in
+			// the commit-tree call below.
+			await this.gitService.exec(repositoryUri, ['read-tree', 'HEAD'], env);
 
-			// Stage entire working directory into temp index
-			await this.gitService.exec(repositoryUri, ['add', '-A', '--', '.'], { GIT_INDEX_FILE: checkpointIndexFile });
+			// Stage only changed files into temp index instead of the entire working
+			// directory. See stageChangedFiles() for GVFS performance rationale.
+			const repository = await this.gitService.getRepository(repositoryUri);
+			const changedFiles = repository ? getChangedFilePaths(repository) : [];
+			await stageChangedFiles(this.gitService, repositoryUri, changedFiles, env, pathspecFile);
 
 			// Write the temp index as a tree object
-			const treeOid = await this.gitService.exec(repositoryUri, ['write-tree'], { GIT_INDEX_FILE: checkpointIndexFile });
+			const treeOid = await this.gitService.exec(repositoryUri, ['write-tree'], env);
 
 			// Create a commit pointing to the tree, chained to the previous checkpoint
 			const commitTreeArgs = ['commit-tree', treeOid, ...(parentCommitOid ? ['-p', parentCommitOid] : []), '-m', `Session ${sessionId} - checkpoint turn ${turnNumber}`];
@@ -241,7 +253,7 @@ export class ChatSessionWorktreeCheckpointService extends Disposable implements 
 			return undefined;
 		} finally {
 			try {
-				await fs.rm(path.dirname(checkpointIndexFile), { recursive: true, force: true });
+				await fs.rm(tmpDir, { recursive: true, force: true });
 			} catch (error) {
 				this.logService.error(`[ChatSessionWorktreeCheckpointService][_createCheckpoint] Error while cleaning up temp index file for session ${sessionId}: ${error}`);
 			}

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorktreeServiceImpl.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/chatSessionWorktreeServiceImpl.ts
@@ -12,7 +12,7 @@ import { IVSCodeExtensionContext } from '../../../platform/extContext/common/ext
 import { IGitCommitMessageService } from '../../../platform/git/common/gitCommitMessageService';
 import { IGitService, RepoContext } from '../../../platform/git/common/gitService';
 import { toGitUri } from '../../../platform/git/common/utils';
-import { parseGitChangesRaw } from '../../../platform/git/vscode-node/utils';
+import { buildTempIndexEnv, getChangedFilePaths, isGvfsRepository, parseGitChangesRaw, stageChangedFiles } from '../../../platform/git/vscode-node/utils';
 import { DiffChange } from '../../../platform/git/vscode/git';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IWorkspaceService } from '../../../platform/workspace/common/workspaceService';
@@ -717,35 +717,47 @@ export class ChatSessionWorktreeService extends Disposable implements IChatSessi
 		if (hasUntrackedChanges) {
 			// Tracked + untracked changes
 			const tmpDirName = `vscode-sessions-${sessionId}-${generateUuid()}`;
-			const diffIndexFile = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName, 'diff.index');
+			const tmpDir = path.join(this.extensionContext.globalStorageUri.fsPath, tmpDirName);
+			const diffIndexFile = path.join(tmpDir, 'diff.index');
+			const pathspecFile = path.join(tmpDir, 'pathspec.txt');
+			const env = buildTempIndexEnv(diffIndexFile);
 
 			try {
 
-				// Create temp index file directory
-				await fs.mkdir(path.dirname(diffIndexFile), { recursive: true });
+				// Create temp directory
+				await fs.mkdir(tmpDir, { recursive: true });
 
 				// Populate temp index from HEAD
-				await this.gitService.exec(worktreePath, ['read-tree', 'HEAD'], { GIT_INDEX_FILE: diffIndexFile });
+				await this.gitService.exec(worktreePath, ['read-tree', 'HEAD'], env);
 
-				// Stage entire working directory into temp index
-				await this.gitService.exec(worktreePath, ['add', '-A', '--', '.'], { GIT_INDEX_FILE: diffIndexFile });
+				// Stage only changed files into temp index instead of the entire working
+				// directory. See stageChangedFiles() for GVFS performance rationale.
+				const changedFiles = getChangedFilePaths(worktreeRepository);
+				await stageChangedFiles(this.gitService, worktreePath, changedFiles, env, pathspecFile);
 
-				// Diff the temp index with the base branch
-				const result = await this.gitService.exec(worktreePath, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--merge-base', worktreeProperties.baseBranchName, '--'], { GIT_INDEX_FILE: diffIndexFile });
+				// Diff the temp index with the base branch.
+				// --no-renames added for GVFS repos to avoid expensive blob hydration
+				// for similarity analysis during rename detection.
+				const gvfs = await isGvfsRepository(this.gitService, worktreePath);
+				const noRenamesArg = gvfs ? ['--no-renames'] : [];
+				const result = await this.gitService.exec(worktreePath, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--merge-base', worktreeProperties.baseBranchName, '--'], env);
 				changes.push(...parseGitChangesRaw(worktreeProperties.worktreePath, result));
 			} catch (error) {
 				this.logService.error(`[ChatSessionWorktreeService][_getWorktreeChanges] Error while processing worktree changes for session ${sessionId}: ${error}`);
 				return undefined;
 			} finally {
 				try {
-					await fs.rm(path.dirname(diffIndexFile), { recursive: true, force: true });
+					await fs.rm(tmpDir, { recursive: true, force: true });
 				} catch (error) {
 					this.logService.error(`[ChatSessionWorktreeService][_getWorktreeChanges] Error while cleaning up temp index file for session ${sessionId}: ${error}`);
 				}
 			}
 		} else {
-			// Tracked changes
-			const result = await this.gitService.exec(worktreePath, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', '--merge-base', worktreeProperties.baseBranchName, '--']);
+			// Tracked changes only (no untracked files).
+			// --no-renames added for GVFS repos to avoid expensive blob hydration.
+			const gvfs = await isGvfsRepository(this.gitService, worktreePath);
+			const noRenamesArg = gvfs ? ['--no-renames'] : [];
+			const result = await this.gitService.exec(worktreePath, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', ...noRenamesArg, '--merge-base', worktreeProperties.baseBranchName, '--']);
 			changes.push(...parseGitChangesRaw(worktreeProperties.worktreePath, result));
 		}
 

--- a/extensions/copilot/src/platform/git/vscode-node/utils.ts
+++ b/extensions/copilot/src/platform/git/vscode-node/utils.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { promises as fs } from 'fs';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import { IGitService, RepoContext } from '../common/gitService';
 import { Change, DiffChange } from '../vscode/git';
 
 export function parseGitChangesRaw(repositoryRoot: string, raw: string): DiffChange[] {
@@ -89,4 +91,133 @@ export function parseGitChangesRaw(repositoryRoot: string, raw: string): DiffCha
 		insertions: numStats.get(change.uri.fsPath)?.insertions ?? 0,
 		deletions: numStats.get(change.uri.fsPath)?.deletions ?? 0,
 	}));
+}
+
+/**
+ * Build the environment variables for git commands that use a temporary index file.
+ * Sets GIT_INDEX_FILE and COMMAND_HOOK_LOCK to prevent the GVFS command hook from
+ * holding the main lock when operating on a temporary index.
+ *
+ * Background: In GVFS repos, the command hook acquires a lock that blocks file writes
+ * while any git command runs. By setting COMMAND_HOOK_LOCK, temp-index operations
+ * (read-tree, add, write-tree, diff --cached) won't hold the main lock.
+ * On non-GVFS repos this env var is simply ignored.
+ */
+export function buildTempIndexEnv(indexFile: string): Record<string, string> {
+	return {
+		GIT_INDEX_FILE: indexFile,
+		COMMAND_HOOK_LOCK: '1',
+	};
+}
+
+/**
+ * Get the list of changed file paths from a repository's change tracker.
+ * Returns paths relative to the repository root, suitable for use with
+ * `--pathspec-from-file`. Includes both sides of renames so the deletion
+ * of the old path is staged.
+ *
+ * Background: We use the VS Code git extension's already-computed change state
+ * (repository.changes) rather than running `git status --porcelain` ourselves,
+ * because (a) the git extension already runs status efficiently (and uses
+ * GVFS-optimized code paths), and (b) gitService.exec() trims stdout which
+ * corrupts porcelain v1 output (leading spaces in the XY status column).
+ */
+export function getChangedFilePaths(repository: RepoContext): string[] {
+	if (!repository.changes) {
+		return [];
+	}
+
+	const allChanges = [
+		...repository.changes.indexChanges,
+		...repository.changes.workingTree,
+		...repository.changes.untrackedChanges,
+		...repository.changes.mergeChanges,
+	];
+
+	const seen = new Set<string>();
+	const result: string[] = [];
+	const rootPath = repository.rootUri.fsPath;
+
+	for (const change of allChanges) {
+		const relativePath = path.relative(rootPath, change.uri.fsPath);
+		if (relativePath && !seen.has(relativePath)) {
+			seen.add(relativePath);
+			result.push(relativePath);
+		}
+		// Include originalUri when it differs, so rename deletions are staged
+		if (change.originalUri && change.originalUri.fsPath !== change.uri.fsPath) {
+			const origRelativePath = path.relative(rootPath, change.originalUri.fsPath);
+			if (origRelativePath && !seen.has(origRelativePath)) {
+				seen.add(origRelativePath);
+				result.push(origRelativePath);
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Stage specific changed files into a temporary index using `--pathspec-from-file`,
+ * replacing `git add -A -- .` which scans the entire directory tree.
+ *
+ * Performance: In GVFS (VFSForGit) repos, `git add -A -- .` hydrates every
+ * directory to enumerate all files, taking >10 minutes on large repos. By staging
+ * only the files that actually changed (as reported by the git extension's status),
+ * this drops to ~0.5 seconds. On non-GVFS repos the behavior is identical.
+ *
+ * We write paths to a temp file and use `--pathspec-from-file` rather than passing
+ * files as command-line arguments to avoid OS command-line length limits, and because
+ * gitService.exec() uses execFile which doesn't support stdin piping.
+ *
+ * @param pathspecFile Temp file path to write the pathspec list into. Caller
+ *   is responsible for cleanup of the parent directory.
+ */
+export async function stageChangedFiles(
+	gitService: IGitService,
+	repositoryUri: Uri,
+	changedFiles: string[],
+	env: Record<string, string>,
+	pathspecFile: string,
+): Promise<void> {
+	if (changedFiles.length === 0) {
+		return;
+	}
+	await fs.writeFile(pathspecFile, changedFiles.join('\n'), 'utf8');
+	await gitService.exec(repositoryUri, ['add', '-A', '--pathspec-from-file=' + pathspecFile], env);
+}
+
+// Cache for GVFS detection per repository root
+const gvfsCache = new Map<string, boolean>();
+
+/**
+ * Detect whether a repository uses GVFS (VFSForGit) by checking for the
+ * `core.virtualfilesystem` git config setting. Results are cached per
+ * repository root for the lifetime of the extension.
+ *
+ * This follows the same detection pattern used in repoInfoTelemetry.ts:
+ * any non-empty value for core.virtualfilesystem means VFS is active
+ * (the value is a path to a hook script).
+ */
+export async function isGvfsRepository(
+	gitService: IGitService,
+	repositoryUri: Uri,
+): Promise<boolean> {
+	const key = repositoryUri.toString();
+	const cached = gvfsCache.get(key);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	try {
+		// Any non-empty value means VFS is active (the value is a path to a hook script)
+		const value = await gitService.exec(repositoryUri, ['config', '--get', 'core.virtualfilesystem']);
+		const isGvfs = value.length > 0;
+		gvfsCache.set(key, isGvfs);
+		return isGvfs;
+	} catch {
+		// git config --get exits non-zero when the key is absent
+		gvfsCache.set(key, false);
+		return false;
+	}
 }


### PR DESCRIPTION
The VS Code Copilot chat sessions extension triggers expensive git commands that are problematic in GVFS (VFSForGit) repos:

1. **`git add -A -- .`** with a temp index scans the entire directory tree, hydrating all placeholder directories in GVFS repos (>10min on large repos -> ~0.5s with this fix)
2. **Temp-index git commands** (`read-tree`, `add`, `write-tree`, `diff --cached`) don't set `COMMAND_HOOK_LOCK`, so the GVFS command hook holds the main lock and blocks file writes
3. **Rename detection** in diff commands downloads blob content for similarity analysis -- extremely expensive in GVFS

## Changes

### Unconditional (safe on all repos):

**Targeted file staging** -- Replace `git add -A -- .` with `--pathspec-from-file` using the git extension's already-computed change list. Only modified files are staged, avoiding full directory tree scans.

**COMMAND_HOOK_LOCK** -- Set on all `exec()` calls that use `GIT_INDEX_FILE`. Prevents the GVFS command hook from holding the main lock during temp-index operations. Ignored on non-GVFS repos.

### GVFS-only (gated on `core.virtualfilesystem`):

**`--no-renames`** -- Added to diff commands when GVFS is detected. Renames appear as delete+add pairs instead.

## Files changed

- `extensions/copilot/src/platform/git/vscode-node/utils.ts` -- New helpers: `buildTempIndexEnv`, `getChangedFilePaths`, `stageChangedFiles`, `isGvfsRepository`
- `chatSessionWorkspaceFolderServiceImpl.ts` -- All three changes applied
- `chatSessionWorktreeServiceImpl.ts` -- All three changes applied
- `chatSessionWorktreeCheckpointServiceImpl.ts` -- Targeted staging + COMMAND_HOOK_LOCK. Also changed `read-tree` to always use HEAD.

## Open questions for reviewers

- **`--numstat` kept**: Main cost driver (255s vs 5s) but `statistics` field is consumed by UI. Could be made lazy in follow-up.

## :warning: Draft status

Not build-tested. Submitted as a draft to propose the approach.
