### PR TITLE
agentHost: Default worktree branch picker to repo default branch

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -13,6 +13,7 @@ export interface IAgentHostGitService {
 	readonly _serviceBrand: undefined;
 	isInsideWorkTree(workingDirectory: URI): Promise<boolean>;
 	getCurrentBranch(workingDirectory: URI): Promise<string | undefined>;
+	getDefaultBranch(workingDirectory: URI): Promise<string | undefined>;
 	getBranches(workingDirectory: URI, options?: { readonly query?: string; readonly limit?: number }): Promise<string[]>;
 	getRepositoryRoot(workingDirectory: URI): Promise<URI | undefined>;
 	getWorktreeRoots(workingDirectory: URI): Promise<URI[]>;
@@ -51,6 +52,16 @@ export class AgentHostGitService implements IAgentHostGitService {
 		return (await this._runGit(workingDirectory, ['branch', '--show-current']))?.trim()
 			|| (await this._runGit(workingDirectory, ['rev-parse', '--short', 'HEAD']))?.trim()
 			|| undefined;
+	}
+
+	async getDefaultBranch(workingDirectory: URI): Promise<string | undefined> {
+		// Try to read the default branch from the remote HEAD reference
+		const remoteRef = (await this._runGit(workingDirectory, ['symbolic-ref', 'refs/remotes/origin/HEAD']))?.trim();
+		if (remoteRef) {
+			const prefix = 'refs/remotes/origin/';
+			return remoteRef.startsWith(prefix) ? remoteRef.substring(prefix.length) : remoteRef;
+		}
+		return undefined;
 	}
 
 	async getBranches(workingDirectory: URI, options?: { readonly query?: string; readonly limit?: number }): Promise<string[]> {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -312,9 +312,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		const values: Record<string, string> = { isolation: isolationValue, autoApprove: autoApproveValue };
 		if (gitInfo) {
+			const branchForMode = isolationValue === 'worktree' ? gitInfo.defaultBranch : gitInfo.currentBranch;
 			values.branch = typeof params.config?.branch === 'string' && isolationValue === 'worktree'
 				? params.config.branch
-				: gitInfo.currentBranch;
+				: branchForMode;
 		}
 
 		const properties: IResolveSessionConfigResult['schema']['properties'] = {
@@ -350,13 +351,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		if (gitInfo) {
 			const branchReadOnly = isolationValue === 'folder';
+			const branchForMode = isolationValue === 'worktree' ? gitInfo.defaultBranch : gitInfo.currentBranch;
 			properties.branch = {
 				type: 'string',
 				title: localize('agentHost.sessionConfig.branch', "Branch"),
 				description: localize('agentHost.sessionConfig.branchDescription', "Base branch to work from"),
-				enum: [gitInfo.currentBranch],
-				enumLabels: [gitInfo.currentBranch],
-				default: gitInfo.currentBranch,
+				enum: [branchForMode],
+				enumLabels: [branchForMode],
+				default: branchForMode,
 				enumDynamic: !branchReadOnly,
 				readOnly: branchReadOnly,
 			};
@@ -642,13 +644,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return agentSession;
 	}
 
-	private async _getGitInfo(workingDirectory: URI): Promise<{ currentBranch: string } | undefined> {
+	private async _getGitInfo(workingDirectory: URI): Promise<{ currentBranch: string; defaultBranch: string } | undefined> {
 		if (!await this._gitService.isInsideWorkTree(workingDirectory)) {
 			return undefined;
 		}
 
 		const currentBranch = await this._gitService.getCurrentBranch(workingDirectory) ?? 'HEAD';
-		return { currentBranch };
+		const defaultBranch = await this._gitService.getDefaultBranch(workingDirectory) ?? currentBranch;
+		return { currentBranch, defaultBranch };
 	}
 
 	private async _getBranches(workingDirectory: URI, query?: string): Promise<string[]> {

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -18,6 +18,7 @@ class TestAgentHostGitService implements IAgentHostGitService {
 
 	async isInsideWorkTree(): Promise<boolean> { return this.insideWorkTree; }
 	async getCurrentBranch(): Promise<string | undefined> { return undefined; }
+	async getDefaultBranch(): Promise<string | undefined> { return undefined; }
 	async getBranches(): Promise<string[]> { return []; }
 	async getRepositoryRoot(): Promise<URI | undefined> { return this.repositoryRoot; }
 	async getWorktreeRoots(): Promise<URI[]> { return this.worktreeRoots; }


### PR DESCRIPTION
When the session config isolation picker is set to **worktree**, the branch picker now defaults to the repository's default branch (looked up via `git symbolic-ref refs/remotes/origin/HEAD`) instead of always using the current branch.

When isolation is **folder**, the branch picker shows the current branch (read-only), matching the previous behavior.

### Changes

- Added `getDefaultBranch()` to `IAgentHostGitService` interface and implementation
- Updated `_getGitInfo()` to return both `currentBranch` and `defaultBranch`
- Updated `resolveSessionConfig()` to pick the appropriate branch based on isolation mode

(Written by Copilot)