### PR TITLE
fix: respect embedded language auto-closing pairs when typing

### DIFF
--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -262,6 +262,23 @@ export class AutoClosingOpenCharTypeOperation {
 			if (!pair.shouldAutoClose(scopedLineTokens, beforeColumn - scopedLineTokens.firstCharOffset)) {
 				return null;
 			}
+			// If the cursor is inside an embedded language region (e.g. LaTeX
+			// embedded inside a markdown `$...$` math block), honor the
+			// embedded language's auto-closing pair configuration. Without
+			// this, the outer language's pairs (e.g. markdown's `<>`) would
+			// leak into regions where they are not meaningful.
+			// See https://github.com/microsoft/vscode/issues/272922 and the
+			// parent issue https://github.com/microsoft/vscode/issues/133397.
+			if (scopedLineTokens.languageId !== config.languageId) {
+				const embeddedConfig = config.languageConfigurationService.getLanguageConfiguration(scopedLineTokens.languageId);
+				const embeddedCandidates = embeddedConfig.getAutoClosingPairs().autoClosingPairsOpenByEnd.get(ch);
+				const hasMatchingEmbeddedPair = embeddedCandidates
+					? embeddedCandidates.some(c => c.open === pair.open && c.close === pair.close)
+					: false;
+				if (!hasMatchingEmbeddedPair) {
+					return null;
+				}
+			}
 			// Typing for example a quote could either start a new string, in which case auto-closing is desirable
 			// or it could end a previously started string, in which case auto-closing is not desirable
 			//

--- a/src/vs/editor/common/cursorCommon.ts
+++ b/src/vs/editor/common/cursorCommon.ts
@@ -84,6 +84,10 @@ export class CursorConfiguration {
 	private readonly _languageId: string;
 	private _electricChars: { [key: string]: boolean } | null;
 
+	public get languageId(): string {
+		return this._languageId;
+	}
+
 	public static shouldRecreate(e: ConfigurationChangedEvent): boolean {
 		return (
 			e.hasChanged(EditorOption.layoutInfo)


### PR DESCRIPTION
## What this PR does

Fixes auto-closing of the outer language's pairs inside embedded language regions. The concrete symptom reported in #272922 is typing `<` inside a markdown LaTeX math block (`$...$` or `$$...$$`) auto-closes to `<>`, even though `<` is a math operator there, not an HTML tag.

## Root cause

`AutoClosingOpenCharTypeOperation.getAutoClosingPairClose` looks up candidate pairs from `config.autoClosingPairs`, which is built solely from the outer document language's configuration. When the cursor is inside an embedded language region (such as LaTeX embedded inside markdown math), pairs that are only defined in the outer language (e.g. markdown's `<>`) leak into regions where they are not meaningful.

This is the root cause @alexdima identified on the parent issue:

> You're perfectly correct, all the typing code always uses the outer language characters because of the way this is implemented

(https://github.com/microsoft/vscode/issues/133397)

## The fix

After a candidate pair is found and the standard token-type check passes, also check the scoped (embedded) language's auto-closing pair configuration. If the pair does not exist in the embedded language (matched by identical open and close), skip auto-closing.

This mirrors the existing pattern already used for electric characters in `CursorConfiguration#onElectricCharacter`, which uses `ScopedLineTokens#languageId` to pick the embedded language's configuration.

The change is conservative:

- When the scoped language equals the outer language (the common case for non-embedded files), behavior is unchanged.
- Only pairs that are absent from the embedded language's configuration are suppressed. Pairs present in both languages (e.g. `()`, `{}`, `[]` for most languages) continue to auto-close as before.
- No grammar / scope renaming is required, so there are no downstream consequences for other language features that rely on the `markup.math.*.markdown` scopes.

## Verification

Repro from #272922 in a `.md` file:

```
$ a < b $
```

Before: typing `<` after `a ` produces `<>`.
After: typing `<` after `a ` produces just `<`.

Also verified:

- Outside math blocks in markdown, `<` still auto-closes to `<>` (markdown HTML use case preserved).
- In plain `.html` files, `<` auto-closing behavior unchanged.
- Fenced code blocks (e.g. ` ```python ` inside markdown) still respect the embedded language's pairs (Python defines `()`, `[]`, `{}`, `""`, `''` but not `<>`, so `<` is no longer auto-closed there either - matching behavior in a standalone `.py` file).

Fixes #272922
Refs #133397