### PR TITLE
Render borders for tables in hover markdown

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -190,6 +190,29 @@
 	margin-bottom: 2px;
 }
 
+/**
+ * Render borders for tables in hover markdown
+ * https://github.com/microsoft/vscode/issues/143884
+ */
+.monaco-hover table {
+	border-collapse: collapse;
+	margin: 8px 0;
+}
+
+.monaco-hover table:first-child {
+	margin-top: 0;
+}
+
+.monaco-hover table:last-child {
+	margin-bottom: 0;
+}
+
+.monaco-hover table th,
+.monaco-hover table td {
+	border: 1px solid var(--vscode-editorHoverWidget-border);
+	padding: 4px 6px;
+}
+
 .monaco-hover-content .action-container a {
 	-webkit-user-select: none;
 	user-select: none;


### PR DESCRIPTION
Fixes #143884

## Problem
Markdown tables rendered inside editor/widget hovers have no visible borders, making them hard to read.

## Fix
Add minimal table styling to `hoverWidget.css` so that tables inside any `.monaco-hover` get:
- `border-collapse: collapse`
- Thin borders on cells/headers using the existing `--vscode-editorHoverWidget-border` theme color
- Small vertical margins that collapse at the edges of the hover content (consistent with the surrounding `p`/`ul` spacing rules)

No theme colors were added; the existing hover border color is reused so the table fits every theme (including High Contrast) automatically.

## Test plan
- [ ] Trigger a hover that contains a markdown table (e.g. the test case attached to #143884 or any LSP hover returning a markdown table) and verify the table has visible borders matching the hover chrome.
- [ ] Verify nothing regresses for hovers without tables.
- [ ] Verify High Contrast themes still look correct.