### PR TITLE
git: discover worktrees when opening a worktree directory (#264209)

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -807,17 +807,17 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				return;
 			}
 
-			if (repository.kind === 'worktree') {
-				this.logger.trace('[Model][open] Automatic detection of git worktrees is not skipped.');
-				return;
-			}
+			// Discover additional worktrees for the repository, but do not
+			// include the currently opened repository itself.
+			const candidateWorktrees = repository.worktrees
+				.filter(w => !pathEquals(w.path, repository.root));
 
-			if (repository.worktrees.length > worktreesLimit) {
-				window.showWarningMessage(l10n.t('The "{0}" repository has {1} worktrees which won\'t be opened automatically. You can still open each one individually by opening a file within.', path.basename(repository.root), repository.worktrees.length));
+			if (candidateWorktrees.length > worktreesLimit) {
+				window.showWarningMessage(l10n.t('The "{0}" repository has {1} worktrees which won\'t be opened automatically. You can still open each one individually by opening a file within.', path.basename(repository.root), candidateWorktrees.length - worktreesLimit));
 				statusListener.dispose();
 			}
 
-			repository.worktrees
+			candidateWorktrees
 				.slice(0, worktreesLimit)
 				.forEach(w => {
 					this.logger.trace(`[Model][open] Opening worktree: '${w.path}'`);


### PR DESCRIPTION
## Summary

When a worktree directory is opened with `git.detectWorktrees` enabled, `checkForWorktrees()` previously returned early without discovering the main repository or sibling worktrees. This left worktree management commands non-functional.

Fixes #264209

## The Problem

Opening a worktree directory (rather than the main repository) over Remote-SSH with `git.detectWorktrees: true` results in no worktree commands being available because:

1. `checkForWorktrees()` bails out immediately when `repository.kind === "worktree"`
2. The main repository is never opened
3. Commands like "Create Worktree" (`repositoryFilter: ["repository", "submodule"]`) find no matching repository
4. "Open Worktree" requires `gitOpenRepositoryCount > 1` — not met with only 1 repo
5. SCM menu items that depend on `scmProviderContext == "repository"` are hidden

## The Fix

Remove the early return for worktree-kind repositories and always filter out the current repository from the worktree candidate list via `pathEquals(w.path, repository.root)`. This:

- **Enables bidirectional discovery**: worktree → main repo, and main repo → worktrees
- **Fixes a pre-existing off-by-one**: the old code included the current repo in `repository.worktrees`, wasting a slot in `detectWorktreesLimit` and triggering the "too many worktrees" warning one entry too early

Safety guarantees:

- **No infinite recursion**: `getRepositoryExact()` short-circuits when a repo is already open
- **Outside-workspace repos allowed**: `isRepositoryOutsideWorkspace()` already recognizes paths in any open repository's worktree list (model.ts L1130-1136)
- **Bare repos handled**: `getWorktreesFS()` excludes the main worktree entry for bare repos
- **Timing safe**: `worktrees` is empty on first call but populated after `onDidRunGitStatus`, which re-triggers `checkForWorktrees()`

Also fixes a confusing log message that said detection "is not skipped" when it was in fact skipping.