### PR TITLE
Enhance welcome view to pre-select and deduplicate selected folder

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/sessionOptionGroupBuilder.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/sessionOptionGroupBuilder.ts
@@ -401,6 +401,15 @@ export class SessionOptionGroupBuilder implements ISessionOptionGroupBuilder {
 			const repositories = await this.copilotCLIFolderMruService.getRecentlyUsedFolders(CancellationToken.None);
 			const newFolder = previousInputState ? this._inputStateNewFolders.get(previousInputState) : undefined;
 			items = folderMRUToChatProviderOptions(repositories);
+			const selectedFolderItem = selectedFolderUri ? items.find(i => i.id === selectedFolderUri.fsPath) : undefined;
+			const selectedItem = selectedFolderItem
+				?? (previouslySelected
+					? items.find(i => i.id === previouslySelected.id) ?? items[0]
+					: items[0]);
+			if (selectedItem) {
+				defaultRepoUri = vscode.Uri.file(selectedItem.id);
+			}
+
 			items.splice(MAX_MRU_ENTRIES); // Limit to max entries
 			if (newFolder) {
 				const newFolderRepo = await this.getTrustedRepository(newFolder, true);
@@ -411,19 +420,16 @@ export class SessionOptionGroupBuilder implements ISessionOptionGroupBuilder {
 				items = items.filter(item => item.id !== newFolderItem.id);
 				items.unshift(newFolderItem);
 			}
+			// If user selected something from the list but it's not there anymore (perhaps its an item at the end of MRU).
+			if (selectedItem && !items.some(item => item.id === selectedItem.id)) {
+				items.push(selectedItem);
+			}
+
 			commands.push({
 				command: OPEN_REPOSITORY_COMMAND_ID,
 				title: l10n.t('Browse folders...')
 			});
 
-			const selectedFolderItem = selectedFolderUri ? items.find(i => i.id === selectedFolderUri.fsPath) : undefined;
-			const selectedItem = selectedFolderItem
-				?? (previouslySelected
-					? items.find(i => i.id === previouslySelected.id) ?? items[0]
-					: items[0]);
-			if (selectedItem) {
-				defaultRepoUri = vscode.Uri.file(selectedItem.id);
-			}
 			optionGroups.push({
 				id: REPOSITORY_OPTION_ID,
 				name: l10n.t('Folder'),

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/sessionOptionGroupBuilder.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/sessionOptionGroupBuilder.spec.ts
@@ -895,6 +895,36 @@ describe('SessionOptionGroupBuilder', () => {
 				expect(repoGroup!.items[0].id).toBe(sharedUri.fsPath);
 			});
 
+			it('does not duplicate selected item when new folder replaces its MRU entry', async () => {
+				// Regression: the selected item was resolved from MRU before
+				// deduplication replaced it with a fresh object. Using reference
+				// equality (Array.includes) caused the stale reference to be
+				// re-appended, creating a duplicate.
+				workspaceService = new NullWorkspaceService([]);
+				builder = new SessionOptionGroupBuilder(
+					gitService, configurationService, context, workspaceService,
+					folderMruService, agentSessionsWorkspace, worktreeService, folderRepositoryManager,
+				);
+				const repoUri = URI.file('/my-repo');
+				folderMruService.getRecentlyUsedFolders.mockResolvedValue([
+					{ folder: repoUri, repository: repoUri, lastAccessed: Date.now() },
+				]);
+				gitService.getRepository.mockResolvedValue(makeRepo(repoUri.fsPath));
+
+				const previousState: vscode.ChatSessionInputState = {
+					onDidChange: Event.None,
+					groups: [],
+				};
+				builder.setNewFolderForInputState(previousState, repoUri as any);
+
+				const groups = await builder.provideChatSessionProviderOptionGroups(previousState);
+				const repoGroup = groups.find(g => g.id === REPOSITORY_OPTION_ID)!;
+				// Selected item must reference an object that is in the items list
+				expect(repoGroup.items.some(i => i.id === repoGroup.selected?.id)).toBe(true);
+				// And there must be exactly one item with that id
+				expect(repoGroup.items.filter(i => i.id === repoUri.fsPath)).toHaveLength(1);
+			});
+
 			it('does not add new folder when no previousInputState', async () => {
 				workspaceService = new NullWorkspaceService([]);
 				builder = new SessionOptionGroupBuilder(


### PR DESCRIPTION
Improve the welcome view by ensuring the selected folder is pre-selected and preventing duplication of the selected item when a new folder replaces its MRU entry. This change enhances user experience in chat session options.

