### PR TITLE
Agents app accessibility fixes

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -573,6 +573,9 @@ export class ActionListWidget<T> extends Disposable {
 						if (element.disabled) {
 							label = localize({ key: 'customQuickFixWidget.labels', comment: [`Action widget labels for accessibility.`] }, "{0}, Disabled Reason: {1}", label, element.disabled);
 						}
+						if (element.submenuActions?.length) {
+							label = localize('actionList.submenuHint', "{0}, use right arrow to access options", label);
+						}
 						return label;
 					}
 					return null;

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -304,11 +304,18 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.refreshAccount();
 	}
 
+	override setFocusable(_focusable: boolean): void {
+		// Don't let the ActionBar remove focusability - this widget must
+		// always be reachable via Tab even when a sibling item is hidden.
+	}
+
 	override render(container: HTMLElement): void {
 		super.render(container);
 
 		this.container = container;
 		container.classList.add('sessions-account-titlebar-widget');
+		container.setAttribute('role', 'button');
+		container.tabIndex = 0;
 
 		this.iconElement = append(container, $('.sessions-account-titlebar-widget-icon'));
 		this.labelElement = append(container, $('span.sessions-account-titlebar-widget-label'));
@@ -322,6 +329,10 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			return;
 		}
 
+		this.showCombinedPanel();
+	}
+
+	togglePanel(): void {
 		this.showCombinedPanel();
 	}
 
@@ -617,6 +628,7 @@ class TitleBarUpdateWidget extends BaseActionViewItem {
 
 		this.container = container;
 		container.classList.add('sessions-update-titlebar-widget');
+		container.setAttribute('role', 'button');
 
 		this.labelElement = append(container, $('span.sessions-update-titlebar-widget-label'));
 		this.hoverAttachment.value = this.updateHoverWidget.attachTo(container);
@@ -679,8 +691,10 @@ class AccountWidgetContribution extends Disposable implements IWorkbenchContribu
 		super();
 
 		// Titlebar update widget (to the right of separator, left of account badge)
+		let updateWidget: TitleBarUpdateWidget | undefined;
 		this._register(actionViewItemService.register(Menus.TitleBarRightLayout, SessionsTitleBarUpdateWidgetAction, (action, options) => {
-			return instantiationService.createInstance(TitleBarUpdateWidget, action, options);
+			updateWidget = instantiationService.createInstance(TitleBarUpdateWidget, action, options);
+			return updateWidget;
 		}, undefined));
 
 		this._register(registerAction2(class extends Action2 {
@@ -698,13 +712,15 @@ class AccountWidgetContribution extends Disposable implements IWorkbenchContribu
 			}
 
 			async run(): Promise<void> {
-				// Handled by the custom view item
+				updateWidget?.onClick();
 			}
 		}));
 
 		// Titlebar account widget (rightmost in titlebar)
+		let accountWidget: TitleBarAccountWidget | undefined;
 		this._register(actionViewItemService.register(Menus.TitleBarRightLayout, SessionsTitleBarAccountWidgetAction, (action, options) => {
-			return instantiationService.createInstance(TitleBarAccountWidget, action, options);
+			accountWidget = instantiationService.createInstance(TitleBarAccountWidget, action, options);
+			return accountWidget;
 		}, undefined));
 
 		this._register(registerAction2(class extends Action2 {
@@ -721,7 +737,7 @@ class AccountWidgetContribution extends Disposable implements IWorkbenchContribu
 			}
 
 			async run(): Promise<void> {
-				// Handled by the custom view item
+				accountWidget?.togglePanel();
 			}
 		}));
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -329,10 +329,10 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			return;
 		}
 
-		this.showCombinedPanel();
+		this.showPanel();
 	}
 
-	togglePanel(): void {
+	showPanel(): void {
 		this.showCombinedPanel();
 	}
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -429,6 +429,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				this.isMenuVisible = false;
 				this.container?.classList.remove('menu-visible');
 				this.renderState();
+				this.container?.focus();
 			}
 		});
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -329,10 +329,6 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			return;
 		}
 
-		this.showPanel();
-	}
-
-	showPanel(): void {
 		this.showCombinedPanel();
 	}
 
@@ -738,7 +734,7 @@ class AccountWidgetContribution extends Disposable implements IWorkbenchContribu
 			}
 
 			async run(): Promise<void> {
-				accountWidget?.togglePanel();
+				accountWidget?.onClick();
 			}
 		}));
 

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -584,7 +584,9 @@ class RunScriptActionViewItem extends BaseActionViewItem {
 
 	override setFocusable(focusable: boolean): void {
 		this._primaryAction.setFocusable(focusable);
-		this._dropdown.setFocusable(focusable);
+		if (!focusable) {
+			this._dropdown.setFocusable(false);
+		}
 	}
 
 	private _getPrimaryActionTooltip(state: IRunScriptActionContext | undefined): string {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -193,7 +193,6 @@ export class PermissionPicker extends Disposable {
 			undefined,
 			[],
 			{
-				getAriaLabel: (item) => item.label ?? '',
 				getWidgetAriaLabel: () => localize('permissionPicker.ariaLabel', "Permission Picker"),
 			},
 			listOptions,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -998,6 +998,10 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	focus(): void {
 		this.tree.domFocus();
+
+		if (this.tree.getFocus().length === 0) {
+			this.tree.focusFirst();
+		}
 	}
 
 	openFind(): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -800,6 +800,10 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	focus(): void {
 		this.sessionsList?.domFocus();
+
+		if ((this.sessionsList?.getFocus().length ?? 0) === 0) {
+			this.sessionsList?.focusFirst();
+		}
 	}
 
 	clearFocus(): void {


### PR DESCRIPTION
- Focus the first session row when "Focus Chat Sessions" is invoked so the focus border is visible (fixes #309620)
- Include description alongside label in screen reader announcements for the permission picker dropdown (fixes #310173)
- Make account menu button kb accessible (fixes #309613)
- Fix action list item aria label missing space between label and description (fixes #309623) 

