### PR TITLE
Fix typo: '2-colum' → '2-column' in agentSessionsWelcome comment

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -827,7 +827,7 @@ export class AgentSessionsWelcomePage extends EditorPane {
 			return;
 		}
 
-		// TODO: @osortega this is a weird way of doing this, maybe we handle the 2-colum layout in the control itself?
+		// TODO: @osortega this is a weird way of doing this, maybe we handle the 2-column layout in the control itself?
 		const sessionsWidth = Math.min(800, this.lastDimension.width - 80);
 		// Calculate height based on actual visible sessions (capped at MAX_SESSIONS)
 		// Use ITEM_HEIGHT per item from AgentSessionsListDelegate


### PR DESCRIPTION
Fix missing 'n' in 'column' in a TODO comment at line 830 of `agentSessionsWelcome.ts`.