### PR TITLE
git: fix MERGE_MSG and SQUASH_MSG path for linked worktrees

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3257,7 +3257,7 @@ export class Repository {
 	}
 
 	async getSquashMessage(): Promise<string | undefined> {
-		const squashMsgPath = path.join(this.repositoryRoot, '.git', 'SQUASH_MSG');
+		const squashMsgPath = path.join(this.dotGit.path, 'SQUASH_MSG');
 
 		try {
 			const raw = await fs.readFile(squashMsgPath, 'utf8');
@@ -3268,7 +3268,7 @@ export class Repository {
 	}
 
 	async getMergeMessage(): Promise<string | undefined> {
-		const mergeMsgPath = path.join(this.repositoryRoot, '.git', 'MERGE_MSG');
+		const mergeMsgPath = path.join(this.dotGit.path, 'MERGE_MSG');
 
 		try {
 			const raw = await fs.readFile(mergeMsgPath, 'utf8');


### PR DESCRIPTION
When working in a linked git worktree (created with `git worktree add`), VS Code fails to populate the commit message input box with the merge/squash message.

`getMergeMessage()` and `getSquashMessage()` in `extensions/git/src/git.ts` construct the path to `MERGE_MSG` / `SQUASH_MSG` using `path.join(repositoryRoot, '.git', ...)`. In a linked worktree, the `.git` entry in the worktree root is a **file** (not a directory) that redirects to the worktree-specific gitdir. Reading a path through it fails with `ENOTDIR`, so both methods silently return `undefined` and the commit message box stays empty after a merge or squash in a linked worktree.

**Fix:** Use `this.dotGit.path` directly â€” the same gitdir pointer already used by `getHEAD()`, `revParse()`, and `getHEADFS()`.

- Regular repository: `dotGit.path === repositoryRoot/.git` â€” behaviour unchanged.
- Linked worktree: `dotGit.path === .git/worktrees/<name>/` â€” correct location where git places `MERGE_MSG` and `SQUASH_MSG` for that worktree.

## Files changed
- `extensions/git/src/git.ts` â€” `getSquashMessage()` and `getMergeMessage()`