### PR TITLE
fix(emmet): pass syntax hint to extractAbbreviation in expandEmmetAbbreviation

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -335,7 +335,7 @@ export function expandEmmetAbbreviation(args: any): Thenable<boolean | undefined
 				return [rangeToReplace, abbr, ''];
 			}
 		}
-		const extractedResults = helper.extractAbbreviation(toLSTextDocument(editor.document), position, { lookAhead: false });
+		const extractedResults = helper.extractAbbreviation(toLSTextDocument(editor.document), position, { lookAhead: false, syntax: isStyleSheet(syntax) ? 'stylesheet' : 'markup' });
 		if (!extractedResults) {
 			return [null, '', ''];
 		}


### PR DESCRIPTION
Upstream fix for microsoft/vscode#233969

## Problem

When a language is mapped to HTML via `emmet.includeLanguages` (e.g. `"erb": "html"`), typing a class abbreviation like `.foo` and pressing Tab fails to expand it. The abbreviation extractor picks up an empty or incorrect range because it does not know whether to apply stylesheet or markup extraction rules.

## Root Cause

`expandEmmetAbbreviation` calls `helper.extractAbbreviation(...)` without the `syntax` option, so the helper defaults to markup mode for all documents â€” including stylesheet languages â€” and vice versa. Compare with `defaultCompletionProvider.ts` which already passes the correct `syntax` value:

```ts
// defaultCompletionProvider.ts (correct)
helper.extractAbbreviation(doc, pos, { lookAhead: false, syntax: isStyleSheet(syntax) ? 'stylesheet' : 'markup' });
```

## Fix

Add the same `syntax` option to the `extractAbbreviation` call inside `expandEmmetAbbreviation`:

```ts
// Before
const extractedResults = helper.extractAbbreviation(
    toLSTextDocument(editor.document), position, { lookAhead: false });

// After  
const extractedResults = helper.extractAbbreviation(
    toLSTextDocument(editor.document), position,
    { lookAhead: false, syntax: isStyleSheet(syntax) ? 'stylesheet' : 'markup' });
```

This is a one-line change that aligns `expandEmmetAbbreviation` with the existing behaviour in `defaultCompletionProvider.ts`.