### PR TITLE
Fix reveal in file explorer showing wrong file (#297084)

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -158,6 +158,18 @@ export function getMultiSelectedResources(commandArg: unknown, listService: ILis
 		}
 	}
 
+	// When the explorer was the last focused list but lost DOM focus (e.g. to a
+	// context menu), its internal focus/selection state is still valid.  Check
+	// the explorer context before falling back to the active editor so that
+	// commands triggered via keyboard shortcut while a context menu is open act
+	// on the right-clicked item rather than the active editor.
+	if (list instanceof AsyncDataTree && list.getFocus().every(item => item instanceof ExplorerItem)) {
+		const context = explorerService.getContext(true, true);
+		if (context.length) {
+			return context.map(c => c.resource);
+		}
+	}
+
 	const result = getResourceForCommand(commandArg, editorSerice, listService);
 	return result ? [result] : [];
 }


### PR DESCRIPTION
## Summary

- When a user right-clicks a file in the Explorer panel and presses the keyboard shortcut for "Reveal in File Explorer" while the context menu is open, the command incorrectly reveals the active editor's file instead of the right-clicked file
- The explorer tree loses DOM focus to the context menu, causing `getMultiSelectedResources` to skip the explorer context check (`isActiveElement` returns false) and fall back to the active editor via `getResourceForCommand`
- Added an additional check for the explorer's internal focus/selection state (which remains valid even when the tree loses DOM focus) before falling back to the active editor

Fixes #297084

## Test plan

- [ ] Open a workspace with multiple files
- [ ] Open file A in the editor
- [ ] Right-click file B in the Explorer panel
- [ ] While the context menu is open, press the keyboard shortcut for "Reveal in File Explorer" (Shift+Alt+R on Windows)
- [ ] Verify that file B (the right-clicked file) is revealed, not file A (the active editor)
- [ ] Verify that clicking "Reveal in File Explorer" from the context menu still works correctly
- [ ] Verify that using Shift+Alt+R with the explorer focused (no context menu) still reveals the focused file
- [ ] Verify that running "Reveal in File Explorer" from the command palette still reveals the active editor's file