### PR TITLE
Update copilotCLI hint setting

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -25,6 +25,9 @@ export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationP
 		markdownDescription: localize('terminal.integrated.initialHint.copilotCli', "When enabled, the terminal initial hint will suggest using Copilot CLI by typing {0} instead of opening Copilot Chat.", '`copilot`'),
 		type: 'boolean',
 		default: false,
-		tags: ['experimental']
+		tags: ['experimental'],
+		experiment: {
+			mode: 'auto'
+		},
 	}
 };

--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -10,7 +10,7 @@ import { TerminalSettingId } from '../../../../../platform/terminal/common/termi
 
 export const enum TerminalInitialHintSettingId {
 	Enabled = 'terminal.integrated.initialHint',
-	CopilotCli = 'terminal.integrated.initialHint.copilotCli',
+	CopilotCli = 'terminal.integrated.initialHintCopilotCli',
 }
 
 export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationPropertySchema> = {


### PR DESCRIPTION
Configuration changes for Copilot CLI terminal hint:

* Renamed the `CopilotCli` setting ID from `terminal.integrated.initialHint.copilotCli` to `terminal.integrated.initialHintCopilotCli` for consistency in naming conventions and to prevent conflicts with parent setting
* Added an `experiment` field with `mode: 'auto'` to the Copilot CLI initial hint configuration, enabling it to be managed as an experimental feature.

