### PR TITLE
Add auto-approve session config for agent host

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -169,10 +169,20 @@ export class AgentSideEffects extends Disposable {
 		sessionKey: ProtocolURI,
 		agent: IAgent,
 	): boolean {
+		// Session-level auto-approve: when the user has set "Bypass Approvals"
+		// or "Autopilot", auto-approve all tool calls unconditionally.
+		const sessionState = this._stateManager.getSessionState(sessionKey);
+		const autoApproveLevel = sessionState?.config?.values?.autoApprove;
+		if (autoApproveLevel === 'autoApprove' || autoApproveLevel === 'autopilot') {
+			this._logService.trace(`[AgentSideEffects] Auto-approving tool call (session autoApprove=${autoApproveLevel})`);
+			this._toolCallAgents.delete(`${sessionKey}:${e.toolCallId}`);
+			agent.respondToPermissionRequest(e.toolCallId, true);
+			return true;
+		}
+
 		// Write auto-approval: only within the session's working directory,
 		// then apply the default glob patterns for protected files.
 		if (e.permissionKind === 'write' && e.permissionPath) {
-			const sessionState = this._stateManager.getSessionState(sessionKey);
 			const workDir = sessionState?.workingDirectory ?? sessionState?.summary.workingDirectory;
 			const workingDirectory = workDir ? URI.parse(workDir) : undefined;
 			if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(URI.file(e.permissionPath)), workingDirectory)) {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -304,7 +304,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 			? params.config.isolation
 			: gitInfo ? 'worktree' : 'folder';
 
-		const values: Record<string, string> = { isolation: isolationValue };
+		const autoApproveValue = params.config?.autoApprove === 'default' || params.config?.autoApprove === 'autoApprove' || params.config?.autoApprove === 'autopilot'
+			? params.config.autoApprove
+			: 'default';
+
+		const values: Record<string, string> = { isolation: isolationValue, autoApprove: autoApproveValue };
 		if (gitInfo) {
 			values.branch = typeof params.config?.branch === 'string' && isolationValue === 'worktree'
 				? params.config.branch
@@ -321,6 +325,24 @@ export class CopilotAgent extends Disposable implements IAgent {
 				enumDescriptions: gitInfo ? [localize('agentHost.sessionConfig.isolation.folderDescription', "Work directly in the folder"), localize('agentHost.sessionConfig.isolation.worktreeDescription', "Create a Git worktree for isolation")] : [localize('agentHost.sessionConfig.isolation.folderDescription', "Work directly in the folder")],
 				default: gitInfo ? 'worktree' : 'folder',
 				readOnly: !gitInfo,
+			},
+			autoApprove: {
+				type: 'string',
+				title: localize('agentHost.sessionConfig.autoApprove', "Approvals"),
+				description: localize('agentHost.sessionConfig.autoApproveDescription', "Tool approval behavior for this session"),
+				enum: ['default', 'autoApprove', 'autopilot'],
+				enumLabels: [
+					localize('agentHost.sessionConfig.autoApprove.default', "Default Approvals"),
+					localize('agentHost.sessionConfig.autoApprove.bypass', "Bypass Approvals"),
+					localize('agentHost.sessionConfig.autoApprove.autopilot', "Autopilot (Preview)"),
+				],
+				enumDescriptions: [
+					localize('agentHost.sessionConfig.autoApprove.defaultDescription', "Copilot uses your configured settings"),
+					localize('agentHost.sessionConfig.autoApprove.bypassDescription', "All tool calls are auto-approved"),
+					localize('agentHost.sessionConfig.autoApprove.autopilotDescription', "Autonomously iterates from start to finish"),
+				],
+				default: 'default',
+				sessionMutable: true,
 			},
 		};
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -602,6 +602,155 @@ suite('AgentSideEffects', () => {
 		});
 	});
 
+	// ---- Session-level auto-approve (config) ----------------------------
+
+	suite('session config auto-approve', () => {
+
+		function setupSessionWithConfig(autoApproveLevel: string): void {
+			setupSession(URI.file('/workspace').toString());
+			// Set config on the session state directly (as agentService.ts does)
+			const state = stateManager.getSessionState(sessionUri.toString());
+			if (state) {
+				state.config = {
+					schema: {
+						type: 'object',
+						properties: {
+							autoApprove: {
+								type: 'string',
+								title: 'Approvals',
+								enum: ['default', 'autoApprove', 'autopilot'],
+								default: 'default',
+								sessionMutable: true,
+							},
+						},
+					},
+					values: { autoApprove: autoApproveLevel },
+				};
+			}
+		}
+
+		test('auto-approves all writes when autoApprove is set to bypass', () => {
+			setupSessionWithConfig('autoApprove');
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-bypass-1',
+				toolName: 'write',
+				displayName: 'Write',
+				invocationMessage: 'Write .env',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-bypass-1',
+				invocationMessage: 'Write .env',
+				permissionKind: 'write',
+				permissionPath: '/workspace/.env',
+			});
+
+			// .env would normally be blocked, but session-level auto-approve overrides
+			assert.deepStrictEqual(agent.respondToPermissionCalls, [
+				{ requestId: 'tc-bypass-1', approved: true },
+			]);
+		});
+
+		test('auto-approves shell commands when autoApprove is set to autopilot', () => {
+			setupSessionWithConfig('autopilot');
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-ap-shell-1',
+				toolName: 'shell',
+				displayName: 'Shell',
+				invocationMessage: 'Run rm -rf /',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-ap-shell-1',
+				invocationMessage: 'Run rm -rf /',
+				permissionKind: 'shell',
+				toolInput: 'rm -rf /',
+			});
+
+			// Dangerous command would normally be blocked, but session-level auto-approve overrides
+			assert.deepStrictEqual(agent.respondToPermissionCalls, [
+				{ requestId: 'tc-ap-shell-1', approved: true },
+			]);
+		});
+
+		test('does NOT auto-approve when autoApprove is default', () => {
+			setupSessionWithConfig('default');
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-default-1',
+				toolName: 'write',
+				displayName: 'Write',
+				invocationMessage: 'Write .env',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-default-1',
+				invocationMessage: 'Write .env',
+				permissionKind: 'write',
+				permissionPath: '/workspace/.env',
+			});
+
+			// .env should still be blocked with default config
+			assert.strictEqual(agent.respondToPermissionCalls.length, 0);
+		});
+
+		test('respects mid-session config change via SessionConfigChanged', () => {
+			setupSessionWithConfig('default');
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			// Change to bypass mid-session
+			stateManager.dispatchServerAction({
+				type: ActionType.SessionConfigChanged,
+				session: sessionUri.toString(),
+				config: { autoApprove: 'autoApprove' },
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-mid-1',
+				toolName: 'write',
+				displayName: 'Write',
+				invocationMessage: 'Write .env',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-mid-1',
+				invocationMessage: 'Write .env',
+				permissionKind: 'write',
+				permissionPath: '/workspace/.env',
+			});
+
+			// Should now be auto-approved after config change
+			assert.deepStrictEqual(agent.respondToPermissionCalls, [
+				{ requestId: 'tc-mid-1', approved: true },
+			]);
+		});
+	});
+
 	// ---- Edit auto-approve ----------------------------------------------
 
 	suite('edit auto-approve', () => {

--- a/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
@@ -276,7 +276,7 @@ class AgentHostSessionConfigPicker extends Disposable {
 		}
 
 		for (const [property, schema] of Object.entries(resolvedConfig.schema.properties)) {
-			if (property === AgentHostSessionConfigBranchNameHintKey) {
+			if (property === AgentHostSessionConfigBranchNameHintKey || property === AUTO_APPROVE_PROPERTY) {
 				continue;
 			}
 			const value = resolvedConfig.values[property] ?? schema.default;
@@ -422,6 +422,11 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 			() => new PickerActionViewItem(instantiationService.createInstance(AgentHostSessionConfigPicker)),
 		));
 		this._register(actionViewItemService.register(
+			Menus.NewSessionControl,
+			NEW_SESSION_APPROVE_PICKER_ID,
+			() => new PickerActionViewItem(instantiationService.createInstance(AgentHostNewSessionApprovePicker)),
+		));
+		this._register(actionViewItemService.register(
 			MenuId.ChatInputSecondary,
 			RUNNING_SESSION_CONFIG_PICKER_ID,
 			() => new PickerActionViewItem(instantiationService.createInstance(AgentHostRunningSessionConfigPicker)),
@@ -429,7 +434,179 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 	}
 }
 
-// ---- Running session config picker (titlebar) ----
+// ---- New session auto-approve picker (left side, NewSessionControl) ----
+
+const NEW_SESSION_APPROVE_PICKER_ID = 'sessions.agentHost.newSessionApprovePicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: NEW_SESSION_APPROVE_PICKER_ID,
+			title: localize2('agentHostNewSessionApprovePicker', "Session Approvals"),
+			f1: false,
+			menu: [{
+				id: Menus.NewSessionControl,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.or(IsActiveSessionLocalAgentHost, IsActiveSessionRemoteAgentHost),
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
+/**
+ * Renders the auto-approve picker in the new session welcome view (left side).
+ * Only renders the autoApprove property from the session config.
+ */
+class AgentHostNewSessionApprovePicker extends Disposable {
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private readonly _providerListeners = this._register(new DisposableMap<string>());
+	private _container: HTMLElement | undefined;
+
+	constructor(
+		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IDialogService private readonly _dialogService: IDialogService,
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (session) {
+				session.loading.read(reader);
+			}
+			this._render();
+		}));
+
+		this._register(this._sessionsProvidersService.onDidChangeProviders(e => {
+			for (const provider of e.removed) {
+				this._providerListeners.deleteAndDispose(provider.id);
+			}
+			this._watchProviders(e.added);
+			this._render();
+		}));
+		this._watchProviders(this._sessionsProvidersService.getProviders());
+	}
+
+	private _watchProviders(providers: readonly ISessionsProvider[]): void {
+		for (const provider of providers) {
+			if (!provider.onDidChangeSessionConfig || this._providerListeners.has(provider.id)) {
+				continue;
+			}
+			this._providerListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._render()));
+		}
+	}
+
+	render(container: HTMLElement): void {
+		this._container = dom.append(container, dom.$('.sessions-chat-agent-host-config'));
+		this._render();
+	}
+
+	private _render(): void {
+		if (!this._container) {
+			return;
+		}
+
+		this._renderDisposables.clear();
+		dom.clearNode(this._container);
+
+		const session = this._sessionsManagementService.activeSession.get();
+		const provider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const config = session && provider?.getSessionConfig?.(session.sessionId);
+		if (!session || !provider || !config) {
+			return;
+		}
+
+		const schema = config.schema.properties[AUTO_APPROVE_PROPERTY];
+		if (!schema) {
+			return;
+		}
+
+		const value = config.values[AUTO_APPROVE_PROPERTY] ?? schema.default;
+		const slot = dom.append(this._container, dom.$('.sessions-chat-picker-slot'));
+		const trigger = renderPickerTrigger(slot, false, this._renderDisposables, () => this._showPicker(provider, session.sessionId, schema, trigger));
+		this._renderTrigger(trigger, schema, value);
+	}
+
+	private _renderTrigger(trigger: HTMLElement, schema: ISessionConfigPropertySchema, value: string | undefined): void {
+		dom.clearNode(trigger);
+		const icon = getConfigIcon(AUTO_APPROVE_PROPERTY, value);
+		if (icon) {
+			dom.append(trigger, renderIcon(icon));
+		}
+		const labelSpan = dom.append(trigger, dom.$('span.sessions-chat-dropdown-label'));
+		const label = this._getLabel(schema, value);
+		labelSpan.textContent = label;
+		trigger.setAttribute('aria-label', localize('agentHostNewSessionApprove.triggerAria', "{0}: {1}", schema.title, label));
+		dom.append(trigger, renderIcon(Codicon.chevronDown));
+		applyAutoApproveTriggerStyles(trigger, AUTO_APPROVE_PROPERTY, value);
+	}
+
+	private async _showPicker(provider: ISessionsProvider, sessionId: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
+		if (this._actionWidgetService.isVisible) {
+			return;
+		}
+
+		const rawItems = (schema.enum ?? []).map((value, index) => ({
+			value,
+			label: schema.enumLabels?.[index] ?? value,
+			description: schema.enumDescriptions?.[index],
+		}));
+
+		const { items, policyRestricted } = applyAutoApproveFiltering(rawItems, AUTO_APPROVE_PROPERTY, this._configurationService);
+
+		if (items.length === 0) {
+			return;
+		}
+
+		const currentValue = provider.getSessionConfig?.(sessionId)?.values[AUTO_APPROVE_PROPERTY];
+		const actionItems = toActionItems(AUTO_APPROVE_PROPERTY, items, currentValue, policyRestricted);
+
+		const delegate: IActionListDelegate<IConfigPickerItem> = {
+			onSelect: async item => {
+				this._actionWidgetService.hide();
+
+				if (item.value === 'autoApprove' || item.value === 'autopilot') {
+					const confirmed = await confirmAutoApproveLevel(item.value, this._dialogService);
+					if (!confirmed) {
+						return;
+					}
+				}
+
+				provider.setSessionConfigValue?.(sessionId, AUTO_APPROVE_PROPERTY, item.value).catch(() => { /* best-effort */ });
+			},
+			onHide: () => trigger.focus(),
+		};
+
+		this._actionWidgetService.show<IConfigPickerItem>(
+			`agentHostNewSessionConfig.${AUTO_APPROVE_PROPERTY}`,
+			false,
+			actionItems,
+			delegate,
+			trigger,
+			undefined,
+			[],
+			{
+				getAriaLabel: item => item.label ?? '',
+				getWidgetAriaLabel: () => localize('agentHostNewSessionApprove.ariaLabel', "{0} Picker", schema.title),
+			},
+		);
+	}
+
+	private _getLabel(schema: ISessionConfigPropertySchema, value: string | undefined): string {
+		if (typeof value === 'string') {
+			const index = schema.enum?.indexOf(value) ?? -1;
+			return index >= 0 ? schema.enumLabels?.[index] ?? value : value;
+		}
+		return schema.title;
+	}
+}
+
+// ---- Running session config picker (ChatInputSecondary) ----
 
 const RUNNING_SESSION_CONFIG_PICKER_ID = 'sessions.agentHost.runningSessionConfigPicker';
 

--- a/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
@@ -11,16 +11,22 @@ import { IActionWidgetService } from '../../../../platform/actionWidget/browser/
 import { BaseActionViewItem } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Delayer } from '../../../../base/common/async.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
+import Severity from '../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { AgentHostSessionConfigBranchNameHintKey } from '../../../../platform/agentHost/common/agentService.js';
 import type { ISessionConfigPropertySchema, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
+import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
+import { ChatContextKeyExprs } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { Menus } from '../../../browser/menus.js';
 import { ActiveSessionProviderIdContext } from '../../../common/contextkeys.js';
@@ -67,15 +73,25 @@ function getConfigIcon(property: string, value: string | undefined): ThemeIcon |
 	if (property === 'branch') {
 		return Codicon.gitBranch;
 	}
+	if (property === 'autoApprove') {
+		if (value === 'autopilot') {
+			return Codicon.rocket;
+		}
+		if (value === 'autoApprove') {
+			return Codicon.warning;
+		}
+		return Codicon.shield;
+	}
 	return undefined;
 }
 
-function toActionItems(property: string, items: readonly IConfigPickerItem[], currentValue: string | undefined): IActionListItem<IConfigPickerItem>[] {
+function toActionItems(property: string, items: readonly IConfigPickerItem[], currentValue: string | undefined, policyRestricted?: boolean): IActionListItem<IConfigPickerItem>[] {
 	return items.map(item => ({
 		kind: ActionListItemKind.Action,
 		label: item.label,
 		description: item.description,
 		group: { title: '', icon: getConfigIcon(property, item.value) },
+		disabled: policyRestricted && (item.value === 'autoApprove' || item.value === 'autopilot'),
 		item: { ...item, label: item.value === currentValue ? `${item.label} ${localize('selected', "(Selected)")}` : item.label },
 	}));
 }
@@ -104,6 +120,98 @@ function renderPickerTrigger(slot: HTMLElement, disabled: boolean, disposables: 
 	return trigger;
 }
 
+/**
+ * Special-cased property name for auto-approve session config.
+ * Used to apply confirmation dialogs and policy enforcement.
+ */
+const AUTO_APPROVE_PROPERTY = 'autoApprove';
+
+// Track whether auto-approve warnings have been shown this VS Code session
+const shownAutoApproveWarnings = new Set<string /* enum value */>();
+
+function hasShownAutoApproveWarning(value: string): boolean {
+	if (shownAutoApproveWarnings.has(value)) {
+		return true;
+	}
+	// Confirming Autopilot implies the user accepted the Bypass risks too
+	if (value === 'autoApprove' && shownAutoApproveWarnings.has('autopilot')) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Filters out autopilot if disabled, and marks bypass/autopilot as disabled
+ * if enterprise policy restricts auto-approval. Returns the filtered items
+ * and policy state.
+ */
+function applyAutoApproveFiltering(
+	items: readonly IConfigPickerItem[],
+	property: string,
+	configurationService: IConfigurationService,
+): { readonly items: readonly IConfigPickerItem[]; readonly policyRestricted: boolean } {
+	if (property !== AUTO_APPROVE_PROPERTY) {
+		return { items, policyRestricted: false };
+	}
+	const isAutopilotEnabled = configurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
+	const policyRestricted = configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
+	const filtered = isAutopilotEnabled ? items : items.filter(item => item.value !== 'autopilot');
+	return { items: filtered, policyRestricted };
+}
+
+/**
+ * Shows a confirmation dialog for elevated auto-approve levels.
+ * Returns true if confirmed or if the warning was already shown this session.
+ */
+async function confirmAutoApproveLevel(value: string, dialogService: IDialogService): Promise<boolean> {
+	if (hasShownAutoApproveWarning(value)) {
+		return true;
+	}
+
+	const isAutopilot = value === 'autopilot';
+	const result = await dialogService.prompt({
+		type: Severity.Warning,
+		message: isAutopilot
+			? localize('agentHostAutoApprove.autopilot.warning.title', "Enable Autopilot?")
+			: localize('agentHostAutoApprove.bypass.warning.title', "Enable Bypass Approvals?"),
+		buttons: [
+			{
+				label: localize('agentHostAutoApprove.warning.confirm', "Enable"),
+				run: () => true,
+			},
+			{
+				label: localize('agentHostAutoApprove.warning.cancel', "Cancel"),
+				run: () => false,
+			},
+		],
+		custom: {
+			icon: isAutopilot ? Codicon.rocket : Codicon.warning,
+			markdownDetails: [{
+				markdown: new MarkdownString(isAutopilot
+					? localize('agentHostAutoApprove.autopilot.warning.detail', "Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")
+					: localize('agentHostAutoApprove.bypass.warning.detail', "Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.")),
+			}],
+		},
+	});
+
+	if (result.result !== true) {
+		return false;
+	}
+
+	shownAutoApproveWarnings.add(value);
+	return true;
+}
+
+/**
+ * Applies warning/info CSS classes to a trigger element for auto-approve levels.
+ */
+function applyAutoApproveTriggerStyles(trigger: HTMLElement, property: string | undefined, value: string | undefined): void {
+	if (property === AUTO_APPROVE_PROPERTY) {
+		trigger.classList.toggle('warning', value === 'autopilot');
+		trigger.classList.toggle('info', value === 'autoApprove');
+	}
+}
+
 class AgentHostSessionConfigPicker extends Disposable {
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
@@ -113,6 +221,8 @@ class AgentHostSessionConfigPicker extends Disposable {
 
 	constructor(
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IDialogService private readonly _dialogService: IDialogService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
 	) {
@@ -191,23 +301,34 @@ class AgentHostSessionConfigPicker extends Disposable {
 		if (!schema.readOnly) {
 			dom.append(trigger, renderIcon(Codicon.chevronDown));
 		}
+		applyAutoApproveTriggerStyles(trigger, property, value);
 	}
 
 	private async _showPicker(provider: ISessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
 		if (schema.readOnly || this._actionWidgetService.isVisible) {
 			return;
 		}
-		const items = await this._getItems(provider, sessionId, property, schema);
+		const rawItems = await this._getItems(provider, sessionId, property, schema);
+		const { items, policyRestricted } = applyAutoApproveFiltering(rawItems, property, this._configurationService);
 		if (items.length === 0) {
 			return;
 		}
 
+		const isAutoApproveProperty = property === AUTO_APPROVE_PROPERTY;
 		const currentValue = provider.getSessionConfig?.(sessionId)?.values[property];
-		const actionItems = toActionItems(property, items, currentValue);
+		const actionItems = toActionItems(property, items, currentValue, policyRestricted);
 
 		const delegate: IActionListDelegate<IConfigPickerItem> = {
-			onSelect: item => {
+			onSelect: async item => {
 				this._actionWidgetService.hide();
+
+				if (isAutoApproveProperty && (item.value === 'autoApprove' || item.value === 'autopilot')) {
+					const confirmed = await confirmAutoApproveLevel(item.value, this._dialogService);
+					if (!confirmed) {
+						return;
+					}
+				}
+
 				provider.setSessionConfigValue?.(sessionId, property, item.value).catch(() => { /* best-effort */ });
 			},
 			onFilter: schema.enumDynamic && provider.getSessionConfigCompletions
@@ -268,8 +389,12 @@ class AgentHostSessionConfigPicker extends Disposable {
 	}
 }
 
+interface IConfigPickerWidget extends IDisposable {
+	render(container: HTMLElement): void;
+}
+
 class PickerActionViewItem extends BaseActionViewItem {
-	constructor(private readonly _picker: AgentHostSessionConfigPicker) {
+	constructor(private readonly _picker: IConfigPickerWidget) {
 		super(undefined, { id: '', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } });
 	}
 
@@ -296,6 +421,185 @@ class AgentHostSessionConfigPickerContribution extends Disposable implements IWo
 			'sessions.agentHost.sessionConfigPicker',
 			() => new PickerActionViewItem(instantiationService.createInstance(AgentHostSessionConfigPicker)),
 		));
+		this._register(actionViewItemService.register(
+			MenuId.ChatInputSecondary,
+			RUNNING_SESSION_CONFIG_PICKER_ID,
+			() => new PickerActionViewItem(instantiationService.createInstance(AgentHostRunningSessionConfigPicker)),
+		));
+	}
+}
+
+// ---- Running session config picker (titlebar) ----
+
+const RUNNING_SESSION_CONFIG_PICKER_ID = 'sessions.agentHost.runningSessionConfigPicker';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RUNNING_SESSION_CONFIG_PICKER_ID,
+			title: localize2('agentHostRunningSessionConfigPicker', "Session Approvals"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatInputSecondary,
+				group: 'navigation',
+				order: 10,
+				when: ChatContextKeyExprs.isAgentHostSession,
+			}],
+		});
+	}
+
+	override async run(): Promise<void> { }
+});
+
+/**
+ * Renders a single picker trigger in the titlebar for the auto-approve session
+ * config property during a running agent host session.
+ */
+class AgentHostRunningSessionConfigPicker extends Disposable {
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private readonly _providerListeners = this._register(new DisposableMap<string>());
+	private _container: HTMLElement | undefined;
+
+	constructor(
+		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IDialogService private readonly _dialogService: IDialogService,
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService private readonly _sessionsProvidersService: ISessionsProvidersService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (session) {
+				session.loading.read(reader);
+			}
+			this._render();
+		}));
+
+		this._register(this._sessionsProvidersService.onDidChangeProviders(e => {
+			for (const provider of e.removed) {
+				this._providerListeners.deleteAndDispose(provider.id);
+			}
+			this._watchProviders(e.added);
+			this._render();
+		}));
+		this._watchProviders(this._sessionsProvidersService.getProviders());
+	}
+
+	private _watchProviders(providers: readonly ISessionsProvider[]): void {
+		for (const provider of providers) {
+			if (!provider.onDidChangeSessionConfig || this._providerListeners.has(provider.id)) {
+				continue;
+			}
+			this._providerListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._render()));
+		}
+	}
+
+	render(container: HTMLElement): void {
+		this._container = dom.append(container, dom.$('.sessions-chat-agent-host-config'));
+		this._render();
+	}
+
+	private _render(): void {
+		if (!this._container) {
+			return;
+		}
+
+		this._renderDisposables.clear();
+		dom.clearNode(this._container);
+
+		const session = this._sessionsManagementService.activeSession.get();
+		const provider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const config = session && provider?.getSessionConfig?.(session.sessionId);
+		if (!session || !provider || !config) {
+			return;
+		}
+
+		// Only render session-mutable properties (i.e., autoApprove)
+		for (const [property, schema] of Object.entries(config.schema.properties)) {
+			if (!schema.sessionMutable) {
+				continue;
+			}
+			const value = config.values[property] ?? schema.default;
+			const slot = dom.append(this._container, dom.$('.sessions-chat-picker-slot'));
+			const trigger = renderPickerTrigger(slot, false, this._renderDisposables, () => this._showPicker(provider, session.sessionId, property, schema, trigger));
+			this._renderTrigger(trigger, schema, value, property);
+		}
+	}
+
+	private _renderTrigger(trigger: HTMLElement, schema: ISessionConfigPropertySchema, value: string | undefined, property: string): void {
+		dom.clearNode(trigger);
+		const icon = getConfigIcon(property, value);
+		if (icon) {
+			dom.append(trigger, renderIcon(icon));
+		}
+		const labelSpan = dom.append(trigger, dom.$('span.sessions-chat-dropdown-label'));
+		const label = this._getLabel(schema, value);
+		labelSpan.textContent = label;
+		trigger.setAttribute('aria-label', localize('agentHostRunningSessionConfig.triggerAria', "{0}: {1}", schema.title, label));
+		dom.append(trigger, renderIcon(Codicon.chevronDown));
+		applyAutoApproveTriggerStyles(trigger, property, value);
+	}
+
+	private async _showPicker(provider: ISessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
+		if (this._actionWidgetService.isVisible) {
+			return;
+		}
+
+		const rawItems = (schema.enum ?? []).map((value, index) => ({
+			value,
+			label: schema.enumLabels?.[index] ?? value,
+			description: schema.enumDescriptions?.[index],
+		}));
+
+		const { items, policyRestricted } = applyAutoApproveFiltering(rawItems, property, this._configurationService);
+		const isAutoApproveProperty = property === AUTO_APPROVE_PROPERTY;
+
+		if (items.length === 0) {
+			return;
+		}
+
+		const currentValue = provider.getSessionConfig?.(sessionId)?.values[property];
+		const actionItems = toActionItems(property, items, currentValue, policyRestricted);
+
+		const delegate: IActionListDelegate<IConfigPickerItem> = {
+			onSelect: async item => {
+				this._actionWidgetService.hide();
+
+				if (isAutoApproveProperty && (item.value === 'autoApprove' || item.value === 'autopilot')) {
+					const confirmed = await confirmAutoApproveLevel(item.value, this._dialogService);
+					if (!confirmed) {
+						return;
+					}
+				}
+
+				provider.setSessionConfigValue?.(sessionId, property, item.value).catch(() => { /* best-effort */ });
+			},
+			onHide: () => trigger.focus(),
+		};
+
+		this._actionWidgetService.show<IConfigPickerItem>(
+			`agentHostRunningSessionConfig.${property}`,
+			false,
+			actionItems,
+			delegate,
+			trigger,
+			undefined,
+			[],
+			{
+				getAriaLabel: item => item.label ?? '',
+				getWidgetAriaLabel: () => localize('agentHostRunningSessionConfig.ariaLabel', "{0} Picker", schema.title),
+			},
+		);
+	}
+
+	private _getLabel(schema: ISessionConfigPropertySchema, value: string | undefined): string {
+		if (typeof value === 'string') {
+			const index = schema.enum?.indexOf(value) ?? -1;
+			return index >= 0 ? schema.enumLabels?.[index] ?? value : value;
+		}
+		return schema.title;
 	}
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/agentHostSessionConfigPicker.css
+++ b/src/vs/sessions/contrib/chat/browser/media/agentHostSessionConfigPicker.css
@@ -12,3 +12,19 @@
 .sessions-chat-agent-host-config:empty {
 	display: none;
 }
+
+.sessions-chat-agent-host-config .action-label.warning {
+	color: var(--vscode-problemsWarningIcon-foreground);
+}
+
+.sessions-chat-agent-host-config .action-label.warning .codicon {
+	color: var(--vscode-problemsWarningIcon-foreground) !important;
+}
+
+.sessions-chat-agent-host-config .action-label.info {
+	color: var(--vscode-problemsInfoIcon-foreground);
+}
+
+.sessions-chat-agent-host-config .action-label.info .codicon {
+	color: var(--vscode-problemsInfoIcon-foreground) !important;
+}

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -34,6 +34,27 @@ const LOCAL_PROVIDER_ID = 'local-agent-host';
 /** Default provider when session metadata does not carry one. */
 const DEFAULT_AGENT_PROVIDER = 'copilot';
 
+/** Known auto-approve config values. */
+const AUTO_APPROVE_ENUM = ['default', 'autoApprove', 'autopilot'];
+
+/**
+ * Builds a minimal session-mutable config schema from changed values.
+ * Used when a restored session receives a ConfigChanged action before
+ * the full schema has been hydrated.
+ */
+function buildMutableConfigSchema(config: Record<string, string>): Record<string, { type: 'string'; title: string; sessionMutable: true; enum: string[] }> {
+	const properties: Record<string, { type: 'string'; title: string; sessionMutable: true; enum: string[] }> = {};
+	for (const key of Object.keys(config)) {
+		properties[key] = {
+			type: 'string',
+			title: key,
+			sessionMutable: true,
+			enum: key === 'autoApprove' ? AUTO_APPROVE_ENUM : [config[key]],
+		};
+	}
+	return properties;
+}
+
 /**
  * Derives the session type / URI scheme from an agent provider name.
  * Must match the type string registered by AgentHostContribution
@@ -217,6 +238,9 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 	private readonly _newSessionAgentProviders = new Map<string, string>();
 	private readonly _newSessionConfigRequests = new Map<string, number>();
 
+	/** Config for running sessions (session-mutable properties only), keyed by session ID. */
+	private readonly _runningSessionConfigs = new Map<string, IResolveSessionConfigResult>();
+
 	private _cacheInitialized = false;
 
 	constructor(
@@ -256,6 +280,8 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 				this._handleIsReadChanged(e.action.session, e.action.isRead);
 			} else if (e.action.type === ActionType.SessionIsDoneChanged && isSessionAction(e.action)) {
 				this._handleIsDoneChanged(e.action.session, e.action.isDone);
+			} else if (e.action.type === ActionType.SessionConfigChanged && isSessionAction(e.action)) {
+				this._handleConfigChanged(e.action.session, e.action.config);
 			}
 		}));
 
@@ -454,18 +480,44 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 	}
 
 	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined {
-		return this._newSessionConfigs.get(sessionId);
+		return this._newSessionConfigs.get(sessionId) ?? this._runningSessionConfigs.get(sessionId);
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void> {
+		// New session (pre-creation): re-resolve the full config schema
 		const workingDirectory = this._newSessionWorkspaces.get(sessionId);
-		if (!workingDirectory) {
+		if (workingDirectory) {
+			const current = this._newSessionConfigs.get(sessionId)?.values ?? {};
+			this._newSessionConfigs.set(sessionId, { ready: false, schema: { type: 'object', properties: {} }, values: { ...current, [property]: value } });
+			this._onDidChangeSessionConfig.fire(sessionId);
+			await this._resolveSessionConfig(sessionId, this._getAgentProviderForSession(sessionId), workingDirectory, { ...current, [property]: value });
 			return;
 		}
-		const current = this._newSessionConfigs.get(sessionId)?.values ?? {};
-		this._newSessionConfigs.set(sessionId, { ready: false, schema: { type: 'object', properties: {} }, values: { ...current, [property]: value } });
+
+		// Running session: dispatch SessionConfigChanged for sessionMutable properties
+		const runningConfig = this._runningSessionConfigs.get(sessionId);
+		if (!runningConfig) {
+			return;
+		}
+		const schema = runningConfig.schema.properties[property];
+		if (!schema?.sessionMutable) {
+			return;
+		}
+
+		// Update local cache optimistically
+		this._runningSessionConfigs.set(sessionId, {
+			...runningConfig,
+			values: { ...runningConfig.values, [property]: value },
+		});
 		this._onDidChangeSessionConfig.fire(sessionId);
-		await this._resolveSessionConfig(sessionId, this._getAgentProviderForSession(sessionId), workingDirectory, { ...current, [property]: value });
+
+		// Dispatch to the agent host
+		const rawId = this._rawIdFromChatId(sessionId);
+		const cached = rawId ? this._sessionCache.get(rawId) : undefined;
+		if (cached && rawId) {
+			const action = { type: ActionType.SessionConfigChanged as const, session: AgentSession.uri(cached.agentProvider, rawId).toString(), config: { [property]: value } };
+			this._agentHostService.dispatch(action);
+		}
 	}
 
 	async getSessionConfigCompletions(sessionId: string, property: string, query?: string): Promise<readonly ISessionConfigValueItem[]> {
@@ -551,6 +603,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 		if (cached && rawId) {
 			await this._agentHostService.disposeSession(AgentSession.uri(cached.agentProvider, rawId));
 			this._sessionCache.delete(rawId);
+			this._runningSessionConfigs.delete(sessionId);
 			this._onDidChangeSessions.fire({ added: [], removed: [cached], changed: [] });
 		}
 	}
@@ -636,6 +689,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 		try {
 			const committedSession = await this._waitForNewSession(existingKeys);
 			if (committedSession) {
+				this._preserveSessionMutableConfig(chatId, committedSession.sessionId);
 				this._currentNewSession = undefined;
 				this._clearNewSessionConfig(chatId);
 				this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
@@ -679,6 +733,36 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 		this._newSessionConfigs.delete(sessionId);
 		this._newSessionAgentProviders.delete(sessionId);
 		this._newSessionConfigRequests.delete(sessionId);
+	}
+
+	/**
+	 * When a session transitions from untitled (new) to committed (running),
+	 * preserve the session-mutable config properties so they can be changed
+	 * during the running session.
+	 */
+	private _preserveSessionMutableConfig(oldSessionId: string, newSessionId: string): void {
+		const config = this._newSessionConfigs.get(oldSessionId);
+		if (!config) {
+			return;
+		}
+		// Filter schema to only include session-mutable properties
+		const mutableProperties: Record<string, typeof config.schema.properties[string]> = {};
+		const mutableValues: Record<string, string> = {};
+		for (const [key, propSchema] of Object.entries(config.schema.properties)) {
+			if (propSchema.sessionMutable) {
+				mutableProperties[key] = propSchema;
+				if (Object.hasOwn(config.values, key)) {
+					mutableValues[key] = config.values[key];
+				}
+			}
+		}
+		if (Object.keys(mutableProperties).length > 0) {
+			this._runningSessionConfigs.set(newSessionId, {
+				ready: true,
+				schema: { type: 'object', properties: mutableProperties },
+				values: mutableValues,
+			});
+		}
 	}
 
 	private _agentProviderFromSessionType(sessionType: string): string {
@@ -727,6 +811,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 			for (const [key, cached] of this._sessionCache) {
 				if (!currentKeys.has(key)) {
 					this._sessionCache.delete(key);
+					this._runningSessionConfigs.delete(cached.sessionId);
 					removed.push(cached);
 				}
 			}
@@ -802,6 +887,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 		const cached = this._sessionCache.get(rawId);
 		if (cached) {
 			this._sessionCache.delete(rawId);
+			this._runningSessionConfigs.delete(cached.sessionId);
 			this._onDidChangeSessions.fire({ added: [], removed: [cached], changed: [] });
 		}
 	}
@@ -831,6 +917,31 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 			cached.isArchived.set(isDone, undefined);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 		}
+	}
+
+	private _handleConfigChanged(session: string, config: Record<string, string>): void {
+		const rawId = AgentSession.id(session);
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+		const sessionId = cached.sessionId;
+		const existing = this._runningSessionConfigs.get(sessionId);
+		if (existing) {
+			this._runningSessionConfigs.set(sessionId, {
+				...existing,
+				values: { ...existing.values, ...config },
+			});
+		} else {
+			// Session was restored (e.g. after reload) — create a minimal
+			// config entry from the changed values so the picker can render.
+			this._runningSessionConfigs.set(sessionId, {
+				ready: true,
+				schema: { type: 'object', properties: buildMutableConfigSchema(config) },
+				values: config,
+			});
+		}
+		this._onDidChangeSessionConfig.fire(sessionId);
 	}
 
 	private _rawIdFromChatId(chatId: string): string | undefined {

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -746,7 +746,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements ISessi
 			return;
 		}
 		// Filter schema to only include session-mutable properties
-		const mutableProperties: Record<string, typeof config.schema.properties[string]> = {};
+		const mutableProperties: IResolveSessionConfigResult['schema']['properties'] = {};
 		const mutableValues: Record<string, string> = {};
 		for (const [key, propSchema] of Object.entries(config.schema.properties)) {
 			if (propSchema.sessionMutable) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -902,7 +902,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			return;
 		}
 		// Filter schema to only include session-mutable properties
-		const mutableProperties: Record<string, typeof config.schema.properties[string]> = {};
+		const mutableProperties: IResolveSessionConfigResult['schema']['properties'] = {};
 		const mutableValues: Record<string, string> = {};
 		for (const [key, propSchema] of Object.entries(config.schema.properties)) {
 			if (propSchema.sessionMutable) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -37,6 +37,27 @@ import { remoteAgentHostSessionTypeId } from '../common/remoteAgentHostSessionTy
 
 const DEFAULT_AGENT_PROVIDER = 'copilot';
 
+/** Known auto-approve config values. */
+const AUTO_APPROVE_ENUM = ['default', 'autoApprove', 'autopilot'];
+
+/**
+ * Builds a minimal session-mutable config schema from changed values.
+ * Used when a restored session receives a ConfigChanged action before
+ * the full schema has been hydrated.
+ */
+function buildMutableConfigSchema(config: Record<string, string>): Record<string, { type: 'string'; title: string; sessionMutable: true; enum: string[] }> {
+	const properties: Record<string, { type: 'string'; title: string; sessionMutable: true; enum: string[] }> = {};
+	for (const key of Object.keys(config)) {
+		properties[key] = {
+			type: 'string',
+			title: key,
+			sessionMutable: true,
+			enum: key === 'autoApprove' ? AUTO_APPROVE_ENUM : [config[key]],
+		};
+	}
+	return properties;
+}
+
 function toLocalProjectUri(uri: URI, connectionAuthority: string): URI {
 	return uri.scheme === Schemas.file ? toAgentHostUri(uri, connectionAuthority) : uri;
 }
@@ -240,6 +261,9 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	private readonly _newSessionAgentProviders = new Map<string, string>();
 	private readonly _newSessionConfigRequests = new Map<string, number>();
 
+	/** Config for running sessions (session-mutable properties only), keyed by session ID. */
+	private readonly _runningSessionConfigs = new Map<string, IResolveSessionConfigResult>();
+
 	private _connection: IAgentConnection | undefined;
 	private _defaultDirectory: string | undefined;
 	private readonly _connectionListeners = this._register(new DisposableStore());
@@ -335,6 +359,8 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 				this._handleIsReadChanged(e.action.session, e.action.isRead);
 			} else if (e.action.type === ActionType.SessionIsDoneChanged && isSessionAction(e.action)) {
 				this._handleIsDoneChanged(e.action.session, e.action.isDone);
+			} else if (e.action.type === ActionType.SessionConfigChanged && isSessionAction(e.action)) {
+				this._handleConfigChanged(e.action.session, e.action.config);
 			}
 		}));
 
@@ -413,6 +439,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			this._pendingSession = undefined;
 		}
 		this._sessionCache.clear();
+		this._runningSessionConfigs.clear();
 		this._cacheInitialized = false;
 		if (removed.length > 0) {
 			this._onDidChangeSessions.fire({ added: [], removed, changed: [] });
@@ -574,18 +601,44 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	}
 
 	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined {
-		return this._newSessionConfigs.get(sessionId);
+		return this._newSessionConfigs.get(sessionId) ?? this._runningSessionConfigs.get(sessionId);
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void> {
+		// New session (pre-creation): re-resolve the full config schema
 		const workingDirectory = this._newSessionWorkspaces.get(sessionId);
-		if (!workingDirectory) {
+		if (workingDirectory) {
+			const current = this._newSessionConfigs.get(sessionId)?.values ?? {};
+			this._newSessionConfigs.set(sessionId, { ready: false, schema: { type: 'object', properties: {} }, values: { ...current, [property]: value } });
+			this._onDidChangeSessionConfig.fire(sessionId);
+			await this._resolveSessionConfig(sessionId, this._getAgentProviderForSession(sessionId), workingDirectory, { ...current, [property]: value });
 			return;
 		}
-		const current = this._newSessionConfigs.get(sessionId)?.values ?? {};
-		this._newSessionConfigs.set(sessionId, { ready: false, schema: { type: 'object', properties: {} }, values: { ...current, [property]: value } });
+
+		// Running session: dispatch SessionConfigChanged for sessionMutable properties
+		const runningConfig = this._runningSessionConfigs.get(sessionId);
+		if (!runningConfig || !this._connection) {
+			return;
+		}
+		const schema = runningConfig.schema.properties[property];
+		if (!schema?.sessionMutable) {
+			return;
+		}
+
+		// Update local cache optimistically
+		this._runningSessionConfigs.set(sessionId, {
+			...runningConfig,
+			values: { ...runningConfig.values, [property]: value },
+		});
 		this._onDidChangeSessionConfig.fire(sessionId);
-		await this._resolveSessionConfig(sessionId, this._getAgentProviderForSession(sessionId), workingDirectory, { ...current, [property]: value });
+
+		// Dispatch to the agent host connection
+		const rawId = this._rawIdFromChatId(sessionId);
+		const cached = rawId ? this._sessionCache.get(rawId) : undefined;
+		if (cached && rawId) {
+			const action = { type: ActionType.SessionConfigChanged as const, session: AgentSession.uri(cached.agentProvider, rawId).toString(), config: { [property]: value } };
+			this._connection.dispatch(action);
+		}
 	}
 
 	async getSessionConfigCompletions(sessionId: string, property: string, query?: string): Promise<readonly ISessionConfigValueItem[]> {
@@ -690,6 +743,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		if (cached && rawId && this._connection) {
 			await this._connection.disposeSession(AgentSession.uri(cached.agentProvider, rawId));
 			this._sessionCache.delete(rawId);
+			this._runningSessionConfigs.delete(sessionId);
 			this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(cached)], changed: [] });
 		}
 	}
@@ -787,6 +841,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		try {
 			const committedSession = await this._waitForNewSession(existingKeys);
 			if (committedSession) {
+				this._preserveSessionMutableConfig(chatId, committedSession.sessionId);
 				this._currentNewSession = undefined;
 				this._clearNewSessionConfig(chatId);
 				this._onDidReplaceSession.fire({ from: newSession, to: committedSession });
@@ -836,6 +891,36 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		this._newSessionConfigRequests.delete(sessionId);
 	}
 
+	/**
+	 * When a session transitions from untitled (new) to committed (running),
+	 * preserve the session-mutable config properties so they can be changed
+	 * during the running session.
+	 */
+	private _preserveSessionMutableConfig(oldSessionId: string, newSessionId: string): void {
+		const config = this._newSessionConfigs.get(oldSessionId);
+		if (!config) {
+			return;
+		}
+		// Filter schema to only include session-mutable properties
+		const mutableProperties: Record<string, typeof config.schema.properties[string]> = {};
+		const mutableValues: Record<string, string> = {};
+		for (const [key, propSchema] of Object.entries(config.schema.properties)) {
+			if (propSchema.sessionMutable) {
+				mutableProperties[key] = propSchema;
+				if (Object.hasOwn(config.values, key)) {
+					mutableValues[key] = config.values[key];
+				}
+			}
+		}
+		if (Object.keys(mutableProperties).length > 0) {
+			this._runningSessionConfigs.set(newSessionId, {
+				ready: true,
+				schema: { type: 'object', properties: mutableProperties },
+				values: mutableValues,
+			});
+		}
+	}
+
 	// -- Private: Session Cache --
 
 	private _cacheInitialized = false;
@@ -879,6 +964,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			for (const [key, cached] of this._sessionCache) {
 				if (!currentKeys.has(key)) {
 					this._sessionCache.delete(key);
+					this._runningSessionConfigs.delete(cached.id);
 					removed.push(this._chatToSession(cached));
 				}
 			}
@@ -968,6 +1054,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		const cached = this._sessionCache.get(rawId);
 		if (cached) {
 			this._sessionCache.delete(rawId);
+			this._runningSessionConfigs.delete(cached.id);
 			this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(cached)], changed: [] });
 		}
 	}
@@ -997,6 +1084,31 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			cached.isArchived.set(isDone, undefined);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(cached)] });
 		}
+	}
+
+	private _handleConfigChanged(session: string, config: Record<string, string>): void {
+		const rawId = AgentSession.id(session);
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+		const sessionId = cached.id;
+		const existing = this._runningSessionConfigs.get(sessionId);
+		if (existing) {
+			this._runningSessionConfigs.set(sessionId, {
+				...existing,
+				values: { ...existing.values, ...config },
+			});
+		} else {
+			// Session was restored (e.g. after reconnect) — create a minimal
+			// config entry from the changed values so the picker can render.
+			this._runningSessionConfigs.set(sessionId, {
+				ready: true,
+				schema: { type: 'object', properties: buildMutableConfigSchema(config) },
+				values: config,
+			});
+		}
+		this._onDidChangeSessionConfig.fire(sessionId);
 	}
 
 	private _rawIdFromChatId(chatId: string): string | undefined {


### PR DESCRIPTION
Add an `autoApprove` session config property to the Copilot agent host with three options matching the extension host permission picker: Default Approvals, Bypass Approvals, and Autopilot (Preview).

## Changes

### Session config schema (`copilotAgent.ts`)
- Add `autoApprove` property to `resolveSessionConfig()` with `sessionMutable: true`
- Three enum values: `default`, `autoApprove`, `autopilot`

### Auto-approval behavior (`agentSideEffects.ts`)
- Early check in `_tryAutoApproveToolReady()`: when `autoApprove` is `autoApprove` or `autopilot`, auto-approve all tool calls unconditionally (bypasses per-file and per-command rules)

### UI — New session picker (`agentHostSessionConfigPicker.ts`)
- Filter autopilot option based on `chat.autopilot.enabled` setting
- Disable bypass/autopilot when enterprise policy restricts `chat.tools.global.autoApprove`
- Confirmation dialogs on first selection of bypass/autopilot (matching extension host pattern)
- Warning/info CSS styling on trigger for elevated levels
- Icons hardcoded in `getConfigIcon()` (shield/warning/rocket)

### UI — Running session picker (`agentHostSessionConfigPicker.ts`)
- New action registered on `MenuId.ChatInputSecondary` (same location as normal agent permission picker)
- Gated by `ChatContextKeyExprs.isAgentHostSession` context key
- Reuses shared helpers for filtering, confirmation dialogs, and styling

### Mid-session config changes (both providers)
- `setSessionConfigValue()` dispatches `SessionConfigChanged` action for running sessions
- `_preserveSessionMutableConfig()` transfers mutable config when session transitions from new to committed
- `_handleConfigChanged()` updates running config cache (creates minimal entry for restored sessions)
- Proper cleanup: `_runningSessionConfigs` entries deleted on session removal/deletion/disconnect

### Tests (`agentSideEffects.test.ts`)
- 4 new tests: bypass auto-approves blocked writes, autopilot auto-approves blocked shell commands, default does NOT auto-approve, mid-session config change works

## Notes
- Autopilot = bypass approvals for agent host (the extension host autopilot continuation loop, task_complete tool, etc. are implemented in the Copilot extension's tool calling loop, not the SDK)

(Written by Copilot)