### PR TITLE
Do not open debug view on first session start when openDebug is openOnDebugBreak

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -641,8 +641,9 @@ export class DebugService implements IDebugService {
 		this._onWillNewSession.fire(session);
 
 		const openDebug = this.configurationService.getValue<IDebugConfiguration>('debug').openDebug;
-		// Open debug viewlet based on the visibility of the side bar and openDebug setting. Do not open for 'run without debug'
-		if (!configuration.resolved.noDebug && (openDebug === 'openOnSessionStart' || (openDebug !== 'neverOpen' && this.viewModel.firstSessionStart)) && !session.suppressDebugView) {
+		// Open debug viewlet based on the visibility of the side bar and openDebug setting. Do not open for 'run without debug'.
+		// Note: 'openOnDebugBreak' is intentionally excluded here - that case is handled in debugSession when a breakpoint is hit.
+		if (!configuration.resolved.noDebug && (openDebug === 'openOnSessionStart' || (openDebug === 'openOnFirstSessionStart' && this.viewModel.firstSessionStart)) && !session.suppressDebugView) {
 			await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
 		}
 


### PR DESCRIPTION
## Summary

Fixes #263434.

The default `debug.openDebug` value is `openOnDebugBreak`, which is documented as opening the debug view when the debugger breaks. However, the view also opened on the very first debug session of a window, regardless of whether a breakpoint was hit.

The previous condition in `DebugService.launchOrAttachToSession` was:

```ts
if (!configuration.resolved.noDebug && (openDebug === 'openOnSessionStart' || (openDebug !== 'neverOpen' && this.viewModel.firstSessionStart)) && !session.suppressDebugView) {
```

The `openDebug !== 'neverOpen'` check caused `openOnDebugBreak` (and any other value) to fall into the first-session-start branch. The fix restricts that branch to the explicit `openOnFirstSessionStart` value, which is what users expect when reading the setting names.

`openOnDebugBreak` is still handled separately in `debugSession.ts` when a thread stops on a `breakpoint` reason, so behavior on actual breaks is unchanged.

## Test plan

- [ ] Set `debug.openDebug` to `openOnDebugBreak` (the default), reload the window, and start a debug session that does not hit a breakpoint immediately. The debug view should not auto-open.
- [ ] With the same setting, hit a breakpoint. The debug view should still auto-open.
- [ ] Set `debug.openDebug` to `openOnFirstSessionStart` and start a debug session in a fresh window. The debug view should open.
- [ ] Set `debug.openDebug` to `openOnSessionStart` and start any debug session. The debug view should open.
- [ ] Set `debug.openDebug` to `neverOpen`. The debug view should never auto-open.