### PR TITLE
feat: add table, task list, details, and footnote snippets to Markdown

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.code-snippets
+++ b/extensions/markdown-basics/snippets/markdown.code-snippets
@@ -101,5 +101,48 @@
 			"$$"
 		],
 		"description": "Insert fenced math"
+	},
+	"Insert table": {
+		"prefix": "table",
+		"body": [
+			"| ${1:Column 1} | ${2:Column 2} | ${3:Column 3} |",
+			"| --- | --- | --- |",
+			"| ${4:Cell} | ${5:Cell} | ${6:Cell} |",
+			"$0"
+		],
+		"description": "Insert a Markdown table"
+	},
+	"Insert task list": {
+		"prefix": "task",
+		"body": "- [ ] ${1:${TM_SELECTED_TEXT:task}}$0",
+		"description": "Insert a task list item"
+	},
+	"Insert task list block": {
+		"prefix": "tasklist",
+		"body": [
+			"- [x] ${1:Completed task}",
+			"- [ ] ${2:Pending task}",
+			"- [ ] ${3:Pending task}",
+			"$0"
+		],
+		"description": "Insert a task list block"
+	},
+	"Insert details block": {
+		"prefix": "details",
+		"body": [
+			"<details>",
+			"<summary>${1:Summary}</summary>",
+			"",
+			"${TM_SELECTED_TEXT:${2:Details}}",
+			"",
+			"</details>",
+			"$0"
+		],
+		"description": "Insert a collapsible details/summary block"
+	},
+	"Insert footnote": {
+		"prefix": "footnote",
+		"body": "${1:${TM_SELECTED_TEXT}}[^${2:1}]\n\n[^${2:1}]: ${3:Footnote text}$0",
+		"description": "Insert a footnote reference and definition"
 	}
 }


### PR DESCRIPTION
## Summary

Adds five Markdown snippets for structural patterns that appear constantly in documentation, READMEs, and GitHub issues but are tedious to type by hand.

### New snippets

| Prefix | What it inserts |
|--------|----------------|
| `table` | 3-column Markdown table with placeholder headers and one data row |
| `task` | Single task list item `- [ ] task` — works with `$TM_SELECTED_TEXT` |
| `tasklist` | Ready-made block of three task items (one checked, two pending) |
| `details` | Collapsible `<details>`/`<summary>` block; wraps selected text |
| `footnote` | Inline footnote reference + its definition at the cursor |

### Why these?

The existing Markdown snippets cover inline and fenced formatting but nothing structural. These are the top patterns GitHub users insert manually dozens of times per week:
- **Tables** are a pain to type; even the minimal 3-column template saves significant effort.
- **Task lists** (`- [ ] …`) are ubiquitous in PRs and project tracking.
- **`<details>`** is the standard GitHub way to hide large output or spoilers.
- **Footnotes** are supported by GitHub-Flavored Markdown and widely used in documentation.