### PR TITLE
fix: re-evaluate active editor repository on SCM repository changes

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -278,9 +278,17 @@ export class SCMViewService implements ISCMViewService {
 			equalsFn: () => false
 		}, this.editorService.onDidActiveEditorChange, () => this.editorService.activeEditor);
 
+		// Track repository additions/removals so that the active editor
+		// repository is re-evaluated when SCM providers become available.
+		const repositoriesChangedObs = observableFromEventOpts<readonly ISCMRepository[]>({
+			owner: this,
+			equalsFn: () => false
+		}, Event.any(this.scmService.onDidAddRepository, this.scmService.onDidRemoveRepository), () => [...this.scmService.repositories]);
+
 		this._activeEditorRepositoryObs = derivedObservableWithCache<ISCMRepository | undefined>(this,
 			(reader, lastValue) => {
 				const activeEditor = this._activeEditorObs.read(reader);
+				repositoriesChangedObs.read(reader);
 				const activeResource = EditorResourceAccessor.getOriginalUri(activeEditor);
 				if (!activeResource) {
 					return lastValue;


### PR DESCRIPTION
## Summary

The `_activeEditorRepositoryObs` observable in `SCMViewService` only re-evaluated when the active editor changed. This caused the active repository context to become stale or empty when:

- An editor was already open before SCM providers finished loading their repositories
- Repositories were added or removed while the same editor remained active

This fix adds a dependency on `onDidAddRepository` / `onDidRemoveRepository` so the active editor repository is re-evaluated whenever the set of known repositories changes.

## Test plan

- Open a multi-root workspace and verify that `${activeRepositoryName}` and `${activeRepositoryBranchName}` window title variables reflect the correct repository immediately after load
- Open an editor, then add/remove a Git repository from the workspace, and verify the active repository context updates without requiring an editor switch

Fixes #267239