### PR TITLE
git: always show clone destination picker when cached repo exists

### DIFF
--- a/extensions/git/src/cloneManager.ts
+++ b/extensions/git/src/cloneManager.ts
@@ -234,10 +234,7 @@ export class CloneManager {
 			return matchingInCurrentWorkspace.workspacePath;
 		}
 
-		let repoForWorkspace: string | undefined = (existingCachedRepositories.length === 1 ? existingCachedRepositories[0].workspacePath : undefined);
-		if (!repoForWorkspace) {
-			repoForWorkspace = await this.chooseExistingRepository(url, existingCachedRepositories, ref, parentPath, postCloneAction);
-		}
+		const repoForWorkspace = await this.chooseExistingRepository(url, existingCachedRepositories, ref, parentPath, postCloneAction);
 		if (repoForWorkspace) {
 			await this.doPostCloneAction(repoForWorkspace, postCloneAction);
 			return repoForWorkspace;


### PR DESCRIPTION
## Problem

When running **Git: Clone** and the repository URL had exactly one cached clone location, `tryOpenExistingRepository()` bypassed the quick pick prompt and directly used that cached path. The user was never shown the "Open Existing Repository Clone" dialog with the "Clone again" option, so they could not choose a new destination folder.

## Root cause

In `cloneManager.ts`, when `existingCachedRepositories.length === 1`, the code short-circuited directly to the cached workspace path without calling `chooseExistingRepository()`.

## Fix

Always route through `chooseExistingRepository()` regardless of the number of cached entries, so the user can pick the existing clone or opt to clone again into a different folder.

Fixes #307824