### PR TITLE
Fix typo: 'paramter' → 'parameter' in snippetForFunctionCall

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts
@@ -33,22 +33,22 @@ function appendJoinedPlaceholders(
 	joiner: string
 ) {
 	for (let i = 0; i < parts.length; ++i) {
-		const paramterPart = parts[i];
-		snippet.appendPlaceholder(paramterPart.text);
+		const parameterPart = parts[i];
+		snippet.appendPlaceholder(parameterPart.text);
 		if (i !== parts.length - 1) {
 			snippet.appendText(joiner);
 		}
 	}
 }
 
-interface ParamterListParts {
+interface ParameterListParts {
 	readonly parts: ReadonlyArray<Proto.SymbolDisplayPart>;
 	readonly hasOptionalParameters: boolean;
 }
 
 function getParameterListParts(
 	displayParts: ReadonlyArray<Proto.SymbolDisplayPart>
-): ParamterListParts {
+): ParameterListParts {
 	const parts: Proto.SymbolDisplayPart[] = [];
 	let optionalParams: Proto.SymbolDisplayPart[] = [];
 	let isInMethod = false;


### PR DESCRIPTION
Fix the misspelling "paramter" (should be "parameter") in `extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts`:
- Renamed local variable `paramterPart` → `parameterPart` (lines 36-37)
- Renamed interface `ParamterListParts` → `ParameterListParts` (line 44)
- All usages of the interface updated accordingly (lines 51, 18)