### PR TITLE
Fix: various spelling corrections in source comments

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/timeline/common/timelineService.ts
+++ b/src/vs/workbench/contrib/timeline/common/timelineService.ts
@@ -90,7 +90,7 @@ export class TimelineService extends Disposable implements ITimelineService {
 
 		const existing = this.providers.get(id);
 		if (existing) {
-			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwritting here (still will be blocked in the Extension Host)
+			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwriting here (still will be blocked in the Extension Host)
 			// TODO@eamodio: Ultimately will need to figure out a way to unregister providers when the Extension Host restarts/crashes
 			// throw new Error(`Timeline Provider ${id} already exists.`);
 			try {


### PR DESCRIPTION
Fixes several misspellings found in source code comments:

- `parcelWatcher.ts`: 'occured' → 'occurred'
- `extHostTypes.ts`: 'seperate' → 'separate'
- `timelineService.ts`: 'overwritting' → 'overwriting'
- `electronTypes.ts`: 'superceded' → 'superseded'