### PR TITLE
feat: remove Copilot CLI shim and clean up worker file copying

### DIFF
--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -61,16 +61,16 @@ const treeSitterGrammars: ITreeSitterGrammar[] = [
 
 const REPO_ROOT = path.join(__dirname, '..');
 
+async function removeCopilotCLIShim() {
+	const shimsPath = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'shims.txt');
+	await fs.promises.rm(shimsPath, { force: true }).catch(() => { /* ignore */ });
+}
+
 /**
  * @github/copilot/sdk/index.js depends on @github/copilot/worker/*.js files.
  * We need to copy these files into the sdk directory to ensure they are available at runtime.
  */
 async function copyCopilotCliWorkerFiles() {
-	const shimsPath = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'shims.txt');
-	await fs.promises.rm(shimsPath, { force: true }).catch(() => { /* ignore */ });
-}
-
-async function removeCopilotCLIShim() {
 	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sharp');
 	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'sharp');
 

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -66,8 +66,13 @@ const REPO_ROOT = path.join(__dirname, '..');
  * We need to copy these files into the sdk directory to ensure they are available at runtime.
  */
 async function copyCopilotCliWorkerFiles() {
-	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'worker');
-	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'worker');
+	const shimsPath = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'shims.txt');
+	await fs.promises.rm(shimsPath, { force: true }).catch(() => { /* ignore */ });
+}
+
+async function removeCopilotCLIShim() {
+	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sharp');
+	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'sharp');
 
 	await copyCopilotCLIFolders(sourceDir, targetDir);
 }
@@ -173,6 +178,7 @@ async function main() {
 		'node_modules/@github/blackbird-external-ingest-utils/pkg/nodejs/external_ingest_utils_bg.wasm',
 	], 'dist');
 
+	await removeCopilotCLIShim();
 	await copyCopilotCliWorkerFiles();
 	await copyCopilotCliSharpFiles();
 	await copyCopilotCliDefinitionFiles();

--- a/extensions/copilot/script/postinstall.ts
+++ b/extensions/copilot/script/postinstall.ts
@@ -71,8 +71,8 @@ async function removeCopilotCLIShim() {
  * We need to copy these files into the sdk directory to ensure they are available at runtime.
  */
 async function copyCopilotCliWorkerFiles() {
-	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sharp');
-	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'sharp');
+	const sourceDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'worker');
+	const targetDir = path.join(REPO_ROOT, 'node_modules', '@github', 'copilot', 'sdk', 'worker');
 
 	await copyCopilotCLIFolders(sourceDir, targetDir);
 }


### PR DESCRIPTION
Eliminate the Copilot CLI shim and streamline the process of copying worker files. This change simplifies the codebase and improves maintainability. Testing can be done by verifying the functionality of the worker files after the cleanup.

