### PR TITLE
Chat customization should open with the currently active harness

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -32,10 +32,14 @@ import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
+import { localChatSessionType } from '../../common/chatSessionsService.js';
+import { CustomizationHarness, ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
+import { IChatWidgetService } from '../chat.js';
 import { AgentPluginItemKind } from '../agentPluginEditor/agentPluginItems.js';
 import {
 	AI_CUSTOMIZATION_ITEM_DISABLED_KEY,
@@ -693,6 +697,23 @@ class AICustomizationManagementActionsContribution extends Disposable implements
 
 			async run(accessor: ServicesAccessor, section?: AICustomizationManagementSection): Promise<void> {
 				const editorService = accessor.get(IEditorService);
+				const chatWidgetService = accessor.get(IChatWidgetService);
+				const harnessService = accessor.get(ICustomizationHarnessService);
+
+				// Detect the active chat session type and switch the harness
+				// so the customization editor opens in the matching context.
+				const sessionResource = chatWidgetService.lastFocusedWidget?.viewModel?.sessionResource;
+				if (sessionResource) {
+					const sessionType = getChatSessionType(sessionResource);
+					const harnessId = sessionType === localChatSessionType
+						? CustomizationHarness.VSCode
+						: sessionType;
+					const available = harnessService.availableHarnesses.get();
+					if (available.some(h => h.id === harnessId)) {
+						harnessService.setActiveHarness(harnessId);
+					}
+				}
+
 				const input = AICustomizationManagementEditorInput.getOrCreate();
 				const pane = await editorService.openEditor(input, { pinned: true });
 				if (section && pane instanceof AICustomizationManagementEditor) {


### PR DESCRIPTION
When the "Open Customizations" command is invoked (e.g. via the gear icon in the chat view), detect the currently active chat session type and set the corresponding harness in the customization editor. This ensures the editor opens filtered to the right harness instead of always defaulting to "Local".

For example, if the user has switched to Copilot CLI in the chat view and clicks the gear, the Customizations editor now opens with the "Copilot CLI" harness selected.

The mapping is:
- `local` session type → `vscode` (Local) harness
- Any other session type (e.g. `copilotcli`) → used directly as the harness ID
- Only switches if the harness exists in the available harnesses list

Fixes #309468