### PR TITLE
xtab: replace getFetchFailure polling with stream-level error propagation

### DIFF
--- a/extensions/copilot/src/extension/xtab/common/fetchStreamError.ts
+++ b/extensions/copilot/src/extension/xtab/common/fetchStreamError.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { NoNextEditReason } from '../../../platform/inlineEdits/common/statelessNextEditProvider';
+
+/**
+ * Typed error thrown when an async line stream is rejected due to a fetch failure.
+ * Consumers can catch this to extract the mapped {@link NoNextEditReason}.
+ */
+export class FetchStreamError extends Error {
+	constructor(readonly reason: NoNextEditReason) {
+		super('Fetch stream failed');
+	}
+}

--- a/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
+++ b/extensions/copilot/src/extension/xtab/node/responseFormatHandlers.ts
@@ -78,14 +78,8 @@ export async function handleEditWindowWithEditIntent(
 	linesStream: AsyncIterable<string>,
 	tracer: ILogger,
 	parseMode: EditIntentParseMode,
-	getFetchFailure: () => NoNextEditReason | undefined,
 ): Promise<ResponseParseResult.EditWindowLines | ResponseParseResult.Done> {
 	const { editIntent, remainingLinesStream, parseError } = await parseEditIntentFromStream(linesStream, tracer, parseMode);
-
-	const fetchFailure = getFetchFailure();
-	if (fetchFailure) {
-		return new ResponseParseResult.Done(fetchFailure);
-	}
 
 	return new ResponseParseResult.EditWindowLines(
 		remainingLinesStream,
@@ -113,17 +107,9 @@ export async function handleUnifiedWithXml(
 	ctx: UnifiedXmlInsertContext,
 	documentBeforeEdits: StringText,
 	tracer: ILogger,
-	getFetchFailure: () => NoNextEditReason | undefined,
 ): Promise<ResponseParseResult.t> {
 	const linesIter = linesStream[Symbol.asyncIterator]();
 	const firstLine = await linesIter.next();
-
-	{
-		const fetchFailure = getFetchFailure();
-		if (fetchFailure) {
-			return new ResponseParseResult.Done(fetchFailure);
-		}
-	}
 
 	if (firstLine.done) {
 		return new ResponseParseResult.Done(
@@ -141,12 +127,12 @@ export async function handleUnifiedWithXml(
 
 	if (trimmedFirstLine === ResponseTags.INSERT.start) {
 		return new ResponseParseResult.DirectEdits(
-			generateInsertEdits(linesIter, ctx, documentBeforeEdits, getFetchFailure),
+			generateInsertEdits(linesIter, ctx, documentBeforeEdits),
 		);
 	}
 
 	if (trimmedFirstLine === ResponseTags.EDIT.start) {
-		const editLines = generateEditLines(linesIter, getFetchFailure);
+		const editLines = generateEditLines(linesIter);
 		return new ResponseParseResult.EditWindowLines(editLines);
 	}
 
@@ -163,20 +149,12 @@ async function* generateInsertEdits(
 	linesIter: AsyncIterator<string>,
 	ctx: UnifiedXmlInsertContext,
 	documentBeforeEdits: StringText,
-	getFetchFailure: () => NoNextEditReason | undefined,
 ): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
 	const { editWindowLines, editWindowLineRange, cursorOriginalLinesOffset, cursorColumnZeroBased, editWindow, originalEditWindow, targetDocument, isFromCursorJump } = ctx;
 
 	const lineWithCursorContinued = await linesIter.next();
 	if (lineWithCursorContinued.done || lineWithCursorContinued.value.includes(ResponseTags.INSERT.end)) {
 		return new NoNextEditReason.NoSuggestions(documentBeforeEdits, editWindow);
-	}
-
-	{
-		const fetchFailure = getFetchFailure();
-		if (fetchFailure) {
-			return fetchFailure;
-		}
 	}
 
 	const cursorLineContent = editWindowLines[cursorOriginalLinesOffset];
@@ -200,13 +178,6 @@ async function* generateInsertEdits(
 		v = await linesIter.next();
 	}
 
-	{
-		const fetchFailure = getFetchFailure();
-		if (fetchFailure) {
-			return fetchFailure;
-		}
-	}
-
 	const line = editWindowLineRange.start + cursorOriginalLinesOffset + 2;
 	yield {
 		edit: new LineReplacement(
@@ -224,14 +195,10 @@ async function* generateInsertEdits(
 
 async function* generateEditLines(
 	linesIter: AsyncIterator<string>,
-	getFetchFailure: () => NoNextEditReason | undefined,
 ): AsyncIterable<string> {
 	let v = await linesIter.next();
 	while (!v.done) {
 		if (v.value.includes(ResponseTags.EDIT.end)) {
-			return;
-		}
-		if (getFetchFailure()) {
 			return;
 		}
 		yield v.value;

--- a/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabCustomDiffPatchResponseHandler.ts
@@ -12,6 +12,7 @@ import { URI } from '../../../util/vs/base/common/uri';
 import { LineReplacement } from '../../../util/vs/editor/common/core/edits/lineEdit';
 import { LineRange } from '../../../util/vs/editor/common/core/ranges/lineRange';
 import { OffsetRange } from '../../../util/vs/editor/common/core/ranges/offsetRange';
+import { FetchStreamError } from '../common/fetchStreamError';
 import { toUniquePath } from '../common/promptCraftingUtils';
 import { ResponseTags } from '../common/tags';
 import { CurrentDocument } from '../common/xtabCurrentDocument';
@@ -70,16 +71,11 @@ export class XtabCustomDiffPatchResponseHandler {
 		workspaceRoot: URI | undefined,
 		window: OffsetRange | undefined,
 		parentTracer: ILogger,
-		getFetchFailure?: () => NoNextEditReason | undefined,
 	): AsyncGenerator<StreamedEdit, NoNextEditReason, void> {
 		const tracer = parentTracer.createSubLogger(['XtabCustomDiffPatchResponseHandler', 'handleResponse']);
 		const activeDocRelativePath = toUniquePath(activeDocumentId, workspaceRoot?.path);
 		try {
 			for await (const edit of XtabCustomDiffPatchResponseHandler.extractEdits(linesStream)) {
-				const fetchFailure = getFetchFailure?.();
-				if (fetchFailure) {
-					return fetchFailure;
-				}
 				const targetDocument = edit.filePath === activeDocRelativePath
 					? activeDocumentId
 					: XtabCustomDiffPatchResponseHandler.resolveTargetDocument(edit.filePath, workspaceRoot);
@@ -95,6 +91,9 @@ export class XtabCustomDiffPatchResponseHandler {
 				} satisfies StreamedEdit;
 			}
 		} catch (e: unknown) {
+			if (e instanceof FetchStreamError) {
+				return e.reason;
+			}
 			const err = ErrorUtils.fromUnknown(e);
 			return new NoNextEditReason.Unexpected(err);
 		}

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -56,6 +56,7 @@ import { DelaySession } from '../../inlineEdits/common/delay';
 import { getOrDeduceSelectionFromLastEdit } from '../../inlineEdits/common/nearbyCursorInlineEditProvider';
 import { UserInteractionMonitor } from '../../inlineEdits/common/userInteractionMonitor';
 import { IgnoreImportChangesAspect } from '../../inlineEdits/node/importFiltering';
+import { FetchStreamError } from '../common/fetchStreamError';
 import { determineIsInlineSuggestionPosition } from '../common/inlineSuggestion';
 import { LintErrors } from '../common/lintErrors';
 import { ClippedDocument, constructTaggedFile, getUserPrompt, N_LINES_ABOVE, N_LINES_AS_CONTEXT, N_LINES_BELOW, PromptPieces } from '../common/promptCrafting';
@@ -133,7 +134,6 @@ namespace FetchResult {
 	export class Lines {
 		constructor(
 			readonly linesStream: AsyncIterable<string>,
-			readonly getFetchFailure: () => NoNextEditReason | undefined,
 			readonly getResponseSoFar: () => string,
 			readonly fetchRequestStopWatch: StopWatch,
 		) { }
@@ -747,8 +747,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		let responseSoFar = '';
 
-		let chatResponseFailure: ChatFetchError | undefined;
-
 		let ttft: number | undefined;
 
 		const firstTokenReceived = new DeferredPromise<void>();
@@ -802,22 +800,23 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		fetchResultPromise
 			.then((response) => {
-				// this's a way to signal the edit-pushing code to know if the request failed and
-				// 	it shouldn't push edits constructed from an erroneous response
-				chatResponseFailure = response.type !== ChatFetchResponseType.Success ? response : undefined;
+				if (response.type !== ChatFetchResponseType.Success) {
+					fetchStreamSource.reject(new FetchStreamError(mapChatFetcherErrorToNoNextEditReason(response)));
+				} else {
+					fetchStreamSource.resolve();
+				}
 			})
 			.catch((err: unknown) => {
 				// in principle this shouldn't happen because ChatMLFetcher's fetchOne should not throw
 				logContext.setError(ErrorUtils.fromUnknown(err));
 				logContext.addLog(`ChatMLFetcher fetch call threw -- this's UNEXPECTED!`);
+				fetchStreamSource.reject(ErrorUtils.fromUnknown(err));
 			}).finally(() => {
 				logContext.setFetchEndTime();
 
 				if (!firstTokenReceived.isSettled) {
 					firstTokenReceived.complete();
 				}
-
-				fetchStreamSource.resolve();
 
 				logContext.setResponse(responseSoFar);
 			});
@@ -837,9 +836,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			return new FetchResult.FetchFailure(mapChatFetcherErrorToNoNextEditReason(fetchRes));
 		}
 
-		const getFetchFailure = (): NoNextEditReason | undefined =>
-			chatResponseFailure ? mapChatFetcherErrorToNoNextEditReason(chatResponseFailure) : undefined;
-
 		const llmLinesStream = AsyncIterUtilsExt.splitLines(AsyncIterUtils.map(fetchStreamSource.stream, (chunk) => chunk.delta.text));
 
 		// logging of times
@@ -856,7 +852,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			}
 		})();
 
-		return new FetchResult.Lines(linesStream, getFetchFailure, () => responseSoFar, fetchRequestStopWatch);
+		return new FetchResult.Lines(linesStream, () => responseSoFar, fetchRequestStopWatch);
 	}
 
 	private async *_streamEditsImpl(
@@ -892,7 +888,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 			return fetchResult.reason;
 		}
 
-		const { linesStream, getFetchFailure, getResponseSoFar, fetchRequestStopWatch } = fetchResult;
+		const { linesStream, getResponseSoFar, fetchRequestStopWatch } = fetchResult;
 
 		// Phase 2: Dispatch to the appropriate response format handler
 		const isFromCursorJump = retryState instanceof RetryState.Retrying && retryState.reason === 'cursorJump';
@@ -913,7 +909,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				const parseMode = responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort
 					? EditIntentParseMode.ShortName
 					: EditIntentParseMode.Tags;
-				parseResult = await handleEditWindowWithEditIntent(linesStream, tracer, parseMode, getFetchFailure);
+				parseResult = await handleEditWindowWithEditIntent(linesStream, tracer, parseMode);
 				break;
 			}
 			case xtabPromptOptions.ResponseFormat.CustomDiffPatch: {
@@ -930,7 +926,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 						activeDoc.workspaceRoot,
 						pseudoEditWindow,
 						tracer,
-						getFetchFailure,
 					),
 				);
 				break;
@@ -950,7 +945,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					},
 					request.documentBeforeEdits,
 					tracer,
-					getFetchFailure,
 				);
 				break;
 			}
@@ -1039,13 +1033,6 @@ export class XtabProvider implements IStatelessNextEditProvider {
 					break;
 				}
 
-				{
-					const fetchFailure = getFetchFailure();
-					if (fetchFailure) {
-						return fetchFailure;
-					}
-				}
-
 				tracer.trace(`ResponseProcessor streamed edit #${i} with latency ${fetchRequestStopWatch.elapsed()} ms`);
 
 				const singleLineEdits: LineReplacement[] = [];
@@ -1104,18 +1091,13 @@ export class XtabProvider implements IStatelessNextEditProvider {
 				return new NoNextEditReason.GotCancelled('cursorLineDiverged');
 			}
 
-			{
-				const fetchFailure = getFetchFailure();
-				if (fetchFailure) {
-					return fetchFailure;
-				}
-			}
-
 			return new NoNextEditReason.NoSuggestions(request.documentBeforeEdits, editWindow);
 
 		} catch (err) {
+			if (err instanceof FetchStreamError) {
+				return err.reason;
+			}
 			logContext.setError(err);
-			// Properly handle the error by pushing it as a result
 			return new NoNextEditReason.Unexpected(ErrorUtils.fromUnknown(err));
 		}
 	}

--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -895,138 +895,138 @@ export class XtabProvider implements IStatelessNextEditProvider {
 
 		let parseResult: ResponseParseResult.t;
 
-		switch (responseOpts.responseFormat) {
-			case xtabPromptOptions.ResponseFormat.EditWindowOnly: {
-				parseResult = handleEditWindowOnly(linesStream);
-				break;
-			}
-			case xtabPromptOptions.ResponseFormat.CodeBlock: {
-				parseResult = handleCodeBlock(linesStream);
-				break;
-			}
-			case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntent:
-			case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort: {
-				const parseMode = responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort
-					? EditIntentParseMode.ShortName
-					: EditIntentParseMode.Tags;
-				parseResult = await handleEditWindowWithEditIntent(linesStream, tracer, parseMode);
-				break;
-			}
-			case xtabPromptOptions.ResponseFormat.CustomDiffPatch: {
-				const activeDoc = request.getActiveDocument();
-				const currentDocument = promptPieces.currentDocument;
-				const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
-				const lastLineLength = lastLine.length;
-				const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
-				parseResult = new ResponseParseResult.DirectEdits(
-					XtabCustomDiffPatchResponseHandler.handleResponse(
+		try {
+			switch (responseOpts.responseFormat) {
+				case xtabPromptOptions.ResponseFormat.EditWindowOnly: {
+					parseResult = handleEditWindowOnly(linesStream);
+					break;
+				}
+				case xtabPromptOptions.ResponseFormat.CodeBlock: {
+					parseResult = handleCodeBlock(linesStream);
+					break;
+				}
+				case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntent:
+				case xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort: {
+					const parseMode = responseOpts.responseFormat === xtabPromptOptions.ResponseFormat.EditWindowWithEditIntentShort
+						? EditIntentParseMode.ShortName
+						: EditIntentParseMode.Tags;
+					parseResult = await handleEditWindowWithEditIntent(linesStream, tracer, parseMode);
+					break;
+				}
+				case xtabPromptOptions.ResponseFormat.CustomDiffPatch: {
+					const activeDoc = request.getActiveDocument();
+					const currentDocument = promptPieces.currentDocument;
+					const lastLine = currentDocument.lines[clippedTaggedCurrentDoc.keptRange.endExclusive - 1];
+					const lastLineLength = lastLine.length;
+					const pseudoEditWindow = currentDocument.transformer.getOffsetRange(new Range(clippedTaggedCurrentDoc.keptRange.start + 1, 1, clippedTaggedCurrentDoc.keptRange.endExclusive, lastLineLength + 1));
+					parseResult = new ResponseParseResult.DirectEdits(
+						XtabCustomDiffPatchResponseHandler.handleResponse(
+							linesStream,
+							currentDocument,
+							activeDoc.id,
+							activeDoc.workspaceRoot,
+							pseudoEditWindow,
+							tracer,
+						),
+					);
+					break;
+				}
+				case xtabPromptOptions.ResponseFormat.UnifiedWithXml: {
+					parseResult = await handleUnifiedWithXml(
 						linesStream,
-						currentDocument,
-						activeDoc.id,
-						activeDoc.workspaceRoot,
-						pseudoEditWindow,
+						{
+							editWindowLines,
+							editWindowLineRange,
+							cursorOriginalLinesOffset,
+							cursorColumnZeroBased: promptPieces.currentDocument.cursorPosition.column - 1,
+							editWindow,
+							originalEditWindow,
+							targetDocument,
+							isFromCursorJump,
+						},
+						request.documentBeforeEdits,
 						tracer,
-					),
-				);
-				break;
+					);
+					break;
+				}
+				default:
+					assertNever(responseOpts.responseFormat);
 			}
-			case xtabPromptOptions.ResponseFormat.UnifiedWithXml: {
-				parseResult = await handleUnifiedWithXml(
-					linesStream,
-					{
-						editWindowLines,
-						editWindowLineRange,
-						cursorOriginalLinesOffset,
-						cursorColumnZeroBased: promptPieces.currentDocument.cursorPosition.column - 1,
-						editWindow,
-						originalEditWindow,
-						targetDocument,
-						isFromCursorJump,
-					},
-					request.documentBeforeEdits,
-					tracer,
-				);
-				break;
+
+			// Handle result uniformly
+			if (parseResult instanceof ResponseParseResult.Done) {
+				return parseResult.reason;
 			}
-			default:
-				assertNever(responseOpts.responseFormat);
-		}
 
-		// Handle result uniformly
-		if (parseResult instanceof ResponseParseResult.Done) {
-			return parseResult.reason;
-		}
-
-		if (parseResult instanceof ResponseParseResult.DirectEdits) {
-			return yield* parseResult.stream;
-		}
-
-		// parseResult is EditWindowLines — log edit-intent telemetry and apply aggressiveness filter
-		if (parseResult.editIntentMetadata) {
-			const { intent, parseError } = parseResult.editIntentMetadata;
-			telemetry.setEditIntent(intent);
-			if (parseError) {
-				telemetry.setEditIntentParseError(parseError);
+			if (parseResult instanceof ResponseParseResult.DirectEdits) {
+				return yield* parseResult.stream;
 			}
-			if (!xtabPromptOptions.EditIntent.shouldShowEdit(intent, promptPieces.aggressivenessLevel)) {
-				tracer.trace(`Filtered out edit due to edit intent "${intent}" with aggressiveness "${promptPieces.aggressivenessLevel}"`);
-				return new NoNextEditReason.FilteredOut(`editIntent:${intent} aggressivenessLevel:${promptPieces.aggressivenessLevel}`);
+
+			// parseResult is EditWindowLines — log edit-intent telemetry and apply aggressiveness filter
+			if (parseResult.editIntentMetadata) {
+				const { intent, parseError } = parseResult.editIntentMetadata;
+				telemetry.setEditIntent(intent);
+				if (parseError) {
+					telemetry.setEditIntentParseError(parseError);
+				}
+				if (!xtabPromptOptions.EditIntent.shouldShowEdit(intent, promptPieces.aggressivenessLevel)) {
+					tracer.trace(`Filtered out edit due to edit intent "${intent}" with aggressiveness "${promptPieces.aggressivenessLevel}"`);
+					return new NoNextEditReason.FilteredOut(`editIntent:${intent} aggressivenessLevel:${promptPieces.aggressivenessLevel}`);
+				}
 			}
-		}
 
-		const cleanedLinesStream = parseResult.lines;
+			const cleanedLinesStream = parseResult.lines;
 
-		const diffOptions: ResponseProcessor.DiffParams = {
-			emitFastCursorLineChange: ResponseProcessor.mapEmitFastCursorLineChange(this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderEmitFastCursorLineChange, this.expService)),
-			nLinesToConverge: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabNNonSignificantLinesToConverge, this.expService),
-			nSignificantLinesToConverge: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabNSignificantLinesToConverge, this.expService),
-		};
+			const diffOptions: ResponseProcessor.DiffParams = {
+				emitFastCursorLineChange: ResponseProcessor.mapEmitFastCursorLineChange(this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabProviderEmitFastCursorLineChange, this.expService)),
+				nLinesToConverge: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabNNonSignificantLinesToConverge, this.expService),
+				nSignificantLinesToConverge: this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabNSignificantLinesToConverge, this.expService),
+			};
 
-		tracer.trace(`starting to diff stream against edit window lines with latency ${fetchRequestStopWatch.elapsed()} ms`);
+			tracer.trace(`starting to diff stream against edit window lines with latency ${fetchRequestStopWatch.elapsed()} ms`);
 
-		// Wrap the line stream to detect early cursor-line divergence.
-		// If the user has typed at the cursor since the request started and the cursor line
-		// in the model's response doesn't match what the user currently has, the response
-		// is stale and we can cancel early instead of waiting for the full response.
-		//
-		// We check compatibility using `isModelCursorLineCompatible`: the user's
-		// cursor-line change must be contained within the model's cursor-line change range
-		// and match via the helper's `startsWith` / auto-close subsequence rules.
-		const earlyCursorLineDivergenceCancellation = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabEarlyCursorLineDivergenceCancellation, this.expService);
-		let cursorLineDiverged = false;
-		const divergenceCheckedStream: AsyncIterable<string> = earlyCursorLineDivergenceCancellation
-			? (async function* () {
-				let lineIdx = 0;
-				for await (const line of cleanedLinesStream) {
-					if (lineIdx === cursorOriginalLinesOffset) {
-						const intermediateEdit = request.intermediateUserEdit;
-						if (intermediateEdit && !intermediateEdit.isEmpty()) {
-							const cursorDocLineIdx = editWindowLineRange.start + cursorOriginalLinesOffset;
-							const currentCursorLine = getCurrentCursorLine(request.documentBeforeEdits.getTransformer(), cursorDocLineIdx, intermediateEdit);
-							if (currentCursorLine !== undefined) {
-								const originalCursorLine = editWindowLines[cursorOriginalLinesOffset];
-								if (currentCursorLine !== originalCursorLine // user changed the cursor line
-									&& !isModelCursorLineCompatible(originalCursorLine, currentCursorLine, line) // model's cursor line isn't compatible with user's typing
-								) {
-									cursorLineDiverged = true;
-									tracer.trace(`Cursor line DIVERGED: model="${line}" current="${currentCursorLine}"`);
-									// Cancel our local fetch token so the HTTP request is
-									// aborted immediately. We own this token, so this is safe.
-									fetchCts.cancel();
-									return;
+			// Wrap the line stream to detect early cursor-line divergence.
+			// If the user has typed at the cursor since the request started and the cursor line
+			// in the model's response doesn't match what the user currently has, the response
+			// is stale and we can cancel early instead of waiting for the full response.
+			//
+			// We check compatibility using `isModelCursorLineCompatible`: the user's
+			// cursor-line change must be contained within the model's cursor-line change range
+			// and match via the helper's `startsWith` / auto-close subsequence rules.
+			const earlyCursorLineDivergenceCancellation = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsXtabEarlyCursorLineDivergenceCancellation, this.expService);
+			let cursorLineDiverged = false;
+			const divergenceCheckedStream: AsyncIterable<string> = earlyCursorLineDivergenceCancellation
+				? (async function* () {
+					let lineIdx = 0;
+					for await (const line of cleanedLinesStream) {
+						if (lineIdx === cursorOriginalLinesOffset) {
+							const intermediateEdit = request.intermediateUserEdit;
+							if (intermediateEdit && !intermediateEdit.isEmpty()) {
+								const cursorDocLineIdx = editWindowLineRange.start + cursorOriginalLinesOffset;
+								const currentCursorLine = getCurrentCursorLine(request.documentBeforeEdits.getTransformer(), cursorDocLineIdx, intermediateEdit);
+								if (currentCursorLine !== undefined) {
+									const originalCursorLine = editWindowLines[cursorOriginalLinesOffset];
+									if (currentCursorLine !== originalCursorLine // user changed the cursor line
+										&& !isModelCursorLineCompatible(originalCursorLine, currentCursorLine, line) // model's cursor line isn't compatible with user's typing
+									) {
+										cursorLineDiverged = true;
+										tracer.trace(`Cursor line DIVERGED: model="${line}" current="${currentCursorLine}"`);
+										// Cancel our local fetch token so the HTTP request is
+										// aborted immediately. We own this token, so this is safe.
+										fetchCts.cancel();
+										return;
+									}
 								}
 							}
 						}
+						yield line;
+						lineIdx++;
 					}
-					yield line;
-					lineIdx++;
-				}
-			})()
-			: cleanedLinesStream;
+				})()
+				: cleanedLinesStream;
 
-		let i = 0;
-		let hasBeenDelayed = false;
-		try {
+			let i = 0;
+			let hasBeenDelayed = false;
 			for await (const edit of ResponseProcessor.diff(editWindowLines, divergenceCheckedStream, cursorOriginalLinesOffset, diffOptions)) {
 
 				if (cursorLineDiverged) {

--- a/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/responseFormatHandlers.spec.ts
@@ -11,6 +11,7 @@ import { ILogger } from '../../../../platform/log/common/logService';
 import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
 import { OffsetRange } from '../../../../util/vs/editor/common/core/ranges/offsetRange';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
+import { FetchStreamError } from '../../common/fetchStreamError';
 import { EditIntentParseMode } from '../../node/editIntent';
 import {
 	handleCodeBlock,
@@ -39,10 +40,6 @@ function createMockLogger(): ILogger {
 	} as unknown as ILogger;
 }
 
-function noFailure(): NoNextEditReason | undefined {
-	return undefined;
-}
-
 function makeInsertContext(overrides?: Partial<UnifiedXmlInsertContext>): UnifiedXmlInsertContext {
 	return {
 		editWindowLines: ['line0', 'cursor_line', 'line2'],
@@ -63,6 +60,16 @@ function makeDocBeforeEdits(): StringText {
 
 async function collectLines(iter: AsyncIterable<string>): Promise<string[]> {
 	return AsyncIterUtils.toArray(iter);
+}
+
+/**
+ * Creates an async iterable that yields `items` and then throws `error`.
+ */
+async function* asyncIterableWithError(items: string[], error: Error): AsyncGenerator<string> {
+	for (const item of items) {
+		yield item;
+	}
+	throw error;
 }
 
 async function consumeDirectEdits(
@@ -135,7 +142,6 @@ describe('handleEditWindowWithEditIntent', () => {
 			AsyncIterUtils.fromArray(input),
 			createMockLogger(),
 			EditIntentParseMode.Tags,
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
@@ -151,7 +157,6 @@ describe('handleEditWindowWithEditIntent', () => {
 			AsyncIterUtils.fromArray(input),
 			createMockLogger(),
 			EditIntentParseMode.ShortName,
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
@@ -159,17 +164,20 @@ describe('handleEditWindowWithEditIntent', () => {
 		expect(ewl.editIntentMetadata?.intent).toBe(EditIntent.Low);
 	});
 
-	it('returns Done when getFetchFailure fires', async () => {
+	it('propagates FetchStreamError through the remaining line stream', async () => {
 		const failureReason = new NoNextEditReason.GotCancelled('test');
 		const result = await handleEditWindowWithEditIntent(
-			AsyncIterUtils.fromArray(['<|edit_intent|>high<|/edit_intent|>', 'line1']),
+			asyncIterableWithError(
+				['<|edit_intent|>high<|/edit_intent|>', 'line1'],
+				new FetchStreamError(failureReason),
+			),
 			createMockLogger(),
 			EditIntentParseMode.Tags,
-			() => failureReason,
 		);
 
-		expect(result).toBeInstanceOf(ResponseParseResult.Done);
-		expect((result as ResponseParseResult.Done).reason).toBe(failureReason);
+		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
+		const ewl = result as ResponseParseResult.EditWindowLines;
+		await expect(collectLines(ewl.lines)).rejects.toThrow(FetchStreamError);
 	});
 
 	it('returns EditWindowLines with parseError on malformed intent', async () => {
@@ -178,7 +186,6 @@ describe('handleEditWindowWithEditIntent', () => {
 			AsyncIterUtils.fromArray(input),
 			createMockLogger(),
 			EditIntentParseMode.Tags,
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
@@ -201,7 +208,6 @@ describe('handleUnifiedWithXml', () => {
 			makeInsertContext(),
 			makeDocBeforeEdits(),
 			createMockLogger(),
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.Done);
@@ -214,7 +220,6 @@ describe('handleUnifiedWithXml', () => {
 			makeInsertContext(),
 			makeDocBeforeEdits(),
 			createMockLogger(),
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.Done);
@@ -227,25 +232,20 @@ describe('handleUnifiedWithXml', () => {
 			makeInsertContext(),
 			makeDocBeforeEdits(),
 			createMockLogger(),
-			noFailure,
 		);
 
 		expect(result).toBeInstanceOf(ResponseParseResult.Done);
 		expect((result as ResponseParseResult.Done).reason).toBeInstanceOf(NoNextEditReason.Unexpected);
 	});
 
-	it('fetch failure after first line returns Done', async () => {
+	it('FetchStreamError on first line read rejects handleUnifiedWithXml', async () => {
 		const failureReason = new NoNextEditReason.GotCancelled('test');
-		const result = await handleUnifiedWithXml(
-			AsyncIterUtils.fromArray(['<EDIT>', 'line1', '</EDIT>']),
+		await expect(handleUnifiedWithXml(
+			asyncIterableWithError([], new FetchStreamError(failureReason)),
 			makeInsertContext(),
 			makeDocBeforeEdits(),
 			createMockLogger(),
-			() => failureReason,
-		);
-
-		expect(result).toBeInstanceOf(ResponseParseResult.Done);
-		expect((result as ResponseParseResult.Done).reason).toBe(failureReason);
+		)).rejects.toThrow(FetchStreamError);
 	});
 
 	describe('<EDIT>', () => {
@@ -255,7 +255,6 @@ describe('handleUnifiedWithXml', () => {
 				makeInsertContext(),
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				noFailure,
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
@@ -269,7 +268,6 @@ describe('handleUnifiedWithXml', () => {
 				makeInsertContext(),
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				noFailure,
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
@@ -277,27 +275,22 @@ describe('handleUnifiedWithXml', () => {
 			expect(await collectLines(ewl.lines)).toEqual(['line1', 'line2']);
 		});
 
-		it('terminates early when getFetchFailure fires mid-stream', async () => {
-			let callCount = 0;
+		it('stream error terminates edit lines mid-stream', async () => {
 			const failureReason = new NoNextEditReason.GotCancelled('test');
 
 			const result = await handleUnifiedWithXml(
-				AsyncIterUtils.fromArray(['<EDIT>', 'line1', 'line2', 'line3', '</EDIT>']),
+				asyncIterableWithError(
+					['<EDIT>', 'line1'],
+					new FetchStreamError(failureReason),
+				),
 				makeInsertContext(),
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				() => {
-					callCount++;
-					// First call is from handleUnifiedWithXml (after first line read).
-					// Second call is inside generateEditLines before yielding line1 → passes.
-					// Third call is before yielding line2 → fails.
-					return callCount > 2 ? failureReason : undefined;
-				},
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.EditWindowLines);
 			const ewl = result as ResponseParseResult.EditWindowLines;
-			expect(await collectLines(ewl.lines)).toEqual(['line1']);
+			await expect(collectLines(ewl.lines)).rejects.toThrow(FetchStreamError);
 		});
 	});
 
@@ -309,7 +302,6 @@ describe('handleUnifiedWithXml', () => {
 				ctx,
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				noFailure,
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
@@ -333,7 +325,6 @@ describe('handleUnifiedWithXml', () => {
 				ctx,
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				noFailure,
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
@@ -352,7 +343,6 @@ describe('handleUnifiedWithXml', () => {
 				makeInsertContext(),
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				noFailure,
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
@@ -361,24 +351,22 @@ describe('handleUnifiedWithXml', () => {
 			expect(returnValue).toBeInstanceOf(NoNextEditReason.NoSuggestions);
 		});
 
-		it('returns fetch failure when it fires mid-INSERT', async () => {
+		it('stream error propagates through direct edits', async () => {
 			const failureReason = new NoNextEditReason.GotCancelled('test');
-			let callCount = 0;
 
 			const result = await handleUnifiedWithXml(
-				AsyncIterUtils.fromArray(['<INSERT>', 'inserted_text', 'more_text', '</INSERT>']),
+				asyncIterableWithError(
+					['<INSERT>', 'inserted_text'],
+					new FetchStreamError(failureReason),
+				),
 				makeInsertContext(),
 				makeDocBeforeEdits(),
 				createMockLogger(),
-				() => {
-					callCount++;
-					return callCount > 1 ? failureReason : undefined;
-				},
 			);
 
 			expect(result).toBeInstanceOf(ResponseParseResult.DirectEdits);
-			const { returnValue } = await consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream);
-			expect(returnValue).toBe(failureReason);
+			// The stream should throw FetchStreamError when trying to read after the second item
+			await expect(consumeDirectEdits((result as ResponseParseResult.DirectEdits).stream)).rejects.toThrow(FetchStreamError);
 		});
 	});
 });

--- a/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabCustomDiffPatchResponseHandler.spec.ts
@@ -8,9 +8,11 @@ import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/do
 import { NoNextEditReason, StreamedEdit } from '../../../../platform/inlineEdits/common/statelessNextEditProvider';
 import { TestLogService } from '../../../../platform/testing/common/testLogService';
 import { AsyncIterUtils } from '../../../../util/common/asyncIterableUtils';
+import { AsyncIterableSource } from '../../../../util/vs/base/common/async';
 import { Position } from '../../../../util/vs/editor/common/core/position';
 import { StringText } from '../../../../util/vs/editor/common/core/text/abstractText';
 import { ensureDependenciesAreSet } from '../../../../util/vs/editor/common/core/text/positionToOffset';
+import { FetchStreamError } from '../../common/fetchStreamError';
 import { CurrentDocument } from '../../common/xtabCurrentDocument';
 import { XtabCustomDiffPatchResponseHandler } from '../../node/xtabCustomDiffPatchResponseHandler';
 
@@ -139,67 +141,50 @@ another_file.js:
 		`);
 	});
 
-	it('stops yielding edits when getFetchFailure returns a failure', async () => {
-		const patchText = `/file.ts:0
--old
-+new
-/file.ts:5
--another old
-+another new`;
-		const linesStream = AsyncIterUtils.fromArray(patchText.split('\n'));
+	it('stops yielding edits when stream rejects with FetchStreamError', async () => {
+		const cancellationReason = new NoNextEditReason.GotCancelled('afterFetchCall');
 		const docId = DocumentId.create('file:///file.ts');
 		const documentBeforeEdits = new CurrentDocument(new StringText('old\n'), new Position(1, 1));
 
-		let yieldCount = 0;
-		const cancellationReason = new NoNextEditReason.GotCancelled('afterFetchCall');
+		// Emit the first patch completely, then reject with FetchStreamError
+		async function* makeStream(): AsyncGenerator<string> {
+			yield '/file.ts:0';
+			yield '-old';
+			yield '+new';
+			yield '/file.ts:5';
+			yield '-another old';
+			yield '+another new';
+			throw new FetchStreamError(cancellationReason);
+		}
 
 		const { edits, returnValue } = await consumeHandleResponse(
-			linesStream,
+			makeStream(),
 			documentBeforeEdits,
 			docId,
 			undefined,
 			undefined,
 			new TestLogService(),
-			() => {
-				// Signal failure after the first edit has been yielded
-				if (yieldCount++ > 0) {
-					return cancellationReason;
-				}
-				return undefined;
-			},
 		);
 
 		expect(edits).toHaveLength(1);
-		expect(returnValue).toBe(cancellationReason);
+		expect(returnValue).toEqual(cancellationReason);
 	});
 
-	it('does not yield incomplete patch when fetch is cancelled mid-stream', async () => {
-		// Stream is truncated before the last line "+one more new" is emitted,
-		// simulating a cancellation that cuts off the response mid-patch.
-		const truncatedPatchText = `/file.ts:0
--old
-+new
-/file.ts:5
--another old
-+another new`;
-		const linesStream = AsyncIterUtils.fromArray(truncatedPatchText.split('\n'));
+	it('returns FetchStreamError reason when stream rejects before any patches', async () => {
+		const cancellationReason = new NoNextEditReason.GotCancelled('afterFetchCall');
 		const docId = DocumentId.create('file:///file.ts');
 		const documentBeforeEdits = new CurrentDocument(new StringText('old\n'), new Position(1, 1));
 
-		const cancellationReason = new NoNextEditReason.GotCancelled('afterFetchCall');
+		const source = new AsyncIterableSource<string>();
+		source.reject(new FetchStreamError(cancellationReason));
 
 		const { edits, returnValue } = await consumeHandleResponse(
-			linesStream,
+			source.asyncIterable,
 			documentBeforeEdits,
 			docId,
 			undefined,
 			undefined,
 			new TestLogService(),
-			() => {
-				// Fetch was cancelled — the full patch had "+one more new" but the
-				// stream was resolved early so it's missing from the second patch.
-				return cancellationReason;
-			},
 		);
 
 		expect(edits).toHaveLength(0);

--- a/extensions/copilot/src/platform/chat/common/chatMLFetcher.ts
+++ b/extensions/copilot/src/platform/chat/common/chatMLFetcher.ts
@@ -109,6 +109,11 @@ export class FetchStreamSource {
 
 		this._stream.resolve();
 	}
+
+	reject(error: Error): void {
+		this._paused = undefined;
+		this._stream.reject(error);
+	}
 }
 
 export class FetchStreamRecorder {


### PR DESCRIPTION
Fixes #308745

## Summary

Replaces the fragile `chatResponseFailure` mutable variable + `getFetchFailure()` polling pattern with stream-level error propagation in the XtabProvider's NES streaming pipeline.

## What changed

**Core mechanism:** `FetchStreamSource` gains a `reject(error)` method that delegates to `AsyncIterableSource.reject()`, propagating errors through the async iterable stream. A new `FetchStreamError` class carries the mapped `NoNextEditReason` so catch sites can extract it cleanly.

**`_performFetch`:** Now calls `fetchStreamSource.reject()` on fetch failure and `fetchStreamSource.resolve()` on success — replacing the pattern of setting a mutable `chatResponseFailure` variable and calling `resolve()` in `.finally()`.

**Removed polling:** All ~7 `getFetchFailure()` call sites across `_streamEditsImpl`, `handleEditWindowWithEditIntent`, `handleUnifiedWithXml`, `generateInsertEdits`, `generateEditLines`, and `XtabCustomDiffPatchResponseHandler.handleResponse` have been removed.

**Error handling:** Two catch sites handle `FetchStreamError`:
- `_streamEditsImpl` — the main orchestrator loop
- `XtabCustomDiffPatchResponseHandler.handleResponse` — has its own `for await` loop

## Layering

`FetchStreamError` lives in `extension/xtab/common/` (same layer as its consumers), keeping `platform/chat` free of `platform/inlineEdits` dependencies.

## Testing

- Updated 6 tests in `responseFormatHandlers.spec.ts` and `xtabCustomDiffPatchResponseHandler.spec.ts` to use stream-based error injection instead of polling callbacks
- All 163 tests pass (3 pre-existing failures unrelated to this change)
- TypeScript compiles cleanly

## Result

Net −58 lines (97 added, 155 removed). Error propagation is now structural rather than polling-based, making it impossible to miss a failure check.