### PR TITLE
Update AI co-author association

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1486,7 +1486,7 @@ export class Repository implements Disposable {
 		commands.executeCommand('_aiEdits.clearAiContributions', resources);
 	}
 
-	private static readonly AI_CO_AUTHOR_TRAILER = 'Co-authored-by: Copilot <copilot@github.com>';
+	private static readonly AI_CO_AUTHOR_TRAILER = 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>';
 
 	private async appendAICoAuthorTrailer(
 		message: string | undefined,

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -631,8 +631,8 @@ suite('git', () => {
 
 		test('AI co-author (Copilot)', function () {
 			assert.deepStrictEqual(
-				parseCoAuthors('Fix bug\n\nCo-authored-by: Copilot <copilot@github.com>'),
-				[{ name: 'Copilot', email: 'copilot@github.com' }]
+				parseCoAuthors('Fix bug\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'),
+				[{ name: 'Copilot', email: '223556219+Copilot@users.noreply.github.com' }]
 			);
 		});
 


### PR DESCRIPTION
**AI Co-author Email Update:**

* Changed the Copilot co-author trailer email from `copilot@github.com` to `223556219+Copilot@users.noreply.github.com` in both the repository logic and the corresponding test. [[1]](diffhunk://#diff-621d0ecf6c2060a5f136c76dde5369e831dd0b43c5c730e2100d9519f8f76a8eL1489-R1489) [[2]](diffhunk://#diff-81f76aafa882d111f3d9dcb3598566ca86f86ad95bd6ae6287501f59b5ef1f17L634-R635)
