### PR TITLE
Refactor CopilotCLIModels for model caching on authentication changes

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -66,7 +66,7 @@ export const ICopilotCLIModels = createServiceIdentifier<ICopilotCLIModels>('ICo
 
 export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 	declare _serviceBrand: undefined;
-	private readonly _availableModels: Lazy<Promise<CopilotCLIModelInfo[]>>;
+	private _availableModels?: Promise<CopilotCLIModelInfo[]>;
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	constructor(
 		@ICopilotCLISDK private readonly copilotCLISDK: ICopilotCLISDK,
@@ -76,9 +76,9 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
-		this._availableModels = new Lazy<Promise<CopilotCLIModelInfo[]>>(() => this._getAvailableModels());
+		this._availableModels = this._getAvailableModels();
 		// Eagerly fetch available models so that they're ready when needed.
-		this._availableModels.value
+		this._availableModels
 			.then(() => this._onDidChange.fire())
 			.catch((error) => {
 				this.logService.error('[CopilotCLIModels] Failed to fetch available models', error);
@@ -86,6 +86,7 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 		this._register(this._authenticationService.onDidAuthenticationChange(() => {
 			// Auth changed which means models could've changed. Fire the event
 			this._onDidChange.fire();
+			this._availableModels = undefined;
 		}));
 	}
 	async resolveModel(modelId: string): Promise<string | undefined> {
@@ -115,7 +116,10 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 		}
 
 		// No need to query sdk multiple times, cache the result, this cannot change during a vscode session.
-		return this._availableModels.value;
+		if (!this._availableModels) {
+			this._availableModels = this._getAvailableModels();
+		}
+		return this._availableModels;
 	}
 
 	private async _getAvailableModels(): Promise<CopilotCLIModelInfo[]> {
@@ -132,7 +136,7 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 				supportsVision: model.capabilities.supports.vision,
 				supportsReasoningEffort: model.capabilities.supports.reasoningEffort,
 				defaultReasoningEffort: model.defaultReasoningEffort,
-				supportedReasoningEfforts: model.supportedReasoningEfforts
+				supportedReasoningEfforts: model.supportedReasoningEfforts,
 			} satisfies CopilotCLIModelInfo));
 		} catch (ex) {
 			this.logService.error(`[CopilotCLISession] Failed to fetch models`, ex);
@@ -155,8 +159,6 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 			}
 		};
 		this._register(lm.registerLanguageModelChatProvider('copilotcli', provider));
-
-		void this._availableModels.value.then(() => this._onDidChange.fire());
 	}
 
 	private async _provideLanguageModelChatInfo(): Promise<vscode.LanguageModelChatInformation[]> {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -85,8 +85,8 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 			});
 		this._register(this._authenticationService.onDidAuthenticationChange(() => {
 			// Auth changed which means models could've changed. Fire the event
-			this._onDidChange.fire();
 			this._availableModels = undefined;
+			this._onDidChange.fire();
 		}));
 	}
 	async resolveModel(modelId: string): Promise<string | undefined> {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
@@ -6,6 +6,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthenticationSession } from 'vscode';
 import { IAuthenticationService } from '../../../../../platform/authentication/common/authentication';
+import { DefaultsOnlyConfigurationService } from '../../../../../platform/configuration/common/defaultsOnlyConfigurationService';
+import { InMemoryConfigurationService } from '../../../../../platform/configuration/test/common/inMemoryConfigurationService';
 import { IVSCodeExtensionContext } from '../../../../../platform/extContext/common/extensionContext';
 import { ILogService } from '../../../../../platform/log/common/logService';
 import { Emitter } from '../../../../../util/vs/base/common/event';
@@ -13,8 +15,6 @@ import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { CopilotCLIModels, type CopilotCLIModelInfo, type ICopilotCLISDK } from '../copilotCli';
-import { DefaultsOnlyConfigurationService } from '../../../../../platform/configuration/common/defaultsOnlyConfigurationService';
-import { InMemoryConfigurationService } from '../../../../../platform/configuration/test/common/inMemoryConfigurationService';
 
 function createMockExtensionContext(): IVSCodeExtensionContext {
 	const state = new Map<string, unknown>();
@@ -275,6 +275,68 @@ describe('CopilotCLIModels', () => {
 			auth.setSession({ id: 'test', accessToken: 'token', scopes: [], account: { id: 'user', label: 'User' } });
 			const result = await models.getModels();
 			expect(result.length).toBe(2);
+		});
+
+		it('invalidates model cache on auth change', async () => {
+			const sdk = createMockSDK();
+			const { models, auth } = createModels({ hasSession: true, sdk });
+
+			// Initial fetch
+			await models.getModels();
+			const initialCallCount = (sdk.getPackage as ReturnType<typeof vi.fn>).mock.calls.length;
+
+			// Fire auth change to invalidate the cache
+			auth.fireAuthenticationChange();
+
+			// Next getModels() call should re-fetch from the SDK
+			await models.getModels();
+			expect((sdk.getPackage as ReturnType<typeof vi.fn>).mock.calls.length).toBe(initialCallCount + 1);
+		});
+
+		it('returns fresh models after auth change', async () => {
+			const updatedModels: CopilotCLIModelInfo[] = [
+				{ id: 'claude-4', name: 'Claude 4', maxContextWindowTokens: 200000, supportsVision: true },
+			];
+			let callCount = 0;
+			const sdk = {
+				_serviceBrand: undefined,
+				getPackage: vi.fn(async () => ({
+					getAvailableModels: vi.fn(async () => {
+						const source = callCount++ === 0 ? FAKE_MODELS : updatedModels;
+						return source.map(m => ({
+							id: m.id,
+							name: m.name,
+							billing: m.multiplier !== undefined ? { multiplier: m.multiplier } : undefined,
+							capabilities: {
+								limits: {
+									max_prompt_tokens: m.maxInputTokens,
+									max_output_tokens: m.maxOutputTokens,
+									max_context_window_tokens: m.maxContextWindowTokens,
+								},
+								supports: { vision: m.supportsVision }
+							},
+						}));
+					}),
+				})),
+				getAuthInfo: vi.fn(async () => ({ type: 'token' as const, token: 'test-token', host: 'https://github.com' })),
+				getRequestId: vi.fn(() => undefined),
+				setRequestId: vi.fn(),
+			} as unknown as ICopilotCLISDK;
+
+			const { models, auth } = createModels({ hasSession: true, sdk });
+
+			// First fetch returns FAKE_MODELS
+			const first = await models.getModels();
+			expect(first.length).toBe(2);
+			expect(first[0].id).toBe('gpt-4o');
+
+			// Auth change invalidates cache
+			auth.fireAuthenticationChange();
+
+			// Next fetch returns updated models
+			const second = await models.getModels();
+			expect(second.length).toBe(1);
+			expect(second[0].id).toBe('claude-4');
 		});
 	});
 


### PR DESCRIPTION
Update CopilotCLIModels to handle model caching more effectively by invalidating the cache when authentication changes occur. This ensures that the latest available models are fetched after an authentication event.

