### PR TITLE
Deprecate `chat.tools.terminal.backgroundNotifications` — always send terminal notifications

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -226,7 +226,11 @@ Best Practices:
 - Use find with -exec or xargs for file operations
 - Be specific with commands to avoid excessive output
 - Avoid printing credentials unless absolutely required
+<<<<<<< HEAD
 - NEVER run sleep or similar wait commands in a terminal. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then
+=======
+- NEVER run sleep or similar wait commands in a terminal. You will be automatically notified on your next turn when async terminal commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then
+>>>>>>> 1e84feb49a4 (Fix #309523)
 
 Interactive Input Handling:
 - When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -146,6 +146,7 @@ function createPowerShellModelDescription(shell: string, isSandboxEnabled: boole
 		'- Be specific with Select-Object properties to avoid excessive output',
 		'- Avoid printing credentials unless absolutely required',
 		`- NEVER run Start-Sleep or similar wait commands. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then`,
+		`- NEVER run Start-Sleep or similar wait commands. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then`,
 		'',
 		'Interactive Input Handling:',
 		'- When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.',
@@ -226,11 +227,7 @@ Best Practices:
 - Use find with -exec or xargs for file operations
 - Be specific with commands to avoid excessive output
 - Avoid printing credentials unless absolutely required
-<<<<<<< HEAD
-- NEVER run sleep or similar wait commands in a terminal. You will be automatically notified on your next turn when async terminal commands or timed-out sync commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then
-=======
 - NEVER run sleep or similar wait commands in a terminal. You will be automatically notified on your next turn when async terminal commands complete or need input. Use ${TerminalToolId.GetTerminalOutput} to check output before then
->>>>>>> 1e84feb49a4 (Fix #309523)
 
 Interactive Input Handling:
 - When a terminal command is waiting for interactive input, do NOT suggest alternatives or ask the user whether to proceed. Instead, use the vscode_askQuestions tool to collect the needed values from the user, then send them.


### PR DESCRIPTION
Fixes #309523 
Fixes https://github.com/microsoft/vscode/issues/308548

## Why this needs to be fixed now

This was filed as part of testing the terminal tool improvements (#309095). The `chat.tools.terminal.backgroundNotifications` setting has an inconsistent off-state: setting it to `false` suppresses notifications for true async terminals (`mode=async`) but **not** for foreground terminals that moved to background (timeout/input-needed). This is because the code intentionally bypasses the setting for fg-to-bg transitions — the tool result already promises the model "you will be notified when it completes," so suppressing the notification would leave the agent unable to learn the command finished.

This means the setting was never truly "off" — it only partially suppressed notifications, making it confusing for users and impossible to test deterministically (#309523).

## What changed

- **Always send completion/input-needed notifications** for any terminal in background execution (both true async and fg-to-bg), except for subagent-initiated terminals which can't receive steering messages
- **Deprecated the setting** with default changed to `true` and a deprecation message
- **Updated tool description text** to always include the notification language, removing the conditional phrasing that was misleading
- Removed the `backgroundNotifications` parameter plumbing from all model description helper functions

## Rationale

- Notifications are strictly better for agent quality than requiring polling — less latency, fewer wasted `get_terminal_output` calls
- The fg-to-bg path already always notified regardless of the setting, so behavior was already inconsistent
- The setting was experimental and gated for A/B rollout (`experiment: { mode: 'auto' }`), not intended as a permanent user preference
- The only cost of always-on is extra LLM turns for true async terminals, which is the correct behavior anyway




