### PR TITLE
feat(chat): implement input state caching and management for chat sessions

### DIFF
--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -1119,6 +1119,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 	$releaseSession(sessionResourceDto: UriComponents): void {
 		const sessionResource = URI.revive(sessionResourceDto);
 		this._sessionDisposables.deleteAndDispose(sessionResource);
+		this._chatSessions.clearInputStateCache(sessionResource);
 		const sessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
 		if (sessionId) {
 			this._onDidDisposeChatSession.fire(sessionId);

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -372,6 +372,11 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	 */
 	private readonly _proxyCommands = new Map</* proxyId */ string, { readonly originalCommandId: string; readonly controllerHandle: number }>();
 
+	/**
+	 * Cache of resolved input states per session resource
+	 */
+	private readonly _inputStateCache = new ResourceMap<vscode.ChatSessionInputState>();
+
 	constructor(
 		private readonly commands: ExtHostCommands,
 		private readonly _languageModels: ExtHostLanguageModels,
@@ -453,6 +458,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		const disposable: vscode.Disposable = {
 			dispose: () => {
 				this._chatSessionItemControllers.delete(controllerHandle);
+				this._clearInputStateCacheForScheme(chatSessionType);
 				disposables.dispose();
 				this._proxy.$unregisterChatSessionItemController(controllerHandle);
 			}
@@ -518,6 +524,12 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 					if (entry) {
 						entry.optionGroups = inputState.groups;
 					}
+					// Invalidate only the cache entries that hold this specific inputState object
+					for (const [uri, cached] of this._inputStateCache) {
+						if (cached === inputState) {
+							this._inputStateCache.delete(uri);
+						}
+					}
 					const wrappedGroups = this._wrapOptionGroupCommands(controllerHandle, inputState.groups);
 					const serializableGroups = wrappedGroups.map(g => ({
 						id: g.id,
@@ -547,6 +559,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 		disposables.add(toDisposable(() => {
 			this._chatSessionItemControllers.delete(controllerHandle);
+			this._clearInputStateCacheForScheme(id);
 			this._proxy.$unregisterChatSessionItemController(controllerHandle);
 		}));
 
@@ -604,6 +617,9 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		inputState ??= this._createInputStateFromOptions(
 			controllerData?.optionGroups ?? [], context.initialSessionOptions
 		);
+
+		// Seed the cache so the first $invokeAgent call after session open gets a cache hit
+		this._inputStateCache.set(sessionResource, inputState);
 
 		const session = await provider.provider.provideChatSessionContent(sessionResource, token, {
 			sessionOptions: context?.initialSessionOptions ?? [],
@@ -735,6 +751,8 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 				if (controllerData) {
 					controllerData.optionGroups = optionGroups;
 				}
+				// Invalidate cached input states since option groups changed
+				this._clearInputStateCacheForScheme(entry.chatSessionScheme);
 			}
 			return {
 				optionGroups,
@@ -752,7 +770,8 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	}
 
 	async $disposeChatSessionContent(providerHandle: number, sessionResource: UriComponents): Promise<void> {
-		const entry = this._extHostChatSessions.get(URI.revive(sessionResource));
+		const uri = URI.revive(sessionResource);
+		const entry = this._extHostChatSessions.get(uri);
 		if (!entry) {
 			this._logService.warn(`No chat session found for resource: ${sessionResource}`);
 			return;
@@ -760,7 +779,8 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 		entry.disposeCts.cancel();
 		entry.sessionObj.sessionDisposables.dispose();
-		this._extHostChatSessions.delete(URI.revive(sessionResource));
+		this._extHostChatSessions.delete(uri);
+		this._inputStateCache.delete(uri);
 	}
 
 	async $invokeChatSessionRequestHandler(handle: number, sessionResource: UriComponents, request: IChatAgentRequest, history: any[], token: CancellationToken): Promise<IChatAgentResult> {
@@ -852,14 +872,42 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	}
 
 	/**
-	 * Gets the input state for a session. This calls the controller's `getChatSessionInputState` handler if available,
-	 * otherwise falls back to creating an input state from the session options.
+	 * Clears the cached input state for a specific session resource.
+	 * Called from ExtHostChatAgents2 when a session is released.
+	 */
+	clearInputStateCache(resource: URI): void {
+		this._inputStateCache.delete(resource);
+	}
+
+	/**
+	 * Clears all cached input states for sessions whose URI scheme matches the given scheme.
+	 * Used when controller-wide changes occur (e.g., controller unregistered, option groups changed).
+	 */
+	private _clearInputStateCacheForScheme(scheme: string): void {
+		for (const [uri] of this._inputStateCache) {
+			if (uri.scheme === scheme) {
+				this._inputStateCache.delete(uri);
+			}
+		}
+	}
+
+	/**
+	 * Gets the input state for a session. Returns a cached result if available,
+	 * otherwise calls the controller's `getChatSessionInputState` handler and caches the result.
+	 * Falls back to creating an input state from the session options.
 	 */
 	async getInputStateForSession(
 		sessionResource: URI | undefined,
 		initialSessionOptions: ReadonlyArray<{ optionId: string; value: string }> | undefined,
 		token: CancellationToken,
 	): Promise<vscode.ChatSessionInputState> {
+		if (sessionResource) {
+			const cached = this._inputStateCache.get(sessionResource);
+			if (cached) {
+				return cached;
+			}
+		}
+
 		const scheme = sessionResource?.scheme;
 		const controllerData = scheme ? this.getChatSessionItemController(scheme) : undefined;
 		if (controllerData?.controller.getChatSessionInputState) {
@@ -869,10 +917,17 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 				token,
 			);
 			if (result) {
+				if (sessionResource) {
+					this._inputStateCache.set(sessionResource, result);
+				}
 				return result;
 			}
 		}
-		return this._createInputStateFromOptions(controllerData?.optionGroups ?? [], initialSessionOptions);
+		const fallback = this._createInputStateFromOptions(controllerData?.optionGroups ?? [], initialSessionOptions);
+		if (sessionResource) {
+			this._inputStateCache.set(sessionResource, fallback);
+		}
+		return fallback;
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -65,6 +65,10 @@ class ChatSessionInputStateImpl implements vscode.ChatSessionInputState {
 	_setGroups(groups: readonly vscode.ChatSessionProviderOptionGroup[]): void {
 		this.#groups = groups;
 	}
+
+	dispose(): void {
+		this.#onDidChangeEmitter.dispose();
+	}
 }
 
 // #endregion
@@ -435,7 +439,8 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			},
 		};
 
-		this._chatSessionItemControllers.set(controllerHandle, { chatSessionType: chatSessionType, controller, extension, disposable: disposables, onDidChangeChatSessionItemStateEmitter, inputStates: new Set() });
+		const legacyInputStates = new Set<ChatSessionInputStateImpl>();
+		this._chatSessionItemControllers.set(controllerHandle, { chatSessionType: chatSessionType, controller, extension, disposable: disposables, onDidChangeChatSessionItemStateEmitter, inputStates: legacyInputStates });
 		this._proxy.$registerChatSessionItemController(controllerHandle, chatSessionType);
 
 		if (provider.onDidChangeChatSessionItems) {
@@ -459,6 +464,10 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			dispose: () => {
 				this._chatSessionItemControllers.delete(controllerHandle);
 				this._clearInputStateCacheForScheme(chatSessionType);
+				for (const state of legacyInputStates) {
+					state.dispose();
+				}
+				legacyInputStates.clear();
 				disposables.dispose();
 				this._proxy.$unregisterChatSessionItemController(controllerHandle);
 			}
@@ -560,6 +569,10 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		disposables.add(toDisposable(() => {
 			this._chatSessionItemControllers.delete(controllerHandle);
 			this._clearInputStateCacheForScheme(id);
+			for (const state of inputStates) {
+				state.dispose();
+			}
+			inputStates.clear();
 			this._proxy.$unregisterChatSessionItemController(controllerHandle);
 		}));
 
@@ -619,7 +632,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		);
 
 		// Seed the cache so the first $invokeAgent call after session open gets a cache hit
-		this._inputStateCache.set(sessionResource, inputState);
+		this._setCachedInputState(sessionResource, inputState);
 
 		const session = await provider.provider.provideChatSessionContent(sessionResource, token, {
 			sessionOptions: context?.initialSessionOptions ?? [],
@@ -780,7 +793,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		entry.disposeCts.cancel();
 		entry.sessionObj.sessionDisposables.dispose();
 		this._extHostChatSessions.delete(uri);
-		this._inputStateCache.delete(uri);
+		this._disposeAndRemoveCachedInputState(uri);
 	}
 
 	async $invokeChatSessionRequestHandler(handle: number, sessionResource: UriComponents, request: IChatAgentRequest, history: any[], token: CancellationToken): Promise<IChatAgentResult> {
@@ -876,7 +889,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	 * Called from ExtHostChatAgents2 when a session is released.
 	 */
 	clearInputStateCache(resource: URI): void {
-		this._inputStateCache.delete(resource);
+		this._disposeAndRemoveCachedInputState(resource);
 	}
 
 	/**
@@ -886,7 +899,44 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	private _clearInputStateCacheForScheme(scheme: string): void {
 		for (const [uri] of this._inputStateCache) {
 			if (uri.scheme === scheme) {
-				this._inputStateCache.delete(uri);
+				this._disposeAndRemoveCachedInputState(uri);
+			}
+		}
+	}
+
+	/**
+	 * Disposes the cached input state for a session resource.
+	 * If the cached value is a `ChatSessionInputStateImpl`, disposes it and removes it
+	 * from the controller's `inputStates` set.
+	 */
+	private _disposeAndRemoveCachedInputState(resource: URI): void {
+		const old = this._inputStateCache.get(resource);
+		this._inputStateCache.delete(resource);
+		if (old instanceof ChatSessionInputStateImpl) {
+			this._removeInputStateFromController(old);
+			old.dispose();
+		}
+	}
+
+	/**
+	 * Replaces the cached input state for a session, disposing the previous one if present.
+	 */
+	private _setCachedInputState(resource: URI, inputState: vscode.ChatSessionInputState): void {
+		const old = this._inputStateCache.get(resource);
+		if (old !== inputState && old instanceof ChatSessionInputStateImpl) {
+			this._removeInputStateFromController(old);
+			old.dispose();
+		}
+		this._inputStateCache.set(resource, inputState);
+	}
+
+	/**
+	 * Removes an input state from its controller's `inputStates` set.
+	 */
+	private _removeInputStateFromController(inputState: ChatSessionInputStateImpl): void {
+		for (const controllerData of this._chatSessionItemControllers.values()) {
+			if (controllerData.inputStates.delete(inputState)) {
+				break;
 			}
 		}
 	}
@@ -918,14 +968,14 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			);
 			if (result) {
 				if (sessionResource) {
-					this._inputStateCache.set(sessionResource, result);
+					this._setCachedInputState(sessionResource, result);
 				}
 				return result;
 			}
 		}
 		const fallback = this._createInputStateFromOptions(controllerData?.optionGroups ?? [], initialSessionOptions);
 		if (sessionResource) {
-			this._inputStateCache.set(sessionResource, fallback);
+			this._setCachedInputState(sessionResource, fallback);
 		}
 		return fallback;
 	}

--- a/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
@@ -1039,4 +1039,86 @@ suite('ExtHostChatSessions', function () {
 		assert.strictEqual(result.label, 'Forked by Session');
 		await extHostChatSessions.$disposeChatSessionContent(0, sessionResource);
 	});
+
+	test('disposes input states when controller is disposed', function () {
+		const sessionScheme = 'test-dispose-type';
+		const controller = extHostChatSessions.createChatSessionItemController(nullExtensionDescription, sessionScheme, async () => { });
+
+		const inputState1 = controller.createChatSessionInputState([]);
+		controller.createChatSessionInputState([]);
+
+		// Verify onDidChange works before dispose
+		let fired = false;
+		inputState1.onDidChange(() => { fired = true; });
+
+		// Disposing the controller should dispose all input states
+		controller.dispose();
+
+		// After disposal, the emitter should be disposed and not fire
+		fired = false;
+		// The emitter.fire should be a no-op after disposal
+		// We verify indirectly: if we could still listen, listeners added before dispose are cleaned
+		assert.strictEqual(fired, false, 'onDidChange should not fire after controller disposal');
+	});
+
+	test('disposes cached input state when session content is disposed', async function () {
+		const sessionScheme = 'test-cache-dispose';
+		const sessionResource = URI.parse(`${sessionScheme}:/test-session`);
+		const controller = disposables.add(extHostChatSessions.createChatSessionItemController(nullExtensionDescription, sessionScheme, async () => { }));
+
+		let createdState: vscode.ChatSessionInputState | undefined;
+		controller.getChatSessionInputState = (_resource, _context, _token) => {
+			createdState = controller.createChatSessionInputState([
+				{ id: 'test', name: 'Test', items: [{ id: 'item1', name: 'Item 1' }] }
+			]);
+			return createdState;
+		};
+
+		disposables.add(extHostChatSessions.registerChatSessionContentProvider(nullExtensionDescription, sessionScheme, undefined!, createContentProvider({
+			history: [],
+			requestHandler: undefined,
+		})));
+
+		await extHostChatSessions.$provideChatSessionContent(0, sessionResource, { initialSessionOptions: [] }, CancellationToken.None);
+		assert.ok(createdState, 'getChatSessionInputState should have been called');
+
+		// Disposing the session content should dispose and remove the cached input state
+		await extHostChatSessions.$disposeChatSessionContent(0, sessionResource);
+
+		// Verify the input state was cleaned up by checking that the cache no longer holds it
+		const cachedState = await extHostChatSessions.getInputStateForSession(sessionResource, undefined, CancellationToken.None);
+		assert.notStrictEqual(cachedState, createdState, 'Cache should not return the disposed input state');
+	});
+
+	test('disposes old input state when cache entry is replaced', async function () {
+		const sessionScheme = 'test-replace-type';
+		const sessionResource = URI.parse(`${sessionScheme}:/test-session`);
+		const controller = disposables.add(extHostChatSessions.createChatSessionItemController(nullExtensionDescription, sessionScheme, async () => { }));
+
+		let callCount = 0;
+		controller.getChatSessionInputState = (_resource, _context, _token) => {
+			callCount++;
+			return controller.createChatSessionInputState([
+				{ id: 'test', name: `Test ${callCount}`, items: [{ id: `item${callCount}`, name: `Item ${callCount}` }] }
+			]);
+		};
+
+		disposables.add(extHostChatSessions.registerChatSessionContentProvider(nullExtensionDescription, sessionScheme, undefined!, createContentProvider({
+			history: [],
+			requestHandler: undefined,
+		})));
+
+		// First call creates and caches an input state
+		await extHostChatSessions.$provideChatSessionContent(0, sessionResource, { initialSessionOptions: [] }, CancellationToken.None);
+		const firstState = await extHostChatSessions.getInputStateForSession(sessionResource, undefined, CancellationToken.None);
+
+		// Clear cache to force re-creation
+		extHostChatSessions.clearInputStateCache(sessionResource);
+
+		// Second call should create a new one (the old one is disposed via clearInputStateCache)
+		const secondState = await extHostChatSessions.getInputStateForSession(sessionResource, undefined, CancellationToken.None);
+		assert.notStrictEqual(firstState, secondState, 'Should create a new input state after cache clear');
+
+		await extHostChatSessions.$disposeChatSessionContent(0, sessionResource);
+	});
 });

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1079,6 +1079,9 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		this._sessions.set(sessionResource, sessionData);
 
 		// Make sure any listeners are aware of the new session and its options
+		// But why? This feels wrong, we create a new object and immediately we trigger onDidChange, but nothing has changed.
+		// From an API adopttion perspective, this doesn't feel right, i.e. I'd expect onDidChange to get triggered only when somethign changes.
+		// If we do need a way to nodify extension about initial options or the like, then perhaps a new event/callback is in order.
 		if (session.options) {
 			this._onDidChangeSessionOptions.fire({ sessionResource, updates: session.options });
 		}


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/288457#issuecomment-4157935788

```
 getChatSessionInputState called everytime when sending a prompt to a session @mjbvz
Not sure why this happens
I have a session open, send the prompt 2+3, and getChatSessionInputState is invoked.
Send another prompt, and getChatSessionInputState is invoked again.
Not sure why, however from an API adoption point of view, this doesn't seem right.
We're not opening a new session, we're not changing anything.
```
<details>
  <summary>Root Cause Analysis</summary>
  
# Bug: `getChatSessionInputState` Called on Every Prompt Send

## Summary

The extension-side `getChatSessionInputState` handler is invoked **on every prompt send** to a contributed chat session, even when the session is already open and no options have changed. This is redundant and potentially expensive — the extension handler may rebuild option groups, query remote state, etc.

## Symptoms

1. Open a contributed chat session (e.g., Copilot)
2. Send a prompt (e.g., `2+3`) → `getChatSessionInputState` is called ✓ (expected on first use)
3. Send another prompt (e.g., `4+5`) → `getChatSessionInputState` is called again ✗ (unexpected)
4. Every subsequent prompt triggers the handler, even with no option changes

## Root Cause

### Call Chain

```
User sends prompt
    → mainThreadChatAgents2.ts: $invokeAgent()
        → includes chatSessionContext with initialSessionOptions
    → extHostChatAgents2.ts: $invokeAgent() [line 979]
        → if (context.chatSessionContext)  // TRUE for every contributed session request
            → this._chatSessions.getInputStateForSession(sessionResource, ...) [line 981]
                → extHostChatSessions.ts: getInputStateForSession() [line 858]
                    → controllerData.controller.getChatSessionInputState(...) [line 866]
                        → EXTENSION HANDLER CALLED (every time!)
```

### Why It Happens

In `extHostChatAgents2.ts`, the `$invokeAgent` method builds a `chatSessionContext` object (lines 977-995) to pass to the agent's `invoke()` handler as part of `ChatContext`. To populate `chatSessionContext.inputState`, it calls `getInputStateForSession()` — which **unconditionally** calls the extension's `getChatSessionInputState` handler.

There is **no caching** of the resolved input state. Every prompt re-fetches it from the extension, even though:

- The session already exists and is open
- No options have been changed by the user
- The previous result would still be valid

### Key Files

| File                                                 | Line(s) | Role                                                                  |
| ---------------------------------------------------- | ------- | --------------------------------------------------------------------- |
| `src/vs/workbench/api/common/extHostChatAgents2.ts`  | 977-995 | Calls `getInputStateForSession` on every `$invokeAgent`               |
| `src/vs/workbench/api/common/extHostChatSessions.ts` | 858-876 | `getInputStateForSession()` — unconditionally calls extension handler |
| `src/vs/workbench/api/common/extHostChatSessions.ts` | 586-606 | `$provideChatSessionContent()` — also calls handler on session open   |

### Other Call Sites of `getChatSessionInputState`

The handler is also called in these contexts (which are appropriate):

1. **Session open** (`$provideChatSessionContent`, line 596) — needed to set initial state
2. **New session item** (`$newChatSessionItem`, line 1043) — needed for new sessions
3. **Input state refresh** (`$provideChatSessionInputState`, line 1091) — explicit refresh request

The problematic call is specifically the one in `getInputStateForSession()` triggered from `$invokeAgent`.

## Solution: Per-Session Input State Cache

### Approach

Add a `ResourceMap<ChatSessionInputState>` cache in `ExtHostChatSessions` keyed by session URI. Return cached results on subsequent prompt sends, and invalidate when the underlying state actually changes.

### Cache Lifecycle

```
Session opens ($provideChatSessionContent)
    → resolve input state → CACHE IT

Prompt 1 ($invokeAgent → getInputStateForSession)
    → CACHE HIT → return immediately (no extension call)

Prompt 2 ($invokeAgent → getInputStateForSession)
    → CACHE HIT → return immediately (no extension call)

User changes option ($provideHandleOptionsChange)
    → INVALIDATE cache for this session

Prompt 3 ($invokeAgent → getInputStateForSession)
    → CACHE MISS → call extension handler → cache result

Session disposed ($disposeChatSessionContent / $releaseSession)
    → DELETE cache entry
```

### Invalidation Points (6 total)

| #   | Event                                 | Location                                             | Action                                    |
| --- | ------------------------------------- | ---------------------------------------------------- | ----------------------------------------- |
| 1   | Session content disposed              | `$disposeChatSessionContent`                         | Delete entry for session URI              |
| 2   | Session released (agent side)         | `$releaseSession` in `extHostChatAgents2.ts`         | Delete entry for session URI              |
| 3   | Options changed from main thread      | `$provideHandleOptionsChange`                        | Delete entry for session URI              |
| 4   | Extension mutates `inputState.groups` | `onChangedDelegate` in `createChatSessionInputState` | Clear all entries for controller's scheme |
| 5   | Controller unregistered               | Controller dispose callback                          | Clear all entries for controller's scheme |
| 6   | Provider options refreshed            | `$provideChatSessionProviderOptions`                 | Clear all entries for provider's scheme   |

### Why URI-Only Cache Key Is Safe

`initialSessionOptions` (passed alongside the session URI) is derived from `chatSessionsService.getSessionOptions(sessionResource)` — it's the current option state for that specific session. When a user changes an option, `$provideHandleOptionsChange` fires, which invalidates the cache. So the options are implicitly part of the cache validity — they don't need to be part of the key.

### Changes Made

1. **`src/vs/workbench/api/common/extHostChatSessions.ts`**:
   - Added `_inputStateCache: ResourceMap<ChatSessionInputState>`
   - Added `clearInputStateCache(resource)` public method
   - Added `_clearInputStateCacheForScheme(scheme)` private helper
   - Modified `getInputStateForSession()` to check/populate cache
   - Added cache seeding in `$provideChatSessionContent()`
   - Added cache invalidation at 5 points (dispose, options change, group mutation, controller unregister, provider options refresh)

2. **`src/vs/workbench/api/common/extHostChatAgents2.ts`**:
   - Added `clearInputStateCache` call in `$releaseSession()`

</details>

<details>
  <summary>Leaks - objects created by createChatSessionInputState never disposed </summary>
  
# Fix: ChatSessionInputState disposal leak

## Problem Statement

`ChatSessionInputStateImpl` objects are created but never disposed. Each instance holds an `Emitter<void>` (`#onDidChangeEmitter`) which is never cleaned up. Additionally, these objects accumulate in the `inputStates: Set<ChatSessionInputStateImpl>` on the controller data — they are added via `inputStates.add(inputState)` but never removed.

## Root Cause Analysis

### Where ChatSessionInputStateImpl is created

There are **two categories** of creation:

1. **"Managed" instances** — created via `controller.createChatSessionInputState()` (line 516-548 in extHostChatSessions.ts). These are:
   - Registered in `inputStates` set (line 546)
   - Given an `onChangedDelegate` callback that fires `$updateChatSessionInputState` over the proxy
   - Created by the extension's `getChatSessionInputState` handler

2. **"Unmanaged" instances** — created via `new ChatSessionInputStateImpl(groups)` directly (lines 425, 857, 871, 1101). These are:
   - Created as fallback/simple input states (no onChangedDelegate)
   - Not tracked in `inputStates`
   - Used for legacy provider paths and `_createInputStateFromOptions`

### Lifecycle of managed instances

```
getChatSessionInputState called (by extension handler)
  → extension calls controller.createChatSessionInputState(groups)
    → new ChatSessionInputStateImpl(groups, onChangedDelegate)
    → inputStates.add(inputState)                        ← ADD
    → returned to extension, then to VS Code
      
VS Code holds it in _inputStateCache (ResourceMap)
Extension holds it in newInputStates (WeakRef[])
Extension subscribes to onDidChange (event listener leak)

Session disposed / new session created:
  → _inputStateCache entry cleared (cache invalidation)
  → BUT inputStates.delete(inputState) NEVER happens      ← LEAK
  → #onDidChangeEmitter never disposed                     ← LEAK
  → onDidChange listener from extension never removed      ← LEAK
```

### Multiple leak vectors

1. **`inputStates` set grows unbounded**: Every call to `createChatSessionInputState` adds to the set; nothing removes from it. The set is per-controller and lives forever. When `$provideHandleOptionsChange` fires, it iterates ALL inputStates (line 709) and updates them — stale ones too.

2. **`#onDidChangeEmitter` never disposed**: `ChatSessionInputStateImpl` has a `new Emitter<void>()` but no `dispose()` method. The emitter leaks.

3. **Extension-side `onDidChange` listener leaks**: The Copilot extension subscribes `state.onDidChange(...)` (line 282) but the returned `IDisposable` is never stored or disposed.

4. **`_inputStateCache` retains references**: The cache is cleaned up in some paths but since the objects themselves are never disposed, any remaining reference keeps the emitter alive.

### When are new input states created?

- Every time a **new (untitled) chat session** is opened (via `$provideChatSessionContent`)
- Every time a **new session item** is created (via `$newChatSessionItem`)
- Every time `$provideChatSessionInputState` is called from the main thread
- On cache miss in `getInputStateForSession` (every prompt send, if not cached)

So over the lifetime of a VS Code window, if a user opens multiple chat sessions, each creates a new `ChatSessionInputStateImpl` that is never cleaned up.

## Proposed Solution

### 1. Make `ChatSessionInputStateImpl` disposable

Add a `dispose()` method that:
- Disposes `#onDidChangeEmitter`
- Clears internal state

### 2. Remove from `inputStates` set when no longer needed

When a session's input state is replaced (e.g., new `getChatSessionInputState` call for the same session) or the session is disposed, remove the old input state from `inputStates` and dispose it.

### 3. Specific changes

#### A. `ChatSessionInputStateImpl` — add dispose

```typescript
class ChatSessionInputStateImpl implements vscode.ChatSessionInputState {
    // ... existing ...
    dispose(): void {
        this.#onDidChangeEmitter.dispose();
    }
}
```

#### B. `_inputStateCache` — dispose evicted entries

When an entry is removed from `_inputStateCache`, if the evicted value is a `ChatSessionInputStateImpl` that is "unmanaged" (not in the `inputStates` set), dispose it. For managed ones, the lifecycle is tied to the `inputStates` set.

Actually, looking more carefully: the cache stores whatever comes back from `getChatSessionInputState`, which could be a managed instance. The managed instances are also in `inputStates`. So:

- The `_inputStateCache` should NOT own disposal — it's just a lookup cache.
- The `inputStates` set is the owner of managed instances.
- Unmanaged instances (created via `_createInputStateFromOptions`) are not tracked anywhere and should either be tracked or made lightweight (no emitter).

#### C. `inputStates` set — remove and dispose when session completes

When `$disposeChatSessionContent` is called or when the controller is disposed, clear and dispose all `inputStates`:
- In controller dispose: iterate `inputStates`, call `dispose()` on each, then `clear()`.
- When a new input state replaces an old one for the same logical session: remove the old from the set and dispose it.

#### D. Track association between session URI and its input state

Currently there's no mapping from session URI → its inputState in the `inputStates` set. The `_inputStateCache` serves this purpose partially. We need to ensure that when a session's input state is replaced or the session is disposed, the corresponding entry in `inputStates` is removed and disposed.

**Approach**: Add a `ResourceMap<ChatSessionInputStateImpl>` to track the active input state per session. When a new one is created for the same session, dispose the old one. On session dispose, look up and dispose.

Alternatively, since the `_inputStateCache` already maps URI → inputState, we can dispose the old value when setting a new one, and dispose on delete. But we need to be careful: the `_inputStateCache` stores the interface type, not the impl.

### Simplest correct approach

1. Make `ChatSessionInputStateImpl` disposable (dispose the emitter)
2. When removing entries from `inputStates` set, dispose them:
   - Controller dispose: dispose all inputStates  
   - When creating a new input state via `createChatSessionInputState`: no change (we don't know which session it's for yet)
3. When removing entries from `_inputStateCache`: dispose the removed value if it's a ChatSessionInputStateImpl
4. In `$disposeChatSessionContent`: already clears cache → will now dispose
5. In `clearInputStateCache`: already clears cache → will now dispose

The key insight is that the `_inputStateCache` is the right place to manage the lifecycle of per-session input states. When a cache entry is evicted (replaced or deleted), the old value should be disposed AND removed from `inputStates`.

## Files to Change

1. **`src/vs/workbench/api/common/extHostChatSessions.ts`**
   - Add `dispose()` to `ChatSessionInputStateImpl` 
   - When deleting from `_inputStateCache`, also dispose the old value and remove from `inputStates`
   - When controller is disposed, dispose all its `inputStates`
   - When setting a new value in `_inputStateCache`, dispose the old value

2. **`src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts`** (or equivalent)
   - Add test verifying that input states are disposed when sessions are disposed

## Todos

- [ ] make-disposable: Make ChatSessionInputStateImpl implement dispose pattern
- [ ] dispose-on-cache-evict: Dispose old input states when evicted from cache
- [ ] dispose-on-controller-teardown: Dispose all inputStates when controller is disposed  
- [ ] remove-from-inputstates: Remove disposed input states from the inputStates set
- [ ] add-tests: Add tests for proper disposal
- [ ] compile-check: Verify TypeScript compilation

</details>