### PR TITLE
Fix: typo 'overriden' → 'overridden' in terminal history

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1042,7 +1042,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentLanguageModel.set(model, undefined);
 
 		if (this.cachedWidth) {
-			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
+			// For quick chat and editor chat, relayout because the input may need to shrink to accommodate the model name
 			this.layout(this.cachedWidth);
 		}
 

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -198,7 +198,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move

--- a/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
@@ -440,7 +440,7 @@ export async function fetchFishHistory(accessor: ServicesAccessor): Promise<IShe
 	 *
 	 * (https://fishshell.com/docs/current/interactive.html#history-search)
 	 */
-	const overridenDataHome = env['XDG_DATA_HOME'];
+	const overriddenDataHome = env['XDG_DATA_HOME'];
 
 	// TODO: Unchecked fish behavior:
 	// What if XDG_DATA_HOME was defined but somehow $XDG_DATA_HOME/fish/fish_history
@@ -449,7 +449,7 @@ export async function fetchFishHistory(accessor: ServicesAccessor): Promise<IShe
 	let folderPrefix: string | undefined;
 	let filePath: string;
 	let sourceLabel: string;
-	if (overridenDataHome) {
+	if (overriddenDataHome) {
 		sourceLabel = '$XDG_DATA_HOME/fish/fish_history';
 		folderPrefix = env['XDG_DATA_HOME'];
 		filePath = 'fish/fish_history';

--- a/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
@@ -511,7 +511,7 @@ suite('Terminal history', () => {
 				});
 			});
 
-			suite('local (overriden path)', () => {
+			suite('local (overridden path)', () => {
 				let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 				setup(() => {
 					originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };
@@ -569,7 +569,7 @@ suite('Terminal history', () => {
 			});
 		});
 
-		suite('remote (overriden path)', () => {
+		suite('remote (overridden path)', () => {
 			let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 			setup(() => {
 				originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };

--- a/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
+++ b/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
@@ -163,7 +163,7 @@ export class ExtensionRunningLocationTracker {
 		// When doing extension host debugging, we will ignore the configured affinity
 		// because we can currently debug a single extension host
 		if (!this._environmentService.isExtensionDevelopment) {
-			// Go through each configured affinity and try to accomodate it
+			// Go through each configured affinity and try to accommodate it
 			const configuredAffinities = this._configurationService.getValue<{ [extensionId: string]: number } | undefined>('extensions.experimental.affinity') || {};
 			const configuredExtensionIds = Object.keys(configuredAffinities);
 			const configuredAffinityToResultingAffinity = new Map<number, number>();


### PR DESCRIPTION
Fixes spelling of 'overridden' (was 'overriden') in terminal history module and related tests.

Changes:
- `history.ts`: Variable `overridenDataHome` → `overriddenDataHome` (and all references)
- `history.test.ts`: Suite names updated to match correct spelling