### PR TITLE
feat: add INI and YAML snippets for common configuration patterns

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -64,6 +64,16 @@
         "scopeName": "source.ini",
         "path": "./syntaxes/ini.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "ini",
+        "path": "./snippets/ini.code-snippets"
+      },
+      {
+        "language": "properties",
+        "path": "./snippets/ini.code-snippets"
+      }
     ]
   },
   "repository": {

--- a/extensions/ini/snippets/ini.code-snippets
+++ b/extensions/ini/snippets/ini.code-snippets
@@ -1,0 +1,111 @@
+{
+	"INI Section": {
+		"prefix": "section",
+		"body": [
+			"[${1:section}]",
+			"$0"
+		],
+		"description": "INI section header"
+	},
+	"INI Key-Value": {
+		"prefix": "kv",
+		"body": [
+			"${1:key} = ${2:value}"
+		],
+		"description": "INI key-value pair"
+	},
+	"INI Comment": {
+		"prefix": "comment",
+		"body": [
+			"; ${1:comment}"
+		],
+		"description": "INI comment"
+	},
+	"INI Section with Keys": {
+		"prefix": "sectionkeys",
+		"body": [
+			"[${1:section}]",
+			"${2:key1} = ${3:value1}",
+			"${4:key2} = ${5:value2}",
+			"$0"
+		],
+		"description": "INI section with key-value pairs"
+	},
+	"INI Boolean": {
+		"prefix": "bool",
+		"body": [
+			"${1:key} = ${2|true,false|}"
+		],
+		"description": "INI boolean value"
+	},
+	"INI Number": {
+		"prefix": "num",
+		"body": [
+			"${1:key} = ${2:0}"
+		],
+		"description": "INI numeric value"
+	},
+	"INI List": {
+		"prefix": "list",
+		"body": [
+			"${1:key}[] = ${2:value1}",
+			"${1:key}[] = ${3:value2}",
+			"${1:key}[] = ${4:value3}"
+		],
+		"description": "INI array/list values"
+	},
+	"INI Database Config": {
+		"prefix": "database",
+		"body": [
+			"[database]",
+			"host = ${1:localhost}",
+			"port = ${2:5432}",
+			"name = ${3:mydb}",
+			"user = ${4:admin}",
+			"password = ${5:secret}"
+		],
+		"description": "Database configuration section"
+	},
+	"INI Server Config": {
+		"prefix": "server",
+		"body": [
+			"[server]",
+			"host = ${1:0.0.0.0}",
+			"port = ${2:8080}",
+			"debug = ${3|false,true|}",
+			"workers = ${4:4}"
+		],
+		"description": "Server configuration section"
+	},
+	"INI Logging Config": {
+		"prefix": "logging",
+		"body": [
+			"[logging]",
+			"level = ${1|DEBUG,INFO,WARNING,ERROR,CRITICAL|}",
+			"file = ${2:app.log}",
+			"format = ${3:%(asctime)s - %(levelname)s - %(message)s}"
+		],
+		"description": "Logging configuration section"
+	},
+	"INI Default Section": {
+		"prefix": "default",
+		"body": [
+			"[DEFAULT]",
+			"${1:key} = ${2:value}",
+			"$0"
+		],
+		"description": "INI DEFAULT section (inherited by all sections)"
+	},
+	"INI File Header": {
+		"prefix": "header",
+		"body": [
+			"; ${1:Application} Configuration",
+			"; Generated: ${2:date}",
+			"; Author: ${3:name}",
+			"",
+			"[${4:section}]",
+			"$0"
+		],
+		"description": "INI file with header comment"
+	}
+}

--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -89,6 +89,12 @@
         ]
       }
     ],
+    "snippets": [
+      {
+        "language": "yaml",
+        "path": "./snippets/yaml.code-snippets"
+      }
+    ],
     "configurationDefaults": {
       "[yaml]": {
         "editor.insertSpaces": true,

--- a/extensions/yaml/snippets/yaml.code-snippets
+++ b/extensions/yaml/snippets/yaml.code-snippets
@@ -1,0 +1,180 @@
+{
+	"YAML Key-Value": {
+		"prefix": "kv",
+		"body": [
+			"${1:key}: ${2:value}"
+		],
+		"description": "YAML key-value pair"
+	},
+	"YAML List Item": {
+		"prefix": "li",
+		"body": [
+			"- ${1:item}"
+		],
+		"description": "YAML list item"
+	},
+	"YAML List": {
+		"prefix": "list",
+		"body": [
+			"${1:items}:",
+			"  - ${2:item1}",
+			"  - ${3:item2}",
+			"  - ${4:item3}"
+		],
+		"description": "YAML list"
+	},
+	"YAML Mapping": {
+		"prefix": "map",
+		"body": [
+			"${1:name}:",
+			"  ${2:key1}: ${3:value1}",
+			"  ${4:key2}: ${5:value2}"
+		],
+		"description": "YAML mapping (nested object)"
+	},
+	"YAML Multiline String (literal)": {
+		"prefix": "multiline",
+		"body": [
+			"${1:key}: |",
+			"  ${2:line one}",
+			"  ${3:line two}"
+		],
+		"description": "YAML literal block scalar (preserves newlines)"
+	},
+	"YAML Multiline String (folded)": {
+		"prefix": "folded",
+		"body": [
+			"${1:key}: >",
+			"  ${2:line one}",
+			"  ${3:line two}"
+		],
+		"description": "YAML folded block scalar (folds newlines to spaces)"
+	},
+	"YAML Anchor": {
+		"prefix": "anchor",
+		"body": [
+			"${1:name}: &${2:anchor}",
+			"  ${3:key}: ${4:value}"
+		],
+		"description": "YAML anchor definition"
+	},
+	"YAML Alias": {
+		"prefix": "alias",
+		"body": [
+			"${1:name}: *${2:anchor}"
+		],
+		"description": "YAML alias reference"
+	},
+	"YAML Comment": {
+		"prefix": "comment",
+		"body": [
+			"# ${1:comment}"
+		],
+		"description": "YAML comment"
+	},
+	"YAML Document Start": {
+		"prefix": "---",
+		"body": [
+			"---",
+			"$0"
+		],
+		"description": "YAML document start marker"
+	},
+	"YAML GitHub Actions Step": {
+		"prefix": "step",
+		"body": [
+			"- name: ${1:Step name}",
+			"  uses: ${2:actions/checkout@v4}",
+			"  with:",
+			"    ${3:key}: ${4:value}"
+		],
+		"description": "GitHub Actions workflow step"
+	},
+	"YAML GitHub Actions Job": {
+		"prefix": "job",
+		"body": [
+			"${1:job-name}:",
+			"  runs-on: ${2|ubuntu-latest,windows-latest,macos-latest|}",
+			"  steps:",
+			"    - uses: actions/checkout@v4",
+			"    - name: ${3:Step name}",
+			"      run: ${4:command}"
+		],
+		"description": "GitHub Actions job"
+	},
+	"YAML GitHub Actions Workflow": {
+		"prefix": "workflow",
+		"body": [
+			"name: ${1:CI}",
+			"",
+			"on:",
+			"  push:",
+			"    branches: [ ${2:main} ]",
+			"  pull_request:",
+			"    branches: [ ${2:main} ]",
+			"",
+			"jobs:",
+			"  ${3:build}:",
+			"    runs-on: ubuntu-latest",
+			"    steps:",
+			"      - uses: actions/checkout@v4",
+			"      - name: ${4:Build}",
+			"        run: ${5:make build}"
+		],
+		"description": "GitHub Actions workflow file"
+	},
+	"YAML Kubernetes Deployment": {
+		"prefix": "k8sdeploy",
+		"body": [
+			"apiVersion: apps/v1",
+			"kind: Deployment",
+			"metadata:",
+			"  name: ${1:my-app}",
+			"  labels:",
+			"    app: ${1:my-app}",
+			"spec:",
+			"  replicas: ${2:3}",
+			"  selector:",
+			"    matchLabels:",
+			"      app: ${1:my-app}",
+			"  template:",
+			"    metadata:",
+			"      labels:",
+			"        app: ${1:my-app}",
+			"    spec:",
+			"      containers:",
+			"        - name: ${1:my-app}",
+			"          image: ${3:nginx:latest}",
+			"          ports:",
+			"            - containerPort: ${4:80}"
+		],
+		"description": "Kubernetes Deployment manifest"
+	},
+	"YAML Kubernetes Service": {
+		"prefix": "k8ssvc",
+		"body": [
+			"apiVersion: v1",
+			"kind: Service",
+			"metadata:",
+			"  name: ${1:my-service}",
+			"spec:",
+			"  selector:",
+			"    app: ${2:my-app}",
+			"  ports:",
+			"    - protocol: TCP",
+			"      port: ${3:80}",
+			"      targetPort: ${4:8080}",
+			"  type: ${5|ClusterIP,NodePort,LoadBalancer|}"
+		],
+		"description": "Kubernetes Service manifest"
+	},
+	"YAML Environment Variables": {
+		"prefix": "env",
+		"body": [
+			"env:",
+			"  - name: ${1:VAR_NAME}",
+			"    value: ${2:value}"
+		],
+		"description": "YAML environment variables list"
+	}
+}


### PR DESCRIPTION
Add code snippets for INI and YAML files:

**INI snippets** (`extensions/ini/snippets/ini.code-snippets`):
- `section` — INI section header
- `kv` — key-value pair
- `comment` — INI comment
- `sectionkeys` — section with multiple keys
- `bool` / `num` — typed values
- `list` — array-style values
- `database` / `server` / `logging` — common config sections
- `default` — DEFAULT section
- `header` — file header template

**YAML snippets** (`extensions/yaml/snippets/yaml.code-snippets`):
- `kv` / `list` / `map` — basic YAML structures
- `multiline` / `folded` — block scalars
- `anchor` / `alias` — YAML anchors
- `comment` / `---` — document markers
- `step` / `job` / `workflow` — GitHub Actions templates
- `k8sdeploy` / `k8ssvc` — Kubernetes manifests
- `env` — environment variables list

Both snippet files are registered for their respective languages in `package.json`.