### PR TITLE
Update rate limit message

### DIFF
--- a/extensions/copilot/src/platform/chat/common/commonTypes.ts
+++ b/extensions/copilot/src/platform/chat/common/commonTypes.ts
@@ -198,7 +198,7 @@ export type ChatResponse = FetchResponse<string>;
 
 export type ChatResponses = FetchResponse<string[]>;
 
-function getRateLimitMessage(fetchResult: ChatFetchError): string {
+function getRateLimitMessage(fetchResult: ChatFetchError, copilotPlan: string | undefined): string {
 	if (fetchResult.type !== ChatFetchResponseType.RateLimited) {
 		throw new Error('Expected RateLimited error');
 	}
@@ -225,8 +225,24 @@ function getRateLimitMessage(fetchResult: ChatFetchError): string {
 		});
 	}
 	if (fetchResult.capiError?.code?.startsWith('user_global_rate_limited')) {
+		if (copilotPlan === 'free' || copilotPlan === 'individual' || copilotPlan === 'individual_pro') {
+			if (fetchResult.retryAfter) {
+				const resetDate = new Date(Date.now() + fetchResult.retryAfter * 1000);
+				const resetDateString = resetDate.toLocaleString(undefined, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+				return l10n.t({
+					message: 'You\'ve reached your weekly rate limit. Please upgrade your plan or wait for your limit to reset on {0}. [Learn More]({1})',
+					args: [resetDateString, 'https://aka.ms/github-copilot-rate-limit-error'],
+					comment: [`{Locked=']({'}`]
+				});
+			}
+			return l10n.t({
+				message: 'You\'ve reached your weekly rate limit. Please upgrade your plan or wait for your limit to reset. [Learn More]({0})',
+				args: ['https://aka.ms/github-copilot-rate-limit-error'],
+				comment: [`{Locked=']({'}`]
+			});
+		}
 		return l10n.t({
-			message: 'You\'ve hit your global rate limit. Please upgrade your plan or wait {0} for your limit to reset. [Learn More]({1})',
+			message: 'You\'ve hit your global rate limit. Please wait {0} for your limit to reset. [Learn More]({1})',
 			args: [retryAfterString, 'https://aka.ms/github-copilot-rate-limit-error'],
 			comment: [`{Locked=']({'}`]
 		});
@@ -332,7 +348,7 @@ function getErrorDetailsFromChatFetchErrorInner(fetchResult: ChatFetchError, cop
 			break;
 		case ChatFetchResponseType.RateLimited:
 			details = {
-				message: getRateLimitMessage(fetchResult),
+				message: getRateLimitMessage(fetchResult, copilotPlan),
 				level: ChatErrorLevel.Info,
 				isRateLimited: true
 			};

--- a/extensions/copilot/src/platform/chat/common/commonTypes.ts
+++ b/extensions/copilot/src/platform/chat/common/commonTypes.ts
@@ -226,23 +226,40 @@ function getRateLimitMessage(fetchResult: ChatFetchError, copilotPlan: string | 
 	}
 	if (fetchResult.capiError?.code?.startsWith('user_global_rate_limited')) {
 		if (copilotPlan === 'free' || copilotPlan === 'individual' || copilotPlan === 'individual_pro') {
-			if (fetchResult.retryAfter) {
-				const resetDate = new Date(Date.now() + fetchResult.retryAfter * 1000);
-				const resetDateString = resetDate.toLocaleString(undefined, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+			return l10n.t({
+				message: 'You\'ve hit your global rate limit. Please upgrade your plan or wait {0} for your limit to reset. [Learn More]({1})',
+				args: [retryAfterString, 'https://aka.ms/github-copilot-rate-limit-error'],
+				comment: [`{Locked=']({'}`]
+			});
+		}
+
+		return l10n.t({
+			message: 'You\'ve hit your global rate limit. Please wait {0} for your limit to reset. [Learn More]({1})',
+			args: [retryAfterString, 'https://aka.ms/github-copilot-rate-limit-error'],
+			comment: [`{Locked=']({'}`]
+		});
+	}
+	if (fetchResult.capiError?.code?.startsWith('user_weekly_rate_limited')) {
+		if (fetchResult.retryAfter) {
+			const resetDate = new Date(Date.now() + fetchResult.retryAfter * 1000);
+			const resetDateString = resetDate.toLocaleString(undefined, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+			if (copilotPlan === 'free' || copilotPlan === 'individual' || copilotPlan === 'individual_pro') {
 				return l10n.t({
 					message: 'You\'ve reached your weekly rate limit. Please upgrade your plan or wait for your limit to reset on {0}. [Learn More]({1})',
 					args: [resetDateString, 'https://aka.ms/github-copilot-rate-limit-error'],
 					comment: [`{Locked=']({'}`]
 				});
 			}
+
 			return l10n.t({
-				message: 'You\'ve reached your weekly rate limit. Please upgrade your plan or wait for your limit to reset. [Learn More]({0})',
-				args: ['https://aka.ms/github-copilot-rate-limit-error'],
+				message: 'You\'ve reached your weekly rate limit. Please wait for your limit to reset on {0}. [Learn More]({1})',
+				args: [resetDateString, 'https://aka.ms/github-copilot-rate-limit-error'],
 				comment: [`{Locked=']({'}`]
 			});
 		}
+
 		return l10n.t({
-			message: 'You\'ve hit your global rate limit. Please wait {0} for your limit to reset. [Learn More]({1})',
+			message: 'You\'ve reached your weekly rate limit. Please wait {0} for your limit to reset. [Learn More]({1})',
 			args: [retryAfterString, 'https://aka.ms/github-copilot-rate-limit-error'],
 			comment: [`{Locked=']({'}`]
 		});

--- a/extensions/copilot/src/platform/chat/common/commonTypes.ts
+++ b/extensions/copilot/src/platform/chat/common/commonTypes.ts
@@ -239,7 +239,7 @@ function getRateLimitMessage(fetchResult: ChatFetchError, copilotPlan: string | 
 			comment: [`{Locked=']({'}`]
 		});
 	}
-	if (fetchResult.capiError?.code?.startsWith('user_weekly_rate_limited')) {
+	if (fetchResult.capiError?.code?.startsWith('user_weekly_rate_limit')) {
 		if (fetchResult.retryAfter) {
 			const resetDate = new Date(Date.now() + fetchResult.retryAfter * 1000);
 			const resetDateString = resetDate.toLocaleString(undefined, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' });

--- a/extensions/copilot/src/platform/chat/common/commonTypes.ts
+++ b/extensions/copilot/src/platform/chat/common/commonTypes.ts
@@ -239,7 +239,7 @@ function getRateLimitMessage(fetchResult: ChatFetchError, copilotPlan: string | 
 			comment: [`{Locked=']({'}`]
 		});
 	}
-	if (fetchResult.capiError?.code?.startsWith('user_weekly_rate_limit')) {
+	if (fetchResult.capiError?.code?.startsWith('user_weekly_rate_limited')) {
 		if (fetchResult.retryAfter) {
 			const resetDate = new Date(Date.now() + fetchResult.retryAfter * 1000);
 			const resetDateString = resetDate.toLocaleString(undefined, { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit' });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
**Error handling improvements:**

* Updated `getRateLimitMessage` to accept a `copilotPlan` parameter and return tailored rate limit messages depending on the user's plan (free, individual, individual_pro) and whether a reset time is available. [[1]](diffhunk://#diff-98796655c17a161ad411fa7c9086735b4397c00eb977cc8d2c92076e78f8619bL201-R201) [[2]](diffhunk://#diff-98796655c17a161ad411fa7c9086735b4397c00eb977cc8d2c92076e78f8619bR228-R245)
* Modified `getErrorDetailsFromChatFetchErrorInner` to pass the `copilotPlan` argument to `getRateLimitMessage`, ensuring the correct message is shown based on the user's plan.