### PR TITLE
json: fix language model cache evicting at capacity instead of overflow

### DIFF
--- a/extensions/json-language-features/server/src/languageModelCache.ts
+++ b/extensions/json-language-features/server/src/languageModelCache.ts
@@ -45,7 +45,7 @@ export function getLanguageModelCache<T>(maxEntries: number, cleanupIntervalTime
 				nModels++;
 			}
 
-			if (nModels === maxEntries) {
+			if (nModels > maxEntries) {
 				let oldestTime = Number.MAX_VALUE;
 				let oldestUri = null;
 				for (const uri in languageModels) {


### PR DESCRIPTION
The `getLanguageModelCache` function in the JSON language server uses `===` to check whether the current entry count equals `maxEntries`. This causes the cache to evict the oldest entry as soon as it reaches its configured maximum size, meaning the cache only holds `maxEntries - 1` entries at steady state instead of the intended `maxEntries`.

This is the same issue fixed in the HTML (`extensions/html-language-features`) and CSS (`extensions/css-language-features`) language servers â€” all three share an identical copy of `languageModelCache.ts`.

**Fix:** Change the condition from `nModels === maxEntries` to `nModels > maxEntries`. Eviction now only occurs after the cache has grown beyond its limit.

**Before:**
```typescript
if (nModels === maxEntries) {
```

**After:**
```typescript
if (nModels > maxEntries) {
```

With `maxEntries = 10` (the default used in the JSON language server), the cache can now properly retain up to 10 parsed JSON document models instead of only 9.