### PR TITLE
Fix inline summarization prompt cache misses

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -658,7 +658,21 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			));
 		}
 
+		const lastMessage = result.messages.at(-1);
+		if (lastMessage?.role === Raw.ChatRole.User) {
+			const currentTurn = promptContext.conversation?.getLatestTurn();
+			if (currentTurn && !currentTurn.getMetadata(RenderedUserMessageMetadata)) {
+				currentTurn.setMetadata(new RenderedUserMessageMetadata(lastMessage.content));
+			}
+		}
+
+		addCacheBreakpoints(result.messages);
+
 		// Post-render: kick off background compaction at ≥ 80% if idle.
+		// This must run AFTER addCacheBreakpoints so that the messages
+		// forwarded to the background summarizer include cache breakpoints,
+		// making the prompt prefix byte-identical to the main agent fetch
+		// and enabling prompt cache hits on the summarization call.
 		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
 			const postRenderRatio = baseBudget > 0
 				? (result.tokenCount + toolTokens) / baseBudget
@@ -681,16 +695,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 				this._startBackgroundSummarization(backgroundSummarizer, result.messages, promptContext, props, token, postRenderRatio, useInlineSummarization);
 			}
 		}
-
-		const lastMessage = result.messages.at(-1);
-		if (lastMessage?.role === Raw.ChatRole.User) {
-			const currentTurn = promptContext.conversation?.getLatestTurn();
-			if (currentTurn && !currentTurn.getMetadata(RenderedUserMessageMetadata)) {
-				currentTurn.setMetadata(new RenderedUserMessageMetadata(lastMessage.content));
-			}
-		}
-
-		addCacheBreakpoints(result.messages);
 
 		if (this.request.command === 'error') {
 			// Should trigger a 400
@@ -805,9 +809,14 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			try {
 				if (useInlineSummarization) {
 					// Inline mode: fork the exact messages from the main render
-					// and append a summary user message. The prompt prefix is
-					// byte-identical to the main agent loop for cache hits.
-					const strippedMainMessages = ToolCallingLoop.stripInternalToolCallIds(mainRenderMessages);
+					// and append a summary user message. The prompt prefix must
+					// be byte-identical to the main agent fetch for cache hits.
+					// Apply the same post-processing as the tool calling loop
+					// (strip internal IDs + validate/filter orphaned tool messages)
+					// so the message arrays match exactly.
+					const strippedMainMessages = ToolCallingLoop.validateToolMessagesCore(
+						ToolCallingLoop.stripInternalToolCallIds(mainRenderMessages),
+					).messages;
 					const summaryMsgResult = await renderPromptElement(
 						this.instantiationService,
 						this.endpoint,


### PR DESCRIPTION
## Problem

The background inline summarization call gets 0% prompt cache hit rate on 2nd+ summarizations within the same turn.

### Root Cause

The background summarizer forks messages from the main render but applies **different post-processing** than the tool calling loop:

- **Main agent call**: `stripInternalToolCallIds` + `validateToolMessages` (filters orphaned tool results that lack matching assistant tool calls)
- **Background summarizer**: `stripInternalToolCallIds` only (no validation)

After a summarization is applied, prompt-tsx re-renders the conversation with summarized history. Tool results that referenced tool calls from the now-summarized rounds become **orphaned**. The main call filters these out via `validateToolMessages`, but the background summarizer keeps them. This causes the message arrays to diverge, breaking prefix-based prompt caching (Anthropic `cache_control`).

### Why it only affects 2nd+ summarizations

- **1st summarization**: no prior summarization applied → no orphaned tool messages → messages match → good cache (65-98%)
- **2nd+ summarization in same turn**: prior summarization created orphaned messages → summarizer keeps them, main call filters them → messages diverge → **0% cache**
- **Later summarizations after many rounds**: orphaned messages from prior summarization are no longer in the prompt (prompt-tsx trimmed them) → messages match again → good cache (98%)

### Evidence

Analyzed multiple conversations across internal telemetry (`CopilotChatEvents` / `engine.messages.length`) and client-side exports (`panel.request` / `summarizedconversationhistory`):

- Tools, system prompt, thinking config, and max window are **all constant** across calls — confirmed from `engine.messages.length` data
- The 0% cache events consistently occur on the **2nd+ summarization** within the same user turn
- 1st summarizations consistently achieve 65-98% cache hit rates
- The `promptcachetokencount` from `summarizedconversationhistory` telemetry events shows the pattern clearly

### Fix

1. **Apply `validateToolMessagesCore`** to the forked messages in the background summarizer, matching the main call's processing pipeline. This ensures orphaned tool messages are filtered identically.

2. **Move `addCacheBreakpoints()`** to run before `_startBackgroundSummarization` for deterministic breakpoint ordering (code clarity).

### Impact

For a ~90K-token summarization call, going from 0% to ~90%+ cache hit means ~80K fewer uncached input tokens per summarization event. This adds up significantly for long agentic conversations that trigger multiple summarizations per turn.