### PR TITLE
sessions: show GitHub avatar in account widget

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -134,12 +134,12 @@ The panel title bar includes actions for controlling the panel:
 
 ### 3.6 Account Widget
 
-The account widget has been moved from the titlebar to the **sidebar footer**. It is rendered as a custom `AccountWidget` action view item:
+The account widget is rendered in the **right side of the titlebar** as a custom `TitleBarAccountWidget` action view item:
 
 - Registered in `contrib/accountMenu/browser/account.contribution.ts`
-- Uses the `Menus.SidebarFooter` menu
-- Shows account button with sign-in/sign-out and an update button when an update is available
-- Account menu shows signed-in user label from `IDefaultAccountService` (or Sign In), Sign Out, Settings, and Check for Updates
+- Uses the `Menus.TitleBarRightLayout` menu
+- Shows the signed-in GitHub profile image when available, and falls back to the existing account codicon when it is not
+- Opens a combined account and Copilot status hover panel with sign-in/sign-out, settings, and update actions
 
 ---
 
@@ -373,7 +373,7 @@ The Agent Sessions workbench uses specialized part implementations that extend t
 
 | Feature | Standard Parts | Agent Session Parts |
 |---------|----------------|---------------------|
-| Activity Bar integration | Full support | No activity bar; account widget in sidebar footer |
+| Activity Bar integration | Full support | No activity bar; account widget in the titlebar |
 | Composite bar position | Configurable (top/bottom/title/hidden) | Fixed: Title |
 | Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible |
 | Auto-hide support | Configurable | Disabled |
@@ -535,7 +535,7 @@ src/vs/sessions/
 │   ├── sessions.html
 │   └── sessions-dev.html
 ├── contrib/                                # Feature contributions
-│   ├── accountMenu/browser/                # Account menu widget for sidebar footer
+│   ├── accountMenu/browser/                # Account menu and titlebar account widget
 │   │   ├── account.contribution.ts
 │   │   └── media/
 │   ├── aiCustomizationManagement/browser/  # AI customization management editor
@@ -653,6 +653,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-14 | Documented the sessions account control as a titlebar widget again and noted that it now prefers the signed-in GitHub profile image, falling back to the existing account codicon when the image is unavailable. |
 | 2026-04-14 | Updated the sessions-only default configuration so notification toasts default to the top-right corner via `workbench.notifications.position: 'top-right'`, without changing the regular workbench default. |
 | 2026-04-10 | Updated the sessions titlebar widget so repository/worktree metadata truncates with ellipsis before the primary AI-generated session title when the command center gets narrow. |
 | 2026-04-10 | Updated workspace/repository section headers in the Sessions sidebar to keep their uppercase titles visible via ellipsis truncation so the section toolbar actions remain reachable when names are long. |

--- a/src/vs/sessions/README.md
+++ b/src/vs/sessions/README.md
@@ -75,7 +75,7 @@ src/vs/sessions/
 │   ├── sessions.html
 │   └── sessions-dev.html
 ├── contrib/                            ← Feature contributions
-│   ├── accountMenu/browser/            ← Account menu widget and sidebar footer
+│   ├── accountMenu/browser/            ← Account menu and titlebar account widget
 │   │   └── account.contribution.ts
 │   ├── aiCustomizationManagement/      ← AI customization management editor
 │   │   └── browser/
@@ -107,8 +107,7 @@ The Agentic Window (`Workbench`) provides a simplified, fixed-layout workbench t
 - **Simplified chrome** — No activity bar, no status bar, no banner
 - **Chat-first UX** — Chat bar is a primary part alongside sidebar and auxiliary bar
 - **Modal editor** — Editors appear as modal overlays rather than in the main grid
-- **Session-aware titlebar** — Titlebar shows active session with a session picker
-- **Sidebar footer** — Account widget and sign-in live in the sidebar footer
+- **Session-aware titlebar** — Titlebar shows the active session, session picker, and signed-in account widget
 
 See [LAYOUT.md](LAYOUT.md) for the detailed layout specification.
 

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -384,7 +384,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		const titleBarIcon = state.dotBadge ? Codicon.account : state.icon;
 
 		this.avatarElement.classList.toggle('visible', hasLoadedAvatar);
-		this.avatarElement.alt = this.getAvatarAltText();
+		this.avatarElement.alt = this.getAvatarAltText(hasLoadedAvatar);
 		if (hasLoadedAvatar) {
 			if (this.avatarElement.src !== loadedAvatarUrl) {
 				this.avatarElement.src = loadedAvatarUrl;
@@ -403,8 +403,8 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.badgeElement.style.display = shouldShowDotBadge ? '' : 'none';
 	}
 
-	private getAvatarAltText(): string {
-		if (this.accountName) {
+	private getAvatarAltText(hasLoadedAvatar: boolean): string {
+		if (hasLoadedAvatar && this.accountProviderId === 'github' && this.accountName) {
 			return localize('accountAvatarAlt', "GitHub profile image for {0}", this.accountName);
 		}
 
@@ -428,6 +428,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		}
 
 		const image = new Image();
+		image.referrerPolicy = 'no-referrer';
 		const clearHandlers = () => {
 			image.onload = null;
 			image.onerror = null;

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -8,7 +8,7 @@ import './media/accountWidget.css';
 import './media/accountTitleBarWidget.css';
 import '../../../../workbench/contrib/chat/browser/chatStatus/media/chatStatus.css';
 import Severity from '../../../../base/common/severity.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Event } from '../../../../base/common/event.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
@@ -39,7 +39,7 @@ import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from
 import { ChatStatusDashboard } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { getAccountTitleBarBadgeKey, getAccountTitleBarState } from './accountTitleBarState.js';
+import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState } from './accountTitleBarState.js';
 import { SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IAuthenticationAccessService } from '../../../../workbench/services/authentication/browser/authenticationAccessService.js';
@@ -264,19 +264,25 @@ registerUpdateMenuItems(AccountMenu, '3_updates');
 class TitleBarAccountWidget extends BaseActionViewItem {
 
 	private container: HTMLElement | undefined;
+	private avatarElement: HTMLImageElement | undefined;
 	private iconElement: HTMLElement | undefined;
 	private labelElement: HTMLElement | undefined;
 	private badgeElement: HTMLElement | undefined;
 	private accountName: string | undefined;
+	private accountProviderId: string | undefined;
 	private accountProviderLabel: string | undefined;
 	private isAccountLoading = true;
 	private accountRequestCounter = 0;
+	private avatarRequestCounter = 0;
+	private currentAvatarUrl: string | undefined;
+	private loadedAvatarUrl: string | undefined;
 	private lastState: ReturnType<typeof getAccountTitleBarState>;
 	private isMenuVisible = false;
 	private lastBadgeKey: string | undefined;
 	private dismissedBadgeKey: string | undefined;
 	private readonly copilotDashboardStore = this._register(new MutableDisposable<DisposableStore>());
 	private readonly clickPanelDisposable = this._register(new MutableDisposable<DisposableStore>());
+	private readonly avatarLoadDisposable = this._register(new MutableDisposable());
 
 	constructor(
 		action: IAction,
@@ -310,6 +316,9 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		this.container = container;
 		container.classList.add('sessions-account-titlebar-widget');
 
+		this.avatarElement = append(container, $('img.sessions-account-titlebar-widget-avatar', { alt: localize('accountAvatarAltFallback', "Account profile image"), draggable: 'false' })) as HTMLImageElement;
+		this.avatarElement.decoding = 'async';
+		this.avatarElement.referrerPolicy = 'no-referrer';
 		this.iconElement = append(container, $('.sessions-account-titlebar-widget-icon'));
 		this.labelElement = append(container, $('span.sessions-account-titlebar-widget-label'));
 		this.badgeElement = append(container, $('span.sessions-account-titlebar-widget-badge'));
@@ -336,13 +345,15 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		}
 
 		this.accountName = account?.accountName;
+		this.accountProviderId = account?.authenticationProvider.id;
 		this.accountProviderLabel = account?.authenticationProvider.name;
 		this.isAccountLoading = false;
+		this.refreshAvatar();
 		this.renderState();
 	}
 
 	private renderState(): void {
-		if (!this.container || !this.iconElement || !this.labelElement || !this.badgeElement) {
+		if (!this.container || !this.avatarElement || !this.iconElement || !this.labelElement || !this.badgeElement) {
 			return;
 		}
 
@@ -368,15 +379,83 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		}
 
 		const shouldShowDotBadge = !!badgeKey && badgeKey !== this.dismissedBadgeKey;
+		const loadedAvatarUrl = !this.isAccountLoading ? this.loadedAvatarUrl : undefined;
+		const hasLoadedAvatar = !!loadedAvatarUrl;
 		const titleBarIcon = state.dotBadge ? Codicon.account : state.icon;
 
+		this.avatarElement.classList.toggle('visible', hasLoadedAvatar);
+		this.avatarElement.alt = this.getAvatarAltText();
+		if (hasLoadedAvatar) {
+			if (this.avatarElement.src !== loadedAvatarUrl) {
+				this.avatarElement.src = loadedAvatarUrl;
+			}
+		} else {
+			this.avatarElement.removeAttribute('src');
+		}
+
 		this.iconElement.className = `sessions-account-titlebar-widget-icon ${ThemeIcon.asClassName(titleBarIcon)}`;
+		this.iconElement.classList.toggle('hidden', hasLoadedAvatar);
 		this.labelElement.textContent = '';
 		this.badgeElement.textContent = '';
 		this.badgeElement.classList.toggle('dot-badge', shouldShowDotBadge);
 		this.badgeElement.classList.toggle('dot-badge-warning', shouldShowDotBadge && state.dotBadge === 'warning');
 		this.badgeElement.classList.toggle('dot-badge-error', shouldShowDotBadge && state.dotBadge === 'error');
 		this.badgeElement.style.display = shouldShowDotBadge ? '' : 'none';
+	}
+
+	private getAvatarAltText(): string {
+		if (this.accountName) {
+			return localize('accountAvatarAlt', "GitHub profile image for {0}", this.accountName);
+		}
+
+		return localize('accountAvatarAltFallback', "Account profile image");
+	}
+
+	private refreshAvatar(): void {
+		const avatarUrl = getAccountProfileImageUrl(this.accountProviderId, this.accountName);
+		if (avatarUrl === this.currentAvatarUrl) {
+			return;
+		}
+
+		this.currentAvatarUrl = avatarUrl;
+		this.loadedAvatarUrl = undefined;
+		this.avatarLoadDisposable.clear();
+		const requestId = ++this.avatarRequestCounter;
+
+		if (!avatarUrl) {
+			this.renderState();
+			return;
+		}
+
+		const image = new Image();
+		const clearHandlers = () => {
+			image.onload = null;
+			image.onerror = null;
+		};
+		image.onload = () => {
+			if (requestId !== this.avatarRequestCounter) {
+				return;
+			}
+
+			this.loadedAvatarUrl = avatarUrl;
+			this.renderState();
+			clearHandlers();
+		};
+		image.onerror = () => {
+			if (requestId !== this.avatarRequestCounter) {
+				return;
+			}
+
+			this.loadedAvatarUrl = undefined;
+			this.renderState();
+			clearHandlers();
+		};
+		this.avatarLoadDisposable.value = toDisposable(() => {
+			clearHandlers();
+			image.src = '';
+		});
+		image.src = avatarUrl;
+		this.renderState();
 	}
 
 	private getHoverTarget(): { targetElements: HTMLElement[]; x: number } {

--- a/src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts
@@ -34,6 +34,14 @@ export interface IAccountTitleBarState {
 	readonly revealLabelOnHover?: boolean;
 }
 
+export function getAccountProfileImageUrl(accountProviderId: string | undefined, accountName: string | undefined): string | undefined {
+	if (accountProviderId !== 'github' || !accountName?.trim()) {
+		return undefined;
+	}
+
+	return `https://github.com/${encodeURIComponent(accountName.trim())}.png?size=64`;
+}
+
 export function getAccountTitleBarBadgeKey(state: IAccountTitleBarState): string | undefined {
 	if (!state.dotBadge) {
 		return undefined;

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -42,6 +42,23 @@
 	color: inherit;
 }
 
+.agent-sessions-workbench .sessions-account-titlebar-widget-icon.hidden {
+	display: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-widget-avatar {
+	display: none;
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-widget-avatar.visible {
+	display: block;
+}
+
 .agent-sessions-workbench .sessions-account-titlebar-widget-label {
 	display: none;
 }

--- a/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
+++ b/src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ChatEntitlement } from '../../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { getAccountTitleBarBadgeKey, getAccountTitleBarState, IAccountTitleBarStateContext } from '../../browser/accountTitleBarState.js';
+import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, IAccountTitleBarStateContext } from '../../browser/accountTitleBarState.js';
 
 suite('Sessions - Account Title Bar State', () => {
 
@@ -142,5 +142,18 @@ suite('Sessions - Account Title Bar State', () => {
 			label: 'Agents Signed Out',
 			kind: 'prominent',
 		});
+	});
+
+	test('returns a GitHub profile image URL for GitHub accounts', () => {
+		assert.strictEqual(
+			getAccountProfileImageUrl('github', 'mona lisa'),
+			'https://github.com/mona%20lisa.png?size=64'
+		);
+	});
+
+	test('falls back to the codicon when no GitHub profile image URL is available', () => {
+		assert.strictEqual(getAccountProfileImageUrl(undefined, 'octocat'), undefined);
+		assert.strictEqual(getAccountProfileImageUrl('github-enterprise', 'octocat'), undefined);
+		assert.strictEqual(getAccountProfileImageUrl('github', undefined), undefined);
 	});
 });


### PR DESCRIPTION
## Summary

Related to https://github.com/microsoft/vscode/issues/310014

- render the signed-in GitHub profile image in the sessions titlebar account widget
- keep the existing account codicon as the fallback for loading, signed-out, non-GitHub, and failed-image cases
- add localized avatar alt text and sync the sessions docs with the current titlebar account widget implementation

<img width="1705" height="1084" alt="Screenshot 2026-04-15 at 4 29 47 PM" src="https://github.com/user-attachments/assets/5d1f5aaf-e325-44ab-b025-8fa0e2d19b15" />

## Testing
- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts src/vs/sessions/contrib/accountMenu/browser/accountTitleBarState.ts src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css src/vs/sessions/contrib/accountMenu/test/browser/accountTitleBarState.test.ts src/vs/sessions/README.md src/vs/sessions/LAYOUT.md`

## Notes
- The Electron unit-test harness did not run successfully in this environment because it crashed before test execution (`app.setPath` on an undefined `app`).