### PR TITLE
fix: preserve focus when list view recycles rows during scroll

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1064,6 +1064,10 @@ export class ListView<T> implements IListView<T> {
 				renderer.disposeElement(item.element, index, item.row.templateData, { height: item.size, onScroll });
 			}
 
+			if (item.row.domNode.contains(document.activeElement)) {
+				this.domNode.focus({ preventScroll: true });
+			}
+
 			this.cache.release(item.row);
 			item.row = null;
 		}


### PR DESCRIPTION
## Problem

When scrolling the Settings UI (or any virtual list) using the mouse wheel, the settings editor loses focus. This is easily visible with `accessibility.dimUnfocused.enabled` set to true — the window dims as you scroll.

## Root cause

In `listView.ts`, `removeItemFromDOM()` recycles rows that leave the viewport by releasing them to the cache. If the row being recycled contains the currently focused element (e.g. a dropdown, checkbox, or input in a settings row), the browser loses focus to `document.body`, triggering the tree's blur event.

## Fix

Before releasing a row to the cache, check if it contains `document.activeElement`. If so, transfer focus to the list container using `this.domNode.focus({ preventScroll: true })` to keep focus within the list without causing scroll jumps.

Fixes #304299