### PR TITLE
chat: animate response copy button feedback

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
@@ -3,18 +3,136 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import * as dom from '../../../../../base/browser/dom.js';
+import { disposableTimeout } from '../../../../../base/common/async.js';
+import { IActionRunner } from '../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable, markAsSingleton, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
-import { localize2 } from '../../../../../nls.js';
-import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
+import { MenuEntryActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { Action2, MenuId, MenuItemAction, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { katexContainerClassName, katexContainerLatexAttributeName } from '../../../markdown/common/markedKatexExtension.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatRequestViewModel, IChatResponseViewModel, isChatTreeItem, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
 import { ChatTreeItem, IChatWidgetService } from '../chat.js';
 import { CHAT_CATEGORY, stringifyItem } from './chatActions.js';
+
+const CopyItemActionId = 'workbench.action.chat.copyItem';
+const copyFeedbackDuration = 1200;
+const copyIconClasses = ThemeIcon.asClassNameArray(Codicon.copy);
+const copiedIconClasses = ThemeIcon.asClassNameArray(Codicon.check);
+
+class ChatCopyActionViewItem extends MenuEntryActionViewItem {
+
+	private readonly copiedStateReset = this._register(new MutableDisposable());
+	private readonly actionRunnerListener = this._register(new MutableDisposable());
+	private copied = false;
+
+	override get actionRunner(): IActionRunner {
+		return super.actionRunner;
+	}
+
+	override set actionRunner(actionRunner: IActionRunner) {
+		super.actionRunner = actionRunner;
+		this.bindActionRunner(actionRunner);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		this.bindActionRunner(super.actionRunner);
+
+		if (!this.element || !this.label) {
+			return;
+		}
+
+		this.element.classList.add('chat-copy-action');
+		this.clearLabelIconClasses();
+		this.label.style.backgroundImage = '';
+		this.label.classList.remove('icon');
+		this.label.textContent = '';
+
+		const iconContainer = dom.append(this.label, dom.$('.chat-copy-action-icons'));
+		const copyIcon = dom.append(iconContainer, dom.$('.chat-copy-action-icon.chat-copy-action-icon-copy'));
+		copyIcon.classList.add(...copyIconClasses);
+		copyIcon.setAttribute('aria-hidden', 'true');
+
+		const copiedIcon = dom.append(iconContainer, dom.$('.chat-copy-action-icon.chat-copy-action-icon-copied'));
+		copiedIcon.classList.add(...copiedIconClasses);
+		copiedIcon.setAttribute('aria-hidden', 'true');
+
+		this.renderCopiedState();
+	}
+
+	protected override getTooltip(): string {
+		return this.copied
+			? localize('interactive.copyItem.copied', "Copied")
+			: super.getTooltip();
+	}
+
+	protected override updateClass(): void {
+		super.updateClass();
+		this.clearLabelIconClasses();
+		if (this.label) {
+			this.label.style.backgroundImage = '';
+			this.label.classList.remove('icon');
+		}
+	}
+
+	private clearLabelIconClasses(): void {
+		this.label?.classList.remove(...copyIconClasses, ...copiedIconClasses);
+	}
+
+	private renderCopiedState(): void {
+		this.element?.classList.toggle('copied', this.copied);
+		this.updateTooltip();
+	}
+
+	private bindActionRunner(actionRunner: IActionRunner): void {
+		this.actionRunnerListener.value = actionRunner.onDidRun(e => {
+			if (e.action.id !== CopyItemActionId || e.error) {
+				return;
+			}
+
+			this.copied = true;
+			this.renderCopiedState();
+			this.copiedStateReset.value = disposableTimeout(() => {
+				this.copied = false;
+				this.renderCopiedState();
+			}, copyFeedbackDuration);
+			status(localize('interactive.copyItem.status', "Copied to clipboard"));
+		});
+	}
+}
+
+export class ChatCopyActionRendering extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.copyActionRendering';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		const disposable = actionViewItemService.register(MenuId.ChatMessageFooter, CopyItemActionId, (action, options) => {
+			if (!(action instanceof MenuItemAction)) {
+				return undefined;
+			}
+
+			return instantiationService.createInstance(ChatCopyActionViewItem, action, options);
+		});
+
+		markAsSingleton(disposable);
+	}
+}
 
 export function registerChatCopyActions() {
 	registerAction2(class CopyAllAction extends Action2 {
@@ -52,7 +170,7 @@ export function registerChatCopyActions() {
 	registerAction2(class CopyItemAction extends Action2 {
 		constructor() {
 			super({
-				id: 'workbench.action.chat.copyItem',
+				id: CopyItemActionId,
 				title: localize2('interactive.copyItem.label', "Copy"),
 				f1: false,
 				category: CHAT_CATEGORY,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
@@ -58,6 +58,7 @@ class ChatCopyActionViewItem extends MenuEntryActionViewItem {
 		this.label.style.backgroundImage = '';
 		this.label.classList.remove('icon');
 		this.label.textContent = '';
+		this.label.setAttribute('aria-hidden', 'true');
 
 		const iconContainer = dom.append(this.label, dom.$('.chat-copy-action-icons'));
 		const copyIcon = dom.append(iconContainer, dom.$('.chat-copy-action-icon.chat-copy-action-icon-copy'));
@@ -75,6 +76,12 @@ class ChatCopyActionViewItem extends MenuEntryActionViewItem {
 		return this.copied
 			? localize('interactive.copyItem.copied', "Copied")
 			: super.getTooltip();
+	}
+
+	protected override updateAriaLabel(): void {
+		this.element?.setAttribute('aria-label', this.copied
+			? localize('interactive.copyItem.copiedAriaLabel', "Copied")
+			: localize('interactive.copyItem.ariaLabel', "Copy"));
 	}
 
 	protected override updateClass(): void {
@@ -97,7 +104,7 @@ class ChatCopyActionViewItem extends MenuEntryActionViewItem {
 
 	private bindActionRunner(actionRunner: IActionRunner): void {
 		this.actionRunnerListener.value = actionRunner.onDidRun(e => {
-			if (e.action.id !== CopyItemActionId || e.error) {
+			if (e.action !== this.action || e.error) {
 				return;
 			}
 
@@ -122,13 +129,13 @@ export class ChatCopyActionRendering extends Disposable implements IWorkbenchCon
 	) {
 		super();
 
-		const disposable = actionViewItemService.register(MenuId.ChatMessageFooter, CopyItemActionId, (action, options) => {
+		const disposable = this._register(actionViewItemService.register(MenuId.ChatMessageFooter, CopyItemActionId, (action, options) => {
 			if (!(action instanceof MenuItemAction)) {
 				return undefined;
 			}
 
 			return instantiationService.createInstance(ChatCopyActionViewItem, action, options);
-		});
+		}));
 
 		markAsSingleton(disposable);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -81,7 +81,7 @@ import { ModeOpenChatGlobalAction, registerChatActions } from './actions/chatAct
 import { CodeBlockActionRendering, registerChatCodeBlockActions, registerChatCodeCompareBlockActions } from './actions/chatCodeblockActions.js';
 import { ChatContextContributions } from './actions/chatContext.js';
 import { registerChatContextActions } from './actions/chatContextActions.js';
-import { registerChatCopyActions } from './actions/chatCopyActions.js';
+import { ChatCopyActionRendering, registerChatCopyActions } from './actions/chatCopyActions.js';
 import { registerChatDeveloperActions } from './actions/chatDeveloperActions.js';
 import { registerChatExecuteActions } from './actions/chatExecuteActions.js';
 import { registerChatFileTreeActions } from './actions/chatFileTreeActions.js';
@@ -2067,6 +2067,7 @@ registerWorkbenchContribution2(LanguageModelToolsExtensionPointHandler.ID, Langu
 registerWorkbenchContribution2(ChatPromptFilesExtensionPointHandler.ID, ChatPromptFilesExtensionPointHandler, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatCompatibilityNotifier.ID, ChatCompatibilityNotifier, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(CodeBlockActionRendering.ID, CodeBlockActionRendering, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ChatCopyActionRendering.ID, ChatCopyActionRendering, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatImplicitContextContribution.ID, ChatImplicitContextContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatViewsWelcomeHandler.ID, ChatViewsWelcomeHandler, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(ChatGettingStartedContribution.ID, ChatGettingStartedContribution, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -217,6 +217,45 @@
 	gap: 4px;
 }
 
+.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action .action-label {
+	position: relative;
+	overflow: hidden;
+}
+
+.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action .chat-copy-action-icons {
+	display: grid;
+	place-items: center;
+	width: 16px;
+	height: 16px;
+}
+
+.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action .chat-copy-action-icon {
+	grid-area: 1 / 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+	opacity: 0;
+	transform: scale(0.92);
+	transition:
+		opacity 140ms cubic-bezier(0.2, 0, 0, 1),
+		transform 140ms cubic-bezier(0.2, 0, 0, 1);
+	will-change: opacity, transform;
+}
+
+.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action:not(.copied) .chat-copy-action-icon-copy,
+.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action.copied .chat-copy-action-icon-copied {
+	opacity: 1;
+	transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.interactive-item-container .chat-footer-toolbar .menu-entry.chat-copy-action .chat-copy-action-icon {
+		transform: none;
+		transition: none;
+	}
+}
+
 .interactive-item-container .chat-footer-toolbar .checked.action-label,
 .interactive-item-container .chat-footer-toolbar .checked.action-label:hover {
 	color: var(--vscode-inputOption-activeForeground) !important;


### PR DESCRIPTION
## Summary
- add a custom footer copy action view item that swaps from the copy glyph to a temporary checkmark after copy succeeds
- animate the icon transition with short opacity/scale motion and restore the copy icon after a brief delay
- trigger the same feedback for both mouse and keyboard activation, with an ARIA status update and reduced-motion handling

https://github.com/user-attachments/assets/9bfb906c-a3e3-492d-8774-e9a064267a36

## Why
The response copy button in the sessions/agents chat worked, but it had no visible confirmation after activation. This adds lightweight feedback without changing the action behavior.

## Notes
- the implementation lives in the shared chat footer action rendering used by the sessions app
- validation included compile, hygiene, and layers checks during development