### PR TITLE
Fix minimap MARK section headers including comment closing delimiters

### DIFF
--- a/src/vs/editor/common/services/findSectionHeaders.ts
+++ b/src/vs/editor/common/services/findSectionHeaders.ts
@@ -40,6 +40,7 @@ export interface SectionHeader {
 }
 
 const trimDashesRegex = /^-+|-+$/g;
+const trailingCommentCloseRegex = /\s*(?:\*\/|-->)\s*$/;
 
 const CHUNK_SIZE = 100;
 const MAX_SECTION_LINES = 5;
@@ -148,7 +149,7 @@ export function collectMarkHeaders(model: ISectionHeaderFinderTarget, options: F
 				endColumn
 			};
 
-			const text2 = (match.groups ?? {})['label'] ?? '';
+			const text2 = stripTrailingCommentClose((match.groups ?? {})['label'] ?? '');
 			const hasSeparatorLine = ((match.groups ?? {})['separator'] ?? '') !== '';
 
 			const sectionHeader = {
@@ -178,4 +179,12 @@ function getHeaderText(text: string): { text: string; hasSeparatorLine: boolean 
 	const hasSeparatorLine = text.startsWith('-');
 	text = text.replace(trimDashesRegex, '');
 	return { text, hasSeparatorLine };
+}
+
+/**
+ * Strip trailing comment closing delimiters from section header label text,
+ * since these are not part of the actual header name.
+ */
+function stripTrailingCommentClose(text: string): string {
+	return text.replace(trailingCommentCloseRegex, '');
 }

--- a/src/vs/editor/test/common/services/findSectionHeaders.test.ts
+++ b/src/vs/editor/test/common/services/findSectionHeaders.test.ts
@@ -405,4 +405,52 @@ suite('FindSectionHeaders', () => {
 		assert.strictEqual(headers[2].range.startLineNumber, 7);
 		assert.strictEqual(headers[2].range.endLineNumber, 9);
 	});
+
+	test('strips trailing HTML comment close from label', () => {
+		const model = new TestSectionHeaderFinderTarget([
+			'<!-- MARK: Label -->',
+		]);
+
+		const options: FindSectionHeaderOptions = {
+			findRegionSectionHeaders: false,
+			findMarkSectionHeaders: true,
+			markSectionHeaderRegex: '\\bMARK:\\s*(?<separator>\\-?)\\s*(?<label>.*)$'
+		};
+
+		const headers = findSectionHeaders(model, options);
+		assert.strictEqual(headers.length, 1);
+		assert.strictEqual(headers[0].text, 'Label');
+	});
+
+	test('strips trailing block comment close from label', () => {
+		const model = new TestSectionHeaderFinderTarget([
+			'/* MARK: this is a test */',
+		]);
+
+		const options: FindSectionHeaderOptions = {
+			findRegionSectionHeaders: false,
+			findMarkSectionHeaders: true,
+			markSectionHeaderRegex: '\\bMARK:\\s*(?<separator>\\-?)\\s*(?<label>.*)$'
+		};
+
+		const headers = findSectionHeaders(model, options);
+		assert.strictEqual(headers.length, 1);
+		assert.strictEqual(headers[0].text, 'this is a test');
+	});
+
+	test('does not strip comment close from middle of label', () => {
+		const model = new TestSectionHeaderFinderTarget([
+			'// MARK: A --> B section',
+		]);
+
+		const options: FindSectionHeaderOptions = {
+			findRegionSectionHeaders: false,
+			findMarkSectionHeaders: true,
+			markSectionHeaderRegex: '\\bMARK:\\s*(?<separator>\\-?)\\s*(?<label>.*)$'
+		};
+
+		const headers = findSectionHeaders(model, options);
+		assert.strictEqual(headers.length, 1);
+		assert.strictEqual(headers[0].text, 'A --> B section');
+	});
 });


### PR DESCRIPTION
Fixes #210371

## Problem

When using `MARK:` inside block comments (HTML `<!-- -->` or C-style `/* */`), the minimap section header displays the comment closing delimiter as part of the label text.

For example:
- `<!-- MARK: Label -->` shows as **"Label -->"** instead of **"Label"**
- `/* MARK: this is a test */` shows as **"this is a test \*/"** instead of **"this is a test"**

This happens because the default `markSectionHeaderRegex` (`\bMARK:\s*(?<separator>\-?)\s*(?<label>.*)$`) captures everything after `MARK:` to end of line, including trailing comment delimiters.

## Solution

Strip trailing comment closing delimiters (`*/` and `-->`) from the captured label text after the regex match, before the text is used as a section header. This is done via a simple regex replacement that only targets these delimiters when they appear at the end of the label string.

This approach:
- Does not change the default regex (no breaking change for users with custom regexes)
- Only strips `*/` and `-->` at the end of the label (not in the middle, so labels like `A --> B section` are preserved)
- Handles both HTML and C-style block comment syntax

## Test plan

- [x] Added unit tests for HTML comment close stripping (`<!-- MARK: Label -->`)
- [x] Added unit tests for block comment close stripping (`/* MARK: this is a test */`)
- [x] Added unit test confirming `-->` in the middle of a label is NOT stripped
- [x] Existing tests continue to pass
- [x] Compile check passes (`npm run compile-check-ts-native`)