### PR TITLE
sessions: fix "Generate New Task" no-op on existing sessions

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -31,7 +31,8 @@ import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/b
 import { SessionsCategories } from '../../../common/categories.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { IsActiveSessionBackgroundProviderContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
-import { ISession } from '../../../services/sessions/common/session.js';
+import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
+import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { Menus } from '../../../browser/menus.js';
 import { INonSessionTaskEntry, ISessionsConfigurationService, ISessionTaskWithTarget, ITaskEntry, TaskStorageTarget } from './sessionsConfigurationService.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
@@ -123,6 +124,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 		@IActionViewItemService private readonly _actionViewItemService: IActionViewItemService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 	) {
 		super();
 
@@ -171,6 +173,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 					that._activeRunState,
 					(session: ISession) => that._showConfigureQuickPick(session),
 					(session: ISession, existingTask: INonSessionTaskEntry, mode?: TaskConfigurationMode) => that._showCustomCommandInput(session, existingTask, mode),
+					(session: ISession) => that._generateNewTask(session),
 				);
 			},
 		));
@@ -267,10 +270,29 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 
 				async run(): Promise<void> {
 					logSessionsInteraction(that._telemetryService, 'generateNewTask', 'menu');
-					await that._sessionManagementService.sendAndCreateChat(session, { query: '/generate-run-commands' });
+					await that._generateNewTask(session);
 				}
 			}));
 		}));
+	}
+
+	private async _generateNewTask(session: ISession): Promise<void> {
+		const query = '/generate-run-commands';
+		if (session.status.get() === SessionStatus.Untitled) {
+			// New session — create the first chat
+			await this._sessionManagementService.sendAndCreateChat(session, { query });
+		} else {
+			// Existing session — send to the active chat widget directly
+			const activeSession = this._sessionManagementService.activeSession.get();
+			if (!activeSession) {
+				return;
+			}
+			const chatResource = activeSession.activeChat.get().resource;
+			const widget = this._chatWidgetService.getWidgetBySessionResource(chatResource);
+			if (widget) {
+				await widget.acceptInput(query);
+			}
+		}
 	}
 
 	private async _showConfigureQuickPick(session: ISession): Promise<ITaskEntry | undefined> {
@@ -480,13 +502,13 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 		private readonly _activeRunState: IObservable<IRunScriptActionContext | undefined>,
 		private readonly _showConfigureQuickPick: (session: ISession) => Promise<ITaskEntry | undefined>,
 		private readonly _showCustomCommandInput: (session: ISession, existingTask: INonSessionTaskEntry, mode?: TaskConfigurationMode) => Promise<ITaskEntry | undefined>,
+		private readonly _generateNewTask: (session: ISession) => Promise<void>,
 		@ICommandService private readonly _commandService: ICommandService,
 		@ISessionsConfigurationService private readonly _sessionsConfigService: ISessionsConfigurationService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 	) {
 		super(undefined, action);
 
@@ -706,7 +728,7 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 			category: tasksCategory,
 			run: async () => {
 				logSessionsInteraction(this._telemetryService, 'generateNewTask', 'actionWidget');
-				await this._sessionsManagementService.sendAndCreateChat(session, { query: '/generate-run-commands' });
+				await this._generateNewTask(session);
 			},
 		});
 

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -31,7 +31,7 @@ import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/b
 import { SessionsCategories } from '../../../common/categories.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { IsActiveSessionBackgroundProviderContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
-import { ISession, SessionStatus } from '../../../services/sessions/common/session.js';
+import { ISession } from '../../../services/sessions/common/session.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { Menus } from '../../../browser/menus.js';
 import { INonSessionTaskEntry, ISessionsConfigurationService, ISessionTaskWithTarget, ITaskEntry, TaskStorageTarget } from './sessionsConfigurationService.js';
@@ -278,19 +278,13 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 
 	private async _generateNewTask(session: ISession): Promise<void> {
 		const query = '/generate-run-commands';
-		if (session.status.get() === SessionStatus.Untitled) {
-			// New session — create the first chat
-			await this._sessionManagementService.sendAndCreateChat(session, { query });
+		// Prefer sending to the already-open chat widget for the session;
+		// fall back to sendAndCreateChat for untitled sessions or when no widget is loaded.
+		const widget = this._chatWidgetService.getWidgetBySessionResource(session.mainChat.resource);
+		if (widget) {
+			await widget.acceptInput(query);
 		} else {
-			// Existing session — send to the active chat widget directly when available,
-			// otherwise fall back to the session service so the action is not a silent no-op.
-			const chatResource = session.mainChat.resource;
-			const widget = this._chatWidgetService.getWidgetBySessionResource(chatResource);
-			if (widget) {
-				await widget.acceptInput(query);
-			} else {
-				await this._sessionManagementService.sendAndCreateChat(session, { query });
-			}
+			await this._sessionManagementService.sendAndCreateChat(session, { query });
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -282,15 +282,14 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 			// New session — create the first chat
 			await this._sessionManagementService.sendAndCreateChat(session, { query });
 		} else {
-			// Existing session — send to the active chat widget directly
-			const activeSession = this._sessionManagementService.activeSession.get();
-			if (!activeSession) {
-				return;
-			}
-			const chatResource = activeSession.activeChat.get().resource;
+			// Existing session — send to the active chat widget directly when available,
+			// otherwise fall back to the session service so the action is not a silent no-op.
+			const chatResource = session.mainChat.resource;
 			const widget = this._chatWidgetService.getWidgetBySessionResource(chatResource);
 			if (widget) {
 				await widget.acceptInput(query);
+			} else {
+				await this._sessionManagementService.sendAndCreateChat(session, { query });
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #308805

"Generate New Task..." from the run task dropdown silently did nothing when invoked from an existing (completed) session.

## Root Cause

`sendAndCreateChat` only works for:
1. **New (untitled) sessions** — routes through `_sendFirstChat`
2. **Existing sessions with multi-chat enabled** — routes through `_sendSubsequentChat`

When multi-chat is disabled (the default), calling `sendAndCreateChat` on an existing session throws `"Session '…' not found or not a new session"`. This error was silently swallowed by the action framework, making the action appear to do nothing.

This explains the commenter's observation that it works from the new session screen but not from existing sessions.

## Fix

Added a `_generateNewTask` helper in `RunScriptContribution` that checks the session status:
- **Untitled sessions**: Uses `sendAndCreateChat` (existing first-chat flow)
- **Existing sessions**: Sends `/generate-run-commands` directly to the active chat widget via `acceptInput`

Both the menu action and the action widget dropdown now use this helper instead of calling `sendAndCreateChat` directly.