### PR TITLE
Fix crash from nulled _session in ChatModel.dispose()

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2819,24 +2819,10 @@ export class ChatModel extends Disposable implements IChatModel {
 	}
 
 	override dispose() {
-		this._requests.forEach(r => {
-			r.response?.dispose();
-			// Break back-reference from request to this model
-			// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
-			(r as any)._session = undefined;
-		});
+		this._requests.forEach(r => r.response?.dispose());
 		this._onDidDispose.fire();
 
 		super.dispose();
-
-		// Null out heavy fields to break retention chains. Even after disposal,
-		// stale references (closures, cached templates, etc.) may prevent GC
-		// from collecting this object. Clearing these fields ensures the
-		// conversation data, serialization snapshot, and editing session are
-		// freed regardless.
-		this._requests.length = 0;
-		this.dataSerializer = undefined;
-		this._editingSession = undefined;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2823,6 +2823,15 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._onDidDispose.fire();
 
 		super.dispose();
+
+		// Null out heavy fields to break retention chains. Even after disposal,
+		// stale references (closures, cached templates, etc.) may prevent GC
+		// from collecting this object. Clearing these fields ensures the
+		// conversation data, serialization snapshot, and editing session are
+		// freed regardless.
+		this._requests.length = 0;
+		this.dataSerializer = undefined;
+		this._editingSession = undefined;
 	}
 }
 


### PR DESCRIPTION
`ChatModel.dispose()` sets `_session = undefined` on each request to break back-references for GC. However, the `_onDidUpdateViewModel` event listener in `chatListRenderer.ts` accesses `template.currentElement.sessionResource`, which resolves through `this._model.session.sessionResource`. When `updateViewModel` fires during a model switch, `template.currentElement` may still reference an item from the old (now-disposed) view model, causing:

```
TypeError: Cannot read properties of undefined (reading 'sessionResource')
```

**Fix:** Remove the `_session = undefined` line. The `_requests` array is already emptied immediately after (`this._requests.length = 0`), so the back-references are broken when the requests are GC'd along with the model.

Fixes #309568

(Written by Copilot)