### PR TITLE
Fix onboarding showing for existing users and sanity test failures

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -97,11 +97,7 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 	) {
 		super();
 
-		// Show onboarding overlay immediately (before waiting for lifecycle restore)
-		if (!this.environmentService.skipWelcome && this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {
-			this.tryShowOnboarding();
-		}
-
+		this.tryShowOnboarding();
 		this.run().then(undefined, onUnexpectedError);
 		this._register(this.editorService.onDidCloseEditor((e) => {
 			if (e.editor instanceof GettingStartedInput) {
@@ -235,7 +231,19 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 	}
 
 	private tryShowOnboarding(): void {
-		if (this.storageService.get(ONBOARDING_STORAGE_KEY, StorageScope.PROFILE)) {
+		if (this.environmentService.skipWelcome) {
+			return; // skip welcome flag is set
+		}
+
+		if (!this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {
+			return; // experimental onboarding is disabled
+		}
+
+		if (!this.storageService.isNew(StorageScope.APPLICATION)) {
+			return; // only show onboarding for new users who have never used the product before
+		}
+
+		if (this.storageService.get(ONBOARDING_STORAGE_KEY, StorageScope.APPLICATION)) {
 			return; // onboarding already completed
 		}
 
@@ -244,7 +252,7 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 
 		// Mark onboarding as completed when dismissed
 		this._register(this.onboardingService.onDidDismiss(() => {
-			this.storageService.store(ONBOARDING_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+			this.storageService.store(ONBOARDING_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 		}));
 	}
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -243,7 +243,7 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 			return; // only show onboarding for new users who have never used the product before
 		}
 
-		if (this.storageService.get(ONBOARDING_STORAGE_KEY, StorageScope.APPLICATION)) {
+		if (this.storageService.getBoolean(ONBOARDING_STORAGE_KEY, StorageScope.APPLICATION)) {
 			return; // onboarding already completed
 		}
 

--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -245,6 +245,7 @@ export function setup(context: TestContext) {
 			'--extensions-dir', test.extensionsDir,
 			'--user-data-dir', test.userDataDir,
 		];
+		args.push('--skip-welcome');
 		args.push(test.workspaceDir);
 
 		context.log(`Starting VS Code ${entryPoint} with args ${args.join(' ')}`);

--- a/test/sanity/src/wsl.test.ts
+++ b/test/sanity/src/wsl.test.ts
@@ -149,6 +149,7 @@ export function setup(context: TestContext) {
 		const args = [
 			'--extensions-dir', context.createTempDir(),
 			'--user-data-dir', test.userDataDir,
+			'--skip-welcome',
 			'--folder-uri', `vscode-remote://wsl+${wslDistro}${wslWorkspaceDir}`,
 		];
 


### PR DESCRIPTION
## Problem

Two issues with the onboarding flow merged in #307262:

1. **Onboarding overlay showing for existing users** — The `tryShowOnboarding()` method only checked if onboarding had been previously completed (`ONBOARDING_STORAGE_KEY`), but never verified the user was actually new. Since `experimentalOnboarding` defaults to `true`, every existing user who upgraded would see the onboarding overlay.

2. **Sanity tests broken** — Sanity tests (`desktop.test.ts`, `wsl.test.ts`) launch VS Code with a fresh `--user-data-dir`, making `isNew(APPLICATION)` true. The onboarding overlay rendered on top of everything, intercepting pointer events and blocking the workspace trust dialog — causing 180s timeouts.

## Fix

### `startupPage.ts`
- Added `isNew(StorageScope.APPLICATION)` guard to only show onboarding for genuinely new users (same pattern used in `gettingStarted.ts` line 997)
- Moved all guard conditions (`skipWelcome`, `experimentalOnboarding`, `isNew`, `ONBOARDING_STORAGE_KEY`) into `tryShowOnboarding()` for clarity  
- Changed `ONBOARDING_STORAGE_KEY` scope from `PROFILE` to `APPLICATION` to match the application-level `isNew` check

### Sanity tests
- Added `--skip-welcome` to Electron launch args in `desktop.test.ts` and `wsl.test.ts`, matching the pattern already used in `test/automation/src/electron.ts` and `test/automation/src/playwrightBrowser.ts`