### PR TITLE
git: clear blame information when switching to editor with no diff info

### DIFF
--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -379,7 +379,11 @@ export class GitBlameController {
 	@throttle
 	private async _updateTextEditorBlameInformation(textEditor: TextEditor | undefined, reason?: 'selection'): Promise<void> {
 		if (textEditor) {
-			if (!textEditor.diffInformation || textEditor !== window.activeTextEditor) {
+			if (textEditor !== window.activeTextEditor) {
+				return;
+			}
+			if (!textEditor.diffInformation) {
+				this.textEditorBlameInformation = undefined;
 				return;
 			}
 		} else {


### PR DESCRIPTION
When switching from a git-tracked file to a file with no SCM diff information (e.g. a file outside any repository, a virtual document, or an untitled file), `_updateTextEditorBlameInformation` returned early because `textEditor.diffInformation` was `undefined`. The two conditions were ORed together in a single guard:

```ts
if (!textEditor.diffInformation || textEditor !== window.activeTextEditor) {
    return;
}
```

This meant the "no diff info" path returned **without** clearing `textEditorBlameInformation`, leaving the previous file's blame decoration and status-bar item visible in the new editor.

**Fix:** Separate the two guards so each has the correct side-effect:

1. **Race-condition guard** (`textEditor !== window.activeTextEditor`) â€” return silently; don't touch state, since we're processing a stale event.
2. **No diff info** (`!textEditor.diffInformation`) â€” set `textEditorBlameInformation = undefined` before returning, so decorations and the status-bar are cleared.

## Files changed
- `extensions/git/src/blame.ts` â€” `_updateTextEditorBlameInformation()`