### PR TITLE
Adopt CodeAction type for built-in css server

### DIFF
--- a/extensions/css-language-features/client/src/cssClient.ts
+++ b/extensions/css-language-features/client/src/cssClient.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, CompletionItem, CompletionItemKind, ExtensionContext, languages, Position, Range, SnippetString, TextEdit, window, TextDocument, CompletionContext, CancellationToken, ProviderResult, CompletionList, FormattingOptions, workspace, l10n } from 'vscode';
+import { CompletionItem, CompletionItemKind, ExtensionContext, languages, Position, Range, SnippetString, TextEdit, TextDocument, CompletionContext, CancellationToken, ProviderResult, CompletionList, FormattingOptions, workspace, l10n } from 'vscode';
 import { Disposable, LanguageClientOptions, ProvideCompletionItemsSignature, NotificationType, BaseLanguageClient, DocumentRangeFormattingParams, DocumentRangeFormattingRequest } from 'vscode-languageclient';
 import { getCustomDataSource } from './customData';
 import { RequestService, serveFileSystemRequests } from './requests';
@@ -145,26 +145,6 @@ export async function startClient(context: ExtensionContext, newLanguageClient: 
 				return null;
 			}
 		});
-	}
-
-	commands.registerCommand('_css.applyCodeAction', applyCodeAction);
-
-	function applyCodeAction(uri: string, documentVersion: number, edits: TextEdit[]) {
-		const textEditor = window.activeTextEditor;
-		if (textEditor && textEditor.document.uri.toString() === uri) {
-			if (textEditor.document.version !== documentVersion) {
-				window.showInformationMessage(l10n.t('CSS fix is outdated and can\'t be applied to the document.'));
-			}
-			textEditor.edit(mutator => {
-				for (const edit of edits) {
-					mutator.replace(client.protocol2CodeConverter.asRange(edit.range), edit.newText);
-				}
-			}).then(success => {
-				if (!success) {
-					window.showErrorMessage(l10n.t('Failed to apply CSS fix to the document. Please consider opening an issue with steps to reproduce.'));
-				}
-			});
-		}
 	}
 
 	function updateFormatterRegistration(registration: FormatterRegistration) {

--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -12,8 +12,7 @@
   "activationEvents": [
     "onLanguage:css",
     "onLanguage:less",
-    "onLanguage:scss",
-    "onCommand:_css.applyCodeAction"
+    "onLanguage:scss"
   ],
   "main": "./client/out/node/cssClientMain",
   "browser": "./client/dist/browser/cssClientMain",

--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -12,7 +12,8 @@
   "activationEvents": [
     "onLanguage:css",
     "onLanguage:less",
-    "onLanguage:scss"
+    "onLanguage:scss",
+    "onCommand:_css.applyCodeAction"
   ],
   "main": "./client/out/node/cssClientMain",
   "browser": "./client/dist/browser/cssClientMain",


### PR DESCRIPTION
### What this PR does

The CSS language server already returns proper `CodeAction` objects (with `edit`) via `doCodeActions2` (see `extensions/css-language-features/server/src/cssServer.ts`). The client, however, still registered a legacy `_css.applyCodeAction` command that was used by the older `Command`-style code actions and is no longer invoked from the server.

This PR removes the now-dead client-side glue:

- Drop the `_css.applyCodeAction` command registration and its `applyCodeAction` helper in `extensions/css-language-features/client/src/cssClient.ts`.
- Drop the unused `commands` and `window` imports that were only used by that helper.
- Drop the `onCommand:_css.applyCodeAction` activation event in `extensions/css-language-features/package.json` so the extension no longer activates on a command nobody fires.

No behavior change is expected: code actions continue to flow through the standard `CodeAction.edit` path that the editor applies directly.

Fixes #237858