### PR TITLE
Add marketplace deeplink for Browse buttons in customizations editor

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -230,6 +230,13 @@ Browser compatibility is required — no Node.js APIs.
 
 All commands and UI respect `ChatContextKeys.enabled`.
 
+### Commands
+
+| Command ID | Purpose |
+|-----------|---------|
+| `aiCustomization.openManagementEditor` | Opens the management editor, optionally accepting an `AICustomizationManagementSection` to deep-link |
+| `aiCustomization.openMarketplace` | Opens the management editor with marketplace browse mode active. Accepts an optional section (`mcpServers` or `plugins`); defaults to `mcpServers` |
+
 ## Settings
 
 User-facing settings use the `chat.customizations.` namespace:

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -114,7 +114,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 
 	readonly welcomePageFeatures = {
 		showGettingStartedBanner: true,
-		showGenerateActions: false,
+		showGenerateActions: true,
 	};
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -114,7 +114,6 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 
 	readonly welcomePageFeatures = {
 		showGettingStartedBanner: true,
-		showGenerateActions: true,
 	};
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -701,6 +701,28 @@ class AICustomizationManagementActionsContribution extends Disposable implements
 			}
 		}));
 
+		// Open Marketplace (hidden command for deep-linking into browse mode)
+		this._register(registerAction2(class extends Action2 {
+			constructor() {
+				super({
+					id: AICustomizationManagementCommands.OpenMarketplace,
+					title: localize2('openMarketplace', "Open Marketplace"),
+					category: CHAT_CATEGORY,
+					precondition: ChatContextKeys.enabled,
+				});
+			}
+
+			async run(accessor: ServicesAccessor, section?: AICustomizationManagementSection): Promise<void> {
+				const editorService = accessor.get(IEditorService);
+				const input = AICustomizationManagementEditorInput.getOrCreate();
+				const pane = await editorService.openEditor(input, { pinned: true });
+				if (pane instanceof AICustomizationManagementEditor) {
+					const targetSection = section ?? AICustomizationManagementSection.McpServers;
+					pane.selectSectionById(targetSection, { showMarketplace: true });
+				}
+			}
+		}));
+
 		// Generate Debug Report
 		this._register(registerAction2(class extends Action2 {
 			constructor() {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -32,6 +32,7 @@ export type AICustomizationWelcomePageVariant = typeof AI_CUSTOMIZATION_WELCOME_
  */
 export const AICustomizationManagementCommands = {
 	OpenEditor: 'aiCustomization.openManagementEditor',
+	OpenMarketplace: 'aiCustomization.openMarketplace',
 	CreateNewAgent: 'aiCustomization.createNewAgent',
 	CreateNewSkill: 'aiCustomization.createNewSkill',
 	CreateNewInstructions: 'aiCustomization.createNewInstructions',

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -771,6 +771,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.workspaceService.welcomePageFeatures,
 			{
 				selectSection: (section) => this.selectSection(section),
+				selectSectionWithMarketplace: (section) => this.selectSection(section, { showMarketplace: true }),
 				closeEditor: () => {
 					if (this.input) {
 						this.group.closeEditor(this.input);
@@ -1008,8 +1009,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.ensureSectionsListReflectsActiveSection(undefined);
 	}
 
-	private selectSection(section: AICustomizationManagementSection): void {
-		if (this.selectedSection === section) {
+	private selectSection(section: AICustomizationManagementSection, options?: { showMarketplace?: boolean }): void {
+		if (this.selectedSection === section && !options?.showMarketplace) {
 			this.ensureSectionsListReflectsActiveSection(section);
 			return;
 		}
@@ -1043,6 +1044,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 
 		this.ensureSectionsListReflectsActiveSection(section);
+
+		// Activate marketplace browse mode if requested
+		if (options?.showMarketplace) {
+			if (section === AICustomizationManagementSection.McpServers) {
+				this.mcpListWidget?.showBrowseMarketplace();
+			} else if (section === AICustomizationManagementSection.Plugins) {
+				this.pluginListWidget?.showBrowseMarketplace();
+			}
+		}
 	}
 
 	private ensureSectionsListReflectsActiveSection(section: AICustomizationManagementSection | undefined = this.selectedSection): void {
@@ -1396,7 +1406,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	/**
 	 * Selects a specific section programmatically.
 	 */
-	public selectSectionById(sectionId: AICustomizationManagementSection): void {
+	public selectSectionById(sectionId: AICustomizationManagementSection, options?: { showMarketplace?: boolean }): void {
 		const index = this.sections.findIndex(s => s.id === sectionId);
 		if (index >= 0) {
 			// Directly update state and UI, bypassing the early-return guard in selectSection
@@ -1424,6 +1434,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 				this.layout(this.dimension);
 			}
 			this.ensureSectionsListReflectsActiveSection(sectionId);
+
+			// Activate marketplace browse mode if requested
+			if (options?.showMarketplace) {
+				if (sectionId === AICustomizationManagementSection.McpServers) {
+					this.mcpListWidget?.showBrowseMarketplace();
+				} else if (sectionId === AICustomizationManagementSection.Plugins) {
+					this.pluginListWidget?.showBrowseMarketplace();
+				}
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePage.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePage.ts
@@ -16,6 +16,7 @@ const $ = DOM.$;
 
 export interface IWelcomePageCallbacks {
 	selectSection(section: AICustomizationManagementSection): void;
+	selectSectionWithMarketplace(section: AICustomizationManagementSection): void;
 	closeEditor(): void;
 	/**
 	 * Prefill the chat input with a query. In the sessions window this

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -93,7 +93,7 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 		heading.textContent = localize('welcomeHeading', "Chat Customizations");
 
 		const subtitle = DOM.append(welcomeInner, $('p.welcome-classic-subtitle'));
-		subtitle.textContent = localize('welcomeSubtitle', "Tailor how AI agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.");
+		subtitle.textContent = localize('welcomeSubtitle', "Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.");
 
 		if (this.welcomePageFeatures?.showGettingStartedBanner !== false) {
 			const gettingStarted = DOM.append(welcomeInner, $('button.welcome-classic-getting-started')) as HTMLButtonElement;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -159,7 +159,7 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 				}
 			}));
 
-			if (category.promptType && this.welcomePageFeatures?.showGenerateActions !== false) {
+			if (category.promptType) {
 				const generateBtn = DOM.append(footer, $('button.welcome-classic-card-generate'));
 				DOM.append(generateBtn, $('span.codicon.codicon-sparkle'));
 				const label = DOM.append(generateBtn, $('span'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -145,9 +145,14 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 			const footer = DOM.append(card, $('.welcome-classic-card-footer'));
 			const browseBtn = DOM.append(footer, $('button.welcome-classic-card-browse'));
 			browseBtn.textContent = localize('browse', "Browse");
+			const hasMarketplace = category.id === AICustomizationManagementSection.McpServers || category.id === AICustomizationManagementSection.Plugins;
 			this.cardDisposables.add(DOM.addDisposableListener(browseBtn, 'click', e => {
 				e.stopPropagation();
-				this.callbacks.selectSection(category.id);
+				if (hasMarketplace) {
+					this.callbacks.selectSectionWithMarketplace(category.id);
+				} else {
+					this.callbacks.selectSection(category.id);
+				}
 			}));
 
 			if (category.promptType && this.welcomePageFeatures?.showGenerateActions !== false) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -168,8 +168,8 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 					e.stopPropagation();
 					this.callbacks.closeEditor();
 					if (this.workspaceService.isSessionsWindow) {
-						const typeLabel = category.label.toLowerCase();
-						this.callbacks.prefillChat(`Create me a ${typeLabel} that `, { isPartialQuery: true });
+						const typeLabel = category.label.toLowerCase().replace(/s$/, '');
+						this.callbacks.prefillChat(`Create me a custom ${typeLabel} that `, { isPartialQuery: true });
 					} else {
 						this.workspaceService.generateCustomization(category.promptType!);
 					}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -112,7 +112,7 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 				if (this.workspaceService.isSessionsWindow) {
 					this.callbacks.prefillChat('Generate agent customizations. ', { isPartialQuery: true });
 				} else {
-					this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customization ', isPartialQuery: true });
+					this.commandService.executeCommand('workbench.action.chat.open', { query: '/init ', isPartialQuery: true });
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic.ts
@@ -109,7 +109,11 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 			chevron.setAttribute('aria-hidden', 'true');
 			this._register(DOM.addDisposableListener(gettingStarted, 'click', () => {
 				this.callbacks.closeEditor();
-				this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customization ', isPartialQuery: true });
+				if (this.workspaceService.isSessionsWindow) {
+					this.callbacks.prefillChat('Generate agent customizations. ', { isPartialQuery: true });
+				} else {
+					this.commandService.executeCommand('workbench.action.chat.open', { query: '/agent-customization ', isPartialQuery: true });
+				}
 			}));
 		}
 
@@ -163,7 +167,12 @@ export class ClassicAICustomizationWelcomePage extends Disposable implements IAI
 				this.cardDisposables.add(DOM.addDisposableListener(generateBtn, 'click', e => {
 					e.stopPropagation();
 					this.callbacks.closeEditor();
-					this.workspaceService.generateCustomization(category.promptType!);
+					if (this.workspaceService.isSessionsWindow) {
+						const typeLabel = category.label.toLowerCase();
+						this.callbacks.prefillChat(`Create me a ${typeLabel} that `, { isPartialQuery: true });
+					} else {
+						this.workspaceService.generateCustomization(category.promptType!);
+					}
 				}));
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -175,7 +175,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 				browseBtn.textContent = localize('browse', "Browse...");
 				this.cardDisposables.add(DOM.addDisposableListener(browseBtn, 'click', e => {
 					e.stopPropagation();
-					this.callbacks.selectSection(category.id);
+					this.callbacks.selectSectionWithMarketplace(category.id);
 				}));
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -109,7 +109,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 			const inputRow = DOM.append(gettingStarted, $('.welcome-prompts-input-row'));
 			this.inputElement = DOM.append(inputRow, $('input.welcome-prompts-input')) as HTMLInputElement;
 			this.inputElement.type = 'text';
-			this.inputElement.placeholder = localize('workflowInputPlaceholder', "Describe your project and coding patterns...");
+			this.inputElement.placeholder = localize('workflowInputPlaceholder', "I'm building a React app with TypeScript and Tailwind...");
 			this.inputElement.setAttribute('aria-label', localize('workflowInputAriaLabel', "Describe your project to generate a workflow"));
 
 			const submitBtn = DOM.append(inputRow, $('button.welcome-prompts-input-submit'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -167,7 +167,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 			descEl.textContent = category.description;
 
 			const footer = DOM.append(card, $('.welcome-prompts-card-footer'));
-			if (category.promptType && this.welcomePageFeatures?.showGenerateActions !== false) {
+			if (category.promptType) {
 				const generateBtn = DOM.append(footer, $('button.welcome-prompts-card-action'));
 				generateBtn.textContent = localize('new', "New...");
 				this.cardDisposables.add(DOM.addDisposableListener(generateBtn, 'click', e => {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -120,7 +120,12 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 			const submit = () => {
 				const value = this.inputElement?.value?.trim();
 				this.callbacks.closeEditor();
-				const query = value ? `/agent-customization ${value}` : '/agent-customization ';
+				let query: string;
+				if (this.workspaceService.isSessionsWindow) {
+					query = value ? `Generate agent customizations. ${value}` : 'Generate agent customizations. ';
+				} else {
+					query = value ? `/agent-customization ${value}` : '/agent-customization ';
+				}
 				this.callbacks.prefillChat(query, { isPartialQuery: !value });
 			};
 			this._register(DOM.addDisposableListener(submitBtn, 'click', submit));
@@ -168,7 +173,12 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 				this.cardDisposables.add(DOM.addDisposableListener(generateBtn, 'click', e => {
 					e.stopPropagation();
 					this.callbacks.closeEditor();
-					this.workspaceService.generateCustomization(category.promptType!);
+					if (this.workspaceService.isSessionsWindow) {
+						const typeLabel = category.label.toLowerCase();
+						this.callbacks.prefillChat(`Create me a ${typeLabel} that `, { isPartialQuery: true });
+					} else {
+						this.workspaceService.generateCustomization(category.promptType!);
+					}
 				}));
 			} else {
 				const browseBtn = DOM.append(footer, $('button.welcome-prompts-card-action'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -124,7 +124,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 				if (this.workspaceService.isSessionsWindow) {
 					query = value ? `Generate agent customizations. ${value}` : 'Generate agent customizations. ';
 				} else {
-					query = value ? `/agent-customization ${value}` : '/agent-customization ';
+					query = value ? `/init ${value}` : '/init ';
 				}
 				this.callbacks.prefillChat(query, { isPartialQuery: !value });
 			};

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -93,7 +93,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 		heading.textContent = localize('welcomeHeading', "Agent Customizations");
 
 		const subtitle = DOM.append(welcomeInner, $('p.welcome-prompts-subtitle'));
-		subtitle.textContent = localize('welcomeSubtitle', "Tailor how your agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.");
+		subtitle.textContent = localize('welcomeSubtitle', "Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.");
 
 		if (this.welcomePageFeatures?.showGettingStartedBanner !== false) {
 			const gettingStarted = DOM.append(welcomeInner, $('.welcome-prompts-primary'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -174,8 +174,8 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 					e.stopPropagation();
 					this.callbacks.closeEditor();
 					if (this.workspaceService.isSessionsWindow) {
-						const typeLabel = category.label.toLowerCase();
-						this.callbacks.prefillChat(`Create me a ${typeLabel} that `, { isPartialQuery: true });
+						const typeLabel = category.label.toLowerCase().replace(/s$/, '');
+						this.callbacks.prefillChat(`Create me a custom ${typeLabel} that `, { isPartialQuery: true });
 					} else {
 						this.workspaceService.generateCustomization(category.promptType!);
 					}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -66,7 +66,6 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 
 	readonly welcomePageFeatures = {
 		showGettingStartedBanner: true,
-		showGenerateActions: true,
 	};
 
 	readonly hasOverrideProjectRoot = constObservable(false);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -587,6 +587,12 @@ export class McpListWidget extends Disposable {
 		}
 	}
 
+	public showBrowseMarketplace(): void {
+		if (!this.browseMode) {
+			this.toggleBrowseMode(true);
+		}
+	}
+
 	private toggleBrowseMode(browse: boolean): void {
 		this.browseMode = browse;
 		this.searchInput.value = '';

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationWelcomePromptLaunchers.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationWelcomePromptLaunchers.css
@@ -27,7 +27,7 @@
 .ai-customization-management-editor .welcome-prompts-subtitle {
 	font-size: 13px;
 	color: var(--vscode-descriptionForeground);
-	margin: 0 0 20px;
+	margin: 0 0 40px;
 	line-height: 1.6;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -583,6 +583,12 @@ export class PluginListWidget extends Disposable {
 		}
 	}
 
+	public showBrowseMarketplace(): void {
+		if (!this.browseMode) {
+			this.toggleBrowseMode(true);
+		}
+	}
+
 	private toggleBrowseMode(browse: boolean): void {
 		this.browseMode = browse;
 		this.searchInput.value = '';

--- a/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
@@ -64,8 +64,6 @@ export interface IStorageSourceFilter {
 export interface IWelcomePageFeatures {
 	/** Show the "Configure Your AI" getting-started banner. */
 	readonly showGettingStartedBanner: boolean;
-	/** Show "Generate with AI" actions on category cards. */
-	readonly showGenerateActions: boolean;
 }
 
 /**

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationListWidget.fixture.ts
@@ -103,7 +103,6 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 		override readonly isSessionsWindow = false;
 		override readonly welcomePageFeatures = {
 			showGettingStartedBanner: true,
-			showGenerateActions: true,
 		};
 		override readonly activeProjectRoot = activeProjectRoot;
 		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -461,7 +461,6 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 				override readonly isSessionsWindow = isSessionsWindow;
 				override readonly welcomePageFeatures = {
 					showGettingStartedBanner: true,
-					showGenerateActions: !isSessionsWindow,
 				};
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
@@ -639,7 +638,6 @@ async function renderMcpBrowseMode(ctx: ComponentFixtureContext): Promise<void> 
 				override readonly isSessionsWindow = false;
 				override readonly welcomePageFeatures = {
 					showGettingStartedBanner: true,
-					showGenerateActions: true,
 				};
 				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
 				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationWelcomePages.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationWelcomePages.fixture.ts
@@ -43,7 +43,6 @@ function createMockWorkspaceService(): IAICustomizationWorkspaceService {
 		override readonly managementSections = Array.from(visibleSections);
 		override readonly welcomePageFeatures = {
 			showGettingStartedBanner: true,
-			showGenerateActions: true,
 		};
 		override readonly activeProjectRoot = constObservable(URI.file('/workspace'));
 		override readonly hasOverrideProjectRoot = constObservable(false);

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationWelcomePages.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationWelcomePages.fixture.ts
@@ -91,6 +91,7 @@ function renderClassicWelcomePage(ctx: ComponentFixtureContext): void {
 		workspaceService.welcomePageFeatures,
 		{
 			selectSection: () => { },
+			selectSectionWithMarketplace: () => { },
 			closeEditor: () => { },
 			prefillChat: () => { },
 		},
@@ -108,6 +109,7 @@ function renderPromptLaunchersWelcomePage(ctx: ComponentFixtureContext): void {
 		workspaceService.welcomePageFeatures,
 		{
 			selectSection: () => { },
+			selectSectionWithMarketplace: () => { },
 			closeEditor: () => { },
 			prefillChat: () => { },
 		},
@@ -128,6 +130,7 @@ function renderSelectedWelcomePage(ctx: ComponentFixtureContext, variant: AICust
 		workspaceService.welcomePageFeatures,
 		{
 			selectSection: () => { },
+			selectSectionWithMarketplace: () => { },
 			closeEditor: () => { },
 			prefillChat: () => { },
 		},


### PR DESCRIPTION
The "Browse..." buttons on MCP Servers and Plugins welcome page cards now open the section with the marketplace browse mode active, instead of just navigating to the installed list.

## Changes

- Add public `showBrowseMarketplace()` to `McpListWidget` and `PluginListWidget`
- Extend `selectSectionById`/`selectSection` with `{ showMarketplace }` option
- Add hidden `aiCustomization.openMarketplace` command for programmatic deeplink
- Add `selectSectionWithMarketplace` callback to `IWelcomePageCallbacks`
- Wire Browse buttons on MCP/Plugin cards to activate marketplace mode in both classic and prompt-launchers welcome pages