### PR TITLE
Disable cache breakpoints in foreground summarization render

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -668,7 +668,7 @@ class ConversationHistorySummarizer {
 		let summarizationPrompt: ChatMessage[];
 		const associatedRequestId = this.props.promptContext.conversation?.getLatestTurn().id;
 		try {
-			summarizationPrompt = (await renderPromptElement(this.instantiationService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo.props, simpleMode: mode === SummaryMode.Simple }, undefined, this.token)).messages;
+			summarizationPrompt = (await renderPromptElement(this.instantiationService, endpoint, ConversationHistorySummarizationPrompt, { ...propsInfo.props, enableCacheBreakpoints: false, simpleMode: mode === SummaryMode.Simple }, undefined, this.token)).messages;
 			this.logInfo(`summarization prompt rendered in ${stopwatch.elapsed()}ms.`, mode);
 		} catch (e) {
 			const budgetExceeded = e instanceof BudgetExceededError;


### PR DESCRIPTION
## Problem

Foreground summarization renders are hitting `BudgetExceededError` ('No lowest priority node found') at a significant rate (~220 events in 3 days across multiple models including claude-sonnet-4.6, claude-opus-4.6, gpt-5.4-mini, gpt-5.3-codex, grok-code-fast-1, claude-haiku-4.5).

## Root Cause

The `ConversationHistorySummarizationPrompt` was rendered with `enableCacheBreakpoints: true` (inherited from the parent props). This caused `<cacheBreakpoint>` nodes to be injected into every tool result in the prompt-tsx tree.

The budget trimmer in prompt-tsx has cache-point preservation logic: each time it encounters a child with a cache breakpoint, it resets its eviction candidate to `undefined`. When **every** child has a cache breakpoint, no candidate survives the loop and the algorithm throws.