### PR TITLE
fix: resolve NoChangeError tool name interpolation and typo

### DIFF
--- a/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
+++ b/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
@@ -1,0 +1,1 @@
+404: Not Found

--- a/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
+++ b/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
@@ -8,6 +8,7 @@ import { realpath } from 'fs/promises';
 import { homedir } from 'os';
 import * as path from 'path';
 import type { LanguageModelChat, PreparedToolInvocation } from 'vscode';
+import { ToolName } from '../common/toolNames';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
 import { IDiffService } from '../../../platform/diff/common/diffService';
@@ -669,7 +670,7 @@ export async function applyEdit(
 
 			if (updatedFile === originalFile) {
 				throw new NoChangeError(
-					'Original and edited file match exactly. Failed to apply edit. Use the ${ToolName.ReadFile} tool to re-read the file and and determine the correct edit.',
+					`Original and edited file match exactly. Failed to apply edit. Use the ${ToolName.ReadFile} tool to re-read the file and determine the correct edit.`,
 					filePath
 				);
 			}


### PR DESCRIPTION
Good day,

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

## Summary

Fixes two issues in the NoChangeError message:

1. **Broken template interpolation**: The original code uses single quotes for a string containing `${ToolName.ReadFile}`, but JavaScript template literals require backticks for interpolation. The model literally receives the text `${ToolName.ReadFile}` instead of `read_file`.

2. **Typo**: Fixed duplicate "and" in "re-read the file and and determine" → "re-read the file and determine".

## Changes

- Changed:`Use the ${ToolName.ReadFile} tool to re-read the file and and determine`

- To: `Use the read_file tool to re-read the file and determine`

This error message is shown when the replace_string_in_file tool produces no actual change. The garbled tool name prevented the model from following the recovery instruction to re-read the file.

Warmly, RoomWithOutRoof