### PR TITLE
chat: fall back to full snapshot on serializer failure

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -371,14 +371,17 @@ export class ChatSessionStore extends Disposable {
 							this.dialogService.prompt({
 								custom: true, // so text is copyable
 								title: localize('chatSessionStore.serializationError', 'Error saving chat session'),
-								message: localize('chatSessionStore.writeError', 'Error serializing chat session for storage. The session will be lost if the window is closed. Please report this issue to the VS Code team:\n\n{0}', e.stack || toErrorMessage(e)),
+								message: localize('chatSessionStore.writeError', 'Error serializing chat session for storage. VS Code will try to recover by writing a full snapshot, but the session may still be lost if that fallback also fails. Please report this issue to the VS Code team:\n\n{0}', e.stack || toErrorMessage(e)),
 								buttons: [
 									{ label: localize('reportIssue', 'Report Issue'), run: () => this.openerService.open('https://github.com/microsoft/vscode/issues/new?template=bug_report.md') }
 								]
 							});
 						}
 
-						throw e;
+						this.logService.warn('ChatSessionStore: Falling back to a full snapshot after incremental chat session serialization failed', toErrorMessage(e));
+						session.dataSerializer = new ChatSessionOperationLog();
+						op = 'replace';
+						data = session.dataSerializer.createInitialFromSerialized(session.toJSON());
 					}
 
 					if (data.byteLength > 0) {

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -381,7 +381,7 @@ export class ChatSessionStore extends Disposable {
 						this.logService.warn('ChatSessionStore: Falling back to a full snapshot after incremental chat session serialization failed', toErrorMessage(e));
 						session.dataSerializer = new ChatSessionOperationLog();
 						op = 'replace';
-						data = session.dataSerializer.createInitialFromSerialized(session.toJSON());
+						data = session.dataSerializer.createInitial(session);
 					}
 
 					if (data.byteLength > 0) {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -19,6 +19,8 @@ import { NullTelemetryService } from '../../../../../../platform/telemetry/commo
 import { IUserDataProfilesService, toUserDataProfile } from '../../../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IAnyWorkspaceIdentifier, IWorkspaceContextService, WorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { TestWorkspace, Workspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
+import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { IDidEnterWorkspaceEvent, IWorkspaceEditingService } from '../../../../../services/workspaces/common/workspaceEditing.js';
 import { InMemoryTestFileService, TestContextService, TestLifecycleService, TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
@@ -80,6 +82,8 @@ suite('ChatSessionStore', () => {
 		instantiationService.stub(IEnvironmentService, { workspaceStorageHome: URI.file('/test/workspaceStorage') });
 		instantiationService.stub(ILifecycleService, testDisposables.add(new TestLifecycleService()));
 		instantiationService.stub(IUserDataProfilesService, { defaultProfile: toUserDataProfile('default', 'Default', URI.file('/test/userdata'), URI.file('/test/cache')) });
+		instantiationService.stub(IDialogService, { prompt: async () => undefined } as unknown as IDialogService);
+		instantiationService.stub(IOpenerService, { open: async () => true } as unknown as IOpenerService);
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
 		mockWorkspaceEditingService = testDisposables.add(new MockWorkspaceEditingService());
 		instantiationService.stub(IWorkspaceEditingService, mockWorkspaceEditingService as unknown as IWorkspaceEditingService);

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -22,7 +22,7 @@ import { TestWorkspace, Workspace } from '../../../../../../platform/workspace/t
 import { ILifecycleService } from '../../../../../services/lifecycle/common/lifecycle.js';
 import { IDidEnterWorkspaceEvent, IWorkspaceEditingService } from '../../../../../services/workspaces/common/workspaceEditing.js';
 import { InMemoryTestFileService, TestContextService, TestLifecycleService, TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
-import { ChatModel, ISerializableChatData3 } from '../../../common/model/chatModel.js';
+import { ChatModel, IChatDataSerializerLog, ISerializableChatData3 } from '../../../common/model/chatModel.js';
 import { ChatSessionStore, IChatTransfer } from '../../../common/model/chatSessionStore.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { MockChatModel } from './mockChatModel.js';
@@ -164,6 +164,27 @@ suite('ChatSessionStore', () => {
 		await store.storeSessions([model]);
 		const session = await store.readSession('session-1');
 
+		assert.ok(session);
+		assert.strictEqual((session.value as ISerializableChatData3).sessionId, 'session-1');
+	});
+
+	test('storeSessions falls back to a full snapshot when incremental serialization fails', async () => {
+		const store = createChatSessionStore();
+		const model = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1')));
+		const failingSerializer = {
+			write: () => {
+				throw new Error('boom');
+			}
+		} as unknown as IChatDataSerializerLog;
+		model.dataSerializer = failingSerializer;
+
+		await store.storeSessions([model]);
+
+		assert.notStrictEqual(model.dataSerializer, failingSerializer);
+		const index = await store.getIndex();
+		assert.ok(index['session-1']);
+
+		const session = await store.readSession('session-1');
 		assert.ok(session);
 		assert.strictEqual((session.value as ISerializableChatData3).sessionId, 'session-1');
 	});


### PR DESCRIPTION
## Summary

This draft PR hardens `ChatSessionStore` against one concrete missing-session failure mode: when incremental chat-session serialization throws, we currently report the error and then abort the write, which can leave the session non-durable and effectively lost.

Instead of bailing out, this change falls back to writing a fresh full snapshot of the current session and then continues updating the session index.

## What changed

- In `chatSessionStore.ts`, when `session.dataSerializer.write(session)` throws, VS Code now:
  - keeps the existing user-facing error prompt
  - logs a warning
  - resets the serializer
  - writes a full replacement snapshot via `createInitial(session)` so the fallback matches the normal persistence schema
- Added a regression test proving that a session is still persisted and readable when incremental serialization fails.
- Stubbed `IDialogService.prompt` and `IOpenerService.open` in the regression test so the failure-path test is deterministic and side-effect free.

## Why this helps

If the append-log serializer is the thing that breaks, we no longer silently lose durability for the session. That should reduce cases where agent/chat work continues but the session is no longer recoverable through the normal session store path.

## Scope / limitations

This is intentionally a **small hardening fix**, not a claim that it explains every disappearing-session report. It addresses one real failure path in the existing code, especially relevant because the surrounding comment already calls out "missing sessions".

## Related

- Related to #309284
- Related to #308369
- Related to #308730
- Related to #307348
- Related to #296890
- Related to #305109
- Related to #308921

If maintainers think the root cause for #309284 is elsewhere, this should still be useful as a targeted durability improvement in the same subsystem.