### PR TITLE
Fix Copy Path separator for git: URIs on Remote SSH

### DIFF
--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -171,7 +171,7 @@ export function tildify(path: string, userHome: string, os = OS): string {
 		return `~/${normalizedPath.substr(normalizedUserHome.length)}`;
 	}
 
-	return path;
+	return normalizedPath;
 }
 
 export function untildify(path: string, userHome: string): string {

--- a/src/vs/base/test/common/labels.test.ts
+++ b/src/vs/base/test/common/labels.test.ts
@@ -227,6 +227,13 @@ suite('Labels', () => {
 		assert.strictEqual(labels.getPathLabel(nixUntitledUri, { os: OperatingSystem.Macintosh, tildify: { userHome: remoteUserHome } }), '~/folder/file.txt');
 		assert.strictEqual(labels.getPathLabel(nixUntitledUri, { os: OperatingSystem.Linux, tildify: { userHome: remoteUserHome } }), '~/folder/file.txt');
 
+		// Tildify: path not under user home with cross-scheme URI (e.g., git: URI on a remote SSH session)
+		const gitSchemeUri = URI.file('/other/folder/file.txt').with({ scheme: 'git' });
+		const remoteUserHome2 = URI.file('/home/user').with({ scheme: 'vscode-remote', authority: 'ssh-remote+host' });
+
+		assert.strictEqual(labels.getPathLabel(gitSchemeUri, { os: OperatingSystem.Linux, tildify: { userHome: remoteUserHome2 } }), '/other/folder/file.txt');
+		assert.strictEqual(labels.getPathLabel(gitSchemeUri, { os: OperatingSystem.Macintosh, tildify: { userHome: remoteUserHome2 } }), '/other/folder/file.txt');
+
 		// Relative
 
 		const winFolder = URI.file('c:/some');


### PR DESCRIPTION
## Summary

- Fix `tildify()` returning un-normalized (backslash) paths when tildification fails on a Windows client targeting a non-Windows remote OS
- This caused the **Copy Path** command on staged files (git: URI scheme) to return `\path\to\file` instead of `/path/to/file` when using Remote SSH from Windows to Linux
- Add test coverage for the cross-scheme tildification non-match scenario

## Problem

When using Remote SSH from a Windows client to a Linux host, the **Copy Path** (Shift+Alt+C) command on **staged** files returned backslash-separated Windows paths. Unstaged files were unaffected because their URIs use the `vscode-remote:` scheme which has a dedicated label formatter.

Staged files use the `git:` URI scheme, which has no label formatter and falls through to `getPathLabel()`. This function calls `tildify()` to shorten home-directory paths with `~`. The `tildify()` function normalizes the path to forward slashes internally for comparison, but when the path is **not** under the user home directory, it returned the **original un-normalized path** (with Windows backslashes) instead of the normalized one.

## Fix

Return the `normalizedPath` (with POSIX separators) instead of the raw `path` from `tildify()` when tildification does not match. This is safe because:

- `tildify()` is only reached when `os !== Windows` (it returns early for Windows targets)
- When `isWindows` is `false`, `normalizedPath === path` (no behavioral change)
- When `isWindows` is `true`, `normalizedPath` has the correct forward slashes for the non-Windows target OS

Fixes #303207

## Test plan

- [x] Added test case for `getPathLabel()` with a `git:` scheme URI, `vscode-remote:` user home, and Linux/macOS target OS where the path is not under the user home
- [ ] Verify existing `labels.test.ts` tests pass
- [ ] Manual test: Windows client, Remote SSH to Linux, stage a file, open staged diff, Copy Path should produce forward-slash path