### PR TITLE
Fix sandbox terminal command display

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -967,7 +967,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			});
 			if (rewriteResult) {
 				rewrittenCommand = rewriteResult.rewritten;
-				forDisplayCommand = rewriteResult.forDisplay ?? forDisplayCommand;
+				forDisplayCommand = forDisplayCommand ?? rewriteResult.forDisplay;
 				if (rewriteResult.isSandboxWrapped) {
 					isSandboxWrapped = true;
 				} else if (rewriteResult.isSandboxWrapped === false) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -405,6 +405,30 @@ suite('RunInTerminalTool', () => {
 			const terminalData = preparedInvocation.toolSpecificData as IChatTerminalToolInvocationData;
 			strictEqual(terminalData.commandLine.isSandboxWrapped, true);
 		});
+
+		test('should not show sandbox wrapper in chat when sandboxed async command is detached', async () => {
+			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
+			setConfig(TerminalChatAgentToolsSettingId.DetachBackgroundProcesses, true);
+			sandboxEnabled = true;
+			sandboxPrereqResult = {
+				enabled: true,
+				sandboxConfigPath: '/tmp/vscode-sandbox-settings.json',
+				failedCheck: undefined,
+			};
+			terminalSandboxService.wrapCommand = (command: string) => ({
+				command: `sandbox-runtime ${command}`,
+				isSandboxWrapped: true,
+			});
+
+			const preparedInvocation = await executeToolTest({ command: 'echo hello', mode: 'async' });
+
+			ok(preparedInvocation, 'Expected prepared invocation to be defined');
+			strictEqual((preparedInvocation.invocationMessage as IMarkdownString).value, 'Running `echo hello` in sandbox');
+
+			const terminalData = preparedInvocation.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.commandLine.forDisplay, 'echo hello');
+			strictEqual(terminalData.commandLine.toolEdited, 'nohup sandbox-runtime echo hello &');
+		});
 	});
 
 	suite('automatic sandbox retry', () => {


### PR DESCRIPTION
## Summary

Fixes #309430

This prevents internal sandbox wrapper commands from leaking into the chat view for terminal tool invocations while running background.

The terminal command pipeline can apply multiple command-line rewrites. The sandbox rewriter correctly sets a clean `forDisplay` command while storing the wrapped command in `toolEdited` for execution. However, later execution-only rewrites, such as background detach wrapping, could replace `forDisplay` with a command that already included sandbox details. The chat UI then used that overwritten display command and showed the sandbox wrapper to the user.

This change makes the first explicit `forDisplay` value sticky during command rewriting:

- execution continues to use the fully rewritten command via `toolEdited`
- chat display continues to use the clean user-facing command via `forDisplay`
- sandboxed invocations still show the sandbox label/icon without exposing the wrapper implementation

## Testing

- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts`

Added regression coverage for a sandboxed async command with background detach enabled, verifying that chat displays `echo hello` while the executed command remains `nohup sandbox-runtime echo hello &`.