### PR TITLE
fix(search): only show Notebook Find Filters toggle for visible notebooks

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -40,7 +40,6 @@ import { NotebookFindFilters } from '../../notebook/browser/contrib/find/findFil
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { NotebookEditorInput } from '../../notebook/common/notebookEditorInput.js';
-import { GroupModelChangeKind } from '../../../common/editor.js';
 import { SearchFindInput } from './searchFindInput.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
@@ -222,10 +221,8 @@ export class SearchWidget extends Widget {
 					this.searchInput.updateFilterStyles();
 				}
 			}));
-		this._register(this.editorService.onDidEditorsChange((e) => {
-			if (this.searchInput &&
-				e.event.editor instanceof NotebookEditorInput &&
-				(e.event.kind === GroupModelChangeKind.EDITOR_OPEN || e.event.kind === GroupModelChangeKind.EDITOR_CLOSE)) {
+		this._register(this.editorService.onDidVisibleEditorsChange(() => {
+			if (this.searchInput) {
 				this.searchInput.filterVisible = this._hasNotebookOpen();
 			}
 		}));
@@ -246,8 +243,7 @@ export class SearchWidget extends Widget {
 	}
 
 	private _hasNotebookOpen(): boolean {
-		const editors = this.editorService.editors;
-		return editors.some(editor => editor instanceof NotebookEditorInput);
+		return this.editorService.visibleEditors.some(editor => editor instanceof NotebookEditorInput);
 	}
 
 	getNotebookFilters() {


### PR DESCRIPTION
## Summary

Fixes #224043

The Notebook Find Filters toggle in the Search view appeared whenever any notebook editor was present in the list of opened editors, even if no notebook was actually visible on screen. With tabs disabled this is easy to hit: a notebook can stay opened (still in the editor stack) without being the active editor in any group, and the toggle would still show even though there is no visible notebook to filter against.

This change:

- Switches `_hasNotebookOpen` to use `editorService.visibleEditors` so we only consider notebooks that are currently active in some editor group.
- Listens to `onDidVisibleEditorsChange` instead of `onDidEditorsChange` (filtered by `EDITOR_OPEN`/`EDITOR_CLOSE`), so the toggle reacts to a notebook becoming visible/hidden, not just to it being added/removed from the list of opened editors.

The result is that the Notebook Find Filters button only appears when a notebook editor is actually visible.

## Test plan

- [ ] Open a workspace with no notebooks. Open the Search view. Confirm the Notebook Find Filters toggle is hidden.
- [ ] Open a `.ipynb` file. Confirm the toggle appears in the Search view.
- [ ] With the notebook visible, switch the editor group to a different (non-notebook) file so no notebook is visible. Confirm the toggle disappears.
- [ ] Disable tabs (`workbench.editor.showTabs: 'none'`), open a notebook, then open a non-notebook editor on top. Confirm the toggle disappears even though the notebook is still in the editor stack.
- [ ] Make the notebook visible again (e.g. via Quick Open). Confirm the toggle reappears.