### PR TITLE
Fix italic tab label clipping at the start

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -393,7 +393,9 @@
 	 * solution is to give the label container a bit more room to fully render.
 	 *
 	 * Refs: https://github.com/microsoft/vscode/issues/207409
+	 * Refs: https://github.com/microsoft/vscode/issues/244136
 	 */
+	padding-left: 1px;
 	padding-right: 1px;
 }
 


### PR DESCRIPTION
## Summary

Fixes #244136.

The workaround for italic tab label clipping at the end (#207409) added `padding-right: 1px` to `.monaco-icon-label.italic > .monaco-icon-label-container`. The same rendering quirk clips italic glyphs at the **start** of the label as well (the parent has `overflow: hidden` and `flex: none`, so the italic ascender on characters like `f` gets cut off on the leading edge).

This applies a symmetric `padding-left: 1px` so italic glyphs have enough room on both sides.

## Test plan

- [ ] Enable a theme or setting that renders a tab label in italic (e.g. open a file in preview/single-click so the tab shows italic).
- [ ] Verify the first character of the italic label is no longer clipped on the leading edge.
- [ ] Verify the previously fixed end clipping from #207409 is still not clipped.
- [ ] Check `workbench.editor.tabSizing` values `fit`, `shrink`, and `fixed`.
- [ ] Check default, high-contrast dark, and high-contrast light themes.