### PR TITLE
Add policyData.jsonc validation test and update add-policy skill

### DIFF
--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -86,6 +86,8 @@ If you need a new field on `IPolicyData`, add it to the interface in `src/vs/bas
 
 **Optional: `enumDescriptions` for enum/string policies:**
 
+**IMPORTANT:** If the configuration property has `type: 'string'` and an `enum` array, you **must** include `enumDescriptions` in the `localization` block with the same number of entries as the `enum` array. Without this, `npm run export-policy-data` will fail with: `enumDescriptions must exist and have the same length as enum_ for policy "..."`.
+
 ```typescript
 localization: {
     description: { key: '...', value: nls.localize('...', "...") },

--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -86,7 +86,7 @@ If you need a new field on `IPolicyData`, add it to the interface in `src/vs/bas
 
 **Optional: `enumDescriptions` for enum/string policies:**
 
-**IMPORTANT:** If the configuration property has `type: 'string'` and an `enum` array, you **must** include `enumDescriptions` in the `localization` block with the same number of entries as the `enum` array. Without this, `npm run export-policy-data` will fail with: `enumDescriptions must exist and have the same length as enum_ for policy "..."`.
+**IMPORTANT:** If the configuration property has `type: 'string'` and an `enum` array, you **must** include `enumDescriptions` in the `localization` block with the same number of entries as the `enum` array. Without this, `npm run export-policy-data` will fail with: `enumDescriptions must exist and have the same length as enum for policy "..."`.
 
 ```typescript
 localization: {

--- a/build/lib/test/policyConversion.test.ts
+++ b/build/lib/test/policyConversion.test.ts
@@ -510,8 +510,10 @@ suite('Policy E2E conversion', () => {
 	test('should successfully parse the checked-in policyData.jsonc', async () => {
 		const policyDataPath = path.join(import.meta.dirname, '..', 'policies', 'policyData.jsonc');
 		const raw = await fs.readFile(policyDataPath, 'utf-8');
-		const policyData: ExportedPolicyDataDto = JSONC.parse(raw);
+		const errors: JSONC.ParseError[] = [];
+		const policyData: ExportedPolicyDataDto = JSONC.parse(raw, errors);
 
+		assert.strictEqual(errors.length, 0, `policyData.jsonc should be valid JSONC: ${JSON.stringify(errors)}`);
 		// This exercises StringEnumPolicy.from() validation, which requires
 		// enumDescriptions to exist and match enum length for string enum policies.
 		const parsed = parsePolicies(policyData);

--- a/build/lib/test/policyConversion.test.ts
+++ b/build/lib/test/policyConversion.test.ts
@@ -15,6 +15,7 @@ import { StringEnumPolicy } from '../policies/stringEnumPolicy.ts';
 import { StringPolicy } from '../policies/stringPolicy.ts';
 import type { Policy, ProductJson } from '../policies/types.ts';
 import { renderGP, renderMacOSPolicy, renderJsonPolicies } from '../policies/render.ts';
+import * as JSONC from 'jsonc-parser';
 
 const PolicyTypes = [
 	BooleanPolicy,
@@ -504,6 +505,17 @@ suite('Policy E2E conversion', () => {
 
 		// Compare the rendered JSON with the fixture
 		assert.deepStrictEqual(result, expectedJson, 'Linux policy JSON should match the fixture');
+	});
+
+	test('should successfully parse the checked-in policyData.jsonc', async () => {
+		const policyDataPath = path.join(import.meta.dirname, '..', 'policies', 'policyData.jsonc');
+		const raw = await fs.readFile(policyDataPath, 'utf-8');
+		const policyData: ExportedPolicyDataDto = JSONC.parse(raw);
+
+		// This exercises StringEnumPolicy.from() validation, which requires
+		// enumDescriptions to exist and match enum length for string enum policies.
+		const parsed = parsePolicies(policyData);
+		assert.ok(parsed.length > 0, 'Should parse at least one policy from policyData.jsonc');
 	});
 
 });


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/pull/310040

- Add test that parses the checked-in policyData.jsonc through parsePolicies() to catch missing/mismatched enumDescriptions on string enum policies
- Update add-policy skill to document that enumDescriptions is required for string enum policies

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
