### PR TITLE
Fix editor sticky scroll shadow missing

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -4,13 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .sticky-widget {
-	overflow: hidden;
-	border-bottom: 1px solid var(--vscode-editorStickyScroll-border);
 	width: 100%;
-	box-shadow: var(--vscode-editorStickyScroll-shadow) 0 4px 2px -2px;
 	z-index: 4;
 	right: initial !important;
 	margin-left: '0px';
+}
+
+.monaco-editor .sticky-widget .sticky-widget-content {
+	overflow: hidden;
+	border-bottom: 1px solid var(--vscode-editorStickyScroll-border);
+}
+
+.monaco-editor .sticky-widget .sticky-widget-shadow {
+	position: absolute;
+	bottom: -3px;
+	left: 0;
+	height: 3px;
+	width: 100%;
+	box-shadow: var(--vscode-editorStickyScroll-shadow) 0 6px 6px -6px inset;
 }
 
 .monaco-editor .sticky-widget .sticky-widget-line-numbers {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -53,9 +53,11 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
 	private readonly _foldingIconStore = this._register(new DisposableStore());
 	private readonly _rootDomNode: HTMLElement = document.createElement('div');
+	private readonly _contentDomNode: HTMLElement = document.createElement('div');
 	private readonly _lineNumbersDomNode: HTMLElement = document.createElement('div');
 	private readonly _linesDomNodeScrollable: HTMLElement = document.createElement('div');
 	private readonly _linesDomNode: HTMLElement = document.createElement('div');
+	private readonly _shadowDomNode: HTMLElement = document.createElement('div');
 
 	private readonly _editor: ICodeEditor;
 
@@ -87,10 +89,16 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._linesDomNodeScrollable.className = 'sticky-widget-lines-scrollable';
 		this._linesDomNodeScrollable.appendChild(this._linesDomNode);
 
+		this._contentDomNode.className = 'sticky-widget-content';
+		this._contentDomNode.appendChild(this._lineNumbersDomNode);
+		this._contentDomNode.appendChild(this._linesDomNodeScrollable);
+
+		this._shadowDomNode.className = 'sticky-widget-shadow';
+
 		this._rootDomNode.className = 'sticky-widget';
 		this._rootDomNode.classList.toggle('peek', editor instanceof EmbeddedCodeEditorWidget);
-		this._rootDomNode.appendChild(this._lineNumbersDomNode);
-		this._rootDomNode.appendChild(this._linesDomNodeScrollable);
+		this._rootDomNode.appendChild(this._contentDomNode);
+		this._rootDomNode.appendChild(this._shadowDomNode);
 		this._setHeight(0);
 
 		const updateScrollLeftPosition = () => {
@@ -266,6 +274,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 			this._rootDomNode.style.display = 'block';
 			this._lineNumbersDomNode.style.height = `${this._height}px`;
 			this._linesDomNodeScrollable.style.height = `${this._height}px`;
+			this._contentDomNode.style.height = `${this._height}px`;
 			this._rootDomNode.style.height = `${this._height}px`;
 		}
 


### PR DESCRIPTION
## Summary

Fixes #300355

The editor sticky scroll's bottom shadow was not rendering because the outward `box-shadow` on the widget root was clipped by its own `overflow: hidden`.

This restructures the sticky scroll widget DOM to match the proven pattern used by the tree view's sticky scroll:

- **`sticky-widget-content`** (new inner wrapper): carries `overflow: hidden` and the bottom border, containing the line numbers and line content
- **`sticky-widget-shadow`** (new element): positioned just below the content area with an `inset` box-shadow that renders reliably regardless of parent overflow
- **`sticky-widget`** (root): no longer has `overflow: hidden`, allowing the shadow element to extend beyond the content bounds

## Test plan

- [ ] Open a file with enough nested scopes to trigger sticky scroll (e.g., nested functions/classes)
- [ ] Scroll down so sticky scroll headers appear at the top of the editor
- [ ] Verify a visible shadow appears at the bottom edge of the sticky scroll, separating it from the editor content below
- [ ] Test with Dark Modern, Light Modern, and High Contrast themes
- [ ] Verify the sticky scroll in the Explorer tree view still has its shadow (unchanged)
- [ ] Verify sticky scroll line content is still clipped horizontally (no overflow)
- [ ] Verify folding icons, hover effects, and click-to-navigate still work on sticky scroll lines
- [ ] Verify sticky scroll in peek view editors still renders correctly