### PR TITLE
Fix: typos triggerd, occured, occurrance, occurance in comments

### DIFF
--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -128,7 +128,7 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}
 
-		// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position
+		// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position
 		let anchor: IMouseEvent | null = null;
 		if (e.target.type !== MouseTargetType.TEXTAREA) {
 			anchor = e.event;

--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -107,7 +107,7 @@ export class MessageController implements IEditorContribution {
 			}
 
 			if (!bounds) {
-				// define bounding box around position and first mouse occurance
+				// define bounding box around position and first mouse occurrence
 				bounds = new Range(position.lineNumber - 3, 1, e.target.position.lineNumber + 3, 1);
 			} else if (!bounds.containsPosition(e.target.position)) {
 				// check if position is still in bounds

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -423,7 +423,7 @@ export class ReplAccessibilityProvider implements IListAccessibilityProvider<IRe
 			return localize('replVariableAriaLabel', "Variable {0}, value {1}", element.name, element.value);
 		}
 		if (element instanceof ReplOutputElement || element instanceof ReplEvaluationInput || element instanceof ReplEvaluationResult) {
-			return element.value + (element instanceof ReplOutputElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrance count.'] },
+			return element.value + (element instanceof ReplOutputElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrence count.'] },
 				", occurred {0} times", element.count) : '');
 		}
 		if (element instanceof RawObjectReplElement) {

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -905,7 +905,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -1007,7 +1007,7 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).


### PR DESCRIPTION
Fix typos in comments across several files:

- `triggerd` → `triggered` in `storedFileWorkingCopy.ts`, `textFileEditorModel.ts`, `contextmenu.ts`
- `occured` → `occurred` in `parcelWatcher.ts`
- `occurrance` → `occurrence` in `replViewer.ts`
- `occurance` → `occurrence` in `messageController.ts`