### PR TITLE
editor: remove debug console.warn logs from render path

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -601,10 +601,6 @@ export class View extends ViewEventHandler {
 				inputLatency.onRenderStart();
 
 				if (!this.domNode.domNode.isConnected) {
-					const model = this._context.viewModel.model;
-					if (model.uri.scheme === 'vscode-chat-code-block') {
-						console.warn(`[EditorView] Render dropped: isConnected=false for ${model.uri.toString()}`);
-					}
 					return null;
 				}
 
@@ -612,10 +608,6 @@ export class View extends ViewEventHandler {
 				const viewLinesShouldRender = this._viewLines.shouldRender();
 				if (!viewLinesShouldRender && viewPartsToRender.length === 0) {
 					// Nothing to render
-					const model = this._context.viewModel.model;
-					if (model.uri.scheme === 'vscode-chat-code-block') {
-						console.warn(`[EditorView] Render dropped: nothing to render for ${model.uri.toString()}, viewLines.shouldRender=${viewLinesShouldRender}, viewParts=${viewPartsToRender.length}`);
-					}
 					return null;
 				}
 


### PR DESCRIPTION
Remove the two `console.warn` messages in `EditorView`'s coordinated rendering path that logged render drops for `vscode-chat-code-block` editors. These were added for debugging and are no longer needed.