### PR TITLE
fix: guard openSearch against undefined view pane container

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1612,7 +1612,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	async openSearch(searchValue: string, preserveFoucs?: boolean): Promise<void> {
-		const viewPaneContainer = (await this.viewsService.openViewContainer(VIEWLET_ID, true))?.getViewPaneContainer() as IExtensionsViewPaneContainer;
+		const viewPaneContainer = (await this.viewsService.openViewContainer(VIEWLET_ID, true))?.getViewPaneContainer() as IExtensionsViewPaneContainer | undefined;
+		if (!viewPaneContainer) {
+			return;
+		}
 		viewPaneContainer.search(searchValue);
 		if (!preserveFoucs) {
 			viewPaneContainer.focus();

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1611,13 +1611,14 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		await this.editorService.openEditor(this.instantiationService.createInstance(ExtensionsInput, extension), options, options?.sideByside ? SIDE_GROUP : useModal ? MODAL_GROUP : ACTIVE_GROUP);
 	}
 
-	async openSearch(searchValue: string, preserveFoucs?: boolean): Promise<void> {
+	async openSearch(searchValue: string, preserveFocus?: boolean): Promise<void> {
 		const viewPaneContainer = (await this.viewsService.openViewContainer(VIEWLET_ID, true))?.getViewPaneContainer() as IExtensionsViewPaneContainer | undefined;
 		if (!viewPaneContainer) {
+			this.logService.trace('ExtensionsWorkbenchService#openSearch: extension view pane container was not available');
 			return;
 		}
 		viewPaneContainer.search(searchValue);
-		if (!preserveFoucs) {
+		if (!preserveFocus) {
 			viewPaneContainer.focus();
 		}
 	}

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -725,8 +725,8 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		return true;
 	}
 
-	async openSearch(searchValue: string, preserveFoucs?: boolean): Promise<void> {
-		await this.extensionsWorkbenchService.openSearch(`@mcp ${searchValue}`, preserveFoucs);
+	async openSearch(searchValue: string, preserveFocus?: boolean): Promise<void> {
+		await this.extensionsWorkbenchService.openSearch(`@mcp ${searchValue}`, preserveFocus);
 	}
 
 	async open(extension: IWorkbenchMcpServer, options?: IEditorOptions): Promise<void> {

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -822,7 +822,7 @@ export interface IMcpWorkbenchService {
 	uninstall(mcpServer: IWorkbenchMcpServer): Promise<void>;
 	getMcpConfigPath(arg: IWorkbenchLocalMcpServer): IMcpConfigPath | undefined;
 	getMcpConfigPath(arg: URI): Promise<IMcpConfigPath | undefined>;
-	openSearch(searchValue: string, preserveFoucs?: boolean): Promise<void>;
+	openSearch(searchValue: string, preserveFocus?: boolean): Promise<void>;
 	open(extension: IWorkbenchMcpServer | string, options?: IMcpServerEditorOptions): Promise<void>;
 }
 


### PR DESCRIPTION
## Problem

Fixes #309920

`openSearch` in `extensionsWorkbenchService.ts` crashes with:

```
Cannot read properties of undefined (reading 'search')
```

when `openViewContainer()` returns `undefined` (or its `getViewPaneContainer()` does). This happens in the **Agents** product where the Extensions viewlet may not be available.

The error appears as an unhandled promise rejection because:
- `openSearch` is `async` and the crash happens after an `await`
- **36 out of 56 callers** are fire-and-forget (no `await`, no `.catch()`) — onClick handlers, action `run()` callbacks, etc.

## Fix

Add a null check in `openSearch` so it silently no-ops when the view pane container is unavailable, rather than throwing. The `as` cast is widened to include `undefined` to match the actual runtime possibility.

This is the correct fix location because:
- No caller treats this error as a meaningful signal (no catch-dependent branching)
- Fixing 36+ callers is impractical and would be wrong — the method should handle its own preconditions
