### PR TITLE
inlineChat: show termination card inline in zone widget instead of modal dialog

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -416,12 +416,12 @@ export class ContinueInlineChatInChatViewAction extends AbstractInlineChatAction
 			id: 'inlineChat2.continueInChat',
 			title: localize2('continueInChat', "Ask in Chat"),
 			icon: Codicon.chatSparkle,
-			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_HOVER_MODE, CTX_INLINE_CHAT_TERMINATED),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_TERMINATED),
 			menu: [{
 				id: MenuId.ChatEditorInlineExecute,
 				group: 'navigation',
 				order: 2,
-				when: ContextKeyExpr.and(CTX_HOVER_MODE, CTX_INLINE_CHAT_TERMINATED)
+				when: CTX_INLINE_CHAT_TERMINATED
 			}]
 		});
 	}
@@ -437,12 +437,12 @@ export class RephraseInlineChatSessionAction extends AbstractInlineChatAction {
 		super({
 			id: 'inlineChat2.rephrase',
 			title: localize2('rephrase', "Rephrase"),
-			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_HOVER_MODE, CTX_INLINE_CHAT_TERMINATED),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_TERMINATED),
 			menu: [{
 				id: MenuId.ChatEditorInlineExecute,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.and(CTX_HOVER_MODE, CTX_INLINE_CHAT_TERMINATED)
+				when: CTX_INLINE_CHAT_TERMINATED
 			}]
 		});
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -54,7 +54,7 @@ import { INotebookService } from '../../notebook/common/notebookService.js';
 import { CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_INLINE_CHAT_PENDING_CONFIRMATION, CTX_INLINE_CHAT_TERMINATED, CTX_INLINE_CHAT_VISIBLE, InlineChatConfigKeys } from '../common/inlineChat.js';
 import { InlineChatAffordance } from './inlineChatAffordance.js';
 import { InlineChatInputWidget, InlineChatSessionOverlayWidget } from './inlineChatOverlayWidget.js';
-import { continueInPanelChat, IInlineChatSession2, IInlineChatSessionService } from './inlineChatSessionService.js';
+import { continueInPanelChat, IInlineChatSession2, IInlineChatSessionService, rephraseInlineChat } from './inlineChatSessionService.js';
 import { EditorBasedInlineChatWidget } from './inlineChatWidget.js';
 import { InlineChatZoneWidget } from './inlineChatZoneWidget.js';
 
@@ -454,6 +454,7 @@ export class InlineChatController implements IEditorContribution {
 			const session = visibleSessionObs.read(r);
 			const response = lastResponseObs.read(r);
 			const terminationState = session?.terminationState.read(r);
+			const renderMode = this.#renderMode.read(r);
 
 			this.#zone.rawValue?.widget.updateInfo('');
 
@@ -463,8 +464,15 @@ export class InlineChatController implements IEditorContribution {
 					// ERROR case
 					this.#zone.rawValue?.widget.updateInfo(`$(error) ${response.result.errorDetails.message}`);
 					alert(response.result.errorDetails.message);
+				} else if (terminationState && renderMode === 'zone') {
+					// Zone mode: show termination card with message and action buttons
+					this.#zone.rawValue?.showTerminationCard(terminationState, this.#instaService);
 				} else if (terminationState) {
 					this.#zone.rawValue?.widget.updateInfo(`$(info) ${renderAsPlaintext(terminationState)}`);
+				}
+
+				if (!terminationState || renderMode !== 'zone') {
+					this.#zone.rawValue?.hideTerminationCard();
 				}
 
 				// no response or not in progress
@@ -755,6 +763,17 @@ export class InlineChatController implements IEditorContribution {
 	async rephraseSession(): Promise<void> {
 		const session = this.#currentSession.get();
 		if (!session) {
+			return;
+		}
+
+		if (this.#renderMode.get() === 'zone') {
+			// Zone mode: clear termination state and restore input text in the chat widget.
+			// The autorun watching terminationState will flip the card back automatically.
+			const requestText = this.#instaService.invokeFunction(rephraseInlineChat, session);
+			if (requestText) {
+				this.#zone.rawValue?.widget.chatWidget.setInput(requestText);
+			}
+			this.#zone.rawValue?.widget.focus();
 			return;
 		}
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -9,25 +9,19 @@ import { autorun, observableFromEvent, observableValue } from '../../../../base/
 import { isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IActiveCodeEditor, isCodeEditor, isCompositeEditor, isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
-import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
-import { localize, localize2 } from '../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IChatAgentService } from '../../chat/common/participants/chatAgents.js';
-import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { ModifiedFileEntryState } from '../../chat/common/editing/chatEditingService.js';
 import { IChatService } from '../../chat/common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../chat/common/tools/languageModelToolsService.js';
 import { CTX_INLINE_CHAT_HAS_AGENT2, CTX_INLINE_CHAT_HAS_NOTEBOOK_AGENT, CTX_INLINE_CHAT_POSSIBLE, InlineChatConfigKeys } from '../common/inlineChat.js';
-import { continueInPanelChat, IInlineChatSession2, IInlineChatSessionService, InlineChatSessionTerminationState, rephraseInlineChat } from './inlineChatSessionService.js';
+import { IInlineChatSession2, IInlineChatSessionService, InlineChatSessionTerminationState } from './inlineChatSessionService.js';
 
 export class InlineChatError extends Error {
 	static readonly code = 'InlineChatError';
@@ -235,9 +229,6 @@ export class InlineChatEnabler {
 export class InlineChatEscapeToolContribution extends Disposable {
 
 	static readonly Id = 'inlineChat.escapeTool';
-
-	static readonly DONT_ASK_AGAIN_KEY = 'inlineChat.dontAskMoveToPanelChat';
-
 	static readonly #data: IToolData = {
 		id: 'inline_chat_exit',
 		source: ToolDataSource.Internal,
@@ -261,13 +252,7 @@ export class InlineChatEscapeToolContribution extends Disposable {
 	constructor(
 		@ILanguageModelToolsService lmTools: ILanguageModelToolsService,
 		@IInlineChatSessionService inlineChatSessionService: IInlineChatSessionService,
-		@IDialogService dialogService: IDialogService,
-		@ICodeEditorService codeEditorService: ICodeEditorService,
-		@IConfigurationService configurationService: IConfigurationService,
-		@IChatService chatService: IChatService,
 		@ILogService logService: ILogService,
-		@IStorageService storageService: IStorageService,
-		@IInstantiationService instaService: IInstantiationService,
 	) {
 
 		super();
@@ -295,66 +280,13 @@ export class InlineChatEscapeToolContribution extends Disposable {
 					return { content: [{ kind: 'text', value: 'Cancel' }], toolResultMessage: localize('tool.cancel', "Cancel") };
 				}
 
-				if (configurationService.getValue<string>(InlineChatConfigKeys.RenderMode) === 'hover') {
+				const response = typeof invocation.parameters?.response === 'string' && invocation.parameters.response.trim().length > 0
+					? invocation.parameters.response.trim()
+					: localize('terminated.message', "Inline chat is designed for making single-file code changes. Continue your request in the Chat view or rephrase it for inline chat.");
 
-					const response = typeof invocation.parameters?.response === 'string' && invocation.parameters.response.trim().length > 0
-						? invocation.parameters.response.trim()
-						: localize('terminated.message', "Inline chat is designed for making single-file code changes. Continue your request in the Chat view or rephrase it for inline chat.");
-
-					session.setTerminationState(response);
-					return { content: [{ kind: 'text', value: 'Success' }] };
-				}
-
-				const dontAskAgain = storageService.getBoolean(InlineChatEscapeToolContribution.DONT_ASK_AGAIN_KEY, StorageScope.PROFILE);
-
-				let result: { confirmed: boolean; checkboxChecked?: boolean };
-				if (dontAskAgain !== undefined) {
-					// Use previously stored user preference: true = 'Continue in Chat view', false = 'Rephrase' (Cancel)
-					result = { confirmed: dontAskAgain, checkboxChecked: false };
-				} else {
-					result = await dialogService.confirm({
-						type: 'question',
-						title: localize('confirm.title', "Do you want to continue in Chat view?"),
-						message: localize('confirm', "Do you want to continue in Chat view?"),
-						detail: localize('confirm.detail', "Inline chat is designed for making single-file code changes. Continue your request in the Chat view or rephrase it for inline chat."),
-						primaryButton: localize('confirm.yes', "Continue in Chat view"),
-						cancelButton: localize('confirm.cancel', "Cancel"),
-						checkbox: { label: localize('chat.remove.confirmation.checkbox', "Don't ask again"), checked: false },
-					});
-				}
-
-				const editor = codeEditorService.getFocusedCodeEditor();
-
-				if (!editor || result.confirmed) {
-					logService.trace('InlineChatEscapeToolContribution: moving session to panel chat');
-					await instaService.invokeFunction(continueInPanelChat, session);
-
-				} else {
-					logService.trace('InlineChatEscapeToolContribution: rephrase prompt');
-					instaService.invokeFunction(rephraseInlineChat, session);
-				}
-
-				if (result.checkboxChecked) {
-					storageService.store(InlineChatEscapeToolContribution.DONT_ASK_AGAIN_KEY, result.confirmed, StorageScope.PROFILE, StorageTarget.USER);
-					logService.trace('InlineChatEscapeToolContribution: stored don\'t ask again preference');
-				}
-
+				session.setTerminationState(response);
 				return { content: [{ kind: 'text', value: 'Success' }] };
 			}
 		}));
 	}
 }
-
-registerAction2(class ResetMoveToPanelChatChoice extends Action2 {
-	constructor() {
-		super({
-			id: 'inlineChat.resetMoveToPanelChatChoice',
-			precondition: ContextKeyExpr.and(ChatContextKeys.Setup.hidden.negate(), ChatContextKeys.Setup.disabledInWorkspace.negate()),
-			title: localize2('resetChoice.label', "Reset Choice for 'Move Inline Chat to Panel Chat'"),
-			f1: true
-		});
-	}
-	run(accessor: ServicesAccessor) {
-		accessor.get(IStorageService).remove(InlineChatEscapeToolContribution.DONT_ASK_AGAIN_KEY, StorageScope.PROFILE);
-	}
-});

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -2,12 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { addDisposableListener, Dimension } from '../../../../base/browser/dom.js';
+import { addDisposableListener, Dimension, $, reset } from '../../../../base/browser/dom.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
-import { toDisposable } from '../../../../base/common/lifecycle.js';
+import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { assertType } from '../../../../base/common/types.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { StableEditorBottomScrollState } from '../../../../editor/browser/stableEditorScroll.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
@@ -19,6 +23,8 @@ import { localize } from '../../../../nls.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { IChatWidgetViewOptions } from '../../chat/browser/chat.js';
 import { IChatWidgetLocationOptions } from '../../chat/browser/widget/chatWidget.js';
 import { ChatMode } from '../../chat/common/chatModes.js';
@@ -49,6 +55,12 @@ export class InlineChatZoneWidget extends ZoneWidget {
 
 	readonly #logService: ILogService;
 
+	readonly #terminationCard: HTMLElement;
+	readonly #terminationIcon: HTMLElement;
+	readonly #terminationMessage: HTMLElement;
+	readonly #terminationToolbar: HTMLElement;
+	readonly #terminationStore = new DisposableStore();
+
 	constructor(
 		location: IChatWidgetLocationOptions,
 		options: IChatWidgetViewOptions | undefined,
@@ -63,6 +75,18 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		this.notebookEditor = editors.notebookEditor;
 
 		this.#logService = logService;
+
+		// Build termination card DOM
+		this.#terminationCard = $('div.inline-chat-terminated-card.hidden');
+		const statusRow = $('div.status');
+		this.#terminationIcon = $('span');
+		this.#terminationMessage = $('span.message');
+		statusRow.appendChild(this.#terminationIcon);
+		statusRow.appendChild(this.#terminationMessage);
+		this.#terminationToolbar = $('div.toolbar');
+		statusRow.appendChild(this.#terminationToolbar);
+		this.#terminationCard.appendChild(statusRow);
+		this._disposables.add(this.#terminationStore);
 
 		this.#ctxCursorPosition = CTX_INLINE_CHAT_OUTER_CURSOR_POSITION.bindTo(contextKeyService);
 
@@ -159,6 +183,65 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		container.style.setProperty('--vscode-inlineChat-background', 'var(--vscode-editor-background)');
 
 		container.appendChild(this.widget.domNode);
+		container.appendChild(this.#terminationCard);
+	}
+
+	showTerminationCard(message: string | IMarkdownString, instaService: IInstantiationService): void {
+		this.#terminationStore.clear();
+
+		// Icon
+		this.#terminationIcon.className = '';
+		this.#terminationIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
+
+		// Message text
+		const text = typeof message === 'string' ? message : message.value;
+		this.#terminationMessage.textContent = '';
+		reset(this.#terminationMessage, ...renderLabelWithIcons(text));
+
+		// Toolbar
+		this.#terminationToolbar.replaceChildren();
+		this.#terminationStore.add(instaService.createInstance(MenuWorkbenchToolBar, this.#terminationToolbar, MenuId.ChatEditorInlineExecute, {
+			telemetrySource: 'inlineChatZone.terminationToolbar',
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			toolbarOptions: {
+				primaryGroup: () => true,
+				useSeparatorsInPrimaryActions: true
+			},
+			menuOptions: { renderShortTitle: true },
+		}));
+
+		// Flip visibility
+		this.widget.domNode.style.display = 'none';
+		this.#terminationCard.classList.remove('hidden');
+
+		// Announce for screen readers
+		aria.status(text);
+
+		// Relayout
+		if (this.position) {
+			const revealFn = this.#createZoneAndScrollRestoreFn(this.position);
+			const height = this.#computeHeight();
+			this._relayout(height.linesValue);
+			revealFn();
+		}
+	}
+
+	hideTerminationCard(): void {
+		this.#terminationStore.clear();
+		this.#terminationCard.classList.add('hidden');
+		this.widget.domNode.style.display = '';
+
+		// Relayout
+		if (this.position) {
+			const revealFn = this.#createZoneAndScrollRestoreFn(this.position);
+			const height = this.#computeHeight();
+			this._relayout(height.linesValue);
+			revealFn();
+		}
+	}
+
+	get isShowingTerminationCard(): boolean {
+		return !this.#terminationCard.classList.contains('hidden');
 	}
 
 	protected override _doLayout(heightInPixel: number): void {
@@ -174,10 +257,16 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	}
 
 	#computeHeight(): { linesValue: number; pixelsValue: number } {
-		const chatContentHeight = this.widget.contentHeight;
 		const editorHeight = this.notebookEditor?.getLayoutInfo().height ?? this.editor.getLayoutInfo().height;
 
-		const contentHeight = this._decoratingElementsHeight() + Math.min(chatContentHeight, Math.max(this.widget.minHeight, editorHeight * 0.42));
+		let innerHeight: number;
+		if (this.isShowingTerminationCard) {
+			innerHeight = this.#terminationCard.offsetHeight || 80; // fallback before first layout
+		} else {
+			innerHeight = this.widget.contentHeight;
+		}
+
+		const contentHeight = this._decoratingElementsHeight() + Math.min(innerHeight, Math.max(this.widget.minHeight, editorHeight * 0.42));
 		const heightInLines = contentHeight / this.editor.getOption(EditorOption.lineHeight);
 		return { linesValue: heightInLines, pixelsValue: contentHeight };
 	}
@@ -274,6 +363,9 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	override hide(): void {
 		const scrollState = StableEditorBottomScrollState.capture(this.editor);
 		this.#ctxCursorPosition.reset();
+		this.#terminationStore.clear();
+		this.#terminationCard.classList.add('hidden');
+		this.widget.domNode.style.display = '';
 		this.widget.chatWidget.setVisible(false);
 		super.hide();
 		aria.status(localize('inlineChatClosed', 'Closed inline chat widget'));

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -2,19 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { addDisposableListener, Dimension, $, reset } from '../../../../base/browser/dom.js';
+import { addDisposableListener, Dimension, $ } from '../../../../base/browser/dom.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { renderMarkdown, renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
-import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { Codicon } from '../../../../base/common/codicons.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { assertType } from '../../../../base/common/types.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { StableEditorBottomScrollState } from '../../../../editor/browser/stableEditorScroll.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
@@ -59,8 +56,6 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	readonly #logService: ILogService;
 
 	readonly #terminationCard: HTMLElement;
-	readonly #terminationIcon: HTMLElement;
-	readonly #terminationMessage: HTMLElement;
 	readonly #terminationMarkdownContainer: HTMLElement;
 	readonly #terminationMarkdownMessage: HTMLElement;
 	readonly #terminationMarkdownScrollable: DomScrollableElement;
@@ -96,14 +91,8 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		}));
 		this.#terminationCard.appendChild(this.#terminationMarkdownScrollable.getDomNode());
 
-		// Content row: status (icon + message) + toolbar
+		// Toolbar row
 		const contentRow = $('div.content-row');
-		const statusNode = $('div.status');
-		this.#terminationIcon = $('span');
-		this.#terminationMessage = $('span.message');
-		statusNode.appendChild(this.#terminationIcon);
-		statusNode.appendChild(this.#terminationMessage);
-		contentRow.appendChild(statusNode);
 		this.#terminationToolbar = $('div.toolbar');
 		contentRow.appendChild(this.#terminationToolbar);
 		this.#terminationCard.appendChild(contentRow);
@@ -210,18 +199,12 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	showTerminationCard(message: string | IMarkdownString, instaService: IInstantiationService): void {
 		this.#terminationStore.clear();
 
-		// Icon
-		this.#terminationIcon.className = '';
-		this.#terminationIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
-
-		// Status message (plain text summary)
+		const rawText = typeof message === 'string' ? message : message.value;
 		const text = renderAsPlaintext(typeof message === 'string' ? new MarkdownString(message) : message);
-		this.#terminationMessage.textContent = '';
-		reset(this.#terminationMessage, ...renderLabelWithIcons(text));
 
-		// Markdown rendering in scrollable area
+		// Markdown rendering with $(info) icon prefix in scrollable area
 		this.#terminationMarkdownMessage.replaceChildren();
-		const md = typeof message === 'string' ? new MarkdownString(message) : message;
+		const md = new MarkdownString(rawText, { supportThemeIcons: true });
 		const rendered = this.#terminationStore.add(renderMarkdown(md));
 		this.#terminationMarkdownMessage.appendChild(rendered.element);
 		this.#terminationMarkdownScrollable.getDomNode().classList.remove('hidden');
@@ -283,6 +266,15 @@ export class InlineChatZoneWidget extends ZoneWidget {
 
 		this.#dimension = new Dimension(width, heightInPixel);
 		this.widget.layout(this.#dimension);
+
+		if (this.isShowingTerminationCard) {
+			// Set explicit maxHeight on the scrollable and its container so DomScrollableElement
+			// knows it needs to show a scrollbar (same pattern as the overlay widget)
+			const maxHeight = Math.max(50, heightInPixel - 40); // reserve space for toolbar row
+			this.#terminationMarkdownScrollable.getDomNode().style.maxHeight = `${maxHeight}px`;
+			this.#terminationMarkdownContainer.style.maxHeight = `${maxHeight}px`;
+			this.#terminationMarkdownScrollable.scanDomNode();
+		}
 	}
 
 	#computeHeight(): { linesValue: number; pixelsValue: number } {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 import { addDisposableListener, Dimension, $, reset } from '../../../../base/browser/dom.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
+import { renderMarkdown, renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
+import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { IMarkdownString } from '../../../../base/common/htmlContent.js';
+import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { isEqual } from '../../../../base/common/resources.js';
+import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import { assertType } from '../../../../base/common/types.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
@@ -58,6 +61,9 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	readonly #terminationCard: HTMLElement;
 	readonly #terminationIcon: HTMLElement;
 	readonly #terminationMessage: HTMLElement;
+	readonly #terminationMarkdownContainer: HTMLElement;
+	readonly #terminationMarkdownMessage: HTMLElement;
+	readonly #terminationMarkdownScrollable: DomScrollableElement;
 	readonly #terminationToolbar: HTMLElement;
 	readonly #terminationStore = new DisposableStore();
 
@@ -78,14 +84,29 @@ export class InlineChatZoneWidget extends ZoneWidget {
 
 		// Build termination card DOM
 		this.#terminationCard = $('div.inline-chat-terminated-card.hidden');
-		const statusRow = $('div.status');
+
+		// Markdown scrollable area
+		this.#terminationMarkdownContainer = $('div.markdown-scroll-container');
+		this.#terminationMarkdownMessage = $('div.markdown-message');
+		this.#terminationMarkdownContainer.appendChild(this.#terminationMarkdownMessage);
+		this.#terminationMarkdownScrollable = this._disposables.add(new DomScrollableElement(this.#terminationMarkdownContainer, {
+			consumeMouseWheelIfScrollbarIsNeeded: true,
+			horizontal: ScrollbarVisibility.Hidden,
+			vertical: ScrollbarVisibility.Auto,
+		}));
+		this.#terminationCard.appendChild(this.#terminationMarkdownScrollable.getDomNode());
+
+		// Content row: status (icon + message) + toolbar
+		const contentRow = $('div.content-row');
+		const statusNode = $('div.status');
 		this.#terminationIcon = $('span');
 		this.#terminationMessage = $('span.message');
-		statusRow.appendChild(this.#terminationIcon);
-		statusRow.appendChild(this.#terminationMessage);
+		statusNode.appendChild(this.#terminationIcon);
+		statusNode.appendChild(this.#terminationMessage);
+		contentRow.appendChild(statusNode);
 		this.#terminationToolbar = $('div.toolbar');
-		statusRow.appendChild(this.#terminationToolbar);
-		this.#terminationCard.appendChild(statusRow);
+		contentRow.appendChild(this.#terminationToolbar);
+		this.#terminationCard.appendChild(contentRow);
 		this._disposables.add(this.#terminationStore);
 
 		this.#ctxCursorPosition = CTX_INLINE_CHAT_OUTER_CURSOR_POSITION.bindTo(contextKeyService);
@@ -193,10 +214,18 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		this.#terminationIcon.className = '';
 		this.#terminationIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
 
-		// Message text
-		const text = typeof message === 'string' ? message : message.value;
+		// Status message (plain text summary)
+		const text = renderAsPlaintext(typeof message === 'string' ? new MarkdownString(message) : message);
 		this.#terminationMessage.textContent = '';
 		reset(this.#terminationMessage, ...renderLabelWithIcons(text));
+
+		// Markdown rendering in scrollable area
+		this.#terminationMarkdownMessage.replaceChildren();
+		const md = typeof message === 'string' ? new MarkdownString(message) : message;
+		const rendered = this.#terminationStore.add(renderMarkdown(md));
+		this.#terminationMarkdownMessage.appendChild(rendered.element);
+		this.#terminationMarkdownScrollable.getDomNode().classList.remove('hidden');
+		this.#terminationMarkdownScrollable.scanDomNode();
 
 		// Toolbar
 		this.#terminationToolbar.replaceChildren();

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -6,6 +6,7 @@ import { addDisposableListener, Dimension, $ } from '../../../../base/browser/do
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { renderMarkdown, renderAsPlaintext } from '../../../../base/browser/markdownRenderer.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { ActionRunner, IAction } from '../../../../base/common/actions.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
@@ -211,11 +212,20 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		this.#terminationMarkdownScrollable.getDomNode().classList.remove('hidden');
 		this.#terminationMarkdownScrollable.scanDomNode();
 
-		// Toolbar
+		// Toolbar - focus the owning editor before running any action so that
+		// EditorAction2-based actions resolve the correct editor instance.
+		const editor = this.editor;
+		const actionRunner = this.#terminationStore.add(new class extends ActionRunner {
+			protected override async runAction(action: IAction, context?: unknown): Promise<void> {
+				editor.focus();
+				return super.runAction(action, context);
+			}
+		});
 		this.#terminationToolbar.replaceChildren();
 		this.#terminationStore.add(instaService.createInstance(MenuWorkbenchToolBar, this.#terminationToolbar, MenuId.ChatEditorInlineExecute, {
 			telemetrySource: 'inlineChatZone.terminationToolbar',
 			hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			actionRunner,
 			toolbarOptions: {
 				primaryGroup: () => true,
 				useSeparatorsInPrimaryActions: true

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -199,13 +199,14 @@ export class InlineChatZoneWidget extends ZoneWidget {
 	showTerminationCard(message: string | IMarkdownString, instaService: IInstantiationService): void {
 		this.#terminationStore.clear();
 
-		const rawText = typeof message === 'string' ? message : message.value;
+		const markdownMessage = typeof message === 'string'
+			? new MarkdownString(message, { supportThemeIcons: true })
+			: message;
 		const text = renderAsPlaintext(typeof message === 'string' ? new MarkdownString(message) : message);
 
 		// Markdown rendering with $(info) icon prefix in scrollable area
 		this.#terminationMarkdownMessage.replaceChildren();
-		const md = new MarkdownString(rawText, { supportThemeIcons: true });
-		const rendered = this.#terminationStore.add(renderMarkdown(md));
+		const rendered = this.#terminationStore.add(renderMarkdown(markdownMessage));
 		this.#terminationMarkdownMessage.appendChild(rendered.element);
 		this.#terminationMarkdownScrollable.getDomNode().classList.remove('hidden');
 		this.#terminationMarkdownScrollable.scanDomNode();

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -321,3 +321,41 @@
 .monaco-workbench .inline-chat .chat-attached-context {
 	padding: 2px 0px;
 }
+
+/* Termination card (zone widget) */
+
+.monaco-workbench .inline-chat-terminated-card {
+	padding: 8px 16px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}
+
+.monaco-workbench .inline-chat-terminated-card.hidden {
+	display: none;
+}
+
+.monaco-workbench .inline-chat-terminated-card > .status {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.monaco-workbench .inline-chat-terminated-card > .status > .message {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	line-height: 1.4;
+}
+
+.monaco-workbench .inline-chat-terminated-card > .status > .toolbar {
+	margin-left: auto;
+	flex-shrink: 0;
+}
+
+.monaco-workbench .inline-chat-terminated-card > .status > .toolbar .monaco-text-button {
+	padding: 2px 8px;
+	font-size: 12px;
+	white-space: nowrap;
+}

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -354,7 +354,6 @@
 	padding: 5px;
 	font-size: 12px;
 	line-height: 1.45;
-	max-height: 3.1lh; /* ~3 lines, then scroll */
 }
 
 .monaco-workbench .inline-chat-terminated-card .markdown-message p {
@@ -372,33 +371,12 @@
 	white-space: pre-wrap;
 }
 
-/* Content row: status + toolbar */
+/* Content row: toolbar */
 .monaco-workbench .inline-chat-terminated-card > .content-row {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: flex-end;
 	gap: 4px;
-	min-width: 0;
-}
-
-.monaco-workbench .inline-chat-terminated-card .status {
-	align-items: center;
-	display: inline-flex;
-	flex: 1;
-	padding: 5px 0 5px 5px;
-	font-size: 12px;
-	overflow: hidden;
-	gap: 6px;
-}
-
-.monaco-workbench .inline-chat-terminated-card .status .message {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.monaco-workbench .inline-chat-terminated-card > .content-row > .toolbar {
-	flex-shrink: 0;
 }
 
 .monaco-workbench .inline-chat-terminated-card > .content-row > .toolbar .monaco-text-button {

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -322,39 +322,86 @@
 	padding: 2px 0px;
 }
 
-/* Termination card (zone widget) */
+/* Termination card (zone widget) — aligned with overlay widget */
 
 .monaco-workbench .inline-chat-terminated-card {
-	padding: 8px 16px;
-	color: var(--vscode-descriptionForeground);
+	padding: 4px;
+	color: var(--vscode-foreground);
 	font-size: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .monaco-workbench .inline-chat-terminated-card.hidden {
 	display: none;
 }
 
-.monaco-workbench .inline-chat-terminated-card > .status {
+/* Markdown scrollable area */
+.monaco-workbench .inline-chat-terminated-card > .monaco-scrollable-element {
+	width: 100%;
+}
+
+.monaco-workbench .inline-chat-terminated-card > .monaco-scrollable-element.hidden {
+	display: none;
+}
+
+.monaco-workbench .inline-chat-terminated-card .markdown-scroll-container {
+	width: 100%;
+}
+
+.monaco-workbench .inline-chat-terminated-card .markdown-message {
+	padding: 5px;
+	font-size: 12px;
+	line-height: 1.45;
+	max-height: 3.1lh; /* ~3 lines, then scroll */
+}
+
+.monaco-workbench .inline-chat-terminated-card .markdown-message p {
+	margin: 0;
+}
+
+.monaco-workbench .inline-chat-terminated-card .markdown-message code {
+	font-family: var(--monaco-monospace-font);
+	font-size: var(--vscode-chat-font-size-body-xs);
+	color: var(--vscode-textPreformat-foreground);
+	background-color: var(--vscode-textPreformat-background);
+	padding: 1px 3px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-textPreformat-border);
+	white-space: pre-wrap;
+}
+
+/* Content row: status + toolbar */
+.monaco-workbench .inline-chat-terminated-card > .content-row {
 	display: flex;
 	align-items: center;
+	justify-content: space-between;
+	gap: 4px;
+	min-width: 0;
+}
+
+.monaco-workbench .inline-chat-terminated-card .status {
+	align-items: center;
+	display: inline-flex;
+	flex: 1;
+	padding: 5px 0 5px 5px;
+	font-size: 12px;
+	overflow: hidden;
 	gap: 6px;
 }
 
-.monaco-workbench .inline-chat-terminated-card > .status > .message {
+.monaco-workbench .inline-chat-terminated-card .status .message {
+	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 3;
-	-webkit-box-orient: vertical;
-	line-height: 1.4;
 }
 
-.monaco-workbench .inline-chat-terminated-card > .status > .toolbar {
-	margin-left: auto;
+.monaco-workbench .inline-chat-terminated-card > .content-row > .toolbar {
 	flex-shrink: 0;
 }
 
-.monaco-workbench .inline-chat-terminated-card > .status > .toolbar .monaco-text-button {
+.monaco-workbench .inline-chat-terminated-card > .content-row > .toolbar .monaco-text-button {
 	padding: 2px 8px;
 	font-size: 12px;
 	white-space: nowrap;


### PR DESCRIPTION
## Summary

When the `inline_chat_exit` tool fires in zone mode (`renderMode=zone`), the termination message and action buttons are now shown **inline** within the zone widget as a card, instead of popping a modal confirmation dialog. This unifies the exit-tool UX across both hover and zone render modes.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Card layout over modal dialog**: The modal `dialogService.confirm()` for zone mode was replaced with an inline termination card that flips the zone widget content. The card shows the message with an info icon and a toolbar with "Rephrase" / "Ask in Chat" buttons, matching the hover mode's overlay widget behavior.
- **Single status row (no markdown duplication)**: Initially implemented with both a markdown area and a status row, causing duplicated message text. Simplified to a single status row with icon + message + toolbar inline.
- **`style.display` over `.hidden` class**: The `.hidden` CSS class on `widget.domNode` (`.inline-chat.in-zone-widget`) was overridden by existing `.inline-chat` CSS rules. Switched to direct `style.display = 'none'` / `style.display = ''` manipulation.
- **Message wrapping**: The message text wraps up to 3 lines before being clipped with ellipsis (`-webkit-line-clamp: 3`).
- **Dead code cleanup**: Removed the `ResetMoveToPanelChatChoice` action, `DONT_ASK_AGAIN_KEY` storage constant, and all associated imports (`IDialogService`, `IStorageService`, `ICodeEditorService`, etc.) since the dialog no longer exists.
- **Accessibility**: The termination card announces its message via `aria.status()` for screen readers.

</details>

## Changes

- **`inlineChatSessionServiceImpl.ts`**: Unified `InlineChatEscapeToolContribution.invoke()` to always call `session.setTerminationState(response)` regardless of render mode. Removed modal dialog, storage preference, and the `ResetMoveToPanelChatChoice` command.
- **`inlineChatZoneWidget.ts`**: Added termination card DOM (icon + message + toolbar using `MenuId.ChatEditorInlineExecute`), `showTerminationCard()` / `hideTerminationCard()` methods, and height computation that accounts for the card.
- **`inlineChatController.ts`**: Controller autorun now drives card visibility based on `terminationState` observable. `rephraseSession()` in zone mode calls `rephraseInlineChat()` to clear termination state and restore input text.
- **`inlineChatActions.ts`**: Removed `CTX_HOVER_MODE` guard from `ContinueInlineChatInChatViewAction` and `RephraseInlineChatSessionAction` so they work in both render modes.
- **`media/inlineChat.css`**: Added termination card styling with inline layout and 3-line message clamping.