### PR TITLE
Re-use anchor layout logic for notebooks too

### DIFF
--- a/src/vs/base/browser/overlayLayoutElement.ts
+++ b/src/vs/base/browser/overlayLayoutElement.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDimension, IDomPosition, setParentFlowTo } from './dom.js';
+import { IDisposable } from '../common/lifecycle.js';
+import { Lazy } from '../common/lazy.js';
+import { generateUuid } from '../common/uuid.js';
+
+/**
+ * Whether CSS anchor positioning is supported
+ */
+const supportsAnchorPositioning = new Lazy(() => CSS.supports('(top: anchor(top))'));
+
+/**
+ * If the element already has an `anchor-name` style, return it.
+ * Otherwise generate a fresh `--overlay-anchor-<uuid>` name, assign it, and return it.
+ */
+function getOrCreateAnchorName(element: HTMLElement): string {
+	const existing = element.style.getPropertyValue('anchor-name');
+	if (existing) {
+		return existing;
+	}
+	const name = `--overlay-anchor-${generateUuid()}`;
+	element.style.setProperty('anchor-name', name);
+	return name;
+}
+
+/**
+ * Positions an element over another element anywhere in the dom using absolute positioning.
+ *
+ * This is useful for cases where a dom node cannot be re-parented without losing its state, such as a iframe.
+ *
+ * Call {@link layoutOverAnchorElement} each time the layout is recalculated. When the
+ * same anchor element is passed again the call is a no-op (the browser keeps them in sync).
+ */
+export class OverlayLayoutElement implements IDisposable {
+
+	private _currentAnchor?: { readonly element: HTMLElement; readonly name: string };
+	private _clippingAnchor?: { readonly element: HTMLElement; readonly name: string };
+
+	/**
+	 * The root element that contains the overlay element.
+	 *
+	 * This also provides clipping support for the overlay element. Clipping is needed when the anchor is
+	 * scrollable and may scroll and be hidden by overflow from its parent container.
+	 */
+	private readonly _root: HTMLElement;
+
+	constructor() {
+		this.content = document.createElement('div');
+		this.content.style.position = 'absolute';
+		this.content.style.overflow = 'hidden';
+
+		if (supportsAnchorPositioning.value) {
+			this.content.style.position = 'fixed';
+			this.content.style.top = 'anchor(top)';
+			this.content.style.left = 'anchor(left)';
+			this.content.style.width = 'anchor-size(width)';
+			this.content.style.height = 'anchor-size(height)';
+			this.content.style.pointerEvents = 'auto';
+		}
+
+		this._root = document.createElement('div');
+		this._root.style.position = 'absolute';
+		this._root.style.pointerEvents = 'none';
+		this._root.appendChild(this.content);
+	}
+
+	public dispose(): void {
+		this.root.remove();
+	}
+
+	/**
+	 * The outermost element. This is what should be appended to the actual dom hierarchy, typically near to
+	 * the document root node.
+	 */
+	public get root(): HTMLElement {
+		return this._root;
+	}
+
+	/**
+	 * The actual element that is positioned over the anchor.
+	 */
+	public readonly content: HTMLElement;
+
+	/**
+	 * Position the content over `anchorElement`.
+	 *
+	 * For legacy browser support this should be called each time the layout is recalculated.
+	 */
+	public layoutOverAnchorElement(
+		anchorElement: HTMLElement,
+		options?: {
+			readonly clippingContainer?: HTMLElement;
+			readonly fallbackDimension?: IDimension;
+			readonly fallbackPosition?: IDomPosition;
+		},
+	): void {
+		if (supportsAnchorPositioning.value) {
+			if (this._currentAnchor?.element !== anchorElement) {
+				const name = getOrCreateAnchorName(anchorElement);
+				this.content.style.setProperty('position-anchor', name);
+				setParentFlowTo(this.content, anchorElement);
+				this._currentAnchor = { element: anchorElement, name };
+			}
+		} else {
+			const cs = this.content.style;
+
+			if (options?.fallbackPosition) {
+				cs.top = `${options.fallbackPosition.top}px`;
+				cs.left = `${options.fallbackPosition.left}px`;
+			} else {
+				const anchorRect = anchorElement.getBoundingClientRect();
+				const parentRect = this.content.parentElement!.getBoundingClientRect();
+				const parentBorderTop = (parentRect.height - this.content.parentElement!.clientHeight) / 2.0;
+				const parentBorderLeft = (parentRect.width - this.content.parentElement!.clientWidth) / 2.0;
+				cs.top = `${anchorRect.top - parentRect.top - parentBorderTop}px`;
+				cs.left = `${anchorRect.left - parentRect.left - parentBorderLeft}px`;
+			}
+
+			setParentFlowTo(this.content, anchorElement);
+
+			const anchorRect = anchorElement.getBoundingClientRect();
+			cs.width = `${options?.fallbackDimension ? options.fallbackDimension.width : anchorRect.width}px`;
+			cs.height = `${options?.fallbackDimension ? options.fallbackDimension.height : anchorRect.height}px`;
+		}
+
+		this._updateClipping(anchorElement, options?.clippingContainer);
+	}
+
+	private _updateClipping(anchorElement: HTMLElement, clippingContainer: HTMLElement | undefined): void {
+		if (supportsAnchorPositioning.value) {
+			if (this._clippingAnchor?.element === clippingContainer) {
+				return;
+			}
+
+			this._root.style.removeProperty('position-anchor');
+
+			const ws = this._root.style;
+			if (clippingContainer) {
+				const name = getOrCreateAnchorName(clippingContainer);
+				ws.clipPath = 'content-box';
+				ws.setProperty('position-anchor', name);
+				ws.setProperty('top', 'anchor(top)');
+				ws.setProperty('left', 'anchor(left)');
+				ws.setProperty('width', `anchor-size(width)`);
+				ws.setProperty('height', `anchor-size(height)`);
+				this._clippingAnchor = { element: clippingContainer, name };
+			} else {
+				ws.clipPath = '';
+				ws.setProperty('top', '0');
+				ws.setProperty('left', '0');
+				ws.setProperty('right', '0');
+				ws.setProperty('bottom', '0');
+				this._clippingAnchor = undefined;
+			}
+		} else {
+			if (clippingContainer) {
+				const anchorRect = anchorElement.getBoundingClientRect();
+				const clipRect = clippingContainer.getBoundingClientRect();
+				const top = Math.max(clipRect.top - anchorRect.top, 0);
+				const right = Math.max(anchorRect.width - (anchorRect.right - clipRect.right), 0);
+				const bottom = Math.max(anchorRect.height - (anchorRect.bottom - clipRect.bottom), 0);
+				const left = Math.max(clipRect.left - anchorRect.left, 0);
+				this.content.style.clipPath = `polygon(${left}px ${top}px, ${right}px ${top}px, ${right}px ${bottom}px, ${left}px ${bottom}px)`;
+				this._clippingAnchor = { element: clippingContainer, name: '' };
+			} else {
+				this.content.style.clipPath = '';
+				this._clippingAnchor = undefined;
+			}
+		}
+	}
+}

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.monaco-workbench .editor-instance .notebook-editor {
+	width: 100%;
+	height: 100%;
+}
+
 .monaco-workbench .notebookOverlay.notebook-editor {
 	box-sizing: border-box;
 	line-height: 22px;
@@ -134,6 +139,7 @@
 	display: flex;
 	align-items: center;
 }
+
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .input-collapse-container .cell-collapse-preview .monaco-tokenized-source {
 	font-size: var(--notebook-cell-input-preview-font-size);
 	font-family: var(--notebook-cell-input-preview-font-family);
@@ -177,7 +183,7 @@
 	left: 0px;
 	padding: 2px;
 	border-radius: 5px;
-	vertical-align:middle;
+	vertical-align: middle;
 	margin-left: 4px;
 	height: 16px;
 	width: 16px;
@@ -347,15 +353,31 @@
 }
 
 /* high contrast border for multi-select */
-.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-top:before, .hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-top:before { border-top-style: dotted; }
-.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-bottom:before, .hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-bottom:before { border-bottom-style: dotted; }
-.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-left:before, .hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-left:before { border-left-style: dotted; }
-.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-right:before, .hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-right:before  { border-right-style: dotted; }
+.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-top:before,
+.hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-top:before {
+	border-top-style: dotted;
+}
+
+.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-bottom:before,
+.hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-focus-indicator-bottom:before {
+	border-bottom-style: dotted;
+}
+
+.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-left:before,
+.hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-left:before {
+	border-left-style: dotted;
+}
+
+.hc-black .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-right:before,
+.hc-light .notebookOverlay .monaco-list.selection-multiple:focus-within .monaco-list-row.selected:not(.focused) .cell-inner-container:not(.cell-editor-focus) .cell-focus-indicator-right:before {
+	border-right-style: dotted;
+}
 
 /** Notebook Cell Comments */
 
 .cell-comment-container.review-widget {
-	border-left: 1px solid var(--vscode-peekView-border); border-right: 1px solid var(--vscode-peekView-border);
+	border-left: 1px solid var(--vscode-peekView-border);
+	border-right: 1px solid var(--vscode-peekView-border);
 	/* Restore text-wrap to default value to avoid inheriting nowrap from monaco-list. */
 	text-wrap: initial;
 }
@@ -411,9 +433,11 @@
 .notebookOverlay .cell-list-top-cell-toolbar-container .action-item {
 	border: solid 1px var(--vscode-notebook-cellToolbarSeparator);
 }
+
 .notebookOverlay .monaco-action-bar .action-item.verticalSeparator {
 	background-color: var(--vscode-notebook-cellToolbarSeparator);
 }
+
 .monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .input-collapse-container {
 	border-bottom: solid 1px var(--vscode-notebook-cellToolbarSeparator);
 }
@@ -484,6 +508,7 @@
 	overflow: hidden;
 	box-sizing: border-box;
 }
+
 /* -- base cursor styling -- */
 .nb-multicursor-cursor {
 	top: 0;
@@ -495,12 +520,14 @@
 	overflow: hidden;
 	box-sizing: border-box;
 }
+
 /* ======================================================================== */
 /* ======================================================================== */
 /* -- block-style -- */
 .nb-cursor-block-style {
 	width: 8px !important;
 }
+
 /* -- underline-style -- */
 .nb-cursor-underline-style {
 	width: 8px !important;
@@ -508,11 +535,13 @@
 	border-bottom-style: solid;
 	background: transparent;
 }
+
 /* -- line-thin-style -- */
 .nb-cursor-line-thin-style {
 	min-width: none;
 	width: 0.9px !important;
 }
+
 /* -- block-outline-style -- */
 .nb-cursor-block-outline-style {
 	width: 8px !important;
@@ -520,6 +549,7 @@
 	border-style: solid;
 	background: transparent;
 }
+
 /* -- underline-thin-style -- */
 .nb-cursor-underline-thin-style {
 	width: 8px !important;
@@ -527,21 +557,26 @@
 	border-bottom-style: solid;
 	background: transparent;
 }
+
 /* ======================================================================== */
 /* ======================================================================== */
 /* -- cursor animations -- */
 .nb-blink {
 	animation: nb-cursor-blink 1s step-end infinite;
 }
+
 .nb-smooth {
 	animation: nb-cursor-smooth 0.5s ease-in-out 0.5s infinite alternate;
 }
+
 .nb-phase {
 	animation: nb-cursor-phase 0.5s ease-in-out 0.5s infinite alternate;
 }
-.nb-expand{
+
+.nb-expand {
 	animation: nb-cursor-expand 0.5s ease-in-out 0.5s infinite alternate;
 }
+
 .nb-smooth-caret-animation {
 	transition: all 80ms;
 }
@@ -551,38 +586,49 @@
 	0% {
 		opacity: 1;
 	}
+
 	50% {
 		opacity: 0;
 	}
+
 	100% {
 		opacity: 1;
 	}
 }
+
 @keyframes nb-cursor-smooth {
+
 	0%,
 	20% {
 		opacity: 1;
 	}
+
 	60%,
 	100% {
 		opacity: 0;
 	}
 }
+
 @keyframes nb-cursor-phase {
+
 	0%,
 	20% {
 		opacity: 1;
 	}
+
 	90%,
 	100% {
 		opacity: 0;
 	}
 }
+
 @keyframes nb-cursor-expand {
+
 	0%,
 	20% {
 		transform: scaleY(1);
 	}
+
 	80%,
 	100% {
 		transform: scaleY(0);
@@ -601,8 +647,13 @@
 }
 
 /** Cell border color */
-.notebookOverlay .cell.markdown h1 { border-color: var(--vscode-notebook-cellBorderColor); }
-.notebookOverlay .monaco-list-row .cell-editor-part:before { outline: solid 1px var(--vscode-notebook-cellBorderColor); }
+.notebookOverlay .cell.markdown h1 {
+	border-color: var(--vscode-notebook-cellBorderColor);
+}
+
+.notebookOverlay .monaco-list-row .cell-editor-part:before {
+	outline: solid 1px var(--vscode-notebook-cellBorderColor);
+}
 
 /** Cell status bar */
 .monaco-workbench .notebookOverlay .cell-statusbar-container .cell-language-picker:hover,
@@ -660,7 +711,9 @@
 	background-color: var(--vscode-diffEditor-removedTextBackground) !important;
 }
 
-.monaco-workbench .notebookOverlay .codicon-debug-continue { color: var(--vscode-icon-foreground) !important; }
+.monaco-workbench .notebookOverlay .codicon-debug-continue {
+	color: var(--vscode-icon-foreground) !important;
+}
 
 /** Cell Chat **/
 .monaco-workbench .notebookOverlay .monaco-list .monaco-list-row.code-cell-row.nb-chatGenerationHighlight .cell-focus-indicator,

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -22,6 +22,7 @@ import './media/notebookChatEditorOverlay.css';
 import * as DOM from '../../../../base/browser/dom.js';
 import * as domStylesheets from '../../../../base/browser/domStylesheets.js';
 import { IMouseWheelEvent, StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
+import { OverlayLayoutElement } from '../../../../base/browser/overlayLayoutElement.js';
 import { IListContextMenuEvent } from '../../../../base/browser/ui/list/list.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { SequencerByKey } from '../../../../base/common/async.js';
@@ -49,7 +50,7 @@ import { IContextKey, IContextKeyService, RawContextKey } from '../../../../plat
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
 import { registerZIndex, ZIndex } from '../../../../platform/layout/browser/zIndexRegistry.js';
 import { IEditorProgressService, IProgressRunner } from '../../../../platform/progress/common/progress.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -92,7 +93,6 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou
 import { NotebookPerfMarks } from '../common/notebookPerformance.js';
 import { BaseCellEditorOptions } from './viewModel/cellEditorOptions.js';
 import { FloatingEditorClickMenu } from '../../../browser/codeeditor.js';
-import { IDimension } from '../../../../editor/common/core/2d/dimension.js';
 import { CellFindMatchModel } from './contrib/find/findModel.js';
 import { INotebookLoggingService } from '../common/notebookLoggingService.js';
 import { Schemas } from '../../../../base/common/network.js';
@@ -190,6 +190,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	//#endregion
 	private _overlayContainer!: HTMLElement;
+	private _overlayLayout!: OverlayLayoutElement;
 	private _notebookTopToolbarContainer!: HTMLElement;
 	private _notebookTopToolbar!: NotebookEditorWorkbenchToolbar;
 	private _notebookStickyScrollContainer!: HTMLElement;
@@ -217,7 +218,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	private _dimension?: DOM.Dimension;
 	private _position?: DOM.IDomPosition;
 	private _shadowElement?: HTMLElement;
-	private _shadowElementViewInfo: { height: number; width: number; top: number; left: number } | null = null;
 	private _cellLayoutManager: NotebookCellLayoutManager | undefined;
 
 	private readonly _editorFocus: IContextKey<boolean>;
@@ -310,14 +310,14 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		readonly creationOptions: INotebookEditorCreationOptions,
 		dimension: DOM.Dimension | undefined,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IEditorGroupsService editorGroupsService: IEditorGroupsService,
+		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
 		@INotebookRendererMessagingService private readonly notebookRendererMessaging: INotebookRendererMessagingService,
 		@INotebookEditorService private readonly notebookEditorService: INotebookEditorService,
 		@INotebookKernelService private readonly notebookKernelService: INotebookKernelService,
 		@INotebookService private readonly _notebookService: INotebookService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@ILayoutService private readonly layoutService: ILayoutService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@INotebookExecutionService private readonly notebookExecutionService: INotebookExecutionService,
@@ -331,7 +331,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this.isReplHistory = creationOptions.isReplHistory ?? false;
 		this._readOnly = creationOptions.isReadOnly ?? false;
 
-		this._overlayContainer = document.createElement('div');
+		this._overlayLayout = new OverlayLayoutElement();
+		this._overlayContainer = this._overlayLayout.content;
 		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this._overlayContainer));
 		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 
@@ -421,8 +422,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				return;
 			}
 
-			this.updateShadowElement(this._shadowElement, this._dimension);
-			this.layoutContainerOverShadowElement(this._dimension, this._position);
+			this.layoutContainerOverShadowElement(this._shadowElement, this._dimension, this._position);
 		}));
 
 		this.notebookEditorService.addNotebookEditor(this);
@@ -434,7 +434,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._overlayContainer.inert = true;
 		this._overlayContainer.style.visibility = 'hidden';
 
-		container.appendChild(this._overlayContainer);
+		container.appendChild(this._overlayLayout.root);
 
 		this._createBody(this._overlayContainer);
 		this._generateFontInfo();
@@ -1880,7 +1880,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	}
 
 	layout(dimension: DOM.Dimension, shadowElement?: HTMLElement, position?: DOM.IDomPosition): void {
-		if (!shadowElement && this._shadowElementViewInfo === null) {
+		if (!shadowElement && !this._shadowElement) {
 			this._dimension = dimension;
 			this._position = position;
 			return;
@@ -1905,12 +1905,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	private layoutNotebook(dimension: DOM.Dimension, shadowElement?: HTMLElement, position?: DOM.IDomPosition) {
 		if (shadowElement) {
-			this.updateShadowElement(shadowElement, dimension, position);
-		}
-
-		if (this._shadowElementViewInfo && this._shadowElementViewInfo.width <= 0 && this._shadowElementViewInfo.height <= 0) {
-			this.onWillHide();
-			return;
+			this._shadowElement = shadowElement;
 		}
 
 		this._dimension = dimension;
@@ -1930,12 +1925,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		this._overlayContainer.inert = false;
-		this._overlayContainer.style.visibility = 'visible';
-		this._overlayContainer.style.display = 'block';
-		this._overlayContainer.style.position = 'absolute';
-		this._overlayContainer.style.overflow = 'hidden';
 
-		this.layoutContainerOverShadowElement(dimension, position);
+		this.layoutContainerOverShadowElement(shadowElement ?? this._shadowElement, dimension, position);
 
 		if (this._webviewTransparentCover) {
 			this._webviewTransparentCover.style.height = `${dimension.height}px`;
@@ -1948,45 +1939,20 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._viewContext?.eventDispatcher.emit([new NotebookLayoutChangedEvent({ width: true, fontInfo: true }, this.getLayoutInfo())]);
 	}
 
-	private updateShadowElement(shadowElement: HTMLElement, dimension?: IDimension, position?: DOM.IDomPosition) {
-		this._shadowElement = shadowElement;
-		if (dimension && position) {
-			this._shadowElementViewInfo = {
-				height: dimension.height,
-				width: dimension.width,
-				top: position.top,
-				left: position.left,
-			};
+	private layoutContainerOverShadowElement(shadowElement: HTMLElement | undefined, dimension?: DOM.Dimension, position?: DOM.IDomPosition): void {
+		if (!shadowElement) {
+			return;
+		}
+
+		const modalEditorContainer = this.editorGroupsService.activeModalEditorPart?.modalElement;
+		let clippingContainer: HTMLElement | undefined;
+		if (DOM.isHTMLElement(modalEditorContainer)) {
+			clippingContainer = modalEditorContainer;
 		} else {
-			// We have to recompute position and size ourselves (which is slow)
-			const containerRect = shadowElement.getBoundingClientRect();
-			this._shadowElementViewInfo = {
-				height: containerRect.height,
-				width: containerRect.width,
-				top: containerRect.top,
-				left: containerRect.left
-			};
-		}
-	}
-
-	private layoutContainerOverShadowElement(dimension?: DOM.Dimension, position?: DOM.IDomPosition): void {
-		if (dimension && position) {
-			this._overlayContainer.style.top = `${position.top}px`;
-			this._overlayContainer.style.left = `${position.left}px`;
-			this._overlayContainer.style.width = `${dimension.width}px`;
-			this._overlayContainer.style.height = `${dimension.height}px`;
-			return;
+			clippingContainer = this.layoutService.getContainer(DOM.getWindow(this.getDomNode()), Parts.EDITOR_PART);
 		}
 
-		if (!this._shadowElementViewInfo) {
-			return;
-		}
-
-		const elementContainerRect = this._overlayContainer.parentElement?.getBoundingClientRect();
-		this._overlayContainer.style.top = `${this._shadowElementViewInfo.top - (elementContainerRect?.top || 0)}px`;
-		this._overlayContainer.style.left = `${this._shadowElementViewInfo.left - (elementContainerRect?.left || 0)}px`;
-		this._overlayContainer.style.width = `${dimension ? dimension.width : this._shadowElementViewInfo.width}px`;
-		this._overlayContainer.style.height = `${dimension ? dimension.height : this._shadowElementViewInfo.height}px`;
+		this._overlayLayout.layoutOverAnchorElement(shadowElement, { clippingContainer, fallbackDimension: dimension, fallbackPosition: position });
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -3,19 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dimension, getWindowById, isHTMLElement } from '../../../../base/browser/dom.js';
+import { Dimension, getWindowById } from '../../../../base/browser/dom.js';
 import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
+import { OverlayLayoutElement } from '../../../../base/browser/overlayLayoutElement.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { Lazy } from '../../../../base/common/lazy.js';
 import { autorun, observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IContextKey, IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
-import { IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IOverlayWebview, IWebview, IWebviewElement, IWebviewService, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_ENABLED, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, WebviewContentOptions, WebviewExtensionDescription, WebviewInitInfo, WebviewMessageReceivedEvent, WebviewOptions } from './webview.js';
 
 /**
@@ -25,19 +24,8 @@ import { IOverlayWebview, IWebview, IWebviewElement, IWebviewService, KEYBINDING
  * Absolutely positioning is needed because webviews (iframes) cannot be re-parented without losing their state.
  * This means that webviews are always placed on a top level and then moved over
  * the element they are anchored to so they visually look like they are part of the original layout.
- *
- * Here's the dom structure of the overlay webview elements:
- *
- * ```
- * root
- *     clippingWrapper — Used for clipping the webview. Needed for cases where the webview is in a container that can be scrolled.
- *         container - Element laid out over the anchor element. Also holds the find widget.
- *             webview - The actual webview element. This is created and destroyed as needed.
- * ```
  */
 export class OverlayWebview extends Disposable implements IOverlayWebview {
-
-	private static readonly _supportsAnchorPositioning = new Lazy(() => CSS.supports('(top: anchor(top))'));
 
 	private _isFirstLoad = true;
 	private readonly _firstLoadPendingMessages = new Set<{ readonly message: unknown; readonly transfer?: readonly ArrayBuffer[]; readonly resolve: (value: boolean) => void }>();
@@ -67,18 +55,13 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 
 	public origin: string;
 
-	private _container: HTMLDivElement | undefined;
-	private _clippingWrapper: HTMLDivElement | undefined;
-
-	private _clippingAnchor: { readonly element: HTMLElement; readonly name: string } | undefined;
-	private _anchor: { readonly element: HTMLElement; readonly name: string } | undefined;
+	private _overlayLayout: OverlayLayoutElement | undefined;
 
 	public constructor(
 		initInfo: WebviewInitInfo,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 		@IWebviewService private readonly _webviewService: IWebviewService,
 		@IContextKeyService private readonly _baseContextKeyService: IContextKeyService,
-		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
 	) {
 		super();
 
@@ -103,10 +86,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	override dispose() {
 		this._isDisposed = true;
 
-		this._clippingWrapper?.remove();
-		this._clippingWrapper = undefined;
-		this._container?.remove();
-		this._container = undefined;
+		this._overlayLayout?.dispose();
+		this._overlayLayout = undefined;
 
 		for (const msg of this._firstLoadPendingMessages) {
 			msg.resolve(false);
@@ -123,43 +104,18 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			throw new Error(`OverlayWebview has been disposed`);
 		}
 
-		if (!this._container) {
-			const node = document.createElement('div');
-			node.style.position = 'absolute';
-			node.style.overflow = 'hidden';
-			node.style.visibility = 'hidden';
-			this._container = node;
+		if (!this._overlayLayout) {
+			this._overlayLayout = new OverlayLayoutElement();
+			this._overlayLayout.content.style.visibility = 'hidden';
 
-			// Webviews cannot be reparented in the dom as it will destroy their contents.
-			// Mount them to a high level node to avoid this depending on the active container.
-			const modalEditorContainer = this._editorGroupsService.activeModalEditorPart?.modalElement;
-			let root: HTMLElement;
-			if (isHTMLElement(modalEditorContainer)) {
-				root = modalEditorContainer;
-			} else {
-				root = this._layoutService.getContainer(this.window);
-			}
-
-			if (OverlayWebview._supportsAnchorPositioning.value) {
-				node.style.position = 'fixed';
-				node.style.top = 'anchor(top)';
-				node.style.left = 'anchor(left)';
-				node.style.width = 'anchor-size(width)';
-				node.style.height = 'anchor-size(height)';
-				node.style.pointerEvents = 'auto';
-
-				this._clippingWrapper = document.createElement('div');
-				this._clippingWrapper.style.position = 'absolute';
-				this._clippingWrapper.style.clipPath = 'content-box';
-				this._clippingWrapper.style.pointerEvents = 'none';
-				root.appendChild(this._clippingWrapper);
-				this._clippingWrapper.appendChild(node);
-			} else {
-				root.appendChild(node);
-			}
+			// // Webviews cannot be reparented in the dom as it will destroy their contents.
+			// // Mount them to a high level node to avoid this depending on the active container.
+			const root = this._layoutService.getContainer(this.window);
+			root.appendChild(this._overlayLayout.root);
+			this._overlayLayout.root.style.zIndex = '2541'; // One level above the modals
 		}
 
-		return this._container;
+		return this._overlayLayout.content;
 	}
 
 	public claim(owner: unknown, targetWindow: CodeWindow, scopedContextKeyService: IContextKeyService | undefined) {
@@ -175,10 +131,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			// since we are moving to a new window, we need to dispose the webview and recreate
 			this._webview.clear();
 			this._webviewEvents.clear();
-			this._clippingWrapper?.remove();
-			this._clippingWrapper = undefined;
-			this._container?.remove();
-			this._container = undefined;
+			this._overlayLayout?.dispose();
+			this._overlayLayout = undefined;
 		}
 
 		this._owner = owner;
@@ -214,8 +168,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		this._scopedContextKeyService.clear();
 
 		this._owner = undefined;
-		if (this._container) {
-			this._container.style.visibility = 'hidden';
+		if (this._overlayLayout) {
+			this._overlayLayout.content.style.visibility = 'hidden';
 		}
 
 		if (this._options.retainContextWhenHidden) {
@@ -230,62 +184,11 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	}
 
 	public layoutWebviewOverElement(anchorElement: HTMLElement, dimension?: Dimension, clippingContainer?: HTMLElement) {
-		if (!this._container || !this._container.parentElement) {
+		if (!this._overlayLayout || !this._overlayLayout.content.parentElement) {
 			return;
 		}
 
-		if (OverlayWebview._supportsAnchorPositioning.value) {
-			// Use CSS anchor positioning when available to let the browser
-			// automatically track position and size changes between explicit layout calls.
-
-			if (this._anchor?.element !== anchorElement) {
-				const name = getOrCreateAnchorName(anchorElement);
-				this._container.style.setProperty('position-anchor', name);
-				this._anchor = { element: anchorElement, name };
-			}
-
-			if (this._clippingAnchor?.element !== clippingContainer) {
-				this._updateWrapperClipping(clippingContainer);
-			}
-		} else {
-			// Legacy positioning
-			const frameRect = anchorElement.getBoundingClientRect();
-			const containerRect = this._container.parentElement.getBoundingClientRect();
-			const parentBorderTop = (containerRect.height - this._container.parentElement.clientHeight) / 2.0;
-			const parentBorderLeft = (containerRect.width - this._container.parentElement.clientWidth) / 2.0;
-
-			this._container.style.top = `${frameRect.top - containerRect.top - parentBorderTop}px`;
-			this._container.style.left = `${frameRect.left - containerRect.left - parentBorderLeft}px`;
-			this._container.style.width = `${dimension ? dimension.width : frameRect.width}px`;
-			this._container.style.height = `${dimension ? dimension.height : frameRect.height}px`;
-
-			if (clippingContainer) {
-				const { top, left, right, bottom } = computeClippingRect(frameRect, clippingContainer);
-				this._container.style.clipPath = `polygon(${left}px ${top}px, ${right}px ${top}px, ${right}px ${bottom}px, ${left}px ${bottom}px)`;
-			}
-		}
-	}
-
-	private _updateWrapperClipping(clippingContainer: HTMLElement | undefined) {
-		if (!this._clippingWrapper) {
-			return;
-		}
-
-		const ws = this._clippingWrapper.style;
-		if (clippingContainer) {
-			const name = getOrCreateAnchorName(clippingContainer);
-			ws.setProperty('position-anchor', name);
-			ws.setProperty('top', 'anchor(top)');
-			ws.setProperty('left', 'anchor(left)');
-			ws.setProperty('width', 'anchor-size(width)');
-			ws.setProperty('height', 'anchor-size(height)');
-			this._clippingAnchor = { element: clippingContainer, name };
-		} else {
-			ws.setProperty('top', '0');
-			ws.setProperty('left', '0');
-			ws.setProperty('right', '0');
-			ws.setProperty('bottom', '0');
-		}
+		this._overlayLayout?.layoutOverAnchorElement(anchorElement, { clippingContainer, fallbackDimension: dimension });
 	}
 
 	private _show(targetWindow: CodeWindow) {
@@ -360,8 +263,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			this._shouldShowFindWidgetOnRestore = false;
 		}
 
-		if (this._container) {
-			this._container.style.visibility = 'visible';
+		if (this._overlayLayout) {
+			this._overlayLayout.content.style.visibility = 'visible';
 		}
 	}
 
@@ -490,25 +393,4 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 	setContextKeyService(contextKeyService: IContextKeyService) {
 		this._webview.value?.setContextKeyService(contextKeyService);
 	}
-}
-
-function getOrCreateAnchorName(element: HTMLElement): string {
-	const existing = element.style.getPropertyValue('anchor-name');
-	if (existing) {
-		return existing;
-	}
-	const name = `--overlay-webview-anchor-${generateUuid()}`;
-	element.style.setProperty('anchor-name', name);
-	return name;
-}
-
-function computeClippingRect(frameRect: DOMRectReadOnly, clipper: HTMLElement) {
-	const rootRect = clipper.getBoundingClientRect();
-
-	const top = Math.max(rootRect.top - frameRect.top, 0);
-	const right = Math.max(frameRect.width - (frameRect.right - rootRect.right), 0);
-	const bottom = Math.max(frameRect.height - (frameRect.bottom - rootRect.bottom), 0);
-	const left = Math.max(rootRect.left - frameRect.left, 0);
-
-	return { top, right, bottom, left };
 }

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -200,7 +200,7 @@ export class WebviewEditor extends EditorPane {
 		const modalEditorContainer = this._editorGroupsService.activeModalEditorPart?.modalElement;
 		let clippingContainer: HTMLElement | undefined;
 		if (isHTMLElement(modalEditorContainer)) {
-			clippingContainer = modalEditorContainer;
+			clippingContainer = undefined;
 		} else {
 			clippingContainer = this._workbenchLayoutService.getContainer(this.window, Parts.EDITOR_PART);
 		}


### PR DESCRIPTION
Follow up on #310030 but making it so notebooks can also use this the anchor based layout logic. This should let us fix some stubborn bugs

Also fixes when showing webviews in modals, which #310030 regressed. Seems like a child can't use anchor-size from a parent?

Fixes #150491
Fixes #267312
Fixes #278055
