### PR TITLE
Add `compile-copilot-extension-full-build` task for copilot

### DIFF
--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -287,6 +287,29 @@ export const compileCopilotExtensionBuildTask = task.define('compile-copilot-ext
 gulp.task(compileCopilotExtensionBuildTask);
 
 /**
+ * Compiles the built-in copilot extension with proper `.vscodeignore` filtering
+ * and materializes native dependency shims (`node-pty`, `ripgrep`).
+ * Produces output equivalent to what CI ships from the pre-built VSIX.
+ *
+ * The result is placed in `.build/extensions/copilot/` and can be copied
+ * directly into a VS Code Insiders installation at:
+ *   `<insiders>/resources/app/extensions/copilot/`
+ */
+export const compileCopilotExtensionFullBuildTask = task.define('compile-copilot-extension-full-build', task.series(
+	// Step 1: Clean previous copilot build output
+	task.define('clean-copilot-build', util.rimraf('.build/extensions/copilot')),
+	// Step 2: Build and package with proper `.vscodeignore` filtering
+	task.define('package-copilot-extension-full', () => ext.packageCopilotExtensionFullStream().pipe(gulp.dest('.build'))),
+	// Step 3: Materialize native dependency shims (`node-pty`, `ripgrep`)
+	task.define('copilot-extension-native-shims', () => {
+		const copilotExtDir = path.join(root, '.build', 'extensions', 'copilot');
+		ext.prepareCopilotExtensionNativeShims(copilotExtDir);
+		return Promise.resolve();
+	})
+));
+gulp.task(compileCopilotExtensionFullBuildTask);
+
+/**
  * Compiles the extensions for the build.
  * This is essentially a helper task that combines {@link cleanExtensionsBuildTask}, {@link compileNonNativeExtensionsBuildTask} and {@link compileNativeExtensionsBuildTask}
  */

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -24,6 +24,7 @@ import { getProductionDependencies } from './dependencies.ts';
 import { type IExtensionDefinition, getExtensionStream } from './builtInExtensions.ts';
 import { fetchUrls, fetchGithub } from './fetch.ts';
 import { createTsgoStream, spawnTsgo } from './tsgo.ts';
+import { prepareBuiltInCopilotExtensionShims } from './copilot.ts';
 import vzip from 'gulp-vinyl-zip';
 
 import { createRequire } from 'module';
@@ -480,6 +481,116 @@ export function packageCopilotExtensionStream(disableMangle: boolean): Stream {
 			.pipe(util2.cleanNodeModules(path.join(root, 'build', '.moduleignore')))
 			.pipe(util2.cleanNodeModules(path.join(root, 'build', `.moduleignore.${process.platform}`)))
 	).pipe(util2.setExecutableBit(['**/*.sh']));
+}
+
+/**
+ * Package the built-in copilot extension as a properly filtered VSIX-equivalent.
+ * Unlike {@link packageCopilotExtensionStream}, this uses vsce.listFiles with
+ * PackageManager.Npm so that .vscodeignore is respected for dependency filtering,
+ * producing output equivalent to what CI ships from the pre-built VSIX.
+ */
+export function packageCopilotExtensionFullStream(): Stream {
+	const vsce = require('@vscode/vsce') as typeof import('@vscode/vsce');
+	const extensionPath = path.join(root, 'extensions', 'copilot');
+	if (!fs.existsSync(extensionPath)) {
+		return es.readArray([]);
+	}
+
+	const esbuildConfigFileName = '.esbuild.ts';
+	const esbuildScript = path.join(extensionPath, esbuildConfigFileName);
+	if (!fs.existsSync(esbuildScript)) {
+		throw new Error(`Copilot esbuild script not found at ${esbuildScript}`);
+	}
+
+	const result = es.through();
+
+	// Step 1: Run esbuild to compile the extension
+	new Promise<void>((resolve, reject) => {
+		const proc = cp.execFile(process.argv[0], [esbuildScript], { cwd: extensionPath }, (error, _stdout, stderr) => {
+			if (error) {
+				return reject(error);
+			}
+			const matches = (stderr || '').match(/\> (.+): error: (.+)?/g);
+			fancyLog(`Bundled extension: ${ansiColors.yellow(path.join('copilot', esbuildConfigFileName))} with ${matches ? matches.length : 0} errors.`);
+			for (const match of matches || []) {
+				fancyLog.error(match);
+			}
+			return resolve();
+		});
+		proc.stdout!.on('data', (data) => {
+			fancyLog(`${ansiColors.green('esbuilding copilot')}: ${data.toString('utf8')}`);
+		});
+	}).then(() => {
+		// Step 2: Use `vsce.listFiles` with Npm package manager so `.vscodeignore`
+		// is applied to both source files AND `node_modules` dependencies.
+		// This is the key difference from `packageCopilotExtensionStream` which
+		// uses `PackageManager.None` and then blindly merges all production deps.
+		return vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Npm });
+	}).then(fileNames => {
+		const files = fileNames
+			.map(fileName => path.join(extensionPath, fileName))
+			.map(filePath => new File({
+				path: filePath,
+				stat: fs.statSync(filePath),
+				base: extensionPath,
+				contents: fs.createReadStream(filePath)
+			}));
+
+		es.readArray(files).pipe(result);
+	}).catch(err => {
+		console.error('Failed to package copilot extension:', err);
+		result.emit('error', err);
+	});
+
+	// Apply the same package.json cleanup as bundled extensions get
+	const cleaned = updateExtensionPackageJSON(
+		result.pipe(rename(p => p.dirname = `extensions/copilot/${p.dirname}`)),
+		(data: any) => {
+			delete data.scripts;
+			delete data.dependencies;
+			delete data.devDependencies;
+			if (data.main) {
+				data.main = data.main.replace('/out/', '/dist/');
+			}
+			return data;
+		}
+	);
+
+	return minifyExtensionResources(cleaned)
+		.pipe(util2.setExecutableBit(['**/*.sh']));
+}
+
+/**
+ * Materializes native dependency shims (`node-pty`, `ripgrep`) into the copilot
+ * extension output at {@link outputDir}. Uses the root `node_modules` as the
+ * source for native binaries, targeting the current platform/arch.
+ *
+ * This is the equivalent of what {@link copyCopilotNativeDepsTask} in
+ * `gulpfile.vscode.ts` does during a full product build, but scoped to
+ * just the standalone copilot extension output.
+ *
+ * Failures are logged as warnings rather than throwing, since the copilot
+ * extension can still create shims at runtime if they are missing.
+ */
+export function prepareCopilotExtensionNativeShims(outputDir: string): void {
+	const platform = process.platform;
+	const arch = process.arch;
+	const appNodeModulesDir = path.join(root, 'node_modules');
+
+	if (!fs.existsSync(outputDir)) {
+		fancyLog.warn('[prepareCopilotExtensionNativeShims] Copilot extension not found at', outputDir, '- skipping shims');
+		return;
+	}
+
+	try {
+		prepareBuiltInCopilotExtensionShims(platform, arch, outputDir, appNodeModulesDir);
+		fancyLog(`[prepareCopilotExtensionNativeShims] Materialized native shims for ${platform}-${arch}`);
+	} catch (err) {
+		// Downgrade to a warning for local builds since the extension
+		// can still function without shims (it creates them at runtime).
+		fancyLog.warn(`[prepareCopilotExtensionNativeShims] Failed to materialize shims: ${err}`);
+		fancyLog.warn('[prepareCopilotExtensionNativeShims] The extension will still work but will create shims at runtime.');
+	}
 }
 
 export function packageMarketplaceExtensionsStream(forWeb: boolean): Stream {


### PR DESCRIPTION
## Summary

Adds a new `compile-copilot-extension-full-build` gulp task that builds the built-in copilot extension from source with correctly filtered `node_modules`, producing output equivalent to what CI ships from the pre-built VSIX. This also materializes native dependency shims (node-pty, ripgrep) into the extension output.

## Motivation

The `compile-copilot-extension-build` task introduced in #309079 enables building the copilot extension from source for local (non-CI) builds. However, it produces a bloated `node_modules` directory containing **every** production dependency from `extensions/copilot/package.json`, even though nearly all of them are already bundled into `dist/extension.js` by esbuild. This is bloated for the purpose of daily driving a bleeding-edge with the latest Copilot from source via, for example, `--extensionDevelopmentPath`.

This happens because `packageCopilotExtensionStream` merges two streams:

1. `fromLocalEsbuild` — runs `.esbuild.ts`, then calls `vsce.listFiles({ packageManager: PackageManager.None })`. `PackageManager.None` skips dependency scanning, so `.vscodeignore` filtering is not applied to `node_modules`.
2. `getProductionDependencies('extensions/copilot')` — runs `npm ls --all --omit=dev` and blindly globs every resolved dependency path into the output.

In CI this is not a problem because **`packageCopilotExtensionStream` is never used** — CI downloads a pre-built `.vsix` (via `downloadCopilotVsix.ts`) that was packaged by `vsce package` with `PackageManager.Npm`, which respects `.vscodeignore` and only includes the `@vscode/copilot-typescript-server-plugin` and `@github/copilot` (SDK subtree) dependencies.

## What this PR does

### `build/lib/extensions.ts`

- **`packageCopilotExtensionFullStream()`** — A new packaging function that:
  - Runs `.esbuild.ts` to compile the extension (same as existing)
  - Uses `vsce.listFiles({ packageManager: PackageManager.Npm })` instead of `PackageManager.None`, so `.vscodeignore` is applied to **both** source files and `node_modules` dependencies
  - Cleans `package.json` (removes `scripts`, `dependencies`, `devDependencies`)

- **`prepareCopilotExtensionNativeShims(outputDir)`** — Calls `prepareBuiltInCopilotExtensionShims` from `build/lib/copilot.ts` to materialize `node-pty` and `ripgrep` binaries into the copilot SDK's expected locations, using the root `node_modules/` as the source. Failures are logged as warnings since the extension can create shims at runtime.

### `build/gulpfile.extensions.ts`

- **`compile-copilot-extension-full-build`** — A new gulp task that runs three steps in series:
  1. `clean-copilot-build` — removes `.build/extensions/copilot/`
  2. `package-copilot-extension-full` — runs `packageCopilotExtensionFullStream` and writes to `.build/`
  3. `copilot-extension-native-shims` — runs `prepareCopilotExtensionNativeShims` on the output

## Usage

```bash
# Build the copilot extension with correct dependency filtering + native shims
npm run gulp compile-copilot-extension-full-build

# Output is at .build/extensions/copilot/
```

## Comparison

`compile-copilot-extension-build`:
```
.build/extensions/copilot/node_modules/
├── @anthropic-ai/
├── @github/
├── @vscode/
├── isbinaryfile/
├── minimatch/
├── ... (hundreds of bundled-at-build-time dependencies)
```

`compile-copilot-extension-full-build`:
```
.build/extensions/copilot/node_modules/
├── @github/
│   └── copilot/
│       ├── package.json
│       ├── sdk/
│       │   ├── *.js
│       │   ├── prebuilds/linux-x64/   ← node-pty shims
│       │   ├── ripgrep/bin/linux-x64/ ← ripgrep shims
│       │   └── definitions/*.yaml
│       └── shims.txt                  ← marker file
└── @vscode/
    └── copilot-typescript-server-plugin/
        ├── package.json
        └── dist/*.js
```

This matches the structure of the copilot extension in released VS Code Insiders builds.

## Notes

- The existing `compile-copilot-extension-build` task and `packageCopilotExtensionStream` are left unchanged — this PR is purely additive.


Fixes https://github.com/microsoft/vscode/issues/310156


cc @joaomoreno 