### PR TITLE
Fix ObjectMutationLog corrupting session files on failed writes

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -384,6 +384,7 @@ export class ChatSessionStore extends Disposable {
 					if (data.byteLength > 0) {
 						await this.fileService.writeFile(storageLocation.log, data, { append: op === 'append' });
 					}
+					session.dataSerializer.confirmWrite();
 				} else {
 					const content = new ChatSessionOperationLog().createInitialFromSerialized(session);
 					await this.fileService.writeFile(storageLocation.log, content);

--- a/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
@@ -225,6 +225,9 @@ const LF = VSBuffer.fromString('\n');
 export class ObjectMutationLog<TFrom, TTo> {
 	private _previous: TTo | undefined;
 	private _entryCount = 0;
+	private _hasPendingWrite = false;
+	private _pendingPrevious: TTo | undefined;
+	private _pendingEntryCount = 0;
 
 	constructor(
 		private readonly _transform: Transform<TFrom, TTo>,
@@ -241,10 +244,16 @@ export class ObjectMutationLog<TFrom, TTo> {
 
 	/**
 	 * Creates an initial log file from the serialized object.
+	 *
+	 * Unlike {@link write}, this commits state immediately without requiring
+	 * {@link confirmWrite}. This is safe because the returned buffer contains
+	 * a self-contained `Initial` entry — if it fails to persist, no
+	 * incremental entries can be appended to a non-existent file.
 	 */
 	createInitialFromSerialized(value: TTo): VSBuffer {
 		this._previous = value;
 		this._entryCount = 1;
+		this._clearPending();
 		const entry: Entry = { kind: EntryKind.Initial, v: value };
 		return VSBuffer.fromString(JSON.stringify(entry) + '\n');
 	}
@@ -274,12 +283,21 @@ export class ObjectMutationLog<TFrom, TTo> {
 							state = entry.v;
 							break;
 						case EntryKind.Set:
+							if (state === undefined) {
+								throw new Error('Log file is missing an initial entry');
+							}
 							this._applySet(state, entry.k, entry.v);
 							break;
 						case EntryKind.Push:
+							if (state === undefined) {
+								throw new Error('Log file is missing an initial entry');
+							}
 							this._applyPush(state, entry.k, entry.v, entry.i);
 							break;
 						case EntryKind.Delete:
+							if (state === undefined) {
+								throw new Error('Log file is missing an initial entry');
+							}
 							this._applySet(state, entry.k, undefined);
 							break;
 						default:
@@ -296,19 +314,26 @@ export class ObjectMutationLog<TFrom, TTo> {
 
 		this._previous = state as TTo;
 		this._entryCount = lineCount;
+		this._clearPending();
 		return state as TTo;
 	}
 
 	/**
 	 * Writes updates to the log. Returns the operation type and data to write.
+	 * The caller **must** invoke {@link confirmWrite} after the data is
+	 * successfully persisted to commit the internal state. Without confirmation,
+	 * the next write is computed against the last confirmed state, and will only
+	 * produce a full initial entry when no confirmed state exists, preventing
+	 * corrupted log files when a write fails.
 	 */
 	write(current: TFrom): { op: 'append' | 'replace'; data: VSBuffer } {
 		const currentValue = this._transform.extract(current);
 
 		if (!this._previous || this._entryCount > this._compactAfterEntries) {
 			// No previous state, create initial
-			this._previous = currentValue;
-			this._entryCount = 1;
+			this._hasPendingWrite = true;
+			this._pendingPrevious = currentValue;
+			this._pendingEntryCount = 1;
 			const entry: Entry = { kind: EntryKind.Initial, v: currentValue };
 			return { op: 'replace', data: VSBuffer.fromString(JSON.stringify(entry) + '\n') };
 		}
@@ -328,11 +353,13 @@ export class ObjectMutationLog<TFrom, TTo> {
 
 		if (entries.length === 0) {
 			// No changes
+			this._clearPending();
 			return { op: 'append', data: VSBuffer.fromString('') };
 		}
 
-		this._entryCount += entries.length;
-		this._previous = currentValue;
+		this._hasPendingWrite = true;
+		this._pendingEntryCount = this._entryCount + entries.length;
+		this._pendingPrevious = currentValue;
 
 		// Append entries - build string directly
 		let data = '';
@@ -340,6 +367,23 @@ export class ObjectMutationLog<TFrom, TTo> {
 			data += JSON.stringify(e) + '\n';
 		}
 		return { op: 'append', data: VSBuffer.fromString(data) };
+	}
+
+	/**
+	 * Commits the internal state after a successful write to disk.
+	 */
+	confirmWrite(): void {
+		if (this._hasPendingWrite) {
+			this._previous = this._pendingPrevious;
+			this._entryCount = this._pendingEntryCount;
+			this._clearPending();
+		}
+	}
+
+	private _clearPending(): void {
+		this._hasPendingWrite = false;
+		this._pendingPrevious = undefined;
+		this._pendingEntryCount = 0;
 	}
 
 	private _applySet(state: unknown, path: ObjectPath, value: unknown): void {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionOperationLog.test.ts
@@ -51,6 +51,7 @@ suite('ChatSessionOperationLog', () => {
 			} else {
 				fileContent = VSBuffer.concat([fileContent, result.data]);
 			}
+			adapter.confirmWrite();
 		}
 
 		// Create new adapter and read back
@@ -210,6 +211,7 @@ suite('ChatSessionOperationLog', () => {
 
 
 			const result1 = adapter.write({ items: [{ id: 'a', value: [1, 2, 3] }] });
+			adapter.confirmWrite();
 			assert.deepStrictEqual(
 				JSON.parse(result1.data.toString().trim()),
 				{ kind: 2, k: ['items', 0, 'value'], v: [3] },
@@ -309,9 +311,12 @@ suite('ChatSessionOperationLog', () => {
 			adapter.createInitial(obj); // Entry 1
 
 			adapter.write({ ...obj, count: 1 }); // Entry 2
+			adapter.confirmWrite();
 			adapter.write({ ...obj, count: 2 }); // Entry 3
+			adapter.confirmWrite();
 
 			const before = adapter.write({ ...obj, count: 3 });
+			adapter.confirmWrite();
 			assert.strictEqual(before.op, 'append');
 
 			// This should trigger compaction
@@ -364,6 +369,7 @@ suite('ChatSessionOperationLog', () => {
 
 			// Change type from 'foo' to 'bar' - should detect change (different prefix)
 			const result1 = adapter.write({ data: { type: 'bar', version: 2 } });
+			adapter.confirmWrite();
 			assert.notStrictEqual(result1.data.toString(), '', 'different type should trigger change');
 			const entry1 = JSON.parse(result1.data.toString().trim());
 			assert.strictEqual(entry1.kind, 1); // EntryKind.Set
@@ -574,6 +580,97 @@ suite('ChatSessionOperationLog', () => {
 			const result = adapter.read(VSBuffer.fromString(logContent));
 
 			assert.deepStrictEqual(result.metadata, { tags: ['b', 'c'] });
+		});
+
+		test('write without confirmWrite resets to initial on next write', () => {
+			const schema = createTestSchema();
+			const adapter = new Adapt.ObjectMutationLog(schema);
+
+			const obj: TestObject = { name: 'test', count: 0, items: [] };
+
+			// First write (no createInitial) — produces Initial replace
+			const result1 = adapter.write(obj);
+			assert.strictEqual(result1.op, 'replace');
+			// Do NOT confirm — simulates a failed persist
+
+			// Next write should produce a full replace again since state was not committed
+			const result2 = adapter.write({ ...obj, count: 2 });
+			assert.deepStrictEqual(
+				{ op: result2.op, entry: JSON.parse(result2.data.toString().trim()) },
+				{ op: 'replace', entry: { kind: 0, v: { name: 'test', count: 2, items: [] } } },
+			);
+		});
+
+		test('confirmWrite commits state so next write is incremental', () => {
+			const schema = createTestSchema();
+			const adapter = new Adapt.ObjectMutationLog(schema);
+
+			const obj: TestObject = { name: 'test', count: 0, items: [] };
+			adapter.createInitial(obj);
+
+			adapter.write({ ...obj, count: 1 });
+			adapter.confirmWrite();
+
+			// Next write should be an incremental append
+			const result = adapter.write({ ...obj, count: 2 });
+			assert.deepStrictEqual(
+				{ op: result.op, entry: JSON.parse(result.data.toString().trim()) },
+				{ op: 'append', entry: { kind: 1, k: ['count'], v: 2 } },
+			);
+		});
+
+		test('read throws on log file missing initial entry', () => {
+			const schema = createTestSchema();
+			const adapter = new Adapt.ObjectMutationLog(schema);
+
+			const logContent = JSON.stringify({ kind: 1, k: ['count'], v: 5 }) + '\n';
+			assert.throws(() => adapter.read(VSBuffer.fromString(logContent)), /missing an initial entry/);
+		});
+
+		test('failed first write followed by successful write produces valid roundtrip', () => {
+			const schema = createTestSchema();
+			const adapter = new Adapt.ObjectMutationLog(schema);
+
+			const initial: TestObject = { name: 'test', count: 0, items: [] };
+
+			// First write "fails" — data not persisted, no confirmWrite
+			const r1 = adapter.write(initial);
+			assert.strictEqual(r1.op, 'replace');
+			// skip confirmWrite — simulates failed persist
+
+			// Second write recovers — produces a full replace again
+			const r2 = adapter.write({ ...initial, count: 3 });
+			assert.strictEqual(r2.op, 'replace');
+			adapter.confirmWrite();
+			const fileContent = r2.data;
+
+			// Read back should give the last committed state
+			const reader = new Adapt.ObjectMutationLog(createTestSchema());
+			const result = reader.read(fileContent);
+			assert.strictEqual(result.count, 3);
+		});
+
+		test('unconfirmed append after createInitial still diffs against initial', () => {
+			const schema = createTestSchema();
+			const adapter = new Adapt.ObjectMutationLog(schema);
+
+			const obj: TestObject = { name: 'test', count: 0, items: [] };
+			let fileContent = adapter.createInitial(obj);
+
+			// Write but do NOT confirm
+			const r1 = adapter.write({ ...obj, count: 1 });
+			assert.strictEqual(r1.op, 'append');
+			// skip confirmWrite — simulates failed persist, data not appended to file
+
+			// Next write diffs against the createInitial state (count: 0)
+			const r2 = adapter.write({ ...obj, count: 2 });
+			assert.strictEqual(r2.op, 'append');
+			adapter.confirmWrite();
+			fileContent = VSBuffer.concat([fileContent, r2.data]);
+
+			const reader = new Adapt.ObjectMutationLog(createTestSchema());
+			const result = reader.read(fileContent);
+			assert.strictEqual(result.count, 2);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/model/objectMutationLog.perf.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/objectMutationLog.perf.test.ts
@@ -54,6 +54,7 @@ interface BenchmarkResult {
 interface BenchmarkWriter<T> {
 	createInitial(current: T): VSBuffer;
 	write(current: T): { op: 'append' | 'replace'; data: VSBuffer };
+	confirmWrite(): void;
 	readonly reusedReferences?: number;
 }
 
@@ -129,6 +130,10 @@ class ReferenceReusingObjectMutationLog<TFrom, TTo> implements BenchmarkWriter<T
 		}
 
 		return { op: 'append', data: VSBuffer.fromString(data) };
+	}
+
+	confirmWrite(): void {
+		// Perf benchmark always succeeds, state is eagerly updated in write()
 	}
 
 	private _diff<T, R>(
@@ -361,6 +366,7 @@ function runBenchmarkRound(writer: BenchmarkWriter<BenchmarkState>, states: read
 	const sw = StopWatch.create();
 	for (let i = 1; i < states.length; i++) {
 		serialized = appendToLog(serialized, writer.write(states[i]));
+		writer.confirmWrite();
 	}
 	const elapsedMs = sw.elapsed();
 


### PR DESCRIPTION
## Bug

When restoring a chat session from a `.jsonl` file, the session fails to load with:

```
ChatSessionStore: Malformed session data in …/chatSessions/….jsonl: Cannot read properties of undefined (reading 'requests')
```

## Root Cause

`ObjectMutationLog.write()` eagerly committed its internal state (`_previous`, `_entryCount`) **before** the caller persisted data to disk. If the initial file write failed (e.g. filesystem error), the log instance believed it had already written the `Initial` entry. Subsequent writes then produced only incremental `Set`/`Push` entries — creating a `.jsonl` file missing the required `Initial` entry. On reload, `read()` tried to apply mutations to `undefined` state, causing the crash.

## Fix

Introduce a two-phase write/confirm pattern in `ObjectMutationLog`:

- **`write()`** now stores updates in pending fields (`_pendingPrevious`, `_pendingEntryCount`) behind an explicit `_hasPendingWrite` flag, without committing them to the live state
- **`confirmWrite()`** (new) commits pending state — the caller must invoke this after the data is successfully persisted to disk
- If the write fails and `confirmWrite()` is never called, the next `write()` will produce a fresh `Initial` entry, preventing corrupted log files
- `createInitialFromSerialized()` and `read()` clear pending state on reset to prevent stale pending writes from being resurrected
- `read()` now throws a clear `'Log file is missing an initial entry'` error instead of crashing with a confusing property-access error

`chatSessionStore.ts` calls `confirmWrite()` after the successful `writeFile`.

## Test Coverage

- Added `confirmWrite()` calls to existing tests that perform sequential writes
- New tests: unconfirmed write resets, confirmed write increments, missing initial entry detection, failed-then-successful roundtrip, unconfirmed append after createInitial
- Updated perf benchmark to use the new `confirmWrite()` API

(Written by Copilot)