### PR TITLE
Fix typo: 'immediatly' → 'immediately' in debug session and service comments

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -727,7 +727,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(listenerDisposables);
 
 		const sessionRunningScheduler = listenerDisposables.add(new RunOnceScheduler(() => {
-			// Do not immediatly defocus the stack frame if the session is running
+			// Do not immediately defocus the stack frame if the session is running
 			if (session.state === State.Running && this.viewModel.focusedSession === session) {
 				this.viewModel.setFocus(undefined, this.viewModel.focusedThread, session, false);
 			}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;


### PR DESCRIPTION
Fix spelling of 'immediately' in two comment lines in the debug module:
- `debugSession.ts` line 1493
- `debugService.ts` line 730