### PR TITLE
sessions: Consolidate agent host model picker and fix default model selection

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostModelPicker.ts
@@ -12,6 +12,7 @@ import { IActionViewItemService } from '../../../../platform/actions/browser/act
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { type ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { type IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
@@ -22,40 +23,43 @@ import { ISessionsManagementService } from '../../../services/sessions/common/se
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { Menus } from '../../../browser/menus.js';
 
-const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/);
+const IsActiveSessionAgentHost = ContextKeyExpr.or(
+	ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host'),
+	ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/),
+);
 
-// -- Remote Agent Host Model Picker Action --
+// -- Agent Host Model Picker Action --
 
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'sessions.remoteAgentHost.modelPicker',
-			title: nls.localize2('remoteModelPicker', "Model"),
+			id: 'sessions.agentHost.modelPicker',
+			title: nls.localize2('agentHostModelPicker', "Model"),
 			f1: false,
 			menu: [{
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
 				order: 1,
-				when: IsActiveSessionRemoteAgentHost,
+				when: IsActiveSessionAgentHost,
 			}],
 		});
 	}
 	override async run(): Promise<void> { /* handled by action view item */ }
 });
 
-// -- Remote Agent Host Model Picker Contribution --
+// -- Agent Host Model Picker Contribution --
 
-function getRemoteAgentHostModels(
+function getAgentHostModels(
 	languageModelsService: ILanguageModelsService,
 	session: ISession | undefined,
 ): ILanguageModelChatMetadataAndIdentifier[] {
 	if (!session) {
 		return [];
 	}
-	// Filter models by resource scheme (unique per-connection) rather than
-	// sessionType, since remote copilot sessions use the platform
-	// COPILOT_CLI_SESSION_TYPE but models are registered under the
-	// per-connection vendor.
+	// Filter models by resource scheme. For remote agent hosts the scheme is
+	// a unique per-connection ID; for local agent hosts it equals the session
+	// type. Both are used as the targetChatSessionType when registering
+	// models via AgentHostLanguageModelProvider.
 	const resourceScheme = session.resource.scheme;
 	return languageModelsService.getLanguageModelIds()
 		.map(id => {
@@ -65,9 +69,11 @@ function getRemoteAgentHostModels(
 		.filter((m): m is ILanguageModelChatMetadataAndIdentifier => !!m && m.metadata.targetChatSessionType === resourceScheme);
 }
 
-class RemoteAgentHostModelPickerContribution extends Disposable implements IWorkbenchContribution {
+const STORAGE_KEY = 'sessions.agentHostModelPicker.selectedModelId';
 
-	static readonly ID = 'sessions.contrib.remoteAgentHostModelPicker';
+class AgentHostModelPickerContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.agentHostModelPicker';
 
 	constructor(
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
@@ -75,23 +81,26 @@ class RemoteAgentHostModelPickerContribution extends Disposable implements IWork
 		@ILanguageModelsService languageModelsService: ILanguageModelsService,
 		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super();
 
 		this._register(actionViewItemService.register(
-			Menus.NewSessionConfig, 'sessions.remoteAgentHost.modelPicker',
+			Menus.NewSessionConfig, 'sessions.agentHost.modelPicker',
 			() => {
 				const currentModel = observableValue<ILanguageModelChatMetadataAndIdentifier | undefined>('currentModel', undefined);
 				const delegate: IModelPickerDelegate = {
 					currentModel,
 					setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
+						currentModel.set(model, undefined);
+						storageService.store(STORAGE_KEY, model.identifier, StorageScope.PROFILE, StorageTarget.MACHINE);
 						const session = sessionsManagementService.activeSession.get();
 						if (session) {
 							const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
 							provider?.setModel(session.sessionId, model.identifier);
 						}
 					},
-					getModels: () => getRemoteAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
+					getModels: () => getAgentHostModels(languageModelsService, sessionsManagementService.activeSession.get()),
 					useGroupedModelPicker: () => true,
 					showManageModelsAction: () => false,
 					showUnavailableFeatured: () => false,
@@ -101,36 +110,63 @@ class RemoteAgentHostModelPickerContribution extends Disposable implements IWork
 					hideChevrons: observableValue('hideChevrons', false),
 					hoverPosition: { hoverPosition: HoverPosition.ABOVE },
 				};
-				const action = { id: 'sessions.remoteAgentHost.modelPicker', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } };
+				const action = { id: 'sessions.agentHost.modelPicker', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } };
 				const modelPicker = instantiationService.createInstance(ModelPickerActionItem, action, delegate, pickerOptions);
 
-				const updatePickerModel = (session: ISession | undefined, sessionModelId: string | undefined) => {
-					const models = getRemoteAgentHostModels(languageModelsService, session);
+				const rememberedModelId = storageService.get(STORAGE_KEY, StorageScope.PROFILE);
+				const initModel = (session: ISession | undefined, sessionModelId: string | undefined) => {
+					const models = getAgentHostModels(languageModelsService, session);
 					modelPicker.setEnabled(models.length > 0);
-					currentModel.set(sessionModelId ? models.find(model => model.identifier === sessionModelId) : undefined, undefined);
+
+					let resolvedModel = sessionModelId
+						? models.find(model => model.identifier === sessionModelId)
+						: undefined;
+
+					// When no model is explicitly selected, restore the
+					// remembered model or pick the first available one so
+					// the picker shows a real model name instead of the
+					// misleading "Auto" label (the copilot "auto"
+					// pseudo-model is not available in agent host sessions).
+					if (!resolvedModel && models.length > 0) {
+						const remembered = rememberedModelId ? models.find(m => m.identifier === rememberedModelId) : undefined;
+						resolvedModel = remembered ?? models[0];
+						delegate.setModel(resolvedModel);
+					}
+
+					currentModel.set(resolvedModel, undefined);
 				};
-				const updatePickerModelFromActiveSession = () => {
+				const initModelFromActiveSession = () => {
 					const session = sessionsManagementService.activeSession.get();
-					updatePickerModel(session, session?.modelId.get());
+					initModel(session, session?.modelId.get());
 				};
-				updatePickerModelFromActiveSession();
+				initModelFromActiveSession();
 
 				const disposableStore = new DisposableStore();
-				disposableStore.add(languageModelsService.onDidChangeLanguageModels(() => updatePickerModelFromActiveSession()));
+				disposableStore.add(languageModelsService.onDidChangeLanguageModels(() => initModelFromActiveSession()));
 
 				disposableStore.add(autorun(reader => {
 					const session = sessionsManagementService.activeSession.read(reader);
 					const sessionModelId = session?.modelId.read(reader);
-					updatePickerModel(session, sessionModelId);
+					initModel(session, sessionModelId);
 				}));
 
-				return new RemoteAgentHostPickerActionViewItem(modelPicker, disposableStore);
+				// When the active session changes, push the selected model to the new session
+				disposableStore.add(autorun(reader => {
+					const session = sessionsManagementService.activeSession.read(reader);
+					const model = currentModel.read(reader);
+					if (session && model) {
+						const provider = sessionsProvidersService.getProviders().find(p => p.id === session.providerId);
+						provider?.setModel(session.sessionId, model.identifier);
+					}
+				}));
+
+				return new AgentHostPickerActionViewItem(modelPicker, disposableStore);
 			},
 		));
 	}
 }
 
-class RemoteAgentHostPickerActionViewItem extends BaseActionViewItem {
+class AgentHostPickerActionViewItem extends BaseActionViewItem {
 	constructor(private readonly picker: { render(container: HTMLElement): void; dispose(): void }, disposable?: DisposableStore) {
 		super(undefined, { id: '', label: '', enabled: true, class: undefined, tooltip: '', run: () => { } });
 		if (disposable) {
@@ -148,4 +184,4 @@ class RemoteAgentHostPickerActionViewItem extends BaseActionViewItem {
 	}
 }
 
-registerWorkbenchContribution2(RemoteAgentHostModelPickerContribution.ID, RemoteAgentHostModelPickerContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentHostModelPickerContribution.ID, AgentHostModelPickerContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -39,7 +39,6 @@ const IsActiveSessionCopilotCloud = ContextKeyExpr.equals(ActiveSessionTypeConte
 const IsActiveCopilotChatSessionProvider = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, COPILOT_PROVIDER_ID);
 const IsActiveSessionCopilotChatCLI = ContextKeyExpr.and(IsActiveSessionCopilotCLI, IsActiveCopilotChatSessionProvider);
 const IsActiveSessionCopilotChatCloud = ContextKeyExpr.and(IsActiveSessionCopilotCloud, IsActiveCopilotChatSessionProvider);
-const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host');
 
 // -- Actions --
 
@@ -108,7 +107,7 @@ registerAction2(class extends Action2 {
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionLocalAgentHost),
+				when: IsActiveSessionCopilotChatCLI,
 			}],
 		});
 	}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -618,3 +618,4 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 // Side-effect registrations for the remote agent host feature
 import './remoteAgentHostActions.js';
+import '../../chat/browser/agentHostModelPicker.js';

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -618,4 +618,3 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 // Side-effect registrations for the remote agent host feature
 import './remoteAgentHostActions.js';
-import './remoteAgentHostModelPicker.js';

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -460,7 +460,6 @@ import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
 import './contrib/chat/browser/agentHostSessionConfigPicker.js';
-import './contrib/chat/browser/agentHostModelPicker.js';
 import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/copilotChatSessions/browser/copilotChatSessions.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -460,6 +460,7 @@ import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
 import './contrib/chat/browser/agentHostSessionConfigPicker.js';
+import './contrib/chat/browser/agentHostModelPicker.js';
 import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/copilotChatSessions/browser/copilotChatSessions.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';


### PR DESCRIPTION
The remote agent host model picker showed "Auto" as the default model, but the copilot "auto" pseudo-model is not registered for agent host sessions. This caused the picker to display a non-functional default.

## Changes

- **Consolidated model picker** — moved `remoteAgentHostModelPicker` to shared `agentHostModelPicker` in `sessions/contrib/chat/browser/` so both local and remote agent hosts use the same picker. The `resource.scheme` filtering works universally (for local AH, `resource.scheme === sessionType`; for remote AH it's the per-connection ID).

- **Fixed default model selection** — when no model is explicitly selected, the picker now restores the remembered model from storage or falls back to `models[0]`, matching `findDefaultModel()` behaviour in the normal workbench. This prevents the misleading "Auto" label.

- **Added model persistence** — selected model is persisted via `IStorageService` (`StorageScope.PROFILE`), matching the local Copilot CLI picker pattern in `copilotChatSessionsActions.ts`.

- **Session change propagation** — selected model is pushed to new sessions on session change, matching the Copilot CLI picker.

- **Cleanup** — removed `IsActiveSessionLocalAgentHost` from `copilotChatSessionsActions.ts` local model picker since local AH now uses the shared agent host picker.

(Written by Copilot)