### PR TITLE
Fix optional chaining on candidate_models in routerDecision telemetry

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -139,7 +139,7 @@ export class RouterDecisionFetcher {
 				routingMethod: result.routing_method ?? '',
 				fallback: String(result.fallback ?? false),
 				fallbackReason: result.fallback_reason ?? '',
-				candidateModel: result.candidate_models[0] ?? '',
+				candidateModel: result.candidate_models?.[0] ?? '',
 			},
 			{
 				confidence: result.confidence,


### PR DESCRIPTION
result.candidate_models[0] throws a TypeError if the router returns a response without candidate_models, crashing the entire sendMSFTTelemetryEvent call and losing all fields on the event.

Use optional chaining (candidate_models?.[0]) so it safely falls back to the empty string default.