### PR TITLE
agentHost: add integration test for CopilotAgent working directory regression

### DIFF
--- a/build/azure-pipelines/copilot/test-steps.yml
+++ b/build/azure-pipelines/copilot/test-steps.yml
@@ -54,3 +54,24 @@ steps:
     - script: xvfb-run -a npm run test:sanity
       workingDirectory: $(Build.SourcesDirectory)/extensions/copilot
       displayName: Run sanity tests
+
+    # Agent host integration tests — exercises real CopilotAgent → Copilot SDK path.
+    # Needs root node_modules (for @github/copilot-sdk at runtime) and
+    # transpiled main sources in out/ (the agent host server runs from there).
+    - script: npm ci --ignore-scripts
+      displayName: Install root dependencies (agent host tests)
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+    - script: npm run transpile-client
+      displayName: Transpile VS Code sources (agent host tests)
+
+    - script: |
+        set -e
+        set -a
+        source extensions/copilot/.env
+        set +a
+        npx mocha --timeout 120000 out/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.js
+      displayName: 🧪 Run agent host cwd integration test
+      timeoutInMinutes: 5

--- a/build/azure-pipelines/copilot/test-steps.yml
+++ b/build/azure-pipelines/copilot/test-steps.yml
@@ -55,23 +55,23 @@ steps:
       workingDirectory: $(Build.SourcesDirectory)/extensions/copilot
       displayName: Run sanity tests
 
-    # Agent host integration tests — exercises real CopilotAgent → Copilot SDK path.
-    # Needs root node_modules (for @github/copilot-sdk at runtime) and
-    # transpiled main sources in out/ (the agent host server runs from there).
-    - script: npm ci --ignore-scripts
-      displayName: Install root dependencies (agent host tests)
-      env:
-        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+  # Agent host integration tests — exercises real CopilotAgent → Copilot SDK path.
+  # Needs root node_modules (for @github/copilot-sdk at runtime) and
+  # transpiled main sources in out/ (the agent host server runs from there).
+  - script: npm ci --ignore-scripts
+    displayName: Install root dependencies (agent host tests)
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
-    - script: npm run transpile-client
-      displayName: Transpile VS Code sources (agent host tests)
+  - script: npm run transpile-client
+    displayName: Transpile VS Code sources (agent host tests)
 
-    - script: |
-        set -e
-        set -a
-        source extensions/copilot/.env
-        set +a
-        npx mocha --timeout 120000 out/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.js
-      displayName: 🧪 Run agent host cwd integration test
-      timeoutInMinutes: 5
+  - script: |
+      set -e
+      set -a
+      source extensions/copilot/.env
+      set +a
+      npx mocha --timeout 120000 out/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.js
+    displayName: 🧪 Run agent host cwd integration test
+    timeoutInMinutes: 5

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
@@ -42,6 +42,7 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 	let tmpDir: string;
 	let ghToken: string;
 	let sessionUri: string | undefined;
+	let sdkSessionId: string | undefined;
 
 	suiteSetup(async function () {
 		this.timeout(30_000);
@@ -52,7 +53,11 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 		ghToken = process.env['GITHUB_OAUTH_TOKEN'] ?? '';
 		if (!ghToken) {
 			try {
-				ghToken = execFileSync('gh', ['auth', 'token'], { encoding: 'utf-8' }).trim();
+				ghToken = execFileSync('gh', ['auth', 'token'], {
+					encoding: 'utf-8',
+					timeout: 5_000,
+					stdio: 'pipe',
+				}).trim();
 			} catch {
 				// Neither env var nor gh CLI available — skip the suite.
 				return this.skip();
@@ -93,6 +98,13 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 		}
 		client?.close();
 		sessionUri = undefined;
+		// Clean up SDK session-state directory for this specific session
+		if (sdkSessionId) {
+			try {
+				fs.rmSync(join(os.homedir(), '.copilot', 'session-state', sdkSessionId), { recursive: true, force: true });
+			} catch { /* best effort */ }
+			sdkSessionId = undefined;
+		}
 		try {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		} catch { /* best effort */ }
@@ -117,6 +129,7 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 			15_000,
 		);
 		sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as ISessionAddedNotification).summary.resource;
+		sdkSessionId = AgentSession.id(URI.parse(sessionUri));
 
 		// 2. Set client tools (mimics what VS Code does before the first message).
 		//    This populates the ActiveClient for the session, so the sendMessage
@@ -139,8 +152,11 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 			},
 		});
 
-		// Give the server a moment to process the activeClientChanged action
-		await new Promise(resolve => setTimeout(resolve, 500));
+		// Give the server time to process the activeClientChanged action
+		await client.waitForNotification(
+			n => isActionNotification(n, 'session/activeClientChanged'),
+			5_000,
+		);
 
 		// 3. Send a trivial message by dispatching a turnStarted action.
 		//    Because the active client was set after createSession, the
@@ -155,7 +171,7 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 		);
 
 		// 4. Read the SDK's events.jsonl and verify the cwd in the session.start event
-		const eventsPath = join(os.homedir(), '.copilot', 'session-state', sessionId, 'events.jsonl');
+		const eventsPath = join(os.homedir(), '.copilot', 'session-state', sdkSessionId, 'events.jsonl');
 		assert.ok(fs.existsSync(eventsPath), `events.jsonl should exist at: ${eventsPath}`);
 
 		const lines = fs.readFileSync(eventsPath, 'utf-8').trim().split('\n');

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
@@ -41,6 +41,7 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 	let client: TestProtocolClient;
 	let tmpDir: string;
 	let ghToken: string;
+	let sessionUri: string | undefined;
 
 	suiteSetup(async function () {
 		this.timeout(30_000);
@@ -83,8 +84,15 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 		});
 	});
 
-	teardown(function () {
+	teardown(async function () {
+		this.timeout(15_000);
+		if (client && sessionUri) {
+			try {
+				await client.call('disposeSession', { session: sessionUri }, 10_000);
+			} catch { /* best effort */ }
+		}
 		client?.close();
+		sessionUri = undefined;
 		try {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		} catch { /* best effort */ }
@@ -108,7 +116,7 @@ suite('CopilotAgent — Working Directory (real SDK)', function () {
 				(n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
 			15_000,
 		);
-		const sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as ISessionAddedNotification).summary.resource;
+		sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as ISessionAddedNotification).summary.resource;
 
 		// 2. Set client tools (mimics what VS Code does before the first message).
 		//    This populates the ActiveClient for the session, so the sendMessage

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from '../../../../../base/common/path.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { AgentSession } from '../../../common/agentService.js';
+import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
+import type { ISessionAddedNotification } from '../../../common/state/sessionActions.js';
+import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
+import {
+	dispatchTurnStarted,
+	isActionNotification,
+	type IServerHandle,
+	TestProtocolClient,
+} from './testHelpers.js';
+import { startCopilotServer } from './copilotAgentCwdHelpers.js';
+
+/**
+ * Integration test that exercises the real CopilotAgent → Copilot SDK path.
+ *
+ * Verifies that the `workingDirectory` passed to `createSession` is correctly
+ * forwarded to the SDK and appears in the `session.start` event in
+ * `events.jsonl`.
+ *
+ * Requirements:
+ *  - `gh auth` logged in (provides the GitHub token)
+ *  - `node_modules` installed
+ *
+ * Run: scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/protocol/copilotAgentCwd.integrationTest.ts
+ */
+suite('CopilotAgent — Working Directory (real SDK)', function () {
+
+	let server: IServerHandle;
+	let client: TestProtocolClient;
+	let tmpDir: string;
+	let ghToken: string;
+
+	suiteSetup(async function () {
+		this.timeout(30_000);
+
+		// Obtain a GitHub token. Prefer GITHUB_OAUTH_TOKEN (used by CI and
+		// the copilot extension's simulation tests), then fall back to the
+		// local `gh` CLI.
+		ghToken = process.env['GITHUB_OAUTH_TOKEN'] ?? '';
+		if (!ghToken) {
+			try {
+				ghToken = execFileSync('gh', ['auth', 'token'], { encoding: 'utf-8' }).trim();
+			} catch {
+				// Neither env var nor gh CLI available — skip the suite.
+				return this.skip();
+			}
+		}
+
+		// Start the agent host server with CopilotAgent (not --quiet, not --enable-mock-agent)
+		server = await startCopilotServer();
+	});
+
+	suiteTeardown(function () {
+		server?.process.kill();
+	});
+
+	setup(async function () {
+		this.timeout(15_000);
+
+		tmpDir = fs.mkdtempSync(join(os.tmpdir(), 'copilot-cwd-test-'));
+		client = new TestProtocolClient(server.port);
+		await client.connect();
+
+		// Handshake
+		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'test-copilot-cwd' });
+
+		// Authenticate with the real GitHub token so CopilotAgent can talk to the API
+		await client.call('authenticate', {
+			resource: 'https://api.github.com',
+			token: ghToken,
+		});
+	});
+
+	teardown(function () {
+		client?.close();
+		try {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		} catch { /* best effort */ }
+	});
+
+	test('session.start event in events.jsonl reports the correct cwd', async function () {
+		this.timeout(120_000);
+
+		// 1. Create a session with a specific working directory
+		const sessionId = generateUuid();
+		const requestedSessionUri = AgentSession.uri('copilot', sessionId).toString();
+		await client.call('createSession', {
+			session: requestedSessionUri,
+			provider: 'copilot',
+			workingDirectory: URI.file(tmpDir).toString(),
+		}, 60_000);
+
+		// Wait for the sessionAdded notification to learn the real session URI
+		const addedNotif = await client.waitForNotification(
+			n => n.method === 'notification' &&
+				(n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
+			15_000,
+		);
+		const sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as ISessionAddedNotification).summary.resource;
+
+		// 2. Set client tools (mimics what VS Code does before the first message).
+		//    This populates the ActiveClient for the session, so the sendMessage
+		//    path sees an outdated snapshot and recreates the SDK session.
+		await client.call('subscribe', { resource: sessionUri }, 5_000);
+		client.clearReceived();
+
+		client.notify('dispatchAction', {
+			clientSeq: 1,
+			action: {
+				type: 'session/activeClientChanged',
+				session: sessionUri,
+				activeClient: {
+					clientId: 'test-copilot-cwd',
+					tools: [{
+						name: 'dummy_tool',
+						description: 'A no-op tool for testing',
+					}],
+				},
+			},
+		});
+
+		// Give the server a moment to process the activeClientChanged action
+		await new Promise(resolve => setTimeout(resolve, 500));
+
+		// 3. Send a trivial message by dispatching a turnStarted action.
+		//    Because the active client was set after createSession, the
+		//    sendMessage path detects an outdated snapshot, disposes the
+		//    existing SDK session, and recreates it via _resumeSession.
+		dispatchTurnStarted(client, sessionUri, 'turn-cwd-1', 'Respond with exactly: HELLO', 2);
+
+		// Wait for the turn to complete (the real LLM processes the request)
+		await client.waitForNotification(
+			n => isActionNotification(n, 'session/turnComplete'),
+			90_000,
+		);
+
+		// 4. Read the SDK's events.jsonl and verify the cwd in the session.start event
+		const eventsPath = join(os.homedir(), '.copilot', 'session-state', sessionId, 'events.jsonl');
+		assert.ok(fs.existsSync(eventsPath), `events.jsonl should exist at: ${eventsPath}`);
+
+		const lines = fs.readFileSync(eventsPath, 'utf-8').trim().split('\n');
+		const sessionStartLine = lines.find(line => line.includes('"session.start"'));
+		assert.ok(sessionStartLine, 'events.jsonl should contain a session.start event');
+
+		const sessionStartEvent = JSON.parse(sessionStartLine);
+		assert.strictEqual(
+			sessionStartEvent.data?.context?.cwd,
+			tmpDir,
+			`session.start cwd should match the requested workingDirectory`,
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwdHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwdHelpers.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { fork } from 'child_process';
+import { fileURLToPath } from 'url';
+import type { IServerHandle } from './testHelpers.js';
+
+/**
+ * Starts the agent host server with the real CopilotAgent registered.
+ *
+ * Unlike {@link startServer} in testHelpers.ts, this does NOT pass
+ * `--enable-mock-agent` or `--quiet`, so the server boots the real
+ * CopilotAgent backed by the Copilot SDK.
+ */
+export function startCopilotServer(): Promise<IServerHandle> {
+	return new Promise((resolve, reject) => {
+		const serverPath = fileURLToPath(new URL('../../../node/agentHostServerMain.js', import.meta.url));
+		const args = ['--port', '0', '--without-connection-token'];
+		const child = fork(serverPath, args, {
+			stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+		});
+
+		const timer = setTimeout(() => {
+			child.kill();
+			reject(new Error('Copilot server startup timed out'));
+		}, 30_000);
+
+		child.stdout!.on('data', (data: Buffer) => {
+			const text = data.toString();
+			const match = text.match(/READY:(\d+)/);
+			if (match) {
+				clearTimeout(timer);
+				resolve({ process: child, port: parseInt(match[1], 10) });
+			}
+		});
+
+		child.stderr!.on('data', () => {
+			// Swallowed — the test runner fails if stderr leaks through.
+		});
+
+		child.on('error', err => {
+			clearTimeout(timer);
+			reject(err);
+		});
+
+		child.on('exit', code => {
+			clearTimeout(timer);
+			reject(new Error(`Copilot server exited prematurely with code ${code}`));
+		});
+	});
+}

--- a/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwdHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/copilotAgentCwdHelpers.ts
@@ -24,20 +24,23 @@ export function startCopilotServer(): Promise<IServerHandle> {
 
 		const timer = setTimeout(() => {
 			child.kill();
-			reject(new Error('Copilot server startup timed out'));
+			reject(new Error(`Copilot server startup timed out.\nstderr: ${stderrBuf}`));
 		}, 30_000);
 
+		let stdoutBuf = '';
+		let stderrBuf = '';
+
 		child.stdout!.on('data', (data: Buffer) => {
-			const text = data.toString();
-			const match = text.match(/READY:(\d+)/);
+			stdoutBuf += data.toString();
+			const match = stdoutBuf.match(/READY:(\d+)/);
 			if (match) {
 				clearTimeout(timer);
 				resolve({ process: child, port: parseInt(match[1], 10) });
 			}
 		});
 
-		child.stderr!.on('data', () => {
-			// Swallowed — the test runner fails if stderr leaks through.
+		child.stderr!.on('data', (data: Buffer) => {
+			stderrBuf += data.toString();
 		});
 
 		child.on('error', err => {
@@ -47,7 +50,7 @@ export function startCopilotServer(): Promise<IServerHandle> {
 
 		child.on('exit', code => {
 			clearTimeout(timer);
-			reject(new Error(`Copilot server exited prematurely with code ${code}`));
+			reject(new Error(`Copilot server exited prematurely with code ${code}.\nstderr: ${stderrBuf}`));
 		});
 	});
 }


### PR DESCRIPTION
Adds an integration test that exercises the real CopilotAgent → Copilot SDK path to reproduce the working directory regression from #309672.

## What this does

The test follows the real-world flow:
1. **`createSession`** with a specific `workingDirectory` (a temp dir)
2. **`session/activeClientChanged`** — sets client tools (populates `ActiveClient`)
3. **`session/turnStarted`** — sends a message, which triggers `sendMessage`

Because the active client was set *after* session creation, `sendMessage` detects an outdated snapshot, disposes the SDK session, and recreates it via `_resumeSession`. The test verifies that the working directory in the SDK's `events.jsonl` `session.start` event matches the originally requested directory.

## Current behavior (test fails ❌)

The recreated session gets the **server's working directory** instead of the one originally passed to `createSession`, confirming the regression.

## Auth

The test accepts `GITHUB_OAUTH_TOKEN` (for CI, matching the copilot extension's simulation test pattern) or falls back to `gh auth token` (for local dev). Auto-skips if neither is available.

(Written by Copilot)