### PR TITLE
Fix: typos superceded → superseded and occurence → occurrence

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -153,8 +153,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 		const oldDecorations: string[] = [];
 		const keys = Object.keys(this.currentOccurrences);
 		for (const decorationId of keys) {
-			const occurence = this.currentOccurrences[decorationId];
-			oldDecorations.push(occurence.decorationId);
+			const occurrence = this.currentOccurrences[decorationId];
+			oldDecorations.push(occurrence.decorationId);
 		}
 
 		const newDecorations: IModelDeltaDecoration[] = [];
@@ -171,8 +171,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 			this.currentOccurrences = {};
 			this.activeLinkDecorationId = null;
 			for (let i = 0, len = decorations.length; i < len; i++) {
-				const occurence = new LinkOccurrence(links[i], decorations[i]);
-				this.currentOccurrences[occurence.decorationId] = occurence;
+				const occurrence = new LinkOccurrence(links[i], decorations[i]);
+				this.currentOccurrences[occurrence.decorationId] = occurrence;
 			}
 		});
 	}


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the contributing guidelines.
- [x] The pull request title follows our guidelines.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typos:
- `superceded` → `superseded` in `src/vs/base/parts/sandbox/electron-browser/electronTypes.ts` (JSDoc comment)
- `occurence` → `occurrence` in `src/vs/editor/contrib/links/browser/links.ts` (local variable name — function-scoped, no API impact)

These are low-risk changes with no functional impact.