### PR TITLE
fix(chat): guard setModel() against disposed inputPart

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1979,6 +1979,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		// Guard against disposal: if the widget was disposed during an async
+		// operation in a caller (e.g. ChatViewPane.showModel), inputPart will
+		// be undefined and accessing it would throw (see #308865).
+		if (!this.inputPartDisposable.value) {
+			return;
+		}
+
 		if (this.viewModel?.editing) {
 			this.finishedEditing();
 		}


### PR DESCRIPTION
## Summary

-  now checks if  still holds a value before proceeding
- This prevents a crash when the widget is disposed during an async operation in  (while awaiting )

Fixes #308865.

## Root cause

PR #307689 added a  call inside . When  awaits , the widget can be disposed before execution resumes. The  getter returns  â€” if the  was cleared by disposal, this is  at runtime, causing:



## Fix

Add a guard that returns early if  is falsy, which is the same pattern already used elsewhere in the file.

## Test plan

- Open chat panel, trigger a rapid open/close sequence while a session is loading
- Confirm no unhandled error appears in the dev tools console
- Verify normal chat functionality (session switching, clear) still works