### PR TITLE
Fix typo: 'concurent' → 'concurrent' in breakpointsView comment

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1686,7 +1686,7 @@ class ExceptionBreakpointInputRenderer implements ICompressibleTreeRenderer<IExc
 			}
 		}));
 		toDispose.add(dom.addDisposableListener(inputBox.inputElement, 'blur', () => {
-			// Need to react with a timeout on the blur event due to possible concurent splices #56443
+			// Need to react with a timeout on the blur event due to possible concurrent splices #56443
 			setTimeout(() => {
 				wrapUp(true);
 			});


### PR DESCRIPTION
Fix missing 'r' in 'concurrent' in a comment at line 1689 of `breakpointsView.ts`.