### PR TITLE
fix: terminal canvas misalignment on zoom level change

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -3,14 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isFirefox } from '../../../../base/browser/browser.js';
+import { isFirefox, onDidChangeZoomLevel } from '../../../../base/browser/browser.js';
+import { PixelRatio } from '../../../../base/browser/pixelRatio.js';
 import { BrowserFeatures } from '../../../../base/browser/canIUse.js';
 import { DataTransfers } from '../../../../base/browser/dnd.js';
 import * as dom from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { Orientation } from '../../../../base/browser/ui/sash/sash.js';
 import { DomScrollableElement } from '../../../../base/browser/ui/scrollbar/scrollableElement.js';
-import { AutoOpenBarrier, Promises, disposableTimeout, timeout } from '../../../../base/common/async.js';
+import { AutoOpenBarrier, Promises, RunOnceScheduler, disposableTimeout, timeout } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { debounce } from '../../../../base/common/decorators.js';
 import { BugIndicatingError, onUnexpectedError } from '../../../../base/common/errors.js';
@@ -608,6 +609,18 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => this._labelComputer?.refreshLabel(this)));
+
+		const zoomRecalcScheduler = this._register(new RunOnceScheduler(() => {
+			this._layoutSettingsChanged = true;
+			this.xterm?.forceRedraw();
+			if (this._lastLayoutDimensions) {
+				this.layout(this._lastLayoutDimensions);
+			} else {
+				this._resize();
+			}
+		}, 50));
+		this._register(PixelRatio.getInstance(dom.getWindow(this._wrapperElement)).onDidChange(() => zoomRecalcScheduler.schedule()));
+		this._register(onDidChangeZoomLevel(() => zoomRecalcScheduler.schedule()));
 
 		// Clear out initial data events after 10 seconds, hopefully extension hosts are up and
 		// running at that point.


### PR DESCRIPTION
## Summary

When the user changes the editor zoom level (Ctrl++/Ctrl+-), the integrated terminal canvas fails to repaint and align correctly. The prompt text gets clipped, disappears, or renders with excess blank space. Inline suggestion ghost text also misaligns.

## Root Cause

The terminal's dimension calculations (`getXtermScaledDimensions`, `_measureFont`) use `window.devicePixelRatio` for canvas rendering and font measurements, but no listener existed to trigger a layout recalculation when the pixel ratio changed due to zoom. Switching tabs worked around the issue because `setVisible(true)` calls `_resize()`, which recalculates dimensions with the now-current DPR.

## Fix

Two event listeners are added in the `TerminalInstance` constructor:

- **`PixelRatio.onDidChange`** — fires when `devicePixelRatio` changes (e.g. browser zoom, display scale)
- **`onDidChangeZoomLevel`** — fires from Electron's zoom API (e.g. `Ctrl++`/`Ctrl+-`)

Both trigger a shared handler that defers (50 ms for DOM settling) a full layout recalculation:

1. Marks font metrics as stale (`_layoutSettingsChanged = true`)
2. Clears the WebGL/canvas texture atlas (`forceRedraw()`)
3. Runs the full `layout()` path to recalculate cols/rows

## Precedent

This matches the established pattern used by other VS Code components that already subscribe to `PixelRatio.onDidChange`:

- Editor (`editorDom.ts`)
- Color picker widget
- Debug toolbar
- Breadcrumbs widget
- Notebook cells

## Demo

[Screencast from 2026-04-11 10-28-43.webm](https://github.com/user-attachments/assets/1c3a4306-6c48-4a01-b6ee-abf5ade0e791)


## Testing Checklist

- [x] `Ctrl++` / `Ctrl+-` — terminal repaints correctly, no clipping or blank space
- [x] Tab switching after zoom — still works as before
- [x] Split terminals — both panes recalculate correctly
- [x] Type-check passes (`tsgo`)
- [x] Layering check passes (`valid-layers-check`)
- [x] ESLint passes
- [x] Hygiene passes


## How to Test

1. Open an integrated terminal
2. Type some text so the prompt is visible
3. Press `Ctrl++` or `Ctrl+-` to zoom in/out
4. Observe the terminal canvas repaints cleanly without clipping, blank space, or misaligned ghost text

Fixes microsoft/vscode#309160