### PR TITLE
Consistent include pathing for new 2026 in theme-defaults

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "vscode://schemas/color-theme",
 	"name": "2026 Dark",
-	"include": "../../theme-defaults/themes/dark_modern.json",
+	"include": "./dark_modern.json",
 	"type": "dark",
 	"colors": {
 		"foreground": "#bfbfbf",

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "vscode://schemas/color-theme",
 	"name": "2026 Light",
-	"include": "../../theme-defaults/themes/light_modern.json",
+	"include": "./light_modern.json",
 	"type": "light",
 	"colors": {
 		"foreground": "#202020",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The new themes use an absolute path instead of the relative one like other themes do (e.g. [dark_modern.json](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_modern.json)). This PR addresses this.