### PR TITLE
Add editor.preserveAlignmentSpacesOnIndent option

### DIFF
--- a/src/vs/editor/common/commands/shiftCommand.ts
+++ b/src/vs/editor/common/commands/shiftCommand.ts
@@ -21,6 +21,12 @@ export interface IShiftCommandOpts {
 	insertSpaces: boolean;
 	useTabStops: boolean;
 	autoIndent: EditorAutoIndentStrategy;
+	/**
+	 * When the file is indented with tabs, preserve spaces that follow the last tab in
+	 * the leading whitespace of a line (alignment spaces) when the indentation level is
+	 * adjusted. See microsoft/vscode#277764.
+	 */
+	preserveAlignmentSpaces?: boolean;
 }
 
 const repeatCache: { [str: string]: string[] } = Object.create(null);
@@ -100,6 +106,35 @@ export class ShiftCommand implements ICommand {
 		}
 	}
 
+	/**
+	 * When the file is indented with tabs, spaces that appear after the last tab in
+	 * the leading whitespace are treated as alignment spaces (e.g. in the line
+	 * `		  foo`, `		` is the indentation and the two trailing spaces align `foo`
+	 * with a token on the previous line). When alignment-space preservation is
+	 * enabled, such spaces are preserved across shift/unshift operations so that
+	 * visual alignment is not destroyed (microsoft/vscode#277764).
+	 *
+	 * Returns the new indentation-end index (the index after the last tab, or the
+	 * original index if no alignment spaces are present) together with the alignment
+	 * spaces substring to re-append after the re-computed indent.
+	 */
+	private static _stripAlignmentSpaces(lineText: string, indentationEndIndex: number): { indentationEndIndex: number; alignmentSpaces: string } {
+		let lastTabIdx = -1;
+		for (let k = indentationEndIndex - 1; k >= 0; k--) {
+			if (lineText.charCodeAt(k) === CharCode.Tab) {
+				lastTabIdx = k;
+				break;
+			}
+		}
+		if (lastTabIdx < 0 || lastTabIdx + 1 >= indentationEndIndex) {
+			return { indentationEndIndex, alignmentSpaces: '' };
+		}
+		return {
+			indentationEndIndex: lastTabIdx + 1,
+			alignmentSpaces: lineText.substring(lastTabIdx + 1, indentationEndIndex)
+		};
+	}
+
 	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
 		const startLine = this._selection.startLineNumber;
 
@@ -110,6 +145,11 @@ export class ShiftCommand implements ICommand {
 
 		const { tabSize, indentSize, insertSpaces } = this._opts;
 		const shouldIndentEmptyLines = (startLine === endLine);
+		// When the file is indented with tabs and the preserveAlignmentSpaces option
+		// is enabled, preserve trailing spaces in the leading whitespace (alignment
+		// spaces) so that column alignment within the code is not destroyed when the
+		// indentation level is adjusted (microsoft/vscode#277764).
+		const preserveAlignment = !!this._opts.preserveAlignmentSpaces && !insertSpaces;
 
 		if (this._opts.useTabStops) {
 			// if indenting or outdenting on a whitespace only line
@@ -139,6 +179,17 @@ export class ShiftCommand implements ICommand {
 				if (indentationEndIndex === -1) {
 					// the entire line is whitespace
 					indentationEndIndex = lineText.length;
+				}
+
+				// Preserve alignment spaces that follow the last tab in the leading
+				// whitespace when the file is indented with tabs. Without this, shifting
+				// or unshifting a line rewrites the leading whitespace as pure tabs and
+				// destroys column alignment within the code (microsoft/vscode#277764).
+				let alignmentSpaces = '';
+				if (preserveAlignment) {
+					const alignment = ShiftCommand._stripAlignmentSpaces(lineText, indentationEndIndex);
+					indentationEndIndex = alignment.indentationEndIndex;
+					alignmentSpaces = alignment.alignmentSpaces;
 				}
 
 				if (lineNumber > 1) {
@@ -188,7 +239,7 @@ export class ShiftCommand implements ICommand {
 					desiredIndent = ShiftCommand.shiftIndent(lineText, indentationEndIndex + 1, tabSize, indentSize, insertSpaces);
 				}
 
-				this._addEditOperation(builder, new Range(lineNumber, 1, lineNumber, indentationEndIndex + 1), desiredIndent);
+				this._addEditOperation(builder, new Range(lineNumber, 1, lineNumber, indentationEndIndex + 1), desiredIndent + alignmentSpaces);
 				if (lineNumber === startLine && !this._selection.isEmpty()) {
 					// Force the startColumn to stay put because we're inserting after it
 					this._selectionStartColumnStaysPut = (this._selection.startColumn <= indentationEndIndex + 1);
@@ -228,6 +279,15 @@ export class ShiftCommand implements ICommand {
 				}
 
 				if (this._opts.isUnshift) {
+
+					// When alignment-space preservation is enabled and the file is indented
+					// with tabs, restrict removal to the tab-based indentation portion so that
+					// alignment spaces following the last tab are preserved
+					// (microsoft/vscode#277764).
+					if (preserveAlignment) {
+						const alignment = ShiftCommand._stripAlignmentSpaces(lineText, indentationEndIndex);
+						indentationEndIndex = alignment.indentationEndIndex;
+					}
 
 					indentationEndIndex = Math.min(indentationEndIndex, indentSize);
 					for (let i = 0; i < indentationEndIndex; i++) {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -747,6 +747,13 @@ export interface IEditorOptions {
 	 */
 	useTabStops?: boolean;
 	/**
+	 * When the file is indented with tabs, preserve trailing spaces in the leading
+	 * whitespace of a line (alignment spaces) when the indentation level is
+	 * adjusted via Tab or Shift+Tab on a selection. See microsoft/vscode#277764.
+	 * Defaults to false to preserve the previous behavior.
+	 */
+	preserveAlignmentSpacesOnIndent?: boolean;
+	/**
 	 * Controls whether the editor should automatically remove indentation whitespace when joining lines with Delete.
 	 * Defaults to false.
 	 */
@@ -5944,7 +5951,8 @@ export const enum EditorOption {
 	effectiveEditContext,
 	scrollOnMiddleClick,
 	effectiveAllowVariableFonts,
-	doubleClickSelectsBlock
+	doubleClickSelectsBlock,
+	preserveAlignmentSpacesOnIndent
 }
 
 export const EditorOptions = {
@@ -6745,6 +6753,10 @@ export const EditorOptions = {
 	useTabStops: register(new EditorBooleanOption(
 		EditorOption.useTabStops, 'useTabStops', true,
 		{ description: nls.localize('useTabStops', "Spaces and tabs are inserted and deleted in alignment with tab stops.") }
+	)),
+	preserveAlignmentSpacesOnIndent: register(new EditorBooleanOption(
+		EditorOption.preserveAlignmentSpacesOnIndent, 'preserveAlignmentSpacesOnIndent', false,
+		{ description: nls.localize('preserveAlignmentSpacesOnIndent', "When the file is indented with tabs, preserve trailing spaces in the leading whitespace (alignment spaces) when Tab or Shift+Tab adjusts the indentation level on a selection.") }
 	)),
 	wordBreak: register(new EditorStringEnumOption(
 		EditorOption.wordBreak, 'wordBreak',

--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -805,7 +805,8 @@ export class TabOperation {
 					indentSize: config.indentSize,
 					insertSpaces: config.insertSpaces,
 					useTabStops: config.useTabStops,
-					autoIndent: config.autoIndent
+					autoIndent: config.autoIndent,
+					preserveAlignmentSpaces: config.preserveAlignmentSpacesOnIndent
 				}, config.languageConfigurationService);
 			}
 		}

--- a/src/vs/editor/common/cursor/cursorTypeOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeOperations.ts
@@ -28,7 +28,8 @@ export class TypeOperations {
 				indentSize: config.indentSize,
 				insertSpaces: config.insertSpaces,
 				useTabStops: config.useTabStops,
-				autoIndent: config.autoIndent
+				autoIndent: config.autoIndent,
+				preserveAlignmentSpaces: config.preserveAlignmentSpacesOnIndent
 			}, config.languageConfigurationService);
 		}
 		return commands;
@@ -43,7 +44,8 @@ export class TypeOperations {
 				indentSize: config.indentSize,
 				insertSpaces: config.insertSpaces,
 				useTabStops: config.useTabStops,
-				autoIndent: config.autoIndent
+				autoIndent: config.autoIndent,
+				preserveAlignmentSpaces: config.preserveAlignmentSpacesOnIndent
 			}, config.languageConfigurationService);
 		}
 		return commands;

--- a/src/vs/editor/common/cursorCommon.ts
+++ b/src/vs/editor/common/cursorCommon.ts
@@ -60,6 +60,7 @@ export class CursorConfiguration {
 	public readonly lineHeight: number;
 	public readonly typicalHalfwidthCharacterWidth: number;
 	public readonly useTabStops: boolean;
+	public readonly preserveAlignmentSpacesOnIndent: boolean;
 	public readonly trimWhitespaceOnDelete: boolean;
 	public readonly wordSeparators: string;
 	public readonly emptySelectionClipboard: boolean;
@@ -99,6 +100,7 @@ export class CursorConfiguration {
 			|| e.hasChanged(EditorOption.autoClosingOvertype)
 			|| e.hasChanged(EditorOption.autoSurround)
 			|| e.hasChanged(EditorOption.useTabStops)
+			|| e.hasChanged(EditorOption.preserveAlignmentSpacesOnIndent)
 			|| e.hasChanged(EditorOption.trimWhitespaceOnDelete)
 			|| e.hasChanged(EditorOption.fontInfo)
 			|| e.hasChanged(EditorOption.readOnly)
@@ -128,6 +130,7 @@ export class CursorConfiguration {
 		this.typicalHalfwidthCharacterWidth = fontInfo.typicalHalfwidthCharacterWidth;
 		this.pageSize = Math.max(1, Math.floor(layoutInfo.height / this.lineHeight) - 2);
 		this.useTabStops = options.get(EditorOption.useTabStops);
+		this.preserveAlignmentSpacesOnIndent = options.get(EditorOption.preserveAlignmentSpacesOnIndent);
 		this.trimWhitespaceOnDelete = options.get(EditorOption.trimWhitespaceOnDelete);
 		this.wordSeparators = options.get(EditorOption.wordSeparators);
 		this.emptySelectionClipboard = options.get(EditorOption.emptySelectionClipboard);

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -347,7 +347,8 @@ export enum EditorOption {
 	effectiveEditContext = 170,
 	scrollOnMiddleClick = 171,
 	effectiveAllowVariableFonts = 172,
-	doubleClickSelectsBlock = 173
+	doubleClickSelectsBlock = 173,
+	preserveAlignmentSpacesOnIndent = 174
 }
 
 /**

--- a/src/vs/editor/test/browser/commands/shiftCommand.test.ts
+++ b/src/vs/editor/test/browser/commands/shiftCommand.test.ts
@@ -996,4 +996,103 @@ suite('Editor Commands - ShiftCommand', () => {
 		}
 	});
 
+	test('issue #277764: Tab on multi-line selection preserves alignment spaces when option is enabled', () => {
+		testCommand(
+			[
+				'\t\t  arg',
+				'next'
+			],
+			null,
+			new Selection(1, 1, 2, 1),
+			(accessor, sel) => new ShiftCommand(sel, {
+				isUnshift: false,
+				tabSize: 4,
+				indentSize: 4,
+				insertSpaces: false,
+				useTabStops: true,
+				autoIndent: EditorAutoIndentStrategy.Full,
+				preserveAlignmentSpaces: true,
+			}, accessor.get(ILanguageConfigurationService)),
+			[
+				'\t\t\t  arg',
+				'next'
+			],
+			new Selection(1, 1, 2, 1)
+		);
+	});
+
+	test('issue #277764: Shift+Tab on multi-line selection preserves alignment spaces when option is enabled', () => {
+		testCommand(
+			[
+				'\t\t  arg',
+				'next'
+			],
+			null,
+			new Selection(1, 1, 2, 1),
+			(accessor, sel) => new ShiftCommand(sel, {
+				isUnshift: true,
+				tabSize: 4,
+				indentSize: 4,
+				insertSpaces: false,
+				useTabStops: true,
+				autoIndent: EditorAutoIndentStrategy.Full,
+				preserveAlignmentSpaces: true,
+			}, accessor.get(ILanguageConfigurationService)),
+			[
+				'\t  arg',
+				'next'
+			],
+			new Selection(1, 1, 2, 1)
+		);
+	});
+
+	test('issue #277764: alignment spaces are not preserved when option is disabled (default behavior)', () => {
+		testCommand(
+			[
+				'\t\t  arg',
+				'next'
+			],
+			null,
+			new Selection(1, 1, 2, 1),
+			(accessor, sel) => new ShiftCommand(sel, {
+				isUnshift: true,
+				tabSize: 4,
+				indentSize: 4,
+				insertSpaces: false,
+				useTabStops: true,
+				autoIndent: EditorAutoIndentStrategy.Full,
+			}, accessor.get(ILanguageConfigurationService)),
+			[
+				'\t\targ',
+				'next'
+			],
+			new Selection(1, 1, 2, 1)
+		);
+	});
+
+	test('issue #277764: preserveAlignmentSpaces is a no-op for insertSpaces=true', () => {
+		testCommand(
+			[
+				'    arg',
+				'next'
+			],
+			null,
+			new Selection(1, 1, 2, 1),
+			(accessor, sel) => new ShiftCommand(sel, {
+				isUnshift: true,
+				tabSize: 4,
+				indentSize: 4,
+				insertSpaces: true,
+				useTabStops: true,
+				autoIndent: EditorAutoIndentStrategy.Full,
+				preserveAlignmentSpaces: true,
+			}, accessor.get(ILanguageConfigurationService)),
+			[
+				'arg',
+				'next'
+			],
+			new Selection(1, 1, 2, 1)
+		);
+	});
+
 });


### PR DESCRIPTION
## Summary

When a tab-indented line contains spaces after the last tab that are used to visually align content with a token on a previous line, the existing Tab/Shift+Tab behavior on a selection rewrites the leading whitespace as pure tab indentation and destroys the alignment. For example, pressing Shift+Tab on:

```
<TAB><TAB>  arg
```

currently produces `<TAB><TAB>arg` (the two alignment spaces are gone) instead of `<TAB>  arg` (one level less of tab indentation, alignment preserved).

This PR introduces a new boolean editor option, `editor.preserveAlignmentSpacesOnIndent`, defaulting to `false` so existing behavior is unchanged. When the option is enabled and the file is indented with tabs (`editor.insertSpaces === false`), `ShiftCommand` treats spaces that follow the last tab in the leading whitespace as alignment spaces and preserves them across shift and unshift operations. This keeps column alignment within the code intact when adjusting the indentation level with Tab or Shift+Tab on a selection.

Changes:
- New `preserveAlignmentSpacesOnIndent` option (`editorOptions.ts`, `standaloneEnums.ts`).
- Plumbed through `CursorConfiguration` (`cursorCommon.ts`) to the `ShiftCommand` construction sites in `cursorTypeOperations.ts` and `cursorTypeEditOperations.ts`.
- `ShiftCommand.getEditOperations` gains an alignment-spaces-stripping step when the new option is enabled, and re-appends the preserved spaces after the re-computed indent.
- Added four unit tests in `shiftCommand.test.ts` covering: Tab with preservation, Shift+Tab with preservation, Shift+Tab with the option off (the previous behavior), and a no-op case when the file uses spaces for indentation.

Fixes #277764

## Test plan

- [ ] `yarn test-browser --run test/browser/commands/shiftCommand.test.ts` passes (new + existing tests).
- [ ] Manual smoke test: open a tab-indented file, enable `editor.preserveAlignmentSpacesOnIndent`, select lines that have alignment spaces after the tabs, and confirm Tab / Shift+Tab shift the tab indentation while preserving the trailing alignment spaces. With the option off, behavior is unchanged.