### PR TITLE
Fix typos: 'coleasing' → 'coalescing', 'intialized' → 'initialized'

### DIFF
--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -172,7 +172,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// Note: since Parcel 2.0.7, the very first event is
 	// emitted without delay if no events occured over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -51,7 +51,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 
 		this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);
 
-		// When the level changes it could change from off to on and we want to make sure telemetry is properly intialized
+		// When the level changes it could change from off to on and we want to make sure telemetry is properly initialized
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(TELEMETRY_SETTING_ID)) {
 				this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);


### PR DESCRIPTION
Fix two spelling errors in comments:
- `src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts` (line 175): "coleasing" → "coalescing"
- `src/vs/workbench/services/telemetry/browser/telemetryService.ts` (line 54): "intialized" → "initialized"