### PR TITLE
testing: align right-click menu with hover bar on compressed result rows

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -655,15 +655,44 @@ export class OutputPeekTree extends Disposable {
 			return;
 		}
 
-		const actions = this.treeActions.provideActionBar(evt.element);
+		// When a row is compressed (e.g. a TestCaseElement is rendered along
+		// with its only TestMessageElement child), the renderer shows the inline
+		// action bar for the parent element. Mirror that logic here so the
+		// right-click menu offers the same actions as the inline action bar
+		// shown on the visible row.
+		const element = this.getRenderedElement(evt.element);
+		const actions = this.treeActions.provideActionBar(element);
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => evt.anchor,
 			getActions: () => actions.secondary.length
 				? [...actions.primary, new Separator(), ...actions.secondary]
 				: actions.primary,
-			getActionsContext: () => evt.element?.context,
+			getActionsContext: () => element.context,
 			actionRunner: this.contextMenuActionRunner,
 		});
+	}
+
+	private getRenderedElement(element: ITreeElement): ITreeElement {
+		// See TestRunElementRenderer.renderCompressedElements for the matching
+		// logic that decides which element gets the inline action bar.
+		if (!(element instanceof TaskElement) && !(element instanceof TestMessageElement)) {
+			return element;
+		}
+
+		try {
+			const compressed = this.tree.getCompressedTreeNode(element as TreeElement);
+			const chain = compressed.element?.elements;
+			if (chain && chain.length >= 2 && chain[chain.length - 1] === element) {
+				const parent = chain[chain.length - 2];
+				if (parent) {
+					return parent;
+				}
+			}
+		} catch {
+			// element may no longer be in the tree; fall through
+		}
+
+		return element;
 	}
 
 	public override dispose() {


### PR DESCRIPTION
## Summary

When a `TestCaseElement` is rendered together with its only `TestMessageElement` child (the result tree compresses single-message test rows), the inline action bar in `TestRunElementRenderer.renderCompressedElements` is built for the parent element. The right-click handler in `OutputPeekTree.onContextMenu`, however, was operating on the compressed-in `TestMessageElement` returned by the tree. This left the right-click menu missing useful actions like **Run Test** and **Debug Test** even though those very same icons were visible in the inline action bar on the same row.

This change introduces a small `getRenderedElement` helper that mirrors the renderer's compression logic and uses the resulting element when computing actions and the action context for the right-click menu, so the menu now matches the inline action bar shown on the visible row.

Fixes #296078

## Test plan

- [ ] Run a project with failing tests (e.g. C# Dev Kit / pytest with one error message per test).
- [ ] In the Test Results view, hover a failed test row whose error message is compressed into the same row and confirm the inline action bar shows Run Test / Debug Test icons.
- [ ] Right-click the same row and verify the context menu now includes the same Run Test / Debug Test entries (in addition to Go to Error / Reveal in Test Explorer / etc).
- [ ] Right-click an expanded standalone `TestMessageElement` and confirm it still shows message-specific actions.
- [ ] Right-click a `TestCaseElement` (not compressed) and confirm behavior is unchanged.