### PR TITLE
Fix OS toast showing wrong terminal command for pending confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWindowNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWindowNotifier.ts
@@ -165,6 +165,10 @@ export class ChatWindowNotifier extends Disposable implements IWorkbenchContribu
 		}
 		for (const part of lastResponse.response.value) {
 			if (part.kind === 'toolInvocation' && part.toolSpecificData?.kind === 'terminal') {
+				const state = part.state.get();
+				if (state?.type !== IChatToolInvocation.StateKind.WaitingForConfirmation && state?.type !== IChatToolInvocation.StateKind.WaitingForPostApproval) {
+					continue;
+				}
 				const terminalData = migrateLegacyTerminalToolSpecificData(part.toolSpecificData);
 				return terminalData.commandLine.forDisplay ?? terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
 			}


### PR DESCRIPTION
Fix `_getPendingTerminalCommand` in chatWindowNotifier.ts to only return the command from a terminal tool invocation that is actually waiting for confirmation, rather than the first terminal invocation in the response. Previously, if a response had multiple terminal tool calls (e.g. `git status --short` followed by a complex `npx playwright test` command), the notification would show the already-completed command instead of the one pending approval.

Fixes #309576 

