### PR TITLE
Fix enterprise BYOK issues: hidden models, disabled button, account carryover

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -147,6 +147,7 @@ export function byokKnownModelToAPIInfo(providerName: string, id: string, capabi
 		family: id,
 		tooltip: `${capabilities.name} is contributed via the ${providerName} provider.`,
 		multiplierNumeric: 0,
+		isUserSelectable: true,
 		capabilities: {
 			toolCalling: capabilities.toolCalling,
 			imageInput: capabilities.vision

--- a/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/byokContribution.ts
@@ -8,7 +8,7 @@ import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { ILogService } from '../../../platform/log/common/logService';
 import { IFetcherService } from '../../../platform/networking/common/fetcherService';
-import { Disposable } from '../../../util/vs/base/common/lifecycle';
+import { Disposable, DisposableStore } from '../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { BYOKKnownModels, isBYOKEnabled } from '../../byok/common/byokProvider';
 import { IExtensionContribution } from '../../common/contributions';
@@ -26,6 +26,7 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 	public readonly id: string = 'byok-contribution';
 	private readonly _byokStorageService: IBYOKStorageService;
 	private readonly _providers: Map<string, LanguageModelChatProvider<LanguageModelChatInformation>> = new Map();
+	private readonly _byokRegistrations = this._register(new DisposableStore());
 	private _byokProvidersRegistered = false;
 
 	constructor(
@@ -46,7 +47,17 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 	}
 
 	private async _authChange(authService: IAuthenticationService, instantiationService: IInstantiationService) {
-		if (authService.copilotToken && isBYOKEnabled(authService.copilotToken, this._capiClientService) && !this._byokProvidersRegistered) {
+		const byokEnabled = authService.copilotToken && isBYOKEnabled(authService.copilotToken, this._capiClientService);
+
+		if (!byokEnabled && this._byokProvidersRegistered) {
+			this._logService.info('BYOK: Disabling BYOK providers due to account change.');
+			this._byokRegistrations.clear();
+			this._providers.clear();
+			this._byokProvidersRegistered = false;
+			return;
+		}
+
+		if (byokEnabled && !this._byokProvidersRegistered) {
 			this._byokProvidersRegistered = true;
 			// Update known models list from CDN so all providers have the same list
 			const knownModels = await this.fetchKnownModelList(this._fetcherService);
@@ -63,7 +74,7 @@ export class BYOKContrib extends Disposable implements IExtensionContribution {
 			this._providers.set(CustomOAIBYOKModelProvider.providerName.toLowerCase(), instantiationService.createInstance(CustomOAIBYOKModelProvider, this._byokStorageService));
 
 			for (const [providerName, provider] of this._providers) {
-				this._store.add(lm.registerLanguageModelChatProvider(providerName, provider));
+				this._byokRegistrations.add(lm.registerLanguageModelChatProvider(providerName, provider));
 			}
 		}
 	}

--- a/extensions/copilot/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
+++ b/extensions/copilot/src/extension/contextKeys/vscode-node/contextKeys.contribution.ts
@@ -61,6 +61,7 @@ export class ContextKeysContribution extends Disposable {
 
 		void this._inspectContext().catch(console.error);
 		void this._updatePermissiveSessionContext().catch(console.error);
+		void this._updateClientByokEnabledContext().catch(console.error);
 		this._register(_authenticationService.onDidAuthenticationChange(async () => await this._onAuthenticationChange()));
 		this._register(commands.registerCommand('github.copilot.refreshToken', async () => await this._inspectContext()));
 		this._register(commands.registerCommand('github.copilot.debug.showChatLogView', async () => {

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget.ts
@@ -772,6 +772,7 @@ class ActionsColumnRenderer extends ModelsTableColumnRenderer<IActionsColumnTemp
 						return;
 					}
 					await this.languageModelsService.removeLanguageModelsProviderGroup(vendorEntry.vendor.vendor, vendorEntry.group.name);
+					this.viewModel.refresh();
 				}
 			}));
 		} else if (vendorEntry.vendor.managementCommand) {
@@ -1336,7 +1337,8 @@ export class ChatModelsWidget extends Disposable {
 	}
 
 	private async addModelsForVendor(vendor: ILanguageModelProviderDescriptor): Promise<void> {
-		this.languageModelsService.configureLanguageModelsProviderGroup(vendor.vendor);
+		await this.languageModelsService.configureLanguageModelsProviderGroup(vendor.vendor);
+		await this.viewModel.refresh();
 	}
 
 	public layout(height: number, width: number): void {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -926,6 +926,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 				}
 			}
 
+			const oldGroups = this._modelsGroups.get(vendorId) ?? [];
 			this._modelsGroups.set(vendorId, languageModelsGroups);
 			const oldModels = this._clearModelCache(vendorId);
 			let hasChanges = false;
@@ -941,6 +942,12 @@ export class LanguageModelsService implements ILanguageModelsService {
 			this._logService.trace(`[LM] Resolved language models for vendor ${vendorId}`, allModels);
 			hasChanges = hasChanges || oldModels.size > 0;
 
+			// Also detect group structure changes (added/removed groups, status changes)
+			// so the UI updates even when individual models haven't changed
+			if (!hasChanges) {
+				hasChanges = this._hasGroupStructureChanged(oldGroups, languageModelsGroups);
+			}
+
 			// Update per-model configurations for this vendor
 			this._clearModelConfigurations(vendorId);
 			for (const [identifier, config] of perModelConfigurations) {
@@ -955,6 +962,24 @@ export class LanguageModelsService implements ILanguageModelsService {
 				this._logService.trace(`[LM] No changes in language models for vendor ${vendorId}`);
 			}
 		});
+	}
+
+	private _hasGroupStructureChanged(oldGroups: readonly ILanguageModelsGroup[], newGroups: readonly ILanguageModelsGroup[]): boolean {
+		if (oldGroups.length !== newGroups.length) {
+			return true;
+		}
+		for (let i = 0; i < oldGroups.length; i++) {
+			const oldGroup = oldGroups[i];
+			const newGroup = newGroups[i];
+			if (oldGroup.group?.name !== newGroup.group?.name
+				|| oldGroup.group?.vendor !== newGroup.group?.vendor
+				|| oldGroup.status?.message !== newGroup.status?.message
+				|| oldGroup.status?.severity !== newGroup.status?.severity
+				|| oldGroup.modelIdentifiers.length !== newGroup.modelIdentifiers.length) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	getLanguageModelGroups(vendor: string): ILanguageModelsGroup[] {


### PR DESCRIPTION
Fixes three bugs reported against #309023 in the BYOK (Bring Your Own Key) model feature:

### #309499 — BYOK model hidden by default
`byokKnownModelToAPIInfo()` was missing `isUserSelectable: true`, so the view model defaulted newly added BYOK models to hidden (`metadata.isUserSelectable ?? false`).

**Fix:** Add `isUserSelectable: true` to the returned `LanguageModelChatInformation`.

### #309492 — Add Models button disabled when BYOK is enabled
`ContextKeysContribution` constructor called `_inspectContext()` and `_updatePermissiveSessionContext()` on init, but never `_updateClientByokEnabledContext()`. The BYOK context key was only set on auth *changes*, so if auth was already established at extension activation, the context key remained unset and `clientByokEnabled` returned `false`.

**Fix:** Call `_updateClientByokEnabledContext()` during initialization.

### #309501 — BYOK model carries over from individual account
BYOK provider registrations were added to the main `DisposableStore` and never cleaned up on account switch. When switching from an individual account (BYOK enabled) to an enterprise account (BYOK disabled), providers remained registered and models persisted in the picker.

**Fix:** Use a separate `DisposableStore` for BYOK provider registrations, clear it when auth changes and BYOK is disabled, and reset the `_byokProvidersRegistered` flag.

---

> **Note:** #309495 (rough edges for invalid BYOK flows — no validation warning on add, no UI auto-update on remove) is not addressed in this PR and needs further investigation.