### PR TITLE
Fix parent repo dialog that cannot be dismissed

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -257,6 +257,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 	}
 
 	private _parentRepositoriesManager: ParentRepositoriesManager;
+	private _parentRepositoryNotificationShown = false;
 	get parentRepositories(): string[] {
 		return this._parentRepositoriesManager.repositories;
 	}
@@ -1162,6 +1163,12 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 	}
 
 	private async showParentRepositoryNotification(): Promise<void> {
+		if (this._parentRepositoryNotificationShown) {
+			return;
+		}
+
+		this._parentRepositoryNotificationShown = true;
+
 		const message = this.parentRepositories.length === 1 ?
 			l10n.t('A git repository was found in the parent folders of the workspace or the open file(s). Would you like to open the repository?') :
 			l10n.t('Git repositories were found in the parent folders of the workspace or the open file(s). Would you like to open the repositories?');


### PR DESCRIPTION
## Summary
- When `git.openRepositoryInParentFolders` is set to `prompt` (the default), opening a directory inside a Git repository shows a notification asking whether to open the parent repository
- If the user dismisses this dialog (clicks X or presses Escape), it can reappear because the dismissal is not tracked — the notification function has no guard against being called again
- This adds a session-scoped flag (`_parentRepositoryNotificationShown`) so the notification is shown at most once per session. The flag is set before `await`ing the dialog, which also prevents concurrent duplicate notifications from race conditions

## Test plan
- [ ] Open VS Code with a workspace folder that is a subdirectory of a git repository
- [ ] With `git.openRepositoryInParentFolders` set to `prompt`, verify the parent repository notification appears
- [ ] Dismiss the notification by clicking X or pressing Escape
- [ ] Switch between editors / open new files — verify the notification does not reappear
- [ ] Restart VS Code — verify the notification appears again on next session (since the flag is session-scoped, not persisted)

Fixes #308449