### PR TITLE
Remove invalid Id's for model messages with phase property

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -125,11 +125,17 @@ export function getResponsesApiCompactionThresholdFromBody(body: Pick<IEndpointB
 	return undefined;
 }
 
-type ResponseInputAssistantMessageWithPhase = Omit<OpenAI.Responses.ResponseOutputMessage, 'id' | 'status' | 'content'> & {
-	content: Array<Pick<OpenAI.Responses.ResponseOutputText, 'type' | 'text'>>;
+interface ResponseInputAssistantTextContentPart {
+	type: 'output_text';
+	text: string;
+}
+
+interface ResponseInputAssistantMessageWithPhase {
+	type: 'message';
 	role: 'assistant';
+	content: ResponseInputAssistantTextContentPart[];
 	phase?: string;
-};
+}
 
 interface ResponseOutputItemWithPhase {
 	phase?: string;

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -20,6 +20,7 @@ import { FinishedCallback, getRequestId, IResponseDelta, OpenAiResponsesFunction
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
 import { ChatCompletion, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
 import { sendEngineMessagesTelemetry, sendResponsesApiCompactionTelemetry } from '../../networking/node/chatStream';
+import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
@@ -28,7 +29,6 @@ import { rawPartAsCompactionData } from '../common/compactionDataContainer';
 import { rawPartAsPhaseData } from '../common/phaseDataContainer';
 import { getIndexOfStatefulMarker, getStatefulMarkerAndIndex } from '../common/statefulMarkerContainer';
 import { rawPartAsThinkingData } from '../common/thinkingDataContainer';
-import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
 
 export function getResponsesApiCompactionThreshold(configService: IConfigurationService, expService: IExperimentationService, endpoint: IChatEndpoint): number | undefined {
 	const contextManagementEnabled = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiContextManagementEnabled, expService) && !modelsWithoutResponsesContextManagement.has(endpoint.family);
@@ -125,7 +125,9 @@ export function getResponsesApiCompactionThresholdFromBody(body: Pick<IEndpointB
 	return undefined;
 }
 
-type ResponseOutputMessageWithPhase = OpenAI.Responses.ResponseOutputMessage & {
+type ResponseInputAssistantMessageWithPhase = Omit<OpenAI.Responses.ResponseOutputMessage, 'id' | 'status' | 'content'> & {
+	content: Array<Pick<OpenAI.Responses.ResponseOutputText, 'type' | 'text'>>;
+	role: 'assistant';
 	phase?: string;
 };
 
@@ -216,18 +218,17 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 				if (message.content.length) {
 					input.push(...extractCompactionData(message.content));
 					input.push(...extractThinkingData(message.content));
-					const asstContent = message.content.map(rawContentToResponsesOutputContent).filter(isDefined);
+					const asstContent = message.content.map(rawContentToResponsesAssistantContent).filter(isDefined);
 					if (asstContent.length) {
-						const assistantMessage: ResponseOutputMessageWithPhase = {
+						const assistantMessage: ResponseInputAssistantMessageWithPhase = {
 							role: 'assistant',
 							content: asstContent,
-							// I don't think this needs to be round-tripped.
-							id: 'msg_123',
-							status: 'completed',
 							type: 'message',
 							phase: extractPhaseData(message.content),
 						};
-						input.push(assistantMessage);
+						// The Responses API expects previous assistant message content as output_text/refusal,
+						// but the SDK's ResponseOutputMessage type requires response-only id/status fields.
+						input.push(assistantMessage as OpenAI.Responses.ResponseInputItem);
 					}
 				}
 				if (message.toolCalls) {
@@ -313,11 +314,11 @@ function rawContentToResponsesContent(part: Raw.ChatCompletionContentPart): Open
 	}
 }
 
-function rawContentToResponsesOutputContent(part: Raw.ChatCompletionContentPart): OpenAI.Responses.ResponseOutputText | OpenAI.Responses.ResponseOutputRefusal | undefined {
+function rawContentToResponsesAssistantContent(part: Raw.ChatCompletionContentPart): Pick<OpenAI.Responses.ResponseOutputText, 'type' | 'text'> | undefined {
 	switch (part.type) {
 		case Raw.ChatCompletionContentPartKind.Text:
 			if (part.text.trim()) {
-				return { type: 'output_text', text: part.text, annotations: [] };
+				return { type: 'output_text', text: part.text };
 			}
 	}
 }

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -476,6 +476,51 @@ describe('createResponsesRequestBody', () => {
 		accessor.dispose();
 		services.dispose();
 	});
+
+	it('sends assistant messages with output content and without a fake output message id', () => {
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'previous answer' }],
+			},
+		];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), testEndpoint.model, testEndpoint));
+
+		expect(body.input).toContainEqual({
+			role: 'assistant',
+			content: [{ type: 'output_text', text: 'previous answer' }],
+			type: 'message',
+			phase: undefined,
+		});
+		expect(body.input?.[0]).not.toHaveProperty('id');
+		expect(body.input?.[0]).not.toHaveProperty('status');
+
+		accessor.dispose();
+		services.dispose();
+	});
+
+	it('does not send whitespace-only assistant messages', () => {
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: '   \n\t' }],
+			},
+		];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), testEndpoint.model, testEndpoint));
+
+		expect(body.input).toHaveLength(0);
+
+		accessor.dispose();
+		services.dispose();
+	});
 });
 
 describe('processResponseFromChatEndpoint telemetry', () => {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -495,7 +495,6 @@ describe('createResponsesRequestBody', () => {
 			content: [{ type: 'output_text', text: 'previous answer' }],
 			type: 'message',
 		});
-		expect(body.input?.[0]).not.toHaveProperty('phase');
 		expect(body.input?.[0]).not.toHaveProperty('id');
 		expect(body.input?.[0]).not.toHaveProperty('status');
 

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -490,12 +490,12 @@ describe('createResponsesRequestBody', () => {
 
 		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, createRequestOptions(messages, false), testEndpoint.model, testEndpoint));
 
-		expect(body.input).toContainEqual({
+		expect(body.input?.[0]).toMatchObject({
 			role: 'assistant',
 			content: [{ type: 'output_text', text: 'previous answer' }],
 			type: 'message',
-			phase: undefined,
 		});
+		expect(body.input?.[0]).not.toHaveProperty('phase');
 		expect(body.input?.[0]).not.toHaveProperty('id');
 		expect(body.input?.[0]).not.toHaveProperty('status');
 


### PR DESCRIPTION
## Summary

Remove invalid Id's for model messages with phase property

## Validation

- Focused test: `src/platform/endpoint/node/test/responsesApi.spec.ts` — 28 passed.
- Touched-file diagnostics: no errors.
- `npm run typecheck` — passed.
- Pre-commit checks — passed during commit.