### PR TITLE
Fix: rename 'continousMatchingGlobPattern' to 'continuousMatchingGlobPattern'

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -591,7 +591,7 @@ export class ExplorerFindProvider implements IAsyncFindProvider<ExplorerItem> {
 	}
 
 	private async searchInWorkspace(patternLowercase: string, root: ExplorerItem, rootIndex: number, isFuzzyMatch: boolean, token: CancellationToken): Promise<{ explorerRoot: ExplorerItem; files: URI[]; directories: URI[]; hitMaxResults: boolean }> {
-		const segmentMatchPattern = isFuzzyMatch ? fuzzyMatchingGlobPattern(patternLowercase) : continousMatchingGlobPattern(patternLowercase);
+		const segmentMatchPattern = isFuzzyMatch ? fuzzyMatchingGlobPattern(patternLowercase) : continuousMatchingGlobPattern(patternLowercase);
 
 		const searchExcludePattern = getExcludes(this.configurationService.getValue<ISearchConfiguration>({ resource: root.resource })) || {};
 		const searchOptions: IFileQuery = {
@@ -692,7 +692,7 @@ function fuzzyMatchingGlobPattern(pattern: string): string {
 	return '*' + pattern.split('').join('*') + '*';
 }
 
-function continousMatchingGlobPattern(pattern: string): string {
+function continuousMatchingGlobPattern(pattern: string): string {
 	if (!pattern) {
 		return '*';
 	}
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {

--- a/src/vs/workbench/contrib/search/browser/searchChatContext.ts
+++ b/src/vs/workbench/contrib/search/browser/searchChatContext.ts
@@ -236,7 +236,7 @@ export async function searchFilesAndFolders(
 	configurationService: IConfigurationService,
 	searchService: ISearchService
 ): Promise<{ folders: URI[]; files: URI[] }> {
-	const segmentMatchPattern = fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continousMatchingGlobPattern(pattern);
+	const segmentMatchPattern = fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continuousMatchingGlobPattern(pattern);
 
 	const searchExcludePattern = getExcludes(configurationService.getValue<ISearchConfiguration>({ resource: workspace })) || {};
 	const searchOptions: IFileQuery = {
@@ -278,7 +278,7 @@ function fuzzyMatchingGlobPattern(pattern: string): string {
 	return '*' + pattern.split('').join('*') + '*';
 }
 
-function continousMatchingGlobPattern(pattern: string): string {
+function continuousMatchingGlobPattern(pattern: string): string {
 	if (!pattern) {
 		return '*';
 	}

--- a/src/vs/workbench/contrib/timeline/common/timelineService.ts
+++ b/src/vs/workbench/contrib/timeline/common/timelineService.ts
@@ -90,7 +90,7 @@ export class TimelineService extends Disposable implements ITimelineService {
 
 		const existing = this.providers.get(id);
 		if (existing) {
-			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwritting here (still will be blocked in the Extension Host)
+			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwriting here (still will be blocked in the Extension Host)
 			// TODO@eamodio: Ultimately will need to figure out a way to unregister providers when the Extension Host restarts/crashes
 			// throw new Error(`Timeline Provider ${id} already exists.`);
 			try {


### PR DESCRIPTION
Corrects spelling of 'continuous' (was 'continous') in function names and related comment.

- `explorerViewer.ts`: renamed function and fixed 'seperately' comment typo
- `searchChatContext.ts`: renamed function