### PR TITLE
fix(editor): treat 'selection' as inactive in Toggle Render Whitespace

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -120,12 +120,12 @@ class ToggleRenderWhitespaceAction extends Action2 {
 
 		const renderWhitespace = configurationService.getValue<string>(renderWhitespaceSetting);
 
-		let newRenderWhitespace: string;
-		if (renderWhitespace === 'none') {
-			newRenderWhitespace = 'all';
-		} else {
-			newRenderWhitespace = 'none';
-		}
+		// Treat only explicitly-visible modes (all/boundary/trailing) as "on".
+		// The default 'selection' mode only renders on selected text and provides no
+		// persistent visual feedback, so toggling from 'selection' should enable all
+		// whitespace rather than disabling it entirely (see #305883).
+		const isActivelyRendering = renderWhitespace === 'all' || renderWhitespace === 'boundary' || renderWhitespace === 'trailing';
+		const newRenderWhitespace = isActivelyRendering ? 'none' : 'all';
 
 		return configurationService.updateValue(renderWhitespaceSetting, newRenderWhitespace);
 	}


### PR DESCRIPTION
Upstream fix for microsoft/vscode#305883

## Problem

The **Toggle Render Whitespace** command (`editor.action.toggleRenderWhitespace`) and the corresponding View > Appearance > Render Whitespace entry appear checked/active by default because the default value of `editor.renderWhitespace` is `'selection'`.

However, `'selection'` only renders whitespace on **selected text** â€” without an active selection the editor looks identical to `'none'`. The old toggle logic treated ANY non-`'none'` value as "on" and disabled rendering, so pressing the toggle from the default `'selection'` state would turn whitespace OFF rather than ON.

Subsequent toggles then bounced between `'none'` and `'all'`, permanently losing the `'selection'` state.

## Fix

Only treat modes that produce **persistent** visual output â€” `'all'`, `'boundary'`, and `'trailing'` â€” as "on". Toggling from `'selection'` or `'none'` now enables all-whitespace rendering; toggling from an actively-rendering mode disables it.

```ts
// Before
if (renderWhitespace === 'none') {
    newRenderWhitespace = 'all';
} else {
    newRenderWhitespace = 'none';
}

// After
const isActivelyRendering = renderWhitespace === 'all' || renderWhitespace === 'boundary' || renderWhitespace === 'trailing';
const newRenderWhitespace = isActivelyRendering ? 'none' : 'all';
```