### PR TITLE
fix: clear GitHub remote source cache when session changes

### DIFF
--- a/extensions/github/src/auth.ts
+++ b/extensions/github/src/auth.ts
@@ -36,6 +36,10 @@ export async function getSession(): Promise<AuthenticationSession> {
 
 let _octokit: Promise<Octokit> | undefined;
 
+export function clearOctokitCache(): void {
+	_octokit = undefined;
+}
+
 export function getOctokit(): Promise<Octokit> {
 	if (!_octokit) {
 		_octokit = getSession().then(async session => {
@@ -71,6 +75,7 @@ export class OctokitService {
 		this._disposables.add(authentication.onDidChangeSessions(e => {
 			if (e.provider.id === 'github') {
 				this._octokitGraphql = undefined;
+				clearOctokitCache();
 				this._onDidChangeSessions.fire();
 			}
 		}));

--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -50,7 +50,9 @@ function initializeGitBaseExtension(): Disposable {
 		try {
 			const gitBaseAPI = gitBaseExtension.getAPI(1);
 
-			disposables.add(gitBaseAPI.registerRemoteSourceProvider(new GithubRemoteSourceProvider()));
+			const remoteSourceProvider = new GithubRemoteSourceProvider();
+			disposables.add(remoteSourceProvider);
+			disposables.add(gitBaseAPI.registerRemoteSourceProvider(remoteSourceProvider));
 		}
 		catch (err) {
 			console.error('Could not initialize GitHub extension');

--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, env, l10n, workspace } from 'vscode';
+import { Disposable, Uri, authentication, env, l10n, workspace } from 'vscode';
 import { RemoteSourceProvider, RemoteSource, RemoteSourceAction } from './typings/git-base.js';
 import { getOctokit } from './auth.js';
 import { Octokit } from '@octokit/rest';
@@ -29,13 +29,26 @@ function asRemoteSource(raw: RemoteSourceResponse): RemoteSource {
 	};
 }
 
-export class GithubRemoteSourceProvider implements RemoteSourceProvider {
+export class GithubRemoteSourceProvider implements RemoteSourceProvider, Disposable {
 
 	readonly name = 'GitHub';
 	readonly icon = 'github';
 	readonly supportsQuery = true;
 
+	private readonly disposables: Disposable[] = [];
 	private userReposCache: RemoteSource[] = [];
+
+	constructor() {
+		this.disposables.push(authentication.onDidChangeSessions(e => {
+			if (e.provider.id === 'github') {
+				this.userReposCache = [];
+			}
+		}));
+	}
+
+	dispose(): void {
+		this.disposables.forEach(d => d.dispose());
+	}
 
 	async getRemoteSources(query?: string): Promise<RemoteSource[]> {
 		const octokit = await getOctokit();


### PR DESCRIPTION
## Summary

- Clears the cached Octokit REST client and user repository list in the GitHub extension when the GitHub authentication session changes (sign-out/sign-in)
- Makes `GithubRemoteSourceProvider` listen to `authentication.onDidChangeSessions` and reset `userReposCache` so previously linked repos no longer appear in the clone dialog after sign-out
- Properly disposes the session change listener when the extension is deactivated

## Test plan

- [ ] Sign into GitHub in VS Code
- [ ] Open Git: Clone and confirm repos from the signed-in GitHub account appear
- [ ] Sign out of GitHub via the account menu
- [ ] Open Git: Clone again and confirm repos from the signed-out account no longer appear (without restarting VS Code)
- [ ] Sign back in to GitHub and confirm repos re-appear

Fixes #164868