### PR TITLE
address screen reader feedback on Agents App

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -24,6 +24,7 @@ import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { SessionsView, SessionsViewId } from '../../sessions/browser/views/sessionsView.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { TerminalContextKeys } from '../../../../workbench/contrib/terminal/common/terminalContextKey.js';
 
 //#region Utilities
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -300,7 +300,7 @@ registerAction2(class extends Action2 {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC,
-				when: IsSessionsWindowContext,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, TerminalContextKeys.focus.negate()),
 			},
 		});
 	}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -298,7 +298,7 @@ registerAction2(class extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyU,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC,
 				when: IsSessionsWindowContext,
 			},
 		});

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -57,7 +57,7 @@ registerAction2(class FocusChangesViewAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG,
 				when: IsSessionsWindowContext,
 			},
 		});
@@ -75,7 +75,7 @@ registerAction2(class FocusChangesFileViewAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.agentSessions.focusChangesFileView',
-			title: localize2('focusChangesFileView', "Focus on File Explorer"),
+			title: localize2('focusChangesFileView', "Focus Files Explorer View"),
 			category: Categories.View,
 			precondition: IsSessionsWindowContext,
 			f1: true,

--- a/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp.ts
@@ -23,11 +23,12 @@ export class SessionsChatAccessibilityHelp implements IAccessibleViewImplementat
 		const viewsService = accessor.get(IViewsService);
 
 		const content: string[] = [];
-		content.push(localize('sessionsChat.overview', "You are in the Agents app chat input. Type a message and press Enter to send it."));
+		content.push(localize('sessionsChat.overview', "You are in the Agents app. The Agents app is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options."));
+		content.push(localize('sessionsChat.input', "You are in the chat input. Type a message and press Enter to send it."));
 		content.push(localize('sessionsChat.workspace', "Shift+Tab to navigate to the workspace picker and choose a workspace for your session."));
 		content.push(localize('sessionsChat.history', "Use up and down arrows to navigate your request history in the input box."));
 		content.push(localize('sessionsChat.changes', "Focus the Changes view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesView>'));
-		content.push(localize('sessionsChat.filesView', "Focus the Changes files view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesFileView>'));
+		content.push(localize('sessionsChat.filesView', "Focus the Files Explorer view{0}.", '<keybinding:workbench.action.agentSessions.focusChangesFileView>'));
 		content.push(localize('sessionsChat.sessionsView', "Focus the Chat Sessions view{0}.", '<keybinding:workbench.action.chat.focusAgentSessionsViewer>'));
 		content.push(localize('sessionsChat.customizations', "Focus the Chat Customizations view{0}.", `<keybinding:${FOCUS_AI_CUSTOMIZATION_VIEW_ID}>`));
 


### PR DESCRIPTION
fixes #309080 — Changed Customizations keybinding from Ctrl+Shift+U to Ctrl+Shift+C
fixes #309081 — Renamed "Focus on File Explorer" to "Focus Files Explorer View", updated a11y help to say "Files Explorer view" instead of "Changes files view"
fixes #309082 — Changed Changes view keybinding from Ctrl+Shift+H to Ctrl+Shift+G
fixes #309083 — Added Agents app explanation to the accessibility help dialog, splitting the overview into a description of the app and a separate input instruction