### PR TITLE
Enable regular and background updates when UAC is disabled

### DIFF
--- a/src/vs/base/node/windowsVersion.ts
+++ b/src/vs/base/node/windowsVersion.ts
@@ -100,6 +100,38 @@ export function getWindowsReleaseSync(): string {
 	return versionInfo?.release ?? os.release();
 }
 
+let _isUACDisabled: boolean | undefined;
+
+/**
+ * Checks whether UAC (User Account Control) is disabled on Windows by reading
+ * the `EnableLUA` registry value under `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`.
+ *
+ * When `EnableLUA` is `0`, UAC is disabled and admin users run with full elevated
+ * privileges without prompts.
+ *
+ * @returns `true` if UAC is disabled, `false` otherwise (including on non-Windows platforms).
+ */
+export async function isUACDisabled(): Promise<boolean> {
+	if (_isUACDisabled !== undefined) {
+		return _isUACDisabled;
+	}
+
+	if (!isWindows) {
+		_isUACDisabled = false;
+		return false;
+	}
+
+	try {
+		const Registry = await import('@vscode/windows-registry');
+		const enableLUA = Registry.GetDWORDRegKey('HKEY_LOCAL_MACHINE', 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System', 'EnableLUA');
+		_isUACDisabled = enableLUA === 0;
+	} catch {
+		_isUACDisabled = false;
+	}
+
+	return _isUACDisabled;
+}
+
 /**
  * Parses the Windows build number from os.release().
  * This is used as a fallback when registry reading is not available.

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -21,7 +21,7 @@ import { URI } from '../../../base/common/uri.js';
 import { checksum } from '../../../base/node/crypto.js';
 import * as pfs from '../../../base/node/pfs.js';
 import { killTree } from '../../../base/node/processes.js';
-import { getWindowsRelease } from '../../../base/node/windowsVersion.js';
+import { getWindowsRelease, isUACDisabled } from '../../../base/node/windowsVersion.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { IFileService } from '../../files/common/files.js';
@@ -60,6 +60,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 
 	private availableUpdate: IAvailableUpdate | undefined;
 	private updateCancellationTokenSource: CancellationTokenSource | undefined;
+	private _canBackgroundUpdateAdminInstall: Promise<boolean> | undefined;
 
 	@memoize
 	get cachePath(): Promise<string> {
@@ -83,6 +84,28 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, telemetryService, applicationStorageMainService, meteredConnectionService, true);
 
 		lifecycleMainService.setRelaunchHandler(this);
+	}
+
+	/**
+	 * Returns whether background updates can be applied for a system/admin install.
+	 * This is true when UAC is disabled and the process is already running elevated,
+	 * meaning the spawned Inno Setup installer inherits admin privileges and can
+	 * write to Program Files without a UAC prompt.
+	 */
+	private canBackgroundUpdateAdminInstall(): Promise<boolean> {
+		if (!this._canBackgroundUpdateAdminInstall) {
+			this._canBackgroundUpdateAdminInstall = (async () => {
+				if (this.productService.target === 'user') {
+					return false;
+				}
+				const [isAdmin, uacDisabled] = await Promise.all([
+					this.nativeHostMainService.isAdmin(undefined),
+					isUACDisabled()
+				]);
+				return isAdmin && uacDisabled;
+			})();
+		}
+		return this._canBackgroundUpdateAdminInstall;
 	}
 
 	handleRelaunch(options?: IRelaunchOptions): boolean {
@@ -111,16 +134,19 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		type WindowsUpdateInitEvent = {
 			osRelease: string;
 			osNodeRelease: string;
+			isAdminNoUac: boolean;
 		};
 		type WindowsUpdateInitClassification = {
 			osRelease: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The Windows OS release version from registry.' };
 			osNodeRelease: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The Windows OS release version from os.release().' };
+			isAdminNoUac: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether this is an admin install with UAC disabled, enabling background updates.' };
 			owner: 'dmitriv';
 			comment: 'Tracks Windows OS release information during update initialization.';
 		};
 		const osRelease = await getWindowsRelease();
 		const osNodeRelease = release();
-		this.telemetryService.publicLog2<WindowsUpdateInitEvent, WindowsUpdateInitClassification>('windowsUpdateInit', { osRelease, osNodeRelease });
+		const isAdminNoUac = await this.canBackgroundUpdateAdminInstall();
+		this.telemetryService.publicLog2<WindowsUpdateInitEvent, WindowsUpdateInitClassification>('windowsUpdateInit', { osRelease, osNodeRelease, isAdminNoUac });
 
 		if (this.productService.target === 'user' && await this.nativeHostMainService.isAdmin(undefined)) {
 			this.setState(State.Disabled(DisablementReason.RunningAsAdmin));
@@ -158,8 +184,9 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		} else {
 			const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
 			// GC for background updates in system setup happens via inno_setup since it requires
-			// elevated permissions.
-			if (fastUpdatesEnabled && this.productService.target === 'user' && this.productService.commit) {
+			// elevated permissions. When UAC is disabled and running as admin, the process
+			// already has write access to Program Files so we can GC directly.
+			if (fastUpdatesEnabled && (this.productService.target === 'user' || await this.canBackgroundUpdateAdminInstall()) && this.productService.commit) {
 				const versionedResourcesFolder = this.productService.commit.substring(0, 10);
 				const innoUpdater = path.join(exeDir, versionedResourcesFolder, 'tools', 'inno_updater.exe');
 				const exeName = basename(exePath);
@@ -276,13 +303,13 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 								.then(() => pfs.Promises.rename(downloadPath, updatePackagePath, false /* no retry */))
 								.then(() => updatePackagePath);
 						});
-					}).then(packagePath => {
+					}).then(async packagePath => {
 						this.availableUpdate = { packagePath };
 						this.saveUpdateMetadata(update);
 						this.setState(State.Downloaded(update, explicit, this._overwrite));
 
 						const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
-						if (fastUpdatesEnabled && this.productService.target === 'user') {
+						if (fastUpdatesEnabled && (this.productService.target === 'user' || await this.canBackgroundUpdateAdminInstall())) {
 							this.doApplyUpdate();
 						} else {
 							this.setState(State.Ready(update, explicit, this._overwrite));
@@ -544,7 +571,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		this.availableUpdate = { packagePath };
 		this.setState(State.Downloaded(update, true, false));
 
-		if (fastUpdatesEnabled && this.productService.target === 'user') {
+		if (fastUpdatesEnabled && (this.productService.target === 'user' || await this.canBackgroundUpdateAdminInstall())) {
 			this.doApplyUpdate();
 		} else {
 			this.setState(State.Ready(update, true, false));

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -98,11 +98,16 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 				if (this.productService.target === 'user') {
 					return false;
 				}
-				const [isAdmin, uacDisabled] = await Promise.all([
-					this.nativeHostMainService.isAdmin(undefined),
-					isUACDisabled()
-				]);
-				return isAdmin && uacDisabled;
+				try {
+					const [isAdmin, uacDisabled] = await Promise.all([
+						this.nativeHostMainService.isAdmin(undefined),
+						isUACDisabled()
+					]);
+					return isAdmin && uacDisabled;
+				} catch (error) {
+					this.logService.warn('update#canBackgroundUpdateAdminInstall(): failed to determine admin/UAC state, falling back to false', error);
+					return false;
+				}
 			})();
 		}
 		return this._canBackgroundUpdateAdminInstall;

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -148,7 +148,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		const isAdminNoUac = await this.canBackgroundUpdateAdminInstall();
 		this.telemetryService.publicLog2<WindowsUpdateInitEvent, WindowsUpdateInitClassification>('windowsUpdateInit', { osRelease, osNodeRelease, isAdminNoUac });
 
-		if (this.productService.target === 'user' && await this.nativeHostMainService.isAdmin(undefined)) {
+		if (this.productService.target === 'user' && await this.nativeHostMainService.isAdmin(undefined) && !await isUACDisabled()) {
 			this.setState(State.Disabled(DisablementReason.RunningAsAdmin));
 			this.logService.info('update#ctor - updates are disabled due to running as Admin in user setup');
 			return;


### PR DESCRIPTION
When UAC is disabled and running as admin on Windows:
- Enable user-install updates
- Enable system-install background updates
