### PR TITLE
Decouple remote agent host session type from resource URI scheme

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -38,7 +38,6 @@ const IsActiveSessionCopilotCloud = ContextKeyExpr.equals(ActiveSessionTypeConte
 const IsActiveCopilotChatSessionProvider = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, COPILOT_PROVIDER_ID);
 const IsActiveSessionCopilotChatCLI = ContextKeyExpr.and(IsActiveSessionCopilotCLI, IsActiveCopilotChatSessionProvider);
 const IsActiveSessionCopilotChatCloud = ContextKeyExpr.and(IsActiveSessionCopilotCloud, IsActiveCopilotChatSessionProvider);
-const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/);
 const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host');
 
 // -- Actions --
@@ -108,7 +107,7 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionRemoteAgentHost, IsActiveSessionLocalAgentHost),
+				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionLocalAgentHost),
 			}],
 		});
 	}

--- a/src/vs/sessions/contrib/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/remoteAgentHost/REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md
@@ -24,11 +24,38 @@ src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
 | `id` | `'agenthost-${sanitizedAuthority}'` |
 | `label` | Connection name or `address` |
 | `icon` | `Codicon.remote` |
-| `sessionTypes` | Dynamically populated from `rootState.agents`; one entry per agent, each id from `remoteAgentHostSessionTypeId(sanitizedAuthority, agent.provider)` (format: `'remote-${sanitizedAuthority}-${agent.provider}'`), label is the agent's `displayName` |
+| `sessionTypes` | Dynamically populated from `rootState.agents`; copilot agents use the platform `COPILOT_CLI_SESSION_TYPE` (`copilotcli`) as the logical session type id, other agents use `remoteAgentHostSessionTypeId(sanitizedAuthority, agent.provider)` (format: `'remote-${sanitizedAuthority}-${agent.provider}'`), label is the agent's `displayName` |
 
-The session type id is built by the pure helper in `common/remoteAgentHostSessionType.ts`. It is used as the `ISession.sessionType`, the resource URI scheme registered via `registerChatSessionContentProvider`, and the `targetChatSessionType` published by `AgentHostLanguageModelProvider` — keeping these unified so the model picker finds the host's own models.
+The per-connection identifier built by `common/remoteAgentHostSessionType.ts` is used as the resource URI scheme registered via `registerChatSessionContentProvider` and the `targetChatSessionType` published by `AgentHostLanguageModelProvider`. For copilot agents, `ISession.sessionType` uses the platform `COPILOT_CLI_SESSION_TYPE` so that remote copilot sessions align with local CLI and cloud copilot sessions. A dedicated remote agent host model picker filters by `session.resource.scheme` to find models for the active connection.
 
 Agents are discovered dynamically from each host's `rootState`; there is no hard-coded allowlist of supported agent providers. A single `RemoteAgentHostSessionsProvider` per host fans out into one `ISessionType` per advertised agent, and fires `onDidChangeSessionTypes` when the host's agent list changes. Each incoming session's type is derived from its backend URI scheme, so sessions for any agent the host exposes route through the same provider.
+
+## IDs and URI Schemes
+
+A remote session uses three distinct identifiers. For a copilot agent on host `myhost:3000`:
+
+| Purpose | Value | Example |
+|---------|-------|---------|
+| `ISession.sessionType` | Platform type — `COPILOT_CLI_SESSION_TYPE` for copilot agents, per-connection ID for others | `copilotcli` |
+| `resource.scheme` | Unique per-connection ID from `remoteAgentHostSessionTypeId()` | `remote-myhost__3000-copilot` |
+| LM vendor / `targetChatSessionType` | Same as resource scheme | `remote-myhost__3000-copilot` |
+
+Decoupling these allows copilot sessions from different providers (local CLI, remote hosts, cloud) to share the platform session type while keeping content-provider and model-provider routing isolated per host.
+
+### How each ID is used
+
+- **`ISession.sessionType`** — The logical session type visible to the sessions framework. Controls session-type pickers, context keys (`activeSessionType`), and behavioral gating (e.g. `isActiveSessionBackgroundProvider`). Copilot agents share `copilotcli` so they behave consistently with local copilot sessions.
+
+- **`resource.scheme`** — The URI scheme of `ISession.resource` (e.g. `remote-myhost__3000-copilot:///abc123`). Routes `registerChatSessionContentProvider` calls to the correct `AgentHostSessionHandler` for each host. The remote agent host model picker filters available models by `session.resource.scheme` (not `session.sessionType`).
+
+- **LM vendor** — The `targetChatSessionType` published by `AgentHostLanguageModelProvider` and used as the vendor when registering language models. Same value as the resource scheme, ensuring each host's models are isolated.
+
+### Other IDs
+
+- **`rawId`** — The session-local identifier (e.g. `abc123`), extracted from the session URI path. Used as the key in `_sessionCache`.
+- **`sessionId`** — `{providerId}:{resource}` (e.g. `agenthost-myhost__3000:remote-myhost__3000-copilot:///abc123`). The provider-scoped ID passed to `ISessionsProvider` methods.
+- **`providerId`** — `agenthost-${sanitizedAuthority}` (e.g. `agenthost-myhost__3000`). Identifies the provider instance, shared across all agents on the same host.
+- **Backend session URI** — `{agentProvider}:///{rawId}` (e.g. `copilot:///abc123`). Used for protocol operations like `disposeSession`, reconstructed via `AgentSession.uri()`.
 
 ## Browse Actions
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -615,3 +615,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 	},
 });
+
+// Side-effect registrations for the remote agent host feature
+import './remoteAgentHostActions.js';
+import './remoteAgentHostModelPicker.js';

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostModelPicker.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseActionViewItem } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { autorun, observableValue } from '../../../../base/common/observable.js';
+import * as nls from '../../../../nls.js';
+import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { type ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
+import { type IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
+import { ModelPickerActionItem, type IModelPickerDelegate } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem.js';
+import { ActiveSessionProviderIdContext } from '../../../common/contextkeys.js';
+import { type ISession } from '../../../services/sessions/common/session.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { Menus } from '../../../browser/menus.js';
+
+const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/);
+
+// -- Remote Agent Host Model Picker Action --
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'sessions.remoteAgentHost.modelPicker',
+			title: nls.localize2('remoteModelPicker', "Model"),
+			f1: false,
+			menu: [{
+				id: Menus.NewSessionConfig,
+				group: 'navigation',
+				order: 1,
+				when: IsActiveSessionRemoteAgentHost,
+			}],
+		});
+	}
+	override async run(): Promise<void> { /* handled by action view item */ }
+});
+
+// -- Remote Agent Host Model Picker Contribution --
+
+function getRemoteAgentHostModels(
+	languageModelsService: ILanguageModelsService,
+	session: ISession | undefined,
+): ILanguageModelChatMetadataAndIdentifier[] {
+	if (!session) {
+		return [];
+	}
+	// Filter models by resource scheme (unique per-connection) rather than
+	// sessionType, since remote copilot sessions use the platform
+	// COPILOT_CLI_SESSION_TYPE but models are registered under the
+	// per-connection vendor.
+	const resourceScheme = session.resource.scheme;
+	return languageModelsService.getLanguageModelIds()
+		.map(id => {
+			const metadata = languageModelsService.lookupLanguageModel(id);
+			return metadata ? { metadata, identifier: id } : undefined;
+		})
+		.filter((m): m is ILanguageModelChatMetadataAndIdentifier => !!m && m.metadata.targetChatSessionType === resourceScheme);
+}
+
+class RemoteAgentHostModelPickerContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.remoteAgentHostModelPicker';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ILanguageModelsService languageModelsService: ILanguageModelsService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+	) {
+		super();
+
+		this._register(actionViewItemService.register(
+			Menus.NewSessionConfig, 'sessions.remoteAgentHost.modelPicker',
+			() => {
+				const currentModel = observableValue<ILanguageModelChatMetadataAndIdentifier | undefined>('currentModel', undefined);
+				const delegate: IModelPickerDelegate = {
+					currentModel,
+					setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
+						const session = sessionsManagementService.activeSession.get();
+						if (session) {
+							const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
+							provider?.setModel(session.sessionId, model.identifier);
+						}
+					},
+					getModels: () => getRemoteAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
+					useGroupedModelPicker: () => true,
+					showManageModelsAction: () => false,
+					showUnavailableFeatured: () => false,
+					showFeatured: () => true,
+				};
+				const pickerOptions: IChatInputPickerOptions = {
+					hideChevrons: observableValue('hideChevrons', false),
+					hoverPosition: { hoverPosition: HoverPosition.ABOVE },
+				};
+				const action = { id: 'sessions.remoteAgentHost.modelPicker', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } };
+				const modelPicker = instantiationService.createInstance(ModelPickerActionItem, action, delegate, pickerOptions);
+
+				const updatePickerModel = (session: ISession | undefined, sessionModelId: string | undefined) => {
+					const models = getRemoteAgentHostModels(languageModelsService, session);
+					modelPicker.setEnabled(models.length > 0);
+					currentModel.set(sessionModelId ? models.find(model => model.identifier === sessionModelId) : undefined, undefined);
+				};
+				const updatePickerModelFromActiveSession = () => {
+					const session = sessionsManagementService.activeSession.get();
+					updatePickerModel(session, session?.modelId.get());
+				};
+				updatePickerModelFromActiveSession();
+
+				const disposableStore = new DisposableStore();
+				disposableStore.add(languageModelsService.onDidChangeLanguageModels(() => updatePickerModelFromActiveSession()));
+
+				disposableStore.add(autorun(reader => {
+					const session = sessionsManagementService.activeSession.read(reader);
+					const sessionModelId = session?.modelId.read(reader);
+					updatePickerModel(session, sessionModelId);
+				}));
+
+				return new RemoteAgentHostPickerActionViewItem(modelPicker, disposableStore);
+			},
+		));
+	}
+}
+
+class RemoteAgentHostPickerActionViewItem extends BaseActionViewItem {
+	constructor(private readonly picker: { render(container: HTMLElement): void; dispose(): void }, disposable?: DisposableStore) {
+		super(undefined, { id: '', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } });
+		if (disposable) {
+			this._register(disposable);
+		}
+	}
+
+	override render(container: HTMLElement): void {
+		this.picker.render(container);
+	}
+
+	override dispose(): void {
+		this.picker.dispose();
+		super.dispose();
+	}
+}
+
+registerWorkbenchContribution2(RemoteAgentHostModelPickerContribution.ID, RemoteAgentHostModelPickerContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -32,10 +32,42 @@ import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/c
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { ISessionChangeEvent, ISendRequestOptions, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
-import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType } from '../../../services/sessions/common/session.js';
+import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType, COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 import { remoteAgentHostSessionTypeId } from '../common/remoteAgentHostSessionType.js';
 
-const DEFAULT_AGENT_PROVIDER = 'copilot';
+/** The default agent provider name used by agent hosts when no explicit provider is specified. */
+const DEFAULT_AGENT_HOST_PROVIDER = 'copilot';
+
+/**
+ * Maps well-known agent host provider names to the local platform session type
+ * they should be associated with. Agent providers not in this map keep the
+ * unique per-connection ID as their logical session type.
+ */
+const WELL_KNOWN_AGENT_SESSION_TYPES: ReadonlyMap<string, string> = new Map([
+	[DEFAULT_AGENT_HOST_PROVIDER, COPILOT_CLI_SESSION_TYPE],
+]);
+
+/**
+ * Look up the well-known local session type for an agent host provider name.
+ * Returns the mapped type (e.g. `copilotcli`) or `undefined` for unknown providers.
+ */
+function wellKnownSessionType(agentProvider: string): string | undefined {
+	return WELL_KNOWN_AGENT_SESSION_TYPES.get(agentProvider);
+}
+
+/**
+ * Reverse lookup: given a local session type, find the well-known agent host
+ * provider name. Returns `undefined` when the session type is a per-connection
+ * ID rather than a well-known mapping.
+ */
+function wellKnownAgentProvider(sessionType: string): string | undefined {
+	for (const [provider, type] of WELL_KNOWN_AGENT_SESSION_TYPES) {
+		if (type === sessionType) {
+			return provider;
+		}
+	}
+	return undefined;
+}
 
 /** Known auto-approve config values. */
 const AUTO_APPROVE_ENUM = ['default', 'autoApprove', 'autopilot'];
@@ -149,7 +181,7 @@ class RemoteSessionAdapter implements IChatData {
 		private readonly _providerLabel: string,
 	) {
 		const rawId = AgentSession.id(metadata.session);
-		this.agentProvider = AgentSession.provider(metadata.session) ?? DEFAULT_AGENT_PROVIDER;
+		this.agentProvider = AgentSession.provider(metadata.session) ?? DEFAULT_AGENT_HOST_PROVIDER;
 		this.resource = URI.from({ scheme: resourceScheme, path: `/${rawId}` });
 		this.id = `${providerId}:${this.resource.toString()}`;
 		this.providerId = providerId;
@@ -157,7 +189,7 @@ class RemoteSessionAdapter implements IChatData {
 		this.createdAt = new Date(metadata.startTime);
 		this.title = observableValue('title', metadata.summary ?? `Session ${rawId.substring(0, 8)}`);
 		this.updatedAt = observableValue('updatedAt', new Date(metadata.modifiedTime));
-		this.modelId = observableValue<string | undefined>('modelId', metadata.model ? `${logicalSessionType}:${metadata.model}` : undefined);
+		this.modelId = observableValue<string | undefined>('modelId', metadata.model ? `${resourceScheme}:${metadata.model}` : undefined);
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
 		this.description = observableValue('description', new MarkdownString().appendText(this._providerLabel));
 		this.workspace = observableValue('workspace', RemoteAgentHostSessionsProvider.buildWorkspace(metadata.project, metadata.workingDirectory, this._providerLabel));
@@ -180,7 +212,7 @@ class RemoteSessionAdapter implements IChatData {
 		if (metadata.isDone !== undefined) {
 			this.isArchived.set(metadata.isDone, undefined);
 		}
-		this.modelId.set(metadata.model ? `${this.sessionType}:${metadata.model}` : undefined, undefined);
+		this.modelId.set(metadata.model ? `${this.resource.scheme}:${metadata.model}` : undefined, undefined);
 		const workspace = RemoteAgentHostSessionsProvider.buildWorkspace(metadata.project, metadata.workingDirectory, this._providerLabel);
 		if (agentHostSessionWorkspaceKey(workspace) !== agentHostSessionWorkspaceKey(this.workspace.get())) {
 			this.workspace.set(workspace, undefined);
@@ -199,8 +231,11 @@ class RemoteSessionAdapter implements IChatData {
  *
  * **URI/ID scheme:**
  * - **rawId** - unique session identifier (e.g. `abc123`), used as the cache key.
- * - **resource** - `{sessionType}:///{rawId}` (e.g. `remote-host__4321-copilot:///abc123`).
- *   The scheme routes the chat service to the correct {@link AgentHostSessionHandler}.
+ * - **resource** - `{resourceScheme}:///{rawId}` (e.g. `remote-host__4321-copilot:///abc123`).
+ *   The scheme is the unique per-connection id and routes the chat service to the
+ *   correct {@link AgentHostSessionHandler}.
+ * - **sessionType** - the logical session type (e.g. `copilotcli` for copilot agents,
+ *   or the per-connection id for other agents). Distinct from the resource scheme.
  * - **sessionId** - `{providerId}:{resource}` - the provider-scoped ID used by
  *   {@link ISessionsProvider} methods. The rawId can be extracted from the resource path.
  * - Protocol operations (e.g. `disposeSession`) use the canonical agent session URI
@@ -220,13 +255,20 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	/**
 	 * Session types for this provider, one per agent discovered on the host.
 	 * Populated dynamically from the connection's root state and updated when
-	 * agents appear or disappear. Each entry's id is the string used as the
-	 * URI scheme, the `ISession.sessionType`, and the language model's
-	 * `targetChatSessionType` — keeping the three boundaries unified lets the
-	 * model picker route requests to the host's own models.
+	 * agents appear or disappear. Each entry's id is the logical session type
+	 * (e.g. `copilotcli` for copilot agents, the unique per-connection ID for
+	 * other agents). The resource URI scheme and language model vendor remain
+	 * the unique per-connection ID produced by {@link remoteAgentHostSessionTypeId}.
 	 */
 	private _sessionTypes: ISessionType[] = [];
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
+
+	/**
+	 * Maps logical session type id → unique per-connection resource scheme.
+	 * Copilot agents map to `COPILOT_CLI_SESSION_TYPE` as the logical type
+	 * but keep the unique per-connection id as the resource scheme.
+	 */
+	private readonly _sessionTypeToResourceScheme = new Map<string, string>();
 
 	private readonly _onDidChangeSessionTypes = this._register(new Emitter<void>());
 	readonly onDidChangeSessionTypes: Event<void> = this._onDidChangeSessionTypes.event;
@@ -389,22 +431,59 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	 * `(<host label>)` with an empty prefix.
 	 */
 	private _syncSessionTypesFromRootState(rootState: IRootState): void {
-		const next = rootState.agents.map((agent): ISessionType => ({
-			id: remoteAgentHostSessionTypeId(this._connectionAuthority, agent.provider),
-			label: this._formatSessionTypeLabel(agent.displayName?.trim() || agent.provider),
-			icon: Codicon.remote,
-		}));
+		const nextMap = new Map<string, string>();
+		const next = rootState.agents.map((agent): ISessionType => {
+			const resourceScheme = remoteAgentHostSessionTypeId(this._connectionAuthority, agent.provider);
+			const logicalType = this._logicalSessionTypeForProvider(agent.provider);
+			nextMap.set(logicalType, resourceScheme);
+			return {
+				id: logicalType,
+				label: this._formatSessionTypeLabel(agent.displayName?.trim() || agent.provider),
+				icon: Codicon.remote,
+			};
+		});
 
 		const prev = this._sessionTypes;
 		if (prev.length === next.length && prev.every((t, i) => t.id === next[i].id && t.label === next[i].label)) {
 			return;
 		}
 		this._sessionTypes = next;
+		this._sessionTypeToResourceScheme.clear();
+		for (const [key, value] of nextMap) {
+			this._sessionTypeToResourceScheme.set(key, value);
+		}
 		this._onDidChangeSessionTypes.fire();
 	}
 
 	private _formatSessionTypeLabel(agentLabel: string): string {
 		return `${agentLabel} [${this.label}]`;
+	}
+
+	/**
+	 * Returns the logical session type for a given agent provider.
+	 * Well-known providers (see {@link WELL_KNOWN_AGENT_SESSION_TYPES}) map
+	 * to the corresponding platform session type so that remote sessions
+	 * align with local and cloud sessions of the same kind.
+	 * Other agents keep the unique per-connection ID.
+	 */
+	private _logicalSessionTypeForProvider(provider: string): string {
+		return wellKnownSessionType(provider) ?? remoteAgentHostSessionTypeId(this._connectionAuthority, provider);
+	}
+
+	/**
+	 * Returns the unique per-connection resource scheme for a session metadata entry.
+	 */
+	private _resourceSchemeForMetadata(meta: IAgentSessionMetadata): string {
+		const provider = AgentSession.provider(meta.session) ?? DEFAULT_AGENT_HOST_PROVIDER;
+		return remoteAgentHostSessionTypeId(this._connectionAuthority, provider);
+	}
+
+	/**
+	 * Returns the logical session type for a session metadata entry.
+	 */
+	private _logicalSessionTypeForMetadata(meta: IAgentSessionMetadata): string {
+		const provider = AgentSession.provider(meta.session) ?? DEFAULT_AGENT_HOST_PROVIDER;
+		return this._logicalSessionTypeForProvider(provider);
 	}
 
 	/**
@@ -425,6 +504,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 
 		if (this._sessionTypes.length > 0) {
 			this._sessionTypes = [];
+			this._sessionTypeToResourceScheme.clear();
 			this._onDidChangeSessionTypes.fire();
 		}
 
@@ -531,8 +611,10 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	/**
 	 * Build a fresh {@link IChatData} for an untitled session rooted on
 	 * {@link workspace} and targeting {@link sessionType}. The resource URI
-	 * scheme is the session type id, which doubles as the chat session
-	 * content provider scheme, keeping routing unified.
+	 * scheme is the unique per-connection resource scheme (looked up from
+	 * {@link _sessionTypeToResourceScheme}), which routes to the correct
+	 * chat session content provider. The logical session type (e.g.
+	 * `copilotcli`) is stored as `ISession.sessionType`.
 	 *
 	 * Returns the status observable separately so callers can still drive
 	 * state transitions (e.g. to {@link SessionStatus.InProgress}) without
@@ -543,7 +625,8 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		if (!workspaceUri) {
 			throw new Error('Workspace has no repository URI');
 		}
-		const resource = URI.from({ scheme: sessionType.id, path: `/untitled-${generateUuid()}` });
+		const resourceScheme = this._sessionTypeToResourceScheme.get(sessionType.id) ?? sessionType.id;
+		const resource = URI.from({ scheme: resourceScheme, path: `/untitled-${generateUuid()}` });
 		const status = observableValue<SessionStatus>(this, SessionStatus.Untitled);
 		const modelId = observableValue<string | undefined>(this, undefined);
 		const data: IChatData = {
@@ -653,7 +736,8 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 		if (cached && rawId && this._connection) {
 			cached.modelId.set(modelId, undefined);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(cached)] });
-			const rawModelId = modelId.startsWith(`${cached.sessionType}:`) ? modelId.substring(cached.sessionType.length + 1) : modelId;
+			const resourceScheme = cached.resource.scheme;
+			const rawModelId = modelId.startsWith(`${resourceScheme}:`) ? modelId.substring(resourceScheme.length + 1) : modelId;
 			const action = { type: ActionType.SessionModelChanged as const, session: AgentSession.uri(cached.agentProvider, rawId).toString(), model: rawModelId };
 			this._connection.dispatch(action);
 		}
@@ -725,7 +809,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 
 		const { query, attachedContext } = options;
 
-		const contribution = this._chatSessionsService.getChatSessionContribution(session.sessionType);
+		const contribution = this._chatSessionsService.getChatSessionContribution(session.resource.scheme);
 
 		const sendOptions: IChatSendRequestOptions = {
 			location: ChatAgentLocation.Chat,
@@ -906,8 +990,9 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 					existing.update(meta);
 					changed.push(this._chatToSession(existing));
 				} else {
-					const sessionType = this._sessionTypeForMetadata(meta);
-					const cached = new RemoteSessionAdapter(meta, this.id, sessionType, sessionType, this.label);
+					const resourceScheme = this._resourceSchemeForMetadata(meta);
+					const logicalType = this._logicalSessionTypeForMetadata(meta);
+					const cached = new RemoteSessionAdapter(meta, this.id, resourceScheme, logicalType, this.label);
 					this._sessionCache.set(rawId, cached);
 					added.push(this._chatToSession(cached));
 				}
@@ -987,20 +1072,11 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 			isRead: summary.isRead,
 			isDone: summary.isDone,
 		};
-		const sessionType = this._sessionTypeForMetadata(meta);
-		const cached = new RemoteSessionAdapter(meta, this.id, sessionType, sessionType, this.label);
+		const resourceScheme = this._resourceSchemeForMetadata(meta);
+		const logicalType = this._logicalSessionTypeForMetadata(meta);
+		const cached = new RemoteSessionAdapter(meta, this.id, resourceScheme, logicalType, this.label);
 		this._sessionCache.set(rawId, cached);
 		this._onDidChangeSessions.fire({ added: [this._chatToSession(cached)], removed: [], changed: [] });
-	}
-
-	/**
-	 * Resolve the session type id for a session metadata entry. Derives the
-	 * agent provider from the backend session URI so every session is routed
-	 * to the correct per-agent URI scheme / chat session contribution.
-	 */
-	private _sessionTypeForMetadata(meta: IAgentSessionMetadata): string {
-		const provider = AgentSession.provider(meta.session) ?? DEFAULT_AGENT_PROVIDER;
-		return remoteAgentHostSessionTypeId(this._connectionAuthority, provider);
 	}
 
 	private _handleSessionRemoved(session: URI | string): void {
@@ -1025,7 +1101,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	private _handleModelChanged(session: string, model: string): void {
 		const rawId = AgentSession.id(session);
 		const cached = this._sessionCache.get(rawId);
-		const modelId = cached ? `${cached.sessionType}:${model}` : undefined;
+		const modelId = cached ? `${cached.resource.scheme}:${model}` : undefined;
 		if (cached && cached.modelId.get() !== modelId) {
 			cached.modelId.set(modelId, undefined);
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(cached)] });
@@ -1086,12 +1162,11 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements ISess
 	}
 
 	private _agentProviderFromSessionType(sessionType: string): string {
-		const prefix = `remote-${this._connectionAuthority}-`;
-		return sessionType.startsWith(prefix) ? sessionType.substring(prefix.length) : DEFAULT_AGENT_PROVIDER;
+		return wellKnownAgentProvider(sessionType) ?? sessionType.substring(`remote-${this._connectionAuthority}-`.length);
 	}
 
 	private _getAgentProviderForSession(sessionId: string): string {
-		return this._newSessionAgentProviders.get(sessionId) ?? DEFAULT_AGENT_PROVIDER;
+		return this._newSessionAgentProviders.get(sessionId) ?? DEFAULT_AGENT_HOST_PROVIDER;
 	}
 	// -- Private: Browse --
 

--- a/src/vs/sessions/contrib/remoteAgentHost/common/remoteAgentHostSessionType.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/common/remoteAgentHostSessionType.ts
@@ -6,17 +6,18 @@
 import { type AgentProvider } from '../../../../platform/agentHost/common/agentService.js';
 
 /**
- * Builds the session type id for a remote agent host.
+ * Builds the unique per-connection identifier for a remote agent host.
  *
- * This single string is used as all three of:
- * - `ISession.sessionType` (the logical session type the sessions app reads)
+ * This string is used as:
  * - The resource URI scheme registered via `registerChatSessionContentProvider`
- * - The language model's `targetChatSessionType` published by `AgentHostLanguageModelProvider`
+ * - The language model vendor / `targetChatSessionType` published by
+ *   `AgentHostLanguageModelProvider`
  *
- * Keeping them unified means the model picker (which filters by
- * `targetChatSessionType === session.sessionType`) automatically finds the
- * remote host's own models, and feature gating based on session type naturally
- * distinguishes remote sessions from local agent host sessions.
+ * It is **not** used as `ISession.sessionType` for copilot agents — those
+ * use the platform-registered `COPILOT_CLI_SESSION_TYPE` (`copilotcli`) so
+ * that remote copilot sessions align with the type used by other copilot
+ * providers (local CLI, cloud). Non-copilot agents continue to use this
+ * value as their `ISession.sessionType`.
  *
  * The helper is provider-agnostic: remote agents are discovered dynamically
  * from each host's root state, so the same formula naturally supports any

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -28,7 +28,7 @@ import { IChatService, type ChatSendResult, type IChatSendRequestOptions } from 
 import { IChatSessionsService } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { ISessionChangeEvent } from '../../../../services/sessions/common/sessionsProvider.js';
-import { SessionStatus } from '../../../../services/sessions/common/session.js';
+import { SessionStatus, COPILOT_CLI_SESSION_TYPE } from '../../../../services/sessions/common/session.js';
 import { remoteAgentHostSessionTypeId } from '../../common/remoteAgentHostSessionType.js';
 import { RemoteAgentHostSessionsProvider, type IRemoteAgentHostSessionsProviderConfig } from '../../browser/remoteAgentHostSessionsProvider.js';
 
@@ -216,14 +216,14 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(provider.id, 'agenthost-10.0.0.1__8080');
 		assert.strictEqual(provider.label, 'My Host');
 		assert.strictEqual(provider.sessionTypes.length, 1);
-		assert.strictEqual(provider.sessionTypes[0].id, remoteAgentHostSessionTypeId('10.0.0.1__8080', 'copilot'));
+		assert.strictEqual(provider.sessionTypes[0].id, COPILOT_CLI_SESSION_TYPE);
 		assert.strictEqual(provider.sessionTypes[0].label, 'Copilot [My Host]');
 	});
 
 	test('session types update when the host advertises additional agents', () => {
 		const provider = createProvider(disposables, connection, { address: '10.0.0.1:8080', connectionName: 'My Host' });
 		assert.deepStrictEqual(provider.sessionTypes.map(t => t.id), [
-			remoteAgentHostSessionTypeId('10.0.0.1__8080', 'copilot'),
+			COPILOT_CLI_SESSION_TYPE,
 		]);
 
 		let changes = 0;
@@ -236,7 +236,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 
 		assert.strictEqual(changes, 1);
 		assert.deepStrictEqual(provider.sessionTypes.map(t => ({ id: t.id, label: t.label })), [
-			{ id: remoteAgentHostSessionTypeId('10.0.0.1__8080', 'copilot'), label: 'Copilot [My Host]' },
+			{ id: COPILOT_CLI_SESSION_TYPE, label: 'Copilot [My Host]' },
 			{ id: remoteAgentHostSessionTypeId('10.0.0.1__8080', 'openai'), label: 'OpenAI [My Host]' },
 		]);
 	});
@@ -298,7 +298,7 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.deepStrictEqual(
 			sessions.map(s => ({ title: s.title.get(), sessionType: s.sessionType })).sort((a, b) => a.title.localeCompare(b.title)),
 			[
-				{ title: 'Copilot Session', sessionType: remoteAgentHostSessionTypeId('localhost__4321', 'copilot') },
+				{ title: 'Copilot Session', sessionType: COPILOT_CLI_SESSION_TYPE },
 				{ title: 'OpenAI Session', sessionType: remoteAgentHostSessionTypeId('localhost__4321', 'openai') },
 			],
 		);

--- a/src/vs/sessions/contrib/remoteAgentHost/test/common/remoteAgentHostSessionType.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/common/remoteAgentHostSessionType.test.ts
@@ -10,14 +10,15 @@ import { remoteAgentHostSessionTypeId } from '../../common/remoteAgentHostSessio
 suite('remoteAgentHostSessionType', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	// This pins the exact wire format that spans three boundaries:
-	//  - `ISession.sessionType` returned by `RemoteAgentHostSessionsProvider`
+	// This pins the exact wire format that spans two boundaries:
 	//  - The resource URI scheme registered via `registerChatSessionContentProvider`
 	//    in `remoteAgentHost.contribution.ts`
-	//  - `AgentHostLanguageModelProvider.targetChatSessionType`
-	// If these drift, the model picker filter
-	// (`m.metadata.targetChatSessionType === session.sessionType`) stops
+	//  - `AgentHostLanguageModelProvider.targetChatSessionType` (the vendor)
+	// If these drift, the remote agent host model picker filter
+	// (`m.metadata.targetChatSessionType === session.resource.scheme`) stops
 	// matching the remote host's own models.
+	// Note: `ISession.sessionType` for copilot agents uses the platform
+	// `COPILOT_CLI_SESSION_TYPE` instead of this per-connection value.
 	test('remoteAgentHostSessionTypeId pins the wire format', () => {
 		assert.strictEqual(remoteAgentHostSessionTypeId('foo', 'copilot'), 'remote-foo-copilot');
 		assert.strictEqual(remoteAgentHostSessionTypeId('10.0.0.1__8080', 'copilot'), 'remote-10.0.0.1__8080-copilot');

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -203,7 +203,6 @@ import '../platform/agentHost/electron-browser/remoteAgentHostService.js';
 import '../platform/agentHost/electron-browser/sshRemoteAgentHostService.js';
 import './contrib/remoteAgentHost/electron-browser/tunnelAgentHostService.js';
 import './contrib/remoteAgentHost/browser/remoteAgentHost.contribution.js';
-import './contrib/remoteAgentHost/browser/remoteAgentHostActions.js';
 import './contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.js';
 
 // Local Agent Host


### PR DESCRIPTION
Decouple `ISession.sessionType` from the resource URI scheme in `RemoteAgentHostSessionsProvider` so that remote copilot sessions share the platform `copilotcli` session type with local and cloud sessions.

## Changes

- **Session type decoupling**: Remote copilot agents now use `COPILOT_CLI_SESSION_TYPE` (`copilotcli`) as their logical session type, while the unique per-connection ID remains the resource URI scheme and language model vendor. This lets remote copilot sessions participate in the same platform behaviors as local/cloud copilot sessions.

- **Well-known agent mapping**: Replace the confusingly-named `DEFAULT_AGENT_PROVIDER` constant with an explicit `WELL_KNOWN_AGENT_SESSION_TYPES` map that maps agent host provider names (e.g. `copilot`) to local platform session types (e.g. `copilotcli`). Includes `wellKnownSessionType()` and `wellKnownAgentProvider()` helpers for forward/reverse lookups.

- **Model picker extraction**: Extract the remote agent host model picker action, contribution, and helper into a dedicated `remoteAgentHostModelPicker.ts` file. Consolidate side-effect imports into `remoteAgentHost.contribution.ts` to reduce import sprawl in `sessions.desktop.main.ts`.

- **Copilot model picker cleanup**: Remove the remote agent host guard from the copilot model picker `when` clause since remote copilot sessions now have their own dedicated model picker.

- **Tests & docs**: Update test assertions for the new session type values and refresh the `REMOTE_AGENT_HOST_SESSIONS_PROVIDER.md` documentation with a structured IDs and URI schemes section.

(Written by Copilot)