### PR TITLE
fix(ts): render safe HTML (including <img>) in JSDoc hovers

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
@@ -239,6 +239,11 @@ export function appendDocumentationAsMarkdown(
 	tags: readonly Proto.JSDocTagInfo[] | undefined,
 	converter: IFilePathToResourceConverter,
 ): vscode.MarkdownString {
+	// Allow a safe subset of html (such as `<img>`) in rendered JSDoc. The markdown
+	// renderer still sanitizes the output, so only tags/attributes allowed by the
+	// sanitizer are kept. See https://github.com/microsoft/vscode/issues/231792.
+	out.supportHtml = true;
+
 	if (documentation) {
 		out.appendMarkdown(asPlainTextWithLinks(documentation, converter));
 	}


### PR DESCRIPTION
### What this PR does

Fixes #231792.

JSDoc comments in JS/TS may contain a safe subset of HTML (including
`<img>`) in addition to markdown, and authors expect these tags to
render in hovers / completion details just like they do in normal
markdown previews. Today, the `<img>` tag is silently stripped because
the `MarkdownString` produced by `appendDocumentationAsMarkdown` does
not opt into `supportHtml`. VS Code's markdown renderer therefore
replaces raw HTML with empty text before the DOM sanitizer gets a
chance to keep it.

### The fix

Set `out.supportHtml = true` on the `MarkdownString` that
`appendDocumentationAsMarkdown` populates (in
`extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts`).
This is the single source all TS/JS hover, completion, and signature
help docs flow through, so the change covers every JSDoc-documentation
surface.

Security-wise this is safe: the renderer still pipes the result through
dompurify using the default allow-list (`img`, `b`, `i`, etc.) and
strips everything else, so scripts / event handlers / unknown tags are
still removed — the difference is only that known-safe tags now survive
into the sanitizer.

### Out of scope

The issue also lists a few cases that look broken but are actually
upstream content problems, not VS Code rendering bugs (they don't
change with this PR and are consistent with normal markdown behavior):

- SVG from `raw.githubusercontent.com` is served as `text/plain`, which
  Chromium refuses to render via `<img>`. Using a proxy that serves the
  correct `image/svg+xml` content-type fixes it.
- `github.com/user-attachments/...` URLs are HTML redirect pages, not
  image bytes.

Data-URL images and direct `.png` links already worked and keep working.

### How to verify

1. In a `.js` or `.ts` file, write:
   ```js
   /**
    * <img src="https://raw.githubusercontent.com/ReturnInfinity/BareMetal-OS/refs/heads/master/images/BareMetal%20OS%20-%20Dark.png">
    */
   const a = 1;
   ```
2. Hover `a`.
3. Before this change: the `<img>` tag is stripped and nothing appears.
4. After this change: the image renders in the hover.