### PR TITLE
feat(macOS): enable cross app update

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="39.8.7"
-ms_build_id="13797146"
+ms_build_id="13841579"
 runtime="electron"
 ignore-scripts=false
 build_from_source="true"

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -101,11 +101,11 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 	});
 }
 
-const { electronVersion } = util.getElectronVersion();
+const { electronVersion, msBuildId } = util.getElectronVersion();
 
 export const config = {
 	version: electronVersion,
-	tag: 'v39.8.7-13826954-dev',
+	tag: product.electronRepository ? `v${electronVersion}-${msBuildId}` : undefined,
 	productAppName: product.nameLong,
 	companyName: 'Microsoft Corporation',
 	copyright: 'Copyright (C) 2026 Microsoft. All rights reserved',

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -101,11 +101,11 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 	});
 }
 
-const { electronVersion, msBuildId } = util.getElectronVersion();
+const { electronVersion } = util.getElectronVersion();
 
 export const config = {
 	version: electronVersion,
-	tag: product.electronRepository ? `v${electronVersion}-${msBuildId}` : undefined,
+	tag: 'v39.8.7-13826954-dev',
 	productAppName: product.nameLong,
 	companyName: 'Microsoft Corporation',
 	copyright: 'Copyright (C) 2026 Microsoft. All rights reserved',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.117.0",
-  "distro": "fe1762079cc05e65effbbcf2121bb2586ec01d30",
+  "distro": "53515a4534020f9b4ffb3172649d2fdd0a5d9f63",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.117.0",
-  "distro": "55ed6ee8e0b2c21bfd4ddc57b6ff1dff5fcc9b2d",
+  "distro": "fe1762079cc05e65effbbcf2121bb2586ec01d30",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -143,6 +143,7 @@ import { McpGatewayChannel } from '../../platform/mcp/node/mcpGatewayChannel.js'
 import { IWebContentExtractorService } from '../../platform/webContentExtractor/common/webContentExtractor.js';
 import { NativeWebContentExtractorService } from '../../platform/webContentExtractor/electron-main/webContentExtractorService.js';
 import { AgentNetworkFilterService, IAgentNetworkFilterService } from '../../platform/networkFilter/common/networkFilterService.js';
+import { CrossAppIPCService, ICrossAppIPCService } from '../../platform/crossAppIpc/electron-main/crossAppIpcService.js';
 import ErrorTelemetry from '../../platform/telemetry/electron-main/errorTelemetry.js';
 
 /**
@@ -1090,6 +1091,9 @@ export class CodeApplication extends Disposable {
 		// Encryption
 		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService));
 
+		// Cross-app IPC
+		services.set(ICrossAppIPCService, new SyncDescriptor(CrossAppIPCService));
+
 		// Browser View
 		services.set(IBrowserViewMainService, new SyncDescriptor(BrowserViewMainService, undefined, false /* proxied to other processes */));
 		services.set(IBrowserViewGroupMainService, new SyncDescriptor(BrowserViewGroupMainService, undefined, false /* proxied to other processes */));
@@ -1236,17 +1240,24 @@ export class CodeApplication extends Disposable {
 		mainProcessElectronServer.registerChannel('userDataProfiles', userDataProfilesService);
 		sharedProcessClient.then(client => client.registerChannel('userDataProfiles', userDataProfilesService));
 
+		// Initialize cross-app IPC on supported platforms so all consumers
+		// (update coordination, secret sharing, etc.) share one connection.
+		const crossAppIPCService = accessor.get(ICrossAppIPCService);
+		if (isMacintosh || isWindows) {
+			crossAppIPCService.initialize();
+		}
+
 		// Update (with cross-app coordination on macOS/Windows where crossAppIPC is available)
 		const localUpdateService = accessor.get(IUpdateService);
 		let effectiveUpdateService: IUpdateService = localUpdateService;
 		const isInsiderOrExploration = this.productService.quality === 'insider' || this.productService.quality === 'exploration';
-		if (isWindows && isInsiderOrExploration) {
+		if ((isMacintosh || isWindows) && isInsiderOrExploration) {
 			const updateCoordinator = this._register(new CrossAppUpdateCoordinator(
 				localUpdateService as AbstractUpdateService,
 				this.logService,
 				this.lifecycleMainService,
+				crossAppIPCService,
 			));
-			updateCoordinator.initialize();
 			effectiveUpdateService = updateCoordinator;
 		}
 		const updateChannel = new UpdateChannel(effectiveUpdateService);
@@ -1262,6 +1273,7 @@ export class CodeApplication extends Disposable {
 				this.environmentMainService,
 				accessor.get(ILaunchMainService),
 				this.lifecycleMainService,
+				crossAppIPCService,
 			));
 		}
 

--- a/src/vs/platform/crossAppIpc/electron-main/crossAppIpcService.ts
+++ b/src/vs/platform/crossAppIpc/electron-main/crossAppIpcService.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as electron from 'electron';
+import { TimeoutTimer } from '../../../base/common/async.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable } from '../../../base/common/lifecycle.js';
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { ILogService } from '../../log/common/log.js';
+
+export const ICrossAppIPCService = createDecorator<ICrossAppIPCService>('crossAppIPCService');
+
+export interface ICrossAppIPCMessage {
+	readonly type: string;
+	readonly data?: unknown;
+}
+
+export interface ICrossAppIPCService {
+	readonly _serviceBrand: undefined;
+
+	/** Whether the Electron crossAppIPC API is supported in this build. */
+	readonly isSupported: boolean;
+
+	/** Whether initialize() has been called and successfully set up the IPC. */
+	readonly initialized: boolean;
+
+	/** Whether the IPC connection is active. */
+	readonly connected: boolean;
+
+	/** Whether this app is the IPC server (`true`) or client (`false`). Only meaningful when connected. */
+	readonly isServer: boolean;
+
+	/** Fires when the peer connects. The boolean indicates whether this app is the server. */
+	readonly onDidConnect: Event<boolean /* isServer */>;
+
+	/** Fires when the peer disconnects. The string is the disconnect reason. */
+	readonly onDidDisconnect: Event<string /* reason */>;
+
+	/** Fires when a message is received from the peer. */
+	readonly onDidReceiveMessage: Event<ICrossAppIPCMessage>;
+
+	/** Send a message to the peer. No-op if not connected. */
+	sendMessage(msg: ICrossAppIPCMessage): void;
+
+	/** Initialize the IPC connection. Call once during startup. */
+	initialize(): void;
+}
+
+/**
+ * Manages the single crossAppIPC connection for the entire application.
+ */
+export class CrossAppIPCService extends Disposable implements ICrossAppIPCService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private ipc: Electron.CrossAppIPC | undefined;
+	private _connected = false;
+	private _isServer = false;
+	private readonly reconnectTimer = this._register(new TimeoutTimer());
+
+	private readonly _onDidConnect = this._register(new Emitter<boolean>());
+	readonly onDidConnect: Event<boolean> = this._onDidConnect.event;
+
+	private readonly _onDidDisconnect = this._register(new Emitter<string>());
+	readonly onDidDisconnect: Event<string> = this._onDidDisconnect.event;
+
+	private readonly _onDidReceiveMessage = this._register(new Emitter<ICrossAppIPCMessage>());
+	readonly onDidReceiveMessage: Event<ICrossAppIPCMessage> = this._onDidReceiveMessage.event;
+
+	get isSupported(): boolean {
+		const crossAppIPC: Electron.CrossAppIPCModule | undefined = (electron as typeof electron & { crossAppIPC?: Electron.CrossAppIPCModule }).crossAppIPC;
+		return crossAppIPC !== undefined;
+	}
+	get initialized(): boolean { return this.ipc !== undefined; }
+	get connected(): boolean { return this._connected; }
+	get isServer(): boolean { return this._isServer; }
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+	}
+
+	initialize(): void {
+		if (this.ipc) {
+			return; // Already initialized
+		}
+
+		const crossAppIPC: Electron.CrossAppIPCModule | undefined = (electron as typeof electron & { crossAppIPC?: Electron.CrossAppIPCModule }).crossAppIPC;
+
+		if (!crossAppIPC) {
+			this.logService.info('CrossAppIPCService: crossAppIPC not available');
+			return;
+		}
+
+		const ipc = crossAppIPC.createCrossAppIPC();
+		this.ipc = ipc;
+
+		ipc.on('connected', () => {
+			this._connected = true;
+			this._isServer = ipc.isServer;
+			this.logService.info(`CrossAppIPCService: connected (isServer=${ipc.isServer})`);
+			this._onDidConnect.fire(ipc.isServer);
+		});
+
+		ipc.on('message', (messageEvent) => {
+			this._onDidReceiveMessage.fire(messageEvent.data as ICrossAppIPCMessage);
+		});
+
+		ipc.on('disconnected', (reason) => {
+			this.logService.info(`CrossAppIPCService: disconnected (${reason})`);
+			this._connected = false;
+			this._isServer = false;
+			this._onDidDisconnect.fire(reason);
+
+			// Reconnect to wait for the peer's next launch.
+			// Delay briefly to allow the old Mach bootstrap service to be
+			// deregistered before re-creating the server endpoint (macOS).
+			if (reason === 'peer-disconnected') {
+				this.reconnectTimer.cancelAndSet(() => ipc.connect(), 1000);
+			}
+		});
+
+		ipc.connect();
+		this.logService.info('CrossAppIPCService: connecting to peer');
+	}
+
+	sendMessage(msg: ICrossAppIPCMessage): void {
+		if (this.ipc?.connected) {
+			this.ipc.postMessage(msg);
+		}
+	}
+
+	override dispose(): void {
+		this.ipc?.close();
+		super.dispose();
+	}
+}

--- a/src/vs/platform/secrets/electron-main/macOSCrossAppSecretSharing.ts
+++ b/src/vs/platform/secrets/electron-main/macOSCrossAppSecretSharing.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as electron from 'electron';
 import { execFile } from 'child_process';
 import { dirname } from '../../../base/common/path.js';
-import { Disposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { ILogService } from '../../log/common/log.js';
 import { IEncryptionMainService } from '../../encryption/common/encryptionService.js';
 import { IStorageMainService } from '../../storage/electron-main/storageMainService.js';
@@ -17,6 +16,7 @@ import { IStorageMain } from '../../storage/electron-main/storageMain.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { ILaunchMainService } from '../../launch/electron-main/launchMainService.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
+import { ICrossAppIPCService } from '../../crossAppIpc/electron-main/crossAppIpcService.js';
 
 const MIGRATION_STATE_KEY = 'crossAppSecretSharing.migrationDone';
 
@@ -43,7 +43,7 @@ interface CrossAppSecretMessage {
  *
  * **Demand-driven**: Only the agents app initiates migration. If it
  * detects that migration hasn't been done yet, it:
- * 1. Creates a crossAppIPC connection and starts listening.
+ * 1. Waits for the crossAppIPC connection (managed by ICrossAppIPCService).
  * 2. Spawns Code.app with `--share-secrets-with-agents-app`, which
  *    either starts Code.app fresh or (if already running) forwards
  *    the arg to the existing instance via the node IPC socket.
@@ -60,10 +60,10 @@ interface CrossAppSecretMessage {
  */
 export class MacOSCrossAppSecretSharing extends Disposable {
 
-	private ipc: Electron.CrossAppIPC | undefined;
 	private readonly isEmbeddedApp: boolean;
 	private readonly applicationStorage: IStorageMain;
 	private _onHostMigrationComplete: (() => void) | undefined;
+	private readonly hostHandshakeListeners = this._register(new DisposableStore());
 
 	constructor(
 		storageMainService: IStorageMainService,
@@ -73,6 +73,7 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 		environmentMainService: IEnvironmentMainService,
 		launchMainService: ILaunchMainService,
 		lifecycleMainService: ILifecycleMainService,
+		private readonly crossAppIPCService: ICrossAppIPCService,
 	) {
 		super();
 		this.isEmbeddedApp = !!(process as INodeProcess).isEmbeddedApp;
@@ -119,47 +120,41 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 		// will write secrets into applicationStorage.
 		await this.applicationStorage.whenInit;
 
-		const crossAppIPC: Electron.CrossAppIPCModule | undefined = electron.crossAppIPC;
-		if (!crossAppIPC) {
-			this.logService.info('[CrossAppSecretSharing] crossAppIPC not available');
+		if (!this.crossAppIPCService.initialized) {
+			this.logService.info('[CrossAppSecretSharing] crossAppIPC not initialized, skipping migration');
 			return;
 		}
 
 		this.logService.info('[CrossAppSecretSharing] Migration needed, starting...');
 
-		const ipc = crossAppIPC.createCrossAppIPC();
-		this.ipc = ipc;
+		// Listen for connection — when connected, request secrets
+		this._register(this.crossAppIPCService.onDidConnect(isServer => {
+			this.logService.info(`[CrossAppSecretSharing] Connected (isServer=${isServer}), requesting secrets from host app`);
+			this.crossAppIPCService.sendMessage({ type: CrossAppSecretMessageType.SecretRequest });
+		}));
 
-		ipc.on('connected', () => {
-			this.logService.info(`[CrossAppSecretSharing] connected (isServer=${ipc.isServer})`);
-			this.logService.info('[CrossAppSecretSharing] Requesting secrets from host app');
-			this.sendMessage({ type: CrossAppSecretMessageType.SecretRequest });
-		});
-
-		ipc.on('message', (messageEvent) => {
-			const msg = messageEvent.data as CrossAppSecretMessage | undefined;
-			if (msg?.type === CrossAppSecretMessageType.SecretResponse) {
-				this.handleSecretResponse(msg.data ?? {});
+		// Listen for messages
+		this._register(this.crossAppIPCService.onDidReceiveMessage(msg => {
+			const secretMsg = msg as CrossAppSecretMessage;
+			if (secretMsg?.type === CrossAppSecretMessageType.SecretResponse) {
+				this.handleSecretResponse(secretMsg.data ?? {});
 			}
-		});
+		}));
 
-		ipc.on('disconnected', (reason) => {
-			this.logService.info(`[CrossAppSecretSharing] disconnected (${reason})`);
-			this.ipc = undefined;
-		});
-
-		ipc.connect();
+		// If already connected (e.g. service was initialized before storage was ready),
+		// send the request immediately.
+		if (this.crossAppIPCService.connected) {
+			this.logService.info(`[CrossAppSecretSharing] Already connected (isServer=${this.crossAppIPCService.isServer}), requesting secrets from host app`);
+			this.crossAppIPCService.sendMessage({ type: CrossAppSecretMessageType.SecretRequest });
+		}
 
 		// Spawn Code.app with --share-secrets-with-agents-app
 		this.spawnHostApp();
 
-		// If Code.app doesn't connect within 30s (e.g. not installed,
-		// failed to launch), give up and clean up the IPC.
+		// Timeout: if migration doesn't complete within 30s, give up
 		setTimeout(() => {
-			if (this.ipc && !this.isMigrationDone()) {
-				this.logService.warn('[CrossAppSecretSharing] Migration timed out, closing IPC');
-				this.ipc.close();
-				this.ipc = undefined;
+			if (!this.isMigrationDone()) {
+				this.logService.warn('[CrossAppSecretSharing] Migration timed out');
 			}
 		}, 30_000);
 	}
@@ -187,9 +182,8 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 			return;
 		}
 
-		const crossAppIPC: Electron.CrossAppIPCModule | undefined = electron.crossAppIPC;
-		if (!crossAppIPC) {
-			this.logService.info('[CrossAppSecretSharing] crossAppIPC not available');
+		if (!this.crossAppIPCService.initialized) {
+			this.logService.info('[CrossAppSecretSharing] crossAppIPC not initialized');
 			onComplete?.();
 			return;
 		}
@@ -198,34 +192,25 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 
 		this.logService.info('[CrossAppSecretSharing] Host app responding to secret sharing request');
 
-		const ipc = crossAppIPC.createCrossAppIPC();
-		this.ipc = ipc;
+		// Dispose previous listeners if initializeAsHostApp is called again
+		// (e.g. via repeated onDidRequestShareSecrets events).
+		this.hostHandshakeListeners.clear();
 
-		ipc.on('connected', () => {
-			this.logService.info(`[CrossAppSecretSharing] connected (isServer=${ipc.isServer})`);
-		});
-
-		ipc.on('message', (messageEvent) => {
-			const msg = messageEvent.data as CrossAppSecretMessage | undefined;
-			if (msg?.type === CrossAppSecretMessageType.SecretRequest) {
+		// Listen for messages from the agents app
+		this.hostHandshakeListeners.add(this.crossAppIPCService.onDidReceiveMessage(msg => {
+			const secretMsg = msg as CrossAppSecretMessage;
+			if (secretMsg?.type === CrossAppSecretMessageType.SecretRequest) {
 				this.handleSecretRequest();
-			} else if (msg?.type === CrossAppSecretMessageType.SecretAck) {
+			} else if (secretMsg?.type === CrossAppSecretMessageType.SecretAck) {
 				this.handleSecretAck();
 			}
-		});
+		}));
 
-		ipc.on('disconnected', (reason) => {
-			this.logService.info(`[CrossAppSecretSharing] disconnected (${reason})`);
-			this.ipc = undefined;
-
-			// If the agents app disconnected before sending SecretAck
-			// (e.g. it crashed), ensure the host app can still quit
-			// when it was launched solely for migration.
+		// If disconnected before ack, still allow the host to quit
+		this.hostHandshakeListeners.add(this.crossAppIPCService.onDidDisconnect(() => {
 			this._onHostMigrationComplete?.();
 			this._onHostMigrationComplete = undefined;
-		});
-
-		ipc.connect();
+		}));
 	}
 
 	private isMigrationDone(): boolean {
@@ -284,10 +269,8 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 			}
 		}
 
-		this.sendMessage({ type: CrossAppSecretMessageType.SecretResponse, data: secrets });
+		this.crossAppIPCService.sendMessage({ type: CrossAppSecretMessageType.SecretResponse, data: secrets });
 		this.logService.info('[CrossAppSecretSharing] Sent secrets response with', Object.keys(secrets).length, 'keys');
-
-		// Don't close yet — wait for SecretAck from agents app
 	}
 
 	private async handleSecretResponse(secrets: Record<string, string>): Promise<void> {
@@ -317,7 +300,7 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 
 		// Tell the host app migration is done so it can also record it.
 		// Don't close here — let the host close first after receiving the ack.
-		this.sendMessage({ type: CrossAppSecretMessageType.SecretAck });
+		this.crossAppIPCService.sendMessage({ type: CrossAppSecretMessageType.SecretAck });
 	}
 
 	private handleSecretAck(): void {
@@ -327,20 +310,6 @@ export class MacOSCrossAppSecretSharing extends Disposable {
 		const onComplete = this._onHostMigrationComplete;
 		this._onHostMigrationComplete = undefined;
 
-		// Host closes — this triggers 'disconnected' on the agents side
-		this.ipc?.close();
-
 		onComplete?.();
-	}
-
-	private sendMessage(msg: CrossAppSecretMessage): void {
-		if (this.ipc?.connected) {
-			this.ipc.postMessage(msg);
-		}
-	}
-
-	override dispose(): void {
-		this.ipc?.close();
-		super.dispose();
 	}
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -86,7 +86,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	private _hasCheckedForOverwriteOnQuit: boolean = false;
 	private readonly overwriteUpdatesCheckInterval = new IntervalTimer();
 	private _internalOrg: string | undefined = undefined;
-	private _suspended = false;
+	protected _suspended = false;
 
 	private readonly _onStateChange = new Emitter<State>();
 	readonly onStateChange: Event<State> = this._onStateChange.event;

--- a/src/vs/platform/update/electron-main/crossAppUpdateIpc.ts
+++ b/src/vs/platform/update/electron-main/crossAppUpdateIpc.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as electron from 'electron';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
+import { ICrossAppIPCService } from '../../crossAppIpc/electron-main/crossAppIpcService.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
 import { IUpdateService, State } from '../common/update.js';
@@ -61,7 +61,6 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 
 	declare readonly _serviceBrand: undefined;
 
-	private ipc: Electron.CrossAppIPC | undefined;
 	private mode: 'standalone' | 'server' | 'client' = 'standalone';
 
 	private _state: State;
@@ -81,6 +80,7 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 		private readonly localUpdateService: AbstractUpdateService,
 		private readonly logService: ILogService,
 		private readonly lifecycleMainService: ILifecycleMainService,
+		private readonly crossAppIPCService: ICrossAppIPCService,
 	) {
 		super();
 
@@ -89,65 +89,31 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 
 		// Track local service state changes (used in standalone/server mode)
 		this.registerLocalStateListener();
-	}
 
-	private registerLocalStateListener(): void {
-		this.localStateListener = this.localUpdateService.onStateChange(state => {
-			this.updateState(state);
-			this.broadcastState(state);
-		});
-	}
+		// Subscribe to cross-app IPC events
+		this._register(this.crossAppIPCService.onDidConnect(isServer => {
+			this.handleConnect(isServer);
+		}));
 
-	initialize(): void {
-		const crossAppIPC: Electron.CrossAppIPCModule | undefined = electron.crossAppIPC;
-
-		if (!crossAppIPC) {
-			this.logService.info('CrossAppUpdateCoordinator: crossAppIPC not available, running in standalone mode');
-			return;
+		// If the service is already connected (e.g. another consumer initialized
+		// it earlier), run the connect logic immediately.
+		if (this.crossAppIPCService.connected) {
+			this.handleConnect(this.crossAppIPCService.isServer);
 		}
 
-		const ipc = crossAppIPC.createCrossAppIPC();
-		this.ipc = ipc;
+		this._register(this.crossAppIPCService.onDidReceiveMessage(msg => {
+			this.handleMessage(msg as CrossAppUpdateMessage);
+		}));
 
-		ipc.on('connected', () => {
-			this.logService.info(`CrossAppUpdateCoordinator: connected (isServer=${ipc.isServer})`);
-
-			if (ipc.isServer) {
-				this.mode = 'server';
-				// Broadcast current state to the newly connected client
-				this.broadcastState(this.localUpdateService.state);
-			} else {
-				this.mode = 'client';
-				// Suspend the local update service and stop listening to its state
-				// changes. All update operations are proxied to the server, so
-				// neither automatic nor manual checks go through the local service.
-				this.localUpdateService.suspend();
-				this.localStateListener?.dispose();
-				this.localStateListener = undefined;
-				// Request current state from the server
-				this.sendMessage({ type: CrossAppUpdateMessageType.RequestInitialState });
-			}
-		});
-
-		ipc.on('message', (messageEvent) => {
-			this.handleMessage(messageEvent.data as CrossAppUpdateMessage);
-		});
-
-		ipc.on('disconnected', (reason) => {
+		this._register(this.crossAppIPCService.onDidDisconnect(reason => {
 			this.logService.info(`CrossAppUpdateCoordinator: disconnected (${reason}), was ${this.mode}`);
 
 			if (this.mode === 'client') {
-				// Resume the local update service — we're now the only app
 				this.localUpdateService.resume();
 				this.registerLocalStateListener();
-				// Sync coordinator state with the local service
 				this.updateState(this.localUpdateService.state);
 			}
 
-			// If the server was waiting for a quit confirmation and the client
-			// disconnected, treat it as an implicit confirmation — the client
-			// quit successfully but the IPC pipe was torn down before the
-			// QuitConfirmed message could be delivered.
 			if (this.mode === 'server' && this.pendingQuitAndInstall) {
 				this.logService.info('CrossAppUpdateCoordinator: client disconnected during pending quit, treating as confirmed');
 				this.pendingQuitAndInstall = false;
@@ -157,17 +123,29 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 			}
 
 			this.mode = 'standalone';
+		}));
+	}
 
-			// Reconnect to wait for the peer's next launch.
-			// Delay briefly to allow the old Mach bootstrap service to be
-			// deregistered before re-creating the server endpoint (macOS).
-			if (reason === 'peer-disconnected') {
-				setTimeout(() => ipc.connect(), 1000);
-			}
+	private handleConnect(isServer: boolean): void {
+		this.logService.info(`CrossAppUpdateCoordinator: connected (isServer=${isServer})`);
+
+		if (isServer) {
+			this.mode = 'server';
+			this.broadcastState(this.localUpdateService.state);
+		} else {
+			this.mode = 'client';
+			this.localUpdateService.suspend();
+			this.localStateListener?.dispose();
+			this.localStateListener = undefined;
+			this.sendMessage({ type: CrossAppUpdateMessageType.RequestInitialState });
+		}
+	}
+
+	private registerLocalStateListener(): void {
+		this.localStateListener = this.localUpdateService.onStateChange(state => {
+			this.updateState(state);
+			this.broadcastState(state);
 		});
-
-		ipc.connect();
-		this.logService.info('CrossAppUpdateCoordinator: connecting to peer');
 	}
 
 	private handleMessage(msg: CrossAppUpdateMessage): void {
@@ -256,9 +234,7 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 	}
 
 	private sendMessage(msg: CrossAppUpdateMessage): void {
-		if (this.ipc?.connected) {
-			this.ipc.postMessage(msg);
-		}
+		this.crossAppIPCService.sendMessage(msg);
 	}
 
 	// --- IUpdateService implementation ---
@@ -296,7 +272,7 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 	 * If no peer is connected (standalone), proceeds directly.
 	 */
 	private doCoordinatedQuitAndInstall(): void {
-		if (this.ipc?.connected) {
+		if (this.crossAppIPCService.connected) {
 			// Ask the client to quit; it will respond with QuitConfirmed/QuitVetoed,
 			// or disconnect (treated as implicit confirmation).
 			this.pendingQuitAndInstall = true;
@@ -329,7 +305,6 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 
 	override dispose(): void {
 		this.localStateListener?.dispose();
-		this.ipc?.close();
 		super.dispose();
 	}
 }

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -20,7 +20,6 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AvailableForDownload, IUpdate, State, StateType, UpdateType } from '../common/update.js';
 import { IMeteredConnectionService } from '../../meteredConnection/common/meteredConnection.js';
 import { AbstractUpdateService, createUpdateURL, getUpdateRequestHeaders, IUpdateURLOptions, UpdateErrorClassification } from './abstractUpdateService.js';
-import { INodeProcess } from '../../../base/common/platform.js';
 
 export class DarwinUpdateService extends AbstractUpdateService implements IRelaunchHandler {
 
@@ -72,13 +71,6 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 	protected override async initialize(): Promise<void> {
 		await super.initialize();
 
-		// In the embedded app we still want to detect available updates via HTTP,
-		// but we must not wire up Electron's autoUpdater (which auto-downloads).
-		if ((process as INodeProcess).isEmbeddedApp) {
-			this.logService.info('update#ctor - embedded app: checking for updates without auto-download');
-			return;
-		}
-
 		this.onRawError(this.onError, this, this.disposables);
 		this.onRawCheckingForUpdate(this.onCheckingForUpdate, this, this.disposables);
 		this.onRawUpdateAvailable(this.onUpdateAvailable, this, this.disposables);
@@ -126,13 +118,6 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 
 		if (!url) {
-			return;
-		}
-
-		// In the embedded app, always check without triggering Electron's auto-download.
-		if ((process as INodeProcess).isEmbeddedApp) {
-			this.logService.info('update#doCheckForUpdates - embedded app: checking for update without auto-download');
-			this.checkForUpdateNoDownload(url, /* canInstall */ false);
 			return;
 		}
 

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -118,6 +118,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 
 		if (!url) {
+			this.setState(State.Idle(UpdateType.Archive));
 			return;
 		}
 
@@ -164,6 +165,11 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 	private onUpdateAvailable(): void {
 		this.logService.trace('update#onUpdateAvailable - Electron autoUpdater reported update available');
 
+		if (this._suspended) {
+			this.logService.trace('update#onUpdateAvailable - suspended, ignoring');
+			return;
+		}
+
 		if (this.state.type !== StateType.CheckingForUpdates && this.state.type !== StateType.Overwriting) {
 			return;
 		}
@@ -172,7 +178,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 	}
 
 	private onUpdateDownloaded(update: IUpdate): void {
-		if (this.state.type !== StateType.Downloading) {
+		if (this._suspended || this.state.type !== StateType.Downloading) {
 			return;
 		}
 
@@ -184,6 +190,11 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 	private onUpdateNotAvailable(): void {
 		this.logService.trace('update#onUpdateNotAvailable - Electron autoUpdater reported no update available');
+
+		if (this._suspended) {
+			this.logService.trace('update#onUpdateNotAvailable - suspended, ignoring');
+			return;
+		}
 
 		if (this.state.type !== StateType.CheckingForUpdates) {
 			return;

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -33,7 +33,7 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isWindows } from '../../../../base/common/platform.js';
+import { isWindows, isMacintosh } from '../../../../base/common/platform.js';
 import { UpdateHoverWidget } from './updateHoverWidget.js';
 import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ChatStatusDashboard } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
@@ -125,7 +125,7 @@ async function runSessionsUpdateAction(
 ): Promise<void> {
 	if (state.type === StateType.AvailableForDownload) {
 		const isInsiderOrExploration = productService.quality === 'insider' || productService.quality === 'exploration';
-		const hasCrossAppCoordinator = isWindows && isInsiderOrExploration;
+		const hasCrossAppCoordinator = (isWindows || isMacintosh) && isInsiderOrExploration;
 		if (!hasCrossAppCoordinator) {
 			const { confirmed } = await dialogService.confirm({
 				message: localize('sessionsUpdateFromVSCode.title', "Update from VS Code"),


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/308646

```
ICrossAppIPCService:
- Owns the single crossAppIPC connection for the application
- Exposes onDidConnect, onDidDisconnect, onDidReceiveMessage events

Secret sharing refactoring:
- MacOSCrossAppSecretSharing now takes ICrossAppIPCService instead of
  creating its own crossAppIPC connection
  ```