### PR TITLE
fix(themes): sync preferred theme settings when workbench.colorTheme changes

### DIFF
--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -349,6 +349,25 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			) {
 				this.restoreColorTheme();
 			}
+			// Keep the preferred theme settings in sync with workbench.colorTheme so that
+			// 'Toggle between Light/Dark Themes' returns to the user's most recently used theme.
+			if (e.affectsConfiguration(ThemeSettings.COLOR_THEME) && !this.settings.isDetectingColorScheme()) {
+				const newSettingId = this.configurationService.getValue<string>(ThemeSettings.COLOR_THEME);
+				const newTheme = this.colorThemeRegistry.findThemeBySettingsId(newSettingId);
+				if (newTheme) {
+					if (newTheme.type === ColorScheme.DARK) {
+						const current = this.configurationService.getValue<string>(ThemeSettings.PREFERRED_DARK_THEME);
+						if (current !== newSettingId) {
+							this.configurationService.updateValue(ThemeSettings.PREFERRED_DARK_THEME, newSettingId, ConfigurationTarget.USER);
+						}
+					} else if (newTheme.type === ColorScheme.LIGHT) {
+						const current = this.configurationService.getValue<string>(ThemeSettings.PREFERRED_LIGHT_THEME);
+						if (current !== newSettingId) {
+							this.configurationService.updateValue(ThemeSettings.PREFERRED_LIGHT_THEME, newSettingId, ConfigurationTarget.USER);
+						}
+					}
+				}
+			}
 			if (e.affectsConfiguration(ThemeSettings.FILE_ICON_THEME)) {
 				this.restoreFileIconTheme();
 			}


### PR DESCRIPTION
Upstream fix for microsoft/vscode#305685

## Problem

Using **Toggle between Light/Dark Themes** resets the theme to VS Code defaults (`VSCode Dark` / `VSCode Light`) instead of returning to the user's previously-selected theme.

## Root Cause

The toggle command reads `workbench.preferredDarkColorTheme` / `workbench.preferredLightColorTheme` to decide which theme to apply. If the user never explicitly configured those settings they contain the default value, so the toggle always switches to the default rather than the theme the user was using.

## Fix

In `installConfigurationListener`, when `workbench.colorTheme` changes and auto-detect is not active, keep the matching preferred-theme setting in sync:

- If the new theme is **dark**, update `workbench.preferredDarkColorTheme` to match.
- If the new theme is **light**, update `workbench.preferredLightColorTheme` to match.

This ensures the toggle always returns to the user's most recently used dark or light theme. The guard `current !== newSettingId` prevents redundant writes (e.g. when the toggle itself sets `workbench.colorTheme`).