### PR TITLE
Centralize permission auto-approve and fix worktree working directory propagation

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -59,6 +59,8 @@ export interface IAgentSessionProjectInfo {
 export interface IAgentCreateSessionResult {
 	readonly session: URI;
 	readonly project?: IAgentSessionProjectInfo;
+	/** The resolved working directory, which may differ from the requested one (e.g. worktree). */
+	readonly workingDirectory?: URI;
 }
 
 export type AgentProvider = string;
@@ -271,8 +273,8 @@ export interface IAgentToolReadyEvent extends IAgentProgressEventBase {
 	readonly toolInput?: string;
 	/** Short title for the confirmation prompt. */
 	readonly confirmationTitle?: StringOrMarkdown;
-	/** Kind of permission being requested (e.g. `'write'`, `'read'`). */
-	readonly permissionKind?: string;
+	/** Kind of permission being requested. */
+	readonly permissionKind?: 'shell' | 'write' | 'mcp' | 'read' | 'url' | 'custom-tool';
 	/** File path associated with the permission request. */
 	readonly permissionPath?: string;
 }

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -252,7 +252,7 @@ export class AgentService extends Disposable implements IAgentService {
 				modifiedAt: Date.now(),
 				...(created.project ? { project: { uri: created.project.uri.toString(), displayName: created.project.displayName } } : {}),
 				model: config?.model,
-				workingDirectory: config.workingDirectory?.toString(),
+				workingDirectory: (created.workingDirectory ?? config.workingDirectory)?.toString(),
 			};
 			const state = this._stateManager.createSession(summary);
 			state.config = sessionConfig;
@@ -268,7 +268,7 @@ export class AgentService extends Disposable implements IAgentService {
 				modifiedAt: Date.now(),
 				...(created.project ? { project: { uri: created.project.uri.toString(), displayName: created.project.displayName } } : {}),
 				model: config?.model,
-				workingDirectory: config?.workingDirectory?.toString(),
+				workingDirectory: (created.workingDirectory ?? config?.workingDirectory)?.toString(),
 			};
 			const state = this._stateManager.createSession(summary);
 			state.config = sessionConfig;

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -12,7 +12,7 @@ import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
-import { IAgent, IAgentAttachment, IAgentProgressEvent } from '../common/agentService.js';
+import { IAgent, IAgentAttachment, IAgentProgressEvent, type IAgentToolReadyEvent } from '../common/agentService.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { ActionType, ISessionAction } from '../common/state/sessionActions.js';
@@ -165,7 +165,7 @@ export class AgentSideEffects extends Disposable {
 	 * dispatched to the state manager), or `false` to proceed normally.
 	 */
 	private _tryAutoApproveToolReady(
-		e: { readonly toolCallId: string; readonly session: URI; readonly permissionKind?: string; readonly permissionPath?: string; readonly toolInput?: string },
+		e: { readonly toolCallId: string; readonly session: URI; readonly permissionKind?: IAgentToolReadyEvent['permissionKind']; readonly permissionPath?: string; readonly toolInput?: string },
 		sessionKey: ProtocolURI,
 		agent: IAgent,
 	): boolean {
@@ -178,6 +178,19 @@ export class AgentSideEffects extends Disposable {
 			this._toolCallAgents.delete(`${sessionKey}:${e.toolCallId}`);
 			agent.respondToPermissionRequest(e.toolCallId, true);
 			return true;
+		}
+
+		// Read auto-approval: approve reads inside the session's working directory.
+		if (e.permissionKind === 'read' && e.permissionPath) {
+			const workDir = sessionState?.workingDirectory ?? sessionState?.summary.workingDirectory;
+			const workingDirectory = workDir ? URI.parse(workDir) : undefined;
+			if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(URI.file(e.permissionPath)), workingDirectory)) {
+				this._logService.trace(`[AgentSideEffects] Auto-approving read of ${e.permissionPath}`);
+				this._toolCallAgents.delete(`${sessionKey}:${e.toolCallId}`);
+				agent.respondToPermissionRequest(e.toolCallId, true);
+				return true;
+			}
+			return false;
 		}
 
 		// Write auto-approval: only within the session's working directory,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -207,7 +207,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				...(project ? { project } : {}),
 				summary: s.summary,
 				model: metadata.model,
-				workingDirectory: typeof s.context?.cwd === 'string' ? URI.file(s.context.cwd) : metadata.workingDirectory,
+				workingDirectory: metadata.workingDirectory ?? (typeof s.context?.cwd === 'string' ? URI.file(s.context.cwd) : undefined),
 			};
 		}));
 		this._logService.info(`[Copilot] Found ${result.length} sessions`);
@@ -290,7 +290,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				this._logService.info(`[Copilot] Forked session created: ${session.toString()}`);
 				const project = await projectFromCopilotContext({ cwd: config.workingDirectory?.fsPath }, this._gitService);
 				await this._storeSessionMetadata(session, config.model, config.workingDirectory, project, true);
-				return { session, ...(project ? { project } : {}) };
+				return { session, workingDirectory: config.workingDirectory, ...(project ? { project } : {}) };
 			});
 		}
 
@@ -327,7 +327,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		// Persist model, working directory, and project so we can recreate the
 		// session if the SDK loses it and avoid rediscovering git metadata.
 		await this._storeSessionMetadata(agentSession.sessionUri, config?.model, workingDirectory, project, true);
-		return { session, ...(project ? { project } : {}) };
+		return { session, workingDirectory, ...(project ? { project } : {}) };
 	}
 
 	async resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<IResolveSessionConfigResult> {
@@ -653,7 +653,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.warn(`[Copilot:${sessionId}] getSessionMetadata failed`, err);
 			return undefined;
 		});
-		const workingDirectory = typeof sessionMetadata?.context?.cwd === 'string' ? URI.file(sessionMetadata.context.cwd) : storedMetadata.workingDirectory;
+		const workingDirectory = storedMetadata.workingDirectory ?? (typeof sessionMetadata?.context?.cwd === 'string' ? URI.file(sessionMetadata.context.cwd) : undefined);
 		if (!workingDirectory) {
 			throw new Error(`workingDirectory is required to resume Copilot session '${sessionId}'`);
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -582,7 +582,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * and returns it. The caller must call {@link CopilotAgentSession.initializeSession}
 	 * to wire up the SDK session.
 	 */
-	private _createAgentSession(wrapperFactory: SessionWrapperFactory, workingDirectory: URI | undefined, sessionId: string, shellManager: ShellManager, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
+	private _createAgentSession(wrapperFactory: SessionWrapperFactory, _workingDirectory: URI | undefined, sessionId: string, shellManager: ShellManager, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
 		const sessionUri = AgentSession.uri(this.id, sessionId);
 
 		const agentSession = this._instantiationService.createInstance(
@@ -590,7 +590,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			{
 				sessionUri,
 				rawSessionId: sessionId,
-				workingDirectory,
 				onDidSessionProgress: this._onDidSessionProgress,
 				wrapperFactory,
 				shellManager,

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -8,12 +8,11 @@ import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
 import { localize } from '../../../../nls.js';
-import { IAgentAttachment, IAgentMessageEvent, IAgentProgressEvent, IAgentSubagentStartedEvent, IAgentToolCompleteEvent, IAgentToolStartEvent } from '../../common/agentService.js';
+import { IAgentAttachment, IAgentMessageEvent, IAgentProgressEvent, IAgentSubagentStartedEvent, IAgentToolCompleteEvent, IAgentToolReadyEvent, IAgentToolStartEvent } from '../../common/agentService.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
 import { SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolResultContentType, type ISessionInputAnswer, type ISessionInputRequest, type IPendingMessage, type IToolCallResult, type IToolResultContent } from '../../common/state/sessionState.js';
 import { CopilotSessionWrapper } from './copilotSessionWrapper.js';
@@ -44,7 +43,7 @@ export interface IActiveClientSnapshot {
  * `resumeSession()`. In tests, it returns a mock wrapper directly.
  */
 export type SessionWrapperFactory = (callbacks: {
-	readonly onPermissionRequest: (request: PermissionRequest) => Promise<PermissionRequestResult>;
+	readonly onPermissionRequest: (request: ITypedPermissionRequest) => Promise<PermissionRequestResult>;
 	readonly onUserInputRequest: (request: IUserInputRequest, invocation: { sessionId: string }) => Promise<IUserInputResponse>;
 	readonly hooks: {
 		readonly onPreToolUse: (input: { toolName: string; toolArgs: unknown }) => Promise<void>;
@@ -67,6 +66,28 @@ interface IUserInputResponse {
 	wasFreeform: boolean;
 }
 
+/**
+ * Extends the SDK's {@link PermissionRequest} with the known extra properties
+ * that arrive on the index-signature. The SDK defines these as `[key: string]: unknown`
+ * so this interface adds proper types for the fields we actually use.
+ */
+interface ITypedPermissionRequest extends PermissionRequest {
+	/** File path — set for `read` permission requests. */
+	path?: string;
+	/** File path — set for `write` permission requests. */
+	fileName?: string;
+	/** Full shell command text — set for `shell` permission requests. */
+	fullCommandText?: string;
+	/** Human-readable intention describing the operation. */
+	intention?: string;
+	/** MCP server name — set for `mcp` permission requests. */
+	serverName?: string;
+	/** Tool name — set for `mcp` and `custom-tool` permission requests. */
+	toolName?: string;
+	/** Tool arguments — set for `custom-tool` permission requests. */
+	args?: Record<string, unknown>;
+}
+
 function tryStringify(value: unknown): string | undefined {
 	try {
 		return JSON.stringify(value);
@@ -78,18 +99,15 @@ function tryStringify(value: unknown): string | undefined {
 /**
  * Derives display fields from a permission request for the tool confirmation UI.
  */
-function getPermissionDisplay(request: { kind: string;[key: string]: unknown }): {
+function getPermissionDisplay(request: ITypedPermissionRequest): {
 	confirmationTitle: string;
 	invocationMessage: string;
 	toolInput?: string;
 	/** Normalized permission kind for auto-approval routing. */
-	permissionKind: string;
+	permissionKind: IAgentToolReadyEvent['permissionKind'];
 } {
-	const path = typeof request.path === 'string' ? request.path : (typeof request.fileName === 'string' ? request.fileName : undefined);
-	const fullCommandText = typeof request.fullCommandText === 'string' ? request.fullCommandText : undefined;
-	const intention = typeof request.intention === 'string' ? request.intention : undefined;
-	const serverName = typeof request.serverName === 'string' ? request.serverName : undefined;
-	const toolName = typeof request.toolName === 'string' ? request.toolName : undefined;
+	const path = request.path ?? request.fileName;
+	const { fullCommandText, intention, serverName, toolName } = request;
 
 	switch (request.kind) {
 		case 'shell':
@@ -102,9 +120,9 @@ function getPermissionDisplay(request: { kind: string;[key: string]: unknown }):
 		case 'custom-tool': {
 			// Custom tool overrides (e.g. our shell tool). Extract the actual
 			// tool args from the SDK's wrapper envelope.
-			const args = typeof request.args === 'object' && request.args !== null ? request.args as Record<string, unknown> : undefined;
+			const args = request.args;
 			const command = typeof args?.command === 'string' ? args.command : undefined;
-			const sdkToolName = typeof request.toolName === 'string' ? request.toolName : undefined;
+			const sdkToolName = request.toolName;
 			if (command && sdkToolName && isShellTool(sdkToolName)) {
 				return {
 					confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal"),
@@ -193,7 +211,6 @@ export class CopilotAgentSession extends Disposable {
 	/** SDK session wrapper, set by {@link initializeSession}. */
 	private _wrapper!: CopilotSessionWrapper;
 
-	private readonly _workingDirectory: URI | undefined;
 	/** Snapshot captured at session creation for refresh detection. */
 	private readonly _appliedSnapshot: IActiveClientSnapshot;
 	/** Tool names that are client-provided, derived from snapshot. */
@@ -214,7 +231,6 @@ export class CopilotAgentSession extends Disposable {
 		super();
 		this.sessionId = options.rawSessionId;
 		this.sessionUri = options.sessionUri;
-		this._workingDirectory = options.workingDirectory;
 		this._onDidSessionProgress = options.onDidSessionProgress;
 		this._wrapperFactory = options.wrapperFactory;
 		this._shellManager = options.shellManager;
@@ -441,18 +457,9 @@ export class CopilotAgentSession extends Disposable {
 	 * side-effects layer to respond via {@link respondToPermissionRequest}.
 	 */
 	async handlePermissionRequest(
-		request: PermissionRequest,
+		request: ITypedPermissionRequest,
 	): Promise<PermissionRequestResult> {
 		this._logService.info(`[Copilot:${this.sessionId}] Permission request: kind=${request.kind}`);
-
-		// Auto-approve reads inside the working directory
-		if (request.kind === 'read') {
-			const requestPath = typeof request.path === 'string' ? request.path : undefined;
-			if (requestPath && this._workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(normalizePath(URI.file(requestPath)), this._workingDirectory)) {
-				this._logService.trace(`[Copilot:${this.sessionId}] Auto-approving read inside working directory: ${requestPath}`);
-				return { kind: 'approved' };
-			}
-		}
 
 		const toolCallId = request.toolCallId;
 		if (!toolCallId) {
@@ -478,7 +485,7 @@ export class CopilotAgentSession extends Disposable {
 			toolInput,
 			confirmationTitle,
 			permissionKind,
-			permissionPath: typeof request.path === 'string' ? request.path : (typeof request.fileName === 'string' ? request.fileName : undefined),
+			permissionPath: request.path ?? request.fileName,
 		});
 
 		const approved = await deferred.p;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -99,6 +99,11 @@ function tryStringify(value: unknown): string | undefined {
 /**
  * Derives display fields from a permission request for the tool confirmation UI.
  */
+/** Safely extract a string value from an SDK field that may be `unknown` at runtime. */
+function str(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
+}
+
 function getPermissionDisplay(request: ITypedPermissionRequest): {
 	confirmationTitle: string;
 	invocationMessage: string;
@@ -106,8 +111,11 @@ function getPermissionDisplay(request: ITypedPermissionRequest): {
 	/** Normalized permission kind for auto-approval routing. */
 	permissionKind: IAgentToolReadyEvent['permissionKind'];
 } {
-	const path = request.path ?? request.fileName;
-	const { fullCommandText, intention, serverName, toolName } = request;
+	const path = str(request.path) ?? str(request.fileName);
+	const fullCommandText = str(request.fullCommandText);
+	const intention = str(request.intention);
+	const serverName = str(request.serverName);
+	const toolName = str(request.toolName);
 
 	switch (request.kind) {
 		case 'shell':
@@ -120,9 +128,9 @@ function getPermissionDisplay(request: ITypedPermissionRequest): {
 		case 'custom-tool': {
 			// Custom tool overrides (e.g. our shell tool). Extract the actual
 			// tool args from the SDK's wrapper envelope.
-			const args = request.args;
+			const args = typeof request.args === 'object' && request.args !== null ? request.args as Record<string, unknown> : undefined;
 			const command = typeof args?.command === 'string' ? args.command : undefined;
-			const sdkToolName = request.toolName;
+			const sdkToolName = str(request.toolName);
 			if (command && sdkToolName && isShellTool(sdkToolName)) {
 				return {
 					confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal"),
@@ -177,7 +185,6 @@ function getPermissionDisplay(request: ITypedPermissionRequest): {
 export interface ICopilotAgentSessionOptions {
 	readonly sessionUri: URI;
 	readonly rawSessionId: string;
-	readonly workingDirectory: URI | undefined;
 	readonly onDidSessionProgress: Emitter<IAgentProgressEvent>;
 	readonly wrapperFactory: SessionWrapperFactory;
 	readonly shellManager: ShellManager | undefined;
@@ -485,7 +492,7 @@ export class CopilotAgentSession extends Disposable {
 			toolInput,
 			confirmationTitle,
 			permissionKind,
-			permissionPath: request.path ?? request.fileName,
+			permissionPath: str(request.path) ?? str(request.fileName),
 		});
 
 		const approved = await deferred.p;

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -485,4 +485,54 @@ suite('AgentService (node dispatcher)', () => {
 			);
 		});
 	});
+
+	// ---- worktree working directory -------------------------------------
+
+	suite('worktree working directory', () => {
+
+		test('createSession uses agent-resolved working directory in state', async () => {
+			// Simulate an agent that resolves a worktree path different from the input
+			const worktreeDir = URI.file('/source/repo.worktrees/agents-xyz');
+			copilotAgent.resolvedWorkingDirectory = worktreeDir;
+			service.registerProvider(copilotAgent);
+
+			const sourceDir = URI.file('/source/repo');
+			const session = await service.createSession({ provider: 'copilot', workingDirectory: sourceDir });
+
+			// The state manager should have the worktree path, not the source path
+			const state = service.stateManager.getSessionState(session.toString());
+			assert.strictEqual(state?.summary.workingDirectory, worktreeDir.toString());
+		});
+
+		test('createSession falls back to config working directory when agent does not resolve', async () => {
+			// Agent does not override the working directory (e.g. folder isolation)
+			copilotAgent.resolvedWorkingDirectory = undefined;
+			service.registerProvider(copilotAgent);
+
+			const sourceDir = URI.file('/source/repo');
+			const session = await service.createSession({ provider: 'copilot', workingDirectory: sourceDir });
+
+			const state = service.stateManager.getSessionState(session.toString());
+			assert.strictEqual(state?.summary.workingDirectory, sourceDir.toString());
+		});
+
+		test('restoreSession uses agent working directory in state', async () => {
+			// Agent returns the worktree path through listSessions
+			const worktreeDir = URI.file('/source/repo.worktrees/agents-xyz');
+			copilotAgent.sessionMetadataOverrides = { workingDirectory: worktreeDir };
+			service.registerProvider(copilotAgent);
+
+			const session = await service.createSession({ provider: 'copilot' });
+
+			// Delete from state to simulate a server restart
+			service.stateManager.deleteSession(session.toString());
+			assert.strictEqual(service.stateManager.getSessionState(session.toString()), undefined);
+
+			// Restore the session (simulates a client subscribing after restart)
+			await service.restoreSession(session);
+
+			const state = service.stateManager.getSessionState(session.toString());
+			assert.strictEqual(state?.summary.workingDirectory, worktreeDir.toString());
+		});
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -902,6 +902,71 @@ suite('AgentSideEffects', () => {
 		});
 	});
 
+	// ---- Read auto-approve -------------------------------------------------
+
+	suite('read auto-approve', () => {
+
+		test('auto-approves reads inside working directory', () => {
+			setupSession(URI.file('/workspace').toString());
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-read-1',
+				toolName: 'read',
+				displayName: 'Read',
+				invocationMessage: 'Read file',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-read-1',
+				invocationMessage: 'Read src/app.ts',
+				permissionKind: 'read',
+				permissionPath: '/workspace/src/app.ts',
+			});
+
+			assert.deepStrictEqual(agent.respondToPermissionCalls, [
+				{ requestId: 'tc-read-1', approved: true },
+			]);
+		});
+
+		test('does not auto-approve reads outside working directory', () => {
+			setupSession(URI.file('/workspace').toString());
+			startTurn('turn-1');
+			disposables.add(sideEffects.registerProgressListener(agent));
+
+			const envelopes: IActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_start',
+				toolCallId: 'tc-read-2',
+				toolName: 'read',
+				displayName: 'Read',
+				invocationMessage: 'Read file',
+			});
+
+			agent.fireProgress({
+				session: sessionUri,
+				type: 'tool_ready',
+				toolCallId: 'tc-read-2',
+				invocationMessage: 'Read /etc/passwd',
+				permissionKind: 'read',
+				permissionPath: '/etc/passwd',
+			});
+
+			assert.strictEqual(agent.respondToPermissionCalls.length, 0);
+
+			const readyAction = envelopes.find(e => e.action.type === ActionType.SessionToolCallReady);
+			assert.ok(readyAction, 'should dispatch tool_ready for read outside working directory');
+		});
+	});
+
 	// ---- Title persistence --------------------------------------------------
 
 	suite('title persistence', () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -115,13 +115,56 @@ suite('CopilotAgentSession', () => {
 
 	suite('permission handling', () => {
 
-		test('auto-approves read inside working directory', async () => {
-			const { session } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
-			const result = await session.handlePermissionRequest({
+		test('does not auto-approve read inside working directory (deferred to side effects)', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+			const resultPromise = session.handlePermissionRequest({
 				kind: 'read',
 				path: '/workspace/src/file.ts',
 				toolCallId: 'tc-1',
 			});
+
+			// Read should NOT be auto-approved at the session level — it fires
+			// a tool_ready event so agentSideEffects can handle it.
+			assert.strictEqual(progressEvents.length, 1);
+			assert.strictEqual(progressEvents[0].type, 'tool_ready');
+
+			assert.ok(session.respondToPermissionRequest('tc-1', true));
+			const result = await resultPromise;
+			assert.strictEqual(result.kind, 'approved');
+		});
+
+		test('does not auto-approve write inside working directory (deferred to side effects)', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+			const resultPromise = session.handlePermissionRequest({
+				kind: 'write',
+				fileName: '/workspace/src/file.ts',
+				toolCallId: 'tc-1',
+			});
+
+			// Write should NOT be auto-approved at the session level — it fires
+			// a tool_ready event so agentSideEffects can apply glob patterns.
+			assert.strictEqual(progressEvents.length, 1);
+			assert.strictEqual(progressEvents[0].type, 'tool_ready');
+
+			assert.ok(session.respondToPermissionRequest('tc-1', true));
+			const result = await resultPromise;
+			assert.strictEqual(result.kind, 'approved');
+		});
+
+		test('does not auto-approve write outside working directory', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+
+			const resultPromise = session.handlePermissionRequest({
+				kind: 'write',
+				fileName: '/other/file.ts',
+				toolCallId: 'tc-write-outside',
+			});
+
+			assert.strictEqual(progressEvents.length, 1);
+			assert.strictEqual(progressEvents[0].type, 'tool_ready');
+
+			assert.ok(session.respondToPermissionRequest('tc-write-outside', true));
+			const result = await resultPromise;
 			assert.strictEqual(result.kind, 'approved');
 		});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -7,7 +7,6 @@ import assert from 'assert';
 import type { CopilotSession, SessionEvent, SessionEventPayload, SessionEventType, TypedSessionEventHandler } from '@github/copilot-sdk';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService, ILogService } from '../../../log/common/log.js';
 import { IFileService } from '../../../files/common/files.js';
@@ -64,7 +63,7 @@ class MockCopilotSession {
 
 // ---- Helpers ----------------------------------------------------------------
 
-async function createAgentSession(disposables: DisposableStore, options?: { workingDirectory?: URI }): Promise<{
+async function createAgentSession(disposables: DisposableStore): Promise<{
 	session: CopilotAgentSession;
 	mockSession: MockCopilotSession;
 	progressEvents: IAgentProgressEvent[];
@@ -90,7 +89,6 @@ async function createAgentSession(disposables: DisposableStore, options?: { work
 		{
 			sessionUri,
 			rawSessionId: 'test-session-1',
-			workingDirectory: options?.workingDirectory,
 			onDidSessionProgress: progressEmitter,
 			wrapperFactory: factory,
 			shellManager: undefined,
@@ -115,16 +113,14 @@ suite('CopilotAgentSession', () => {
 
 	suite('permission handling', () => {
 
-		test('does not auto-approve read inside working directory (deferred to side effects)', async () => {
-			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+		test('read permission fires tool_ready (deferred to side effects)', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables);
 			const resultPromise = session.handlePermissionRequest({
 				kind: 'read',
 				path: '/workspace/src/file.ts',
 				toolCallId: 'tc-1',
 			});
 
-			// Read should NOT be auto-approved at the session level — it fires
-			// a tool_ready event so agentSideEffects can handle it.
 			assert.strictEqual(progressEvents.length, 1);
 			assert.strictEqual(progressEvents[0].type, 'tool_ready');
 
@@ -133,16 +129,14 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'approved');
 		});
 
-		test('does not auto-approve write inside working directory (deferred to side effects)', async () => {
-			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+		test('write permission fires tool_ready (deferred to side effects)', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables);
 			const resultPromise = session.handlePermissionRequest({
 				kind: 'write',
 				fileName: '/workspace/src/file.ts',
 				toolCallId: 'tc-1',
 			});
 
-			// Write should NOT be auto-approved at the session level — it fires
-			// a tool_ready event so agentSideEffects can apply glob patterns.
 			assert.strictEqual(progressEvents.length, 1);
 			assert.strictEqual(progressEvents[0].type, 'tool_ready');
 
@@ -151,8 +145,8 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'approved');
 		});
 
-		test('does not auto-approve write outside working directory', async () => {
-			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+		test('write permission outside working directory fires tool_ready', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables);
 
 			const resultPromise = session.handlePermissionRequest({
 				kind: 'write',
@@ -168,8 +162,8 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'approved');
 		});
 
-		test('does not auto-approve read outside working directory', async () => {
-			const { session, progressEvents } = await createAgentSession(disposables, { workingDirectory: URI.file('/workspace') });
+		test('read permission outside working directory fires tool_ready', async () => {
+			const { session, progressEvents } = await createAgentSession(disposables);
 
 			// Kick off permission request but don't await — it will block
 			const resultPromise = session.handlePermissionRequest({

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -72,11 +72,14 @@ export class MockAgent implements IAgent {
 		return [...this._sessions.values()].map(s => ({ session: s, startTime: Date.now(), modifiedTime: Date.now(), project: mockProject(this.id), ...this.sessionMetadataOverrides }));
 	}
 
+	/** Optional override for the working directory returned by createSession. */
+	resolvedWorkingDirectory: URI | undefined;
+
 	async createSession(_config?: IAgentCreateSessionConfig): Promise<IAgentCreateSessionResult> {
 		const rawId = `${this.id}-session-${this._nextId++}`;
 		const session = AgentSession.uri(this.id, rawId);
 		this._sessions.set(rawId, session);
-		return { session, project: mockProject(this.id) };
+		return { session, project: mockProject(this.id), workingDirectory: this.resolvedWorkingDirectory };
 	}
 
 	async resolveSessionConfig(params: IAgentResolveSessionConfigParams): Promise<IResolveSessionConfigResult> {


### PR DESCRIPTION
Consolidates permission auto-approval logic and fixes worktree working directory propagation in the agent host.

## Changes

### Permission auto-approval centralized in `agentSideEffects`
- Moved read auto-approval from `copilotAgentSession.handlePermissionRequest` to `agentSideEffects._tryAutoApproveToolReady`, alongside write and shell auto-approval
- All permission kinds (read, write, shell) are now handled in one place with consistent working-directory checks
- Added `ITypedPermissionRequest` interface to properly type the SDK's loosely-typed `PermissionRequest` (which uses `[key: string]: unknown`)
- Narrowed `permissionKind` on `IAgentToolReadyEvent` from `string` to the literal union `'shell' | 'write' | 'mcp' | 'read' | 'url' | 'custom-tool'`

### Worktree working directory fix
- `CopilotAgent.createSession` now returns the resolved worktree path via `IAgentCreateSessionResult.workingDirectory`
- `AgentService.createSession` uses the agent-resolved path (falling back to `config.workingDirectory`) in the state manager summary
- `listSessions` and `_resumeSession` prefer stored metadata `workingDirectory` over the SDK's `context.cwd`, which points to the source directory instead of the worktree

### Tests
- Updated permission handling tests to verify reads/writes flow through `tool_ready` events (not session-level auto-approve)
- Added 3 integration tests for worktree working directory propagation (create, fallback, restore)
- Added `resolvedWorkingDirectory` field to `MockAgent` for testing

(Written by Copilot)