### PR TITLE
fix: add null guard for editor model in word replacement view (#309039)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -95,7 +95,8 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			return this._userInteractionService.createHoverTracker(elem.element, reader.store).read(reader);
 		});
 		this._renderTextEffect = derived(this, _reader => {
-			const tm = this._editor.model.get()!;
+			const tm = this._editor.model.get();
+			if (!tm) { return; }
 			const origLine = tm.getLineContent(this._viewData.edit.range.startLineNumber);
 
 			const edit = StringReplacement.replace(new OffsetRange(this._viewData.edit.range.startColumn - 1, this._viewData.edit.range.endColumn - 1), this._viewData.edit.text);


### PR DESCRIPTION
## Summary

Fixes #309039

**Bug:** A null reference error occurs when reading `getLineContent` in `inlineEditsWordReplacementView.ts` at line 99, crashing the editor.

**Root Cause:** `this._editor.model.get()` was called with a non-null assertion (`!`), but the model can be `null` during editor disposal or in certain lifecycle states.

**Fix:** Removed the non-null assertion operator and added an early return guard (`if (!tm) { return; }`), preventing the crash when the editor model is unavailable. This follows the established null-guard pattern used throughout the inline completions codebase.

## Changes

- `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts`: Replaced `this._editor.model.get()!` with a safe access pattern that returns early if the model is null.

## Testing

- The fix is a defensive null guard; when the model is null, the derived signal simply returns `undefined` instead of throwing.
- All existing tests continue to pass since the behavior is unchanged when the model is present.