### PR TITLE
fix: exclude source annotations from text selection in debug console

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/repl.css
+++ b/src/vs/workbench/contrib/debug/browser/media/repl.css
@@ -89,6 +89,8 @@
 	/*Use direction so the source shows elipses on the left*/
 	direction: rtl;
 	max-width: 400px;
+	user-select: none;
+	-webkit-user-select: none;
 }
 
 .monaco-workbench .repl .repl-tree .output.expression > .value,


### PR DESCRIPTION
## Summary

- Fixes source location annotations (e.g. `repl:1`) being included in clipboard text when selecting and copying multi-line output from the Debug Console
- Adds `user-select: none` to the `.source` element in the REPL tree so the annotation is excluded from native text selections while remaining visible and clickable

## Root cause

The REPL tree enables text selection on `.monaco-tl-contents` via `user-select: text`. The source annotation (rendered by `SourceWidget` as a `.source` element) lives inside the same flex container (`.value-and-source`) as the output value. When a user selects text across multiple output lines, the browser's native selection includes the source annotation text, causing strings like `repl:1` to appear in the pasted result.

## Test plan

- [ ] Start a debug session and hit a breakpoint
- [ ] In the Debug Console, run `console.log('hello \n there')`
- [ ] Select the multi-line "hello there" output text
- [ ] Copy and paste — verify the result is `hello \n there` without `repl:1` inserted
- [ ] Verify the source annotation is still visible and clickable (opens the source location)

Fixes #275702