### PR TITLE
Fix: typos seperate, dependecies, suported in comments and code

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -620,8 +620,8 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 		const allDependenciesAndPacks: { gallery: IGalleryExtension; manifest: IExtensionManifest }[] = [];
 		const collectDependenciesAndPackExtensionsToInstall = async (extensionIdentifier: IExtensionIdentifier, manifest: IExtensionManifest): Promise<void> => {
 			knownIdentifiers.push(extensionIdentifier);
-			const dependecies: string[] = manifest.extensionDependencies ? manifest.extensionDependencies.filter(dep => !installed.some(e => areSameExtensions(e.identifier, { id: dep }))) : [];
-			const dependenciesAndPackExtensions = [...dependecies];
+			const dependencies: string[] = manifest.extensionDependencies ? manifest.extensionDependencies.filter(dep => !installed.some(e => areSameExtensions(e.identifier, { id: dep }))) : [];
+			const dependenciesAndPackExtensions = [...dependencies];
 			if (manifest.extensionPack) {
 				const existing = installed.find(e => areSameExtensions(e.identifier, extensionIdentifier));
 				for (const extension of manifest.extensionPack) {
@@ -643,7 +643,7 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 						if (knownIdentifiers.find(identifier => areSameExtensions(identifier, galleryExtension.identifier))) {
 							continue;
 						}
-						const isDependency = dependecies.some(id => areSameExtensions({ id }, galleryExtension.identifier));
+						const isDependency = dependencies.some(id => areSameExtensions({ id }, galleryExtension.identifier));
 						let compatible;
 						try {
 							compatible = await this.checkAndGetCompatibleVersion(galleryExtension, false, preferPreRelease, productVersion);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWebWorker.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWebWorker.ts
@@ -206,7 +206,7 @@ export class LanguageDetectionWorker implements ILanguageDetectionWorker {
 			case 'csv':
 			case 'toml':
 				// Other considerations for negativeConfidenceCorrection that
-				// aren't built in but suported by the model include:
+				// aren't built in but supported by the model include:
 				// * Assembly, TeX - These languages didn't have clear language modes in the community
 				// * Markdown, Dockerfile - These languages are simple but they embed other languages
 				modelResult.confidence -= LanguageDetectionWorker.negativeConfidenceCorrection;

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -436,7 +436,7 @@ export class IndexedDBStorageDatabase extends Disposable implements IIndexedDBSt
 	}
 
 	async optimize(): Promise<void> {
-		// not suported in IndexedDB
+		// not supported in IndexedDB
 	}
 
 	async close(): Promise<void> {


### PR DESCRIPTION
Fix several typos across the codebase:

- `seperate` → `separate` in `extHostTypes.ts` (comment)
- `dependecies` → `dependencies` in `abstractExtensionManagementService.ts` (local variable, 3 occurrences)
- `suported` → `supported` in `languageDetectionWebWorker.ts` (comment)
- `suported` → `supported` in `storageService.ts` (comment)