### PR TITLE
Git - provide undo for discard untracked files

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1631,6 +1631,11 @@ export class Repository implements Disposable {
 		}
 
 		if (discardUntrackedChangesToTrash) {
+			// Snapshot file contents (capped) so we can offer an in-product Undo action
+			// after a successful move-to-trash. Files exceeding the per-file or total
+			// budget are still discarded but excluded from the snapshot.
+			const snapshots = await this._snapshotUntrackedForUndo(resources);
+
 			try {
 				// Attempt to move the first resource to the recycle bin/trash to check
 				// if it is supported. If it fails, we show a confirmation dialog and
@@ -1640,6 +1645,8 @@ export class Repository implements Disposable {
 				const limiter = new Limiter<void>(5);
 				await Promise.all(resources.slice(1).map(fsPath => limiter.queue(
 					async () => await workspace.fs.delete(Uri.file(fsPath), { useTrash: true }))));
+
+				this._showDiscardUntrackedUndoNotification(resources, snapshots);
 			} catch {
 				const message = isWindows
 					? l10n.t('Failed to delete using the Recycle Bin. Do you want to permanently delete instead?')
@@ -1657,6 +1664,72 @@ export class Repository implements Disposable {
 		} else {
 			await this.repository.clean(resources);
 		}
+	}
+
+	private static readonly _DiscardUntrackedUndoMaxFileSize = 5 * 1024 * 1024;
+	private static readonly _DiscardUntrackedUndoMaxTotalSize = 50 * 1024 * 1024;
+
+	private async _snapshotUntrackedForUndo(resources: string[]): Promise<Map<string, Buffer>> {
+		const snapshots = new Map<string, Buffer>();
+		let total = 0;
+
+		const limiter = new Limiter<void>(5);
+		await Promise.all(resources.map(fsPath => limiter.queue(async () => {
+			try {
+				const stat = await fsPromises.stat(fsPath);
+				if (!stat.isFile()) {
+					return;
+				}
+				if (stat.size > Repository._DiscardUntrackedUndoMaxFileSize) {
+					return;
+				}
+				if (total + stat.size > Repository._DiscardUntrackedUndoMaxTotalSize) {
+					return;
+				}
+				const buffer = await fsPromises.readFile(fsPath);
+				snapshots.set(fsPath, buffer);
+				total += buffer.length;
+			} catch {
+				// File may be inaccessible (permissions, symlink, etc.) - skip it.
+			}
+		})));
+
+		return snapshots;
+	}
+
+	private _showDiscardUntrackedUndoNotification(resources: string[], snapshots: Map<string, Buffer>): void {
+		if (snapshots.size === 0) {
+			return;
+		}
+
+		const message = resources.length === 1
+			? l10n.t("Discarded untracked file '{0}'.", path.basename(resources[0]))
+			: l10n.t('Discarded {0} untracked files.', resources.length);
+
+		const undo = l10n.t('Undo');
+
+		void window.showInformationMessage(message, undo).then(async pick => {
+			if (pick !== undo) {
+				return;
+			}
+
+			const failures: string[] = [];
+			const limiter = new Limiter<void>(5);
+			await Promise.all(Array.from(snapshots.entries()).map(([fsPath, buffer]) => limiter.queue(async () => {
+				try {
+					await fsPromises.mkdir(path.dirname(fsPath), { recursive: true });
+					await fsPromises.writeFile(fsPath, buffer, { flag: 'wx' });
+				} catch {
+					failures.push(fsPath);
+				}
+			})));
+
+			if (failures.length > 0) {
+				void window.showWarningMessage(failures.length === 1
+					? l10n.t("Could not restore '{0}'. The file may already exist or the location is no longer writable.", path.basename(failures[0]))
+					: l10n.t('Could not restore {0} of {1} files. They may already exist or their locations are no longer writable.', failures.length, snapshots.size));
+			}
+		});
 	}
 
 	closeDiffEditors(indexResources: string[] | undefined, workingTreeResources: string[] | undefined, ignoreSetting = false): void {


### PR DESCRIPTION
## What this PR does

Adds an in-product `Undo` affordance after discarding untracked files via the SCM view, addressing #241884.

When `git.discardUntrackedChangesToTrash` is enabled (default on supported platforms), the previous behavior moved untracked files to the OS Recycle Bin/Trash but offered no Undo path inside VS Code. Pressing `Ctrl+Z` in an editor only undoes the file creation, not the deletion, so users had to navigate to the system trash to recover.

## Approach

In `Repository._clean` (`extensions/git/src/repository.ts`):

1. Before issuing the `useTrash: true` deletes, snapshot file contents into memory:
   - Per-file cap: 5 MB
   - Total cap: 50 MB
   - Files exceeding either budget, non-files (symlinks/dirs), or unreadable files are skipped silently and still discarded.
2. After the trash deletes succeed, show an information notification (`Discarded untracked file '<name>'.` or `Discarded N untracked files.`) with a single `Undo` action.
3. On `Undo`, recreate each snapshotted file via `fs.writeFile` with the `wx` flag (fail if the path now exists) and `mkdir { recursive: true }` to handle directories cleaned up by the OS. Failures are reported via a follow-up warning notification and never overwrite existing files.

The undo path is only offered on the trash branch — the permanent-delete fallback (when trash fails) and the `discardUntrackedChangesToTrash: false` branch are unchanged.

## Why these limits

The snapshot is held in memory only for the lifetime of the notification dialog promise, but a user could still discard a directory tree containing very large generated files (build artifacts, media, etc.). The 5 MB / 50 MB caps keep memory bounded while comfortably covering the common case of accidentally-discarded source files.

Fixes #241884