### PR TITLE
agentHost: Fall back to origin/<branch> when no local default branch exists

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -58,8 +58,15 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// Try to read the default branch from the remote HEAD reference
 		const remoteRef = (await this._runGit(workingDirectory, ['symbolic-ref', 'refs/remotes/origin/HEAD']))?.trim();
 		if (remoteRef) {
-			const prefix = 'refs/remotes/origin/';
-			return remoteRef.startsWith(prefix) ? remoteRef.substring(prefix.length) : remoteRef;
+			if (!remoteRef.startsWith('refs/remotes/origin/')) {
+				return remoteRef;
+			}
+
+			const branch = remoteRef.substring('refs/remotes/origin/'.length);
+			// Check whether a local branch exists; if not, use the remote-tracking ref
+			// so that 'git worktree add ... <startPoint>' resolves correctly.
+			const hasLocalBranch = (await this._runGit(workingDirectory, ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])) !== undefined;
+			return hasLocalBranch ? branch : `origin/${branch}`;
 		}
 		return undefined;
 	}


### PR DESCRIPTION
Follow-up to #309676.

When the default branch (e.g. `main`) exists only as a remote-tracking ref (`origin/main`) and not as a local branch, `git worktree add -b <new> <path> main` would fail because git can't resolve the start point. This checks for a local `refs/heads/<branch>` first; if absent, returns `origin/<branch>` instead.

(Written by Copilot)