### PR TITLE
Sessions: filter out Claude customization directories

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -14,8 +14,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
-import { HOOKS_SOURCE_FOLDER, SKILL_FILENAME } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
-import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { HOOKS_SOURCE_FOLDER, IPromptSourceFolder, SKILL_FILENAME } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
+import { PromptFileSource, PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IAgentSkill, IPromptPath, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { BUILTIN_STORAGE, IBuiltinPromptPath } from '../../chat/common/builtinPromptsStorage.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
@@ -253,6 +253,18 @@ class AgenticPromptFilesLocator extends PromptFilesLocator {
 		return Event.fromObservableLight(this.customizationWorkspaceService.activeProjectRoot);
 	}
 
+	/**
+	 * Filter out Claude-specific source folders in the sessions app.
+	 * The sessions window only supports .github and .copilot customization directories.
+	 */
+	protected override getPromptSourceFolders(type: PromptsType): IPromptSourceFolder[] {
+		return super.getPromptSourceFolders(type).filter(f => !isClaudeSource(f.source));
+	}
+
+	protected override getDefaultSourceFolders(type: PromptsType): readonly IPromptSourceFolder[] {
+		return super.getDefaultSourceFolders(type).filter(f => !isClaudeSource(f.source));
+	}
+
 	public override async getHookSourceFolders(): Promise<readonly URI[]> {
 		const configured = await super.getHookSourceFolders();
 		if (configured.length > 0) {
@@ -299,5 +311,15 @@ function getCliUserSubfolder(type: PromptsType): string | undefined {
 function sanitizeSkillText(text: string, maxLength: number): string {
 	const sanitized = text.replace(/<[^>]+>/g, '');
 	return sanitized.length > maxLength ? sanitized.substring(0, maxLength) : sanitized;
+}
+
+/**
+ * Returns whether the given source is a Claude-specific location.
+ * The sessions app does not support Claude customization directories.
+ */
+function isClaudeSource(source: PromptFileSource): boolean {
+	return source === PromptFileSource.ClaudePersonal
+		|| source === PromptFileSource.ClaudeWorkspace
+		|| source === PromptFileSource.ClaudeWorkspaceLocal;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -255,14 +255,14 @@ class AgenticPromptFilesLocator extends PromptFilesLocator {
 
 	/**
 	 * Filter out Claude-specific source folders in the sessions app.
-	 * The sessions window only supports .github and .copilot customization directories.
+	 * Claude customization directories are not supported in the sessions window.
 	 */
 	protected override getPromptSourceFolders(type: PromptsType): IPromptSourceFolder[] {
-		return super.getPromptSourceFolders(type).filter(f => !isClaudeSource(f.source));
+		return super.getPromptSourceFolders(type).filter(f => !isClaudeFolder(f));
 	}
 
 	protected override getDefaultSourceFolders(type: PromptsType): readonly IPromptSourceFolder[] {
-		return super.getDefaultSourceFolders(type).filter(f => !isClaudeSource(f.source));
+		return super.getDefaultSourceFolders(type).filter(f => !isClaudeFolder(f));
 	}
 
 	public override async getHookSourceFolders(): Promise<readonly URI[]> {
@@ -314,12 +314,17 @@ function sanitizeSkillText(text: string, maxLength: number): string {
 }
 
 /**
- * Returns whether the given source is a Claude-specific location.
- * The sessions app does not support Claude customization directories.
+ * Returns whether the given source folder targets a Claude-specific location.
+ * Checks both the typed source enum and the path string to also catch
+ * user-configured entries that use ConfigWorkspace/ConfigPersonal sources.
  */
-function isClaudeSource(source: PromptFileSource): boolean {
-	return source === PromptFileSource.ClaudePersonal
-		|| source === PromptFileSource.ClaudeWorkspace
-		|| source === PromptFileSource.ClaudeWorkspaceLocal;
+function isClaudeFolder(folder: IPromptSourceFolder): boolean {
+	if (folder.source === PromptFileSource.ClaudePersonal
+		|| folder.source === PromptFileSource.ClaudeWorkspace
+		|| folder.source === PromptFileSource.ClaudeWorkspaceLocal) {
+		return true;
+	}
+	// User-configured paths get Config* source types, so also check the path
+	return folder.path.startsWith('.claude/') || folder.path.includes('/.claude/');
 }
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -261,7 +261,7 @@ export class PromptFilesLocator {
 
 	/**
 	 * Gets the hook source folders for creating new hooks.
-	 * Returns folders from config, excluding user storage and Claude paths (which are read-only).
+	 * Returns configured hook folders, excluding Claude paths (which are read-only).
 	 */
 	public async getHookSourceFolders(): Promise<readonly URI[]> {
 		const configuredLocations = this.getPromptSourceFolders(PromptsType.hook);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -81,6 +81,22 @@ export class PromptFilesLocator {
 		return Event.map(this.workspaceService.onDidChangeWorkspaceFolders, () => undefined);
 	}
 
+	/**
+	 * Returns the configured prompt source folders for the given type.
+	 * Subclasses can override to filter out unsupported sources.
+	 */
+	protected getPromptSourceFolders(type: PromptsType): IPromptSourceFolder[] {
+		return PromptsConfig.promptSourceFolders(this.configService, type);
+	}
+
+	/**
+	 * Returns the default prompt source folders for the given type.
+	 * Subclasses can override to filter out unsupported sources.
+	 */
+	protected getDefaultSourceFolders(type: PromptsType): readonly IPromptSourceFolder[] {
+		return getPromptFileDefaultLocations(type);
+	}
+
 	public async getWorkspaceFolderRoots(includeParents: boolean, logger?: Logger): Promise<URI[]> {
 		const workspaceFolders = this.getWorkspaceFolders();
 		if (includeParents) {
@@ -152,7 +168,7 @@ export class PromptFilesLocator {
 			throw new Error(`Unsupported prompt file storage: ${storage}`);
 		}
 
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+		const configuredLocations = this.getPromptSourceFolders(type);
 		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations.filter(loc => loc.storage === storage));
 
 		if (storage === PromptsStorage.user && (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt)) {
@@ -201,7 +217,7 @@ export class PromptFilesLocator {
 
 		const update = async () => {
 			try {
-				const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+				const configuredLocations = this.getPromptSourceFolders(type);
 				parentFolders = await this.toAbsoluteLocations(type, configuredLocations, undefined);
 
 				if (token.isCancellationRequested) {
@@ -248,7 +264,7 @@ export class PromptFilesLocator {
 	 * Returns folders from config, excluding user storage and Claude paths (which are read-only).
 	 */
 	public async getHookSourceFolders(): Promise<readonly URI[]> {
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, PromptsType.hook);
+		const configuredLocations = this.getPromptSourceFolders(PromptsType.hook);
 
 		// Ignore claude folders since they aren't first-class supported, so we don't want to create invalid formats
 		// Check for .claude as an actual path segment (starts with ".claude/" or contains "/.claude/")
@@ -283,7 +299,7 @@ export class PromptFilesLocator {
 	 * @returns List of possible unambiguous prompt file folders.
 	 */
 	public async getConfigBasedSourceFolders(type: PromptsType): Promise<readonly URI[]> {
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+		const configuredLocations = this.getPromptSourceFolders(type);
 		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations);
 
 		// For anything that doesn't support glob patterns, we can return
@@ -364,8 +380,8 @@ export class PromptFilesLocator {
 	 * This merges default folders with configured locations.
 	 */
 	private async getLocalStorageFolders(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
-		const defaultFolders = getPromptFileDefaultLocations(type);
+		const configuredLocations = this.getPromptSourceFolders(type);
+		const defaultFolders = this.getDefaultSourceFolders(type);
 
 		// Merge default folders with configured locations, avoiding duplicates
 		const allFolders = [
@@ -724,7 +740,7 @@ export class PromptFilesLocator {
 	 * Searches for skills in all configured locations.
 	 */
 	public async findAgentSkills(token: CancellationToken): Promise<IPromptPath[]> {
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, PromptsType.skill);
+		const configuredLocations = this.getPromptSourceFolders(PromptsType.skill);
 		const absoluteLocations = await this.toAbsoluteLocations(PromptsType.skill, configuredLocations);
 		const allResults: IPromptPath[] = [];
 


### PR DESCRIPTION
The sessions (Agents) window was incorrectly showing `.claude` directories in the customization picker and tree view, allowing users to browse and create customizations in `.claude` paths. The sessions app should only support `.github` and `.copilot` directories.

## Changes

**`PromptFilesLocator` (base class refactor)**
- Added two `protected` hook methods: `getPromptSourceFolders()` and `getDefaultSourceFolders()`
- Replaced all direct calls to `PromptsConfig.promptSourceFolders()` and `getPromptFileDefaultLocations()` with these overridable methods
- No behavioral change for the base class — pure refactor to enable subclass filtering

**`AgenticPromptFilesLocator` (sessions subclass)**
- Overrides both hooks to filter out `ClaudePersonal`, `ClaudeWorkspace`, and `ClaudeWorkspaceLocal` sources
- This removes `.claude` directories from file listing, creation targets, file watching, and skill discovery in the sessions app