### PR TITLE
Remove dead requestHandler from AgentHostChatSession

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -147,14 +147,12 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 	private readonly _onDidStartServerRequest = this._register(new Emitter<{ prompt: string }>());
 	readonly onDidStartServerRequest = this._onDidStartServerRequest.event;
 
-	readonly requestHandler: IChatSession['requestHandler'];
 	interruptActiveResponseCallback: IChatSession['interruptActiveResponseCallback'];
 	readonly forkSession: IChatSession['forkSession'];
 
 	constructor(
 		readonly sessionResource: URI,
 		readonly history: readonly IChatSessionHistoryItem[],
-		private readonly _sendRequest: (request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, token: CancellationToken) => Promise<void>,
 		private readonly _forkSession: ((request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => Promise<IChatSessionItem>),
 		initialProgress: IChatProgress[] | undefined,
 		onDispose: () => void,
@@ -170,13 +168,6 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 
 		this._register(toDisposable(() => this._onWillDispose.fire()));
 		this._register(toDisposable(onDispose));
-
-		this.requestHandler = async (request, progress, _history, cancellationToken) => {
-			this._logService.info('[AgentHost] requestHandler called');
-			this.isCompleteObs.set(false, undefined);
-			await this._sendRequest(request, progress, cancellationToken);
-			this.isCompleteObs.set(true, undefined);
-		};
 
 		// Provide interrupt callback when reconnecting to an active turn or
 		// when this is a brand-new session (no history yet).
@@ -475,20 +466,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			AgentHostChatSession,
 			sessionResource,
 			history,
-			async (request: IChatAgentRequest, progress: (parts: IChatProgress[]) => void, token: CancellationToken) => {
-				// todo@connor4312, I think IChatSession.requestHandler is actually
-				// dead code and I don't believe this is ever called.
-				const backendSession = resolvedSession ?? await this._createAndSubscribe(sessionResource, request.userSelectedModelId, undefined, request.agentHostSessionConfig);
-				if (!resolvedSession) {
-					resolvedSession = backendSession;
-					this._sessionToBackend.set(sessionResource, backendSession);
-				}
-				// For existing sessions, set up pending message sync on the first turn
-				// (after the ChatModel becomes available in the ChatService).
-				this._ensurePendingMessageSubscription(sessionResource, backendSession);
-				return this._handleTurn(backendSession, request, progress, token);
-			},
-			(request, token) => {
+			(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
 				resolvedSession ??= this._sessionToBackend.get(sessionResource);
 				if (!resolvedSession) {
 					throw new BugIndicatingError('Cannot fork session before the initial request');

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -48,7 +48,6 @@ import { IAgentSubscription } from '../../../../../../platform/agentHost/common/
 import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHostTerminalService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
-import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 
 // ---- Mock agent host service ------------------------------------------------
 
@@ -286,15 +285,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
 	});
-	instantiationService.stub(IConfigurationService, {
-		getValue: (...args: unknown[]) => {
-			if (args[0] === 'chat.agentHost.clientTools') {
-				return [];
-			}
-			return true;
-		},
-		onDidChangeConfiguration: Event.None,
-	});
+	instantiationService.stub(IConfigurationService, { getValue: () => true });
 	instantiationService.stub(IOutputService, { getChannel: () => undefined });
 	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null });
 	instantiationService.stub(IChatEditingService, {
@@ -327,14 +318,6 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		registerResolver: () => toDisposable(() => { }),
 		resolve: sessionResource => workingDirectoryResolver?.resolve(sessionResource),
 	});
-	instantiationService.stub(ILanguageModelToolsService, {
-		observeTools: () => observableValue('tools', []),
-		onDidChangeTools: Event.None,
-		getToolByName: () => undefined,
-		invokeTool: async () => ({ content: [] }),
-		onDidPrepareToolCallBecomeUnresponsive: Event.None,
-		onDidInvokeTool: Event.None,
-	});
 
 	return { instantiationService, agentHostService, chatAgentService };
 }
@@ -357,11 +340,11 @@ function createContribution(disposables: DisposableStore) {
 	return { contribution, listController, sessionHandler, agentHostService, chatAgentService };
 }
 
-function makeRequest(overrides: Partial<{ message: string; sessionResource: URI; variables: IChatAgentRequest['variables']; userSelectedModelId: string; agentHostSessionConfig: Record<string, string> }> = {}): IChatAgentRequest {
+function makeRequest(overrides: Partial<{ message: string; sessionResource: URI; variables: IChatAgentRequest['variables']; userSelectedModelId: string; agentHostSessionConfig: Record<string, string>; agentId: string }> = {}): IChatAgentRequest {
 	return upcastPartial<IChatAgentRequest>({
 		sessionResource: overrides.sessionResource ?? URI.from({ scheme: 'untitled', path: '/chat-1' }),
 		requestId: 'req-1',
-		agentId: 'agent-host-copilot',
+		agentId: overrides.agentId ?? 'agent-host-copilot',
 		message: overrides.message ?? 'Hello',
 		variables: overrides.variables ?? { variables: [] },
 		location: ChatAgentLocation.Chat,
@@ -380,12 +363,13 @@ function textOf(value: string | IMarkdownString | undefined): string | undefined
 
 /**
  * Start a turn through the state-driven flow. Creates a chat session,
- * starts the requestHandler (non-blocking), and waits for the first action
+ * invokes the agent (non-blocking), and waits for the first action
  * to be dispatched. Returns helpers to fire server action envelopes.
  */
 async function startTurn(
 	sessionHandler: AgentHostSessionHandler,
 	agentHostService: MockAgentHostService,
+	chatAgentService: MockChatAgentService,
 	ds: DisposableStore,
 	overrides?: Partial<{
 		message: string;
@@ -394,9 +378,11 @@ async function startTurn(
 		userSelectedModelId: string;
 		agentHostSessionConfig: Record<string, string>;
 		cancellationToken: CancellationToken;
+		agentId: string;
 	}>,
 ) {
-	const sessionResource = overrides?.sessionResource ?? URI.from({ scheme: 'agent-host-copilot', path: '/untitled-turntest' });
+	const agentId = overrides?.agentId ?? 'agent-host-copilot';
+	const sessionResource = overrides?.sessionResource ?? URI.from({ scheme: agentId, path: '/untitled-turntest' });
 	const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
 	ds.add(toDisposable(() => chatSession.dispose()));
 
@@ -407,13 +393,17 @@ async function startTurn(
 	const collected: IChatProgress[][] = [];
 	const seq = { v: 1 };
 
-	const turnPromise = chatSession.requestHandler!(
+	const registered = chatAgentService.registeredAgents.get(agentId);
+	assert.ok(registered, `${agentId} agent should be registered`);
+
+	const turnPromise = registered.impl.invoke(
 		makeRequest({
 			message: overrides?.message ?? 'Hello',
 			sessionResource,
 			variables: overrides?.variables,
 			userSelectedModelId: overrides?.userSelectedModelId,
 			agentHostSessionConfig: overrides?.agentHostSessionConfig,
+			agentId,
 		}),
 		(parts) => collected.push(parts),
 		[],
@@ -473,6 +463,7 @@ async function startDynamicAgentTurn(
 			variables: overrides?.variables,
 			userSelectedModelId: overrides?.userSelectedModelId,
 			agentHostSessionConfig: overrides?.agentHostSessionConfig,
+			agentId,
 		}),
 		parts => collected.push(parts),
 		[],
@@ -565,9 +556,9 @@ suite('AgentHostChatContribution', () => {
 	suite('session ID resolution', () => {
 
 		test('creates new SDK session for untitled resource', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, { message: 'Hello' });
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, { message: 'Hello' });
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 
@@ -578,7 +569,7 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('reuses SDK session for same resource on second message', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const resource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-reuse' });
 			const chatSession = await sessionHandler.provideChatSessionContent(resource, CancellationToken.None);
@@ -587,8 +578,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// First turn
-			const turn1Promise = chatSession.requestHandler!(
+			const turn1Promise = registered.impl.invoke(
 				makeRequest({ message: 'First', sessionResource: resource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -601,7 +594,7 @@ suite('AgentHostChatContribution', () => {
 			await turn1Promise;
 
 			// Second turn
-			const turn2Promise = chatSession.requestHandler!(
+			const turn2Promise = registered.impl.invoke(
 				makeRequest({ message: 'Second', sessionResource: resource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -620,9 +613,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('uses sessionId from agent-host scheme resource', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hi',
 				sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/existing-session-42' }),
 			});
@@ -633,9 +626,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('agent-host scheme with untitled path creates new session via mapping', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hi',
 				sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/untitled-abc123' }),
 			});
@@ -646,9 +639,9 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(AgentSession.id(URI.parse(session)).startsWith('sdk-session-'));
 		}));
 		test('passes raw model id extracted from language model identifier', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hi',
 				userSelectedModelId: 'agent-host-copilot:claude-sonnet-4-20250514',
 			});
@@ -660,9 +653,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('passes model id as-is when no vendor prefix', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hi',
 				userSelectedModelId: 'gpt-4o',
 			});
@@ -690,9 +683,9 @@ suite('AgentHostChatContribution', () => {
 	suite('progress routing', () => {
 
 		test('delta events become markdownContent progress', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/responsePart', session, turnId, part: { kind: 'markdown', id: 'md-1', content: 'hello ' } } as ISessionAction);
 			fire({ type: 'session/delta', session, turnId, partId: 'md-1', content: 'world' } as ISessionAction);
@@ -707,9 +700,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('tool_start events become toolInvocation progress', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-1', toolName: 'read_file', displayName: 'Read File' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-1', invocationMessage: 'Reading file', confirmed: 'not-needed' } as ISessionAction);
@@ -722,9 +715,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('tool_complete event transitions toolInvocation to completed', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-2', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-2', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
@@ -744,9 +737,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('tool_complete with failure sets error state', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-3', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-3', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
@@ -765,9 +758,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('malformed toolArguments does not throw', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-bad', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-bad', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
@@ -780,9 +773,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('outstanding tool invocations are completed on idle', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			// tool_start without tool_complete
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-orphan', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
@@ -798,9 +791,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('events from other sessions are ignored', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			// Delta from a different session — will be ignored (session not subscribed)
 			agentHostService.fireAction({
@@ -823,12 +816,12 @@ suite('AgentHostChatContribution', () => {
 	suite('cancellation', () => {
 
 		test('cancellation resolves the agent invoke', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
 			disposables.add(cts);
 
-			const { turnPromise } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				cancellationToken: cts.token,
 			});
 
@@ -839,12 +832,12 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('cancellation force-completes outstanding tool invocations', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
 			disposables.add(cts);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				cancellationToken: cts.token,
 			});
 
@@ -863,12 +856,12 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('cancellation calls abortSession on the agent host service', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const cts = new CancellationTokenSource();
 			disposables.add(cts);
 
-			const { turnPromise } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				cancellationToken: cts.token,
 			});
 
@@ -885,9 +878,9 @@ suite('AgentHostChatContribution', () => {
 	suite('error events', () => {
 
 		test('error event renders error message and finishes the request', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			agentHostService.fireAction({
 				action: {
@@ -914,9 +907,9 @@ suite('AgentHostChatContribution', () => {
 	suite('permission requests', () => {
 
 		test('permission_request event shows confirmation and responds when confirmed', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			// Simulate a tool call requiring confirmation via toolCallStart + toolCallReady
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-perm-1', toolName: 'shell', displayName: 'Shell' } as ISessionAction);
@@ -956,9 +949,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('permission_request denied when user skips', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-perm-2', toolName: 'write', displayName: 'Write File' } as ISessionAction);
 			fire({
@@ -990,9 +983,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('shell permission shows input-style confirmation data with toolInput', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-perm-shell', toolName: 'shell', displayName: 'Shell' } as ISessionAction);
 			fire({
@@ -1014,9 +1007,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('read permission shows input-style confirmation data', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-perm-read', toolName: 'read_file', displayName: 'Read File' } as ISessionAction);
 			fire({
@@ -1090,9 +1083,9 @@ suite('AgentHostChatContribution', () => {
 	suite('tool invocation rendering', () => {
 
 		test('bash tool renders as terminal command block with output', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-shell', toolName: 'bash', displayName: 'Bash', _meta: { toolKind: 'terminal', language: 'shellscript' } } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-shell', invocationMessage: 'Running `echo hello`', toolInput: 'echo hello', confirmed: 'not-needed' } as ISessionAction);
@@ -1128,9 +1121,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('bash tool failure sets exit code 1 and error output', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-fail', toolName: 'bash', displayName: 'Bash', _meta: { toolKind: 'terminal', language: 'shellscript' } } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-fail', invocationMessage: 'Running `bad_cmd`', toolInput: 'bad_cmd', confirmed: 'not-needed' } as ISessionAction);
@@ -1156,9 +1149,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('generic tool has invocation message and no toolSpecificData', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-gen', toolName: 'custom_tool', displayName: 'custom_tool' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-gen', invocationMessage: 'Using "custom_tool"', confirmed: 'not-needed' } as ISessionAction);
@@ -1183,9 +1176,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('bash tool without arguments has no terminal data', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-noargs', toolName: 'bash', displayName: 'Bash', toolKind: 'terminal' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-noargs', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
@@ -1210,9 +1203,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('view tool shows file path in messages', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-view', toolName: 'view', displayName: 'View File' } as ISessionAction);
 			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-view', invocationMessage: 'Reading /tmp/test.txt', confirmed: 'not-needed' } as ISessionAction);
@@ -1368,9 +1361,9 @@ suite('AgentHostChatContribution', () => {
 	suite('server error handling', () => {
 
 		test('server-side error resolves the agent invoke without throwing', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 
 			// Simulate a server-side error (e.g. sendMessage failure on the server)
 			agentHostService.fireAction({
@@ -1461,9 +1454,9 @@ suite('AgentHostChatContribution', () => {
 	suite('attachment context', () => {
 
 		test('file variable with file:// URI becomes file attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'check this file',
 				variables: {
 					variables: [
@@ -1482,9 +1475,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('directory variable with file:// URI becomes directory attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'check this dir',
 				variables: {
 					variables: [
@@ -1503,9 +1496,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('implicit selection variable becomes selection attachment', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'explain this',
 				variables: {
 					variables: [
@@ -1524,9 +1517,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('non-file URIs are skipped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'check this',
 				variables: {
 					variables: [
@@ -1544,9 +1537,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('tool variables are skipped', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'use tools',
 				variables: {
 					variables: [
@@ -1563,9 +1556,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('mixed variables extracts only supported types', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'mixed',
 				variables: {
 					variables: [
@@ -1588,9 +1581,9 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('no variables results in no attachments argument', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hello',
 			});
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
@@ -1663,7 +1656,7 @@ suite('AgentHostChatContribution', () => {
 		});
 
 		test('handler uses resolveWorkingDirectory callback', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 
 			const handler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
 				provider: 'copilot' as const,
@@ -1676,7 +1669,7 @@ suite('AgentHostChatContribution', () => {
 				resolveWorkingDirectory: () => URI.file('/custom/working/dir'),
 			}));
 
-			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables);
+			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, chatAgentService, disposables, { agentId: 'workdir-test' });
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 
@@ -1720,7 +1713,7 @@ suite('AgentHostChatContribution', () => {
 
 		test('handler uses registered working directory resolver', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const resolvedWorkingDirectory = URI.file('/resolved/working/dir');
-			const { instantiationService, agentHostService } = createTestServices(disposables, {
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables, {
 				resolve: () => resolvedWorkingDirectory,
 			});
 
@@ -1734,7 +1727,7 @@ suite('AgentHostChatContribution', () => {
 				connectionAuthority: 'local',
 			}));
 
-			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables);
+			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, chatAgentService, disposables, { agentId: 'workdir-resolver-test' });
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 
@@ -1743,7 +1736,7 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('handler passes vscode-agent-host URI as-is to createSession', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 
 			// The workspace repository URI in the Sessions app is a
 			// vscode-agent-host:// URI. It must be passed through unchanged
@@ -1766,7 +1759,7 @@ suite('AgentHostChatContribution', () => {
 				resolveWorkingDirectory: () => agentHostUri,
 			}));
 
-			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables);
+			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, chatAgentService, disposables, { agentId: 'workdir-agenthost-test' });
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 
@@ -1818,8 +1811,9 @@ suite('AgentHostChatContribution', () => {
 			assert.ok(chatAgentService.registeredAgents.has('connection-test'));
 
 			// Verify it can run a turn through the IAgentConnection path
-			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, disposables, {
+			const { turnPromise, session, turnId, fire } = await startTurn(handler, agentHostService, chatAgentService, disposables, {
 				message: 'Test message',
+				agentId: 'connection-test',
 			});
 
 			fire({ type: 'session/delta', session, turnId, content: 'Response' } as ISessionAction);
@@ -2117,7 +2111,7 @@ suite('AgentHostChatContribution', () => {
 	suite('server-initiated turns', () => {
 
 		test('detects server-initiated turn and fires onDidStartServerRequest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			// Create and subscribe a session
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-turn' });
@@ -2127,8 +2121,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// First, do a normal turn so the backend session is created
-			const turn1Promise = chatSession.requestHandler!(
+			const turn1Promise = registered.impl.invoke(
 				makeRequest({ message: 'Hello', sessionResource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -2168,7 +2164,7 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('server-initiated turn streams progress through progressObs', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-progress' });
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -2177,8 +2173,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// Normal turn to create backend session
-			const turn1Promise = chatSession.requestHandler!(
+			const turn1Promise = registered.impl.invoke(
 				makeRequest({ message: 'Init', sessionResource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -2240,7 +2238,7 @@ suite('AgentHostChatContribution', () => {
 		});
 
 		test('client-dispatched turns are not treated as server-initiated', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-no-dupe' });
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -2252,8 +2250,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// Normal client turn — should NOT fire onDidStartServerRequest
-			const turnPromise = chatSession.requestHandler!(
+			const turnPromise = registered.impl.invoke(
 				makeRequest({ message: 'Client turn', sessionResource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -2268,7 +2268,7 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('server-initiated turn does not duplicate tool calls on repeated state changes', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-tool-dedup' });
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -2277,8 +2277,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// First, do a normal turn so the backend session is created
-			const turn1Promise = chatSession.requestHandler!(
+			const turn1Promise = registered.impl.invoke(
 				makeRequest({ message: 'Init', sessionResource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -2334,7 +2336,7 @@ suite('AgentHostChatContribution', () => {
 		}));
 
 		test('server-initiated turn picks up markdown arriving with turnStarted', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
-			const { sessionHandler, agentHostService } = createContribution(disposables);
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
 			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-server-md-initial' });
 			const chatSession = await sessionHandler.provideChatSessionContent(sessionResource, CancellationToken.None);
@@ -2343,8 +2345,10 @@ suite('AgentHostChatContribution', () => {
 			// Clear lifecycle actions so only turn dispatches are counted
 			agentHostService.dispatchedActions.length = 0;
 
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+
 			// First, do a normal turn so the backend session is created
-			const turn1Promise = chatSession.requestHandler!(
+			const turn1Promise = registered.impl.invoke(
 				makeRequest({ message: 'Init', sessionResource }),
 				() => { }, [], CancellationToken.None,
 			);
@@ -2394,7 +2398,7 @@ suite('AgentHostChatContribution', () => {
 	suite('customizations', () => {
 
 		test('dispatches activeClientChanged when a new session is created', async () => {
-			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 
 			const customizations = observableValue<ICustomizationRef[]>('customizations', [
 				{ uri: 'file:///plugin-a', displayName: 'Plugin A' },
@@ -2411,7 +2415,7 @@ suite('AgentHostChatContribution', () => {
 				customizations,
 			}));
 
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 
@@ -2425,7 +2429,7 @@ suite('AgentHostChatContribution', () => {
 		});
 
 		test('re-dispatches activeClientChanged when customizations observable changes', async () => {
-			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 
 			const customizations = observableValue<ICustomizationRef[]>('customizations', []);
 
@@ -2441,7 +2445,7 @@ suite('AgentHostChatContribution', () => {
 			}));
 
 			// Create a session first
-			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables);
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -48,6 +48,7 @@ import { IAgentSubscription } from '../../../../../../platform/agentHost/common/
 import { ITerminalChatService } from '../../../../terminal/browser/terminal.js';
 import { IAgentHostTerminalService } from '../../../../terminal/browser/agentHostTerminalService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
+import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 
 // ---- Mock agent host service ------------------------------------------------
 
@@ -285,7 +286,16 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
 	});
-	instantiationService.stub(IConfigurationService, { getValue: () => true });
+	instantiationService.stub(IConfigurationService, {
+		onDidChangeConfiguration: Event.None,
+		getValue: (...args: any[]) => typeof args[0] === 'string' && args[0] === 'chat.agentHost.clientTools' ? [] : true,
+	});
+	instantiationService.stub(ILanguageModelToolsService, {
+		observeTools: () => observableValue('tools', []),
+		onDidChangeTools: Event.None,
+		getTools: () => [],
+		_serviceBrand: undefined,
+	});
 	instantiationService.stub(IOutputService, { getChannel: () => undefined });
 	instantiationService.stub(IWorkspaceContextService, { getWorkspace: () => ({ id: '', folders: [] }), getWorkspaceFolder: () => null });
 	instantiationService.stub(IChatEditingService, {


### PR DESCRIPTION
Remove the unused `requestHandler` property and `_sendRequest` constructor parameter from `AgentHostChatSession`. The real code path uses registered agent `invoke()` → `_invokeAgent()` → `_handleTurn()`, making `requestHandler` dead code (confirmed by an existing `todo@connor4312` comment).

### Changes
- **agentHostSessionHandler.ts**: Removed `requestHandler` property, `_sendRequest` constructor parameter, and the dead `_sendRequest` callback at the `createInstance` call site
- **agentHostChatContribution.test.ts**: Updated `startTurn` / `startDynamicAgentTurn` helpers and all call sites to invoke turns through the registered agent's `invoke()` method instead of calling `requestHandler` directly

(Written by Copilot)