### PR TITLE
jsonEdit: preserve comments above a property when it is deleted

### DIFF
--- a/src/vs/base/common/jsonEdit.ts
+++ b/src/vs/base/common/jsonEdit.ts
@@ -48,12 +48,45 @@ export function setProperty(text: string, originalPath: JSONPath, value: unknown
 				const propertyIndex = parent.children.indexOf(existing.parent);
 				let removeBegin: number;
 				let removeEnd = existing.parent.offset + existing.parent.length;
+
+				// Find the start of the line that contains the property being deleted,
+				// including the newline that precedes it. This ensures that a comment
+				// placed on the line immediately above the property is not accidentally
+				// deleted alongside it.
+				const propOffset = existing.parent.offset;
+				let propLineStart = propOffset;
+				while (propLineStart > 0 && text[propLineStart - 1] !== '\n') {
+					propLineStart--;
+				}
+				// Include the preceding newline so the removed line doesn't leave a blank line
+				const propLineWithNewline = propLineStart > 0 ? propLineStart - 1 : propLineStart;
+
 				if (propertyIndex > 0) {
-					// remove the comma of the previous node
 					const previous = parent.children[propertyIndex - 1];
-					removeBegin = previous.offset + previous.length;
+					const commaOffset = previous.offset + previous.length;
+					if (propLineWithNewline > commaOffset) {
+						// There is content (e.g. a comment) between the previous property and
+						// the property being deleted. Use two edits to preserve that content:
+						// 1. Remove the trailing comma of the previous property.
+						// 2. Remove the property's own line (including its trailing comma for
+						//    middle properties, so the JSON remains valid).
+						let lineRemoveEnd = removeEnd;
+						if (lineRemoveEnd < text.length && text[lineRemoveEnd] === ',') {
+							lineRemoveEnd++; // include trailing comma of a middle property
+						}
+						const commaEdit: Edit = { offset: commaOffset, length: 1, content: '' };
+						const lineEdit: Edit = { offset: propLineWithNewline, length: lineRemoveEnd - propLineWithNewline, content: '' };
+						// Return higher-offset edit first so that applyEdits can apply them
+						// right-to-left without offset interference.
+						return [
+							...withFormatting(text, lineEdit, formattingOptions),
+							...withFormatting(text, commaEdit, formattingOptions)
+						];
+					}
+					// No gap — use the original single-range approach
+					removeBegin = commaOffset;
 				} else {
-					removeBegin = parent.offset + 1;
+					removeBegin = propLineWithNewline > parent.offset + 1 ? propLineWithNewline : parent.offset + 1;
 					if (parent.children.length > 1) {
 						// remove the comma of the next node
 						const next = parent.children[1];

--- a/src/vs/base/test/common/jsonEdit.test.ts
+++ b/src/vs/base/test/common/jsonEdit.test.ts
@@ -121,6 +121,24 @@ suite('JSON - edits', () => {
 		assertEdit(content, edits, '{\n  "x": "y"\n}');
 	});
 
+	test('remove property preserves preceding comments', () => {
+		// Only property preceded by a comment — comment must not be deleted
+		let content = '{\n  // comment\n  "x": "y"\n}';
+		let edits = removeProperty(content, ['x'], formatterOptions);
+		assertEdit(content, edits, '{\n  // comment\n}');
+
+		// Non-first property preceded by a comment
+		content = '{\n  "a": 1,\n  // comment\n  "x": "y"\n}';
+		edits = removeProperty(content, ['x'], formatterOptions);
+		assertEdit(content, edits, '{\n  "a": 1,\n  // comment\n}');
+
+		// Middle property preceded by a comment — comment must not be deleted,
+		// and the surrounding properties should remain valid JSON
+		content = '{\n  "a": 1,\n  // comment\n  "x": "y",\n  "b": 2\n}';
+		edits = removeProperty(content, ['x'], formatterOptions);
+		assertEdit(content, edits, '{\n  "a": 1,\n  // comment\n  "b": 2\n}');
+	});
+
 	test('insert item at 0', () => {
 		const content = '[\n  2,\n  3\n]';
 		const edits = setProperty(content, [0], 1, formatterOptions);


### PR DESCRIPTION
When `removeProperty` (called e.g. when a setting is reset to its default value via the Settings UI or keyboard shortcuts) removed a property from `settings.json`, it also silently deleted any comment placed on the line immediately above the property.

## Root cause

The deletion range was anchored to surrounding structure rather than to the property's own line:

| Case | `removeBegin` (before fix) | Problem |
|------|---------------------------|---------|
| First / only property | `parent.offset + 1` (just after `{`) | Includes all comment lines between `{` and the property |
| Non-first property | `previous.offset + previous.length` (trailing comma of the previous sibling) | Includes all comment lines between the previous property and the current one |

## Fix

Anchor the removal to the **property's own line** (using the newline that precedes the line as the boundary):

- **First/only property** (`propertyIndex === 0`): `removeBegin` is set to the start of the property's line (including its preceding newline) instead of `parent.offset + 1`.
- **Non-first property** (`propertyIndex > 0`) with a comment between the previous property and this one: two separate edits are returned â€” one that removes only the trailing comma from the previous sibling, and one that removes the property's line (including its own trailing comma for middle properties). The intermediate content (comments) is left intact.
- When no content separates the comma from the property (same-line or comment-free formatting), the original single-range approach is preserved â€” no behavioural change for the common case.

## Tests

Three new test cases in `jsonEdit.test.ts`:
1. Only property with a preceding comment.
2. Last property (non-first) with a preceding comment.
3. Middle property with a preceding comment â€” surrounding properties remain valid JSON.

Fixes #275792