### PR TITLE
git: fix REBASE_HEAD, MERGE_HEAD and CHERRY_PICK_HEAD paths for linked worktrees

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3105,9 +3105,9 @@ export class Repository implements Disposable {
 	}
 
 	private async getRebaseCommit(): Promise<Commit | undefined> {
-		const rebaseHeadPath = path.join(this.repository.root, '.git', 'REBASE_HEAD');
-		const rebaseApplyPath = path.join(this.repository.root, '.git', 'rebase-apply');
-		const rebaseMergePath = path.join(this.repository.root, '.git', 'rebase-merge');
+		const rebaseHeadPath = path.join(this.repository.dotGit.path, 'REBASE_HEAD');
+		const rebaseApplyPath = path.join(this.repository.dotGit.path, 'rebase-apply');
+		const rebaseMergePath = path.join(this.repository.dotGit.path, 'rebase-merge');
 
 		try {
 			const [rebaseApplyExists, rebaseMergePathExists, rebaseHead] = await Promise.all([
@@ -3125,12 +3125,12 @@ export class Repository implements Disposable {
 	}
 
 	private isMergeInProgress(): Promise<boolean> {
-		const mergeHeadPath = path.join(this.repository.root, '.git', 'MERGE_HEAD');
+		const mergeHeadPath = path.join(this.repository.dotGit.path, 'MERGE_HEAD');
 		return new Promise<boolean>(resolve => fs.exists(mergeHeadPath, resolve));
 	}
 
 	private isCherryPickInProgress(): Promise<boolean> {
-		const cherryPickHeadPath = path.join(this.repository.root, '.git', 'CHERRY_PICK_HEAD');
+		const cherryPickHeadPath = path.join(this.repository.dotGit.path, 'CHERRY_PICK_HEAD');
 		return new Promise<boolean>(resolve => fs.exists(cherryPickHeadPath, resolve));
 	}
 


### PR DESCRIPTION
In a linked git worktree (`git worktree add`), the worktree-specific gitdir files â€” `REBASE_HEAD`, `MERGE_HEAD`, `CHERRY_PICK_HEAD`, `rebase-apply/`, `rebase-merge/` â€” live under `dotGit.path` (`.git/worktrees/<name>/`), **not** under the working-tree root's `.git` entry, which is a plain redirect file.

Three methods in `extensions/git/src/repository.ts` were building those paths with `path.join(this.repository.root, '.git', ...)`:

| Method | File |
|---|---|
| `getRebaseCommit()` | `REBASE_HEAD`, `rebase-apply/`, `rebase-merge/` |
| `isMergeInProgress()` | `MERGE_HEAD` |
| `isCherryPickInProgress()` | `CHERRY_PICK_HEAD` |

Because `repository.root/.git` is a **file** (not a directory) in a linked worktree, all `fs.exists()` calls returned `false` and `fs.readFile` threw. As a result VS Code never detected an in-progress rebase, merge, or cherry-pick in a linked worktree: the Source Control view showed no rebase commit, no merge conflict indicators, and no cherry-pick state.

**Fix:** Use `this.repository.dotGit.path` in all three methods â€” the same gitdir pointer already used by `getHEADFS()`, `revParse()`, and the `DotGitWatcher`. For the main worktree, `dotGit.path` equals `<root>/.git/`, so behaviour is unchanged there.

## Files changed
- `extensions/git/src/repository.ts` â€” `getRebaseCommit()`, `isMergeInProgress()`, `isCherryPickInProgress()`