### PR TITLE
sessions: add pinned sidebar section

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -487,6 +487,7 @@ The Sessions view is registered in `contrib/sessions/browser/sessions.contributi
 - **Window visibility**: `WindowVisibility.Sessions`
 - **Primary action**: The sidebar content starts with a left-aligned secondary "New Session" button rendered as `$(plus) Session`, with an inline shortcut hint that reflects the active `workbench.action.sessions.newChat` keybinding when one is available
 - **Header layout**: The sessions list header label remains visible as the sidebar narrows and truncates with ellipsis instead of being hidden outright; the inline find widget still replaces both the label and actions while open
+- **Pinned section**: Pinned chats render in their own uppercase "Pinned" section header at the top of the list; that section reuses the standard section-header styling and only exposes the section-level "Mark All as Done" action (not workspace-specific actions like "New Session")
 
 ---
 
@@ -654,6 +655,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-15 | Updated the Sessions sidebar so pinned chats render in their own "Pinned" section header using the standard uppercase section styling, and that header only exposes the "Mark All as Done" section action. |
 | 2026-04-14 | Documented the sessions account control as a titlebar widget again and noted that it now prefers the signed-in GitHub profile image, falling back to the existing account codicon when the image is unavailable. |
 | 2026-04-14 | Updated the sessions-only default configuration so notification toasts default to the top-right corner via `workbench.notifications.position: 'top-right'`, without changing the regular workbench default. |
 | 2026-04-10 | Updated the sessions titlebar widget so repository/worktree metadata truncates with ellipsis before the primary AI-generated session title when the command center gets narrow. |

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -876,46 +876,16 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}
 
-		const sorted = this.sortSessions(filtered);
-
-		// Separate pinned and archived sessions (archived always wins over pinned)
-		const pinned: ISession[] = [];
-		const archived: ISession[] = [];
-		const regular: ISession[] = [];
-		for (const session of sorted) {
-			if (session.isArchived.get()) {
-				archived.push(session);
-			} else if (this.isSessionPinned(session)) {
-				pinned.push(session);
-			} else {
-				regular.push(session);
-			}
-		}
-
 		const grouping = this.options.grouping();
-		const sections: ISessionSection[] = [];
-
-		// Group remaining non-archived sessions
-		const grouped = grouping === SessionsGrouping.Workspace
-			? this.groupByWorkspace(regular)
-			: this.groupByDate(regular);
-		sections.push(...grouped);
-
-		// Add archived section at the bottom
-		if (archived.length > 0) {
-			sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
-		}
+		const sections = groupSessionsForList(filtered, grouping, this.options.sorting(), session => this.isSessionPinned(session));
 
 		const hasTodaySessions = sections.some(s => s.id === 'today' && s.sessions.length > 0);
 
-		// Pinned sessions appear flat at the top (no section header)
-		const children: IObjectTreeElement<SessionListItem>[] = [
-			...pinned.map(session => ({ element: session as SessionListItem })),
-		];
+		const children: IObjectTreeElement<SessionListItem>[] = [];
 
 		children.push(...sections.map(section => {
 			const isWorkspaceGroup = grouping === SessionsGrouping.Workspace
-				&& section.id !== 'archived';
+				&& section.id.startsWith('workspace:');
 			const isCapped = isWorkspaceGroup && this.workspaceGroupCapped
 				&& !this.findOpen
 				&& !this.expandedWorkspaceGroups.has(section.label)
@@ -1239,21 +1209,6 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this.storageService.store(SessionsList.SECTION_COLLAPSE_STATE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
 	}
 
-	// -- Sorting --
-
-	private sortSessions(sessions: ISession[]): ISession[] {
-		return sortSessions(sessions, this.options.sorting());
-	}
-
-	// -- Grouping --
-
-	private groupByWorkspace(sessions: ISession[]): ISessionSection[] {
-		return groupByWorkspace(sessions);
-	}
-
-	private groupByDate(sessions: ISession[]): ISessionSection[] {
-		return groupByDate(sessions, this.options.sorting());
-	}
 }
 
 //#endregion
@@ -1282,6 +1237,44 @@ export function sortSessions(sessions: ISession[], sorting: SessionsSorting): IS
 		}
 		return b.createdAt.getTime() - a.createdAt.getTime();
 	});
+}
+
+export function groupSessionsForList(
+	sessions: ISession[],
+	grouping: SessionsGrouping,
+	sorting: SessionsSorting,
+	isSessionPinned: (session: ISession) => boolean,
+): ISessionSection[] {
+	const sorted = sortSessions(sessions, sorting);
+
+	// Archived always wins over pinned so done sessions stay grouped together.
+	const pinned: ISession[] = [];
+	const archived: ISession[] = [];
+	const regular: ISession[] = [];
+	for (const session of sorted) {
+		if (session.isArchived.get()) {
+			archived.push(session);
+		} else if (isSessionPinned(session)) {
+			pinned.push(session);
+		} else {
+			regular.push(session);
+		}
+	}
+
+	const sections: ISessionSection[] = [];
+	if (pinned.length > 0) {
+		sections.push({ id: 'pinned', label: localize('pinned', "Pinned"), sessions: pinned });
+	}
+
+	sections.push(...(grouping === SessionsGrouping.Workspace
+		? groupByWorkspace(regular)
+		: groupByDate(regular, sorting)));
+
+	if (archived.length > 0) {
+		sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
+	}
+
+	return sections;
 }
 
 export function groupByWorkspace(sessions: ISession[]): ISessionSection[] {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -277,6 +277,22 @@ registerAction2(class NewSessionForWorkspaceAction extends Action2 {
 
 const ConfirmArchiveStorageKey = 'sessions.confirmArchive';
 
+function getArchiveSectionConfirmationMessage(context: ISessionSection): string {
+	if (context.id === 'pinned') {
+		if (context.sessions.length === 1) {
+			return localize('archivePinnedSectionSessions.confirmSingle', "Are you sure you want to mark 1 pinned session as done?");
+		}
+
+		return localize('archivePinnedSectionSessions.confirm', "Are you sure you want to mark {0} pinned sessions as done?", context.sessions.length);
+	}
+
+	if (context.sessions.length === 1) {
+		return localize('archiveSectionSessions.confirmSingle', "Are you sure you want to mark 1 session from '{0}' as done?", context.label);
+	}
+
+	return localize('archiveSectionSessions.confirm', "Are you sure you want to mark {0} sessions from '{1}' as done?", context.sessions.length, context.label);
+}
+
 registerAction2(class ArchiveSectionAction extends Action2 {
 	constructor() {
 		super({
@@ -302,15 +318,8 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 
 		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 		if (!skipConfirmation) {
-			const isPinnedSection = context.id === 'pinned';
 			const confirmed = await dialogService.confirm({
-				message: isPinnedSection
-					? (context.sessions.length === 1
-						? localize('archivePinnedSectionSessions.confirmSingle', "Are you sure you want to mark 1 pinned session as done?")
-						: localize('archivePinnedSectionSessions.confirm', "Are you sure you want to mark {0} pinned sessions as done?", context.sessions.length))
-					: (context.sessions.length === 1
-						? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to mark 1 session from '{0}' as done?", context.label)
-						: localize('archiveSectionSessions.confirm', "Are you sure you want to mark {0} sessions from '{1}' as done?", context.sessions.length, context.label)),
+				message: getArchiveSectionConfirmationMessage(context),
 				detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
 				primaryButton: localize('archiveSectionSessions.archive', "Mark All as Done"),
 				checkbox: {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -302,10 +302,15 @@ registerAction2(class ArchiveSectionAction extends Action2 {
 
 		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 		if (!skipConfirmation) {
+			const isPinnedSection = context.id === 'pinned';
 			const confirmed = await dialogService.confirm({
-				message: context.sessions.length === 1
-					? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to mark 1 session from '{0}' as done?", context.label)
-					: localize('archiveSectionSessions.confirm', "Are you sure you want to mark {0} sessions from '{1}' as done?", context.sessions.length, context.label),
+				message: isPinnedSection
+					? (context.sessions.length === 1
+						? localize('archivePinnedSectionSessions.confirmSingle', "Are you sure you want to mark 1 pinned session as done?")
+						: localize('archivePinnedSectionSessions.confirm', "Are you sure you want to mark {0} pinned sessions as done?", context.sessions.length))
+					: (context.sessions.length === 1
+						? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to mark 1 session from '{0}' as done?", context.label)
+						: localize('archiveSectionSessions.confirm', "Are you sure you want to mark {0} sessions from '{1}' as done?", context.sessions.length, context.label)),
 				detail: localize('archiveSectionSessions.detail', "You can restore sessions later if needed from the sessions view."),
 				primaryButton: localize('archiveSectionSessions.archive', "Mark All as Done"),
 				checkbox: {

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -9,7 +9,7 @@ import { observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { groupByWorkspace, sortSessions, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
 
 function createSession(id: string, opts: {
 	workspaceLabel?: string;
@@ -152,6 +152,36 @@ suite('Sessions - SessionsList Helpers', () => {
 			const sorted = sortSessions(sessions, SessionsSorting.Updated);
 
 			assert.deepStrictEqual(sorted.map(s => s.sessionId), ['b', 'c', 'a']);
+		});
+	});
+
+	suite('groupSessionsForList', () => {
+
+		test('shows pinned sessions in a dedicated top section', () => {
+			const pinned = createSession('pinned', { workspaceLabel: 'Alpha', createdAt: new Date('2024-06-01') });
+			const regular = createSession('regular', { workspaceLabel: 'Beta', createdAt: new Date('2024-05-01') });
+			const sections = groupSessionsForList(
+				[pinned, regular],
+				SessionsGrouping.Workspace,
+				SessionsSorting.Created,
+				session => session.sessionId === pinned.sessionId,
+			);
+
+			assert.deepStrictEqual(sections.map(section => section.id), ['pinned', 'workspace:Beta']);
+			assert.deepStrictEqual(sections[0].sessions.map(session => session.sessionId), ['pinned']);
+		});
+
+		test('keeps archived sessions in Done even when pinned', () => {
+			const archivedPinned = createSession('archived-pinned', { workspaceLabel: 'Alpha', isArchived: true, createdAt: new Date('2024-06-01') });
+			const sections = groupSessionsForList(
+				[archivedPinned],
+				SessionsGrouping.Workspace,
+				SessionsSorting.Created,
+				() => true,
+			);
+
+			assert.deepStrictEqual(sections.map(section => section.id), ['archived']);
+			assert.deepStrictEqual(sections[0].sessions.map(session => session.sessionId), ['archived-pinned']);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Related to https://github.com/microsoft/vscode/issues/310018

- render pinned chats under a dedicated `Pinned` section header in the sessions sidebar
- reuse the existing section-header presentation so the label stays uppercase like workspace and folder headers
- keep the pinned section toolbar limited to `Mark All as Done`, without workspace-specific actions like `New Session`
- add grouping tests and update the sessions layout spec

<img width="1705" height="1084" alt="Screenshot 2026-04-15 at 6 08 18 PM" src="https://github.com/user-attachments/assets/383c48f7-070a-4a9c-a7bb-562280a8e01b" />
<img width="1705" height="1084" alt="Screenshot 2026-04-15 at 6 08 25 PM" src="https://github.com/user-attachments/assets/6fad2c77-a11b-4d76-9a11-76c536fd0890" />

## Notes
- compile-check and hygiene passed in this environment
- the targeted Electron-backed unit test bootstrap failed in this CLI environment before reaching the sessions code (`app.setPath` on an undefined Electron app)