### PR TITLE
Add new chat items to inProgressItem instead of the controller

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -438,7 +438,7 @@ export class ClaudeChatSessionItemController extends Disposable {
 				permissionMode,
 				cwd: folder,
 			};
-			this._controller.items.add(item);
+			this._inProgressItems.set(newSessionId, item);
 			return item;
 		};
 


### PR DESCRIPTION
Since they have not yet been created on disk, we should keep these in the inProgress map so they're maintained across refreshes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
