### PR TITLE
feat: apply selected option values to active chat sessions on update

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1156,6 +1156,21 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	public setOptionGroupsForSessionType(chatSessionType: string, handle: number, optionGroups?: IChatSessionProviderOptionGroup[]): void {
 		if (optionGroups) {
 			this._sessionTypeOptions.set(chatSessionType, optionGroups);
+
+			// Apply selected values from the updated option groups directly to all active
+			// sessions of this type. We write to the session's option cache without firing
+			// _onDidChangeSessionOptions to avoid a feedback loop: that event triggers
+			// $provideHandleOptionsChange back to the extension host, which may re-set
+			// inputState.groups -> $updateChatSessionInputState -> here again.
+			for (const [_, sessionData] of this._sessions) {
+				if (sessionData.chatSessionType === chatSessionType) {
+					for (const group of optionGroups) {
+						if (group.selected) {
+							sessionData.setOption(group.id, group.selected);
+						}
+					}
+				}
+			}
 		} else {
 			this._sessionTypeOptions.delete(chatSessionType);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
for https://github.com/microsoft/vscode/issues/288457#issuecomment-4157935788

Initializing selected property after handling onDidChange doesn't work, I can see the items in the dropdown have change, however the selected value in the UI is still the old value @mjbvz @DonJayamanne
This is a blocker in multi-root workspace or empty workspace
