### PR TITLE
agents: ellipsize titlebar repo metadata first

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -83,6 +83,7 @@ The Agent Sessions titlebar includes a command center with a custom title bar wi
 The widget:
 - Extends `BaseActionViewItem` and renders a clickable label showing the active session title
 - Shows kind icon (provider type icon), session title, repository folder name, and the active git branch/worktree name in parentheses when available, plus the changes summary (+insertions -deletions)
+- Truncates the repository/worktree metadata with ellipsis before truncating the primary AI-generated session title when command center space is constrained
 - On click, opens the `AgentSessionsPicker` quick pick to switch between sessions
 - Gets the active session label from `IActiveSessionService.getActiveSession()` and the live model title from `IChatService`, falling back to "New Session" if no active session is found
 - Re-renders automatically when the active session changes via `autorun` on `IActiveSessionService.activeSession`, and when session data changes via `IAgentSessionsService.model.onDidChangeSessions`
@@ -650,6 +651,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-10 | Updated the sessions titlebar widget so repository/worktree metadata truncates with ellipsis before the primary AI-generated session title when the command center gets narrow. |
 | 2026-04-10 | Updated workspace/repository section headers in the Sessions sidebar to keep their uppercase titles visible via ellipsis truncation so the section toolbar actions remain reachable when names are long. |
 | 2026-04-10 | Updated the Sessions view header so the sidebar "Sessions" label stays visible and truncates with ellipsis when space is tight instead of being hidden; documented the find-widget exception in the Sessions view spec. |
 | 2026-04-10 | Updated both sessions chat input surfaces so the standalone new-chat input and the active chat widget input switch their border to `focusBorder` while focused, matching the core workbench chat widget focus treatment. |

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -72,9 +72,11 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
+	flex: 1 1 auto;
 	min-width: 0;
 	justify-content: flex-start;
 	cursor: pointer;
+	overflow: hidden;
 }
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-icon {
 	display: flex;
@@ -89,17 +91,30 @@
 
 /* Label (title) */
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-label {
+	flex: 0 1 auto;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-weight: 500;
 }
 
-/* Repository/folder label */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-repo {
+/* Repository/worktree metadata shrinks before the primary title. */
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-details {
 	display: flex;
 	align-items: center;
-	flex-shrink: 0;
+	flex: 0 999 auto;
+	gap: 6px;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-repo {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	opacity: 0.7;
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -173,13 +173,18 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 
 			// Folder shown next to the title
 			if (repoLabel) {
+				const detailsEl = $('span.agent-sessions-titlebar-details');
+
 				const separator1 = $('span.agent-sessions-titlebar-separator');
 				separator1.textContent = '\u00B7';
-				centerGroup.appendChild(separator1);
+				separator1.setAttribute('aria-hidden', 'true');
+				detailsEl.appendChild(separator1);
 
 				const repoEl = $('span.agent-sessions-titlebar-repo');
 				repoEl.textContent = repoDetailLabel ? `${repoLabel} (${repoDetailLabel})` : repoLabel;
-				centerGroup.appendChild(repoEl);
+				detailsEl.appendChild(repoEl);
+
+				centerGroup.appendChild(detailsEl);
 			}
 
 			sessionPill.appendChild(centerGroup);


### PR DESCRIPTION
## Summary
- wrap the repo/worktree suffix in the sessions titlebar widget so it can truncate independently
- apply ellipsis styling to the repo/worktree metadata and let it shrink before the primary AI-generated session title
- document the updated command center truncation behavior in the sessions layout spec

Current behavior:

<img width="380" height="80" alt="Screenshot 2026-04-10 at 6 06 19 PM" src="https://github.com/user-attachments/assets/a6237823-0865-4929-b534-ee411464cc0e" />

Change:

https://github.com/user-attachments/assets/f1c7c4b7-7b1b-4815-b324-1f6d4c9bdc6f

## Why
When the sessions chat panel is collapsed and command center space gets tight, the primary title was truncating first while the repo/worktree metadata stayed fixed. This change preserves the main session title longer and only truncates it after the suffix has collapsed.