### PR TITLE
Read autoModeRoutingMethod experiment variable before router gate

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -187,9 +187,14 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			entry.needsReEval = false;
 		}
 
+		// Read the routing method experiment variable eagerly so the experiment
+		// framework records the assignment for ALL auto-mode users, not just the
+		// subset that also has UseAutoModeRouting enabled.
+		const routingMethod = this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModeRoutingMethod, this._expService) || undefined;
+
 		const routerResult = skipRouter
 			? { lastRoutedPrompt: chatRequest?.prompt?.trim() ?? entry?.lastRoutedPrompt }
-			: await this._tryRouterSelection(chatRequest, conversationId, entry, token, knownEndpoints);
+			: await this._tryRouterSelection(chatRequest, conversationId, entry, token, knownEndpoints, routingMethod);
 		let selectedModel = routerResult.selectedModel;
 		const lastRoutedPrompt = routerResult.lastRoutedPrompt;
 		const routerFallbackReason = routerResult.fallbackReason;
@@ -248,6 +253,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		entry: AutoModelCacheEntry | undefined,
 		token: AutoModeAPIResponse,
 		knownEndpoints: IChatEndpoint[],
+		routingMethod?: string,
 	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string }> {
 		const prompt = chatRequest?.prompt?.trim();
 		const lastRoutedPrompt = entry?.lastRoutedPrompt ?? prompt;
@@ -277,7 +283,6 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 				previous_model: entry?.endpoint?.model,
 				turn_number: (entry?.turnCount ?? 0) + 1,
 			};
-			const routingMethod = this._configurationService.getExperimentBasedConfig(ConfigKey.TeamInternal.AutoModeRoutingMethod, this._expService) || undefined;
 			const result = await this._routerDecisionFetcher.getRouterDecision(prompt, token.session_token, token.available_models, undefined, contextSignals, chatRequest?.sessionId, chatRequest?.id, routingMethod);
 
 			if (result.fallback) {


### PR DESCRIPTION
## Problem

The `autoModeRoutingMethod` experiment variable (`hydra`/`binary`/empty) was only read inside `_tryRouterSelection()` **after** the `_isRouterEnabled()` check (which gates on the separate `useAutoModeRouter` experiment). This meant the experiment framework only recorded the variable assignment for users who were in **both** experiments, making the Hydra experiment cohort appear much smaller than intended.

```
resolveAutoModeEndpoint()
  -> _tryRouterSelection()
       hasImage? -> fallback
       _isRouterEnabled()? -> NO -> return (never reads routingMethod)
       YES -> reads AutoModeRoutingMethod -> calls router
```

## Fix

Read the routing method eagerly in `resolveAutoModeEndpoint()` before the router-enabled gate, so the experiment framework records the assignment for **all** auto-mode users. The value is then passed through to `_tryRouterSelection()` for actual use when routing is enabled.

```
resolveAutoModeEndpoint()
  reads AutoModeRoutingMethod (all auto-mode users)
  -> _tryRouterSelection(... routingMethod)
       _isRouterEnabled()? -> NO -> return
       YES -> uses routingMethod -> calls router
```

## Impact

No behavioral change — routing still only happens when `useAutoModeRouter=true`. But the experiment framework now sees the `autoModeRoutingMethod` variable being queried by all auto-mode users, giving accurate cohort sizes for the Hydra A/B/C experiment.
