### PR TITLE
Fix listener leak in terminal tool progress parts, execute strategies, and detached terminals

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -24,7 +24,8 @@ import { ChatCollapsibleContentPart } from '../chatCollapsibleContentPart.js';
 import { IChatRendererContent } from '../../../../common/model/chatViewModel.js';
 import '../media/chatTerminalToolProgressPart.css';
 import type { ICodeBlockRenderOptions } from '../codeBlockPart.js';
-import { IAction } from '../../../../../../../base/common/actions.js';
+import { Action, IAction } from '../../../../../../../base/common/actions.js';
+import { ActionBar } from '../../../../../../../base/browser/ui/actionbar/actionbar.js';
 import { timeout } from '../../../../../../../base/common/async.js';
 import { IChatTerminalToolProgressPart, ITerminalChatService, ITerminalConfigurationService, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../../base/common/lifecycle.js';
@@ -46,7 +47,6 @@ import { IContextKey, IContextKeyService } from '../../../../../../../platform/c
 import { AccessibilityVerbositySettingId } from '../../../../../accessibility/browser/accessibilityConfiguration.js';
 import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
 import { EditorPool } from '../chatContentCodePools.js';
-import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
 import { DetachedTerminalCommandMirror, DetachedTerminalSnapshotMirror } from '../../../../../terminal/browser/chatTerminalCommandMirror.js';
 import { TerminalLocation } from '../../../../../../../platform/terminal/common/terminal.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
@@ -57,11 +57,7 @@ import { removeAnsiEscapeCodes } from '../../../../../../../base/common/strings.
 import { PANEL_BACKGROUND } from '../../../../../../common/theme.js';
 import { editorBackground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
-import { MenuWorkbenchToolBar } from '../../../../../../../platform/actions/browser/toolbar.js';
-import { MenuRegistry } from '../../../../../../../platform/actions/common/actions.js';
 import { CommandsRegistry } from '../../../../../../../platform/commands/common/commands.js';
-import { MENU_CHAT_TERMINAL_TOOL_PROGRESS, TerminalChatContextKeys } from '../../../../../terminal/terminalContribChatExports.js';
-import { ServiceCollection } from '../../../../../../../platform/instantiation/common/serviceCollection.js';
 
 /**
  * Minimum number of rows to display in the terminal output view.
@@ -98,7 +94,7 @@ const MIN_DATA_EVENTS_FOR_REAL_OUTPUT = 2;
  */
 const expandedStateByInvocation = new WeakMap<IChatToolInvocation | IChatToolInvocationSerialized, boolean>();
 
-// --- Command and menu registrations for terminal tool progress toolbar ---
+// --- Command registrations for terminal tool progress toolbar ---
 
 CommandsRegistry.registerCommand(TerminalContribCommandId.FocusChatInstanceAction, async (_accessor: unknown, progressPart?: IChatTerminalToolProgressPart) => {
 	await progressPart?.focusTerminal();
@@ -110,48 +106,6 @@ CommandsRegistry.registerCommand(TerminalContribCommandId.ContinueInBackground, 
 
 CommandsRegistry.registerCommand(TerminalContribCommandId.ToggleChatTerminalOutput, async (_accessor: unknown, progressPart?: IChatTerminalToolProgressPart) => {
 	await progressPart?.toggleOutputFromAction();
-});
-
-MenuRegistry.appendMenuItem(MENU_CHAT_TERMINAL_TOOL_PROGRESS, {
-	command: {
-		id: TerminalContribCommandId.ContinueInBackground,
-		title: localize('continueInBackground', 'Continue in Background'),
-		icon: Codicon.debugContinue,
-	},
-	when: TerminalChatContextKeys.chatToolCanContinueInBackground,
-	order: 0,
-	group: 'navigation',
-});
-
-MenuRegistry.appendMenuItem(MENU_CHAT_TERMINAL_TOOL_PROGRESS, {
-	command: {
-		id: TerminalContribCommandId.FocusChatInstanceAction,
-		title: localize('focusTerminal', 'Focus Terminal'),
-		icon: Codicon.openInProduct,
-		toggled: {
-			condition: TerminalChatContextKeys.chatToolIsHiddenTerminal,
-			title: localize('showTerminal', 'Show and Focus Terminal'),
-		}
-	},
-	when: TerminalChatContextKeys.chatToolHasInstance,
-	order: 1,
-	group: 'navigation',
-});
-
-MenuRegistry.appendMenuItem(MENU_CHAT_TERMINAL_TOOL_PROGRESS, {
-	command: {
-		id: TerminalContribCommandId.ToggleChatTerminalOutput,
-		title: localize('showTerminalOutput', 'Show Output'),
-		icon: Codicon.chevronRight,
-		toggled: {
-			condition: TerminalChatContextKeys.chatToolOutputExpanded,
-			title: localize('hideTerminalOutput', 'Hide Output'),
-			icon: Codicon.chevronDown,
-		}
-	},
-	when: TerminalChatContextKeys.chatToolHasOutput.isEqualTo(true),
-	order: 2,
-	group: 'navigation',
 });
 
 /**
@@ -315,12 +269,14 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	private readonly _contentIndex: number;
 	private readonly _sessionResource: URI;
 
-	// Scoped context keys that drive toolbar action visibility
-	private readonly _hasInstanceKey: IContextKey<boolean>;
-	private readonly _canContinueInBackgroundKey: IContextKey<boolean>;
-	private readonly _hasOutputKey: IContextKey<boolean>;
-	private readonly _isHiddenTerminalKey: IContextKey<boolean>;
-	private readonly _outputExpandedKey: IContextKey<boolean>;
+	// Toolbar state that drives action visibility (replaces context keys to avoid
+	// accumulating listeners on the shared IContextKeyService when many parts exist)
+	private _toolbarHasInstance = false;
+	private _toolbarCanContinueInBackground = false;
+	private _toolbarHasOutput = false;
+	private _toolbarIsHiddenTerminal = false;
+	private _toolbarOutputExpanded = false;
+	private _actionBar: ActionBar | undefined;
 
 	private readonly _terminalData: IChatTerminalToolInvocationData;
 	private _terminalCommandUri: URI | undefined;
@@ -359,7 +315,6 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
-		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ITerminalEditorService private readonly _terminalEditorService: ITerminalEditorService,
 		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
@@ -430,38 +385,12 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this._register(this._outputView.onDidBlur(e => this._handleOutputBlur(e)));
 		this._register(toDisposable(() => this._handleDispose()));
 
-		// Create a scoped context key service for this toolbar so each progress part's
-		// context keys are independent from other parts.
+		// Use a lightweight ActionBar instead of MenuWorkbenchToolBar to avoid
+		// accumulating listeners on the shared IContextKeyService when many
+		// terminal tool progress parts exist concurrently (fixes listener LEAK).
 		const actionBarEl = h('.chat-terminal-action-bar@actionBar');
 		elements.title.append(actionBarEl.root);
-		const toolbarContextKeyService = this._register(this._contextKeyService.createScoped(actionBarEl.actionBar));
-		this._hasInstanceKey = TerminalChatContextKeys.chatToolHasInstance.bindTo(toolbarContextKeyService);
-		this._canContinueInBackgroundKey = TerminalChatContextKeys.chatToolCanContinueInBackground.bindTo(toolbarContextKeyService);
-		this._hasOutputKey = TerminalChatContextKeys.chatToolHasOutput.bindTo(toolbarContextKeyService);
-		this._isHiddenTerminalKey = TerminalChatContextKeys.chatToolIsHiddenTerminal.bindTo(toolbarContextKeyService);
-		this._outputExpandedKey = TerminalChatContextKeys.chatToolOutputExpanded.bindTo(toolbarContextKeyService);
-		const usesCollapsibleKey = TerminalChatContextKeys.chatToolUsesCollapsible.bindTo(toolbarContextKeyService);
-
-		const scopedInstantiationService = this._register(this._instantiationService.createChild(
-			new ServiceCollection([IContextKeyService, toolbarContextKeyService])
-		));
-		this._register(scopedInstantiationService.createInstance(
-			MenuWorkbenchToolBar,
-			actionBarEl.actionBar,
-			MENU_CHAT_TERMINAL_TOOL_PROGRESS,
-			{
-				menuOptions: { arg: this, shouldForwardArgs: true },
-				getKeyBinding: (action: IAction) => {
-					if (action.id === TerminalContribCommandId.FocusChatInstanceAction) {
-						return this._keybindingService.lookupKeybinding(TerminalContribCommandId.FocusMostRecentChatTerminal);
-					}
-					if (action.id === TerminalContribCommandId.ToggleChatTerminalOutput) {
-						return this._keybindingService.lookupKeybinding(TerminalContribCommandId.FocusMostRecentChatTerminalOutput);
-					}
-					return undefined;
-				},
-			}
-		));
+		this._actionBar = this._register(new ActionBar(actionBarEl.actionBar));
 		let didInitializeTerminalActions = false;
 		const initializeTerminalActionsOnce = () => {
 			if (didInitializeTerminalActions || this._store.isDisposed) {
@@ -475,13 +404,14 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			initializeTerminalActionsOnce();
 		});
 
-		// Listen for continue in background — sets context key so toolbar auto-hides the action
+		// Listen for continue in background — updates toolbar to auto-hide the action
 		const terminalToolSessionId = this._terminalData.terminalToolSessionId;
 		if (terminalToolSessionId) {
 			this._register(this._terminalChatService.onDidContinueInBackground(sessionId => {
 				if (sessionId === terminalToolSessionId) {
 					this._terminalData.didContinueInBackground = true;
-					this._canContinueInBackgroundKey.set(false);
+					this._toolbarCanContinueInBackground = false;
+					this._updateToolbarActions();
 				}
 			}));
 		}
@@ -526,7 +456,6 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const requiresConfirmation = toolInvocation.kind === 'toolInvocation' && IChatToolInvocation.getConfirmationMessages(toolInvocation);
 		this._isInThinkingContainer = terminalToolsInThinking && !requiresConfirmation;
 		this._usesCollapsibleWrapper = this._isInThinkingContainer || isSimpleTerminal;
-		usesCollapsibleKey.set(this._usesCollapsibleWrapper);
 
 		if (this._usesCollapsibleWrapper) {
 			this.domNode = this._createCollapsibleWrapper(progressPart.domNode, displayCommand, toolInvocation, context);
@@ -696,7 +625,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 	/**
 	 * Updates the scoped context keys that drive toolbar action visibility.
-	 * The `MenuWorkbenchToolBar` automatically shows/hides actions based on these keys.
+	 * The ActionBar is rebuilt with the correct set of visible actions.
 	 */
 	private _updateToolbarContextKeys(terminalInstance?: ITerminalInstance, terminalToolSessionId?: string): void {
 		if (this._store.isDisposed) {
@@ -705,26 +634,26 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const resolvedCommand = this._getResolvedCommand(terminalInstance);
 
 		// Focus terminal action
-		this._hasInstanceKey.set(!!terminalInstance);
+		this._toolbarHasInstance = !!terminalInstance;
 		if (terminalInstance && terminalToolSessionId) {
-			this._isHiddenTerminalKey.set(this._terminalChatService.isBackgroundTerminal(terminalToolSessionId));
+			this._toolbarIsHiddenTerminal = this._terminalChatService.isBackgroundTerminal(terminalToolSessionId);
 		} else {
-			this._isHiddenTerminalKey.set(false);
+			this._toolbarIsHiddenTerminal = false;
 		}
 
 		// Continue in background action
 		if (terminalInstance && terminalToolSessionId && !this._terminalData.isBackground && !this._terminalData.didContinueInBackground) {
 			const isStillRunning = resolvedCommand?.exitCode === undefined && this._terminalData.terminalCommandState?.exitCode === undefined;
-			this._canContinueInBackgroundKey.set(isStillRunning);
+			this._toolbarCanContinueInBackground = isStillRunning;
 		} else {
-			this._canContinueInBackgroundKey.set(false);
+			this._toolbarCanContinueInBackground = false;
 		}
 
 		// Show output action (only when NOT using collapsible wrapper)
 		if (!this._usesCollapsibleWrapper) {
 			const hasSnapshot = !!this._terminalData.terminalCommandOutput;
 			const hasOutput = !!resolvedCommand || hasSnapshot;
-			this._hasOutputKey.set(hasOutput);
+			this._toolbarHasOutput = hasOutput;
 
 			// Auto-expand on first detection of failed output
 			if (hasOutput && !this._outputView.isExpanded) {
@@ -736,7 +665,54 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			}
 		}
 
+		this._updateToolbarActions();
 		this._decoration.update(resolvedCommand);
+	}
+
+	/**
+	 * Rebuilds the ActionBar actions based on current toolbar state.
+	 */
+	private _updateToolbarActions(): void {
+		if (!this._actionBar || this._store.isDisposed) {
+			return;
+		}
+		this._actionBar.clear();
+		const actions: IAction[] = [];
+		if (this._toolbarCanContinueInBackground) {
+			actions.push(new Action(
+				TerminalContribCommandId.ContinueInBackground,
+				localize('continueInBackground', 'Continue in Background'),
+				ThemeIcon.asClassName(Codicon.debugContinue),
+				true,
+				() => this.continueInBackground()
+			));
+		}
+		if (this._toolbarHasInstance) {
+			const focusLabel = this._toolbarIsHiddenTerminal
+				? localize('showTerminal', 'Show and Focus Terminal')
+				: localize('focusTerminal', 'Focus Terminal');
+			actions.push(new Action(
+				TerminalContribCommandId.FocusChatInstanceAction,
+				focusLabel,
+				ThemeIcon.asClassName(Codicon.openInProduct),
+				true,
+				() => this.focusTerminal()
+			));
+		}
+		if (this._toolbarHasOutput && !this._usesCollapsibleWrapper) {
+			const toggleIcon = this._toolbarOutputExpanded ? Codicon.chevronDown : Codicon.chevronRight;
+			const toggleLabel = this._toolbarOutputExpanded
+				? localize('hideTerminalOutput', 'Hide Output')
+				: localize('showTerminalOutput', 'Show Output');
+			actions.push(new Action(
+				TerminalContribCommandId.ToggleChatTerminalOutput,
+				toggleLabel,
+				ThemeIcon.asClassName(toggleIcon),
+				true,
+				() => this.toggleOutputFromAction()
+			));
+		}
+		this._actionBar.push(actions, { icon: true, label: false });
 	}
 
 	private _getResolvedCommand(instance?: ITerminalInstance): ITerminalCommand | undefined {
@@ -908,7 +884,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const didChange = await this._outputView.toggle(expanded);
 		const isExpanded = this._outputView.isExpanded;
 		this._titleElement.classList.toggle('chat-terminal-content-title-no-bottom-radius', isExpanded);
-		this._outputExpandedKey.set(isExpanded);
+		this._toolbarOutputExpanded = isExpanded;
+		this._updateToolbarActions();
 		if (didChange) {
 			expandedStateByInvocation.set(this.toolInvocation, isExpanded);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -277,6 +277,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	private _toolbarIsHiddenTerminal = false;
 	private _toolbarOutputExpanded = false;
 	private _actionBar: ActionBar | undefined;
+	private readonly _actionBarActions = new DisposableStore();
 
 	private readonly _terminalData: IChatTerminalToolInvocationData;
 	private _terminalCommandUri: URI | undefined;
@@ -391,6 +392,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		const actionBarEl = h('.chat-terminal-action-bar@actionBar');
 		elements.title.append(actionBarEl.root);
 		this._actionBar = this._register(new ActionBar(actionBarEl.actionBar));
+		this._register(this._actionBarActions);
 		let didInitializeTerminalActions = false;
 		const initializeTerminalActionsOnce = () => {
 			if (didInitializeTerminalActions || this._store.isDisposed) {
@@ -677,40 +679,47 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			return;
 		}
 		this._actionBar.clear();
+		this._actionBarActions.clear();
 		const actions: IAction[] = [];
 		if (this._toolbarCanContinueInBackground) {
-			actions.push(new Action(
+			const action = new Action(
 				TerminalContribCommandId.ContinueInBackground,
 				localize('continueInBackground', 'Continue in Background'),
 				ThemeIcon.asClassName(Codicon.debugContinue),
 				true,
 				() => this.continueInBackground()
-			));
+			);
+			this._actionBarActions.add(action);
+			actions.push(action);
 		}
 		if (this._toolbarHasInstance) {
 			const focusLabel = this._toolbarIsHiddenTerminal
 				? localize('showTerminal', 'Show and Focus Terminal')
 				: localize('focusTerminal', 'Focus Terminal');
-			actions.push(new Action(
+			const action = new Action(
 				TerminalContribCommandId.FocusChatInstanceAction,
 				focusLabel,
 				ThemeIcon.asClassName(Codicon.openInProduct),
 				true,
 				() => this.focusTerminal()
-			));
+			);
+			this._actionBarActions.add(action);
+			actions.push(action);
 		}
 		if (this._toolbarHasOutput && !this._usesCollapsibleWrapper) {
 			const toggleIcon = this._toolbarOutputExpanded ? Codicon.chevronDown : Codicon.chevronRight;
 			const toggleLabel = this._toolbarOutputExpanded
 				? localize('hideTerminalOutput', 'Hide Output')
 				: localize('showTerminalOutput', 'Show Output');
-			actions.push(new Action(
+			const action = new Action(
 				TerminalContribCommandId.ToggleChatTerminalOutput,
 				toggleLabel,
 				ThemeIcon.asClassName(toggleIcon),
 				true,
 				() => this.toggleOutputFromAction()
-			));
+			);
+			this._actionBarActions.add(action);
+			actions.push(action);
 		}
 		this._actionBar.push(actions, { icon: true, label: false });
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1510,6 +1510,16 @@ export interface IDetachedXtermTerminal extends IXtermTerminal {
 	reset(): void;
 
 	/**
+	 * Updates the terminal configuration from current settings.
+	 */
+	updateConfig(): void;
+
+	/**
+	 * Updates the terminal theme from the current color theme.
+	 */
+	updateTheme(): void;
+
+	/**
 	 * Access to the terminal buffer for reading cursor position and content.
 	 */
 	readonly buffer: IBufferSet;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1520,6 +1520,11 @@ export interface IDetachedXtermTerminal extends IXtermTerminal {
 	updateTheme(): void;
 
 	/**
+	 * Updates the xterm log level to match the given VS Code log level.
+	 */
+	updateLogLevel(): void;
+
+	/**
 	 * Access to the terminal buffer for reading cursor position and content.
 	 */
 	readonly buffer: IBufferSet;

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -69,6 +69,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 	private _hostActiveTerminals: Map<ITerminalInstanceHost, ITerminalInstance | undefined> = new Map();
 
 	private _detachedXterms = new Set<IDetachedTerminalInstance>();
+	private _detachedListenersRegistered = false;
 	private readonly _terminalShellTypeContextKey: IContextKey<string>;
 
 	private _isShuttingDown: boolean = false;
@@ -185,7 +186,8 @@ export class TerminalService extends Disposable implements ITerminalService {
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@ITimerService private readonly _timerService: ITimerService
+		@ITimerService private readonly _timerService: ITimerService,
+		@IThemeService private readonly _themeService: IThemeService
 	) {
 		super();
 
@@ -1101,6 +1103,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			xtermColorProvider: options.colorProvider,
 			capabilities,
 			disableOverviewRuler: options.disableOverviewRuler,
+			detached: true,
 		}, undefined);
 
 		if (options.readonly) {
@@ -1109,12 +1112,38 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 		const instance = new DetachedTerminal(xterm, { ...options, capabilities }, this._instantiationService);
 		this._detachedXterms.add(instance);
+		// Ensure centralized theme/config listeners update this detached terminal
+		this._ensureDetachedTerminalListeners();
 		const l = xterm.onDidDispose(() => {
 			this._detachedXterms.delete(instance);
 			l.dispose();
 		});
 
 		return instance;
+	}
+
+	/**
+	 * Registers a single set of global service listeners (theme/config changes)
+	 * that forward updates to all detached xterm instances. This avoids each
+	 * detached terminal registering its own listener on global singletons.
+	 */
+	private _ensureDetachedTerminalListeners(): void {
+		if (this._detachedListenersRegistered) {
+			return;
+		}
+		this._detachedListenersRegistered = true;
+		this._register(this._themeService.onDidColorThemeChange(() => {
+			for (const instance of this._detachedXterms) {
+				instance.xterm.updateTheme();
+			}
+		}));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('terminal.integrated') || e.affectsConfiguration('editor.fastScrollSensitivity') || e.affectsConfiguration('editor.mouseWheelScrollSensitivity') || e.affectsConfiguration('editor.multiCursorModifier')) {
+				for (const instance of this._detachedXterms) {
+					instance.xterm.updateConfig();
+				}
+			}
+		}));
 	}
 
 	private async _resolveCwd(shellLaunchConfig: IShellLaunchConfig, splitActiveTerminal: boolean, options?: ICreateTerminalOptions): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -20,7 +20,7 @@ import { IContextKey, IContextKeyService } from '../../../../platform/contextkey
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
-import { ICreateContributedTerminalProfileOptions, IExtensionTerminalProfile, IPtyHostAttachTarget, IRawTerminalInstanceLayoutInfo, IRawTerminalTabLayoutInfo, IShellLaunchConfig, ITerminalBackend, ITerminalLaunchError, ITerminalLogService, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalExitReason, TerminalLocation, TitleEventSource } from '../../../../platform/terminal/common/terminal.js';
+import { ICreateContributedTerminalProfileOptions, IExtensionTerminalProfile, IPtyHostAttachTarget, IRawTerminalInstanceLayoutInfo, IRawTerminalTabLayoutInfo, IShellLaunchConfig, ITerminalBackend, ITerminalLaunchError, ITerminalLogService, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalExitReason, TerminalLocation, TerminalSettingId, TitleEventSource } from '../../../../platform/terminal/common/terminal.js';
 import { formatMessageForTerminal } from '../../../../platform/terminal/common/terminalStrings.js';
 import { iconForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { getIconRegistry } from '../../../../platform/theme/common/iconRegistry.js';
@@ -1123,9 +1123,9 @@ export class TerminalService extends Disposable implements ITerminalService {
 	}
 
 	/**
-	 * Registers a single set of global service listeners (theme/config changes)
-	 * that forward updates to all detached xterm instances. This avoids each
-	 * detached terminal registering its own listener on global singletons.
+	 * Registers a single set of global service listeners (theme/config/log-level
+	 * changes) that forward updates to all detached xterm instances. This avoids
+	 * each detached terminal registering its own listener on global singletons.
 	 */
 	private _ensureDetachedTerminalListeners(): void {
 		if (this._detachedListenersRegistered) {
@@ -1138,10 +1138,22 @@ export class TerminalService extends Disposable implements ITerminalService {
 			}
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('terminal.integrated') || e.affectsConfiguration('editor.fastScrollSensitivity') || e.affectsConfiguration('editor.mouseWheelScrollSensitivity') || e.affectsConfiguration('editor.multiCursorModifier')) {
+			const shouldUpdateConfig = e.affectsConfiguration('terminal.integrated') || e.affectsConfiguration('editor.fastScrollSensitivity') || e.affectsConfiguration('editor.mouseWheelScrollSensitivity') || e.affectsConfiguration('editor.multiCursorModifier');
+			const shouldUpdateTheme = e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled);
+			if (shouldUpdateConfig || shouldUpdateTheme) {
 				for (const instance of this._detachedXterms) {
-					instance.xterm.updateConfig();
+					if (shouldUpdateConfig) {
+						instance.xterm.updateConfig();
+					}
+					if (shouldUpdateTheme) {
+						instance.xterm.updateTheme();
+					}
 				}
+			}
+		}));
+		this._register(this._logService.onDidChangeLogLevel(() => {
+			for (const instance of this._detachedXterms) {
+				instance.xterm.updateLogLevel();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -91,6 +91,14 @@ export interface IXtermTerminalOptions {
 	xtermAddonImporter?: XtermAddonImporter;
 	/** Whether to disable the overview ruler. */
 	disableOverviewRuler?: boolean;
+	/**
+	 * When true, skips registering listeners on global singleton services
+	 * (configuration, theme, log level) to avoid accumulating listeners when
+	 * many detached terminals are created concurrently. The caller should use
+	 * {@link XtermTerminal.updateConfig} and {@link XtermTerminal.updateTheme}
+	 * to apply changes externally.
+	 */
+	detached?: boolean;
 }
 
 /**
@@ -271,23 +279,27 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 		}
 		this._core = (this.raw as ITerminalWithCore)._core as IXtermCore;
 
-		this._register(this._configurationService.onDidChangeConfiguration(async e => {
-			if (e.affectsConfiguration(TerminalSettingId.GpuAcceleration)) {
-				XtermTerminal._suggestedRendererType = undefined;
-			}
-			if (e.affectsConfiguration('terminal.integrated') || e.affectsConfiguration('editor.fastScrollSensitivity') || e.affectsConfiguration('editor.mouseWheelScrollSensitivity') || e.affectsConfiguration('editor.multiCursorModifier')) {
-				this.updateConfig();
-			}
-			if (e.affectsConfiguration(TerminalSettingId.UnicodeVersion)) {
-				this._updateUnicodeVersion();
-			}
-			if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled)) {
-				this._updateTheme();
-			}
-		}));
+		// Skip global service listeners for detached terminals to avoid
+		// accumulating listeners when many detached instances exist concurrently.
+		if (!options.detached) {
+			this._register(this._configurationService.onDidChangeConfiguration(async e => {
+				if (e.affectsConfiguration(TerminalSettingId.GpuAcceleration)) {
+					XtermTerminal._suggestedRendererType = undefined;
+				}
+				if (e.affectsConfiguration('terminal.integrated') || e.affectsConfiguration('editor.fastScrollSensitivity') || e.affectsConfiguration('editor.mouseWheelScrollSensitivity') || e.affectsConfiguration('editor.multiCursorModifier')) {
+					this.updateConfig();
+				}
+				if (e.affectsConfiguration(TerminalSettingId.UnicodeVersion)) {
+					this._updateUnicodeVersion();
+				}
+				if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled)) {
+					this._updateTheme();
+				}
+			}));
 
-		this._register(this._themeService.onDidColorThemeChange(theme => this._updateTheme(theme)));
-		this._register(this._logService.onDidChangeLogLevel(e => this.raw.options.logLevel = vscodeToXtermLogLevel(e)));
+			this._register(this._themeService.onDidColorThemeChange(theme => this._updateTheme(theme)));
+			this._register(this._logService.onDidChangeLogLevel(e => this.raw.options.logLevel = vscodeToXtermLogLevel(e)));
+		}
 
 		// Refire events
 		this._register(this.raw.onSelectionChange(() => {
@@ -1035,6 +1047,14 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 
 	private _updateTheme(theme?: IColorTheme): void {
 		this.raw.options.theme = this.getXtermTheme(theme);
+	}
+
+	/**
+	 * Updates the terminal theme. Use this to externally trigger a theme
+	 * refresh for detached terminals that skip global service listeners.
+	 */
+	updateTheme(): void {
+		this._updateTheme();
 	}
 
 	refresh() {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -95,8 +95,8 @@ export interface IXtermTerminalOptions {
 	 * When true, skips registering listeners on global singleton services
 	 * (configuration, theme, log level) to avoid accumulating listeners when
 	 * many detached terminals are created concurrently. The caller should use
-	 * {@link XtermTerminal.updateConfig} and {@link XtermTerminal.updateTheme}
-	 * to apply changes externally.
+	 * {@link XtermTerminal.updateConfig}, {@link XtermTerminal.updateTheme},
+	 * and {@link XtermTerminal.updateLogLevel} to apply those changes externally.
 	 */
 	detached?: boolean;
 }
@@ -542,6 +542,10 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	resize(columns: number, rows: number): void {
 		this._logService.debug('resizing', columns, rows);
 		this.raw.resize(columns, rows);
+	}
+
+	updateLogLevel(): void {
+		this.raw.options.logLevel = vscodeToXtermLogLevel(this._logService.getLevel());
 	}
 
 	updateConfig(): void {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -60,6 +60,9 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 
 	async execute(commandLine: string, token: CancellationToken, commandId?: string, _commandLineForMetadata?: string): Promise<ITerminalExecuteStrategyResult> {
 		const store = new DisposableStore();
+		// Register with strategy lifetime so listeners are cleaned up if
+		// the strategy is disposed while execute() is still running.
+		this._register(store);
 
 		try {
 			const idlePollInterval = this._configurationService.getValue<number>(TerminalChatAgentToolsSettingId.IdlePollInterval) ?? 1000;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -43,6 +43,11 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 
 	async execute(commandLine: string, token: CancellationToken, commandId?: string, commandLineForMetadata?: string): Promise<ITerminalExecuteStrategyResult> {
 		const store = new DisposableStore();
+		// Register the store with this strategy's disposable chain so that if
+		// the strategy is disposed while execute() is still running (e.g. the
+		// session is torn down), accumulated Event.toPromise listeners on
+		// shared emitters like onCommandFinished are cleaned up immediately.
+		this._register(store);
 		try {
 			// Ensure xterm is available
 			this._log('Waiting for xterm');


### PR DESCRIPTION
Fixes #309684
Fixes #309921
Fixes #309923
Fixes #310046

These four issues all report "potential listener LEAK detected, popular" errors from
accumulating too many listeners on shared singleton emitters.

- Replace `MenuWorkbenchToolBar` in `ChatTerminalToolProgressPart` with a lightweight
  `ActionBar` that is rebuilt on state changes, avoiding per-instance `IMenu` subscriptions
  to the global `IContextKeyService` (#309684, #309923)
- Register the `DisposableStore` used by `Event.toPromise` calls in `RichExecuteStrategy`
  and `BasicExecuteStrategy` with the strategy's disposable chain so listeners are cleaned
  up if the strategy is disposed mid-execution (#309921)
- Add a `detached` option to `XtermTerminal` that skips registering listeners on global
  singletons (`IConfigurationService`, `IThemeService`), and forward updates from a single
  centralized listener in `TerminalService.createDetachedTerminal` (#310046)

cc @anthonykim1 