### PR TITLE
Agents: Open Agents Application in a new window by default

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -44,7 +44,7 @@ export class OpenAgentsWindowAction extends Action2 {
 			await openerService.open(URI.from({ scheme: productService.embedded.urlProtocol, authority: Schemas.file }), { openExternal: true });
 		} else {
 			const nativeHostService = accessor.get(INativeHostService);
-			await nativeHostService.openAgentsWindow({ forceNewWindow: options?.forceNewWindow });
+			await nativeHostService.openAgentsWindow({ forceNewWindow: options?.forceNewWindow ?? true });
 		}
 	}
 }


### PR DESCRIPTION
Default `forceNewWindow` to `true` in `OpenAgentsWindowAction` so the "Open Agents Application" command opens a new window instead of reusing an existing one. Callers that explicitly pass `forceNewWindow: false` are still respected.