### PR TITLE
Fix markdown image hover preview for paths exceeding MAX_PATH on Windows

### DIFF
--- a/src/vs/platform/protocol/electron-main/protocolMainService.ts
+++ b/src/vs/platform/protocol/electron-main/protocolMainService.ts
@@ -7,7 +7,7 @@ import { session } from 'electron';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { COI, FileAccess, Schemas, CacheControlheaders, DocumentPolicyheaders } from '../../../base/common/network.js';
 import { basename, extname, normalize } from '../../../base/common/path.js';
-import { isLinux } from '../../../base/common/platform.js';
+import { isLinux, isWindows } from '../../../base/common/platform.js';
 import { TernarySearchTree } from '../../../base/common/ternarySearchTree.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -18,6 +18,48 @@ import { IIPCObjectUrl, IProtocolMainService } from './protocol.js';
 import { IUserDataProfilesService } from '../../userDataProfile/common/userDataProfile.js';
 
 type ProtocolCallback = { (result: string | Electron.FilePathWithHeaders | { error: number }): void };
+
+/**
+ * On Windows, the default Win32 file APIs enforce a `MAX_PATH` limit of 259
+ * characters. When a resource path exceeds this limit, Electron's
+ * `registerFileProtocol` handler fails to load the file (see
+ * https://github.com/microsoft/vscode/issues/261880 and
+ * https://github.com/electron/electron/issues/49101).
+ *
+ * Prefixing an absolute path with `\\?\` (or `\\?\UNC\` for UNC paths)
+ * opts the Win32 APIs into extended-length path mode which bypasses
+ * `MAX_PATH`.
+ */
+const WINDOWS_LONG_PATH_THRESHOLD = 248; // conservative: Win32 directory limit is 248 while file limit is 259
+const WINDOWS_EXTENDED_PATH_PREFIX = '\\\\?\\';
+const WINDOWS_EXTENDED_UNC_PREFIX = '\\\\?\\UNC\\';
+
+function toWindowsLongPathIfNeeded(path: string): string {
+	if (!isWindows) {
+		return path;
+	}
+
+	if (path.length < WINDOWS_LONG_PATH_THRESHOLD) {
+		return path;
+	}
+
+	// Already using the extended-length prefix
+	if (path.startsWith(WINDOWS_EXTENDED_PATH_PREFIX)) {
+		return path;
+	}
+
+	// UNC path: \\server\share\... -> \\?\UNC\server\share\...
+	if (path.length >= 2 && path.charCodeAt(0) === 92 /* \ */ && path.charCodeAt(1) === 92 /* \ */) {
+		return WINDOWS_EXTENDED_UNC_PREFIX + path.substring(2);
+	}
+
+	// Drive-letter absolute path: C:\... -> \\?\C:\...
+	if (path.length >= 3 && path.charCodeAt(1) === 58 /* : */) {
+		return WINDOWS_EXTENDED_PATH_PREFIX + path;
+	}
+
+	return path;
+}
 
 export class ProtocolMainService extends Disposable implements IProtocolMainService {
 
@@ -123,14 +165,20 @@ export class ProtocolMainService extends Disposable implements IProtocolMainServ
 			};
 		}
 
+		// On Windows, paths longer than MAX_PATH (259) cause Electron's file
+		// protocol handler to fail. Apply the `\\?\` extended-length prefix so
+		// Win32 APIs bypass the limit (e.g. markdown image hover previews for
+		// deeply nested files). See https://github.com/microsoft/vscode/issues/261880.
+		const resolvedPath = toWindowsLongPathIfNeeded(path);
+
 		// first check by validRoots
 		if (this.validRoots.findSubstr(path)) {
-			return callback({ path, headers });
+			return callback({ path: resolvedPath, headers });
 		}
 
 		// then check by validExtensions
 		if (this.validExtensions.has(extname(path).toLowerCase())) {
-			return callback({ path, headers });
+			return callback({ path: resolvedPath, headers });
 		}
 
 		// finally block to load the resource


### PR DESCRIPTION
## What / Why

On Windows, the markdown image hover preview fails when a file's absolute path exceeds `MAX_PATH` (259 characters), even though the full preview panel renders the image correctly. The root cause is that the hover preview loads images through Electron's `registerFileProtocol` (the `vscode-file://` handler in `ProtocolMainService`), and Electron's handler bottoms out in a Win32 API call that does not use the extended-length path prefix — so anything over `MAX_PATH` is rejected by the OS. This was diagnosed in the issue thread by @busorgin and tracked upstream at electron/electron#49101.

Fixes #261880

## Fix

Before handing a resolved path to Electron's protocol callback, transform it on Windows to the extended-length form:

- `C:\...` becomes `\?\C:\...`
- `\server\share\...` becomes `\?\UNC\server\share\...`

This opts the underlying Win32 APIs into extended-length path mode, which bypasses the `MAX_PATH` limit. The transformation is:

- **Windows-only** — no-op on macOS and Linux, where the limit does not apply.
- **Only applied past a conservative threshold** (248 chars) so normal short paths are passed through unchanged and untouched behavior is preserved.
- **Idempotent** — already-prefixed paths are returned as-is.
- **Applied only to the value handed to Electron.** The `validRoots` / `validExtensions` allow-list checks continue to run against the original normalized path, so the security boundary around `vscode-file://` is unchanged.

## Testing

- Manually verified on Windows 11 by creating a markdown file that references an image whose absolute path is ~290 characters. Before the fix, hovering the image link showed the broken-image placeholder. After the fix, the hover preview renders the image, matching the behavior of the full preview panel.
- Short paths continue to work unchanged; the transformation is skipped for any path under the threshold.
- UNC paths, drive-letter paths, and already-prefixed paths are each handled explicitly and covered by the guard branches in `toWindowsLongPathIfNeeded`.

## Notes

- This is a workaround for electron/electron#49101. If/when Electron starts applying the extended-length prefix internally, this helper can be removed.