### PR TITLE
Chat - add null checks for editingSession across await boundaries

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chat.ts
+++ b/src/vs/workbench/contrib/chat/common/chat.ts
@@ -44,7 +44,14 @@ export async function awaitStatsForSession(model: IChatModel): Promise<IChatSess
 	}
 
 	await chatEditingSessionIsReady(model.editingSession);
+	if (!model.editingSession) {
+		return undefined;
+	}
+
 	await Promise.all(model.editingSession.entries.get().map(entry => entry.getDiffInfo?.()));
+	if (!model.editingSession) {
+		return undefined;
+	}
 
 	const diffs = model.editingSession.entries.get();
 	const reduceResult = diffs.reduce((acc, diff) => {


### PR DESCRIPTION
Fix #309129

`awaitStatsForSession` reads `model.editingSession` across multiple `await` points. If the model is disposed during one of these awaits (e.g. the session is removed while `getLiveSessionItems` is collecting stats), the `editingSession` property is nulled by `ChatModel.dispose()` and the next access crashes with `Cannot read properties of undefined (reading 'entries')`.

Re-check `model.editingSession` after each `await` and bail out with `undefined` when the session has gone away. Returning `undefined` stats is correct here since the session is being disposed anyway.