### PR TITLE
git: show warning-only git output as warning notification instead of error

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5644,7 +5644,8 @@ export class CommandCenter {
 						options.modal = false;
 						break;
 					default: {
-						const hintLines = (err.stderr || err.stdout || err.message || String(err))
+						const rawOutput = err.stderr || err.stdout || err.message || String(err);
+						const hintLines = rawOutput
 							.replace(/^error: /mi, '')
 							.replace(/^> husky.*$/mi, '')
 							.split(/[\r\n]/)
@@ -5653,6 +5654,12 @@ export class CommandCenter {
 						message = hintLines.length > 0
 							? l10n.t('Git: {0}', err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
 							: l10n.t('Git error');
+
+						// If all non-empty lines in the output are warnings, treat as warning
+						if (hintLines.length > 0 && hintLines.every((line: string) => /^warning:/i.test(line))) {
+							type = 'warning';
+							options.modal = false;
+						}
 
 						break;
 					}


### PR DESCRIPTION
When git/SSH outputs lines prefixed with `warning:` (such as the SSH "permanently added to the list of known hosts" message), the notification was incorrectly displayed with error-level styling (red X icon), alarming users unnecessarily.

## Root cause
In the `default` error case of the git command error handler, the notification `type` always defaulted to `'error'`. There was no check to distinguish warning-only output from actual errors.

## Fix
Detect when all non-empty output lines begin with `warning:` (case-insensitive) and downgrade the notification type to `'warning'` with non-modal display, consistent with how other warning cases (merge conflicts, stash conflicts) are handled.

## Before / After
- **Before**: `Warning: Permanently added 'gitlab.com' to the list of known hosts` â†’ red error dialog
- **After**: same message â†’ yellow warning notification (non-modal)

Fixes #280834