### PR TITLE
Fix hover.onKeyboardModifier triggering on Ctrl on macOS

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
 import { IEditorMouseEvent } from '../../../browser/editorBrowser.js';
 
 const enum PADDING {
@@ -23,7 +24,8 @@ export function isMousePositionWithinElement(element: HTMLElement, posx: number,
 /**
  * Determines whether hover should be shown based on the hover setting and current keyboard modifiers.
  * When `hoverEnabled` is 'onKeyboardModifier', hover is shown when the user presses the opposite
- * modifier key from the multi-cursor modifier (e.g., if multi-cursor uses Alt, hover shows on Ctrl/Cmd).
+ * modifier key from the multi-cursor modifier (e.g., if multi-cursor uses Alt, hover shows on
+ * Cmd on macOS / Ctrl on Windows and Linux).
  *
  * @param hoverEnabled - The hover enabled setting
  * @param multiCursorModifier - The modifier key used for multi-cursor operations
@@ -47,13 +49,17 @@ export function shouldShowHover(
 /**
  * Returns true if the trigger modifier (inverse of multi-cursor modifier) is pressed.
  * This works with both mouse and keyboard events by relying only on the modifier flags.
+ *
+ * When the multi-cursor modifier is `altKey`, the trigger modifier is the platform's primary
+ * modifier (`metaKey` / Cmd on macOS, `ctrlKey` / Ctrl on Windows and Linux). This mirrors
+ * how `multiCursorModifier === 'ctrlCmd'` resolves and matches the documented hover behavior.
  */
 export function isTriggerModifierPressed(
 	multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey',
 	event: { ctrlKey: boolean; metaKey: boolean; altKey: boolean }
 ): boolean {
 	if (multiCursorModifier === 'altKey') {
-		return event.ctrlKey || event.metaKey;
+		return isMacintosh ? event.metaKey : event.ctrlKey;
 	}
 	return event.altKey; // multiCursorModifier is ctrlKey or metaKey
 }

--- a/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
+++ b/src/vs/editor/contrib/hover/test/browser/hoverUtils.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { isMacintosh } from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { isMousePositionWithinElement, isTriggerModifierPressed, shouldShowHover } from '../../browser/hoverUtils.js';
 import { IEditorMouseEvent } from '../../../../browser/editorBrowser.js';
@@ -37,10 +38,10 @@ suite('Hover Utils', () => {
 			assert.strictEqual(result, false);
 		});
 
-		test('returns true with ctrl pressed when multiCursorModifier is altKey', () => {
+		test('returns true with ctrl pressed when multiCursorModifier is altKey on Windows/Linux', () => {
 			const mouseEvent = createMockMouseEvent(true, false, false);
 			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
-			assert.strictEqual(result, true);
+			assert.strictEqual(result, !isMacintosh);
 		});
 
 		test('returns false without ctrl pressed when multiCursorModifier is altKey', () => {
@@ -49,10 +50,10 @@ suite('Hover Utils', () => {
 			assert.strictEqual(result, false);
 		});
 
-		test('returns true with metaKey pressed when multiCursorModifier is altKey', () => {
+		test('returns true with metaKey pressed when multiCursorModifier is altKey on macOS', () => {
 			const mouseEvent = createMockMouseEvent(false, false, true);
 			const result = shouldShowHover('onKeyboardModifier', 'altKey', mouseEvent);
-			assert.strictEqual(result, true);
+			assert.strictEqual(result, isMacintosh);
 		});
 
 		test('returns true with alt pressed when multiCursorModifier is ctrlKey', () => {
@@ -166,18 +167,19 @@ suite('Hover Utils', () => {
 			return { ctrlKey, altKey, metaKey };
 		}
 
-		test('returns true with ctrl pressed when multiCursorModifier is altKey', () => {
+		test('returns true with ctrl pressed when multiCursorModifier is altKey on Windows/Linux', () => {
 			const event = createModifierEvent(true, false, false);
-			assert.strictEqual(isTriggerModifierPressed('altKey', event), true);
+			assert.strictEqual(isTriggerModifierPressed('altKey', event), !isMacintosh);
 		});
 
-		test('returns true with metaKey pressed when multiCursorModifier is altKey', () => {
+		test('returns true with metaKey pressed when multiCursorModifier is altKey on macOS', () => {
 			const event = createModifierEvent(false, false, true);
-			assert.strictEqual(isTriggerModifierPressed('altKey', event), true);
+			assert.strictEqual(isTriggerModifierPressed('altKey', event), isMacintosh);
 		});
 
 		test('returns true with both ctrl and metaKey pressed when multiCursorModifier is altKey', () => {
 			const event = createModifierEvent(true, false, true);
+			// One of the two always matches the platform's primary modifier
 			assert.strictEqual(isTriggerModifierPressed('altKey', event), true);
 		});
 


### PR DESCRIPTION
Fixes #280852

When `editor.hover.enabled` is set to `onKeyboardModifier`, holding either `Ctrl` or `Cmd` on macOS would activate the hover. Only the platform's primary modifier (`Cmd` on macOS, `Ctrl` on Windows/Linux) should trigger it. This matches the documented behavior in the `hover.enabled.onKeyboardModifier` setting description and how `multiCursorModifier === 'ctrlCmd'` resolves.

## Change

In `isTriggerModifierPressed`, when the multi-cursor modifier is `altKey`, return the platform-specific primary modifier flag instead of accepting both `ctrlKey || metaKey`.

```ts
if (multiCursorModifier === 'altKey') {
    return isMacintosh ? event.metaKey : event.ctrlKey;
}
```

The four affected unit tests in `hoverUtils.test.ts` are updated to be platform-aware.

## Test plan

- [x] `npm run compile-check-ts-native` passes
- [ ] On macOS, set `editor.hover.enabled` to `onKeyboardModifier`. Hover over a symbol while holding `Ctrl` — hover should NOT appear.
- [ ] On macOS, hover over a symbol while holding `Cmd` — hover should appear.
- [ ] On Windows/Linux, behavior with `Ctrl` is unchanged (still triggers hover).
- [ ] When `multiCursorModifier` is set to `ctrlCmd`, holding `Alt`/`Option` triggers the hover (unchanged).