### PR TITLE
Update editor widget border color to use transparent foreground

### DIFF
--- a/src/vs/platform/theme/common/colors/editorColors.ts
+++ b/src/vs/platform/theme/common/colors/editorColors.ts
@@ -55,7 +55,7 @@ export const editorWidgetForeground = registerColor('editorWidget.foreground',
 	nls.localize('editorWidgetForeground', 'Foreground color of editor widgets, such as find/replace.'));
 
 export const editorWidgetBorder = registerColor('editorWidget.border',
-	{ dark: '#454545', light: '#C8C8C8', hcDark: contrastBorder, hcLight: contrastBorder },
+	{ dark: transparent(foreground, 0.2), light: transparent(foreground, 0.2), hcDark: contrastBorder, hcLight: contrastBorder },
 	nls.localize('editorWidgetBorder', 'Border color of editor widgets. The color is only used if the widget chooses to have a border and if the color is not overridden by a widget.'));
 
 export const editorWidgetResizeBorder = registerColor('editorWidget.resizeBorder',

--- a/src/vs/platform/theme/common/colors/editorColors.ts
+++ b/src/vs/platform/theme/common/colors/editorColors.ts
@@ -55,7 +55,7 @@ export const editorWidgetForeground = registerColor('editorWidget.foreground',
 	nls.localize('editorWidgetForeground', 'Foreground color of editor widgets, such as find/replace.'));
 
 export const editorWidgetBorder = registerColor('editorWidget.border',
-	{ dark: transparent(foreground, 0.2), light: transparent(foreground, 0.2), hcDark: contrastBorder, hcLight: contrastBorder },
+	{ dark: transparent(editorWidgetForeground, 0.2), light: transparent(editorWidgetForeground, 0.2), hcDark: contrastBorder, hcLight: contrastBorder },
 	nls.localize('editorWidgetBorder', 'Border color of editor widgets. The color is only used if the widget chooses to have a border and if the color is not overridden by a widget.'));
 
 export const editorWidgetResizeBorder = registerColor('editorWidget.resizeBorder',


### PR DESCRIPTION
Adjust the editor widget border color to utilize a transparent foreground, enhancing the visual integration of widgets.

