### PR TITLE
Fix Source Control view dropping files with long paths on Windows

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -384,6 +384,26 @@ export interface ICloneOptions {
 	readonly ref?: string;
 }
 
+// On Windows, augment git invocations with `-c core.longpaths=true` so that
+// commands such as `git status` and `git diff` do not silently drop entries
+// whose absolute paths exceed MAX_PATH (260 characters). The option is
+// idempotent, so it is skipped if the caller already supplied an explicit
+// `core.longpaths` configuration override.
+// See https://github.com/microsoft/vscode/issues/240770.
+function injectLongPathsOptionIfNeeded(args: string[]): string[] {
+	if (!isWindows) {
+		return args;
+	}
+
+	for (let i = 0; i + 1 < args.length; i++) {
+		if (args[i] === '-c' && args[i + 1].toLowerCase().startsWith('core.longpaths=')) {
+			return args;
+		}
+	}
+
+	return ['-c', 'core.longpaths=true', ...args];
+}
+
 export class Git {
 
 	readonly path: string;
@@ -693,6 +713,16 @@ export class Git {
 			LANG: 'en_US.UTF-8',
 			GIT_PAGER: 'cat'
 		});
+
+		// On Windows, git silently omits files whose absolute path exceeds
+		// MAX_PATH (260 characters) from commands like `status` and `diff` unless
+		// the `core.longpaths` config is enabled. This causes long-path files to
+		// be missing from the Source Control view even though they show up when
+		// running `git diff` in a shell that has the option set globally.
+		// Inject the option for every invocation so that the extension's behavior
+		// does not depend on the user's global git configuration.
+		// See https://github.com/microsoft/vscode/issues/240770.
+		args = injectLongPathsOptionIfNeeded(args);
 
 		const cwd = this.getCwd(options);
 		if (cwd) {


### PR DESCRIPTION
## What / Why

On Windows, `git status` and `git diff` silently omit files whose absolute path exceeds `MAX_PATH` (260 characters) unless the `core.longpaths` config is enabled. Because the git extension does not opt in, those files are missing from the Source Control view and from commit comparison views, even though running `git diff` in a terminal (with the option enabled globally) lists them.

This is a frequent pain point for Windows users with deeply-nested workspaces — see #240770.

Fixes #240770

## Fix

Inject `-c core.longpaths=true` into every git invocation made by the extension on Windows, via a small helper that runs inside `Git.spawn`:

- **Windows-only** — no-op on macOS and Linux, where the limit does not apply.
- **Idempotent** — skipped if the caller already supplied an explicit `core.longpaths` override (so per-command opt-outs still win).
- **Non-invasive** — does not modify the user's git configuration; the option is only set for the lifetime of the spawned process.

This keeps the extension's behavior consistent regardless of whether the user has `core.longpaths` set in their global git config, and matches what users expect after seeing the file in their terminal `git status` output.

## Testing

- Verified manually on Windows 11 by creating a file inside a deeply nested directory whose absolute path exceeds 260 characters, modifying it, and confirming that:
  - Before the change, the file did not appear in the Source Control view, and the commit comparison view did not list it.
  - After the change, the file appears in the Changes group and in the commit's compare view, matching `git diff` behavior in the terminal.
- Existing short-path repositories continue to work unchanged.
- Verified the helper is a no-op when the call site already passes `-c core.longpaths=...`.