### PR TITLE
Fix typo: 'indeces' → 'indices' in historyService comment

### DIFF
--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -1805,7 +1805,7 @@ ${entryLabels.join('\n')}
 		// to each other to prevent no-op navigations.
 		this.flatten();
 
-		// Reset indeces
+		// Reset indices
 		this.index = this.stack.length - 1;
 		this.previousIndex = -1;
 


### PR DESCRIPTION
Fix spelling of 'indices' (plural of 'index') in a comment at line 1808 of `historyService.ts`.