### PR TITLE
Remove page.route handler that breaks loading complex pages

### DIFF
--- a/src/vs/platform/browserView/node/playwrightTab.ts
+++ b/src/vs/platform/browserView/node/playwrightTab.ts
@@ -62,26 +62,6 @@ export class PlaywrightTab {
 			.on('dialog', dialog => this._handleDialog(dialog))
 			.on('download', download => this._handleDownload(download));
 
-		// Block outgoing network requests according to agent network policy.
-		page.route('**/*', (route) => {
-			const requestUrl = route.request().url();
-			try {
-				const uri = URI.parse(requestUrl);
-				if (!this.agentNetworkFilterService.isUriAllowed(uri)) {
-					this._logs.push({
-						type: 'requestBlocked',
-						time: Date.now(),
-						description: this.agentNetworkFilterService.formatError(uri)
-					});
-					route.abort('blockedbyclient').catch(() => { });
-					return;
-				}
-			} catch {
-				// If we can't parse the URL, let it through
-			}
-			route.continue().catch(() => { });
-		}).catch(() => { });
-
 		this._initialized = this._initialize();
 	}
 


### PR DESCRIPTION
Fixes integrated browser not working (regression from network filter changes).
