### PR TITLE
feat: add Ruby and SQL snippets for common programming patterns

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -67,6 +67,12 @@
         "path": "./syntaxes/ruby.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "ruby",
+        "path": "./snippets/ruby.code-snippets"
+      }
+    ],
     "configurationDefaults": {
       "[ruby]": {
         "editor.defaultColorDecorators": "never"

--- a/extensions/ruby/snippets/ruby.code-snippets
+++ b/extensions/ruby/snippets/ruby.code-snippets
@@ -1,0 +1,223 @@
+{
+	"Ruby Method": {
+		"prefix": "def",
+		"body": [
+			"def ${1:method_name}(${2:params})",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby method definition"
+	},
+	"Ruby Class": {
+		"prefix": "class",
+		"body": [
+			"class ${1:ClassName}",
+			"  def initialize(${2:params})",
+			"    $0",
+			"  end",
+			"end"
+		],
+		"description": "Ruby class definition"
+	},
+	"Ruby Class with Inheritance": {
+		"prefix": "classi",
+		"body": [
+			"class ${1:ClassName} < ${2:ParentClass}",
+			"  def initialize(${3:params})",
+			"    super",
+			"    $0",
+			"  end",
+			"end"
+		],
+		"description": "Ruby class with inheritance"
+	},
+	"Ruby Module": {
+		"prefix": "module",
+		"body": [
+			"module ${1:ModuleName}",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby module definition"
+	},
+	"Ruby If Statement": {
+		"prefix": "if",
+		"body": [
+			"if ${1:condition}",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby if statement"
+	},
+	"Ruby If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if ${1:condition}",
+			"  ${2:# true branch}",
+			"else",
+			"  ${3:# false branch}",
+			"end"
+		],
+		"description": "Ruby if-else statement"
+	},
+	"Ruby Unless": {
+		"prefix": "unless",
+		"body": [
+			"unless ${1:condition}",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby unless statement"
+	},
+	"Ruby Each Loop": {
+		"prefix": "each",
+		"body": [
+			"${1:collection}.each do |${2:item}|",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby each iterator"
+	},
+	"Ruby Times Loop": {
+		"prefix": "times",
+		"body": [
+			"${1:n}.times do |${2:i}|",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby times loop"
+	},
+	"Ruby Map": {
+		"prefix": "map",
+		"body": [
+			"${1:collection}.map { |${2:item}| ${3:item} }"
+		],
+		"description": "Ruby map/collect"
+	},
+	"Ruby Select/Filter": {
+		"prefix": "select",
+		"body": [
+			"${1:collection}.select { |${2:item}| ${3:condition} }"
+		],
+		"description": "Ruby select/filter"
+	},
+	"Ruby Reduce": {
+		"prefix": "reduce",
+		"body": [
+			"${1:collection}.reduce(${2:0}) { |${3:acc}, ${4:item}| ${3:acc} + ${4:item} }"
+		],
+		"description": "Ruby reduce/inject"
+	},
+	"Ruby Lambda": {
+		"prefix": "lambda",
+		"body": [
+			"${1:name} = ->(${2:params}) { ${3:body} }"
+		],
+		"description": "Ruby lambda"
+	},
+	"Ruby Proc": {
+		"prefix": "proc",
+		"body": [
+			"${1:name} = Proc.new { |${2:params}| ${3:body} }"
+		],
+		"description": "Ruby Proc"
+	},
+	"Ruby Begin-Rescue": {
+		"prefix": "rescue",
+		"body": [
+			"begin",
+			"  $1",
+			"rescue ${2:StandardError} => e",
+			"  ${3:puts e.message}",
+			"end"
+		],
+		"description": "Ruby begin-rescue exception handling"
+	},
+	"Ruby Begin-Rescue-Ensure": {
+		"prefix": "rescuef",
+		"body": [
+			"begin",
+			"  $1",
+			"rescue ${2:StandardError} => e",
+			"  ${3:puts e.message}",
+			"ensure",
+			"  $0",
+			"end"
+		],
+		"description": "Ruby begin-rescue-ensure block"
+	},
+	"Ruby attr_accessor": {
+		"prefix": "attr",
+		"body": [
+			"attr_accessor :${1:name}"
+		],
+		"description": "Ruby attr_accessor"
+	},
+	"Ruby attr_reader": {
+		"prefix": "attrr",
+		"body": [
+			"attr_reader :${1:name}"
+		],
+		"description": "Ruby attr_reader"
+	},
+	"Ruby attr_writer": {
+		"prefix": "attrw",
+		"body": [
+			"attr_writer :${1:name}"
+		],
+		"description": "Ruby attr_writer"
+	},
+	"Ruby Hash": {
+		"prefix": "hash",
+		"body": [
+			"${1:name} = {",
+			"  ${2:key}: ${3:value},",
+			"  $0",
+			"}"
+		],
+		"description": "Ruby hash literal"
+	},
+	"Ruby Symbol": {
+		"prefix": "sym",
+		"body": [
+			":${1:symbol}"
+		],
+		"description": "Ruby symbol"
+	},
+	"Ruby Frozen String Literal": {
+		"prefix": "frozen",
+		"body": [
+			"# frozen_string_literal: true",
+			"",
+			"$0"
+		],
+		"description": "Ruby frozen string literal magic comment"
+	},
+	"Ruby RSpec Describe": {
+		"prefix": "describe",
+		"body": [
+			"describe ${1:ClassName} do",
+			"  it '${2:does something}' do",
+			"    $0",
+			"  end",
+			"end"
+		],
+		"description": "RSpec describe block"
+	},
+	"Ruby RSpec It Block": {
+		"prefix": "it",
+		"body": [
+			"it '${1:description}' do",
+			"  $0",
+			"end"
+		],
+		"description": "RSpec it block"
+	},
+	"Ruby Require": {
+		"prefix": "req",
+		"body": [
+			"require '${1:module}'"
+		],
+		"description": "Ruby require statement"
+	}
+}

--- a/extensions/sql/package.json
+++ b/extensions/sql/package.json
@@ -33,6 +33,12 @@
         "scopeName": "source.sql",
         "path": "./syntaxes/sql.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "sql",
+        "path": "./snippets/sql.code-snippets"
+      }
     ]
   },
   "repository": {

--- a/extensions/sql/snippets/sql.code-snippets
+++ b/extensions/sql/snippets/sql.code-snippets
@@ -1,0 +1,196 @@
+{
+	"SQL SELECT": {
+		"prefix": "sel",
+		"body": [
+			"SELECT ${1:*}",
+			"FROM ${2:table_name}",
+			"WHERE ${3:condition};"
+		],
+		"description": "SQL SELECT statement"
+	},
+	"SQL SELECT ALL": {
+		"prefix": "selall",
+		"body": [
+			"SELECT *",
+			"FROM ${1:table_name};"
+		],
+		"description": "SQL SELECT all columns"
+	},
+	"SQL SELECT with JOIN": {
+		"prefix": "selj",
+		"body": [
+			"SELECT ${1:t1.column1}, ${2:t2.column2}",
+			"FROM ${3:table1} t1",
+			"${4|INNER JOIN,LEFT JOIN,RIGHT JOIN,FULL OUTER JOIN|} ${5:table2} t2 ON t1.${6:id} = t2.${7:foreign_id}",
+			"WHERE ${8:condition};"
+		],
+		"description": "SQL SELECT with JOIN"
+	},
+	"SQL INSERT": {
+		"prefix": "ins",
+		"body": [
+			"INSERT INTO ${1:table_name} (${2:column1}, ${3:column2})",
+			"VALUES (${4:value1}, ${5:value2});"
+		],
+		"description": "SQL INSERT statement"
+	},
+	"SQL UPDATE": {
+		"prefix": "upd",
+		"body": [
+			"UPDATE ${1:table_name}",
+			"SET ${2:column1} = ${3:value1}",
+			"WHERE ${4:condition};"
+		],
+		"description": "SQL UPDATE statement"
+	},
+	"SQL DELETE": {
+		"prefix": "del",
+		"body": [
+			"DELETE FROM ${1:table_name}",
+			"WHERE ${2:condition};"
+		],
+		"description": "SQL DELETE statement"
+	},
+	"SQL CREATE TABLE": {
+		"prefix": "crttbl",
+		"body": [
+			"CREATE TABLE ${1:table_name} (",
+			"  ${2:id} ${3|INT,BIGINT,SERIAL|} PRIMARY KEY,",
+			"  ${4:column_name} ${5|VARCHAR(255),TEXT,INT,BOOLEAN,TIMESTAMP|} ${6:NOT NULL},",
+			"  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
+			");"
+		],
+		"description": "SQL CREATE TABLE statement"
+	},
+	"SQL DROP TABLE": {
+		"prefix": "droptbl",
+		"body": [
+			"DROP TABLE IF EXISTS ${1:table_name};"
+		],
+		"description": "SQL DROP TABLE statement"
+	},
+	"SQL ALTER TABLE ADD COLUMN": {
+		"prefix": "altadd",
+		"body": [
+			"ALTER TABLE ${1:table_name}",
+			"ADD COLUMN ${2:column_name} ${3:VARCHAR(255)};"
+		],
+		"description": "SQL ALTER TABLE ADD COLUMN"
+	},
+	"SQL ALTER TABLE DROP COLUMN": {
+		"prefix": "altdrop",
+		"body": [
+			"ALTER TABLE ${1:table_name}",
+			"DROP COLUMN ${2:column_name};"
+		],
+		"description": "SQL ALTER TABLE DROP COLUMN"
+	},
+	"SQL CREATE INDEX": {
+		"prefix": "idx",
+		"body": [
+			"CREATE ${1|,UNIQUE |}INDEX ${2:idx_name}",
+			"ON ${3:table_name} (${4:column_name});"
+		],
+		"description": "SQL CREATE INDEX"
+	},
+	"SQL GROUP BY": {
+		"prefix": "grpby",
+		"body": [
+			"SELECT ${1:column}, ${2:COUNT(*)}",
+			"FROM ${3:table_name}",
+			"GROUP BY ${1:column}",
+			"HAVING ${4:condition};"
+		],
+		"description": "SQL GROUP BY with HAVING"
+	},
+	"SQL ORDER BY": {
+		"prefix": "ordby",
+		"body": [
+			"SELECT ${1:*}",
+			"FROM ${2:table_name}",
+			"ORDER BY ${3:column} ${4|ASC,DESC|};"
+		],
+		"description": "SQL ORDER BY"
+	},
+	"SQL LIMIT OFFSET": {
+		"prefix": "limit",
+		"body": [
+			"SELECT ${1:*}",
+			"FROM ${2:table_name}",
+			"LIMIT ${3:10} OFFSET ${4:0};"
+		],
+		"description": "SQL LIMIT with OFFSET for pagination"
+	},
+	"SQL Subquery": {
+		"prefix": "subq",
+		"body": [
+			"SELECT ${1:*}",
+			"FROM ${2:table_name}",
+			"WHERE ${3:column} IN (",
+			"  SELECT ${4:column}",
+			"  FROM ${5:other_table}",
+			"  WHERE ${6:condition}",
+			");"
+		],
+		"description": "SQL subquery"
+	},
+	"SQL CTE (Common Table Expression)": {
+		"prefix": "cte",
+		"body": [
+			"WITH ${1:cte_name} AS (",
+			"  SELECT ${2:*}",
+			"  FROM ${3:table_name}",
+			"  WHERE ${4:condition}",
+			")",
+			"SELECT *",
+			"FROM ${1:cte_name};"
+		],
+		"description": "SQL Common Table Expression (CTE)"
+	},
+	"SQL CASE Expression": {
+		"prefix": "case",
+		"body": [
+			"CASE",
+			"  WHEN ${1:condition1} THEN ${2:result1}",
+			"  WHEN ${3:condition2} THEN ${4:result2}",
+			"  ELSE ${5:default_result}",
+			"END"
+		],
+		"description": "SQL CASE expression"
+	},
+	"SQL Transaction": {
+		"prefix": "txn",
+		"body": [
+			"BEGIN;",
+			"",
+			"${1:-- SQL statements}",
+			"",
+			"COMMIT;",
+			"-- ROLLBACK;"
+		],
+		"description": "SQL transaction block"
+	},
+	"SQL CREATE VIEW": {
+		"prefix": "view",
+		"body": [
+			"CREATE OR REPLACE VIEW ${1:view_name} AS",
+			"SELECT ${2:*}",
+			"FROM ${3:table_name}",
+			"WHERE ${4:condition};"
+		],
+		"description": "SQL CREATE VIEW"
+	},
+	"SQL Window Function": {
+		"prefix": "window",
+		"body": [
+			"SELECT",
+			"  ${1:column},",
+			"  ${2|ROW_NUMBER(),RANK(),DENSE_RANK(),SUM(amount),AVG(amount)|} OVER (",
+			"    PARTITION BY ${3:partition_column}",
+			"    ORDER BY ${4:order_column} ${5|ASC,DESC|}",
+			"  ) AS ${6:row_num}",
+			"FROM ${7:table_name};"
+		],
+		"description": "SQL window function"
+	}
+}


### PR DESCRIPTION
Add code snippets for Ruby and SQL files:

**Ruby snippets** (`extensions/ruby/snippets/ruby.code-snippets`):
- `def` / `class` / `classi` / `module` — class/method definitions
- `if` / `ife` / `unless` — conditionals
- `each` / `times` — iterators
- `map` / `select` / `reduce` — enumerable methods
- `lambda` / `proc` — callable objects
- `rescue` / `rescuef` — exception handling
- `attr` / `attrr` / `attrw` — accessor macros
- `hash` / `sym` — data structures
- `frozen` — frozen string literal magic comment
- `describe` / `it` — RSpec test blocks
- `req` — require statement

**SQL snippets** (`extensions/sql/snippets/sql.code-snippets`):
- `sel` / `selall` / `selj` — SELECT variations with JOIN support
- `ins` / `upd` / `del` — DML statements
- `crttbl` / `droptbl` / `altadd` / `altdrop` — DDL statements
- `idx` — CREATE INDEX
- `grpby` / `ordby` / `limit` — query clauses
- `subq` — subquery
- `cte` — Common Table Expression
- `case` — CASE expression
- `txn` — transaction block
- `view` — CREATE VIEW
- `window` — window function