### PR TITLE
product: rename GHE.com label to GHE

### DIFF
--- a/product.json
+++ b/product.json
@@ -105,7 +105,7 @@
 			},
 			"enterprise": {
 				"id": "github-enterprise",
-				"name": "GHE.com"
+				"name": "GHE"
 			},
 			"google": {
 				"id": "google",


### PR DESCRIPTION
## Summary
- rename the GitHub Enterprise auth provider label in `product.json` from `GHE.com` to `GHE`

## Why
- use the shorter product name in the sign-in provider label

## Notes
- `npm run compile-check-ts-native` passed
- `npm run hygiene` currently fails on an unrelated pre-existing issue in `extensions/mermaid-chat-features/chat-webview-out/codicon.css` (`Missing or bad copyright statement`)