### PR TITLE
Onboarding polish

### DIFF
--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -24,7 +24,6 @@ import { EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT, IGalleryExtension, IExtensi
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import product from '../../../../platform/product/common/product.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
@@ -136,7 +135,6 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		@IFileService private readonly fileService: IFileService,
 		@IPathService private readonly pathService: IPathService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
@@ -241,9 +239,11 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		this.disposables.add(addDisposableListener(this.overlay, EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
 
+			// Prevent all keyboard shortcuts from reaching the keybinding service
+			e.stopPropagation();
+
 			if (event.keyCode === KeyCode.Escape) {
 				e.preventDefault();
-				e.stopPropagation();
 				this._dismiss('skip');
 				return;
 			}
@@ -491,30 +491,8 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		const disclaimerCol = append(footer, $('.onboarding-a-signin-disclaimer-col'));
 
-		// VS Code telemetry disclaimer
-		const telemetryDisclaimer = append(disclaimerCol, $('.onboarding-a-signin-disclaimer'));
-		const telemetryTitle = append(telemetryDisclaimer, $('strong'));
-		telemetryTitle.textContent = localize('onboarding.signIn.disclaimer.telemetryTitle', "VS Code: ");
-		telemetryDisclaimer.append(localize('onboarding.signIn.telemetry', "{0} collects usage data. Read our ", product.nameShort));
-		if (product.privacyStatementUrl) {
-			this._createInlineLink(telemetryDisclaimer, localize('onboarding.signIn.telemetry.privacy', "privacy statement"), product.privacyStatementUrl);
-		} else {
-			telemetryDisclaimer.append(localize('onboarding.signIn.telemetry.privacyPlain', "privacy statement"));
-		}
-		telemetryDisclaimer.append(localize('onboarding.signIn.telemetry.optOut', " and learn how to "));
-		const optOutLink = this._registerStepFocusable(append(telemetryDisclaimer, $<HTMLAnchorElement>('a.onboarding-a-inline-link')));
-		optOutLink.textContent = localize('onboarding.signIn.telemetry.optOutLink', "opt out");
-		optOutLink.href = '#';
-		this.stepDisposables.add(addDisposableListener(optOutLink, EventType.CLICK, (e) => {
-			e.preventDefault();
-			this.commandService.executeCommand('settings.filterByTelemetry');
-		}));
-		telemetryDisclaimer.append('.');
-
 		// GitHub Copilot disclaimer
 		const copilotDisclaimer = append(disclaimerCol, $('.onboarding-a-signin-disclaimer'));
-		const copilotTitle = append(copilotDisclaimer, $('strong'));
-		copilotTitle.textContent = localize('onboarding.signIn.disclaimer.copilotTitle', "GitHub Copilot: ");
 		copilotDisclaimer.append(localize('onboarding.signIn.disclaimer.prefix', "By signing in, you agree to {0}'s ", defaultChat.provider.default.name));
 		this._createInlineLink(copilotDisclaimer, localize('onboarding.signIn.disclaimer.terms', "Terms"), defaultChat.termsStatementUrl);
 		copilotDisclaimer.append(localize('onboarding.signIn.disclaimer.middle', " and "));
@@ -1124,12 +1102,12 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		const features = append(wrapper, $('.onboarding-a-sessions-features'));
 
 		this._createFeatureCard(features, Codicon.deviceDesktop,
-			localize('onboarding.sessions.local', "Local Sessions"),
+			localize('onboarding.sessions.local', "Local"),
 			localize('onboarding.sessions.local.desc', "Run agents interactively in the editor with full access to your workspace, tools, and terminal. Best for hands-on work where you want to review changes as they happen."));
 
 		this._createFeatureCard(features, Codicon.cloud,
-			localize('onboarding.sessions.cloud', "Cloud Sessions"),
-			localize('onboarding.sessions.cloud.desc', "Delegate tasks to a cloud agent that creates a branch, implements changes, and opens a pull request — even after you close VS Code."));
+			localize('onboarding.sessions.cloud', "Cloud"),
+			localize('onboarding.sessions.cloud.desc', "Delegate tasks to a cloud agent that creates a branch, implements changes, and opens a pull request. The agent continues working even if you close VS Code."));
 
 		this._createFeatureCard(features, Codicon.worktree,
 			localize('onboarding.sessions.worktree', "Copilot CLI"),
@@ -1147,7 +1125,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 		// Tutorial link at bottom of content, above footer
 		const docsRow = append(wrapper, $('.onboarding-a-sessions-docs'));
-		this._createDocLink(docsRow, localize('onboarding.sessions.videoTutorials', "Watch video tutorials"), 'https://aka.ms/vscode-getting-started-video', 'videoTutorials');
+		this._createDocLink(docsRow, localize('onboarding.sessions.agentsTutorial', "Agents tutorial"), 'https://code.visualstudio.com/docs/copilot/agents/agents-tutorial', 'agentsTutorial');
 	}
 
 	private _createFeatureCard(parent: HTMLElement, icon: ThemeIcon, title: string, description?: string): HTMLElement {


### PR DESCRIPTION
**UI and Content Updates:**

* Simplified the sign-in footer by removing the VS Code telemetry disclaimer and its associated opt-out link, leaving only the GitHub Copilot disclaimer.
* Updated the session feature titles and descriptions for "Local" and "Cloud" sessions to be shorter and clearer. The cloud session description now explicitly mentions that agents continue working after VS Code is closed.
* Changed the tutorial link at the bottom of the onboarding content to point to the "Agents tutorial" instead of video tutorials, updating both the label and URL.

**Code and Event Handling Improvements:**

* Modified keyboard event handling to stop propagation of all keyboard shortcuts within the onboarding overlay, ensuring they do not reach the keybinding service.

**Dependency Cleanup:**

* Removed the unused `ICommandService` dependency and related imports from the onboarding class, reflecting the removal of the telemetry opt-out link. [[1]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL27) [[2]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL139)


Addresses: 
- https://github.com/microsoft/vscode/issues/309378
- https://github.com/microsoft/vscode/issues/309387
- Legal blurb polish
- Swap video link with Agents Tutorials 