### PR TITLE
fix: treat '.' as current folder in multi-root search includes/excludes

### DIFF
--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -502,8 +502,8 @@ export class QueryBuilder {
 				searchPath: workspaceUri,
 				pattern: cleanedPattern
 			}];
-		} else if (searchPath === './' || searchPath === '.\\') {
-			return []; // ./ or ./**/foo makes sense for single-folder but not multi-folder workspaces
+		} else if (searchPath === '.' || searchPath === './' || searchPath === '.\\') {
+			return []; // ., ./ and .\ refer to the current workspace folder which only makes sense in a single-folder workspace
 		} else {
 			const searchPathWithoutDotSlash = searchPath.replace(/^\.[\/\\]/, '');
 			const folders = this.workspaceContextService.getWorkspace().folders;

--- a/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
@@ -878,6 +878,18 @@ suite('QueryBuilder', () => {
 					}
 				],
 				[
+					'.',
+					{
+						searchPaths: undefined
+					}
+				],
+				[
+					'.\\',
+					{
+						searchPaths: undefined
+					}
+				],
+				[
 					'./root1',
 					{
 						searchPaths: [{


### PR DESCRIPTION
## Summary
Fixes #263244.

When a user enters just `.` in the **files to include** or **files to exclude** field of the search view in a multi-root workspace, the query builder threw:

> Workspace folder does not exist: .

instead of treating the dot as the current workspace folder. The existing code already short-circuits `./` and `.\` for the same reason, so this extends that handling to a bare `.`.

## Details
`QueryBuilder.parseSearchPaths` classifies any segment matching `^\.\.?([\/\]|$)` as a search path, which means a bare `.` is forwarded to `expandOneSearchPath`. In multi-root mode, that method only special-cased `./` and `.\`, so `.` fell through to the workspace-folder-name lookup and threw the misleading error.

The fix simply adds `.` to the existing single-folder-only short-circuit, matching the comment in the surrounding code.

## Test plan
- [x] Added two new cases (`.` and `.\`) to the existing `relative includes w/multiple ambiguous root folders` test in `queryBuilder.test.ts`, expecting `searchPaths: undefined` to mirror the existing `./` case.
- [ ] Manually: open a multi-root workspace, open the search view, enter `.` in **files to exclude**, type a query and confirm no error appears and results are returned.