### PR TITLE
feat: add useful Handlebars snippets for common template patterns

### DIFF
--- a/extensions/handlebars/package.json
+++ b/extensions/handlebars/package.json
@@ -47,6 +47,12 @@
         "languageId": "handlebars",
         "autoInsert": true
       }
+    ],
+    "snippets": [
+      {
+        "language": "handlebars",
+        "path": "./snippets/handlebars.code-snippets"
+      }
     ]
   },
   "repository": {

--- a/extensions/handlebars/snippets/handlebars.code-snippets
+++ b/extensions/handlebars/snippets/handlebars.code-snippets
@@ -1,0 +1,139 @@
+{
+	"Handlebars expression": {
+		"prefix": "hb",
+		"body": [
+			"{{${1:expression}}}"
+		],
+		"description": "Handlebars expression"
+	},
+	"Handlebars unescaped": {
+		"prefix": "hbu",
+		"body": [
+			"{{{${1:expression}}}}"
+		],
+		"description": "Handlebars unescaped HTML expression"
+	},
+	"Handlebars if block": {
+		"prefix": "if",
+		"body": [
+			"{{#if ${1:condition}}}",
+			"\t$0",
+			"{{/if}}"
+		],
+		"description": "Handlebars #if block"
+	},
+	"Handlebars if-else block": {
+		"prefix": "ifelse",
+		"body": [
+			"{{#if ${1:condition}}}",
+			"\t${2}",
+			"{{else}}",
+			"\t$0",
+			"{{/if}}"
+		],
+		"description": "Handlebars #if-else block"
+	},
+	"Handlebars unless block": {
+		"prefix": "unless",
+		"body": [
+			"{{#unless ${1:condition}}}",
+			"\t$0",
+			"{{/unless}}"
+		],
+		"description": "Handlebars #unless block"
+	},
+	"Handlebars each block": {
+		"prefix": "each",
+		"body": [
+			"{{#each ${1:items}}}",
+			"\t$0",
+			"{{/each}}"
+		],
+		"description": "Handlebars #each loop"
+	},
+	"Handlebars each with index": {
+		"prefix": "eachi",
+		"body": [
+			"{{#each ${1:items}}}",
+			"\t{{@index}}: ${2:{{this}}}",
+			"\t$0",
+			"{{/each}}"
+		],
+		"description": "Handlebars #each with index"
+	},
+	"Handlebars with block": {
+		"prefix": "with",
+		"body": [
+			"{{#with ${1:object}}}",
+			"\t$0",
+			"{{/with}}"
+		],
+		"description": "Handlebars #with context block"
+	},
+	"Handlebars partial": {
+		"prefix": "partial",
+		"body": [
+			"{{> ${1:partialName}}}"
+		],
+		"description": "Handlebars partial"
+	},
+	"Handlebars partial with context": {
+		"prefix": "partialctx",
+		"body": [
+			"{{> ${1:partialName} ${2:context}}}"
+		],
+		"description": "Handlebars partial with context"
+	},
+	"Handlebars helper": {
+		"prefix": "helper",
+		"body": [
+			"{{${1:helperName} ${2:arg}}}"
+		],
+		"description": "Handlebars helper call"
+	},
+	"Handlebars block helper": {
+		"prefix": "blockhelper",
+		"body": [
+			"{{#${1:helperName} ${2:arg}}}",
+			"\t$0",
+			"{{/${1:helperName}}}"
+		],
+		"description": "Handlebars block helper"
+	},
+	"Handlebars comment": {
+		"prefix": "comment",
+		"body": [
+			"{{!-- ${1:comment} --}}"
+		],
+		"description": "Handlebars comment"
+	},
+	"Handlebars lookup": {
+		"prefix": "lookup",
+		"body": [
+			"{{lookup ${1:object} ${2:key}}}"
+		],
+		"description": "Handlebars lookup helper"
+	},
+	"Handlebars log": {
+		"prefix": "log",
+		"body": [
+			"{{log ${1:value}}}"
+		],
+		"description": "Handlebars log helper"
+	},
+	"Handlebars HTML template": {
+		"prefix": "tmpl",
+		"body": [
+			"<!DOCTYPE html>",
+			"<html>",
+			"<head>",
+			"\t<title>{{${1:title}}}</title>",
+			"</head>",
+			"<body>",
+			"\t$0",
+			"</body>",
+			"</html>"
+		],
+		"description": "Handlebars HTML template"
+	}
+}


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the contributing guidelines.
- [x] The pull request title follows our guidelines.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] New option for existing rule  

#### What changes did you make?

Added a comprehensive set of Handlebars template snippets to `extensions/handlebars/snippets/handlebars.code-snippets` and registered them in `extensions/handlebars/package.json`.

The snippets cover common Handlebars patterns:
- Expressions: `hb` (escaped), `hbu` (unescaped HTML)
- Conditionals: `if`, `ifelse`, `unless`
- Iteration: `each`, `eachi` (with index)
- Context: `with`
- Partials: `partial`, `partialctx`
- Helpers: `helper`, `blockhelper`, `lookup`, `log`
- Comments: `comment`
- Template: `tmpl` (HTML page template)

These snippets reduce boilerplate for Handlebars template developers working in VS Code, complementing the existing syntax highlighting already in the Handlebars extension.