### PR TITLE
sessions: use focus border for chat inputs

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -430,6 +430,7 @@ Parts manage their own border and background styling via the `updateStyles()` me
 | Panel | Card appearance via CSS variables `--part-background` / `--part-border-color`, with a light-theme-only CSS border-color override | Uses `sessionsPanelBackground` / `PANEL_BORDER`; default light themes map this card to `editorBackground` and darken the outline with `editorWidget.border`, while dark and high-contrast themes keep the existing sidebar-style surface; margins create card offset |
 
 The sessions workbench also scopes its resize sash styling in `browser/media/style.css`, rounding the sash hover indicator and orthogonal drag handles so the layout chrome matches the card surfaces.
+Both sessions chat input surfaces keep the unfocused `editorWidget.border` outline in light themes, but switch to `focusBorder` while focused so the new-chat view and the active chat input match the core workbench chat widget focus treatment.
 
 ---
 
@@ -648,6 +649,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-10 | Updated both sessions chat input surfaces so the standalone new-chat input and the active chat widget input switch their border to `focusBorder` while focused, matching the core workbench chat widget focus treatment. |
 | 2026-04-08 | Darkened the light-theme-only chat, auxiliary bar, and panel card borders with a sessions-specific CSS `border-color` override that uses `editorWidget.border`; dark and high-contrast themes continue using the existing part border tokens. |
 | 2026-04-08 | Rounded the sessions workbench sash hover indicators and orthogonal drag handles via `browser/media/style.css` so resize handles use rounded corners instead of square edges. |
 | 2026-04-04 | Inverted the default light-theme surface mapping so the sessions window background uses the off-white workbench/sidebar surface while the chat, changes, and panel cards use the brighter editor background; dark and high-contrast mappings remain unchanged. |

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -138,6 +138,10 @@
 	border-radius: var(--vscode-cornerRadius-large);
 	border-color: var(--vscode-editorWidget-border, var(--vscode-widget-border)) !important;
 }
+
+.agent-sessions-workbench .interactive-session .chat-input-container.focused {
+	border-color: var(--vscode-focusBorder) !important;
+}
 .agent-sessions-workbench .interactive-session .interactive-input-part {
 	width: 100%;
 	max-width: 950px;

--- a/src/vs/sessions/browser/widget/AGENTS_CHAT_WIDGET.md
+++ b/src/vs/sessions/browser/widget/AGENTS_CHAT_WIDGET.md
@@ -155,7 +155,7 @@ Renders the welcome view when the chat is empty:
 - **Option pickers** — extension-contributed option groups (repository, folder, etc.)
 - **Input slot** — where the chat input is placed when in welcome mode
 
-The welcome part reads from `IAgentChatTargetConfig` and the `IChatSessionsService` for option groups.
+The welcome part reads from `IAgentChatTargetConfig` and the `IChatSessionsService` for option groups. When the shared `ChatInputPart` is rendered in this slot, the sessions window preserves the core `.chat-input-container.focused` focus border behavior so the active chat input uses `focusBorder` while focused.
 
 ### 3.4 `AgentSessionsChatInputPart`
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -35,7 +35,7 @@
 }
 
 .sessions-chat-input-area:focus-within {
-	border-color: var(--vscode-editorWidget-border, var(--vscode-widget-border, var(--vscode-contrastBorder, transparent)));
+	border-color: var(--vscode-focusBorder);
 }
 
 /* Editor */


### PR DESCRIPTION
## Summary
- switch the sessions new-chat input border to `focusBorder` while focused
- restore the active sessions chat widget input border to `focusBorder` when `.chat-input-container.focused` is applied
- document the focused border behavior in the sessions layout and chat widget docs

<img width="1820" height="1162" alt="Screenshot 2026-04-10 at 1 11 28 PM" src="https://github.com/user-attachments/assets/90040c56-3692-466f-98d8-f654720fb417" />
<img width="1820" height="1162" alt="Screenshot 2026-04-10 at 1 11 45 PM" src="https://github.com/user-attachments/assets/2e70bb77-bd4c-4757-b4dc-28f8cd4df0fe" />

## Why
The sessions app was keeping the unfocused border styling even when the input had focus. This aligns both the new chat view and active chat view with the core VS Code chat input widget focus treatment.