### PR TITLE
Fix typo: 'paramterLabel' → 'parameterLabel' in parameterHints test

### DIFF
--- a/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
+++ b/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
@@ -401,7 +401,7 @@ suite('ParameterHintsModel', () => {
 		const triggerChar = 'a';
 		const firstProviderId = 'firstProvider';
 		const secondProviderId = 'secondProvider';
-		const paramterLabel = 'parameter';
+		const parameterLabel = 'parameter';
 
 		const editor = createMockEditor('');
 		const model = disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -423,7 +423,7 @@ suite('ParameterHintsModel', () => {
 								signatures: [{
 									label: firstProviderId,
 									parameters: [
-										{ label: paramterLabel }
+										{ label: parameterLabel }
 									]
 								}]
 							},
@@ -468,12 +468,12 @@ suite('ParameterHintsModel', () => {
 			const firstHint = (await getNextHint(model))!.value;
 			assert.strictEqual(firstHint.signatures[0].label, firstProviderId);
 			assert.strictEqual(firstHint.activeSignature, 0);
-			assert.strictEqual(firstHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(firstHint.signatures[0].parameters[0].label, parameterLabel);
 
 			const secondHint = (await getNextHint(model))!.value;
 			assert.strictEqual(secondHint.signatures[0].label, secondProviderId);
 			assert.strictEqual(secondHint.activeSignature, 1);
-			assert.strictEqual(secondHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(secondHint.signatures[0].parameters[0].label, parameterLabel);
 		});
 	});
 


### PR DESCRIPTION
Fix the misspelling of local variable `paramterLabel` → `parameterLabel` in `src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts` (4 occurrences: declaration and 3 usages).