### PR TITLE
Fix menu border color to use default fallback

### DIFF
--- a/src/vs/platform/theme/browser/defaultStyles.ts
+++ b/src/vs/platform/theme/browser/defaultStyles.ts
@@ -241,7 +241,7 @@ export function getSelectBoxStyles(override: IStyleOverride<ISelectBoxStyles>): 
 
 export const defaultMenuStyles: IMenuStyles = {
 	shadowColor: asCssVariable(widgetShadow),
-	borderColor: asCssVariableWithDefault(menuBorder, asCssVariable(editorWidgetBorder)),
+	borderColor: asCssVariableWithDefault(menuBorder, editorWidgetBorder),
 	foregroundColor: asCssVariable(menuForeground),
 	backgroundColor: asCssVariable(menuBackground),
 	selectionForegroundColor: asCssVariable(listHoverForeground),

--- a/src/vs/platform/theme/browser/defaultStyles.ts
+++ b/src/vs/platform/theme/browser/defaultStyles.ts
@@ -241,7 +241,7 @@ export function getSelectBoxStyles(override: IStyleOverride<ISelectBoxStyles>): 
 
 export const defaultMenuStyles: IMenuStyles = {
 	shadowColor: asCssVariable(widgetShadow),
-	borderColor: asCssVariable(menuBorder),
+	borderColor: asCssVariableWithDefault(menuBorder, asCssVariable(editorWidgetBorder)),
 	foregroundColor: asCssVariable(menuForeground),
 	backgroundColor: asCssVariable(menuBackground),
 	selectionForegroundColor: asCssVariable(listHoverForeground),


### PR DESCRIPTION
Update the menu border color to utilize a default fallback, ensuring consistent styling across the application. This change enhances the visual appearance of the menu by providing a more reliable color reference.

