### PR TITLE
Fix use-after-dispose in AICustomizationListWidget (fixes #309919)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -822,6 +822,9 @@ export class AICustomizationListWidget extends Disposable {
 		this.currentSection = section;
 		this.updateSectionHeader();
 		await this.loadItems();
+		if (this._store.isDisposed) {
+			return;
+		}
 		this.updateAddButton();
 	}
 
@@ -1103,6 +1106,9 @@ export class AICustomizationListWidget extends Disposable {
 	 */
 	async refresh(): Promise<void> {
 		await this.loadItems();
+		if (this._store.isDisposed) {
+			return;
+		}
 		this.updateAddButton();
 	}
 
@@ -1122,8 +1128,8 @@ export class AICustomizationListWidget extends Disposable {
 			items = [];
 		}
 
-		if (this.currentSection !== section || this._loadItemsSeq !== seq) {
-			return; // section changed or a newer load started while loading
+		if (this._store.isDisposed || this.currentSection !== section || this._loadItemsSeq !== seq) {
+			return; // disposed, section changed, or a newer load started while loading
 		}
 
 		this.allItems = items;
@@ -1509,6 +1515,9 @@ export class AICustomizationListWidget extends Disposable {
 	async generateDebugReport(): Promise<string> {
 		// Ensure items are loaded before capturing the snapshot
 		await this.loadItems();
+		if (this._store.isDisposed) {
+			return '';
+		}
 		const activeDescriptor = this.harnessService.getActiveDescriptor();
 		return generateCustomizationDebugReport(
 			this.currentSection,

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
@@ -4,9 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DeferredPromise } from '../../../../../../base/common/async.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
+import { AICustomizationListWidget } from '../../../browser/aiCustomization/aiCustomizationListWidget.js';
 import { extractExtensionIdFromPath, getCustomizationSecondaryText, truncateToFirstLine } from '../../../browser/aiCustomization/aiCustomizationListWidgetUtils.js';
+import { AICustomizationManagementSection, IAICustomizationWorkspaceService } from '../../../common/aiCustomizationWorkspaceService.js';
+import { ICustomizationHarnessService, ICustomizationItem, IHarnessDescriptor, IStorageSourceFilter } from '../../../common/customizationHarnessService.js';
+import { ContributionEnablementState } from '../../../common/enablement.js';
+import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
+import { IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
 
 suite('aiCustomizationListWidget', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -112,6 +128,135 @@ suite('aiCustomizationListWidget', () => {
 				extractExtensionIdFromPath('/workspace/extensions/my-extension/SKILL.md'),
 				undefined
 			);
+		});
+	});
+
+	suite('dispose-during-async guards', () => {
+
+		let disposables: DisposableStore;
+		let instaService: TestInstantiationService;
+		let fetchDeferred: DeferredPromise<ICustomizationItem[] | undefined>;
+
+		function createMockHarnessDescriptor(): IHarnessDescriptor {
+			return {
+				id: 'test',
+				label: 'Test',
+				icon: Codicon.settingsGear,
+				getStorageSourceFilter: (): IStorageSourceFilter => ({ sources: [PromptsStorage.local, PromptsStorage.user] }),
+				itemProvider: {
+					onDidChange: Event.None,
+					provideChatSessionCustomizations: (_token: CancellationToken) => {
+						return fetchDeferred.p;
+					},
+				},
+			};
+		}
+
+		setup(() => {
+			disposables = new DisposableStore();
+			fetchDeferred = new DeferredPromise();
+			const descriptor = createMockHarnessDescriptor();
+
+			instaService = workbenchInstantiationService({}, disposables);
+
+			instaService.stub(IPromptsService, {
+				onDidChangeCustomAgents: Event.None,
+				onDidChangeSlashCommands: Event.None,
+				onDidChangeSkills: Event.None,
+				onDidChangeHooks: Event.None,
+				onDidChangeInstructions: Event.None,
+				listPromptFiles: async () => [],
+				getCustomAgents: async () => [],
+				findAgentSkills: async () => [],
+				getHooks: async () => undefined,
+				getInstructionFiles: async () => [],
+				getDisabledPromptFiles: () => new ResourceMap(),
+			});
+
+			instaService.stub(IAICustomizationWorkspaceService, {
+				activeProjectRoot: observableValue('test', undefined),
+				getActiveProjectRoot: () => undefined,
+				managementSections: [AICustomizationManagementSection.Agents],
+				isSessionsWindow: false,
+				welcomePageFeatures: { showGettingStartedBanner: false },
+				getStorageSourceFilter: () => ({ sources: [] }),
+				getSkillUIIntegrations: () => new Map(),
+				hasOverrideProjectRoot: observableValue('test', false),
+				commitFiles: async () => { },
+				deleteFiles: async () => { },
+				generateCustomization: async () => { },
+				setOverrideProjectRoot: () => { },
+				clearOverrideProjectRoot: () => { },
+			});
+
+			instaService.stub(ICustomizationHarnessService, {
+				activeHarness: observableValue('test', 'test'),
+				availableHarnesses: observableValue('test', [descriptor]),
+				setActiveHarness: () => { },
+				getStorageSourceFilter: () => ({ sources: [] }),
+				getActiveDescriptor: () => descriptor,
+				registerExternalHarness: () => ({ dispose() { } }),
+			});
+
+			instaService.stub(IAgentPluginService, {
+				plugins: observableValue('test', []),
+				enablementModel: {
+					readEnabled: () => ContributionEnablementState.EnabledProfile,
+					setEnabled: () => { },
+					remove: () => { },
+				},
+			});
+
+			instaService.stub(ICommandService, {
+				executeCommand: async () => undefined,
+				onWillExecuteCommand: Event.None,
+				onDidExecuteCommand: Event.None,
+			});
+		});
+
+		teardown(() => {
+			// Resolve any pending deferred to avoid hanging promises.
+			if (!fetchDeferred.isSettled) {
+				fetchDeferred.complete(undefined);
+			}
+			disposables.dispose();
+		});
+
+		test('refresh does not throw when disposed during loadItems', async () => {
+			const widget = disposables.add(instaService.createInstance(AICustomizationListWidget));
+
+			// Start refresh — loadItems will await fetchItemsForSection
+			// which blocks on our deferred
+			const refreshPromise = widget.refresh();
+
+			// Dispose before async completes
+			widget.dispose();
+
+			// Resolve the deferred — this should not cause an error
+			// because the disposal guard prevents updateAddButton() from running
+			await fetchDeferred.complete(undefined);
+			await refreshPromise;
+		});
+
+		test('setSection does not throw when disposed during loadItems', async () => {
+			const widget = disposables.add(instaService.createInstance(AICustomizationListWidget));
+
+			const setSectionPromise = widget.setSection(AICustomizationManagementSection.Instructions);
+			widget.dispose();
+
+			await fetchDeferred.complete(undefined);
+			await setSectionPromise;
+		});
+
+		test('generateDebugReport returns empty string when disposed during loadItems', async () => {
+			const widget = disposables.add(instaService.createInstance(AICustomizationListWidget));
+
+			const reportPromise = widget.generateDebugReport();
+			widget.dispose();
+
+			await fetchDeferred.complete(undefined);
+			const result = await reportPromise;
+			assert.strictEqual(result, '');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
@@ -15,14 +15,14 @@ import { TestInstantiationService } from '../../../../../../platform/instantiati
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { AICustomizationListWidget } from '../../../browser/aiCustomization/aiCustomizationListWidget.js';
 import { extractExtensionIdFromPath, getCustomizationSecondaryText, truncateToFirstLine } from '../../../browser/aiCustomization/aiCustomizationListWidgetUtils.js';
-import { AICustomizationManagementSection, IAICustomizationWorkspaceService } from '../../../common/aiCustomizationWorkspaceService.js';
-import { ICustomizationHarnessService, ICustomizationItem, IHarnessDescriptor, IStorageSourceFilter } from '../../../common/customizationHarnessService.js';
+import { AICustomizationManagementSection, IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../common/aiCustomizationWorkspaceService.js';
+import { ICustomizationHarnessService, ICustomizationItem, IHarnessDescriptor } from '../../../common/customizationHarnessService.js';
 import { ContributionEnablementState } from '../../../common/enablement.js';
 import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
 import { IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { ResourceMap } from '../../../../../../base/common/map.js';
+import { ResourceSet } from '../../../../../../base/common/map.js';
 
 suite('aiCustomizationListWidget', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -136,6 +136,7 @@ suite('aiCustomizationListWidget', () => {
 		let disposables: DisposableStore;
 		let instaService: TestInstantiationService;
 		let fetchDeferred: DeferredPromise<ICustomizationItem[] | undefined>;
+		let fetchStarted: DeferredPromise<void>;
 
 		function createMockHarnessDescriptor(): IHarnessDescriptor {
 			return {
@@ -146,6 +147,7 @@ suite('aiCustomizationListWidget', () => {
 				itemProvider: {
 					onDidChange: Event.None,
 					provideChatSessionCustomizations: (_token: CancellationToken) => {
+						fetchStarted.complete();
 						return fetchDeferred.p;
 					},
 				},
@@ -155,6 +157,7 @@ suite('aiCustomizationListWidget', () => {
 		setup(() => {
 			disposables = new DisposableStore();
 			fetchDeferred = new DeferredPromise();
+			fetchStarted = new DeferredPromise();
 			const descriptor = createMockHarnessDescriptor();
 
 			instaService = workbenchInstantiationService({}, disposables);
@@ -170,7 +173,7 @@ suite('aiCustomizationListWidget', () => {
 				findAgentSkills: async () => [],
 				getHooks: async () => undefined,
 				getInstructionFiles: async () => [],
-				getDisabledPromptFiles: () => new ResourceMap(),
+				getDisabledPromptFiles: () => new ResourceSet(),
 			});
 
 			instaService.stub(IAICustomizationWorkspaceService, {
@@ -229,12 +232,13 @@ suite('aiCustomizationListWidget', () => {
 			// which blocks on our deferred
 			const refreshPromise = widget.refresh();
 
-			// Dispose before async completes
+			// Wait until the provider is actually called before disposing
+			await fetchStarted.p;
 			widget.dispose();
 
 			// Resolve the deferred — this should not cause an error
 			// because the disposal guard prevents updateAddButton() from running
-			await fetchDeferred.complete(undefined);
+			fetchDeferred.complete(undefined);
 			await refreshPromise;
 		});
 
@@ -242,9 +246,11 @@ suite('aiCustomizationListWidget', () => {
 			const widget = disposables.add(instaService.createInstance(AICustomizationListWidget));
 
 			const setSectionPromise = widget.setSection(AICustomizationManagementSection.Instructions);
+
+			await fetchStarted.p;
 			widget.dispose();
 
-			await fetchDeferred.complete(undefined);
+			fetchDeferred.complete(undefined);
 			await setSectionPromise;
 		});
 
@@ -252,9 +258,11 @@ suite('aiCustomizationListWidget', () => {
 			const widget = disposables.add(instaService.createInstance(AICustomizationListWidget));
 
 			const reportPromise = widget.generateDebugReport();
+
+			await fetchStarted.p;
 			widget.dispose();
 
-			await fetchDeferred.complete(undefined);
+			fetchDeferred.complete(undefined);
 			const result = await reportPromise;
 			assert.strictEqual(result, '');
 		});


### PR DESCRIPTION
## Summary

Fixes #309919 — `AbstractContextKeyService has been disposed` error in the Agents product.

## Root Cause

`AICustomizationListWidget.refresh()` is async — it `await`s `loadItems()` then calls `updateAddButton()`. If the widget's scoped `contextKeyService` is disposed while `loadItems()` is running (e.g., during session teardown), the post-await `updateAddButton()` → `buildCreateActions()` → `menuService.getMenuActions()` call passes the disposed service, which throws.

This is a classic use-after-dispose async race condition. The same pattern exists in `setSection()` and `generateDebugReport()`.

## Fix

Add `this._store.isDisposed` disposal guards after every async await point, following the standard VS Code pattern:

- **`refresh()`** — guard after `await this.loadItems()` before `updateAddButton()`
- **`setSection()`** — same pattern
- **`loadItems()`** — extended the existing stale-check to also bail on disposed widget (prevents DOM mutations via `filterItems()` → `list.splice()`)
- **`generateDebugReport()`** — guard after `await this.loadItems()`, returning `''`

## Tests

Added 3 tests exercising the dispose-during-async race condition using `DeferredPromise` to control async timing and a `fetchStarted` signal for deterministic synchronization:
- `refresh does not throw when disposed during loadItems`
- `setSection does not throw when disposed during loadItems`
- `generateDebugReport returns empty string when disposed during loadItems`