### PR TITLE
Fix focus keybindings in sessions window

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -23,6 +23,8 @@ import { KeybindingWeight } from '../../../../platform/keybinding/common/keybind
 import { IPaneCompositePartService } from '../../../../workbench/services/panecomposite/browser/panecomposite.js';
 import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { ChangesViewPane } from './changesView.js';
+import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
+import { SESSIONS_FILES_VIEW_ID } from '../../files/browser/filesView.js';
 
 const openChangesViewActionOptions: IAction2Options = {
 	id: 'workbench.action.agentSessions.openChangesView',
@@ -87,8 +89,13 @@ registerAction2(class FocusChangesFileViewAction extends Action2 {
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
+		const paneCompositeService = accessor.get(IPaneCompositePartService);
 		const viewsService = accessor.get(IViewsService);
-		await viewsService.openView('sessions.files.explorer', true);
+		await paneCompositeService.openPaneComposite(SESSIONS_FILES_CONTAINER_ID, ViewContainerLocation.AuxiliaryBar, true);
+		const view = await viewsService.openView(SESSIONS_FILES_VIEW_ID, true);
+		if (view) {
+			view.focus();
+		}
 	}
 });
 

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -5,7 +5,8 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { localize2 } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { alert } from '../../../../base/browser/ui/aria/aria.js';
 import { Action2, IAction2Options, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
@@ -65,6 +66,13 @@ registerAction2(class FocusChangesViewAction extends Action2 {
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
+		const sessionManagementService = accessor.get(ISessionsManagementService);
+		const activeSession = sessionManagementService.activeSession.get();
+		const changes = activeSession?.changes.get();
+		if (!changes || changes.length === 0) {
+			alert(localize('focusChangesView.noChanges', "There are no changes."));
+			return;
+		}
 		const paneCompositeService = accessor.get(IPaneCompositePartService);
 		const viewsService = accessor.get(IViewsService);
 		await paneCompositeService.openPaneComposite(CHANGES_VIEW_CONTAINER_ID, ViewContainerLocation.AuxiliaryBar, true);

--- a/src/vs/workbench/contrib/externalTerminal/electron-browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/electron-browser/externalTerminal.contribution.ts
@@ -23,12 +23,14 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 
 const OPEN_NATIVE_CONSOLE_COMMAND_ID = 'workbench.action.terminal.openNativeConsole';
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: OPEN_NATIVE_CONSOLE_COMMAND_ID,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC,
-	when: TerminalContextKeys.notFocus,
+	when: ContextKeyExpr.and(TerminalContextKeys.notFocus, IsSessionsWindowContext.negate()),
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: async (accessor) => {
 		const historyService = accessor.get(IHistoryService);


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode/issues/309475
Addresses https://github.com/microsoft/vscode/issues/309475
Addresses https://github.com/microsoft/vscode/issues/309476

- Fix `focusChangesFileView` action to properly open the pane composite, expand the view, and focus it
- Fix `focusChangesView` action to alert "There are no changes." when the active session has no changes instead of silently failing
- Exclude sessions window from the external terminal keybinding (`Cmd+Shift+C`) so `Focus Chat Customizations` can be invoked