### PR TITLE
Stop sending top_p to Anthropic Messages API

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -225,7 +225,6 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 		...messagesResult,
 		stream: true,
 		tools: finalTools.length > 0 ? finalTools : undefined,
-		top_p: options.postOptions.top_p,
 		max_tokens: options.postOptions.max_tokens,
 		thinking: thinkingConfig,
 		...(effort ? { output_config: { effort } } : {}),


### PR DESCRIPTION
- We always set `top_p: 1` (the default), which is a no-op — it means "consider all tokens" (nucleus sampling disabled)
- `temperature` and `top_k` are already not sent on this path
