### PR TITLE
Fix typo: 'explict' → 'explicit' in chat editing entry comments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -269,7 +269,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (!config.autoSave || !this._textFileService.isDirty(this.modifiedURI)) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			try {
 				await this._textFileService.save(this.modifiedURI, {
 					reason: SaveReason.EXPLICIT,

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -421,7 +421,7 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (this.modifiedModel.uri.scheme !== Schemas.untitled && (!config.autoSave || !this.notebookResolver.isDirty(this.modifiedURI))) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			await this._applyEdits(async () => {
 				try {
 					await this.modifiedResourceRef.object.save({


### PR DESCRIPTION
Fix the misspelling "explict" (should be "explicit") in two comment lines:
- `src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts` (line 424)
- `src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts` (line 272)