### PR TITLE
terminal: add sandbox policy enum descriptions

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -291,7 +291,17 @@
                 "description": {
                     "key": "agentSandbox.enabledSetting",
                     "value": "Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system."
-                }
+                },
+                "enumDescriptions": [
+                    {
+                        "key": "agentSandbox.enabledSetting.offDescription",
+                        "value": "Disable sandboxing for agent mode tools."
+                    },
+                    {
+                        "key": "agentSandbox.enabledSetting.onDescription",
+                        "value": "Enable sandboxing for agent mode tools."
+                    }
+                ]
             },
             "type": "string",
             "default": "off",

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -546,7 +546,17 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 				description: {
 					key: 'agentSandbox.enabledSetting',
 					value: localize('agentSandbox.enabledSetting', "Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system."),
-				}
+				},
+				enumDescriptions: [
+					{
+						key: 'agentSandbox.enabledSetting.offDescription',
+						value: localize('agentSandbox.enabledSetting.offDescription', 'Disable sandboxing for agent mode tools.'),
+					},
+					{
+						key: 'agentSandbox.enabledSetting.onDescription',
+						value: localize('agentSandbox.enabledSetting.onDescription', 'Enable sandboxing for agent mode tools.'),
+					},
+				]
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- Add localized enum descriptions to the `ChatAgentSandboxEnabled` policy metadata.
- Update generated policy data so `StringEnumPolicy` generation has descriptions matching the `off`/`on` enum values.

## Validation
- `node build/lib/policies/policyGenerator.ts build/lib/policies/policyData.jsonc linux`
- VS Code diagnostics reported no errors for the edited files.