### PR TITLE
Fix typo: 'superceded' → 'superseded' in electronTypes

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;


### PR DESCRIPTION
Fix a spelling error in a JSDoc comment in `src/vs/base/parts/sandbox/electron-browser/electronTypes.ts`. Changed "superceded" to "superseded" (line 186). The correct form of the word is "superseded".