### PR TITLE
scm: add Collapse All action to the Source Control Graph view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -285,6 +285,28 @@ registerAction2(class extends ViewAction<SCMHistoryViewPane> {
 	}
 });
 
+registerAction2(class extends ViewAction<SCMHistoryViewPane> {
+	constructor() {
+		super({
+			id: 'workbench.scm.action.graph.collapseAll',
+			title: localize('collapseAll', "Collapse All"),
+			icon: Codicon.collapseAll,
+			viewId: HISTORY_VIEW_PANE_ID,
+			precondition: ContextKeys.SCMHistoryItemCount.notEqualsTo(0),
+			f1: false,
+			menu: {
+				id: MenuId.SCMHistoryTitle,
+				group: '9_viewmode',
+				order: 3
+			}
+		});
+	}
+
+	async runInView(_: ServicesAccessor, view: SCMHistoryViewPane): Promise<void> {
+		view.collapseAll();
+	}
+});
+
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
@@ -1981,6 +2003,10 @@ export class SCMHistoryViewPane extends ViewPane {
 
 	setViewMode(viewMode: ViewMode): void {
 		this._treeViewModel.setViewMode(viewMode);
+	}
+
+	collapseAll(): void {
+		this._tree.collapseAll();
 	}
 
 	private _createTree(container: HTMLElement): void {


### PR DESCRIPTION
Users working with repositories that have many expanded commits had no toolbar button to collapse them all. The only known workaround was the undiscoverable `Ctrl+Left` keyboard shortcut.

## Change

Adds a **Collapse All** action to the `SCMHistoryTitle` overflow menu (the `9_viewmode` group alongside *View as List / View as Tree*).

- Uses the standard `collapseAll` codicon.
- The action is disabled (`precondition`) when the history list is empty â€” consistent with the *Go to Current History Item* action.
- Delegates to the tree's built-in `collapseAll()` method, which recursively collapses all expanded nodes.
- Users can move the item to the main toolbar via *Customize Layout â†’ Source Control Graph* if they prefer a dedicated button.

## Files changed

| File | Change |
|------|--------|
| `src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts` | Register `workbench.scm.action.graph.collapseAll` action; add `collapseAll()` method to `SCMHistoryViewPane` |

Fixes #275608