### PR TITLE
feat: add .env and Objective-C snippets for common patterns

### DIFF
--- a/extensions/dotenv/package.json
+++ b/extensions/dotenv/package.json
@@ -39,6 +39,12 @@
         "scopeName": "source.dotenv",
         "path": "./syntaxes/dotenv.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "dotenv",
+        "path": "./snippets/dotenv.code-snippets"
+      }
     ]
   },
   "repository": {

--- a/extensions/dotenv/snippets/dotenv.code-snippets
+++ b/extensions/dotenv/snippets/dotenv.code-snippets
@@ -1,0 +1,143 @@
+{
+	"Dotenv Variable": {
+		"prefix": "var",
+		"body": [
+			"${1:VARIABLE_NAME}=${2:value}"
+		],
+		"description": "Environment variable assignment"
+	},
+	"Dotenv Quoted Variable": {
+		"prefix": "varq",
+		"body": [
+			"${1:VARIABLE_NAME}=\"${2:value}\""
+		],
+		"description": "Environment variable with quoted value"
+	},
+	"Dotenv Comment": {
+		"prefix": "comment",
+		"body": [
+			"# ${1:comment}"
+		],
+		"description": "Dotenv comment"
+	},
+	"Dotenv Section Comment": {
+		"prefix": "section",
+		"body": [
+			"",
+			"# ${1:Section Name}",
+			"# ${2:Description}",
+			"${3:VAR_NAME}=${4:value}"
+		],
+		"description": "Dotenv section with comment"
+	},
+	"Dotenv Database Config": {
+		"prefix": "db",
+		"body": [
+			"# Database",
+			"DB_HOST=${1:localhost}",
+			"DB_PORT=${2:5432}",
+			"DB_NAME=${3:mydb}",
+			"DB_USER=${4:postgres}",
+			"DB_PASSWORD=${5:secret}"
+		],
+		"description": "Database connection environment variables"
+	},
+	"Dotenv App Config": {
+		"prefix": "app",
+		"body": [
+			"# Application",
+			"APP_NAME=${1:my-app}",
+			"APP_ENV=${2|development,staging,production|}",
+			"APP_PORT=${3:3000}",
+			"APP_DEBUG=${4|true,false|}",
+			"APP_SECRET=${5:changeme}"
+		],
+		"description": "Basic application environment variables"
+	},
+	"Dotenv JWT Config": {
+		"prefix": "jwt",
+		"body": [
+			"# JWT",
+			"JWT_SECRET=${1:your-secret-key}",
+			"JWT_EXPIRES_IN=${2:7d}",
+			"JWT_ALGORITHM=${3:HS256}"
+		],
+		"description": "JWT authentication environment variables"
+	},
+	"Dotenv SMTP Config": {
+		"prefix": "smtp",
+		"body": [
+			"# SMTP / Email",
+			"SMTP_HOST=${1:smtp.gmail.com}",
+			"SMTP_PORT=${2:587}",
+			"SMTP_USER=${3:user@example.com}",
+			"SMTP_PASS=${4:password}",
+			"SMTP_FROM=${5:noreply@example.com}"
+		],
+		"description": "SMTP email environment variables"
+	},
+	"Dotenv Redis Config": {
+		"prefix": "redis",
+		"body": [
+			"# Redis",
+			"REDIS_HOST=${1:localhost}",
+			"REDIS_PORT=${2:6379}",
+			"REDIS_PASSWORD=${3:}",
+			"REDIS_DB=${4:0}"
+		],
+		"description": "Redis connection environment variables"
+	},
+	"Dotenv AWS Config": {
+		"prefix": "aws",
+		"body": [
+			"# AWS",
+			"AWS_ACCESS_KEY_ID=${1:your-access-key}",
+			"AWS_SECRET_ACCESS_KEY=${2:your-secret-key}",
+			"AWS_REGION=${3:us-east-1}",
+			"AWS_S3_BUCKET=${4:my-bucket}"
+		],
+		"description": "AWS credentials environment variables"
+	},
+	"Dotenv API Keys": {
+		"prefix": "api",
+		"body": [
+			"# API Keys",
+			"${1:SERVICE}_API_KEY=${2:your-api-key}",
+			"${1:SERVICE}_API_SECRET=${3:your-api-secret}",
+			"${1:SERVICE}_API_URL=${4:https://api.example.com}"
+		],
+		"description": "API key environment variables"
+	},
+	"Dotenv OAuth Config": {
+		"prefix": "oauth",
+		"body": [
+			"# OAuth",
+			"OAUTH_CLIENT_ID=${1:client-id}",
+			"OAUTH_CLIENT_SECRET=${2:client-secret}",
+			"OAUTH_CALLBACK_URL=${3:http://localhost:3000/auth/callback}"
+		],
+		"description": "OAuth configuration environment variables"
+	},
+	"Dotenv Full Template": {
+		"prefix": "template",
+		"body": [
+			"# Application",
+			"APP_NAME=${1:my-app}",
+			"APP_ENV=${2|development,staging,production|}",
+			"APP_PORT=${3:3000}",
+			"APP_SECRET=${4:changeme}",
+			"",
+			"# Database",
+			"DB_HOST=${5:localhost}",
+			"DB_PORT=${6:5432}",
+			"DB_NAME=${7:mydb}",
+			"DB_USER=${8:postgres}",
+			"DB_PASSWORD=${9:secret}",
+			"",
+			"# Logging",
+			"LOG_LEVEL=${10|debug,info,warn,error|}",
+			""
+		],
+		"description": "Full .env file template"
+	}
+}

--- a/extensions/objective-c/package.json
+++ b/extensions/objective-c/package.json
@@ -46,6 +46,16 @@
         "scopeName": "source.objcpp",
         "path": "./syntaxes/objective-c++.tmLanguage.json"
       }
+    ],
+    "snippets": [
+      {
+        "language": "objective-c",
+        "path": "./snippets/objc.code-snippets"
+      },
+      {
+        "language": "objective-cpp",
+        "path": "./snippets/objc.code-snippets"
+      }
     ]
   },
   "repository": {

--- a/extensions/objective-c/snippets/objc.code-snippets
+++ b/extensions/objective-c/snippets/objc.code-snippets
@@ -1,0 +1,185 @@
+{
+	"Objective-C Interface": {
+		"prefix": "@interface",
+		"body": [
+			"@interface ${1:ClassName} : ${2:NSObject}",
+			"",
+			"${0:// Properties and method declarations}",
+			"",
+			"@end"
+		],
+		"description": "Objective-C class interface declaration"
+	},
+	"Objective-C Implementation": {
+		"prefix": "@implementation",
+		"body": [
+			"@implementation ${1:ClassName}",
+			"",
+			"$0",
+			"",
+			"@end"
+		],
+		"description": "Objective-C class implementation"
+	},
+	"Objective-C Property": {
+		"prefix": "@property",
+		"body": [
+			"@property (${1|nonatomic, strong|,nonatomic, weak|,nonatomic, copy|,nonatomic, assign|,atomic, strong|}) ${2:NSString} *${3:propertyName};"
+		],
+		"description": "Objective-C property declaration"
+	},
+	"Objective-C Method Declaration": {
+		"prefix": "method",
+		"body": [
+			"- (${1:void})${2:methodName};"
+		],
+		"description": "Objective-C instance method declaration"
+	},
+	"Objective-C Method Implementation": {
+		"prefix": "methodi",
+		"body": [
+			"- (${1:void})${2:methodName} {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C instance method implementation"
+	},
+	"Objective-C Method with Parameter": {
+		"prefix": "methodp",
+		"body": [
+			"- (${1:void})${2:methodName}:(${3:NSString *})${4:param} {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C method with parameter"
+	},
+	"Objective-C Class Method": {
+		"prefix": "classmethod",
+		"body": [
+			"+ (${1:instancetype})${2:sharedInstance} {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C class method"
+	},
+	"Objective-C Init": {
+		"prefix": "init",
+		"body": [
+			"- (instancetype)init {",
+			"  self = [super init];",
+			"  if (self) {",
+			"    $0",
+			"  }",
+			"  return self;",
+			"}"
+		],
+		"description": "Objective-C designated initializer"
+	},
+	"Objective-C If Statement": {
+		"prefix": "if",
+		"body": [
+			"if (${1:condition}) {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C if statement"
+	},
+	"Objective-C For Loop": {
+		"prefix": "for",
+		"body": [
+			"for (NSInteger ${1:i} = 0; ${1:i} < ${2:count}; ${1:i}++) {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C for loop"
+	},
+	"Objective-C Fast Enumeration": {
+		"prefix": "foreach",
+		"body": [
+			"for (${1:id} ${2:item} in ${3:collection}) {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C fast enumeration"
+	},
+	"Objective-C NSLog": {
+		"prefix": "log",
+		"body": [
+			"NSLog(@\"${1:%@}\", ${2:variable});"
+		],
+		"description": "NSLog statement"
+	},
+	"Objective-C String": {
+		"prefix": "str",
+		"body": [
+			"NSString *${1:str} = @\"${2:value}\";"
+		],
+		"description": "Objective-C NSString literal"
+	},
+	"Objective-C Array": {
+		"prefix": "arr",
+		"body": [
+			"NSArray *${1:arr} = @[${2:@\"item1\"}, ${3:@\"item2\"}];"
+		],
+		"description": "Objective-C NSArray literal"
+	},
+	"Objective-C Mutable Array": {
+		"prefix": "marrr",
+		"body": [
+			"NSMutableArray *${1:arr} = [NSMutableArray array];"
+		],
+		"description": "Objective-C NSMutableArray"
+	},
+	"Objective-C Dictionary": {
+		"prefix": "dict",
+		"body": [
+			"NSDictionary *${1:dict} = @{",
+			"  @\"${2:key}\": ${3:@\"value\"},",
+			"};"
+		],
+		"description": "Objective-C NSDictionary literal"
+	},
+	"Objective-C Block": {
+		"prefix": "block",
+		"body": [
+			"^${1:void}(${2:id ${3:obj}}) {",
+			"  $0",
+			"}"
+		],
+		"description": "Objective-C block"
+	},
+	"Objective-C Dispatch Async": {
+		"prefix": "async",
+		"body": [
+			"dispatch_async(dispatch_get_${1|main_queue,global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)|}(), ^{",
+			"  $0",
+			"});"
+		],
+		"description": "Objective-C dispatch_async"
+	},
+	"Objective-C Protocol": {
+		"prefix": "@protocol",
+		"body": [
+			"@protocol ${1:ProtocolName} <${2:NSObject}>",
+			"",
+			"$0",
+			"",
+			"@end"
+		],
+		"description": "Objective-C protocol declaration"
+	},
+	"Objective-C Singleton": {
+		"prefix": "singleton",
+		"body": [
+			"+ (instancetype)sharedInstance {",
+			"  static ${1:ClassName} *_sharedInstance = nil;",
+			"  static dispatch_once_t onceToken;",
+			"  dispatch_once(&onceToken, ^{",
+			"    _sharedInstance = [[${1:ClassName} alloc] init];",
+			"  });",
+			"  return _sharedInstance;",
+			"}"
+		],
+		"description": "Objective-C singleton pattern"
+	}
+}


### PR DESCRIPTION
Add code snippets for .env and Objective-C files:

**.env snippets** (`extensions/dotenv/snippets/dotenv.code-snippets`):
- `var` / `varq` — variable assignment (plain and quoted)
- `comment` / `section` — comments and sections
- `db` — database connection variables
- `app` — application configuration
- `jwt` — JWT auth variables
- `smtp` — email/SMTP configuration
- `redis` — Redis connection variables
- `aws` — AWS credentials
- `api` — API key variables
- `oauth` — OAuth configuration
- `template` — full .env file template

**Objective-C snippets** (`extensions/objective-c/snippets/objc.code-snippets`):
- `@interface` / `@implementation` — class structure
- `@property` — property declaration
- `method` / `methodi` / `methodp` / `classmethod` — method definitions
- `init` — designated initializer
- `if` / `for` / `foreach` — control flow
- `log` — NSLog statement
- `str` / `arr` / `dict` — collection literals
- `block` — Objective-C block
- `async` — dispatch_async
- `@protocol` — protocol declaration
- `singleton` — thread-safe singleton pattern