### PR TITLE
Lay out webview view after claim to avoid flash in wrong area

### DIFF
--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -163,6 +163,15 @@ export class WebviewViewPane extends ViewPane {
 		if (this.isBodyVisible()) {
 			this.activate();
 			this._webview.value?.claim(this, getWindow(this.element), undefined);
+			// Lay out the webview immediately after claiming so that it is
+			// positioned over the current view container before the next paint.
+			// Without this, the overlay container may briefly become visible at
+			// stale coordinates from a previous layout (for example, when the
+			// pane was last shown in a different part of the workbench), causing
+			// a one-frame flash in the wrong location. See #243038.
+			if (this._container) {
+				this.layoutWebview();
+			}
 		} else {
 			this._webview.value?.release(this);
 		}


### PR DESCRIPTION
Fixes #243038

## What
When a sidebar (or auxiliary bar) webview view is toggled while the panel alignment is set to `justify`, the webview briefly flashes in the panel area before settling back into its correct location.

## Why
`OverlayWebview` is absolutely positioned and reuses its DOM element across shows/hides. `WebviewViewPane.updateTreeVisibility()` calls `claim()` to make the overlay container visible, but it does not trigger an immediate layout pass. The container therefore becomes visible at whatever coordinates `doLayoutWebviewOverElement` set the last time the overlay was laid out. When the workbench layout has changed in the interim (e.g. the panel was opened in `justify` alignment, which shifts the bounding rect of the side bar), those stale coordinates can land in the panel area for a single frame, producing the observed flash. The next layout call (driven by `layoutBody` / the resize observer) then snaps the overlay back into the correct place.

## Fix
After `claim()`, explicitly call `layoutWebview()` so that the overlay is repositioned over the current view pane container before the next paint. This is guarded on `_container` being set, so it is a no-op until `renderBody` has run. The existing `layoutBody`-driven layout path still runs as before; this just ensures the very first paint after a claim uses up-to-date coordinates rather than the stale ones from the previous show.

## Risk
Very small. The change adds one extra synchronous `layoutWebviewOverElement` call on visibility transitions, which already happens on every resize. No behavior change when `_container` is unset (initial construction), and `release()` continues to hide the overlay as before.