### PR TITLE
Fix TypeError when no harnesses are registered in CustomizationHarnessServiceBase

### DIFF
--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -257,6 +257,13 @@ export interface ICustomizationHarnessService {
 // #region Shared filter constants
 
 /**
+ * Empty filter returned when no harness is registered yet.
+ */
+const EMPTY_FILTER: IStorageSourceFilter = {
+	sources: [],
+};
+
+/**
  * Hooks filter — local, user, and plugin sources.
  */
 const HOOKS_FILTER: IStorageSourceFilter = {
@@ -489,7 +496,7 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 		const activeId = this._activeHarness.get();
 		const all = this._getAllHarnesses();
 		const descriptor = all.find(h => h.id === activeId) ?? all[0];
-		return descriptor?.getStorageSourceFilter(type) ?? { sources: [] };
+		return descriptor?.getStorageSourceFilter(type) ?? EMPTY_FILTER;
 	}
 
 	getActiveDescriptor(): IHarnessDescriptor {

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -488,8 +488,8 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
 		const activeId = this._activeHarness.get();
 		const all = this._getAllHarnesses();
-		const descriptor = all.find(h => h.id === activeId);
-		return descriptor?.getStorageSourceFilter(type) ?? all[0].getStorageSourceFilter(type);
+		const descriptor = all.find(h => h.id === activeId) ?? all[0];
+		return descriptor?.getStorageSourceFilter(type) ?? { sources: [] };
 	}
 
 	getActiveDescriptor(): IHarnessDescriptor {


### PR DESCRIPTION
## Problem

`SessionsCustomizationHarnessService` is constructed with an empty harness array (`super([], '')`). Before any external harness is registered via `registerExternalHarness()`, calling `getStorageSourceFilter()` crashes:

```
ERR Cannot read properties of undefined (reading 'getStorageSourceFilter')
```

This happens because `_getAllHarnesses()` returns `[]`, so both `all.find(...)` and the `all[0]` fallback are `undefined`.

## Fix

Consolidate the fallback into a single optional-chained lookup and return an empty sources filter (`{ sources: [] }`) when no harnesses exist yet.