### PR TITLE
Fix select-all hijacked by editor when webview/custom editor has focus

### DIFF
--- a/src/vs/editor/browser/coreCommands.ts
+++ b/src/vs/editor/browser/coreCommands.ts
@@ -328,6 +328,15 @@ abstract class EditorOrNativeTextInputCommand {
 
 		// 3. (default) handle case when focus is somewhere else.
 		target.addImplementation(0, 'generic-dom', (accessor: ServicesAccessor, args: unknown) => {
+			// If focus is currently inside an iframe (e.g. a webview / custom
+			// editor), do not steal focus away to the active code editor.
+			// Otherwise commands like select-all/undo/redo would always be
+			// hijacked by the underlying text editor instead of being handled
+			// by the focused iframe content. See #236373.
+			const activeElement = getActiveElement();
+			if (activeElement && activeElement.tagName.toLowerCase() === 'iframe') {
+				return false;
+			}
 			// Redirecting to active editor
 			const activeEditor = accessor.get(ICodeEditorService).getActiveCodeEditor();
 			if (activeEditor) {


### PR DESCRIPTION
Fixes #236373

## Problem

When a webview-based custom editor has focus, pressing <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd> triggers the built-in `editor.action.selectAll` against the active code editor instead of letting the webview handle select-all in its own way. As a result, extensions backing custom editors with a webview cannot override the keybinding behaviour.

## Cause

`editor.action.selectAll` (and similarly `undo`/`redo`) is registered through `EditorOrNativeTextInputCommand`, which adds three implementations to the `MultiCommand`:

1. weight `10000`: run on the focused code editor (only fires when a code editor has text focus).
2. weight `1000`: run a native DOM `execCommand` on the focused editable element (`<input>`, `<textarea>`, contenteditable with `editContext`).
3. weight `0` (fallback): redirect to the active code editor and force-focus it.

When focus is on a webview iframe, the active element is the `<iframe>` itself. It is neither a focused code editor nor an editable element, so implementation (1) and (2) bail out and the fallback (3) runs, stealing focus to the surrounding code editor (or, for a custom editor, the previously active text editor) and selecting its contents.

## Fix

In the fallback implementation, skip the redirect when the active element is an `<iframe>`. Focus being inside an iframe means another document/extension is responsible for handling the keystroke, so the right behaviour is to let the command fall through (return `false`) rather than hijack it.

This is a minimal, layering-safe change: it does not introduce any webview-specific knowledge in the editor core, it just respects iframe focus boundaries that already exist in the DOM.

## Behaviour after the fix

- <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd> in a code editor: unchanged (handled by impl #1).
- <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd> in a native input/textarea/contenteditable: unchanged (handled by impl #2).
- <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd> with no focus / focus in a non-iframe non-editable element: unchanged (handled by impl #3).
- <kbd>Ctrl/Cmd</kbd>+<kbd>A</kbd> with focus inside a webview iframe: command no longer steals focus, so the webview/custom editor (or an extension keybinding scoped to it) can handle it. This same correction also applies to `undo`/`redo` which use the same dispatch mechanism.