### PR TITLE
Skip effort picker when only one reasoning effort level exists

### DIFF
--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -56,7 +56,7 @@ const experimentalAutoModelHintMarkers = ['minimax', 'mp3yn0h7', 'yaqq2gxh'];
  */
 function buildConfigurationSchema(endpoint: IChatEndpoint): { configurationSchema?: vscode.LanguageModelConfigurationSchema } {
 	const effortLevels = endpoint.supportsReasoningEffort;
-	if (!effortLevels || effortLevels.length === 0) {
+	if (!effortLevels || effortLevels.length <= 1) {
 		return {};
 	}
 

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -169,7 +169,7 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	if (thinkingConfig && endpoint.supportsReasoningEffort?.length) {
 		const candidateEffort = configurationService.getConfig(ConfigKey.TeamInternal.AnthropicThinkingEffort)
 			?? reasoningEffort
-			?? (endpoint.supportsReasoningEffort.length === 1 ? endpoint.supportsReasoningEffort[0] : undefined);
+			?? (endpoint.supportsReasoningEffort.length === 1 ? endpoint.supportsReasoningEffort[0] : 'medium');
 		if (candidateEffort === 'low' || candidateEffort === 'medium' || candidateEffort === 'high') {
 			effort = candidateEffort;
 		}

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -167,7 +167,9 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	const thinkingEnabled = !!thinkingConfig;
 	let effort: 'low' | 'medium' | 'high' | undefined;
 	if (thinkingConfig && endpoint.supportsReasoningEffort?.length) {
-		const candidateEffort = configurationService.getConfig(ConfigKey.TeamInternal.AnthropicThinkingEffort) ?? reasoningEffort;
+		const candidateEffort = configurationService.getConfig(ConfigKey.TeamInternal.AnthropicThinkingEffort)
+			?? reasoningEffort
+			?? (endpoint.supportsReasoningEffort.length === 1 ? endpoint.supportsReasoningEffort[0] : undefined);
 		if (candidateEffort === 'low' || candidateEffort === 'medium' || candidateEffort === 'high') {
 			effort = candidateEffort;
 		}


### PR DESCRIPTION
Skips the thinking effort picker in the model picker UI when a model only advertises a single reasoning effort level, and auto-selects that level in the Anthropic messages API request body.

## Changes

- `languageModelAccess.ts`: `buildConfigurationSchema` returns `{}` when `effortLevels.length <= 1` so no picker is registered for single-effort models.
- `messagesApi.ts`: when building the request body, falls back to the single advertised effort level after config and user-selected `reasoningEffort` checks:
  ```
  config override → reasoningEffort (from picker) → single advertised level
  ```
  Config remains the source of truth.