### PR TITLE
fix(extensions): skip path-less workspace folder URIs in extensions config file watcher

### DIFF
--- a/src/vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.ts
+++ b/src/vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig.ts
@@ -61,7 +61,7 @@ export class WorkspaceExtensionsConfigService extends Disposable implements IWor
 		this._register(fileService.onDidFilesChange(e => {
 			const workspace = workspaceContextService.getWorkspace();
 			if ((workspace.configuration && e.affects(workspace.configuration))
-				|| workspace.folders.some(folder => e.affects(folder.toResource(EXTENSIONS_CONFIG)))
+				|| workspace.folders.some(folder => folder.uri.path && e.affects(folder.toResource(EXTENSIONS_CONFIG)))
 			) {
 				this._onDidChangeExtensionsConfigs.fire();
 			}


### PR DESCRIPTION
## Summary

- Guard `WorkspaceFolder.toResource()` call in the `onDidFilesChange` handler against workspace folders whose URI has no path component
- Avoids `[UriError]: cannot call joinPath on URI without path` crash

Fixes #308827.

## Root cause

`AgentSessionAdapter._buildWorkspace()` creates workspace folders with `URI.parse("unknown://")` as a fallback when session metadata contains no repository information. This URI has an empty path. When any `onDidFilesChange` event fires, `WorkspaceExtensionsConfigService` iterates workspace folders and calls `folder.toResource(EXTENSIONS_CONFIG)`, which calls `joinPath(folder.uri, relativePath)`. If `folder.uri.path` is empty, `joinPath` throws the URI error.

## Fix

Add a `folder.uri.path &&` guard before calling `toResource`, consistent with how other places in the codebase skip path-less URIs. No valid workspace folder extension config can exist at a path-less URI, so skipping them is semantically correct.

## Test plan

- Open VS Code with an agents chat session that has no repository metadata
- Trigger a file system event (edit any file, or save)
- Confirm no unhandled `[UriError]` appears in the developer tools console
- Verify that normal workspace extension recommendations still work