### PR TITLE
Fix: Guard against null model in inline edits word/line replacement view renders

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -76,7 +76,8 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 			const maxPrefixTrim = prefixTrim.prefixTrim;
 			const modifiedBubbles = rangesToBubbleRanges(edit.replacements.map(r => r.modifiedRange)).map(r => new Range(r.startLineNumber, r.startColumn - maxPrefixTrim, r.endLineNumber, r.endColumn - maxPrefixTrim));
 
-			const textModel = this._editor.model.get()!;
+			const textModel = this._editor.model.get();
+			if (!textModel) { return undefined; }
 			const startLineNumber = edit.modifiedRange.startLineNumber;
 			for (let i = 0; i < edit.modifiedRange.length; i++) {
 				const line = document.createElement('div');

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -95,7 +95,8 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			return this._userInteractionService.createHoverTracker(elem.element, reader.store).read(reader);
 		});
 		this._renderTextEffect = derived(this, _reader => {
-			const tm = this._editor.model.get()!;
+			const tm = this._editor.model.get();
+			if (!tm) { return; }
 			const origLine = tm.getLineContent(this._viewData.edit.range.startLineNumber);
 
 			const edit = StringReplacement.replace(new OffsetRange(this._viewData.edit.range.startColumn - 1, this._viewData.edit.range.endColumn - 1), this._viewData.edit.text);


### PR DESCRIPTION
Fixes #309039

## Root Cause

`InlineEditsWordReplacementView._renderTextEffect` and `InlineEditsLineReplacementView._modifiedLineElements` both use `this._editor.model.get()!` — a non-null assertion — then immediately call `getLineContent` / `tokenizeLinesAt` on the result.

When the editor is detached or the workspace is closed while a derived observable is mid-recompute (e.g., rapid close during an active inline completion suggestion), `model.get()` legitimately returns `null`. The TypeScript assertion passes silently, and the first method call on `null` throws:

```
Cannot read properties of null (reading 'getLineContent')
    at InlineEditsWordReplacementView._renderTextEffect (inlineEditsWordReplacementView.ts:99)
```

## Fix

Remove the `!` assertions and return early from both derived computations when the model is null. A null model means no tokenization data is available — skipping the render is the correct behavior (the derived will recompute when the model becomes non-null again).

Two files changed:
- `inlineEditsWordReplacementView.ts` — `_renderTextEffect` returns early
- `inlineEditsLineReplacementView.ts` — `_modifiedLineElements` returns `undefined` (consistent with the existing `!edit || !prefixTrim` guard two lines above)

## How to test

The crash happens on an edge case race condition (close workspace during active inline completion), but the pattern is straightforward to verify:
1. Open a file and trigger an inline completion suggestion
2. While the word-replacement widget is visible, rapidly close the file/workspace
3. **Before:** unhandled `TypeError: Cannot read properties of null (reading 'getLineContent')`
4. **After:** no crash; the derived silently returns without rendering