### PR TITLE
chat: handle invalid URIs in extractCodeblockUrisFromText

### DIFF
--- a/src/vs/workbench/contrib/chat/common/widget/annotations.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/annotations.ts
@@ -218,7 +218,12 @@ export function extractCodeblockUrisFromText(text: string): { uri: URI; isEdit?:
 	if (match) {
 		const [all, isEdit, , encodedSubAgentId, uriString] = match;
 		if (uriString) {
-			const result = URI.parse(uriString);
+			let result: URI;
+			try {
+				result = URI.parse(uriString);
+			} catch {
+				return undefined;
+			}
 			const textWithoutResult = text.substring(0, match.index) + text.substring(match.index + all.length);
 			let subAgentInvocationId: string | undefined;
 			if (encodedSubAgentId) {

--- a/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
@@ -143,9 +143,10 @@ suite('Annotations', function () {
 		});
 
 		test('returns undefined for invalid URI content inside codeblock uri tag', () => {
-			// Backtick at start of content causes URI.parse to throw because
-			// the scheme contains illegal characters
-			const invalidTag = '<vscode_codeblock_uri>`typescript`</vscode_codeblock_uri>';
+			// When content contains backticks and a colon, URI.parse extracts
+			// the text before the colon as the scheme. Backticks are illegal
+			// scheme characters, causing URI.parse to throw.
+			const invalidTag = '<vscode_codeblock_uri>```typescript\nconst uri: string\n```</vscode_codeblock_uri>';
 			const result = extractCodeblockUrisFromText(invalidTag);
 			assert.strictEqual(result, undefined);
 		});

--- a/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
@@ -142,6 +142,14 @@ suite('Annotations', function () {
 			assert.strictEqual(result.isEdit, true);
 		});
 
+		test('returns undefined for invalid URI content inside codeblock uri tag', () => {
+			// Backtick at start of content causes URI.parse to throw because
+			// the scheme contains illegal characters
+			const invalidTag = '<vscode_codeblock_uri>`typescript`</vscode_codeblock_uri>';
+			const result = extractCodeblockUrisFromText(invalidTag);
+			assert.strictEqual(result, undefined);
+		});
+
 		test('round-trip encoding/decoding with special characters', () => {
 			const subAgentId = 'agent/with spaces&special=chars?more';
 			const uri = URI.parse('file:///path/to/file.ts');


### PR DESCRIPTION
## Summary

Fixes a crash in the chat renderer when an LLM response contains a literal `<vscode_codeblock_uri>` tag with non-URI content (e.g. backtick-fenced code blocks).

## Problem

When a Copilot agent discusses VS Code's own chat annotation code, it may include a literal `<vscode_codeblock_uri>` XML tag in its markdown response. The regex in `extractCodeblockUrisFromText` matches the tag and passes the inner content to `URI.parse()`. When that content starts with a backtick or other illegal URI scheme character, `URI.parse` throws a `UriError` that propagates up through `trackToolMetadata` → `appendItem` → `renderMarkdown` → `renderChatContentPart`, crashing the chat list renderer.

## Fix

Wrap the `URI.parse(uriString)` call in a try-catch that returns `undefined` on failure. All callers already handle `undefined` gracefully:

- **`trackToolMetadata`** (thinking header): Falls to the else branch → shows "Edited file" label
- **`chatMarkdownContentPart`** (code block rendering): `codemapperUri` stays `undefined` → renders as a normal code block instead of an edit pill

Added a test case for the invalid URI scenario.

Fix #309299