### PR TITLE
image preview: show size/zoom status bar when preview is visible

### DIFF
--- a/extensions/media-preview/src/imagePreview/index.ts
+++ b/extensions/media-preview/src/imagePreview/index.ts
@@ -165,7 +165,7 @@ class ImagePreview extends MediaPreview {
 			return;
 		}
 
-		if (this._webviewEditor.active) {
+		if (this._webviewEditor.visible) {
 			this.sizeStatusBarEntry.show(this, this._imageSize || '');
 			this.zoomStatusBarEntry.show(this, this._imageZoom || 'fit');
 		} else {

--- a/extensions/media-preview/src/mediaPreview.ts
+++ b/extensions/media-preview/src/mediaPreview.ts
@@ -102,10 +102,14 @@ export abstract class MediaPreview extends Disposable {
 
 		if (this._webviewEditor.active) {
 			this.previewState = PreviewState.Active;
+		} else {
+			this.previewState = PreviewState.Visible;
+		}
+
+		if (this._webviewEditor.visible) {
 			this._binarySizeStatusBarEntry.show(this, this._binarySize);
 		} else {
 			this._binarySizeStatusBarEntry.hide(this);
-			this.previewState = PreviewState.Visible;
 		}
 	}
 }


### PR DESCRIPTION
## Problem

When viewing images locally (for example, in a side-by-side group or while another editor has focus), the image preview's size and zoom status bar entries were missing. They only appeared while the preview webview was focused.

## Root cause

`ImagePreview.updateState()` and `MediaPreview.updateState()` gated `show()` of the status bar entries on `webviewEditor.active` (focused) rather than `webviewEditor.visible` (on screen). As soon as focus moved elsewhere, the entries were hidden.

## Fix

Switch the `show`/`hide` gate for the size and zoom status bar entries to `webviewEditor.visible`. Keep the `previewState` transitions (`Active` vs `Visible`) tied to `.active` since that still reflects focus semantics used elsewhere.

Fixes #271120