### PR TITLE
Fix typo: 'avaiable' → 'available' in editorActions and remoteTunnel

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2527,7 +2527,7 @@ export class ToggleEditorTypeAction extends Action2 {
 			return;
 		}
 
-		// Replace the current editor with the next avaiable editor type
+		// Replace the current editor with the next available editor type
 		await editorService.replaceEditors([
 			{
 				editor: activeEditorPane.input,

--- a/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
@@ -195,7 +195,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 							key: 'recommend.remoteExtension',
 							comment: ['{0} will be a tunnel name, {1} will the link address to the web UI, {6} an extension name. [label](command:commandId) is a markdown link. Only translate the label, do not modify the format']
 						},
-						"Tunnel '{0}' is avaiable for remote access. The {1} extension can be used to connect to it.",
+						"Tunnel '{0}' is available for remote access. The {1} extension can be used to connect to it.",
 						usedOnHost, remoteExtension.friendlyName
 					),
 				actions: {


### PR DESCRIPTION
Fix missing 'l' in 'available' in two files:
- `editorActions.ts` line 2530: comment spelling fix
- `remoteTunnel.contribution.ts` line 198: user-facing tunnel notification string