### PR TITLE
git: clarify that addAICoAuthor only applies to UI commits

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -246,7 +246,7 @@
 	"config.worktreeIncludeFiles": "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) for files and folders that are included when creating a new worktree. Only files and folders that match the patterns and are listed in `.gitignore` will be copied to the newly created worktree.",
 	"config.alwaysShowStagedChangesResourceGroup": "Always show the Staged Changes resource group.",
 	"config.alwaysSignOff": "Controls the signoff flag for all commits.",
-	"config.addAICoAuthor": "Controls whether a 'Co-authored-by' trailer is automatically added to the commit message when AI-generated code is included in the commit.",
+	"config.addAICoAuthor": "Controls whether a 'Co-authored-by' trailer is automatically added to the commit message when AI-generated code is included in the commit. This setting only applies to commits made from the Source Control view; it does not affect commits made from the command line.",
 	"config.addAICoAuthor.off": "Never add the AI co-author trailer.",
 	"config.addAICoAuthor.chatAndAgent": "Add the AI co-author trailer when code from chat or agent edits is included.",
 	"config.addAICoAuthor.all": "Add the AI co-author trailer when any AI-generated code is included, such as inline completions, chat, or agent edits.",


### PR DESCRIPTION
## Summary

The `git.addAICoAuthor` setting only takes effect for commits made from the VS Code Source Control view; commits made from the command line are not affected because the extension does not install a `prepare-commit-msg` hook. The current setting description does not mention this, which can mislead users into expecting CLI commits to gain a `Co-authored-by` trailer too.

This PR updates the setting description to make the scope explicit.

Fixes #297415

## Test plan

- [x] `git.addAICoAuthor` description in Settings UI shows the new wording explaining it only applies to commits made from the Source Control view
- [x] No code paths are affected; this is a string-only change in `extensions/git/package.nls.json`