### PR TITLE
Use TSgo for the copilot extension typecheck

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6245,7 +6245,7 @@
 		"watch:tsc-extension": "tsc --noEmit --watch --project tsconfig.json",
 		"watch:tsc-extension-web": "tsc --noEmit --watch --project tsconfig.worker.json",
 		"watch:tsc-simulation-workbench": "tsc --noEmit --watch --project test/simulation/workbench/tsconfig.json",
-		"typecheck": "tsc --noEmit --project tsconfig.json && tsc --noEmit --project test/simulation/workbench/tsconfig.json && tsc --noEmit --project tsconfig.worker.json && tsc --noEmit --project src/extension/completions-core/vscode-node/extension/src/copilotPanel/webView/tsconfig.json",
+		"typecheck": "tsgo --noEmit --project tsconfig.json && tsgo --noEmit --project test/simulation/workbench/tsconfig.json && tsgo --noEmit --project tsconfig.worker.json && tsgo --noEmit --project src/extension/completions-core/vscode-node/extension/src/copilotPanel/webView/tsconfig.json",
 		"lint": "eslint . --max-warnings=0",
 		"lint-staged": "eslint --max-warnings=0",
 		"tsfmt": "npx tsfmt -r --verify",

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotPanel/webView/tsconfig.json
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/copilotPanel/webView/tsconfig.json
@@ -5,9 +5,12 @@
 		"skipLibCheck": true, // https://github.com/DataDog/datadog-ci/issues/1059
 		"sourceMap": true,
 		"rootDir": ".",
-		"lib": ["ES2021", "dom"],
+		"lib": [
+			"ES2021",
+			"dom"
+		],
 		// Reset values set in the parent tsconfig
-		"strict": true,   /* enable all strict type-checking options */
+		"strict": true, /* enable all strict type-checking options */
 		/* Additional Checks */
 		"noUnusedLocals": true, /* Report errors on unused locals. */
 		"noImplicitOverride": true, /* Force use of `override` keyword. */
@@ -17,6 +20,9 @@
 		"resolveJsonModule": true,
 		"experimentalDecorators": true,
 		"isolatedModules": false,
+		"types": [
+			"vscode-webview"
+		],
 	},
 	"exclude": [],
 }


### PR DESCRIPTION
For typechecks we're pretty confident that tsgo and tsc should behave the same. Tsgo is faster though

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
