### PR TITLE
agentHost: Fix workingDirectory for new sessions

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -198,7 +198,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			let { project, resolved } = metadata;
 			if (!resolved) {
 				project = await this._resolveSessionProject(s.context, projectLimiter, projectByContext);
-				this._storeSessionProjectResolution(session, project);
+				void this._storeSessionProjectResolution(session, project);
 			}
 			return {
 				session,
@@ -235,6 +235,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	async createSession(config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
+		if (!config?.workingDirectory) {
+			throw new Error('workingDirectory is required to create a Copilot session');
+		}
+
 		this._logService.info(`[Copilot] Creating session... ${config?.model ? `model=${config.model}` : ''}`);
 		const client = await this._ensureClient();
 
@@ -285,7 +289,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				const session = agentSession.sessionUri;
 				this._logService.info(`[Copilot] Forked session created: ${session.toString()}`);
 				const project = await projectFromCopilotContext({ cwd: config.workingDirectory?.fsPath }, this._gitService);
-				this._storeSessionMetadata(session, config.model, config.workingDirectory, project, true);
+				await this._storeSessionMetadata(session, config.model, config.workingDirectory, project, true);
 				return { session, ...(project ? { project } : {}) };
 			});
 		}
@@ -322,7 +326,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const project = await projectFromCopilotContext({ cwd: workingDirectory?.fsPath }, this._gitService);
 		// Persist model, working directory, and project so we can recreate the
 		// session if the SDK loses it and avoid rediscovering git metadata.
-		this._storeSessionMetadata(agentSession.sessionUri, config?.model, workingDirectory, project, true);
+		await this._storeSessionMetadata(agentSession.sessionUri, config?.model, workingDirectory, project, true);
 		return { session, ...(project ? { project } : {}) };
 	}
 
@@ -524,7 +528,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		if (entry) {
 			await entry.setModel(model);
 		}
-		this._storeSessionMetadata(session, model, undefined, undefined);
+		await this._storeSessionMetadata(session, model, undefined, undefined);
 	}
 
 	async shutdown(): Promise<void> {
@@ -651,6 +655,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 			return undefined;
 		});
 		const workingDirectory = typeof sessionMetadata?.context?.cwd === 'string' ? URI.file(sessionMetadata.context.cwd) : storedMetadata.workingDirectory;
+		if (!workingDirectory) {
+			throw new Error(`workingDirectory is required to resume Copilot session '${sessionId}'`);
+		}
+
 		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri);
 		const sessionConfig = this._buildSessionConfig(snapshot, shellManager);
 
@@ -745,13 +753,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private static readonly _META_PROJECT_URI = 'copilot.project.uri';
 	private static readonly _META_PROJECT_DISPLAY_NAME = 'copilot.project.displayName';
 
-	private _storeSessionMetadata(session: URI, model: string | undefined, workingDirectory: URI | undefined, project: IAgentSessionProjectInfo | undefined, projectResolved = project !== undefined): void {
-		const dbRef = this._sessionDataService.tryOpenDatabase(session);
-		dbRef?.then(ref => {
-			if (!ref) {
-				return;
-			}
-			const db = ref.object;
+	private async _storeSessionMetadata(session: URI, model: string | undefined, workingDirectory: URI | undefined, project: IAgentSessionProjectInfo | undefined, projectResolved = project !== undefined): Promise<void> {
+		const dbRef = this._sessionDataService.openDatabase(session);
+		const db = dbRef.object;
+		try {
 			const work: Promise<void>[] = [];
 			if (model) {
 				work.push(db.setMetadata(CopilotAgent._META_MODEL, model));
@@ -766,8 +771,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 				work.push(db.setMetadata(CopilotAgent._META_PROJECT_URI, project.uri.toString()));
 				work.push(db.setMetadata(CopilotAgent._META_PROJECT_DISPLAY_NAME, project.displayName));
 			}
-			Promise.all(work).finally(() => ref.dispose());
-		});
+			await Promise.all(work);
+		} finally {
+			dbRef.dispose();
+		}
 	}
 
 	private async _readSessionMetadata(session: URI): Promise<{ model?: string; workingDirectory?: URI }> {
@@ -809,8 +816,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 	}
 
-	private _storeSessionProjectResolution(session: URI, project: IAgentSessionProjectInfo | undefined): void {
-		this._storeSessionMetadata(session, undefined, undefined, project, true);
+	private async _storeSessionProjectResolution(session: URI, project: IAgentSessionProjectInfo | undefined): Promise<void> {
+		await this._storeSessionMetadata(session, undefined, undefined, project, true);
 	}
 
 	private _resolveSessionProject(context: ICopilotSessionContext | undefined, limiter: Limiter<IAgentSessionProjectInfo | undefined>, projectByContext: Map<string, Promise<IAgentSessionProjectInfo | undefined>>): Promise<IAgentSessionProjectInfo | undefined> {


### PR DESCRIPTION
From https://github.com/microsoft/vscode/pull/309672.
1. `getSessionMetadata` does indeed actually fail immediately after creating the session, this is the problem from last week
2. But we also try to store the metadata via `_storeSessionMetadata`- which fails because it uses `tryOpenDatabase` and nothing has created the db yet
3. Then we go through this path https://github.com/microsoft/vscode/blob/bfc9f24e5630cca636a68ed2707d29aee784e6fd/src/vs/platform/agentHost/node/copilot/copilotAgent.ts#L436-L440 then go through `_resumeSession` which fails because we don't have a cwd from the SDK, or from our own store.
4. And the SDK forgets its own workingDirectory unless it's passed in

Co-authored-by: Copilot <copilot@github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
