### PR TITLE
feat: add 'Insert Console Log for Selection' command to TypeScript extension

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2907,6 +2907,11 @@
         "category": "JavaScript"
       },
       {
+        "command": "typescript.insertConsoleLog",
+        "title": "%typescript.insertConsoleLog.title%",
+        "category": "TypeScript"
+      },
+      {
         "command": "typescript.experimental.enableTsgo",
         "title": "Use TypeScript Go (Experimental)",
         "category": "TypeScript",
@@ -2988,6 +2993,10 @@
         {
           "command": "javascript.removeUnusedImports",
           "when": "supportedCodeAction =~ /(\\s|^)source\\.removeUnusedImports\\b/ && editorLangId =~ /^javascript(react)?$/"
+        },
+        {
+          "command": "typescript.insertConsoleLog",
+          "when": "editorLangId =~ /^(java|type)script(react)?$/ && typescript.isManagedFile"
         }
       ],
       "editor/context": [

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -305,6 +305,7 @@
 	"configuration.workspaceSymbols.scope.unifiedDeprecationMessage": "This setting is deprecated. Use `#js/ts.workspaceSymbols.scope#` instead.",
 	"typescript.sortImports": "Sort Imports",
 	"typescript.removeUnusedImports": "Remove Unused Imports",
+	"typescript.insertConsoleLog.title": "Insert Console Log for Selection",
 	"typescript.findAllFileReferences": "Find File References",
 	"typescript.goToSourceDefinition": "Go to Source Definition",
 	"configuration.suggest.classMemberSnippets.enabled": "Enable/disable snippet completions for class members.",

--- a/extensions/typescript-language-features/src/commands/index.ts
+++ b/extensions/typescript-language-features/src/commands/index.ts
@@ -9,6 +9,7 @@ import { ActiveJsTsEditorTracker } from '../ui/activeJsTsEditorTracker';
 import { Lazy } from '../utils/lazy';
 import { CommandManager } from './commandManager';
 import { ConfigurePluginCommand } from './configurePlugin';
+import { InsertConsoleLogCommand } from './insertConsoleLog';
 import { EnableTsgoCommand, DisableTsgoCommand } from './useTsgo';
 import { JavaScriptGoToProjectConfigCommand, TypeScriptGoToProjectConfigCommand } from './goToProjectConfiguration';
 import { LearnMoreAboutRefactoringsCommand } from './learnMoreAboutRefactorings';
@@ -36,6 +37,7 @@ export function registerBaseCommands(
 	commandManager.register(new LearnMoreAboutRefactoringsCommand());
 	commandManager.register(new TSServerRequestCommand(lazyClientHost));
 	commandManager.register(new OpenJsDocLinkCommand());
+	commandManager.register(new InsertConsoleLogCommand());
 	commandManager.register(new EnableTsgoCommand());
 	commandManager.register(new DisableTsgoCommand());
 }

--- a/extensions/typescript-language-features/src/commands/insertConsoleLog.ts
+++ b/extensions/typescript-language-features/src/commands/insertConsoleLog.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Command } from './commandManager';
+
+/**
+ * Inserts a `console.log` statement for the currently selected text or the word
+ * under the cursor.
+ *
+ * Usage: select a variable name (or place the cursor on it) and invoke the command.
+ * A `console.log('<name>:', <name>)` statement is inserted on the line immediately
+ * after the current line, indented to match.
+ *
+ * Example – given:
+ *   const myVar = getSomeValue();   // cursor/selection on `myVar`
+ *
+ * The command produces:
+ *   const myVar = getSomeValue();
+ *   console.log('myVar:', myVar);
+ */
+export class InsertConsoleLogCommand implements Command {
+	public static readonly ID = 'typescript.insertConsoleLog';
+	public readonly id = InsertConsoleLogCommand.ID;
+
+	public async execute(): Promise<void> {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			return;
+		}
+
+		const document = editor.document;
+		const selection = editor.selection;
+
+		// Resolve the target symbol: prefer explicit selection, fall back to word at cursor.
+		let symbol: string;
+		if (!selection.isEmpty) {
+			symbol = document.getText(selection);
+		} else {
+			const wordRange = document.getWordRangeAtPosition(selection.active);
+			if (!wordRange) {
+				return;
+			}
+			symbol = document.getText(wordRange);
+		}
+
+		symbol = symbol.trim();
+		if (!symbol) {
+			return;
+		}
+
+		// Derive indentation from the current line so the inserted statement aligns naturally.
+		const currentLine = document.lineAt(selection.active.line);
+		const indentMatch = currentLine.text.match(/^(\s*)/);
+		const indent = indentMatch ? indentMatch[1] : '';
+
+		const logStatement = `${indent}console.log('${symbol}:', ${symbol});`;
+
+		// Insert on the line immediately after the current line.
+		const endOfCurrentLine = currentLine.range.end;
+
+		const success = await editor.edit(editBuilder => {
+			editBuilder.insert(endOfCurrentLine, `\n${logStatement}`);
+		});
+
+		if (success) {
+			// Move the cursor to the end of the newly inserted statement.
+			const newLineNumber = currentLine.lineNumber + 1;
+			const newLineLength = logStatement.length;
+			const newPosition = new vscode.Position(newLineNumber, newLineLength);
+			editor.selection = new vscode.Selection(newPosition, newPosition);
+			editor.revealRange(new vscode.Range(newPosition, newPosition));
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new editor command **`typescript.insertConsoleLog`** that inserts a `console.log` statement for the currently selected variable or the word under the cursor — directly from the keyboard.

### How it works

1. Place the cursor on a variable name **or** select any expression in a JavaScript / TypeScript file.
2. Run the command (via the Command Palette → *"Insert Console Log for Selection"*, or assign a custom keyboard shortcut such as `Ctrl+Shift+L`).
3. The extension inserts:
   ```js
   console.log('<symbol>:', <symbol>);
   ```
   on the line immediately after the current one, matching the existing indentation. The cursor moves to the end of the inserted statement.

### Example

Before (cursor on `myValue`):
```ts
    const myValue = getSomeValue();
```

After invoking the command:
```ts
    const myValue = getSomeValue();
    console.log('myValue:', myValue);
```

### Why in core?

Manually writing `console.log` statements is one of the most repetitive tasks in day-to-day JavaScript/TypeScript development. While third-party extensions offer similar functionality, having it as a built-in command means:

- Zero extension overhead.
- It is always available, even in restricted/remote environments.
- Users can bind it to a preferred shortcut via `keybindings.json`.

### Files changed

| File | Change |
|------|--------|
| `commands/insertConsoleLog.ts` | New command implementation |
| `commands/index.ts` | Register the command |
| `package.json` | Contribute command + Command Palette visibility |
| `package.nls.json` | Add localized command title |

### Testing

1. Open a `.ts` or `.js` file.
2. Place the cursor on any variable name.
3. Open the Command Palette and search *Insert Console Log for Selection*.
4. Verify a `console.log` line is inserted below the current line with the correct indentation.