### PR TITLE
terminal: reduce sandbox URL false positives

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -142,6 +142,11 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		'py', 'rar', 'rs', 'so', 'sql', 'svg', 'tar', 'tgz', 'toml', 'ts', 'tsx', 'txt', 'wasm', 'webp',
 		'xml', 'yaml', 'yml', 'zip'
 	]);
+	// Bare host detection is a heuristic used only to prompt before running commands that appear to access the network.
+	// Keep this list intentionally conservative and focused on TLDs commonly used for coding-related hosts and services.
+	private static readonly _wellKnownDomainSuffixes = new Set([
+		'ai', 'cloud', 'com', 'dev', 'io', 'me', 'net', 'org', 'tech'
+	]);
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -579,6 +584,9 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		if (!fromUrl) {
 			const lastLabel = host.slice(host.lastIndexOf('.') + 1);
 			if (TerminalSandboxService._fileExtensionSuffixes.has(lastLabel)) {
+				return undefined;
+			}
+			if (!TerminalSandboxService._wellKnownDomainSuffixes.has(lastLabel)) {
 				return undefined;
 			}
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -427,6 +427,36 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(jsonResult.blockedDomains, undefined, 'File extensions such as .json should not be reported as domains');
 	});
 
+	test('should ignore bare dotted values with unknown domain suffixes', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const commands = [
+			'echo test.invalidtld',
+			'echo test.org.invalidtld',
+			'echo session.completed',
+		];
+
+		for (const command of commands) {
+			const wrapResult = sandboxService.wrapCommand(command, false, 'bash');
+			strictEqual(wrapResult.isSandboxWrapped, true, `Command ${command} should remain sandboxed`);
+			strictEqual(wrapResult.blockedDomains, undefined, `Command ${command} should not report a blocked domain`);
+		}
+	});
+
+	test('should still detect bare hosts with well-known domain suffixes', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const testComResult = sandboxService.wrapCommand('curl test.com', false, 'bash');
+		strictEqual(testComResult.isSandboxWrapped, false, 'Well-known bare domain suffixes should trigger domain checks');
+		deepStrictEqual(testComResult.blockedDomains, ['test.com']);
+
+		const testOrgComResult = sandboxService.wrapCommand('curl test.org.com', false, 'bash');
+		strictEqual(testOrgComResult.isSandboxWrapped, false, 'Well-known bare domain suffixes should trigger domain checks for multi-label hosts');
+		deepStrictEqual(testOrgComResult.blockedDomains, ['test.org.com']);
+	});
+
 	test('should still treat URL authorities with file-like suffixes as domains', async () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 		await sandboxService.getSandboxConfigPath();
@@ -435,6 +465,16 @@ suite('TerminalSandboxService - network domains', () => {
 
 		strictEqual(wrapResult.isSandboxWrapped, false, 'URL authorities should still trigger blocked-domain prompts even when their suffix looks like a file extension');
 		deepStrictEqual(wrapResult.blockedDomains, ['example.zip']);
+	});
+
+	test('should still treat URL authorities with unknown suffixes as domains', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const wrapResult = sandboxService.wrapCommand('curl https://example.bar/path', false, 'bash');
+
+		strictEqual(wrapResult.isSandboxWrapped, false, 'URL authorities should not require a well-known bare-host suffix');
+		deepStrictEqual(wrapResult.blockedDomains, ['example.bar']);
 	});
 
 	test('should still treat ssh remotes with file-like suffixes as domains', async () => {


### PR DESCRIPTION
## Summary
- make bare host detection more conservative by requiring a small set of coding-related domain suffixes
- continue treating explicit URLs and SSH remotes as domains even when the suffix looks file-like or otherwise uncommon
- add regression tests covering valid/invalid bare suffixes, multi-label hosts, explicit URLs, and dotted non-domain identifiers

## Testing
- `npm run transpile-client`
- `npm run test-browser-no-install -- --browser chromium --grep "TerminalSandboxService - network domains"`
- `gulp hygiene` *(fails on unrelated pre-existing/generated file: `extensions/mermaid-chat-features/chat-webview-out/codicon.css: Missing or bad copyright statement`)*

Fixes #308785