### PR TITLE
Fix typo: 'orignal' → 'original' in scmHistoryViewPane comment

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -2111,7 +2111,7 @@ export class SCMHistoryViewPane extends ViewPane {
 
 			const historyItemRefMenuItems = MenuRegistry.getMenuItems(MenuId.SCMHistoryItemRefContext).filter(item => isIMenuItem(item));
 
-			// If there are any history item references we have to add a submenu item for each orignal action,
+			// If there are any history item references we have to add a submenu item for each original action,
 			// and a menu item for each history item ref that matches the `when` clause of the original action.
 			if (historyItemRefMenuItems.length > 0 && element.historyItemViewModel.historyItem.references?.length) {
 				const historyItemRefActions = new Map<string, ISCMHistoryItemRef[]>();


### PR DESCRIPTION
Fix missing 'i' in 'original' in a comment at line 2114 of `scmHistoryViewPane.ts`.