### PR TITLE
Fix Administrator label missing in command center

### DIFF
--- a/src/vs/sessions/browser/parts/titlebarPart.ts
+++ b/src/vs/sessions/browser/parts/titlebarPart.ts
@@ -69,6 +69,9 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 	private readonly _onMenubarVisibilityChange = this._register(new Emitter<boolean>());
 	readonly onMenubarVisibilityChange = this._onMenubarVisibilityChange.event;
 
+	private readonly _onDidChangeTitleProperties = this._register(new Emitter<ITitleProperties>());
+	readonly onDidChangeTitleProperties = this._onDidChangeTitleProperties.event;
+
 	private readonly _onWillDispose = this._register(new Emitter<void>());
 	readonly onWillDispose = this._onWillDispose.event;
 
@@ -123,6 +126,8 @@ export class TitlebarPart extends Part implements ITitlebarPart {
 		this.isInactive = false;
 		this.updateStyles();
 	}
+
+	readonly titleProperties: ITitleProperties = {};
 
 	updateProperties(_properties: ITitleProperties): void {
 		// No window title to update in simplified titlebar
@@ -440,10 +445,17 @@ export class TitleService extends MultiWindowParts<TitlebarPart> implements ITit
 
 	readonly onMenubarVisibilityChange: Event<boolean>;
 
+	private readonly _onDidChangeTitleProperties = this._register(new Emitter<ITitleProperties>());
+	readonly onDidChangeTitleProperties = this._onDidChangeTitleProperties.event;
+
+	readonly titleProperties: ITitleProperties = {};
+
 	updateProperties(properties: ITitleProperties): void {
 		for (const part of this.parts) {
 			part.updateProperties(properties);
 		}
+
+		this._onDidChangeTitleProperties.fire(properties);
 	}
 
 	registerVariables(variables: ITitleVariable[]): void {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -76,6 +76,16 @@ export interface ITitlebarPart extends IDisposable {
 	readonly onMenubarVisibilityChange: Event<boolean>;
 
 	/**
+	 * An event when the title properties change.
+	 */
+	readonly onDidChangeTitleProperties: Event<ITitleProperties>;
+
+	/**
+	 * The current title properties.
+	 */
+	readonly titleProperties: ITitleProperties;
+
+	/**
 	 * Update some environmental title properties.
 	 */
 	updateProperties(properties: ITitleProperties): void;
@@ -164,8 +174,8 @@ export class BrowserTitleService extends MultiWindowParts<BrowserTitlebarPart> i
 		disposables.add(Event.runAndSubscribe(titlebarPart.onDidChange, () => titlebarPartContainer.style.height = `${titlebarPart.height}px`));
 		titlebarPart.create(titlebarPartContainer);
 
-		if (this.properties) {
-			titlebarPart.updateProperties(this.properties);
+		if (this._titleProperties) {
+			titlebarPart.updateProperties(this._titleProperties);
 		}
 
 		if (this.variables.size) {
@@ -188,14 +198,23 @@ export class BrowserTitleService extends MultiWindowParts<BrowserTitlebarPart> i
 
 	readonly onMenubarVisibilityChange: Event<boolean>;
 
-	private properties: ITitleProperties | undefined = undefined;
+	private readonly _onDidChangeTitleProperties = this._register(new Emitter<ITitleProperties>());
+	readonly onDidChangeTitleProperties = this._onDidChangeTitleProperties.event;
+
+	private _titleProperties: ITitleProperties = {};
+
+	get titleProperties(): ITitleProperties {
+		return this._titleProperties;
+	}
 
 	updateProperties(properties: ITitleProperties): void {
-		this.properties = properties;
+		this._titleProperties = properties;
 
 		for (const part of this.parts) {
 			part.updateProperties(properties);
 		}
+
+		this._onDidChangeTitleProperties.fire(properties);
 	}
 
 	private readonly variables = new Map<string, ITitleVariable>();
@@ -243,6 +262,9 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 	private _onMenubarVisibilityChange = this._register(new Emitter<boolean>());
 	readonly onMenubarVisibilityChange = this._onMenubarVisibilityChange.event;
+
+	private readonly _onDidChangeTitleProperties = this._register(new Emitter<ITitleProperties>());
+	readonly onDidChangeTitleProperties = this._onDidChangeTitleProperties.event;
 
 	private readonly _onWillDispose = this._register(new Emitter<void>());
 	readonly onWillDispose = this._onWillDispose.event;
@@ -447,8 +469,16 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 		}
 	}
 
+	private _titleProperties: ITitleProperties = {};
+
+	get titleProperties(): ITitleProperties {
+		return this._titleProperties;
+	}
+
 	updateProperties(properties: ITitleProperties): void {
+		this._titleProperties = properties;
 		this.windowTitle.updateProperties(properties);
+		this._onDidChangeTitleProperties.fire(properties);
 	}
 
 	registerVariables(variables: ITitleVariable[]): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
@@ -43,6 +43,7 @@ import { ChatConfiguration } from '../../../common/constants.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IChatWidgetService } from '../../chat.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { ITitleService } from '../../../../../services/title/browser/titleService.js';
 
 // Telemetry types
 type AgentStatusClickAction =
@@ -171,6 +172,7 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@ITitleService private readonly titleService: ITitleService,
 	) {
 		super(undefined, action, options);
 
@@ -182,6 +184,13 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 
 		// Create WindowTitle to honor the user's window.title setting
 		this._windowTitle = this._register(this.instantiationService.createInstance(WindowTitle, mainWindow));
+
+		// Sync title properties (isAdmin, isPure, prefix) from the title service
+		// so that decorations like [Administrator] are shown correctly
+		this._windowTitle.updateProperties(this.titleService.titleProperties);
+		this._register(this.titleService.onDidChangeTitleProperties(properties => {
+			this._windowTitle.updateProperties(properties);
+		}));
 
 		// Re-render when control mode or session info changes
 		this._register(this.agentTitleBarStatusService.onDidChangeMode(() => {


### PR DESCRIPTION
## Summary

- The `[Administrator]` label stopped appearing in the command center search bar because the `AgentTitleBarStatusWidget` (which replaces the default command center in compact/agent mode) creates its own `WindowTitle` instance that never receives the `isAdmin`/`isPure` property updates flowing through the title service
- Expose `titleProperties` and `onDidChangeTitleProperties` on the `ITitlebarPart` interface, then sync these properties from the title service into the widget's `WindowTitle` so `getTitleDecorations()` returns the correct `[Administrator]` suffix

Fixes #308595

## Test plan

- [ ] Run VS Code as Administrator on Windows
- [ ] Verify `[Administrator]` label appears in the command center search bar with default settings (agent status compact mode)
- [ ] Verify `[Administrator]` label appears when agent status is in non-compact mode
- [ ] Verify `[Administrator]` label appears in the plain text title bar when command center is disabled
- [ ] On Linux, verify `[Superuser]` label appears when running as root