### PR TITLE
ci: fix intermittent fontconfig SIGSEGV on Linux CI

### DIFF
--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -136,6 +136,88 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Workaround expat NULL deref CVEs in fontconfig parsing
+        run: |
+          set -e
+          # Ubuntu 24.04 ships expat 2.6.1 which has multiple NULL dereference
+          # CVEs triggered when fontconfig parses <include> directives via
+          # expat's XML_ExternalEntityParserCreate:
+          #   CVE-2026-24515 (backported but crash persists)
+          #   CVE-2026-32776 (not yet backported) - empty external parameter entities
+          #   CVE-2026-32778 (not yet backported) - setContext after OOM
+          # All three are fixed upstream in expat >= 2.7.5.
+          # Check if the runner already has the fix — skip workaround if so.
+          EXPAT_VER=$(dpkg-query -W -f='${Version}' libexpat1 2>/dev/null || echo "0")
+          if dpkg --compare-versions "$EXPAT_VER" ge "2.7.5"; then
+            echo "::warning::libexpat1 $EXPAT_VER includes all CVE fixes (>= 2.7.5). The fontconfig workaround in this workflow can be removed."
+            exit 0
+          fi
+          echo "Installed expat: $EXPAT_VER — applying fontconfig workaround"
+          # Workaround: use a minimal fontconfig config with no <include> directives,
+          # avoiding the external entity parser codepath entirely. Based on upstream
+          # fontconfig 2.15.0 fonts.conf.in with <include> removed, generic family
+          # aliases inlined, and default font mappings for generic families added
+          # (from conf.d/49-sansserif.conf and DejaVu font configs).
+          # Remove once Ubuntu backports the remaining CVE fixes.
+          cat > /tmp/fonts-minimal.conf << 'FONTCONFIG_EOF'
+          <?xml version="1.0"?>
+          <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+          <fontconfig>
+            <dir>/usr/share/fonts</dir>
+            <dir>/usr/local/share/fonts</dir>
+            <dir prefix="xdg">fonts</dir>
+            <cachedir>/var/cache/fontconfig</cachedir>
+            <cachedir prefix="xdg">fontconfig</cachedir>
+            <!-- Generic family aliases from upstream fonts.conf -->
+            <match target="pattern">
+              <test qual="any" name="family"><string>mono</string></test>
+              <edit name="family" mode="assign" binding="same"><string>monospace</string></edit>
+            </match>
+            <match target="pattern">
+              <test qual="any" name="family"><string>sans serif</string></test>
+              <edit name="family" mode="assign" binding="same"><string>sans-serif</string></edit>
+            </match>
+            <match target="pattern">
+              <test qual="any" name="family"><string>sans</string></test>
+              <edit name="family" mode="assign" binding="same"><string>sans-serif</string></edit>
+            </match>
+            <match target="pattern">
+              <test qual="any" name="family"><string>system ui</string></test>
+              <edit name="family" mode="assign" binding="same"><string>system-ui</string></edit>
+            </match>
+            <!-- Map generic families to actual fonts (from conf.d/49-sansserif, 57-dejavu) -->
+            <alias>
+              <family>monospace</family>
+              <prefer><family>DejaVu Sans Mono</family></prefer>
+            </alias>
+            <alias>
+              <family>sans-serif</family>
+              <prefer><family>DejaVu Sans</family></prefer>
+            </alias>
+            <alias>
+              <family>serif</family>
+              <prefer><family>DejaVu Serif</family></prefer>
+            </alias>
+            <!-- Fallback: assign sans-serif to unmatched families (from 49-sansserif.conf) -->
+            <match target="pattern">
+              <test qual="all" name="family" compare="not_eq"><string>sans-serif</string></test>
+              <test qual="all" name="family" compare="not_eq"><string>serif</string></test>
+              <test qual="all" name="family" compare="not_eq"><string>monospace</string></test>
+              <edit name="family" mode="append_last"><string>sans-serif</string></edit>
+            </match>
+            <!-- Rendering defaults -->
+            <match target="font">
+              <edit name="antialias" mode="assign"><bool>true</bool></edit>
+              <edit name="hinting" mode="assign"><bool>true</bool></edit>
+              <edit name="hintstyle" mode="assign"><const>hintslight</const></edit>
+            </match>
+            <config>
+              <rescan><int>0</int></rescan>
+            </config>
+          </fontconfig>
+          FONTCONFIG_EOF
+          echo "FONTCONFIG_FILE=/tmp/fonts-minimal.conf" >> "$GITHUB_ENV"
+
       - name: Fontconfig diagnostics and cache reset
         run: |
           set -e
@@ -145,10 +227,15 @@ jobs:
           echo "--- Installed font packages ---"
           apt list --installed 2>/dev/null | grep -E 'fonts-|fontconfig' || true
           echo ""
-          echo "--- Verify fonts.conf integrity ---"
+          echo "--- Active fontconfig file ---"
+          echo "FONTCONFIG_FILE=${FONTCONFIG_FILE:-/etc/fonts/fonts.conf}"
+          echo ""
+          echo "--- Verify active config integrity ---"
           python3 -c "
-          import xml.etree.ElementTree as ET, glob, sys
-          for f in ['/etc/fonts/fonts.conf'] + sorted(glob.glob('/etc/fonts/conf.d/*.conf')):
+          import xml.etree.ElementTree as ET, os, glob, sys
+          fc = os.environ.get('FONTCONFIG_FILE', '/etc/fonts/fonts.conf')
+          files = [fc] if os.path.exists(fc) else ['/etc/fonts/fonts.conf'] + sorted(glob.glob('/etc/fonts/conf.d/*.conf'))
+          for f in files:
               try:
                   ET.parse(f)
               except Exception as e:


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/308495

Still crashes in libexpat with updated runner https://github.com/microsoft/vscode/actions/runs/24335373723/job/71050924332

Minimal config is based on https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/fonts.conf.in