### PR TITLE
git: fix wrong value used when migrating user inputValidation setting

### DIFF
--- a/extensions/git/src/diagnostics.ts
+++ b/extensions/git/src/diagnostics.ts
@@ -48,7 +48,7 @@ export class GitCommitInputBoxDiagnosticsManager {
 
 			// User setting
 			if (typeof inputValidation.globalValue === 'string') {
-				await config.update('inputValidation', inputValidation.workspaceValue !== 'off', true);
+				await config.update('inputValidation', inputValidation.globalValue !== 'off', true);
 			}
 		} catch { }
 	}


### PR DESCRIPTION
When migrating the legacy string-based `git.inputValidation` setting to the new boolean form, the user (global) setting migration incorrectly read `workspaceValue` instead of `globalValue` to compute the new boolean.

This meant that if someone had a workspace setting but not a user setting, the migration would still run (since `globalValue` is checked for the `typeof` guard), but would use the workspace value instead of the user value, producing incorrect results.

**Before:**
```typescript
// User setting
if (typeof inputValidation.globalValue === string) {
    await config.update(inputValidation, inputValidation.workspaceValue !== off, true);
}
```

**After:**
```typescript
// User setting
if (typeof inputValidation.globalValue === string) {
    await config.update(inputValidation, inputValidation.globalValue !== off, true);
}
```

Fixes the copy-paste mistake introduced in the migration helper.