### PR TITLE
Don't intercept ctrl+f/ctrl+p in webviews on macOS

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-TaWGDzV7c9rUH2q/5ygOyYUHSyHIqBMYfucPh3lnKvU=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-MHMdj69j7s+XOj/Ua5WTqF2BSUKbqG+ei6wZtfA19Ts=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -33,6 +33,7 @@
 		const ID = searchParams.get('id');
 		const webviewOrigin = searchParams.get('origin');
 		const onElectron = searchParams.get('platform') === 'electron';
+		const isMacintosh = (navigator.userAgentData ? navigator.userAgentData.platform : navigator.platform).toLowerCase().indexOf('mac') >= 0;
 		const disableServiceWorker = searchParams.has('disableServiceWorker');
 		const expectedWorkerVersion = parseInt(searchParams.get('swVersion'));
 
@@ -688,7 +689,9 @@
 		 * @return {boolean}
 		 */
 		function isPrint(e) {
-			const hasMeta = e.ctrlKey || e.metaKey;
+			// On macOS, the system print shortcut is Cmd+P. Ctrl+P is a cursor movement
+			// shortcut in text inputs and should not be intercepted as a browser shortcut.
+			const hasMeta = isMacintosh ? e.metaKey : (e.ctrlKey || e.metaKey);
 			// 80: keyCode of "P"
 			return hasMeta && e.keyCode === 80;
 		}
@@ -698,7 +701,9 @@
 		 * @return {boolean}
 		 */
 		function isFindEvent(e) {
-			const hasMeta = e.ctrlKey || e.metaKey;
+			// On macOS, the system find shortcut is Cmd+F. Ctrl+F is a cursor movement
+			// shortcut in text inputs and should not be intercepted as a browser shortcut.
+			const hasMeta = isMacintosh ? e.metaKey : (e.ctrlKey || e.metaKey);
 			// 70: keyCode of "F"
 			return hasMeta && e.keyCode === 70;
 		}


### PR DESCRIPTION
Fixes #244924

## Problem

On macOS, `ctrl+f` is bound to *cursor right* and `ctrl+p` is bound to *cursor up* when in a text input. However, the webview's inner keydown handler in `src/vs/workbench/contrib/webview/browser/pre/index.html` was treating any `(ctrlKey || metaKey) + F/P` as a browser Find / Print shortcut and calling `preventDefault` on it, swallowing the cursor movement when a text input inside a webview was focused.

This was reported in https://github.com/microsoft/vscode/issues/244924.

Repro:
1. Open a webview extension that contains a `<textarea>` (e.g. the `webview-sample` extension).
2. Type some text, then press `ctrl+b` -- cursor moves left.
3. Press `ctrl+f` -- cursor does NOT move right (it should).

## Fix

On macOS, the actual system shortcuts for Find and Print use Cmd (`metaKey`), not Ctrl. Make `isPrint` and `isFindEvent` platform-aware so that on macOS only `metaKey` is treated as the browser shortcut modifier; on other platforms behaviour is unchanged.

Also bumps the inline-script CSP `sha256` hash to match the new contents.

## Notes

Scoped narrowly to the two helpers explicitly called out in the issue (`isPrint` / `isFindEvent`). The other helpers (`isUndoRedo`, `isSaveEvent`, `isCopyPasteOrCut`, etc.) are intentionally left alone in this PR -- they have the same pattern but the user-visible bug is the one the issue describes.