### PR TITLE
Include terminal output in sendToTerminal result and improve notification labels

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
@@ -9,10 +9,16 @@ import { truncateOutputKeepingTail } from './runInTerminalHelpers.js';
 
 const MAX_OUTPUT_LENGTH = 16000;
 
-export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarker): string {
+export interface IGetOutputOptions {
+	/** When set, only return the last N non-empty lines from the bottom of the buffer. */
+	lastNLines?: number;
+}
+
+export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarker, options?: IGetOutputOptions): string {
 	if (!instance.xterm || !instance.xterm.raw) {
 		return '';
 	}
+
 	const buffer = instance.xterm.raw.buffer.active;
 	let startLine = Math.max(startMarker?.line ?? 0, 0);
 	while (startLine > 0 && buffer.getLine(startLine)?.isWrapped) {
@@ -37,6 +43,11 @@ export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarke
 	}
 	if (currentLine) {
 		lines.push(currentLine);
+	}
+
+	if (options?.lastNLines !== undefined) {
+		const nonEmpty = lines.filter(l => l.trim().length > 0);
+		return nonEmpty.slice(-options.lastNLines).join('\n');
 	}
 
 	let output = lines.join('\n');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2190,7 +2190,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					...sendOptions,
 					queue: ChatRequestQueueKind.Steering,
 					isSystemInitiated: true,
-					systemInitiatedLabel: localize('backgroundTaskNeedsInput', "Background task `{0}` needs input", commandName),
+					systemInitiatedLabel: localize('terminalNeedsInput', "`{0}` needs input", commandName),
 					terminalExecutionId: termId,
 				}).catch(e => {
 					this._logService.warn(`RunInTerminalTool: Failed to send input-needed notification for terminal ${termId}`, e);
@@ -2238,7 +2238,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				...sendOptions,
 				queue: ChatRequestQueueKind.Steering,
 				isSystemInitiated: true,
-				systemInitiatedLabel: localize('backgroundTaskCompleted', "Background task `{0}` completed", commandName),
+				systemInitiatedLabel: localize('terminalCommandCompleted', "`{0}` completed", commandName),
 				terminalExecutionId: termId,
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -826,7 +826,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				cdPrefix,
 			};
 
-			confirmationTitle = localize('runInTerminal.inDirectory', "Run `{0}` command within `{1}`?", shellType, escapeMarkdownSyntaxTokens(directoryLabel));
+			confirmationTitle = localize('runInTerminal.inDirectory', "Run `{0}` command within `{1}`?", shellType, directoryLabel);
 		} else {
 			toolSpecificData.confirmation = {
 				commandLine: commandToDisplay,
@@ -847,9 +847,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				};
 				if (extractedCd && toolSpecificData.confirmation?.cwdLabel) {
 					if (presenterResult.languageDisplayName) {
-						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory', "Run `{0}` command in `{1}` within `{2}`?", presenterResult.languageDisplayName, shellType, escapeMarkdownSyntaxTokens(toolSpecificData.confirmation.cwdLabel));
+						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory', "Run `{0}` command in `{1}` within `{2}`?", presenterResult.languageDisplayName, shellType, toolSpecificData.confirmation.cwdLabel);
 					} else {
-						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory.withoutLanguage', "Run command in `{0}` within `{1}`?", shellType, escapeMarkdownSyntaxTokens(toolSpecificData.confirmation.cwdLabel));
+						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory.withoutLanguage', "Run command in `{0}` within `{1}`?", shellType, toolSpecificData.confirmation.cwdLabel);
 					}
 				} else {
 					if (presenterResult.languageDisplayName) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -9,7 +9,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
@@ -621,7 +621,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const partialInput = context.rawInput as Partial<IRunInTerminalInputParams> | undefined;
 		if (partialInput && typeof partialInput === 'object' && partialInput.command) {
 			const truncatedCommand = buildCommandDisplayText(partialInput.command);
-			const invocationMessage = new MarkdownString(localize('runInTerminal.streaming', "Running `{0}`", truncatedCommand));
+			const invocationMessage = new MarkdownString(localize('runInTerminal.streaming', "Running `{0}`", escapeMarkdownSyntaxTokens(truncatedCommand)));
 			return { invocationMessage };
 		}
 		return { invocationMessage: localize('runInTerminal.streaming.default', "Running command") };
@@ -826,7 +826,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				cdPrefix,
 			};
 
-			confirmationTitle = localize('runInTerminal.inDirectory', "Run `{0}` command within `{1}`?", shellType, directoryLabel);
+			confirmationTitle = localize('runInTerminal.inDirectory', "Run `{0}` command within `{1}`?", shellType, escapeMarkdownSyntaxTokens(directoryLabel));
 		} else {
 			toolSpecificData.confirmation = {
 				commandLine: commandToDisplay,
@@ -847,9 +847,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				};
 				if (extractedCd && toolSpecificData.confirmation?.cwdLabel) {
 					if (presenterResult.languageDisplayName) {
-						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory', "Run `{0}` command in `{1}` within `{2}`?", presenterResult.languageDisplayName, shellType, toolSpecificData.confirmation.cwdLabel);
+						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory', "Run `{0}` command in `{1}` within `{2}`?", presenterResult.languageDisplayName, shellType, escapeMarkdownSyntaxTokens(toolSpecificData.confirmation.cwdLabel));
 					} else {
-						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory.withoutLanguage', "Run command in `{0}` within `{1}`?", shellType, toolSpecificData.confirmation.cwdLabel);
+						confirmationTitle = localize('runInTerminal.presentationOverride.inDirectory.withoutLanguage', "Run command in `{0}` within `{1}`?", shellType, escapeMarkdownSyntaxTokens(toolSpecificData.confirmation.cwdLabel));
 					}
 				} else {
 					if (presenterResult.languageDisplayName) {
@@ -896,8 +896,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			? rawDisplayCommand.substring(0, 77) + '...'
 			: rawDisplayCommand;
 		const invocationMessage = toolSpecificData.commandLine.isSandboxWrapped
-			? new MarkdownString(localize('runInTerminal.invocation.sandbox', "Running `{0}` in sandbox", displayCommand))
-			: new MarkdownString(localize('runInTerminal.invocation', "Running `{0}`", displayCommand));
+			? new MarkdownString(localize('runInTerminal.invocation.sandbox', "Running `{0}` in sandbox", escapeMarkdownSyntaxTokens(displayCommand)))
+			: new MarkdownString(localize('runInTerminal.invocation', "Running `{0}`", escapeMarkdownSyntaxTokens(displayCommand)));
 
 		return {
 			invocationMessage,
@@ -1029,7 +1029,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				new MarkdownString(localize(
 					'runInTerminal.unsandboxed.autoRetry.confirmationMessage',
 					"`{0}`",
-					buildCommandDisplayText(command)
+					escapeMarkdownSyntaxTokens(buildCommandDisplayText(command))
 				)),
 				'',
 				localize('allow', 'Allow'),
@@ -1078,7 +1078,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			toolCallId,
 			toolName: localize('runInTerminalTool.displayName', 'Run in Terminal'),
 			isComplete,
-			invocationMessage: new MarkdownString(localize('runInTerminal.unsandboxed.autoRetry.invocation', "Running `{0}` outside the sandbox", displayCommand)),
+			invocationMessage: new MarkdownString(localize('runInTerminal.unsandboxed.autoRetry.invocation', "Running `{0}` outside the sandbox", escapeMarkdownSyntaxTokens(displayCommand))),
 			pastTenseMessage: toolResultMessage,
 			toolSpecificData,
 		};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { timeout } from '../../../../../../base/common/async.js';
 import type { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { createCommandUri, isMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
@@ -16,6 +17,7 @@ import { IChatService, IChatMultiSelectAnswer, IChatQuestionAnswerValue, IChatQu
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
+import { getOutput } from '../outputHelpers.js';
 import { buildCommandDisplayText, normalizeCommandForExecution } from '../runInTerminalHelpers.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
 import { isSessionAutoApproveLevel } from './terminalToolAutoApprove.js';
@@ -25,7 +27,7 @@ export const SendToTerminalToolData: IToolData = {
 	id: TerminalToolId.SendToTerminal,
 	toolReferenceName: 'sendToTerminal',
 	displayName: localize('sendToTerminalTool.displayName', 'Send to Terminal'),
-	modelDescription: `Send input text to a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). After sending, use ${TerminalToolId.GetTerminalOutput} to check updated output for persistent terminals.`,
+	modelDescription: `Send input text to a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). The result includes the last few lines of terminal output captured shortly after sending.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -361,10 +363,13 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 
 			await instance.sendText(normalizeCommandForExecution(args.command), true);
 
+			await timeout(100);
+			const recentOutput = getOutput(instance, undefined, { lastNLines: 5 });
+
 			return {
 				content: [{
 					kind: 'text',
-					value: `Successfully sent command to foreground terminal ${args.terminalId}. Use ${TerminalToolId.GetTerminalOutput} with terminalId ${args.terminalId} to check for updated output.`
+					value: `Successfully sent command to foreground terminal ${args.terminalId}.${recentOutput ? `\n\nTerminal output (last 5 lines):\n${recentOutput}` : ''}`
 				}]
 			};
 		}
@@ -382,10 +387,13 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 
 		await execution.instance.sendText(normalizeCommandForExecution(args.command), true);
 
+		await timeout(100);
+		const recentOutput = getOutput(execution.instance, undefined, { lastNLines: 5 });
+
 		return {
 			content: [{
 				kind: 'text',
-				value: `Successfully sent command to terminal ${args.id}. Use ${TerminalToolId.GetTerminalOutput} to check for updated output.`
+				value: `Successfully sent command to terminal ${args.id}.${recentOutput ? `\n\nTerminal output (last 5 lines):\n${recentOutput}` : ''}`
 			}]
 		};
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -111,7 +111,6 @@ suite('SendToTerminalTool', () => {
 		const value = (result.content[0] as { value: string }).value;
 		assert.ok(value.includes('Successfully sent command'));
 		assert.ok(value.includes(KNOWN_TERMINAL_ID));
-		assert.ok(value.includes('get_terminal_output'), 'should direct agent to use get_terminal_output');
 
 		// Verify sendText was called with shouldExecute=true
 		assert.strictEqual(mockExecution.sentTexts.length, 1);


### PR DESCRIPTION
Fixes #309509

- After sending input to a terminal, delay 100ms and return the last 5 lines of output in the tool result. This covers interactive cases (prompt → answer → next prompt) without requiring a separate `getTerminalOutput` call, saving an agent turn and tokens.
- Add `lastNLines` option to `getOutput` to support efficient tail reads.
- Simplify async terminal notification labels from "Background task `X` completed/needs input" to `` `X` completed/needs input ``.

https://github.com/user-attachments/assets/3ffac361-e4e6-49bf-9748-027d6d0caeeb


