### PR TITLE
Add automode.routerModelSelection telemetry with actualModel

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/automodeService.ts
+++ b/extensions/copilot/src/platform/endpoint/node/automodeService.ts
@@ -215,6 +215,29 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 
 		selectedModel = this._applyVisionFallback(chatRequest, selectedModel, token.available_models, knownEndpoints);
 
+		// Emit the final model selection alongside the router's recommendation
+		// so analysts can detect overrides without fragile telemetry joins
+		if (!skipRouter && routerResult.candidateModel) {
+			/* __GDPR__
+				"automode.routerModelSelection" : {
+					"owner": "aashnagarg",
+					"comment": "Reports the router's recommended model vs the actual model used after all client-side overrides",
+					"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The conversation ID" },
+					"candidateModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The router's top candidate model (candidate_models[0])" },
+					"actualModel": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model actually selected after all client-side overrides" },
+					"overrideReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Why the actual model differs from the candidate: none or clientOverride" }
+				}
+			*/
+			const candidateModel = routerResult.candidateModel;
+			const overrideReason = candidateModel === selectedModel.model ? 'none' : 'clientOverride';
+			this._telemetryService.sendMSFTTelemetryEvent('automode.routerModelSelection', {
+				conversationId: conversationId ?? '',
+				candidateModel,
+				actualModel: selectedModel.model,
+				overrideReason,
+			});
+		}
+
 		// Reuse the cached endpoint if the session token and model haven't changed
 		const autoEndpoint = (entry?.endpoint && entry.lastSessionToken === token.session_token && entry.endpoint.model === selectedModel.model)
 			? entry.endpoint
@@ -250,7 +273,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 		entry: AutoModelCacheEntry | undefined,
 		token: AutoModeAPIResponse,
 		knownEndpoints: IChatEndpoint[],
-	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string }> {
+	): Promise<{ selectedModel?: IChatEndpoint; lastRoutedPrompt?: string; fallbackReason?: string; candidateModel?: string }> {
 		const prompt = chatRequest?.prompt?.trim();
 		const lastRoutedPrompt = entry?.lastRoutedPrompt ?? prompt;
 
@@ -298,7 +321,7 @@ export class AutomodeService extends Disposable implements IAutomodeService {
 			if (result.sticky_override) {
 				this._logService.trace(`[AutomodeService] Sticky routing override: confidence=${(result.confidence * 100).toFixed(1)}%, label=${result.predicted_label}, router_model=${result.candidate_models[0]}, actual_model=${selectedModel.model}`);
 			}
-			return { selectedModel, lastRoutedPrompt: prompt };
+			return { selectedModel, lastRoutedPrompt: prompt, candidateModel: result.candidate_models[0] };
 		} catch (e) {
 			const isTimeout = isAbortError(e);
 			let fallbackReason: string;

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -17,7 +17,7 @@ import { ILogService } from '../../../log/common/logService';
 import { IChatEndpoint } from '../../../networking/common/networking';
 import { NullRequestLogger } from '../../../requestLogger/node/nullRequestLogger';
 import { IExperimentationService, NullExperimentationService } from '../../../telemetry/common/nullExperimentationService';
-import { NullTelemetryService } from '../../../telemetry/common/nullTelemetryService';
+import { ITelemetryService } from '../../../telemetry/common/telemetry';
 import { ICAPIClientService } from '../../common/capiClient';
 import { AutomodeService } from '../automodeService';
 
@@ -60,6 +60,7 @@ describe('AutomodeService', () => {
 	let configurationService: IConfigurationService;
 	let mockChatEndpoint: IChatEndpoint;
 	let envService: NullEnvService;
+	let mockTelemetryService: ITelemetryService & { sendMSFTTelemetryEvent: ReturnType<typeof vi.fn> };
 
 	function createEndpoint(model: string, provider: string, overrides?: Partial<IChatEndpoint>): IChatEndpoint {
 		return {
@@ -87,7 +88,7 @@ describe('AutomodeService', () => {
 			mockExpService,
 			configurationService,
 			envService,
-			new NullTelemetryService(),
+			mockTelemetryService,
 			new NullRequestLogger()
 		);
 	}
@@ -145,6 +146,13 @@ describe('AutomodeService', () => {
 
 		configurationService = new InMemoryConfigurationService(new DefaultsOnlyConfigurationService());
 		envService = new NullEnvService();
+		mockTelemetryService = {
+			sendTelemetryEvent: vi.fn(),
+			sendMSFTTelemetryEvent: vi.fn(),
+			sendTelemetryErrorEvent: vi.fn(),
+			sendMSFTTelemetryErrorEvent: vi.fn(),
+			sendSharedTelemetryEvent: vi.fn(),
+		} as unknown as ITelemetryService & { sendMSFTTelemetryEvent: ReturnType<typeof vi.fn> };
 	});
 
 	afterEach(() => {
@@ -1016,6 +1024,120 @@ describe('AutomodeService', () => {
 			expect(mockLogService.warn).toHaveBeenCalledWith(
 				expect.stringContaining('no vision-capable model')
 			);
+		});
+	});
+
+	describe('routerModelSelection telemetry', () => {
+		function mockRouterResponse(available_models: string[], routerResult: { chosen_model: string; candidate_models: string[] }, session_token = 'test-token'): void {
+			(mockCAPIClientService.makeRequest as ReturnType<typeof vi.fn>).mockImplementation((_body: any, opts: any) => {
+				if (opts?.type === RequestType.ModelRouter) {
+					return Promise.resolve({
+						ok: true,
+						status: 200,
+						headers: createMockHeaders(),
+						text: vi.fn().mockResolvedValue(JSON.stringify({
+							predicted_label: 'needs_reasoning',
+							confidence: 0.9,
+							latency_ms: 30,
+							chosen_model: routerResult.chosen_model,
+							candidate_models: routerResult.candidate_models,
+							scores: { needs_reasoning: 0.9, no_reasoning: 0.1 },
+							sticky_override: false
+						}))
+					});
+				}
+				return Promise.resolve(
+					makeMockTokenResponse({
+						available_models,
+						expires_at: Math.floor(Date.now() / 1000) + 3600,
+						session_token,
+					})
+				);
+			});
+		}
+
+		it('should emit routerModelSelection with candidateModel and actualModel when router is used', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic');
+
+			mockRouterResponse(
+				['gpt-4o', 'claude-sonnet'],
+				{ chosen_model: 'gpt-4o', candidate_models: ['gpt-4o', 'claude-sonnet'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-telemetry-test'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			expect(selectionEvent).toBeDefined();
+			expect(selectionEvent![1]).toMatchObject({
+				candidateModel: 'gpt-4o',
+				actualModel: 'gpt-4o',
+				overrideReason: 'none',
+			});
+		});
+
+		it('should emit overrideReason=clientOverride when vision fallback changes the model', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI', { supportsVision: true });
+			const claudeEndpoint = createEndpoint('claude-sonnet', 'Anthropic', { supportsVision: false });
+
+			// Router picks claude-sonnet (no vision), vision fallback should override to gpt-4o
+			mockRouterResponse(
+				['claude-sonnet', 'gpt-4o'],
+				{ chosen_model: 'claude-sonnet', candidate_models: ['claude-sonnet', 'gpt-4o'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'describe this image',
+				sessionId: 'session-telemetry-vision',
+				references: [{ id: 'img', value: { mimeType: 'image/png', data: new Uint8Array() } }] as any
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint, claudeEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			expect(selectionEvent).toBeDefined();
+			expect(selectionEvent![1]).toMatchObject({
+				candidateModel: 'claude-sonnet',
+				actualModel: 'gpt-4o',
+				overrideReason: 'clientOverride',
+			});
+		});
+
+		it('should not emit routerModelSelection when router fails', async () => {
+			enableRouter();
+			const gpt4oEndpoint = createEndpoint('gpt-4o', 'OpenAI');
+
+			mockRouterResponse(
+				['gpt-4o'],
+				{ chosen_model: 'unknown-model', candidate_models: ['unknown-model'] }
+			);
+
+			automodeService = createService();
+			const chatRequest: Partial<ChatRequest> = {
+				location: ChatLocation.Panel,
+				prompt: 'test prompt',
+				sessionId: 'session-telemetry-no-emit'
+			};
+
+			await automodeService.resolveAutoModeEndpoint(chatRequest as ChatRequest, [gpt4oEndpoint]);
+
+			const telemetryCalls = mockTelemetryService.sendMSFTTelemetryEvent.mock.calls;
+			const selectionEvent = telemetryCalls.find((call: unknown[]) => call[0] === 'automode.routerModelSelection');
+			// candidateModel is not set when router returns unknown model, so event should not emit
+			expect(selectionEvent).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
Emits a new telemetry event `automode.routerModelSelection` after all client-side model overrides (same-provider, vision fallback, default selection) are applied.

## Properties

| Property | Description |
|----------|-------------|
| `candidateModel` | The router's top pick (`candidate_models[0]`) |
| `actualModel` | The model actually used after all overrides |
| `overrideReason` | `none` or `clientOverride` |
| `conversationId` | For correlation |

## Why

The existing `automode.routerDecision` event captures the router's recommendation, but doesn't know what model was ultimately selected — vision fallback and default selection happen afterward. This event enables accurate switch attribution:

```kql
automode.routerModelSelection
| where candidateModel != actualModel
| summarize count() by candidateModel, actualModel
```

## Design note

`candidateModel` is only set when `_tryRouterSelection` succeeds (i.e., the router returned a valid model with a matching endpoint). When the router fails or returns an unknown model, the event is NOT emitted — those cases are covered by `automode.routerFallback` instead. This means `overrideReason` will never be `defaultFallback` — it's always `none` or `clientOverride`.
