### PR TITLE
feat: add useful console and timing snippets to JavaScript

### DIFF
--- a/extensions/javascript/snippets/javascript.code-snippets
+++ b/extensions/javascript/snippets/javascript.code-snippets
@@ -262,5 +262,47 @@
 			"}"
 		],
 		"description": "Async Function Expression"
+	},
+	"Log labeled value to the console": {
+		"prefix": "logl",
+		"body": [
+			"console.log('${1:label}:', ${1:label});",
+			"$0"
+		],
+		"description": "Log a labeled value to the console: console.log('value:', value)"
+	},
+	"Log value as JSON to the console": {
+		"prefix": "logj",
+		"body": [
+			"console.log('${1:label}:', JSON.stringify(${1:label}, null, 2));",
+			"$0"
+		],
+		"description": "Log a value as formatted JSON to the console"
+	},
+	"Log table to the console": {
+		"prefix": "logt",
+		"body": [
+			"console.table(${1:variable});",
+			"$0"
+		],
+		"description": "Log tabular data to the console using console.table"
+	},
+	"Console time measurement": {
+		"prefix": "timer",
+		"body": [
+			"console.time('${1:label}');",
+			"$TM_SELECTED_TEXT$0",
+			"console.timeEnd('${1:label}');"
+		],
+		"description": "Measure execution time with console.time / console.timeEnd"
+	},
+	"Console group": {
+		"prefix": "cgroup",
+		"body": [
+			"console.group('${1:label}');",
+			"\t$TM_SELECTED_TEXT$0",
+			"console.groupEnd();"
+		],
+		"description": "Group console messages with console.group / console.groupEnd"
 	}
 }


### PR DESCRIPTION
## Summary

Adds five new built-in JavaScript code snippets for patterns that developers write repeatedly every day.

### New snippets

| Prefix | Expands to | Description |
|--------|-----------|-------------|
| `logl` | `console.log('label:', label);` | Log a **labeled** value — the most useful debugging pattern |
| `logj` | `console.log('label:', JSON.stringify(label, null, 2));` | Pretty-print a value as formatted JSON |
| `logt` | `console.table(variable);` | Print tabular data with `console.table` |
| `timer` | `console.time('label'); … console.timeEnd('label');` | Measure execution time; wraps selected code |
| `cgroup` | `console.group('label'); … console.groupEnd();` | Group related log messages; wraps selected code |

### Motivation

The existing `log` snippet expands to `console.log()` — just a bare call. In practice the most common patterns are:
- Labeled values: `console.log('myVar:', myVar)` — you can scan output instantly
- JSON pretty-print for objects/arrays
- Timing blocks around a section of code

These cover the 80% case without installing an extension.

The `timer` and `cgroup` snippets use `$TM_SELECTED_TEXT` so they wrap whatever code the developer has highlighted, matching the pattern already used by `newpromise` and `async function` snippets.