### PR TITLE
Detect dead connections via keepalive timeout

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.net.ts
+++ b/src/vs/base/parts/ipc/common/ipc.net.ts
@@ -136,9 +136,15 @@ export interface WebSocketCloseEvent {
 
 export type SocketCloseEvent = NodeSocketCloseEvent | WebSocketCloseEvent | undefined;
 
+export const enum SocketTimeoutReason {
+	UNACKNOWLEDGED_MESSAGE = 'unacknowledgedMessage',
+	KEEP_ALIVE = 'keepAlive',
+}
+
 export interface SocketTimeoutEvent {
+	readonly reason: SocketTimeoutReason;
 	readonly unacknowledgedMsgCount: number;
-	readonly timeSinceOldestUnacknowledgedMsg: number;
+	readonly timeSinceOldestUnacknowledgedMsg?: number;
 	readonly timeSinceLastReceivedSomeData: number;
 }
 
@@ -1149,6 +1155,7 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 				// Trash the socket
 				this._lastSocketTimeoutTime = Date.now();
 				this._onSocketTimeout.fire({
+					reason: SocketTimeoutReason.UNACKNOWLEDGED_MESSAGE,
 					unacknowledgedMsgCount: this._outgoingUnackMsg.length(),
 					timeSinceOldestUnacknowledgedMsg,
 					timeSinceLastReceivedSomeData
@@ -1193,10 +1200,12 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 			// But this might be caused by the event loop being busy and failing to read messages
 			if (!this._loadEstimator.hasHighLoad()) {
 				this._lastSocketTimeoutTime = now;
+				const unacknowledgedMsgCount = this._outgoingUnackMsg.length();
 				const oldestUnacknowledgedMsg = this._outgoingUnackMsg.peek();
 				this._onSocketTimeout.fire({
-					unacknowledgedMsgCount: this._outgoingUnackMsg.length(),
-					timeSinceOldestUnacknowledgedMsg: oldestUnacknowledgedMsg ? now - oldestUnacknowledgedMsg.writtenTime : 0,
+					reason: SocketTimeoutReason.KEEP_ALIVE,
+					unacknowledgedMsgCount,
+					timeSinceOldestUnacknowledgedMsg: oldestUnacknowledgedMsg ? now - oldestUnacknowledgedMsg.writtenTime : undefined,
 					timeSinceLastReceivedSomeData
 				});
 			}

--- a/src/vs/base/parts/ipc/common/ipc.net.ts
+++ b/src/vs/base/parts/ipc/common/ipc.net.ts
@@ -1170,6 +1170,39 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 		}, minimumTimeUntilTimeout);
 	}
 
+	/**
+	 * Called after sending a keepalive. Both sides of this protocol send
+	 * keepalives every KeepAliveSendTime (5s), so receiving no data for
+	 * TimeoutTime (20s) means the connection is dead. This catches silent
+	 * connection deaths that _recvAckCheck cannot detect because there are
+	 * no unacknowledged regular messages.
+	 */
+	private _keepAliveTimeoutCheck(): void {
+		if (this._isReconnecting) {
+			return;
+		}
+
+		const now = Date.now();
+		const timeSinceLastReceivedSomeData = now - this._socketReader.lastReadTime;
+		const timeSinceLastTimeout = now - this._lastSocketTimeoutTime;
+
+		if (
+			timeSinceLastReceivedSomeData >= ProtocolConstants.TimeoutTime
+			&& timeSinceLastTimeout >= ProtocolConstants.TimeoutTime
+		) {
+			// But this might be caused by the event loop being busy and failing to read messages
+			if (!this._loadEstimator.hasHighLoad()) {
+				this._lastSocketTimeoutTime = now;
+				const oldestUnacknowledgedMsg = this._outgoingUnackMsg.peek();
+				this._onSocketTimeout.fire({
+					unacknowledgedMsgCount: this._outgoingUnackMsg.length(),
+					timeSinceOldestUnacknowledgedMsg: oldestUnacknowledgedMsg ? now - oldestUnacknowledgedMsg.writtenTime : 0,
+					timeSinceLastReceivedSomeData
+				});
+			}
+		}
+	}
+
 	private _sendAck(): void {
 		if (this._incomingMsgId <= this._incomingAckId) {
 			// nothink to acknowledge
@@ -1185,5 +1218,6 @@ export class PersistentProtocol implements IMessagePassingProtocol {
 		this._incomingAckId = this._incomingMsgId;
 		const msg = new ProtocolMessage(ProtocolMessageType.KeepAlive, 0, this._incomingAckId, getEmptyBuffer());
 		this._socketWriter.write(msg);
+		this._keepAliveTimeoutCheck();
 	}
 }

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -12,7 +12,7 @@ import { Barrier, timeout } from '../../../../common/async.js';
 import { VSBuffer } from '../../../../common/buffer.js';
 import { Emitter, Event } from '../../../../common/event.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../common/lifecycle.js';
-import { ILoadEstimator, PersistentProtocol, Protocol, ProtocolConstants, SocketCloseEvent, SocketDiagnosticsEventType } from '../../common/ipc.net.js';
+import { ILoadEstimator, PersistentProtocol, Protocol, ProtocolConstants, SocketCloseEvent, SocketDiagnosticsEventType, SocketTimeoutReason } from '../../common/ipc.net.js';
 import { createRandomIPCHandle, createStaticIPCHandle, NodeSocket, WebSocketNodeSocket } from '../../node/ipc.net.js';
 import { flakySuite } from '../../../../test/common/testUtils.js';
 import { runWithFakedTimers } from '../../../../test/common/timeTravelScheduler.js';
@@ -537,16 +537,18 @@ suite('PersistentProtocol reconnection', () => {
 				// confirm no unacknowledged messages
 				assert.strictEqual(a.unacknowledgedCount, 0);
 
-				// now kill b's ability to send anything (simulates dead connection
+				// now kill b's ability to send anything (simulates a dead connection
 				// where the remote side's keepalives stop arriving)
 				b.pauseSocketWriting();
 
 				// wait for timeout to be detected via keepalive
 				const socketTimeoutEvent = await Event.toPromise(a.onSocketTimeout);
 
+				assert.strictEqual(socketTimeoutEvent.reason, SocketTimeoutReason.KEEP_ALIVE);
 				assert.ok(socketTimeoutEvent.timeSinceLastReceivedSomeData >= ProtocolConstants.TimeoutTime);
 				// no regular messages were pending
 				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgCount, 0);
+				assert.strictEqual(socketTimeoutEvent.timeSinceOldestUnacknowledgedMsg, undefined);
 
 				aMessages.dispose();
 				bMessages.dispose();

--- a/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.net.test.ts
@@ -506,6 +506,56 @@ suite('PersistentProtocol reconnection', () => {
 		);
 	});
 
+	test('keepalive detects dead connection when no regular messages are pending', async () => {
+		await runWithFakedTimers(
+			{
+				useFakeTimers: true,
+				useSetImmediate: true,
+				maxTaskCount: 1000
+			},
+			async () => {
+
+				const loadEstimator: ILoadEstimator = {
+					hasHighLoad: () => false
+				};
+				const ether = new Ether();
+				const aSocket = new NodeSocket(ether.a);
+				const a = new PersistentProtocol({ socket: aSocket, loadEstimator });
+				const aMessages = new MessageStream(a);
+				const bSocket = new NodeSocket(ether.b);
+				const b = new PersistentProtocol({ socket: bSocket, loadEstimator });
+				const bMessages = new MessageStream(b);
+
+				// exchange a message so both sides are in a good state
+				a.send(VSBuffer.fromString('a1'));
+				const a1 = await bMessages.waitForOne();
+				assert.strictEqual(a1.toString(), 'a1');
+
+				// wait for ack to arrive
+				await timeout(ProtocolConstants.AcknowledgeTime * 2);
+
+				// confirm no unacknowledged messages
+				assert.strictEqual(a.unacknowledgedCount, 0);
+
+				// now kill b's ability to send anything (simulates dead connection
+				// where the remote side's keepalives stop arriving)
+				b.pauseSocketWriting();
+
+				// wait for timeout to be detected via keepalive
+				const socketTimeoutEvent = await Event.toPromise(a.onSocketTimeout);
+
+				assert.ok(socketTimeoutEvent.timeSinceLastReceivedSomeData >= ProtocolConstants.TimeoutTime);
+				// no regular messages were pending
+				assert.strictEqual(socketTimeoutEvent.unacknowledgedMsgCount, 0);
+
+				aMessages.dispose();
+				bMessages.dispose();
+				a.dispose();
+				b.dispose();
+			}
+		);
+	});
+
 	test('writing can be paused', async () => {
 		await runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 100 }, async () => {
 			const loadEstimator: ILoadEstimator = {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -596,7 +596,7 @@ export abstract class PersistentConnection extends Disposable {
 		}));
 		this._register(protocol.onSocketTimeout((e) => {
 			const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
-			this._options.logService.info(`${logPrefix} received socket timeout event (unacknowledgedMsgCount: ${e.unacknowledgedMsgCount}, timeSinceOldestUnacknowledgedMsg: ${e.timeSinceOldestUnacknowledgedMsg}, timeSinceLastReceivedSomeData: ${e.timeSinceLastReceivedSomeData}).`);
+			this._options.logService.info(`${logPrefix} received socket timeout event (reason: ${e.reason}, unacknowledgedMsgCount: ${e.unacknowledgedMsgCount}, timeSinceOldestUnacknowledgedMsg: ${e.timeSinceOldestUnacknowledgedMsg}, timeSinceLastReceivedSomeData: ${e.timeSinceLastReceivedSomeData}).`);
 			this._beginReconnecting();
 		}));
 


### PR DESCRIPTION
`_recvAckCheck` only fires when there are unacknowledged regular messages. If a connection dies silently while idle, the timeout is never detected.

Add` _keepAliveTimeoutCheck`: since both sides send keepalives every 5s, receiving no data for 20s means the connection is dead. Called from `_sendKeepAlive` after each keepalive is sent. This assumes that there is symmetry, if the client sends keepalives then so should the server.

Related to https://github.com/microsoft/vscode-remote-release/issues/11538