### PR TITLE
build: migrate tests from mocha to node native test runner

### DIFF
--- a/build/lib/test/booleanPolicy.test.ts
+++ b/build/lib/test/booleanPolicy.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { BooleanPolicy } from '../policies/booleanPolicy.ts';
 import { type LanguageTranslations, PolicyType } from '../policies/types.ts';
 import type { CategoryDto, PolicyDto } from '../policies/policyDto.ts';

--- a/build/lib/test/checkCyclicDependencies.test.ts
+++ b/build/lib/test/checkCyclicDependencies.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test, beforeEach, afterEach } from 'node:test';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -104,11 +105,11 @@ suite('checkCyclicDependencies', () => {
 
 		let tmpDir: string;
 
-		setup(() => {
+		beforeEach(() => {
 			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cyclic-test-'));
 		});
 
-		teardown(() => {
+		afterEach(() => {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		});
 

--- a/build/lib/test/i18n.test.ts
+++ b/build/lib/test/i18n.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import * as i18n from '../i18n.ts';
 
 suite('XLF Parser Tests', () => {

--- a/build/lib/test/numberPolicy.test.ts
+++ b/build/lib/test/numberPolicy.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { NumberPolicy } from '../policies/numberPolicy.ts';
 import { type LanguageTranslations, PolicyType } from '../policies/types.ts';
 import type { CategoryDto, PolicyDto } from '../policies/policyDto.ts';

--- a/build/lib/test/objectPolicy.test.ts
+++ b/build/lib/test/objectPolicy.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { ObjectPolicy } from '../policies/objectPolicy.ts';
 import { type LanguageTranslations, PolicyType } from '../policies/types.ts';
 import type { CategoryDto, PolicyDto } from '../policies/policyDto.ts';

--- a/build/lib/test/policyConversion.test.ts
+++ b/build/lib/test/policyConversion.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { promises as fs } from 'fs';
 import path from 'path';
 import type { ExportedPolicyDataDto, CategoryDto } from '../policies/policyDto.ts';

--- a/build/lib/test/render.test.ts
+++ b/build/lib/test/render.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { renderADMLString, renderProfileString, renderADMX, renderADML, renderProfileManifest, renderMacOSPolicy, renderGP, renderJsonPolicies } from '../policies/render.ts';
 import { type NlsString, type LanguageTranslations, type Category, type Policy, PolicyType } from '../policies/types.ts';
 

--- a/build/lib/test/stringEnumPolicy.test.ts
+++ b/build/lib/test/stringEnumPolicy.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { StringEnumPolicy } from '../policies/stringEnumPolicy.ts';
 import { PolicyType, type LanguageTranslations } from '../policies/types.ts';
 import type { CategoryDto, PolicyDto } from '../policies/policyDto.ts';

--- a/build/lib/test/stringPolicy.test.ts
+++ b/build/lib/test/stringPolicy.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { StringPolicy } from '../policies/stringPolicy.ts';
 import { PolicyType, type LanguageTranslations } from '../policies/types.ts';
 import type { CategoryDto, PolicyDto } from '../policies/policyDto.ts';

--- a/build/next/test/nls-sourcemap.test.ts
+++ b/build/next/test/nls-sourcemap.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import * as esbuild from 'esbuild';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/build/next/test/private-to-property.test.ts
+++ b/build/next/test/private-to-property.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { suite, test } from 'node:test';
 import { convertPrivateFields, adjustSourceMap } from '../private-to-property.ts';
 import { SourceMapConsumer, SourceMapGenerator, type RawSourceMap } from 'source-map';
 

--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -38,7 +38,6 @@
         "@types/mime": "0.0.29",
         "@types/minimatch": "^3.0.3",
         "@types/minimist": "^1.2.1",
-        "@types/mocha": "^10.0.10",
         "@types/node": "^22.18.10",
         "@types/p-all": "^1.0.0",
         "@types/pump": "^1.0.1",
@@ -1771,13 +1770,6 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
       "dev": true
-    },
-    "node_modules/@types/mocha": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
-      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.32",

--- a/build/package.json
+++ b/build/package.json
@@ -32,7 +32,6 @@
     "@types/mime": "0.0.29",
     "@types/minimatch": "^3.0.3",
     "@types/minimist": "^1.2.1",
-    "@types/mocha": "^10.0.10",
     "@types/node": "^22.18.10",
     "@types/p-all": "^1.0.0",
     "@types/pump": "^1.0.1",
@@ -70,7 +69,7 @@
     "pretypecheck": "npm run copy-policy-dto",
     "typecheck": "cd .. && npx tsgo --project build/tsconfig.json",
     "watch": "npm run typecheck -- --watch",
-    "test": "mocha --ui tdd '{lib,next}/**/*.test.ts'"
+    "test": "node --test '{lib,next}/**/*.test.ts'"
   },
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -4,9 +4,7 @@
 		"lib": [
 			"ES2024"
 		],
-		"types": [
-			"mocha"
-		],
+		"types": [],
 		"module": "nodenext",
 		"noEmit": true,
 		"erasableSyntaxOnly": true,


### PR DESCRIPTION
## Summary

Migrate all 11 test files in `build/{lib,next}` from Mocha to Node's native test runner (`node:test`).

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Use `suite`/`test` from `node:test`**: Chose these over `describe`/`it` to minimize diff size since the existing code already uses Mocha's TDD UI (`suite`/`test`). The `node:test` module exports both with compatible signatures.
- **`setup`/`teardown` mapped to `beforeEach`/`afterEach`**: Only `checkCyclicDependencies.test.ts` used Mocha hooks. These create/remove a temp directory per test, so `beforeEach`/`afterEach` is the correct mapping.
- **No assertion changes needed**: All tests already use Node's built-in `assert` module - no Mocha-specific assertion patterns were in use.
- **No test behavior changes**: No `.only`, `.skip`, `this.timeout()`, or other Mocha-specific features were used. The migration is purely mechanical (add imports, update config).

</details>

## Changes

- **`build/package.json`**: Removed `@types/mocha` from devDependencies, changed test script from `mocha --ui tdd` to `node --test`
- **`build/tsconfig.json`**: Removed `"mocha"` from `types` array
- **11 test files**: Added `import { suite, test } from 'node:test'` (and `beforeEach`/`afterEach` in one file) to replace Mocha's global injections
- **`build/package-lock.json`**: Updated after removing `@types/mocha`