### PR TITLE
Refactor: remove unused input state handling in CopilotCLIChatSessionContentProvider

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -169,7 +169,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 				}
 			}
 		));
-		const inputStateForNewSession = new ResourceMap<WeakRef<vscode.ChatSessionInputState>>();
 		controller.newChatSessionItemHandler = async (context) => {
 			const sessionId = this.sessionService.createNewSessionId();
 			const resource = SessionIdForCLI.getResource(sessionId);
@@ -185,8 +184,6 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 
 			controller.items.add(session);
 			this.newSessions.set(resource, session);
-			const groups = await this._optionGroupBuilder.provideChatSessionProviderOptionGroups(context.inputState);
-			inputStateForNewSession.set(resource, new WeakRef(controller.createChatSessionInputState(groups)));
 			return session;
 		};
 		if (this.configurationService.getConfig(ConfigKey.Advanced.CLIForkSessionsEnabled)) {
@@ -249,12 +246,7 @@ export class CopilotCLIChatSessionContentProvider extends Disposable implements 
 				const groups = await this._optionGroupBuilder.buildExistingSessionInputStateGroups(sessionResource, token);
 				return controller.createChatSessionInputState(groups);
 			} else {
-				// Possible we've already handled the newChatSessionItemHandler for this same uri
-				// In which case the proper inputState would have been sent.
-				// There's a bug in core where after newChatSessionItemHandler is called, we get
-				// another call for getChatSessionInputState, but this time the previous input state is incorrect.
-				const previousInputState = sessionResource ? inputStateForNewSession.get(sessionResource)?.deref() : undefined;
-				const groups = await this._optionGroupBuilder.provideChatSessionProviderOptionGroups(previousInputState);
+				const groups = await this._optionGroupBuilder.provideChatSessionProviderOptionGroups(context.previousInputState);
 				const state = controller.createChatSessionInputState(groups);
 				// Only wire dynamic updates for new sessions (existing sessions are fully locked).
 				// Note: don't use the getChatSessionInputState token here — it's a one-shot token


### PR DESCRIPTION
Eliminate unnecessary input state handling in the CopilotCLIChatSessionContentProvider to streamline the code and improve maintainability. This change simplifies the session management logic by removing redundant state management. Testing can be done by verifying that chat sessions function correctly without the removed input state handling.

