### PR TITLE
Fix: typo in 'Start Continuous Run Using...' UI label

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -313,7 +313,7 @@ export class ContinuousRunUsingProfileTestAction extends Action2 {
 	constructor() {
 		super({
 			id: TestCommandId.ContinousRunUsingForTest,
-			title: localize2('testing.startContinuousRunUsing', 'Start Continous Run Using...'),
+			title: localize2('testing.startContinuousRunUsing', 'Start Continuous Run Using...'),
 			icon: icons.testingDebugIcon,
 			menu: [
 				{


### PR DESCRIPTION
Fixes a typo in the user-facing label for the continuous test run action.

The label displayed to users said 'Start **Continous** Run Using...' (missing the 'u'). This corrects it to 'Start **Continuous** Run Using...'.