### PR TITLE
Fix: spelling correction in git extension source (refrence -> reference)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -48,7 +48,7 @@ export interface IQuickDiffModelService {
 
 	/**
 	 * Returns `undefined` if the editor model is not resolved.
-	 * Model refrence has to be disposed once not needed anymore.
+	 * Model reference has to be disposed once not needed anymore.
 	 * @param resource
 	 * @param options
 	 */


### PR DESCRIPTION
## Summary

- Fixes a typo in a JSDoc comment in `src/vs/workbench/contrib/scm/browser/quickDiffModel.ts`: `refrence` → `reference` on line 51.

## Test plan

- [ ] No functional change; comment-only fix.
- [ ] Verify the corrected spelling in the JSDoc for `IQuickDiffModelService.createQuickDiffModelReference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)