### PR TITLE
Fix double compaction on first-turn budget exceeded

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -465,8 +465,9 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			? (this._lastRenderTokenCount + toolTokens) / baseBudget
 			: 0;
 
-		// Track whether we applied a summary in this iteration so we don't
-		// immediately re-trigger background compaction in the post-render check.
+		// Track whether this iteration already performed compaction-related work
+		// (including applying a summary or using a foreground fallback path) so
+		// we don't immediately re-trigger background compaction in the post-render check.
 		let didSummarizeThisIteration = false;
 
 		// If a previous background pass completed, apply its summary now.

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -467,7 +467,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 
 		// Track whether we applied a summary in this iteration so we don't
 		// immediately re-trigger background compaction in the post-render check.
-		let summaryAppliedThisIteration = false;
+		let didSummarizeThisIteration = false;
 
 		// If a previous background pass completed, apply its summary now.
 		if (summarizationEnabled && backgroundSummarizer?.state === BackgroundSummarizationState.Completed) {
@@ -478,7 +478,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				this._applySummaryToRounds(bgResult, promptContext);
 				this._persistSummaryOnTurn(bgResult, promptContext, this._lastRenderTokenCount);
 				this._sendBackgroundCompactionTelemetry('preRender', 'applied', contextRatio, promptContext);
-				summaryAppliedThisIteration = true;
+				didSummarizeThisIteration = true;
 			} else {
 				this.logService.warn(`[ConversationHistorySummarizer] background compaction state was Completed but consumeAndReset returned no result`);
 				this._sendBackgroundCompactionTelemetry('preRender', 'noResult', contextRatio, promptContext);
@@ -611,7 +611,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						this._applySummaryToRounds(bgResult, promptContext);
 						this._persistSummaryOnTurn(bgResult, promptContext, contextLengthBefore);
 						this._sendBackgroundCompactionTelemetry(budgetExceededTrigger, 'applied', contextRatio, promptContext);
-						summaryAppliedThisIteration = true;
+						didSummarizeThisIteration = true;
 						// Re-render with the compacted history
 						const renderer = PromptRenderer.create(this.instantiationService, endpoint, this.prompt, { ...props, promptContext });
 						result = await renderer.render(progress, token);
@@ -621,9 +621,11 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						this._recordBackgroundCompactionFailure(promptContext, budgetExceededTrigger);
 						// Background compaction failed — fall back to synchronous summarization
 						result = await renderWithSummarization(`budget exceeded(${e.message}), background compaction failed`);
+						didSummarizeThisIteration = true;
 					}
 				} else {
 					result = await renderWithSummarization(`budget exceeded(${e.message})`);
+					didSummarizeThisIteration = true;
 				}
 			} else {
 				throw e;
@@ -656,7 +658,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		}
 
 		// Post-render: kick off background compaction at ≥ 80% if idle.
-		if (summarizationEnabled && backgroundSummarizer && !summaryAppliedThisIteration) {
+		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
 			const postRenderRatio = baseBudget > 0
 				? (result.tokenCount + toolTokens) / baseBudget
 				: 0;


### PR DESCRIPTION
On a first-turn `BudgetExceededError` with the background summarizer `Idle`, we fall back to synchronous foreground `full` summarization via `renderWithSummarization`. That path did not set the 'summary applied this iteration' flag, so the post-render gate (>= 80% + Idle) would *also* kick off a background `inline` compaction in the same `buildPrompt` call — producing both `summarizeConversationHistory-full` and `summarizeConversationHistory-inline` requests back-to-back.

### Fix

- Set `didSummarizeThisIteration = true` on both synchronous `renderWithSummarization` fallback call sites in the `BudgetExceededError` catch so the post-render gate correctly short-circuits.
- Rename `summaryAppliedThisIteration` → `didSummarizeThisIteration` so the name reflects that it covers any summarization work done this iteration (pre-render bg apply, budget-exceeded bg apply, or foreground fallback), not just applying a background result to rounds.
