### PR TITLE
chat: make codeblock editors simple widgets

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -264,9 +264,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		this.chatContentMarkdownRenderer = this.instantiationService.createInstance(ChatContentMarkdownRenderer);
 		this.markdownDecorationsRenderer = this.instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
-		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode, false));
+		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode, true));
 		this._toolEditorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode, true));
-		this._diffEditorPool = this._register(this.instantiationService.createInstance(DiffEditorPool, editorOptions, delegate, overflowWidgetsDomNode, false));
+		this._diffEditorPool = this._register(this.instantiationService.createInstance(DiffEditorPool, editorOptions, delegate, overflowWidgetsDomNode, true));
 		this._treePool = this._register(this.instantiationService.createInstance(TreePool, this._onDidChangeVisibility.event));
 		this._contentReferencesListPool = this._register(this.instantiationService.createInstance(CollapsibleListPool, this._onDidChangeVisibility.event, undefined, undefined));
 


### PR DESCRIPTION
For #307753

Mark chat codeblock and diff editor pools as simple widgets (`isSimpleWidget: true`) so their text models are not synced to the extension host.

## Background

Chat codeblock editors originally started as simple widgets. In #204780 (Feb 2024), they were experimentally made non-simple to "test in insiders to see the impact." That change stuck, meaning all codeblock text models are currently synced to the extension host via `mainThreadDocumentsAndEditors`.

The tool editor pool was already correctly marked as simple in #255578.

## What this changes

Sets `isSimpleWidget: true` for:
- `_editorPool` — chat response codeblocks
- `_diffEditorPool` — text edit diff editors

This causes `shouldSynchronizeModel()` to return `false` for these models, so they are **not synced to the extension host**.

## What features are affected

Because the models/editors are no longer visible to extensions:

- **Extension-provided language features** — no diagnostics, code actions, quick fixes from language extensions
- **Extension-provided hovers** — no rich type info on hover from language servers
- **Go to Definition / References** — won't resolve through extension language servers
- **Document symbols** — extensions can't provide symbol information
- **Extension-contributed decorations** — decorations by URI won't apply
- **`vscode.workspace.textDocuments` / `vscode.window.visibleTextEditors`** — codeblock models/editors won't appear in extension API

**Preserved** (editor-side, not extension-dependent):
- Syntax highlighting (TextMate grammars)
- Bracket matching, smart select, word highlighting
- Context menus, hover controllers, link detection
- Copy/paste, selection clipboard