### PR TITLE
fix: add null guards for color toString in inline edits views (#309036)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -248,7 +248,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 								...rectToProps(reader => layout.read(reader).background.translateX(-contentLeft)),
 								borderRadius: `${INLINE_EDITS_BORDER_RADIUS}px`,
 
-								border: getEditorBlendedColor(originalBorderColor, this._themeService).map(c => `1px solid ${c.toString()}`),
+								border: getEditorBlendedColor(originalBorderColor, this._themeService).map(c => c ? `1px solid ${c.toString()}` : undefined),
 								pointerEvents: 'none',
 								boxSizing: 'border-box',
 								background: asCssVariable(originalBackgroundColor),

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts
@@ -450,7 +450,7 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 						class: 'originalCornerCutoutBackground',
 						style: {
 							position: 'absolute', top: '0px', left: '0px', width: '100%', height: '100%',
-							backgroundColor: getEditorBlendedColor(originalBackgroundColor, this._themeService).map(c => c.toString()),
+							backgroundColor: getEditorBlendedColor(originalBackgroundColor, this._themeService).map(c => c?.toString()),
 						}
 					}),
 					n.div({
@@ -485,7 +485,7 @@ export class InlineEditsSideBySideView extends Disposable implements IInlineEdit
 
 			const separatorWidth = separatorWidthObs.read(reader);
 			const borderRadius = isModifiedLower.map(isLower => `0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px ${isLower ? BORDER_RADIUS : 0}px`);
-			const borderStyling = getEditorBlendedColor(getModifiedBorderColor(this._tabAction), this._themeService).map(c => `1px solid ${c.toString()}`);
+			const borderStyling = getEditorBlendedColor(getModifiedBorderColor(this._tabAction), this._themeService).map(c => c ? `1px solid ${c.toString()}` : undefined);
 			const borderStylingSeparator = `${BORDER_WIDTH + separatorWidth}px solid ${editorBackground}`;
 
 			const overlayRect = layoutInfoObs.map(layoutInfo => layoutInfo.editRect.withMargin(0, BORDER_WIDTH));


### PR DESCRIPTION
## Summary

Fixes #309036

**Bug:** Calling `.toString()` on a potentially undefined color value from `getEditorBlendedColor()` causes a runtime error "Cannot read properties of undefined (reading 'toString')".

**Root Cause:** `getEditorBlendedColor()` can return `undefined` when the theme does not define the requested color, but the calling code assumed it always returns a valid `Color` object.

**Fix:** Added null/undefined guards before calling `.toString()` on the color values in three locations across the inline edits views.

## Changes

- `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts`: Added ternary guard (`c ? ... : undefined`) before `.toString()` on line 251
- `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsSideBySideView.ts`: Added optional chaining (`c?.toString()`) on line 453 and ternary guard on line 488

## Testing

- The fix is defensive: it prevents the runtime crash by gracefully handling `undefined` color values
- All existing tests continue to pass