### PR TITLE
Fix PascalCase keys in copilot cgmanifest.json

### DIFF
--- a/extensions/copilot/cgmanifest.json
+++ b/extensions/copilot/cgmanifest.json
@@ -1,16 +1,16 @@
 {
 	"$schema": "https://json.schemastore.org/component-detection-manifest.json",
-	"Registrations": [
+	"registrations": [
 		{
-			"Component": {
-				"Type": "git",
+			"component": {
+				"type": "git",
 				"git": {
-					"Name": "codex",
-					"RepositoryUrl": "https://github.com/openai/codex",
-					"CommitHash": "acc4acc81eea0339ad46d1c6f8459f58eaee6211"
-				},
-				"DevelopmentDependency": false
-			}
+					"name": "codex",
+					"repositoryUrl": "https://github.com/openai/codex",
+					"commitHash": "acc4acc81eea0339ad46d1c6f8459f58eaee6211"
+				}
+			},
+			"developmentDependency": false
 		}
 	]
 }


### PR DESCRIPTION
The `extensions/copilot/cgmanifest.json` uses PascalCase keys (`Registrations`, `Component`, `Type`, etc.) instead of the camelCase required by the [official schema](https://json.schemastore.org/component-detection-manifest.json). This caused the OSS license tool in vscode-build-tools to crash silently — `fileContents.registrations` was `undefined` because the key was `Registrations`.

This normalizes the file to use camelCase keys matching every other `cgmanifest.json` in the repo.

Companion PR: microsoft/vscode-build-tools — adds defensive PascalCase→camelCase normalization in the OSS tool.