### PR TITLE
Add 'TypeScript: Select Node Path' command

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2857,6 +2857,11 @@
         "category": "TypeScript"
       },
       {
+        "command": "typescript.selectTypeScriptNodePath",
+        "title": "%typescript.selectTypeScriptNodePath.title%",
+        "category": "TypeScript"
+      },
+      {
         "command": "typescript.goToProjectConfig",
         "title": "%typescript.goToProjectConfig.title%",
         "category": "TypeScript"
@@ -2955,6 +2960,10 @@
         },
         {
           "command": "typescript.selectTypeScriptVersion",
+          "when": "typescript.isManagedFile"
+        },
+        {
+          "command": "typescript.selectTypeScriptNodePath",
           "when": "typescript.isManagedFile"
         },
         {

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -98,6 +98,7 @@
 	"typescript.openTsServerLog.title": "Open TS Server log",
 	"typescript.restartTsServer": "Restart TS Server",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version...",
+	"typescript.selectTypeScriptNodePath.title": "Select TypeScript Node Path...",
 	"typescript.reportStyleChecksAsWarnings": "Report style checks as warnings.",
 	"configuration.reportStyleChecksAsWarnings.unifiedDeprecationMessage": "This setting is deprecated. Use `#js/ts.reportStyleChecksAsWarnings#` instead.",
 	"typescript.npm": "Specifies the path to the npm executable used for [Automatic Type Acquisition](https://code.visualstudio.com/docs/nodejs/working-with-javascript#_typings-and-automatic-type-acquisition).",

--- a/extensions/typescript-language-features/src/commands/index.ts
+++ b/extensions/typescript-language-features/src/commands/index.ts
@@ -17,6 +17,7 @@ import { OpenTsServerLogCommand } from './openTsServerLog';
 import { ReloadJavaScriptProjectsCommand, ReloadTypeScriptProjectsCommand } from './reloadProject';
 import { RestartTsServerCommand } from './restartTsServer';
 import { SelectTypeScriptVersionCommand } from './selectTypeScriptVersion';
+import { SelectTypeScriptNodePathCommand } from './selectNodePath';
 import { TSServerRequestCommand } from './tsserverRequests';
 
 export function registerBaseCommands(
@@ -28,6 +29,7 @@ export function registerBaseCommands(
 	commandManager.register(new ReloadTypeScriptProjectsCommand(lazyClientHost));
 	commandManager.register(new ReloadJavaScriptProjectsCommand(lazyClientHost));
 	commandManager.register(new SelectTypeScriptVersionCommand(lazyClientHost));
+	commandManager.register(new SelectTypeScriptNodePathCommand(lazyClientHost));
 	commandManager.register(new OpenTsServerLogCommand(lazyClientHost));
 	commandManager.register(new RestartTsServerCommand(lazyClientHost));
 	commandManager.register(new TypeScriptGoToProjectConfigCommand(activeJsTsEditorTracker, lazyClientHost));

--- a/extensions/typescript-language-features/src/commands/selectNodePath.ts
+++ b/extensions/typescript-language-features/src/commands/selectNodePath.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import TypeScriptServiceClientHost from '../typeScriptServiceClientHost';
+import { Lazy } from '../utils/lazy';
+import { Command } from './commandManager';
+
+export class SelectTypeScriptNodePathCommand implements Command {
+	public static readonly id = 'typescript.selectTypeScriptNodePath';
+	public readonly id = SelectTypeScriptNodePathCommand.id;
+
+	public constructor(
+		private readonly lazyClientHost: Lazy<TypeScriptServiceClientHost>
+	) { }
+
+	public execute() {
+		this.lazyClientHost.value.serviceClient.showNodeVersionPicker();
+	}
+}

--- a/extensions/typescript-language-features/src/tsServer/nodeManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/nodeManager.ts
@@ -14,6 +14,10 @@ const lastKnownWorkspaceNodeStorageKey = 'typescript.lastKnownWorkspaceNode';
 type UseWorkspaceNodeState = undefined | boolean;
 type LastKnownWorkspaceNodeState = undefined | string;
 
+interface NodePathQuickPickItem extends vscode.QuickPickItem {
+	run(): Promise<string | undefined>;
+}
+
 export class NodeVersionManager extends Disposable {
 	private _currentVersion: string | undefined;
 
@@ -124,6 +128,61 @@ export class NodeVersionManager extends Disposable {
 		if (version !== undefined) {
 			this.updateActiveVersion(version);
 		}
+	}
+
+	public async promptUserForNodeVersion(): Promise<void> {
+		const workspaceVersion = vscode.workspace.isTrusted ? this.configuration.localNodePath : null;
+		const globalVersion = this.configuration.globalNodePath;
+
+		const items: NodePathQuickPickItem[] = [];
+
+		items.push({
+			label: (this._currentVersion === undefined ? '• ' : '') + vscode.l10n.t("Use VS Code's Bundled Node"),
+			description: vscode.l10n.t('Ignore any configured Node path'),
+			run: async () => {
+				if (workspaceVersion) {
+					await this.setUseWorkspaceNodeState(false, workspaceVersion);
+				}
+				return undefined;
+			},
+		});
+
+		if (globalVersion) {
+			items.push({
+				label: (this._currentVersion === globalVersion ? '• ' : '') + vscode.l10n.t('Use User Setting Node'),
+				description: globalVersion,
+				run: async () => globalVersion,
+			});
+		}
+
+		if (workspaceVersion) {
+			items.push({
+				label: (this._currentVersion === workspaceVersion ? '• ' : '') + vscode.l10n.t('Use Workspace Setting Node'),
+				description: workspaceVersion,
+				run: async () => {
+					const trusted = await vscode.workspace.requestWorkspaceTrust();
+					if (!trusted) {
+						return this._currentVersion;
+					}
+					await this.setUseWorkspaceNodeState(true, workspaceVersion);
+					return workspaceVersion;
+				},
+			});
+		}
+
+		if (!workspaceVersion && !globalVersion) {
+			vscode.window.showInformationMessage(vscode.l10n.t("No Node path is configured. Set 'typescript.tsserver.nodePath' to select a Node installation."));
+			return;
+		}
+
+		const selected = await vscode.window.showQuickPick<NodePathQuickPickItem>(items, {
+			placeHolder: vscode.l10n.t('Select the Node installation used to run TS Server'),
+		});
+		if (!selected) {
+			return;
+		}
+		const picked = await selected.run();
+		this.updateActiveVersion(picked);
 	}
 
 	private updateActiveVersion(pickedVersion: string | undefined): void {

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -533,6 +533,10 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		this._versionManager.promptUserForVersion();
 	}
 
+	public async showNodeVersionPicker(): Promise<void> {
+		this._nodeVersionManager.promptUserForNodeVersion();
+	}
+
 	public async openTsServerLogFile(): Promise<boolean> {
 		if (this._configuration.tsServerLogLevel === TsServerLogLevel.Off) {
 			vscode.window.showErrorMessage<vscode.MessageItem>(


### PR DESCRIPTION
Fixes #247088

## What this PR does

Adds a new `TypeScript: Select TypeScript Node Path...` command (id: `typescript.selectTypeScriptNodePath`) so users can revisit their Node path selection after dismissing the workspace-trust modal prompt that is shown when `typescript.tsserver.nodePath` is set at the workspace level.

Previously, if a user dismissed that modal (picking "Not now" or closing it), there was no UI entry point to re-open it. The user had to either edit the setting, reload the window, or manually clear workspace state.

This mirrors the existing `TypeScript: Select TypeScript Version...` command, but for the Node path used to run tsserver.

## Behavior

The command shows a QuickPick listing:

- **Use VS Code's Bundled Node** — ignore any configured node path. If a workspace-level node path exists, this persists a "No" choice in workspace state.
- **Use User Setting Node** — shown when `typescript.tsserver.nodePath` (or `js/ts.tsserver.node.path`) is set at the user/global level.
- **Use Workspace Setting Node** — shown when the setting is at workspace level. Requires workspace trust; selecting it persists the "Yes" choice and a new TS Server is spawned with that node.

The currently-active option is marked with a bullet. If neither a user nor workspace node path is configured, the command shows an informational message telling the user to set `typescript.tsserver.nodePath`.

## Files touched

- `extensions/typescript-language-features/src/tsServer/nodeManager.ts` — new `promptUserForNodeVersion()` public method.
- `extensions/typescript-language-features/src/typescriptServiceClient.ts` — new `showNodeVersionPicker()` passthrough.
- `extensions/typescript-language-features/src/commands/selectNodePath.ts` — new command class.
- `extensions/typescript-language-features/src/commands/index.ts` — register the command.
- `extensions/typescript-language-features/package.json` — declare the command + command-palette `when` clause.
- `extensions/typescript-language-features/package.nls.json` — localised title.

No changes to existing behavior; the initial modal prompt flow is unchanged.