### PR TITLE
Replace images with placeholders in summarization prompt

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -700,6 +700,7 @@ class ConversationHistorySummarizer {
 			} : undefined;
 
 			stripCacheBreakpoints(summarizationPrompt);
+			replaceImageContentWithPlaceholders(summarizationPrompt);
 
 			let messages = ToolCallingLoop.stripInternalToolCallIds(summarizationPrompt);
 
@@ -908,6 +909,17 @@ function stripCacheBreakpoints(messages: ChatMessage[]): void {
 	messages.forEach(message => {
 		message.content = message.content.filter(part => {
 			return part.type !== Raw.ChatCompletionContentPartKind.CacheBreakpoint;
+		});
+	});
+}
+
+function replaceImageContentWithPlaceholders(messages: ChatMessage[]): void {
+	messages.forEach(message => {
+		message.content = message.content.map(part => {
+			if (part.type === Raw.ChatCompletionContentPartKind.Image) {
+				return { type: Raw.ChatCompletionContentPartKind.Text, text: '[Image was attached]' };
+			}
+			return part;
 		});
 	});
 }


### PR DESCRIPTION
## Problem

Gemini models hit "Too many images in request: 11 images provided, but the model supports a maximum of 10 images" during foreground, background, and inline summarization (~29 events in 3 days across gemini-3.1-pro-preview and gemini-3-flash-preview).

## Root Cause

The summarization prompt renders the full conversation history including all image content parts (user-attached images and tool-result screenshots). When a conversation accumulates >10 images, Gemini rejects the request.

## Fix

Replaces `Image` content parts with a `[Image was attached]` text placeholder.
