### PR TITLE
sessions: show restore button instead of checkmark for done sessions

### DIFF
--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -12,6 +12,7 @@ export const IsNewChatSessionContext = new RawContextKey<boolean>('isNewChatSess
 export const ActiveSessionProviderIdContext = new RawContextKey<string>('activeSessionProviderId', '', localize('activeSessionProviderId', "The provider ID of the active session"));
 export const ActiveSessionTypeContext = new RawContextKey<string>('activeSessionType', '', localize('activeSessionType', "The session type of the active session"));
 export const IsActiveSessionBackgroundProviderContext = new RawContextKey<boolean>('isActiveSessionBackgroundProvider', false, localize('isActiveSessionBackgroundProvider', "Whether the active session uses the background agent provider"));
+export const IsActiveSessionArchivedContext = new RawContextKey<boolean>('isActiveSessionArchived', false, localize('isActiveSessionArchived', "Whether the active session is archived (marked as done)"));
 export const ActiveSessionHasGitRepositoryContext = new RawContextKey<boolean>('activeSessionHasGitRepository', false, localize('activeSessionHasGitRepository', "Whether the active session has an associated git repository"));
 export const ChatSessionProviderIdContext = new RawContextKey<string>('chatSessionProviderId', '', localize('chatSessionProviderId', "The provider ID of a session in context menu overlays"));
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -18,7 +18,7 @@ import { EditorsVisibleContext, IsAuxiliaryWindowContext, IsSessionsWindowContex
 import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browser/chat.js';
 import { AUX_WINDOW_GROUP } from '../../../../../workbench/services/editor/common/editorService.js';
 import { SessionsCategories } from '../../../../common/categories.js';
-import { ChatSessionProviderIdContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
+import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
 import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext } from './sessionsView.js';
@@ -502,15 +502,28 @@ registerAction2(class UnarchiveSessionAction extends Action2 {
 				group: '1_edit',
 				order: 2,
 				when: ContextKeyExpr.equals(IsSessionArchivedContext.key, true),
+			}, {
+				id: Menus.CommandCenter,
+				order: 103,
+				when: ContextKeyExpr.and(
+					IsAuxiliaryWindowContext.negate(),
+					SessionsWelcomeVisibleContext.negate(),
+					IsNewChatSessionContext.negate(),
+					IsActiveSessionArchivedContext
+				)
 			}]
 		});
 	}
 	async run(accessor: ServicesAccessor, context?: ISession | ISession[]): Promise<void> {
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		if (!context) {
+			const activeSession = sessionsManagementService.activeSession.get();
+			if (activeSession) {
+				await sessionsManagementService.unarchiveSession(activeSession);
+			}
 			return;
 		}
 		const sessions = Array.isArray(context) ? context : [context];
-		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		for (const session of sessions) {
 			await sessionsManagementService.unarchiveSession(session);
 		}
@@ -680,7 +693,8 @@ registerAction2(class MarkSessionAsDoneAction extends Action2 {
 				when: ContextKeyExpr.and(
 					IsAuxiliaryWindowContext.negate(),
 					SessionsWelcomeVisibleContext.negate(),
-					IsNewChatSessionContext.negate()
+					IsNewChatSessionContext.negate(),
+					IsActiveSessionArchivedContext.negate()
 				)
 			},
 			{

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -12,7 +12,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
-import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionBackgroundProviderContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
+import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, IsActiveSessionBackgroundProviderContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
 import { ActiveSessionSupportsMultiChatContext, IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
@@ -43,6 +43,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 	private readonly _activeSessionProviderId: IContextKey<string>;
 	private readonly _activeSessionType: IContextKey<string>;
 	private readonly _isBackgroundProvider: IContextKey<boolean>;
+	private readonly _isActiveSessionArchived: IContextKey<boolean>;
 	private readonly _supportsMultiChat: IContextKey<boolean>;
 	private _activeChatObservable: ISettableObservable<IChat> | undefined;
 	private _activeSessionDisposables = this._register(new DisposableStore());
@@ -64,6 +65,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._activeSessionProviderId = ActiveSessionProviderIdContext.bindTo(contextKeyService);
 		this._activeSessionType = ActiveSessionTypeContext.bindTo(contextKeyService);
 		this._isBackgroundProvider = IsActiveSessionBackgroundProviderContext.bindTo(contextKeyService);
+		this._isActiveSessionArchived = IsActiveSessionArchivedContext.bindTo(contextKeyService);
 		this._supportsMultiChat = ActiveSessionSupportsMultiChatContext.bindTo(contextKeyService);
 
 		// Load last selected session
@@ -327,6 +329,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this._activeSessionProviderId.set(session?.providerId ?? '');
 		this._activeSessionType.set(session?.sessionType ?? '');
 		this._isBackgroundProvider.set(session?.sessionType === COPILOT_CLI_SESSION_TYPE);
+		this._isActiveSessionArchived.set(session?.isArchived.get() ?? false);
 		const provider = session ? this.sessionsProvidersService.getProviders().find(p => p.id === session.providerId) : undefined;
 		this._supportsMultiChat.set(provider?.capabilities.multipleChatsPerSession ?? false);
 
@@ -353,14 +356,15 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 
 			this._activeSession.set(activeSession, undefined);
 
-			// Listen for the active session becoming archived
-			if (!session.isArchived.get()) {
-				this._activeSessionDisposables.add(autorun(reader => {
-					if (session.isArchived.read(reader)) {
-						this.openNewSessionView();
-					}
-				}));
-			}
+			// Track archived state changes for the active session
+			const wasArchivedOnActivation = session.isArchived.get();
+			this._activeSessionDisposables.add(autorun(reader => {
+				const isArchived = session.isArchived.read(reader);
+				this._isActiveSessionArchived.set(isArchived);
+				if (isArchived && !wasArchivedOnActivation) {
+					this.openNewSessionView();
+				}
+			}));
 		} else {
 			this._activeChatObservable = undefined;
 			this._activeSession.set(undefined, undefined);

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -357,13 +357,14 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 			this._activeSession.set(activeSession, undefined);
 
 			// Track archived state changes for the active session
-			const wasArchivedOnActivation = session.isArchived.get();
+			let wasArchived = session.isArchived.get();
 			this._activeSessionDisposables.add(autorun(reader => {
 				const isArchived = session.isArchived.read(reader);
 				this._isActiveSessionArchived.set(isArchived);
-				if (isArchived && !wasArchivedOnActivation) {
+				if (isArchived && !wasArchived) {
 					this.openNewSessionView();
 				}
+				wasArchived = isArchived;
 			}));
 		} else {
 			this._activeChatObservable = undefined;


### PR DESCRIPTION
## Summary

When a session is already marked as done, the checkmark button in the command center was still shown but did nothing on click. This PR replaces it with a **Restore** button so users can un-archive the session.

## Changes

- **`IsActiveSessionArchivedContext`** — new context key that reactively tracks whether the active session is archived
- **`MarkSessionAsDoneAction`** — hidden from the command center when the active session is already archived
- **`UnarchiveSessionAction`** — added to the command center (with active-session fallback when invoked without context) so the restore button appears for done sessions
- **`sessionsManagementService`** — reactively updates `IsActiveSessionArchivedContext` via an autorun on the active session's `isArchived` observable

## Before / After

| Before | After |
|--------|-------|
| Checkmark shown for done sessions (no-op on click) | Restore (discard) icon shown for done sessions |

Fixes #307712