### PR TITLE
inlineChat: fix model picker overflow when selecting Auto

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -113,6 +113,7 @@
 	.chat-attachments-container > .chat-input-toolbar {
 		margin-left: auto;
 		margin-right: 16px;
+		width: 100%;
 	}
 
 	/* TODO@jrieken this isn't the nicest selector... */


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/vscode/issues/309424

When selecting the "Auto" model in the inline chat model picker, the picker would collapse into the toolbar overflow menu ("..."). This happened because the toolbar element lacked a fixed width - its width was content-based and shrank when switching to a shorter label like "Auto", causing the responsive overflow logic to hide it.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Root cause**: When `renderInputToolbarBelowInput` is true (inline chat v2), the toolbar is placed in `.chat-attachments-container` instead of `.chat-input-toolbars`. The CSS rule `.chat-input-toolbars > .chat-input-toolbar { width: 100% }` doesn't match because the parent element is different. Without `width: 100%`, the toolbar width is content-based and shrinks when the model label changes. The `ResizeObserver` on the toolbar fires with the smaller width, and the responsive overflow logic in `toolbar.ts#updateActions()` decides items need to be hidden.
- **Fix approach**: Add `width: 100%` to the existing `.chat-attachments-container > .chat-input-toolbar` rule in the inline chat v2 CSS block, matching the behavior of the normal chat layout.
- **Why only "Auto"**: "Auto" has a short label. The toolbar shrinks enough that `minimumWidth > containerWidth`, triggering overflow. Longer model names keep the toolbar wide enough to avoid this threshold.

</details>

## Changes

- Added `width: 100%` to `.chat-attachments-container > .chat-input-toolbar` in the inline chat v2 CSS block so the toolbar takes the full container width regardless of label content length.
