### PR TITLE
Don't show onboarding on web

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -31,6 +31,7 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { AuxiliaryBarMaximizedContext } from '../../../common/contextkeys.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { getActiveElement } from '../../../../base/browser/dom.js';
+import { isWeb } from '../../../../base/common/platform.js';
 import { IOnboardingService } from '../../welcomeOnboarding/common/onboardingService.js';
 import { ONBOARDING_STORAGE_KEY } from '../../welcomeOnboarding/common/onboardingTypes.js';
 
@@ -233,6 +234,10 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 	private tryShowOnboarding(): void {
 		if (this.environmentService.skipWelcome) {
 			return; // skip welcome flag is set
+		}
+
+		if (isWeb && !this.environmentService.remoteAuthority) {
+			return; // not supported on web without remote authority (e.g. github.dev)
 		}
 
 		if (!this.configurationService.getValue<boolean>('workbench.welcomePage.experimentalOnboarding')) {


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode/issues/309557

Environment-specific onboarding logic:

* Added a check using `isWeb` to skip the onboarding page when running in a web environment without a remote authority, preventing unsupported scenarios (e.g., github.dev). (`src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts`) [[1]](diffhunk://#diff-9090a153d4c0d709ee549d7de1b1e1aa00402c45cd8344d3aee2e7aa170cbfeaR34) [[2]](diffhunk://#diff-9090a153d4c0d709ee549d7de1b1e1aa00402c45cd8344d3aee2e7aa170cbfeaR239-R242)