### PR TITLE
terminal: preserve special characters in file names dropped into terminal

### DIFF
--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -7,9 +7,9 @@ import { OperatingSystem, OS } from '../../../base/common/platform.js';
 import { IShellLaunchConfig, TerminalShellType, PosixShellType, WindowsShellType, GeneralShellType } from './terminal.js';
 
 /**
- * Aggressively escape non-windows paths to prepare for being sent to a shell. This will do some
- * escaping inaccurately to be careful about possible script injection via the file path. For
- * example, we're trying to prevent this sort of attack: `/foo/file$(echo evil)`.
+ * Escape non-windows paths to prepare for being sent to a shell. The path is wrapped in
+ * shell-appropriate quotes so that special characters (e.g. `~`, `!`, `$`, `|`, `;`) that
+ * appear in file names are treated as literals and cannot cause shell injection.
  */
 export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType): string {
 	let newPath = path;
@@ -64,10 +64,6 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			};
 			break;
 	}
-
-	// Remove dangerous characters except single and double quotes, which we'll escape properly
-	const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
-	newPath = newPath.replace(bannedChars, '');
 
 	// Apply shell-specific escaping based on quote content
 	if (newPath.includes('\'') && newPath.includes('"')) {

--- a/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
@@ -91,9 +91,15 @@ suite('terminalEnvironment', () => {
 			strictEqual(escapeNonWindowsPath('/foo/bar\'baz'), '\'/foo/bar\\\'baz\'');
 		});
 
-		test('should remove dangerous characters', () => {
-			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar(echo evil)\'');
-			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/barwhoami\'');
+		test('should preserve special characters that are safe inside single quotes', () => {
+			// Characters like $, `, ~, !, #, ^, &, *, |, ;, <, > are all literal inside single quotes
+			// and must be preserved so that file names containing them are passed correctly.
+			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar$(echo evil)\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/bar`whoami`\'');
+			strictEqual(escapeNonWindowsPath('/foo/file~name', PosixShellType.Bash), '\'/foo/file~name\'');
+			strictEqual(escapeNonWindowsPath('/foo/file!name', PosixShellType.Bash), '\'/foo/file!name\'');
+			strictEqual(escapeNonWindowsPath('/foo/file#name', PosixShellType.Bash), '\'/foo/file#name\'');
+			strictEqual(escapeNonWindowsPath('/foo/file;name', PosixShellType.Bash), '\'/foo/file;name\'');
 		});
 	});
 });


### PR DESCRIPTION
Characters such as `~`, `` ` ``, `!`, `#`, `$`, `^`, `&`, `*`, `|`, `;`, `<`, `>` were silently stripped from file paths when dragging files from the Explorer into the terminal. This produced invalid paths pointing to non-existent files.

## Root cause

`escapeNonWindowsPath` in `src/vs/platform/terminal/common/terminalEnvironment.ts` applied a `bannedChars` regex replacement that removed those characters before quoting:

```ts
const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
newPath = newPath.replace(bannedChars, '');
```

## Why the removal is both wrong and unnecessary

The function **always** wraps the resulting path in shell-appropriate quotes (single quotes for bash/sh/zsh, `$'...'` ANSI C quoting when both quote types are present). Inside single quotes **all** of the listed characters are treated as literals â€” they cannot cause shell injection. Removing them was incorrect behavior that corrupted valid file names.

## Fix

Remove the `bannedChars` stripping. The quoting already provides full safety. Update the related test to assert the correct preserving behavior and add coverage for the affected characters.

## Test

The existing `'should remove dangerous characters'` test has been renamed `'should preserve special characters that are safe inside single quotes'` with corrected expectations.

Fixes #276999