### PR TITLE
Fix word wrap not breaking ligatures exceeding viewport

### DIFF
--- a/src/vs/editor/browser/view/domLineBreaksComputer.ts
+++ b/src/vs/editor/browser/view/domLineBreaksComputer.ts
@@ -136,8 +136,9 @@ function createLineBreaks(targetWindow: Window, context: ILineBreaksComputerCont
 		containerDomNode.style.wordBreak = 'keep-all';
 		containerDomNode.style.overflowWrap = 'anywhere';
 	} else {
-		// overflow-wrap: break-word
-		containerDomNode.style.wordBreak = 'inherit';
+		// word-break: break-all; overflow-wrap: break-word
+		// Use break-all to allow breaks within ligature glyphs that may exceed viewport width
+		containerDomNode.style.wordBreak = 'break-all';
 		containerDomNode.style.overflowWrap = 'break-word';
 	}
 	targetWindow.document.body.appendChild(containerDomNode);


### PR DESCRIPTION
## Summary

- When font ligatures are enabled and a ligature glyph is wider than the viewport (e.g., repeated Tamil character `ௌ` U+0BCC), word wrap fails to break the ligature, causing horizontal overflow
- The DOM-based line breaks computer uses `overflow-wrap: break-word` to ask the browser where to place line breaks, but browsers treat wide ligatures as atomic inline content that `overflow-wrap` alone cannot break
- Changed `word-break` from `inherit` to `break-all` in the DOM line breaks measurement container so the browser can find break points within wide ligature glyphs

Fixes #296151

## Test plan

- [ ] Enable word wrap (`editor.wordWrap: on`) and wrapping strategy advanced (`editor.wrappingStrategy: advanced`)
- [ ] Create a file with repeated `ௌ` characters (U+0BCC) that form a ligature wider than the viewport
- [ ] Verify the line wraps correctly and does not overflow horizontally
- [ ] Verify normal word wrapping still works correctly with regular text
- [ ] Verify CJK text wrapping behavior is not affected