### PR TITLE
Fix Git sync failing when ssh config has VisualHostKey=yes

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3244,7 +3244,11 @@ export class Repository {
 
 	async getDefaultBranch(remoteName: string): Promise<Branch> {
 		const result = await this.exec(['symbolic-ref', '--short', `refs/remotes/${remoteName}/HEAD`]);
-		if (!result.stdout || result.stderr) {
+		// Some ssh configurations (e.g. `VisualHostKey yes`) print an ASCII-art host
+		// key fingerprint on stderr while the command still succeeds, so rely on the
+		// non-zero exit code to surface real errors rather than treating any stderr
+		// output as failure. See https://github.com/microsoft/vscode/issues/247862.
+		if (!result.stdout) {
 			throw new Error('No default branch');
 		}
 
@@ -3344,11 +3348,11 @@ export class Repository {
 
 	async revList(ref1: string, ref2: string): Promise<string[]> {
 		const result = await this.exec(['rev-list', `${ref1}..${ref2}`]);
-		if (result.stderr) {
-			return [];
-		}
-
-		return result.stdout.trim().split('\n');
+		// Do not treat stderr content as failure: ssh may emit non-error output
+		// (e.g. `VisualHostKey yes` ASCII-art fingerprints) alongside a zero exit
+		// code. See https://github.com/microsoft/vscode/issues/247862.
+		const stdout = result.stdout.trim();
+		return stdout ? stdout.split('\n') : [];
 	}
 
 	async revParse(ref: string): Promise<string | undefined> {
@@ -3361,10 +3365,10 @@ export class Repository {
 
 		try {
 			const result = await this.exec(['rev-parse', ref]);
-			if (result.stderr) {
-				return undefined;
-			}
-			return result.stdout.trim();
+			// Do not treat stderr content as failure: ssh may emit non-error output
+			// (e.g. `VisualHostKey yes` ASCII-art fingerprints) alongside a zero exit
+			// code. See https://github.com/microsoft/vscode/issues/247862.
+			return result.stdout.trim() || undefined;
 		} catch (err) {
 			return undefined;
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
When a user sets `VisualHostKey yes` in their `~/.ssh/config`, OpenSSH
prints an ASCII-art fingerprint of the remote host key to stderr on
every connect. The git extension was treating any stderr output from
certain local git commands as a failure signal, which caused `Git: Sync`
(and other flows) to fail even though the underlying git command
actually succeeded.

The behavior was most visible when syncing after first publishing a
branch - running the same `git push`/`git pull` in a terminal worked,
but the VS Code command surfaced an error dialog.

Fixes #247862.

## What is the new behavior?
Three call sites in `extensions/git/src/git.ts` were using non-empty
`stderr` as a failure signal regardless of the process exit code:

- `getDefaultBranch` (`symbolic-ref`)
- `revList` (`rev-list`)
- `revParse` (`rev-parse`)

These now rely on the non-zero exit code already surfaced by the shared
`exec()` helper to detect real failures, and fall back to checking
`stdout` to decide success. Any informational noise emitted on stderr
by ssh (VisualHostKey output, banners, etc.) is now ignored.

## Additional context
- No behavior change when stderr is empty (the common case) or when the
  command exits non-zero (error is thrown as before).
- The fix follows the same pattern already used elsewhere in `git.ts`
  (e.g. `checkIfMaybeRebased`), which uses `result.exitCode` rather
  than `result.stderr` to determine success.