### PR TITLE
Disable experimental onboarding by default

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -341,7 +341,7 @@ configurationRegistry.registerConfiguration({
 		'workbench.welcomePage.experimentalOnboarding': {
 			scope: ConfigurationScope.APPLICATION,
 			type: 'boolean',
-			default: true,
+			default: false,
 			tags: ['experimental'],
 			description: localize('workbench.welcomePage.experimentalOnboarding', "When enabled, show the new onboarding experience instead of the classic walkthrough on first launch.")
 		}


### PR DESCRIPTION
Sets `workbench.welcomePage.experimentalOnboarding` default to `false` on the release branch, disabling the new 2026 onboarding experience and falling back to the classic walkthrough.