### PR TITLE
Add policy for agent sandbox setting

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -283,6 +283,25 @@
             "included": true
         },
         {
+            "key": "chat.agent.sandbox.enabled",
+            "name": "ChatAgentSandboxEnabled",
+            "category": "IntegratedTerminal",
+            "minimumVersion": "1.116",
+            "localization": {
+                "description": {
+                    "key": "agentSandbox.enabledSetting",
+                    "value": "Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system."
+                }
+            },
+            "type": "string",
+            "default": "off",
+            "enum": [
+                "off",
+                "on"
+            ],
+            "included": true
+        },
+        {
             "key": "update.mode",
             "name": "UpdateMode",
             "category": "Update",

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -537,6 +537,17 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		restricted: true,
 		experiment: {
 			mode: 'auto'
+		},
+		policy: {
+			name: 'ChatAgentSandboxEnabled',
+			category: PolicyCategory.IntegratedTerminal,
+			minimumVersion: '1.116',
+			localization: {
+				description: {
+					key: 'agentSandbox.enabledSetting',
+					value: localize('agentSandbox.enabledSetting', "Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system."),
+				}
+			}
 		}
 	},
 	[TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem]: {


### PR DESCRIPTION
Cherry-pick of 8e2f29b41aa to the release branch.

This adds policy metadata for `chat.agent.sandbox.enabled` using the `ChatAgentSandboxEnabled` policy name and the setting's sandbox description.

fixes #309984