### PR TITLE
chat: fix crash on disposed widget in scopedTools derived (#309547)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2571,6 +2571,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// When the widget has loaded a new session, return a snapshot of the tools for this session.
 		// Only sync with the tools model when this session is shown with the same mode.
 		const scopedTools = derived(reader => {
+			if (this._store.isDisposed) {
+				return lastToolsSnapshot;
+			}
 			const activeSession = this._viewModelObs.read(reader)?.sessionResource;
 			const currentModeId = this.input.currentModeObs.read(reader).id;
 			if (isEqual(activeSession, sessionResource) && currentModeId === capturedModeId) {


### PR DESCRIPTION
Fix #309547

The `derived` observable created in `getModeRequestOptions()` outlives the `ChatWidget` — it's returned in request options and kept alive by the session. When an MCP server uninstall triggers tool deletion from an observable set, the derived recomputes. By then, the widget is disposed, so `this.input` is `undefined` (the backing `MutableDisposable` was cleared), and accessing `.currentModeObs` crashes with:

```
Cannot read properties of undefined (reading 'currentModeObs')
```

**Fix:** Add a `this._store.isDisposed` guard at the top of the derived callback. When the widget is disposed, it returns the last known tools snapshot instead of trying to read from the destroyed input part.

(Written by Copilot)