### PR TITLE
nes: show thumbsdown icon for previously rejected NES in log tree

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -333,6 +333,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			logger.trace('cached edit was previously rejected');
 			telemetryBuilder.setStatus('previouslyRejectedCache');
 			telemetryBuilder.setWasPreviouslyRejected();
+			logContext.markAsPreviouslyRejected();
 			const rejectedEdit = cachedEdit.rebasedEdit ?? cachedEdit.edit;
 			if (rejectedEdit) {
 				this._rejectionCollector.reject(docId, rejectedEdit);
@@ -446,6 +447,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 			logger.trace('edit was previously rejected');
 			telemetryBuilder.setStatus('previouslyRejected');
 			telemetryBuilder.setWasPreviouslyRejected();
+			logContext.markAsPreviouslyRejected();
 			return emptyResult;
 		}
 

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -35,6 +35,7 @@ export interface MarkdownLoggable {
  * - `skipped`: request was skipped or fetch-cancelled
  * - `cancelled`: request was cancelled via CancellationToken (shown as skipped)
  * - `errored`: an error occurred
+ * - `previouslyRejected`: result matches a suggestion that was previously rejected
  */
 type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored' | 'previouslyRejected';
 

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -36,7 +36,7 @@ export interface MarkdownLoggable {
  * - `cancelled`: request was cancelled via CancellationToken (shown as skipped)
  * - `errored`: an error occurred
  */
-type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored';
+type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored' | 'previouslyRejected';
 
 export class InlineEditRequestLogContext {
 
@@ -377,6 +377,7 @@ export class InlineEditRequestLogContext {
 			case 'skipped':
 			case 'cancelled': return Icon.skipped;
 			case 'errored': return Icon.error;
+			case 'previouslyRejected': return Icon.thumbsdown;
 		}
 	}
 
@@ -398,6 +399,14 @@ export class InlineEditRequestLogContext {
 
 	public markAsNoSuggestions() {
 		this._setOutcome('noSuggestions');
+		this._isVisible = true;
+		this.fireDidChange();
+	}
+
+	public markAsPreviouslyRejected() {
+		// Direct assignment — bypasses _setOutcome guard because this transition
+		// legitimately overrides 'succeeded' when a fetched edit turns out to be rejected.
+		this._outcome = 'previouslyRejected';
 		this._isVisible = true;
 		this.fireDidChange();
 	}

--- a/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
@@ -63,6 +63,11 @@ export namespace Icon {
 		themeIcon: ThemeIcon.fromId('check'),
 		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="m14.431 3.323l-8.47 10l-.79-.036l-3.35-4.77l.818-.574l2.978 4.24l8.051-9.506z" clip-rule="evenodd"/></svg>`,
 	};
+
+	export const thumbsdown: t = {
+		themeIcon: ThemeIcon.fromId('thumbsdown'),
+		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M3.5 1h-2A1.5 1.5 0 0 0 0 2.5v5A1.5 1.5 0 0 0 1.5 9h2A1.5 1.5 0 0 0 5 7.5v-5A1.5 1.5 0 0 0 3.5 1M6 7.5a2.5 2.5 0 0 1-1 2V12a3 3 0 0 0 3 3h2.764a2 2 0 0 0 1.789-1.106l2.106-4.212A2 2 0 0 0 16 8.5V8a2 2 0 0 0-2-2h-3.5a.5.5 0 0 1-.5-.5V3a2 2 0 0 0-2-2H7a1 1 0 0 0-1 1z"/></svg>`,
+	};
 }
 
 export function shortenOpportunityId(opportunityId: string): string {


### PR DESCRIPTION
Previously rejected NES entries now show a 👎 icon instead of no specific icon. Uses direct outcome assignment to avoid false warnings on the succeeded→previouslyRejected transition. Also registers the rebasedEdit (when present) with the rejection collector.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
