### PR TITLE
Preserve user-managed /usr/local/bin/code in RPM %post scriptlet

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -49,9 +49,16 @@ cp usr/share/bash-completion/completions/%{name} %{buildroot}%{_datadir}/bash-co
 cp usr/share/zsh/site-functions/_%{name} %{buildroot}%{_datadir}/zsh/site-functions/_%{name}
 
 %post
-# Remove the legacy bin command if this is the stable build
-if [ "%{name}" = "code" ]; then
-	rm -f /usr/local/bin/code
+# Remove the legacy bin command if this is the stable build.
+# Only remove it when it is a symlink pointing at the location previously
+# installed by this package, so that user-managed files or symlinks at
+# /usr/local/bin/code (e.g. wrapper scripts) are preserved.
+# See https://github.com/microsoft/vscode/issues/236132
+if [ "%{name}" = "code" ] && [ -L /usr/local/bin/code ]; then
+	LEGACY_LINK_TARGET=$(readlink /usr/local/bin/code 2>/dev/null || true)
+	if [ "$LEGACY_LINK_TARGET" = "/usr/share/code/bin/code" ] || [ "$LEGACY_LINK_TARGET" = "%{_datadir}/%{name}/bin/%{name}" ]; then
+		rm -f /usr/local/bin/code
+	fi
 fi
 
 # Register yum repository


### PR DESCRIPTION
## What this PR does

The RPM `%post` scriptlet currently removes `/usr/local/bin/code` unconditionally on every install/upgrade of the stable `code` package:

```spec
%post
# Remove the legacy bin command if this is the stable build
if [ "%{name}" = "code" ]; then
    rm -f /usr/local/bin/code
fi
```

`/usr/local/bin/code` is not a path owned by this package, and it's a common place for users to drop a wrapper script (for example, to launch `/usr/bin/code` with extra flags like `--ozone-platform=wayland` system-wide). Deleting it on every RPM upgrade silently destroys user-managed files.

This PR keeps the legacy cleanup, but only when the file is a symlink pointing at the target the package itself used to install (`/usr/share/code/bin/code` / `%{_datadir}/%{name}/bin/%{name}`). Regular files (user wrapper scripts) and symlinks to other targets are left untouched.

## Behavior change

- Before: `rm -f /usr/local/bin/code` ran on every `%post`, removing whatever was at that path.
- After: removal happens only when `/usr/local/bin/code` is a symlink whose target is the legacy package-installed location.

This preserves the original intent (cleaning up the legacy symlink from very old packages) without trampling files the user owns.

## Testing notes

This affects RPM packaging only and is exercised at install time. Manual verification scenarios:

1. A regular file at `/usr/local/bin/code` (e.g. a wrapper shell script) -> preserved across RPM upgrade.
2. A symlink at `/usr/local/bin/code` -> `/some/user/path/code` -> preserved across RPM upgrade.
3. A symlink at `/usr/local/bin/code` -> `/usr/share/code/bin/code` (legacy package layout) -> removed, matching previous cleanup behavior.
4. No file at `/usr/local/bin/code` -> no-op.

Fixes #236132