### PR TITLE
fix: AI customization welcome page - prefill active session & update placeholder

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -88,6 +88,7 @@ import { ICustomizationHarnessService, CustomizationHarness, matchesWorkspaceSub
 import { ChatConfiguration } from '../../common/constants.js';
 import { AICustomizationWelcomePage } from './aiCustomizationWelcomePage.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
+import { IChatWidgetService } from '../chat.js';
 
 const $ = DOM.$;
 
@@ -349,6 +350,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 		@IViewsService private readonly viewsService: IViewsService,
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 	) {
 		super(AICustomizationManagementEditor.ID, group, telemetryService, themeService, storageService);
 
@@ -814,15 +816,23 @@ export class AICustomizationManagementEditor extends EditorPane {
 				},
 				prefillChat: (query, options) => {
 					if (this.workspaceService.isSessionsWindow) {
-						const sessionsViewId = 'workbench.view.sessions.chat';
-						this.viewsService.openView(sessionsViewId, true).then(view => {
-							const chatView = view as unknown as { prefillInput?(text: string): void; sendQuery?(text: string): void } | undefined;
-							if (options?.isPartialQuery && chatView?.prefillInput) {
-								chatView.prefillInput(query);
-							} else if (chatView?.sendQuery) {
-								chatView.sendQuery(query);
-							}
-						});
+						const widget = this.chatWidgetService.lastFocusedWidget;
+						if (widget) {
+							this.chatWidgetService.reveal(widget).then(() => {
+								widget.setInput(query);
+								widget.focusInput();
+							});
+						} else {
+							const sessionsViewId = 'workbench.view.sessions.chat';
+							this.viewsService.openView(sessionsViewId, true).then(view => {
+								const chatView = view as unknown as { prefillInput?(text: string): void; sendQuery?(text: string): void } | undefined;
+								if (options?.isPartialQuery && chatView?.prefillInput) {
+									chatView.prefillInput(query);
+								} else if (chatView?.sendQuery) {
+									chatView.sendQuery(query);
+								}
+							});
+						}
 					} else {
 						this.commandService.executeCommand('workbench.action.chat.open', { query, isPartialQuery: options?.isPartialQuery ?? false });
 					}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -101,19 +101,19 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 			const icon = DOM.append(header, $('span.welcome-prompts-section-label-icon.codicon.codicon-sparkle'));
 			icon.setAttribute('aria-hidden', 'true');
 			const title = DOM.append(header, $('span'));
-			title.textContent = localize('gettingStartedTitle', "Generate Workflow");
+			title.textContent = localize('gettingStartedTitle', "Customize Your Agent");
 
 			const description = DOM.append(gettingStarted, $('p.welcome-prompts-input-helper'));
-			description.textContent = localize('gettingStartedDesc', "Describe your stack, conventions, and workflow to draft agents, skills, and instructions.");
+			description.textContent = localize('gettingStartedDesc', "Describe your preferences and conventions to draft agents, skills, and instructions.");
 
 			const inputRow = DOM.append(gettingStarted, $('.welcome-prompts-input-row'));
 			this.inputElement = DOM.append(inputRow, $('input.welcome-prompts-input')) as HTMLInputElement;
 			this.inputElement.type = 'text';
 			this.inputElement.placeholder = localize('workflowInputPlaceholder', "Prefer concise commits, thorough reviews, and tested code...");
-			this.inputElement.setAttribute('aria-label', localize('workflowInputAriaLabel', "Describe your project to generate a workflow"));
+			this.inputElement.setAttribute('aria-label', localize('workflowInputAriaLabel', "Describe your preferences to customize your agent"));
 
 			const submitBtn = DOM.append(inputRow, $('button.welcome-prompts-input-submit'));
-			submitBtn.setAttribute('aria-label', localize('workflowSubmitAriaLabel', "Generate workflow"));
+			submitBtn.setAttribute('aria-label', localize('workflowSubmitAriaLabel', "Customize agent"));
 			const chevron = DOM.append(submitBtn, $('span.codicon.codicon-arrow-up'));
 			chevron.setAttribute('aria-hidden', 'true');
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers.ts
@@ -109,7 +109,7 @@ export class PromptLaunchersAICustomizationWelcomePage extends Disposable implem
 			const inputRow = DOM.append(gettingStarted, $('.welcome-prompts-input-row'));
 			this.inputElement = DOM.append(inputRow, $('input.welcome-prompts-input')) as HTMLInputElement;
 			this.inputElement.type = 'text';
-			this.inputElement.placeholder = localize('workflowInputPlaceholder', "I'm building a React app with TypeScript and Tailwind...");
+			this.inputElement.placeholder = localize('workflowInputPlaceholder', "Prefer concise commits, thorough reviews, and tested code...");
 			this.inputElement.setAttribute('aria-label', localize('workflowInputAriaLabel', "Describe your project to generate a workflow"));
 
 			const submitBtn = DOM.append(inputRow, $('button.welcome-prompts-input-submit'));

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -24,6 +24,7 @@ import { IWorkspace, IWorkspaceContextService, WorkbenchState } from '../../../.
 import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
+import { IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
@@ -503,6 +504,10 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 			reg.defineInstance(IQuickInputService, new class extends mock<IQuickInputService>() { }());
 			reg.defineInstance(IViewsService, new class extends mock<IViewsService>() {
 				override async openView<T extends {}>(_id: string, _focus?: boolean) { return null as T | null; }
+			}());
+			reg.defineInstance(IChatWidgetService, new class extends mock<IChatWidgetService>() {
+				override get lastFocusedWidget() { return undefined; }
+				override async reveal() { return false; }
 			}());
 			reg.defineInstance(IRequestService, new class extends mock<IRequestService>() { }());
 			reg.defineInstance(IMarkdownRendererService, new class extends mock<IMarkdownRendererService>() {


### PR DESCRIPTION
## Summary

Two improvements to the AI customization welcome page:

### 1. Fix "New..." button to target active session's chat input
Previously, the "New..." button always opened the `NewChatViewPane` (new-session view) to prefill text. When a session was already active, this was the wrong target — the text should go into the active session's chat widget instead.

**Fix:** The `prefillChat` callback now checks `IChatWidgetService.lastFocusedWidget` first. If an active widget exists, it reveals it and sets the input there. Falls back to the `NewChatViewPane` only when no session is active.

### 2. Update placeholder text
Changed from `"I'm building a React app with TypeScript and Tailwind..."` to `"Prefer concise commits, thorough reviews, and tested code..."` — a more workflow-oriented example that better matches the "Generate Workflow" purpose of the input.