### PR TITLE
fix: normalize OTel message JSON to GenAI semantic conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ test/componentFixtures/.screenshots/*
 !test/componentFixtures/.screenshots/baseline/
 dist
 .playwright-cli
+.playwright-mcp
 .claude/
 .agents/agents/*.local.md
 .github/agents/*.local.md

--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -489,21 +489,30 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 					[StdAttr.SERVER_ADDRESS]: 'api.anthropic.com',
 				},
 			});
-			// Opt-in: capture input messages
+			// Opt-in: capture input messages in OTel GenAI format
 			if (this._otelService.config.captureContent) {
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
 					const inputMsgs = messages.map(m => {
 						const msg = m as LanguageModelChatMessage;
 						const role = roleNames[msg.role] ?? String(msg.role);
-						const textParts: string[] = [];
+						const parts: Array<{ type: string; content?: string | unknown; id?: string; name?: string; arguments?: unknown; response?: unknown }> = [];
 						if (Array.isArray(msg.content)) {
 							for (const p of msg.content) {
-								if (p instanceof LanguageModelTextPart) { textParts.push(p.value); }
+								if (p instanceof LanguageModelTextPart) {
+									parts.push({ type: 'text', content: p.value });
+								} else if (p instanceof LanguageModelToolCallPart) {
+									parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
+								} else if (p instanceof LanguageModelToolResultPart) {
+									const resultText = p.content.map((c: unknown) => c instanceof LanguageModelTextPart ? c.value : '').join('');
+									parts.push({ type: 'tool_call_response', id: p.callId, response: resultText });
+								}
 							}
 						}
-						const content = textParts.length > 0 ? textParts.join('') : '[non-text content]';
-						return { role, parts: [{ type: 'text', content }] };
+						if (parts.length === 0) {
+							parts.push({ type: 'text', content: '[non-text content]' });
+						}
+						return { role, parts };
 					});
 					otelSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(inputMsgs)));
 				} catch { /* swallow */ }

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -344,21 +344,27 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 					[StdAttr.SERVER_ADDRESS]: 'generativelanguage.googleapis.com',
 				},
 			});
-			// Opt-in: capture input messages
+			// Opt-in: capture input messages in OTel GenAI format
 			if (this._otelService.config.captureContent) {
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
 					const inputMsgs = messages.map(m => {
 						const msg = m as LanguageModelChatMessage;
 						const role = roleNames[msg.role] ?? String(msg.role);
-						const textParts: string[] = [];
+						const parts: Array<{ type: string; content?: string; id?: string; name?: string; arguments?: unknown }> = [];
 						if (Array.isArray(msg.content)) {
 							for (const p of msg.content) {
-								if (p instanceof LanguageModelTextPart) { textParts.push(p.value); }
+								if (p instanceof LanguageModelTextPart) {
+									parts.push({ type: 'text', content: p.value });
+								} else if (p instanceof LanguageModelToolCallPart) {
+									parts.push({ type: 'tool_call', id: p.callId, name: p.name, arguments: p.input });
+								}
 							}
 						}
-						const content = textParts.length > 0 ? textParts.join('') : '[non-text content]';
-						return { role, parts: [{ type: 'text', content }] };
+						if (parts.length === 0) {
+							parts.push({ type: 'text', content: '[non-text content]' });
+						}
+						return { role, parts };
 					});
 					otelSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(inputMsgs)));
 				} catch { /* swallow */ }

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -28,7 +28,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, StdAttr, toInputMessages, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -280,20 +280,17 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 						} else {
 							systemText = JSON.stringify(systemContent);
 						}
-						otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, systemText);
+						// Format as OTel GenAI system instruction JSON schema
+						otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, JSON.stringify(toSystemInstructions(systemText)));
 					}
 				}
 
 				// Always capture full request content for the debug panel
 				if (otelInferenceSpan) {
-					const capiMessages = (requestBody.messages ?? requestBody.input) as ReadonlyArray<{ role?: string; content?: string | unknown[] }> | undefined;
+					const capiMessages = (requestBody.messages ?? requestBody.input) as ReadonlyArray<Record<string, unknown>> | undefined;
 					if (capiMessages) {
-						// Normalize non-string content (Anthropic arrays, Responses API parts) to strings for OTel schema
-						const normalized = capiMessages.map(m => ({
-							...m,
-							content: typeof m.content === 'string' ? m.content : m.content ? JSON.stringify(m.content) : undefined,
-						}));
-						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(toInputMessages(normalized))));
+						// Normalize provider-specific content (Anthropic tool_use/tool_result, OpenAI tool messages) to OTel schema
+						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(normalizeProviderMessages(capiMessages))));
 					}
 				}
 				tokenCount = await countTokens();

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -281,7 +281,10 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 							systemText = JSON.stringify(systemContent);
 						}
 						// Format as OTel GenAI system instruction JSON schema
-						otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, JSON.stringify(toSystemInstructions(systemText)));
+						const systemInstructions = toSystemInstructions(systemText);
+						if (systemInstructions) {
+							otelInferenceSpan.setAttribute(GenAiAttr.SYSTEM_INSTRUCTIONS, JSON.stringify(systemInstructions));
+						}
 					}
 				}
 

--- a/extensions/copilot/src/platform/otel/common/genAiEvents.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiEvents.ts
@@ -64,9 +64,10 @@ export function emitInferenceDetailsEvent(
 			const systemText = typeof request.systemMessage === 'string'
 				? request.systemMessage
 				: JSON.stringify(request.systemMessage);
-			attributes[GenAiAttr.SYSTEM_INSTRUCTIONS] = truncateForOTel(JSON.stringify(
-				toSystemInstructions(systemText)
-			));
+			const systemInstructions = toSystemInstructions(systemText);
+			if (systemInstructions !== undefined) {
+				attributes[GenAiAttr.SYSTEM_INSTRUCTIONS] = truncateForOTel(JSON.stringify(systemInstructions));
+			}
 		}
 		if (request.tools !== undefined) {
 			attributes[GenAiAttr.TOOL_DEFINITIONS] = truncateForOTel(JSON.stringify(request.tools));

--- a/extensions/copilot/src/platform/otel/common/genAiEvents.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiEvents.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { GenAiAttr, GenAiOperationName, StdAttr } from './genAiAttributes';
-import { truncateForOTel } from './messageFormatters';
+import { normalizeProviderMessages, toSystemInstructions, truncateForOTel } from './messageFormatters';
 import type { IOTelService } from './otelService';
 import { type WorkspaceOTelMetadata, workspaceMetadataToOTelAttributes } from './workspaceOTelMetadata';
 
@@ -52,12 +52,21 @@ export function emitInferenceDetailsEvent(
 	}
 
 	// Full content capture with truncation to prevent OTLP batch failures
+	// Normalize to OTel GenAI semantic convention format
 	if (otel.config.captureContent) {
 		if (request.messages !== undefined) {
-			attributes[GenAiAttr.INPUT_MESSAGES] = truncateForOTel(JSON.stringify(request.messages));
+			const msgs = Array.isArray(request.messages) ? request.messages as ReadonlyArray<Record<string, unknown>> : undefined;
+			attributes[GenAiAttr.INPUT_MESSAGES] = truncateForOTel(JSON.stringify(
+				msgs ? normalizeProviderMessages(msgs) : request.messages
+			));
 		}
 		if (request.systemMessage !== undefined) {
-			attributes[GenAiAttr.SYSTEM_INSTRUCTIONS] = truncateForOTel(JSON.stringify(request.systemMessage));
+			const systemText = typeof request.systemMessage === 'string'
+				? request.systemMessage
+				: JSON.stringify(request.systemMessage);
+			attributes[GenAiAttr.SYSTEM_INSTRUCTIONS] = truncateForOTel(JSON.stringify(
+				toSystemInstructions(systemText)
+			));
 		}
 		if (request.tools !== undefined) {
 			attributes[GenAiAttr.TOOL_DEFINITIONS] = truncateForOTel(JSON.stringify(request.tools));

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -6,7 +6,7 @@
 export { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
 export { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitToolCallEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
-export { toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
+export { normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';
 export { resolveOTelConfig, DEFAULT_OTLP_ENDPOINT, type OTelConfig, type OTelConfigInput } from './otelConfig';
 export { IOTelService, SpanKind, SpanStatusCode, type ICompletedSpanData, type ISpanEventData, type ISpanEventRecord, type ISpanHandle, type OTelModelOptions, type SpanOptions, type TraceContext } from './otelService';

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -40,7 +40,7 @@ export interface OTelOutputMessage extends OTelChatMessage {
 export type OTelMessagePart =
 	| { type: 'text'; content: string }
 	| { type: 'tool_call'; id: string; name: string; arguments: unknown }
-	| { type: 'tool_call_response'; id: string; content: unknown }
+	| { type: 'tool_call_response'; id: string; response: unknown }
 	| { type: 'reasoning'; content: string };
 
 export type OTelSystemInstruction = Array<{ type: 'text'; content: string }>;
@@ -54,10 +54,17 @@ export interface OTelToolDefinition {
 
 /**
  * Convert an array of internal messages to OTel input message format.
+ * Handles OpenAI format (tool_calls, tool_call_id) natively.
  */
-export function toInputMessages(messages: ReadonlyArray<{ role?: string; content?: string; tool_calls?: ReadonlyArray<{ id: string; function: { name: string; arguments: string } }> }>): OTelChatMessage[] {
+export function toInputMessages(messages: ReadonlyArray<{ role?: string; content?: string; tool_calls?: ReadonlyArray<{ id: string; function: { name: string; arguments: string } }>; tool_call_id?: string }>): OTelChatMessage[] {
 	return messages.map(msg => {
 		const parts: OTelMessagePart[] = [];
+
+		// OpenAI tool-result message (role=tool): map to tool_call_response
+		if (msg.role === 'tool' && msg.tool_call_id) {
+			parts.push({ type: 'tool_call_response', id: msg.tool_call_id, response: msg.content ?? '' });
+			return { role: msg.role, parts };
+		}
 
 		if (msg.content) {
 			parts.push({ type: 'text', content: msg.content });
@@ -124,6 +131,92 @@ export function toSystemInstructions(systemMessage: string | undefined): OTelSys
 		return undefined;
 	}
 	return [{ type: 'text', content: systemMessage }];
+}
+
+/**
+ * Normalize provider-specific messages (Anthropic content blocks, OpenAI tool messages)
+ * to OTel GenAI semantic convention format.
+ *
+ * Handles:
+ * - Anthropic content block arrays: tool_use → tool_call, tool_result → tool_call_response
+ * - OpenAI format: tool_calls, role=tool with tool_call_id
+ * - Plain string content
+ */
+export function normalizeProviderMessages(messages: ReadonlyArray<Record<string, unknown>>): OTelChatMessage[] {
+	return messages.map(msg => {
+		const role = msg.role as string | undefined;
+		const parts: OTelMessagePart[] = [];
+		const content = msg.content;
+
+		// OpenAI tool-result message
+		if (role === 'tool' && typeof msg.tool_call_id === 'string') {
+			parts.push({ type: 'tool_call_response', id: msg.tool_call_id, response: content ?? '' });
+			return { role, parts };
+		}
+
+		if (typeof content === 'string') {
+			parts.push({ type: 'text', content });
+		} else if (Array.isArray(content)) {
+			// Anthropic content block array
+			for (const block of content) {
+				if (!block || typeof block !== 'object') { continue; }
+				const b = block as Record<string, unknown>;
+				switch (b.type) {
+					case 'text':
+						if (typeof b.text === 'string') {
+							parts.push({ type: 'text', content: b.text });
+						}
+						break;
+					case 'tool_use':
+						parts.push({
+							type: 'tool_call',
+							id: String(b.id ?? ''),
+							name: String(b.name ?? ''),
+							arguments: b.input,
+						});
+						break;
+					case 'tool_result':
+						parts.push({
+							type: 'tool_call_response',
+							id: String(b.tool_use_id ?? ''),
+							response: b.content ?? '',
+						});
+						break;
+					case 'thinking':
+						if (typeof b.thinking === 'string') {
+							parts.push({ type: 'reasoning', content: b.thinking });
+						}
+						break;
+					default:
+						// Unknown block type — include as text fallback
+						parts.push({ type: 'text', content: JSON.stringify(b) });
+						break;
+				}
+			}
+		}
+
+		// OpenAI tool_calls
+		const toolCalls = msg.tool_calls;
+		if (Array.isArray(toolCalls)) {
+			for (const tc of toolCalls) {
+				if (!tc || typeof tc !== 'object') { continue; }
+				const call = tc as Record<string, unknown>;
+				const fn = call.function as Record<string, unknown> | undefined;
+				if (fn) {
+					let args: unknown;
+					try { args = typeof fn.arguments === 'string' ? JSON.parse(fn.arguments) : fn.arguments; } catch { args = fn.arguments; }
+					parts.push({
+						type: 'tool_call',
+						id: String(call.id ?? ''),
+						name: String(fn.name ?? ''),
+						arguments: args,
+					});
+				}
+			}
+		}
+
+		return { role, parts };
+	});
 }
 
 /**

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -154,7 +154,7 @@ export function normalizeProviderMessages(messages: ReadonlyArray<Record<string,
 			return { role, parts };
 		}
 
-		if (typeof content === 'string') {
+		if (typeof content === 'string' && content.length > 0) {
 			parts.push({ type: 'text', content });
 		} else if (Array.isArray(content)) {
 			// Anthropic content block array

--- a/extensions/copilot/src/platform/otel/common/test/genAiEvents.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/genAiEvents.spec.ts
@@ -73,7 +73,7 @@ describe('emitInferenceDetailsEvent', () => {
 
 	it('includes content attributes when captureContent is true', () => {
 		const otel = createMockOTel(true);
-		const messages = [{ role: 'user', text: 'hello' }];
+		const messages = [{ role: 'user', content: 'hello' }];
 		const systemMsg = 'You are helpful';
 		const tools = [{ name: 'readFile' }];
 
@@ -83,8 +83,10 @@ describe('emitInferenceDetailsEvent', () => {
 		);
 
 		const attrs = otel.emitLogRecord.mock.calls[0][1];
-		expect(attrs[GenAiAttr.INPUT_MESSAGES]).toBe(JSON.stringify(messages));
-		expect(attrs[GenAiAttr.SYSTEM_INSTRUCTIONS]).toBe(JSON.stringify(systemMsg));
+		// Messages should be normalized to OTel GenAI format
+		expect(attrs[GenAiAttr.INPUT_MESSAGES]).toBe(JSON.stringify([{ role: 'user', parts: [{ type: 'text', content: 'hello' }] }]));
+		// System instructions should be wrapped in OTel format
+		expect(attrs[GenAiAttr.SYSTEM_INSTRUCTIONS]).toBe(JSON.stringify([{ type: 'text', content: 'You are helpful' }]));
 		expect(attrs[GenAiAttr.TOOL_DEFINITIONS]).toBe(JSON.stringify(tools));
 	});
 

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
+import { normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../messageFormatters';
 
 describe('toInputMessages', () => {
 	it('converts a simple text message', () => {
@@ -69,6 +69,95 @@ describe('toInputMessages', () => {
 	it('preserves undefined role', () => {
 		const result = toInputMessages([{ content: 'no role' }]);
 		expect(result[0].role).toBeUndefined();
+	});
+
+	it('converts OpenAI tool-result messages to tool_call_response', () => {
+		const result = toInputMessages([{
+			role: 'tool',
+			content: 'file contents here',
+			tool_call_id: 'call_abc123',
+		}]);
+		expect(result).toEqual([{
+			role: 'tool',
+			parts: [{ type: 'tool_call_response', id: 'call_abc123', response: 'file contents here' }],
+		}]);
+	});
+});
+
+describe('normalizeProviderMessages', () => {
+	it('converts Anthropic tool_use blocks to tool_call', () => {
+		const result = normalizeProviderMessages([{
+			role: 'assistant',
+			content: [
+				{ type: 'text', text: 'Let me read that file' },
+				{ type: 'tool_use', id: 'toolu_123', name: 'readFile', input: { path: 'foo.ts' } },
+			],
+		}]);
+		expect(result).toEqual([{
+			role: 'assistant',
+			parts: [
+				{ type: 'text', content: 'Let me read that file' },
+				{ type: 'tool_call', id: 'toolu_123', name: 'readFile', arguments: { path: 'foo.ts' } },
+			],
+		}]);
+	});
+
+	it('converts Anthropic tool_result blocks to tool_call_response', () => {
+		const result = normalizeProviderMessages([{
+			role: 'user',
+			content: [
+				{ type: 'tool_result', tool_use_id: 'toolu_123', content: 'file contents' },
+			],
+		}]);
+		expect(result).toEqual([{
+			role: 'user',
+			parts: [
+				{ type: 'tool_call_response', id: 'toolu_123', response: 'file contents' },
+			],
+		}]);
+	});
+
+	it('converts OpenAI tool-result messages', () => {
+		const result = normalizeProviderMessages([{
+			role: 'tool',
+			tool_call_id: 'call_abc',
+			content: 'result text',
+		}]);
+		expect(result).toEqual([{
+			role: 'tool',
+			parts: [{ type: 'tool_call_response', id: 'call_abc', response: 'result text' }],
+		}]);
+	});
+
+	it('converts OpenAI tool_calls array', () => {
+		const result = normalizeProviderMessages([{
+			role: 'assistant',
+			content: 'thinking...',
+			tool_calls: [{ id: 'call_1', function: { name: 'search', arguments: '{"q":"test"}' } }],
+		}]);
+		expect(result).toEqual([{
+			role: 'assistant',
+			parts: [
+				{ type: 'text', content: 'thinking...' },
+				{ type: 'tool_call', id: 'call_1', name: 'search', arguments: { q: 'test' } },
+			],
+		}]);
+	});
+
+	it('handles plain string content', () => {
+		const result = normalizeProviderMessages([{ role: 'user', content: 'hello' }]);
+		expect(result).toEqual([{ role: 'user', parts: [{ type: 'text', content: 'hello' }] }]);
+	});
+
+	it('handles Anthropic thinking blocks', () => {
+		const result = normalizeProviderMessages([{
+			role: 'assistant',
+			content: [{ type: 'thinking', thinking: 'Let me consider...' }],
+		}]);
+		expect(result).toEqual([{
+			role: 'assistant',
+			parts: [{ type: 'reasoning', content: 'Let me consider...' }],
+		}]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes the OTel message attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`) to conform to the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md) JSON schemas.

Previously, raw provider-specific JSON was sent as telemetry (e.g., Anthropic's `tool_use`/`tool_result` types, plain text system instructions), causing errors in OTel-compatible dashboards like Aspire.

## Changes

- **`messageFormatters.ts`**: Add `normalizeProviderMessages()` — converts Anthropic content blocks (`tool_use` → `tool_call`, `tool_result` → `tool_call_response`) and OpenAI tool messages to OTel standard. Fix `tool_call_response` to use `response` field per spec (was `content`). Extend `toInputMessages()` to handle OpenAI `role: "tool"` messages.
- **`chatMLFetcher.ts`**: Use `normalizeProviderMessages()` for `gen_ai.input.messages`. Wrap `gen_ai.system_instructions` via `toSystemInstructions()` as JSON array `[{ type: "text", content: "..." }]` instead of raw string.
- **`genAiEvents.ts`**: Apply `normalizeProviderMessages()` and `toSystemInstructions()` when capturing content in inference detail events.
- **`anthropicProvider.ts`**: Input message capture now includes `LanguageModelToolCallPart` → `tool_call` and `LanguageModelToolResultPart` → `tool_call_response` (was text-only).
- **`geminiNativeProvider.ts`**: Input message capture now includes `LanguageModelToolCallPart` → `tool_call` (was text-only).
- **Tests**: 8 new tests for `normalizeProviderMessages` and updated assertions in `genAiEvents.spec.ts`.

## Verified

- All 151 OTel tests pass
- Aspire Dashboard renders GenAI details without "Error displaying GenAI content" for both Anthropic and Gemini models
- All provider paths audited (Anthropic, Gemini, OpenAI/CAPI, Azure, Ollama, xAI, OpenRouter)

Fixes #299931
Fixes #306746