### PR TITLE
emmet: add erb and html.erb language mappings for Emmet support

### DIFF
--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -123,7 +123,9 @@ export function getMappingForIncludedLanguages(): Record<string, string> {
 	// language specific extensions can provide emmet completion support
 	const MAPPED_MODES: Record<string, string> = {
 		'handlebars': 'html',
-		'php': 'html'
+		'php': 'html',
+		'erb': 'html',
+		'html.erb': 'html'
 	};
 
 	const finalMappedModes: Record<string, string> = {};


### PR DESCRIPTION
Adds `erb` and `html.erb` language IDs to the built-in Emmet language mappings so that ERB (Embedded Ruby) template files receive proper HTML Emmet expansion support without requiring manual configuration of `emmet.includeLanguages`.

This follows the same pattern as the existing `handlebars` and `php` mappings. Users with a Ruby extension that assigns the `erb` or `html.erb` language ID to `.erb` files can now use Emmet abbreviations (e.g., `.container`, `div.wrapper`) without having to manually set the `emmet.includeLanguages` setting.

Fixes #233969