### PR TITLE
Fix typo: 'overriden' → 'overridden' in test files

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
@@ -35,33 +35,33 @@ suite('mockService', () => {
 			assert.strictEqual(
 				mock.bar,
 				'oh hi!',
-				'bar should be overriden',
+				'bar should be overridden',
 			);
 
 			assert.strictEqual(
 				mock.baz,
 				42,
-				'baz should be overriden',
+				'baz should be overridden',
 			);
 
 			assert(
 				!(mock.anotherMethod(490274)),
-				'Must execute overriden method correctly 1.',
+				'Must execute overridden method correctly 1.',
 			);
 
 			assert(
 				mock.anotherMethod(NaN),
-				'Must execute overriden method correctly 2.',
+				'Must execute overridden method correctly 2.',
 			);
 
 			assert.throws(() => {
-				// property is not overriden so must throw
+				// property is not overridden so must throw
 				// eslint-disable-next-line local/code-no-unused-expressions
 				mock.foo;
 			});
 
 			assert.throws(() => {
-				// function is not overriden so must throw
+				// function is not overridden so must throw
 				mock.someMethod(randomBoolean());
 			});
 		});

--- a/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
@@ -511,7 +511,7 @@ suite('Terminal history', () => {
 				});
 			});
 
-			suite('local (overriden path)', () => {
+			suite('local (overridden path)', () => {
 				let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 				setup(() => {
 					originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };
@@ -569,7 +569,7 @@ suite('Terminal history', () => {
 			});
 		});
 
-		suite('remote (overriden path)', () => {
+		suite('remote (overridden path)', () => {
 			let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 			setup(() => {
 				originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -2482,7 +2482,7 @@ suite('EditorService', () => {
 		const untypedInput1 = input1.toUntyped();
 		assert.ok(untypedInput1);
 
-		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overriden
+		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overridden
 		await service.openEditor(input1);
 		assert.strictEqual(editorCount, 0);
 


### PR DESCRIPTION
Fix 9 occurrences of the misspelling "overriden" (should be "overridden") in test files:
- `src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts` (2 occurrences in suite names)
- `src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts` (6 occurrences in test descriptions)
- `src/vs/workbench/services/editor/test/browser/editorService.test.ts` (1 occurrence in a comment)