### PR TITLE
enable having space-separated args for terminal.external.linuxExec

### DIFF
--- a/src/vs/platform/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/platform/externalTerminal/node/externalTerminalService.ts
@@ -327,7 +327,7 @@ export class LinuxExternalTerminalService extends ExternalTerminalService implem
 				const env = getSanitizedEnvironment(process);
 				const basename = path.basename(exec).toLowerCase();
 				const args = basename === 'ghostty' && cwd ? [`--working-directory=${cwd}`] : [];
-				const child = spawner.spawn(exec, args, { cwd, env });
+				const child = spawner.spawn(exec, args, { cwd, env, shell: true });
 				child.on('error', e);
 				child.on('exit', () => c());
 			});


### PR DESCRIPTION
Currently, the setting terminal.external.linuxExec can only be processed as a single string.
This makes it impossible to have args in the exec command. Workaround exists in the form of creating a script with the desired command and its arguments, but this is far from clean.
It is also nowhere near efficient, especially in the case where the user only wants to add an option or two to modify their terminal behavior.
It is especially painstaking in properly having external terminal setting when running it as Flatpak application (where one would need to wrap the command in flatpak-spawn).
