### PR TITLE
fix: clear element disposables in notebook outline renderElement (#309038)

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -102,6 +102,9 @@ class NotebookOutlineRenderer implements ITreeRenderer<OutlineEntry, FuzzyScore,
 	}
 
 	renderElement(node: ITreeNode<OutlineEntry, FuzzyScore>, _index: number, template: NotebookOutlineTemplate): void {
+		template.elementDisposables.clear();
+		DOM.clearNode(template.actionMenu);
+
 		const extraClasses: string[] = [];
 		const options: IIconLabelValueOptions = {
 			matches: createMatches(node.filterData),


### PR DESCRIPTION
## Summary

Fixes #309038

**Bug:** Listener LEAK detected in `notebookOutline.ts` at line 223 due to event listeners accumulating on re-renders.

**Root Cause:** `NotebookOutlineRenderer.renderElement()` adds new event listeners to `template.actionMenu` on every call without cleaning up listeners from previous renders. When tree nodes are re-rendered (reusing the same template), listeners stack up and trigger the leak detector.

**Fix:** Added `template.elementDisposables.clear()` and `DOM.clearNode(template.actionMenu)` at the beginning of `renderElement()` to properly dispose previous listeners before registering new ones. This follows the standard pattern used by many other tree renderers in the VS Code codebase (e.g., `BreakpointsRenderer`, `CallStackRenderer`).

## Changes

- `src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts`: Added cleanup of `elementDisposables` and `actionMenu` DOM node at the start of `renderElement()` to prevent listener accumulation across re-renders.

## Testing

- The fix follows the established disposal pattern used across the codebase, ensuring consistency.
- Existing notebook outline tests continue to pass.
- The listener leak warning at line 223 should no longer be triggered during notebook outline interactions.