### PR TITLE
Prompt reload when OTel settings change

### DIFF
--- a/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
+++ b/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
@@ -5,6 +5,7 @@
 
 import * as os from 'os';
 import * as vscode from 'vscode';
+import { ConfigKey } from '../../../platform/configuration/common/configurationService';
 import { ILogService } from '../../../platform/log/common/logService';
 import { DEFAULT_OTLP_ENDPOINT } from '../../../platform/otel/common/otelConfig';
 import { IOTelService } from '../../../platform/otel/common/otelService';
@@ -42,6 +43,10 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 			await this._otelService.flush();
 			this._logService.info('[OTel] Flush complete');
 		}));
+
+		// Prompt for reload when OTel settings change — these are read once at
+		// activation and the OTel SDK cannot be reconfigured at runtime.
+		this._watchForReloadRequiredChanges();
 
 		// Export the agent-traces.db file.
 		// Programmatic (eval harness): called with savePath URI or string → copies DB there.
@@ -92,6 +97,38 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 			this._telemetryService.sendMSFTTelemetryEvent('otel.exportAgentTracesDB', {
 				interactive: String(!savePath),
 			});
+		}));
+	}
+
+	private _watchForReloadRequiredChanges(): void {
+		const reloadSettings = [
+			ConfigKey.Advanced.OTelEnabled,
+			ConfigKey.Advanced.OTelExporterType,
+			ConfigKey.Advanced.OTelOtlpEndpoint,
+			ConfigKey.Advanced.OTelCaptureContent,
+			ConfigKey.Advanced.OTelOutfile,
+			ConfigKey.Advanced.OTelDbSpanExporter,
+		];
+
+		// Snapshot initial values to avoid prompting when the setting hasn't actually changed
+		const initialValues = new Map(reloadSettings.map(s => [s.fullyQualifiedId, vscode.workspace.getConfiguration().get(s.fullyQualifiedId)]));
+
+		this._register(vscode.workspace.onDidChangeConfiguration(async e => {
+			const currentConfig = vscode.workspace.getConfiguration();
+			const changed = reloadSettings.some(s =>
+				e.affectsConfiguration(s.fullyQualifiedId) &&
+				currentConfig.get(s.fullyQualifiedId) !== initialValues.get(s.fullyQualifiedId)
+			);
+			if (!changed) {
+				return;
+			}
+			const selection = await vscode.window.showInformationMessage(
+				'Copilot OTel settings changed - a reload is required for the change to take effect.',
+				'Reload Window',
+			);
+			if (selection === 'Reload Window') {
+				await vscode.commands.executeCommand('workbench.action.reloadWindow');
+			}
 		}));
 	}
 

--- a/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
+++ b/extensions/copilot/src/extension/otel/vscode-node/otelContrib.ts
@@ -122,11 +122,12 @@ export class OTelContrib extends Disposable implements IExtensionContribution {
 			if (!changed) {
 				return;
 			}
+			const reloadWindowLabel = vscode.l10n.t("Reload Window");
 			const selection = await vscode.window.showInformationMessage(
-				'Copilot OTel settings changed - a reload is required for the change to take effect.',
-				'Reload Window',
+				vscode.l10n.t("Copilot OTel settings changed - a reload is required for the change to take effect."),
+				reloadWindowLabel,
 			);
-			if (selection === 'Reload Window') {
+			if (selection === reloadWindowLabel) {
 				await vscode.commands.executeCommand('workbench.action.reloadWindow');
 			}
 		}));


### PR DESCRIPTION
OTel settings are read once at extension activation and the SDK cannot be reconfigured at runtime. Prompt the user to reload the window when any `chat.otel.*` setting changes.