### PR TITLE
Extract IAgentHostSessionsProvider types out of ISessionsProvider

### DIFF
--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -24,9 +24,9 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 
 	// -- Dynamic Session Config --
 
-	/** Fires when dynamic configuration for a new session changes. */
+	/** Fires when dynamic configuration for a session changes. */
 	readonly onDidChangeSessionConfig: Event<string>;
-	/** Returns the last resolved dynamic configuration for a new session. */
+	/** Returns the last resolved dynamic configuration for a session. */
 	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined;
 	/** Sets one dynamic configuration property and re-resolves the schema. */
 	setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void>;
@@ -41,7 +41,10 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
 const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
 
-/** Type guard that checks whether a provider implements {@link IAgentHostSessionsProvider}. */
+/**
+ * Checks whether a provider is an agent host provider based on its
+ * reserved provider ID (`local-agent-host` or `agenthost-*` prefix).
+ */
 export function isAgentHostProvider(provider: ISessionsProvider): provider is IAgentHostSessionsProvider {
 	return provider.id === LOCAL_AGENT_HOST_PROVIDER_ID || provider.id.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX);
 }

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../base/common/event.js';
+import { IObservable } from '../../base/common/observable.js';
+import { RemoteAgentHostConnectionStatus } from '../../platform/agentHost/common/remoteAgentHostService.js';
+import { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../platform/agentHost/common/state/protocol/commands.js';
+import { ISessionsProvider } from '../services/sessions/common/sessionsProvider.js';
+
+/**
+ * Extended sessions provider for agent host providers (local and remote).
+ * Adds remote connection properties and dynamic session configuration.
+ */
+export interface IAgentHostSessionsProvider extends ISessionsProvider {
+	// -- Remote Connection (optional, used by remote agent host providers) --
+	/** Connection status observable, present on remote providers. */
+	readonly connectionStatus?: IObservable<RemoteAgentHostConnectionStatus>;
+	/** Remote address string, present on remote providers. */
+	readonly remoteAddress?: string;
+	/** Output channel ID for remote provider logs. */
+	outputChannelId?: string;
+
+	// -- Dynamic Session Config --
+
+	/** Fires when dynamic configuration for a new session changes. */
+	readonly onDidChangeSessionConfig: Event<string>;
+	/** Returns the last resolved dynamic configuration for a new session. */
+	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined;
+	/** Sets one dynamic configuration property and re-resolves the schema. */
+	setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void>;
+	/** Returns dynamic completions for a configuration property. */
+	getSessionConfigCompletions(sessionId: string, property: string, query?: string): Promise<readonly ISessionConfigValueItem[]>;
+	/** Returns the resolved config that should be sent to createSession. */
+	getCreateSessionConfig(sessionId: string): Record<string, string> | undefined;
+	/** Clears dynamic configuration state for an abandoned new session. */
+	clearSessionConfig(sessionId: string): void;
+}
+
+const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
+const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
+
+/** Type guard that checks whether a provider implements {@link IAgentHostSessionsProvider}. */
+export function isAgentHostProvider(provider: ISessionsProvider): provider is IAgentHostSessionsProvider {
+	return provider.id === LOCAL_AGENT_HOST_PROVIDER_ID || provider.id.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX);
+}

--- a/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
@@ -33,6 +33,7 @@ import { ActiveSessionProviderIdContext } from '../../../common/contextkeys.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import type { ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
+import { type IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 
 const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/);
 const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host');
@@ -248,7 +249,7 @@ class AgentHostSessionConfigPicker extends Disposable {
 
 	private _watchProviders(providers: readonly ISessionsProvider[]): void {
 		for (const provider of providers) {
-			if (!provider.onDidChangeSessionConfig || this._providerListeners.has(provider.id)) {
+			if (!isAgentHostProvider(provider) || this._providerListeners.has(provider.id)) {
 				continue;
 			}
 			this._providerListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._renderConfigPickers()));
@@ -270,7 +271,7 @@ class AgentHostSessionConfigPicker extends Disposable {
 
 		const session = this._sessionsManagementService.activeSession.get();
 		const provider = session ? this._getProvider(session.providerId) : undefined;
-		const resolvedConfig = session && provider?.getSessionConfig?.(session.sessionId);
+		const resolvedConfig = session && provider?.getSessionConfig(session.sessionId);
 		if (!session || !provider || !resolvedConfig) {
 			return;
 		}
@@ -304,7 +305,7 @@ class AgentHostSessionConfigPicker extends Disposable {
 		applyAutoApproveTriggerStyles(trigger, property, value);
 	}
 
-	private async _showPicker(provider: ISessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
+	private async _showPicker(provider: IAgentHostSessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
 		if (schema.readOnly || this._actionWidgetService.isVisible) {
 			return;
 		}
@@ -315,7 +316,7 @@ class AgentHostSessionConfigPicker extends Disposable {
 		}
 
 		const isAutoApproveProperty = property === AUTO_APPROVE_PROPERTY;
-		const currentValue = provider.getSessionConfig?.(sessionId)?.values[property];
+		const currentValue = provider.getSessionConfig(sessionId)?.values[property];
 		const actionItems = toActionItems(property, items, currentValue, policyRestricted);
 
 		const delegate: IActionListDelegate<IConfigPickerItem> = {
@@ -329,10 +330,10 @@ class AgentHostSessionConfigPicker extends Disposable {
 					}
 				}
 
-				provider.setSessionConfigValue?.(sessionId, property, item.value).catch(() => { /* best-effort */ });
+				provider.setSessionConfigValue(sessionId, property, item.value).catch(() => { /* best-effort */ });
 			},
-			onFilter: schema.enumDynamic && provider.getSessionConfigCompletions
-				? query => this._filterDelayer.trigger(async () => toActionItems(property, await this._getItems(provider, sessionId, property, schema, query), provider.getSessionConfig?.(sessionId)?.values[property]))
+			onFilter: schema.enumDynamic
+				? query => this._filterDelayer.trigger(async () => toActionItems(property, await this._getItems(provider, sessionId, property, schema, query), provider.getSessionConfig(sessionId)?.values[property]))
 				: undefined,
 			onHide: () => trigger.focus(),
 		};
@@ -353,8 +354,8 @@ class AgentHostSessionConfigPicker extends Disposable {
 		);
 	}
 
-	private async _getItems(provider: ISessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, query?: string): Promise<readonly IConfigPickerItem[]> {
-		const dynamicItems = schema.enumDynamic && provider.getSessionConfigCompletions
+	private async _getItems(provider: IAgentHostSessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, query?: string): Promise<readonly IConfigPickerItem[]> {
+		const dynamicItems = schema.enumDynamic
 			? await provider.getSessionConfigCompletions(sessionId, property, query)
 			: undefined;
 		if (dynamicItems?.length) {
@@ -384,8 +385,9 @@ class AgentHostSessionConfigPicker extends Disposable {
 		return schema.title;
 	}
 
-	private _getProvider(providerId: string): ISessionsProvider | undefined {
-		return this._sessionsProvidersService.getProvider(providerId);
+	private _getProvider(providerId: string): IAgentHostSessionsProvider | undefined {
+		const provider = this._sessionsProvidersService.getProvider(providerId);
+		return provider && isAgentHostProvider(provider) ? provider : undefined;
 	}
 }
 
@@ -494,7 +496,7 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 
 	private _watchProviders(providers: readonly ISessionsProvider[]): void {
 		for (const provider of providers) {
-			if (!provider.onDidChangeSessionConfig || this._providerListeners.has(provider.id)) {
+			if (!isAgentHostProvider(provider) || this._providerListeners.has(provider.id)) {
 				continue;
 			}
 			this._providerListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._render()));
@@ -515,8 +517,9 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 		dom.clearNode(this._container);
 
 		const session = this._sessionsManagementService.activeSession.get();
-		const provider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
-		const config = session && provider?.getSessionConfig?.(session.sessionId);
+		const rawProvider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const provider = rawProvider && isAgentHostProvider(rawProvider) ? rawProvider : undefined;
+		const config = session && provider?.getSessionConfig(session.sessionId);
 		if (!session || !provider || !config) {
 			return;
 		}
@@ -546,7 +549,7 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 		applyAutoApproveTriggerStyles(trigger, AUTO_APPROVE_PROPERTY, value);
 	}
 
-	private async _showPicker(provider: ISessionsProvider, sessionId: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
+	private async _showPicker(provider: IAgentHostSessionsProvider, sessionId: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
 		if (this._actionWidgetService.isVisible) {
 			return;
 		}
@@ -563,7 +566,7 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 			return;
 		}
 
-		const currentValue = provider.getSessionConfig?.(sessionId)?.values[AUTO_APPROVE_PROPERTY];
+		const currentValue = provider.getSessionConfig(sessionId)?.values[AUTO_APPROVE_PROPERTY];
 		const actionItems = toActionItems(AUTO_APPROVE_PROPERTY, items, currentValue, policyRestricted);
 
 		const delegate: IActionListDelegate<IConfigPickerItem> = {
@@ -577,7 +580,7 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 					}
 				}
 
-				provider.setSessionConfigValue?.(sessionId, AUTO_APPROVE_PROPERTY, item.value).catch(() => { /* best-effort */ });
+				provider.setSessionConfigValue(sessionId, AUTO_APPROVE_PROPERTY, item.value).catch(() => { /* best-effort */ });
 			},
 			onHide: () => trigger.focus(),
 		};
@@ -666,7 +669,7 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 
 	private _watchProviders(providers: readonly ISessionsProvider[]): void {
 		for (const provider of providers) {
-			if (!provider.onDidChangeSessionConfig || this._providerListeners.has(provider.id)) {
+			if (!isAgentHostProvider(provider) || this._providerListeners.has(provider.id)) {
 				continue;
 			}
 			this._providerListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._render()));
@@ -687,8 +690,9 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 		dom.clearNode(this._container);
 
 		const session = this._sessionsManagementService.activeSession.get();
-		const provider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
-		const config = session && provider?.getSessionConfig?.(session.sessionId);
+		const rawProvider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const provider = rawProvider && isAgentHostProvider(rawProvider) ? rawProvider : undefined;
+		const config = session && provider?.getSessionConfig(session.sessionId);
 		if (!session || !provider || !config) {
 			return;
 		}
@@ -719,7 +723,7 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 		applyAutoApproveTriggerStyles(trigger, property, value);
 	}
 
-	private async _showPicker(provider: ISessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
+	private async _showPicker(provider: IAgentHostSessionsProvider, sessionId: string, property: string, schema: ISessionConfigPropertySchema, trigger: HTMLElement): Promise<void> {
 		if (this._actionWidgetService.isVisible) {
 			return;
 		}
@@ -737,7 +741,7 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 			return;
 		}
 
-		const currentValue = provider.getSessionConfig?.(sessionId)?.values[property];
+		const currentValue = provider.getSessionConfig(sessionId)?.values[property];
 		const actionItems = toActionItems(property, items, currentValue, policyRestricted);
 
 		const delegate: IActionListDelegate<IConfigPickerItem> = {
@@ -751,7 +755,7 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 					}
 				}
 
-				provider.setSessionConfigValue?.(sessionId, property, item.value).catch(() => { /* best-effort */ });
+				provider.setSessionConfigValue(sessionId, property, item.value).catch(() => { /* best-effort */ });
 			},
 			onHide: () => trigger.focus(),
 		};

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -48,6 +48,7 @@ import { SessionsChatAccessibilityHelp } from './sessionsChatAccessibilityHelp.j
 import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { IRemoteAgentHostService, IRemoteAgentHostSSHConnection, RemoteAgentHostEntryType } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
 
 export class OpenSessionWorktreeInVSCodeAction extends Action2 {
@@ -145,7 +146,7 @@ export function resolveRemoteAuthority(
 	remoteAgentHostService: IRemoteAgentHostService,
 ): string | undefined {
 	const provider = sessionsProvidersService.getProvider(providerId);
-	if (!provider?.remoteAddress) {
+	if (!provider || !isAgentHostProvider(provider) || !provider.remoteAddress) {
 		return undefined;
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -39,6 +39,7 @@ import { localize } from '../../../../nls.js';
 import * as aria from '../../../../base/browser/ui/aria/aria.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import type { ISession } from '../../../services/sessions/common/session.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
@@ -570,7 +571,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 	private _watchSessionConfigProviders(): void {
 		for (const provider of this.sessionsProvidersService.getProviders()) {
-			if (!provider.onDidChangeSessionConfig || this._sessionConfigListeners.has(provider.id)) {
+			if (!isAgentHostProvider(provider) || this._sessionConfigListeners.has(provider.id)) {
 				continue;
 			}
 			this._sessionConfigListeners.set(provider.id, provider.onDidChangeSessionConfig(() => this._updateSendButtonState()));
@@ -579,7 +580,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 	private _isSessionConfigReady(session: ISession): boolean {
 		const provider = this.sessionsProvidersService.getProvider(session.providerId);
-		if (!provider?.getSessionConfig) {
+		if (!provider || !isAgentHostProvider(provider)) {
 			return true;
 		}
 		return provider.getSessionConfig(session.sessionId)?.ready ?? true;

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -30,7 +30,7 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction } from '../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
-import { ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
+import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 
 const LEGACY_STORAGE_KEY_RECENT_PROJECTS = 'sessions.recentlyPickedProjects';
@@ -64,7 +64,7 @@ interface IWorkspacePickerItem {
 	readonly browseActionIndex?: number;
 	readonly checked?: boolean;
 	/** Remote provider reference for gear menu actions. */
-	readonly remoteProvider?: ISessionsProvider;
+	readonly remoteProvider?: IAgentHostSessionsProvider;
 	/** When true, clicking this item triggers the tunnel connection command. */
 	readonly tunnelAction?: boolean;
 }
@@ -371,7 +371,7 @@ export class WorkspacePicker extends Disposable {
 		// Browse actions from all providers
 		const allBrowseActions = this._getAllBrowseActions();
 		// Remote providers with connection status
-		const remoteProviders = allProviders.filter(p => p.connectionStatus !== undefined);
+		const remoteProviders = allProviders.filter(isAgentHostProvider).filter(p => p.connectionStatus !== undefined);
 
 		if (items.length > 0 && (allBrowseActions.length > 0 || remoteProviders.length > 0)) {
 			items.push({ kind: ActionListItemKind.Separator, label: '' });
@@ -529,12 +529,12 @@ export class WorkspacePicker extends Disposable {
 	 * This ensures the action widget has fully hidden before the quickpick opens,
 	 * preventing focus conflicts that cause the quickpick to flash and disappear.
 	 */
-	private _showRemoteHostOptionsDelayed(provider: ISessionsProvider): void {
+	private _showRemoteHostOptionsDelayed(provider: IAgentHostSessionsProvider): void {
 		const timeout = setTimeout(() => this._showRemoteHostOptions(provider), 1);
 		this._renderDisposables.add({ dispose: () => clearTimeout(timeout) });
 	}
 
-	private async _showRemoteHostOptions(provider: ISessionsProvider): Promise<void> {
+	private async _showRemoteHostOptions(provider: IAgentHostSessionsProvider): Promise<void> {
 		const address = provider.remoteAddress;
 		if (!address) {
 			return;
@@ -611,8 +611,8 @@ export class WorkspacePicker extends Disposable {
 	 * Returns false for providers without connection status (e.g. local providers).
 	 */
 	private _isProviderUnavailable(providerId: string): boolean {
-		const provider = this.sessionsProvidersService.getProviders().find(p => p.id === providerId);
-		if (!provider?.connectionStatus) {
+		const provider = this.sessionsProvidersService.getProvider(providerId);
+		if (!provider || !isAgentHostProvider(provider) || !provider.connectionStatus) {
 			return false;
 		}
 		return provider.connectionStatus.get() !== RemoteAgentHostConnectionStatus.Connected;
@@ -624,7 +624,7 @@ export class WorkspacePicker extends Disposable {
 	 * provider. When a remote reconnects, try to restore a stored workspace.
 	 */
 	private _watchConnectionStatus(): void {
-		const remoteProviders = this.sessionsProvidersService.getProviders().filter(p => p.connectionStatus !== undefined);
+		const remoteProviders = this.sessionsProvidersService.getProviders().filter(isAgentHostProvider).filter(p => p.connectionStatus !== undefined);
 		if (remoteProviders.length === 0) {
 			this._connectionStatusListener.clear();
 			return;

--- a/src/vs/sessions/contrib/chat/test/browser/resolveRemoteAuthority.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/resolveRemoteAuthority.test.ts
@@ -16,7 +16,7 @@ suite('resolveRemoteAuthority', () => {
 
 	function makeProvidersService(remoteAddress?: string): ISessionsProvidersService {
 		return {
-			getProvider: () => remoteAddress ? { remoteAddress } : undefined,
+			getProvider: (id: string) => remoteAddress ? { id, remoteAddress } : undefined,
 		} as unknown as ISessionsProvidersService; // no-as-any justification: lightweight test mock for a multi-method service interface
 	}
 
@@ -37,10 +37,10 @@ suite('resolveRemoteAuthority', () => {
 
 	test('returns undefined when provider has no remoteAddress', () => {
 		const noRemoteProviders = {
-			getProvider: () => ({ /* no remoteAddress */ }),
+			getProvider: (id: string) => ({ id /* no remoteAddress */ }),
 		} as unknown as ISessionsProvidersService; // no-as-any justification: lightweight test mock for a multi-method service interface
 		const result = resolveRemoteAuthority(
-			'some-id',
+			'agenthost-no-address',
 			noRemoteProviders,
 			makeRemoteAgentHostService() as IRemoteAgentHostService,
 		);

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -23,6 +23,7 @@ import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/
 import { extUri } from '../../../../../base/common/resources.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
+import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
 import { ISessionWorkspace } from '../../../../services/sessions/common/session.js';
 import { WorkspacePicker, IWorkspaceSelection } from '../../browser/sessionWorkspacePicker.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
@@ -35,13 +36,12 @@ const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
 function createMockProvider(id: string, opts?: {
 	connectionStatus?: ISettableObservable<RemoteAgentHostConnectionStatus>;
 }): ISessionsProvider {
-	return {
+	const base = {
 		id,
 		label: `Provider ${id}`,
 		icon: Codicon.remote,
 		sessionTypes: [],
 		onDidChangeSessionTypes: Event.None,
-		connectionStatus: opts?.connectionStatus,
 		browseActions: [],
 		resolveWorkspace: (uri: URI): ISessionWorkspace => ({
 			label: uri.path.substring(1) || uri.path,
@@ -63,6 +63,19 @@ function createMockProvider(id: string, opts?: {
 		capabilities: { multipleChatsPerSession: false },
 		onDidChangeCapabilities: Event.None,
 	};
+	if (opts?.connectionStatus) {
+		return {
+			...base,
+			connectionStatus: opts.connectionStatus,
+			onDidChangeSessionConfig: Event.None,
+			getSessionConfig: () => undefined,
+			setSessionConfigValue: async () => { },
+			getSessionConfigCompletions: async () => [],
+			getCreateSessionConfig: () => undefined,
+			clearSessionConfig: () => { },
+		} as IAgentHostSessionsProvider;
+	}
+	return base;
 }
 
 class MockSessionsProvidersService extends Disposable {
@@ -154,12 +167,12 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('restore skips unavailable (disconnected) provider', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Disconnected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 		const localProvider = createMockProvider('local-1');
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 			{ uri: URI.file('/local/project'), providerId: 'local-1', checked: false },
 		]);
 
@@ -172,12 +185,12 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('restore skips connecting provider', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connecting);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 		const localProvider = createMockProvider('local-1');
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 			{ uri: URI.file('/local/project'), providerId: 'local-1', checked: false },
 		]);
 
@@ -189,31 +202,31 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('restore picks connected remote provider', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 		]);
 
 		providersService.setProviders([remoteProvider]);
 		const picker = createTestPicker(disposables, providersService, storage);
 
-		assertSelectedProvider(picker, 'remote-1');
+		assertSelectedProvider(picker, 'agenthost-remote-1');
 	});
 
 	test('disconnect clears selection from that provider', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 		]);
 
 		providersService.setProviders([remoteProvider]);
 		const picker = createTestPicker(disposables, providersService, storage);
-		assertSelectedProvider(picker, 'remote-1');
+		assertSelectedProvider(picker, 'agenthost-remote-1');
 
 		// Disconnect
 		remoteStatus.set(RemoteAgentHostConnectionStatus.Disconnected, undefined);
@@ -222,16 +235,16 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('reconnect restores the same workspace', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 		]);
 
 		providersService.setProviders([remoteProvider]);
 		const picker = createTestPicker(disposables, providersService, storage);
-		assertSelectedProvider(picker, 'remote-1');
+		assertSelectedProvider(picker, 'agenthost-remote-1');
 
 		// Disconnect — clears selection
 		remoteStatus.set(RemoteAgentHostConnectionStatus.Disconnected, undefined);
@@ -239,7 +252,7 @@ suite('WorkspacePicker - Connection Status', () => {
 
 		// Reconnect — should restore
 		remoteStatus.set(RemoteAgentHostConnectionStatus.Connected, undefined);
-		assertSelectedProvider(picker, 'remote-1', 'Should restore after reconnect');
+		assertSelectedProvider(picker, 'agenthost-remote-1', 'Should restore after reconnect');
 		assert.strictEqual(
 			picker.selectedProject?.workspace.repositories[0]?.uri.path,
 			'/remote/project',
@@ -249,18 +262,18 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('disconnect does not auto-select another provider workspace', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 		const localProvider = createMockProvider('local-1');
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 			{ uri: URI.file('/local/project'), providerId: 'local-1', checked: false },
 		]);
 
 		providersService.setProviders([remoteProvider, localProvider]);
 		const picker = createTestPicker(disposables, providersService, storage);
-		assertSelectedProvider(picker, 'remote-1');
+		assertSelectedProvider(picker, 'agenthost-remote-1');
 
 		// Disconnect remote
 		remoteStatus.set(RemoteAgentHostConnectionStatus.Disconnected, undefined);
@@ -272,11 +285,11 @@ suite('WorkspacePicker - Connection Status', () => {
 	test('checked is globally unique after persist', () => {
 		const localProvider = createMockProvider('local-1');
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 			{ uri: URI.file('/local/project'), providerId: 'local-1', checked: false },
 		]);
 
@@ -301,11 +314,11 @@ suite('WorkspacePicker - Connection Status', () => {
 
 	test('onDidSelectWorkspace fires on reconnect restore', () => {
 		const remoteStatus = observableValue<RemoteAgentHostConnectionStatus>('status', RemoteAgentHostConnectionStatus.Connected);
-		const remoteProvider = createMockProvider('remote-1', { connectionStatus: remoteStatus });
+		const remoteProvider = createMockProvider('agenthost-remote-1', { connectionStatus: remoteStatus });
 
 		const storage = disposables.add(new TestStorageService());
 		seedStorage(storage, [
-			{ uri: URI.file('/remote/project'), providerId: 'remote-1', checked: true },
+			{ uri: URI.file('/remote/project'), providerId: 'agenthost-remote-1', checked: true },
 		]);
 
 		providersService.setProviders([remoteProvider]);
@@ -323,7 +336,7 @@ suite('WorkspacePicker - Connection Status', () => {
 		remoteStatus.set(RemoteAgentHostConnectionStatus.Connected, undefined);
 
 		assert.strictEqual(selected.length, 1, 'onDidSelectWorkspace should fire once on reconnect');
-		assert.strictEqual(selected[0].providerId, 'remote-1');
+		assert.strictEqual(selected[0].providerId, 'agenthost-remote-1');
 		assert.strictEqual(selected[0].workspace.repositories[0]?.uri.path, '/remote/project', 'Event should carry the correct workspace URI');
 	});
 

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -26,7 +26,8 @@ import { IChatSessionFileChange, IChatSessionsService } from '../../../../workbe
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
-import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
+import { ISendRequestOptions, ISessionChangeEvent } from '../../../services/sessions/common/sessionsProvider.js';
+import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, type IGitHubInfo, ISessionType } from '../../../services/sessions/common/session.js';
 
 const LOCAL_PROVIDER_ID = 'local-agent-host';
@@ -206,7 +207,7 @@ class LocalSessionAdapter implements ISession {
  * - **sessionId** - `local-agent-host:agent-host-{provider}:///{rawId}` — the
  *   provider-scoped ID used by {@link ISessionsProvider}.
  */
-export class LocalAgentHostSessionsProvider extends Disposable implements ISessionsProvider {
+export class LocalAgentHostSessionsProvider extends Disposable implements IAgentHostSessionsProvider {
 
 	readonly id = LOCAL_PROVIDER_ID;
 	readonly label: string;

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -19,6 +19,7 @@ import { SessionsCategories } from '../../../common/categories.js';
 import { NewChatViewPane, SessionsViewId } from '../../chat/browser/newChatViewPane.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 
 registerAction2(class extends Action2 {
 	constructor() {
@@ -363,7 +364,7 @@ async function promptForRemoteFolder(
 
 	// The provider is created synchronously during addSSHConnection's
 	// onDidChangeConnections event, so it should exist by now.
-	const provider = sessionsProvidersService.getProviders().find(p => p.remoteAddress === connection.localAddress);
+	const provider = sessionsProvidersService.getProviders().find((p): p is IAgentHostSessionsProvider => isAgentHostProvider(p) && p.remoteAddress === connection.localAddress);
 	if (!provider) {
 		return;
 	}
@@ -615,7 +616,7 @@ async function promptForTunnelFolder(
 
 	// The provider is created by TunnelAgentHostContribution when the
 	// tunnel is cached (via onDidChangeTunnels / _reconcileProviders).
-	const provider = sessionsProvidersService.getProviders().find(p => p.remoteAddress === tunnelAddress);
+	const provider = sessionsProvidersService.getProviders().find((p): p is IAgentHostSessionsProvider => isAgentHostProvider(p) && p.remoteAddress === tunnelAddress);
 	if (!provider) {
 		return;
 	}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -31,7 +31,8 @@ import { IChatSessionFileChange, IChatSessionsService } from '../../../../workbe
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
-import { ISessionChangeEvent, ISendRequestOptions, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
+import { ISessionChangeEvent, ISendRequestOptions } from '../../../services/sessions/common/sessionsProvider.js';
+import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType, COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 import { remoteAgentHostSessionTypeId } from '../common/remoteAgentHostSessionType.js';
 
@@ -241,7 +242,7 @@ class RemoteSessionAdapter implements IChatData {
  * - Protocol operations (e.g. `disposeSession`) use the canonical agent session URI
  *   (`copilot:///abc123`), reconstructed via {@link AgentSession.uri}.
  */
-export class RemoteAgentHostSessionsProvider extends Disposable implements ISessionsProvider {
+export class RemoteAgentHostSessionsProvider extends Disposable implements IAgentHostSessionsProvider {
 
 	readonly id: string;
 	readonly label: string;

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -313,9 +313,6 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		if (previousSession?.sessionId === session?.sessionId) {
 			return;
 		}
-		if (previousSession?.status.get() === SessionStatus.Untitled) {
-			this._getProvider(previousSession)?.clearSessionConfig?.(previousSession.sessionId);
-		}
 
 		// Update context keys from session data
 		this._activeSessionProviderId.set(session?.providerId ?? '');

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -4,11 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../base/common/event.js';
-import { IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
-import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction } from './session.js';
 
@@ -169,27 +166,4 @@ export interface ISessionsProvider {
 	 * @param options Options for the request, including the query and any attached context entries.
 	 */
 	sendAndCreateChat(sessionId: string, options: ISendRequestOptions): Promise<ISession>;
-
-	// -- Remote Connection (optional, used by remote agent host providers) --
-	/** Connection status observable, present on remote providers. */
-	readonly connectionStatus?: IObservable<RemoteAgentHostConnectionStatus>;
-	/** Remote address string, present on remote providers. */
-	readonly remoteAddress?: string;
-	/** Output channel ID for remote provider logs. */
-	outputChannelId?: string;
-
-	// -- Dynamic Session Config --
-
-	/** Optional. Fires when dynamic configuration for a new session changes. */
-	readonly onDidChangeSessionConfig?: Event<string>;
-	/** Optional. Returns the last resolved dynamic configuration for a new session. */
-	getSessionConfig?(sessionId: string): IResolveSessionConfigResult | undefined;
-	/** Optional. Sets one dynamic configuration property and re-resolves the schema. */
-	setSessionConfigValue?(sessionId: string, property: string, value: string): Promise<void>;
-	/** Optional. Returns dynamic completions for a configuration property. */
-	getSessionConfigCompletions?(sessionId: string, property: string, query?: string): Promise<readonly ISessionConfigValueItem[]>;
-	/** Optional. Returns the resolved config that should be sent to createSession. */
-	getCreateSessionConfig?(sessionId: string): Record<string, string> | undefined;
-	/** Optional. Clears dynamic configuration state for an abandoned new session. */
-	clearSessionConfig?(sessionId: string): void;
 }


### PR DESCRIPTION
Move agent-host-specific properties out of the common `ISessionsProvider` interface into a new `IAgentHostSessionsProvider` interface in `sessions/common/agentHostSessionsProvider.ts`.

### Changes

- **New file** `src/vs/sessions/common/agentHostSessionsProvider.ts` — contains `IAgentHostSessionsProvider` (extends `ISessionsProvider`) with connection status, remote address, output channel, and dynamic session config methods
- **ID-based type guard** `isAgentHostProvider()` replaces all unsafe `as IAgentHostSessionsProvider` casts and `getProvider<IAgentHostSessionsProvider>()` calls
- **Removed** `clearSessionConfig` coupling from `sessionsManagementService` — already handled by `createNewSession` internally
- **Updated** all consumers: config pickers, workspace picker, new chat view, chat contribution, remote agent host actions, and tests