### PR TITLE
Fix typo: 'interpretted' → 'interpreted' in cursorTypeEditOperations comment

### DIFF
--- a/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeEditOperations.ts
@@ -343,7 +343,7 @@ export class AutoClosingOpenCharTypeOperation {
 	}
 
 	private static _isBeforeClosingBrace(config: CursorConfiguration, lineAfter: string) {
-		// If the start of lineAfter can be interpretted as both a starting or ending brace, default to returning false
+		// If the start of lineAfter can be interpreted as both a starting or ending brace, default to returning false
 		const nextChar = lineAfter.charAt(0);
 		const potentialStartingBraces = config.autoClosingPairs.autoClosingPairsOpenByStart.get(nextChar) || [];
 		const potentialClosingBraces = config.autoClosingPairs.autoClosingPairsCloseByStart.get(nextChar) || [];


### PR DESCRIPTION
Fix double 't' in 'interpreted' in a comment at line 346 of `cursorTypeEditOperations.ts`.