### PR TITLE
feat: add Shell Script and XML snippets for common patterns

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -89,6 +89,12 @@
         ]
       }
     ],
+    "snippets": [
+      {
+        "language": "shellscript",
+        "path": "./snippets/shellscript.code-snippets"
+      }
+    ],
     "configurationDefaults": {
       "[shellscript]": {
         "files.eol": "\n",

--- a/extensions/shellscript/snippets/shellscript.code-snippets
+++ b/extensions/shellscript/snippets/shellscript.code-snippets
@@ -1,0 +1,225 @@
+{
+	"Shell Shebang Bash": {
+		"prefix": "shebang",
+		"body": [
+			"#!/usr/bin/env bash",
+			"set -euo pipefail",
+			"",
+			"$0"
+		],
+		"description": "Bash shebang with strict mode"
+	},
+	"Shell Shebang sh": {
+		"prefix": "shebangs",
+		"body": [
+			"#!/bin/sh",
+			"set -eu",
+			"",
+			"$0"
+		],
+		"description": "POSIX sh shebang with strict mode"
+	},
+	"Shell Variable": {
+		"prefix": "var",
+		"body": [
+			"${1:VAR}=\"${2:value}\""
+		],
+		"description": "Shell variable assignment"
+	},
+	"Shell If Statement": {
+		"prefix": "if",
+		"body": [
+			"if ${1:[ condition ]}; then",
+			"  $0",
+			"fi"
+		],
+		"description": "Shell if statement"
+	},
+	"Shell If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if ${1:[ condition ]}; then",
+			"  ${2:# true branch}",
+			"else",
+			"  ${3:# false branch}",
+			"fi"
+		],
+		"description": "Shell if-else statement"
+	},
+	"Shell If-Elif-Else": {
+		"prefix": "ifelif",
+		"body": [
+			"if ${1:[ condition1 ]}; then",
+			"  ${2:# first branch}",
+			"elif ${3:[ condition2 ]}; then",
+			"  ${4:# second branch}",
+			"else",
+			"  ${5:# default branch}",
+			"fi"
+		],
+		"description": "Shell if-elif-else statement"
+	},
+	"Shell For Loop": {
+		"prefix": "for",
+		"body": [
+			"for ${1:item} in ${2:\\$list}; do",
+			"  $0",
+			"done"
+		],
+		"description": "Shell for loop"
+	},
+	"Shell For Range": {
+		"prefix": "forr",
+		"body": [
+			"for ${1:i} in \\$(seq ${2:1} ${3:10}); do",
+			"  $0",
+			"done"
+		],
+		"description": "Shell for range loop"
+	},
+	"Shell While Loop": {
+		"prefix": "while",
+		"body": [
+			"while ${1:[ condition ]}; do",
+			"  $0",
+			"done"
+		],
+		"description": "Shell while loop"
+	},
+	"Shell Until Loop": {
+		"prefix": "until",
+		"body": [
+			"until ${1:[ condition ]}; do",
+			"  $0",
+			"done"
+		],
+		"description": "Shell until loop"
+	},
+	"Shell Case Statement": {
+		"prefix": "case",
+		"body": [
+			"case \\$${1:variable} in",
+			"  ${2:pattern1})",
+			"    ${3:# action1}",
+			"    ;;",
+			"  ${4:pattern2})",
+			"    ${5:# action2}",
+			"    ;;",
+			"  *)",
+			"    ${6:# default}",
+			"    ;;",
+			"esac"
+		],
+		"description": "Shell case statement"
+	},
+	"Shell Function": {
+		"prefix": "fn",
+		"body": [
+			"${1:function_name}() {",
+			"  $0",
+			"}"
+		],
+		"description": "Shell function definition"
+	},
+	"Shell Function with Args": {
+		"prefix": "fnargs",
+		"body": [
+			"${1:function_name}() {",
+			"  local ${2:arg1}=\"\\$1\"",
+			"  local ${3:arg2}=\"\\$2\"",
+			"  $0",
+			"}"
+		],
+		"description": "Shell function with local variables"
+	},
+	"Shell Echo": {
+		"prefix": "echo",
+		"body": [
+			"echo \"${1:message}\""
+		],
+		"description": "Shell echo"
+	},
+	"Shell Printf": {
+		"prefix": "printf",
+		"body": [
+			"printf '%s\\n' \"${1:message}\""
+		],
+		"description": "Shell printf"
+	},
+	"Shell Check Command Exists": {
+		"prefix": "cmdexists",
+		"body": [
+			"if ! command -v ${1:command} &>/dev/null; then",
+			"  echo \"Error: ${1:command} not found\" >&2",
+			"  exit 1",
+			"fi"
+		],
+		"description": "Check if a command exists"
+	},
+	"Shell Check File Exists": {
+		"prefix": "fileexists",
+		"body": [
+			"if [ -f \"${1:\\$file}\" ]; then",
+			"  ${2:# file exists}",
+			"fi"
+		],
+		"description": "Check if a file exists"
+	},
+	"Shell Check Directory Exists": {
+		"prefix": "direxists",
+		"body": [
+			"if [ -d \"${1:\\$dir}\" ]; then",
+			"  ${2:# directory exists}",
+			"fi"
+		],
+		"description": "Check if a directory exists"
+	},
+	"Shell Read Input": {
+		"prefix": "read",
+		"body": [
+			"read -rp \"${1:Enter value: }\" ${2:VAR}"
+		],
+		"description": "Shell read user input"
+	},
+	"Shell Trap Exit": {
+		"prefix": "trap",
+		"body": [
+			"cleanup() {",
+			"  ${1:# cleanup code}",
+			"}",
+			"trap cleanup EXIT"
+		],
+		"description": "Shell trap on EXIT for cleanup"
+	},
+	"Shell Script Header": {
+		"prefix": "header",
+		"body": [
+			"#!/usr/bin/env bash",
+			"# ${1:Script description}",
+			"# Usage: \\$(basename \"\\$0\") ${2:[options]}",
+			"",
+			"set -euo pipefail",
+			"",
+			"SCRIPT_DIR=\"\\$(cd \"\\$(dirname \"\\${BASH_SOURCE[0]}\")\" && pwd)\"",
+			"",
+			"$0"
+		],
+		"description": "Shell script header with common setup"
+	},
+	"Shell Array": {
+		"prefix": "arr",
+		"body": [
+			"${1:arr}=(${2:\"item1\"} ${3:\"item2\"} ${4:\"item3\"})"
+		],
+		"description": "Shell array declaration"
+	},
+	"Shell Iterate Array": {
+		"prefix": "forarr",
+		"body": [
+			"for ${1:item} in \"\\${${2:arr}[@]}\"; do",
+			"  $0",
+			"done"
+		],
+		"description": "Shell iterate over array"
+	}
+}

--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -108,6 +108,16 @@
         "scopeName": "text.xml.xsl",
         "path": "./syntaxes/xsl.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "xml",
+        "path": "./snippets/xml.code-snippets"
+      },
+      {
+        "language": "xsl",
+        "path": "./snippets/xml.code-snippets"
+      }
     ]
   },
   "scripts": {

--- a/extensions/xml/snippets/xml.code-snippets
+++ b/extensions/xml/snippets/xml.code-snippets
@@ -1,0 +1,159 @@
+{
+	"XML Declaration": {
+		"prefix": "xmldecl",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+			"$0"
+		],
+		"description": "XML declaration"
+	},
+	"XML Element": {
+		"prefix": "tag",
+		"body": [
+			"<${1:element}>${2:content}</${1:element}>"
+		],
+		"description": "XML element"
+	},
+	"XML Self-Closing Element": {
+		"prefix": "stag",
+		"body": [
+			"<${1:element} />"
+		],
+		"description": "XML self-closing element"
+	},
+	"XML Element with Attribute": {
+		"prefix": "taga",
+		"body": [
+			"<${1:element} ${2:attr}=\"${3:value}\">${4:content}</${1:element}>"
+		],
+		"description": "XML element with attribute"
+	},
+	"XML Comment": {
+		"prefix": "comment",
+		"body": [
+			"<!-- ${1:comment} -->"
+		],
+		"description": "XML comment"
+	},
+	"XML CDATA": {
+		"prefix": "cdata",
+		"body": [
+			"<![CDATA[",
+			"  $0",
+			"]]>"
+		],
+		"description": "XML CDATA section"
+	},
+	"XML Processing Instruction": {
+		"prefix": "pi",
+		"body": [
+			"<?${1:target} ${2:data}?>"
+		],
+		"description": "XML processing instruction"
+	},
+	"XML Namespace": {
+		"prefix": "ns",
+		"body": [
+			"xmlns:${1:prefix}=\"${2:namespace-uri}\""
+		],
+		"description": "XML namespace declaration"
+	},
+	"XML Root Element": {
+		"prefix": "root",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+			"<${1:root}>",
+			"  $0",
+			"</${1:root}>"
+		],
+		"description": "XML root element with declaration"
+	},
+	"XML Maven POM": {
+		"prefix": "pom",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+			"<project xmlns=\"http://maven.apache.org/POM/4.0.0\"",
+			"         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"",
+			"         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">",
+			"  <modelVersion>4.0.0</modelVersion>",
+			"",
+			"  <groupId>${1:com.example}</groupId>",
+			"  <artifactId>${2:my-app}</artifactId>",
+			"  <version>${3:1.0.0}</version>",
+			"  <packaging>${4|jar,war,pom|}</packaging>",
+			"",
+			"  <properties>",
+			"    <maven.compiler.source>${5:17}</maven.compiler.source>",
+			"    <maven.compiler.target>${5:17}</maven.compiler.target>",
+			"  </properties>",
+			"",
+			"  <dependencies>",
+			"    $0",
+			"  </dependencies>",
+			"</project>"
+		],
+		"description": "Maven POM file template"
+	},
+	"XML Maven Dependency": {
+		"prefix": "dep",
+		"body": [
+			"<dependency>",
+			"  <groupId>${1:groupId}</groupId>",
+			"  <artifactId>${2:artifactId}</artifactId>",
+			"  <version>${3:version}</version>",
+			"</dependency>"
+		],
+		"description": "Maven dependency entry"
+	},
+	"XML Spring Bean": {
+		"prefix": "bean",
+		"body": [
+			"<bean id=\"${1:beanId}\" class=\"${2:com.example.ClassName}\">",
+			"  <property name=\"${3:propertyName}\" value=\"${4:value}\" />",
+			"</bean>"
+		],
+		"description": "Spring XML bean definition"
+	},
+	"XML RSS Feed": {
+		"prefix": "rss",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+			"<rss version=\"2.0\">",
+			"  <channel>",
+			"    <title>${1:Feed Title}</title>",
+			"    <link>${2:https://example.com}</link>",
+			"    <description>${3:Feed description}</description>",
+			"    <item>",
+			"      <title>${4:Item title}</title>",
+			"      <link>${5:https://example.com/item}</link>",
+			"      <description>${6:Item description}</description>",
+			"    </item>",
+			"  </channel>",
+			"</rss>"
+		],
+		"description": "RSS feed template"
+	},
+	"XML SVG Element": {
+		"prefix": "svg",
+		"body": [
+			"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"${1:100}\" height=\"${2:100}\" viewBox=\"0 0 ${1:100} ${2:100}\">",
+			"  $0",
+			"</svg>"
+		],
+		"description": "SVG element"
+	},
+	"XML XSLT Stylesheet": {
+		"prefix": "xslt",
+		"body": [
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+			"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">",
+			"",
+			"  <xsl:template match=\"/\">",
+			"    $0",
+			"  </xsl:template>",
+			"",
+			"</xsl:stylesheet>"
+		],
+		"description": "XSLT stylesheet template"
+	}
+}


### PR DESCRIPTION
Add code snippets for Shell Script and XML files:

**Shell Script snippets** (`extensions/shellscript/snippets/shellscript.code-snippets`):
- `shebang` / `shebangs` — Bash/sh shebang with strict mode
- `var` — variable assignment
- `if` / `ife` / `ifelif` — conditionals
- `for` / `forr` / `while` / `until` — loops
- `case` — case statement
- `fn` / `fnargs` — function definitions
- `echo` / `printf` — output commands
- `cmdexists` / `fileexists` / `direxists` — guard checks
- `read` — user input
- `trap` — EXIT trap for cleanup
- `header` — full script header with setup
- `arr` / `forarr` — array operations

**XML snippets** (`extensions/xml/snippets/xml.code-snippets`):
- `xmldecl` — XML declaration
- `tag` / `stag` / `taga` — element variations
- `comment` / `cdata` / `pi` — XML constructs
- `ns` — namespace declaration
- `root` — root element template
- `pom` / `dep` — Maven POM and dependency
- `bean` — Spring XML bean
- `rss` — RSS feed template
- `svg` — SVG element
- `xslt` — XSLT stylesheet template