### PR TITLE
Fix inline summarization 0% prompt cache hit rate

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -658,7 +658,21 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			));
 		}
 
+		const lastMessage = result.messages.at(-1);
+		if (lastMessage?.role === Raw.ChatRole.User) {
+			const currentTurn = promptContext.conversation?.getLatestTurn();
+			if (currentTurn && !currentTurn.getMetadata(RenderedUserMessageMetadata)) {
+				currentTurn.setMetadata(new RenderedUserMessageMetadata(lastMessage.content));
+			}
+		}
+
+		addCacheBreakpoints(result.messages);
+
 		// Post-render: kick off background compaction at ≥ 80% if idle.
+		// This must run AFTER addCacheBreakpoints so that the messages
+		// forwarded to the background summarizer include cache breakpoints,
+		// making the prompt prefix byte-identical to the main agent fetch
+		// and enabling prompt cache hits on the summarization call.
 		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
 			const postRenderRatio = baseBudget > 0
 				? (result.tokenCount + toolTokens) / baseBudget
@@ -681,16 +695,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				this._startBackgroundSummarization(backgroundSummarizer, result.messages, promptContext, props, token, postRenderRatio, useInlineSummarization);
 			}
 		}
-
-		const lastMessage = result.messages.at(-1);
-		if (lastMessage?.role === Raw.ChatRole.User) {
-			const currentTurn = promptContext.conversation?.getLatestTurn();
-			if (currentTurn && !currentTurn.getMetadata(RenderedUserMessageMetadata)) {
-				currentTurn.setMetadata(new RenderedUserMessageMetadata(lastMessage.content));
-			}
-		}
-
-		addCacheBreakpoints(result.messages);
 
 		if (this.request.command === 'error') {
 			// Should trigger a 400


### PR DESCRIPTION
## Problem

The background inline summarization call gets 0% prompt cache hit rate on 2nd+ summarizations within the same turn.

### Root Cause

The background summarizer forks messages from the main render but applies **different post-processing** than the tool calling loop:

- **Main agent call**: `stripInternalToolCallIds` + `validateToolMessages` (filters orphaned tool results that lack matching assistant tool calls)
- **Background summarizer**: `stripInternalToolCallIds` only (no validation)

After a summarization is applied, prompt-tsx re-renders the conversation with summarized history. Tool results that referenced tool calls from the now-summarized rounds become **orphaned**. The main call filters these out via `validateToolMessages`, but the background summarizer keeps them. This causes the message arrays to diverge, breaking prefix-based prompt caching (Anthropic `cache_control`).

### Why it only affects 2nd+ summarizations

- **1st summarization**: no prior summarization applied → no orphaned tool messages → messages match → good cache (65-98%)
- **2nd+ summarization in same turn**: prior summarization created orphaned messages → summarizer keeps them, main call filters them → messages diverge → **0% cache**
- **Later summarizations after many rounds**: orphaned messages from prior summarization are no longer in the prompt (prompt-tsx trimmed them) → messages match again → good cache (98%)

### Evidence

Analyzed 5 conversations across internal telemetry and client-side exports:

| Conversation | Summarizations | 0% cache hits | Pattern |
|---|---|---|---|
| `3758afbc` | 2 | 1 | 2nd summ = 0% |
| `f1a7602b` | 4 | 1 | 2nd summ = 0%, later = 98% |
| `9f075330` | 2 | 1 | 2nd summ = 0% |
| `17969642` | 67 | Many | Pattern consistent |
| `6e44a104` | 85 | Many | Pattern consistent |

From `engine.messages.length` events: tools (constant), system prompt (constant), thinking config (constant), and max window (constant) are all identical across all calls. The only difference is in the message content after summarization boundaries.

### Fix

1. **Apply `validateToolMessagesCore`** to the forked messages in the background summarizer, matching the main call's processing pipeline. This ensures orphaned tool messages are filtered identically.

2. **Move `addCacheBreakpoints()`** to run before `_startBackgroundSummarization` for deterministic breakpoint ordering (code clarity).

### Impact

For a ~90K-token summarization call, going from 0% to ~90%+ cache hit means ~80K fewer uncached input tokens per summarization event. This is significant for long agentic conversations that trigger multiple summarizations.