### PR TITLE
chat: queue/steer falls back to normal send when idle

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -67,14 +67,10 @@ export class ChatQueueMessageAction extends Action2 {
 			f1: false,
 			category: CHAT_CATEGORY,
 
-			precondition: ContextKeyExpr.and(
-				queuingActionsPresent,
-				ChatContextKeys.inputHasText,
-			),
+			precondition: ChatContextKeys.inputHasText,
 			keybinding: [{
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
-					queuingActionsPresent,
 					effectiveDefaultIsSteer,
 				),
 				primary: KeyMod.Alt | KeyCode.Enter,
@@ -100,6 +96,12 @@ export class ChatQueueMessageAction extends Action2 {
 
 		const inputValue = widget.getInput();
 		if (!inputValue.trim()) {
+			return;
+		}
+
+		// If no request is in progress, send as a normal message instead of queuing
+		if (!widget.viewModel.model.requestInProgress.get()) {
+			widget.acceptInput();
 			return;
 		}
 
@@ -118,10 +120,7 @@ export class ChatSteerWithMessageAction extends Action2 {
 			icon: Codicon.arrowUp,
 			f1: false,
 			category: CHAT_CATEGORY,
-			precondition: ContextKeyExpr.and(
-				queuingActionsPresent,
-				ChatContextKeys.inputHasText,
-			),
+			precondition: ChatContextKeys.inputHasText,
 			keybinding: [{
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
@@ -133,7 +132,6 @@ export class ChatSteerWithMessageAction extends Action2 {
 			}, {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
-					queuingActionsPresent,
 					effectiveDefaultIsQueue,
 				),
 				primary: KeyMod.Alt | KeyCode.Enter,
@@ -151,6 +149,12 @@ export class ChatSteerWithMessageAction extends Action2 {
 
 		const inputValue = widget.getInput();
 		if (!inputValue.trim()) {
+			return;
+		}
+
+		// If no request is in progress, send as a normal message instead of steering
+		if (!widget.viewModel.model.requestInProgress.get()) {
+			widget.acceptInput();
 			return;
 		}
 


### PR DESCRIPTION
When the chat queue or steer action is invoked but no request is currently in progress, send the message as a normal chat message instead of silently doing nothing.

## Problem

If you queue a message assuming the session is still running, but it has already finished, the queue action does nothing — the message is lost in the input box with no feedback.

## Changes

- Relaxed the `precondition` on both `ChatQueueMessageAction` and `ChatSteerWithMessageAction` to only require `inputHasText` (removed `queuingActionsPresent`)
- Removed `queuingActionsPresent` from the **Alt+Enter** keybinding `when` clause so the actions remain reachable after the session finishes
- Kept the **Enter** keybinding gated behind `queuingActionsPresent` so it doesn't conflict with the regular submit action
- Added a runtime check in both `run()` methods: if `requestInProgress` is false, calls `widget.acceptInput()` (normal send) instead of queuing/steering

The queue submenu in the toolbar still only appears during active requests (its own `when` clause is unchanged).

(Written by Copilot)