### PR TITLE
feat: add Pug and reStructuredText snippets for common template patterns

### DIFF
--- a/extensions/pug/package.json
+++ b/extensions/pug/package.json
@@ -35,6 +35,12 @@
         "path": "./syntaxes/pug.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "jade",
+        "path": "./snippets/pug.code-snippets"
+      }
+    ],
     "configurationDefaults": {
       "[jade]": {
         "diffEditor.ignoreTrimWhitespace": false

--- a/extensions/pug/snippets/pug.code-snippets
+++ b/extensions/pug/snippets/pug.code-snippets
@@ -1,0 +1,169 @@
+{
+	"Pug Doctype HTML5": {
+		"prefix": "doctype",
+		"body": [
+			"doctype html"
+		],
+		"description": "HTML5 doctype"
+	},
+	"Pug HTML Structure": {
+		"prefix": "html",
+		"body": [
+			"html(lang='${1:en}')",
+			"  head",
+			"    meta(charset='UTF-8')",
+			"    meta(name='viewport', content='width=device-width, initial-scale=1.0')",
+			"    title ${2:Document}",
+			"  body",
+			"    $0"
+		],
+		"description": "Basic Pug HTML document structure"
+	},
+	"Pug Tag": {
+		"prefix": "tag",
+		"body": [
+			"${1:div}$0"
+		],
+		"description": "Pug HTML tag"
+	},
+	"Pug Tag with Class": {
+		"prefix": "tagc",
+		"body": [
+			"${1:div}.${2:class-name} $0"
+		],
+		"description": "Pug tag with class"
+	},
+	"Pug Tag with ID": {
+		"prefix": "tagi",
+		"body": [
+			"${1:div}#${2:id-name} $0"
+		],
+		"description": "Pug tag with ID"
+	},
+	"Pug Tag with Attribute": {
+		"prefix": "taga",
+		"body": [
+			"${1:a}(${2:href}='${3:#}') ${4:link text}"
+		],
+		"description": "Pug tag with attribute"
+	},
+	"Pug Comment": {
+		"prefix": "comment",
+		"body": [
+			"// ${1:comment}"
+		],
+		"description": "Pug comment (rendered in HTML)"
+	},
+	"Pug Unbuffered Comment": {
+		"prefix": "commentu",
+		"body": [
+			"//- ${1:comment}"
+		],
+		"description": "Pug unbuffered comment (not rendered)"
+	},
+	"Pug If Statement": {
+		"prefix": "if",
+		"body": [
+			"if ${1:condition}",
+			"  $0"
+		],
+		"description": "Pug if statement"
+	},
+	"Pug If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if ${1:condition}",
+			"  ${2:// true}",
+			"else",
+			"  ${3:// false}"
+		],
+		"description": "Pug if-else statement"
+	},
+	"Pug Each Loop": {
+		"prefix": "each",
+		"body": [
+			"each ${1:item} in ${2:items}",
+			"  $0"
+		],
+		"description": "Pug each loop"
+	},
+	"Pug Each with Index": {
+		"prefix": "eachi",
+		"body": [
+			"each ${1:item}, ${2:index} in ${3:items}",
+			"  $0"
+		],
+		"description": "Pug each loop with index"
+	},
+	"Pug Mixin": {
+		"prefix": "mixin",
+		"body": [
+			"mixin ${1:name}(${2:params})",
+			"  $0"
+		],
+		"description": "Pug mixin definition"
+	},
+	"Pug Mixin Call": {
+		"prefix": "+mixin",
+		"body": [
+			"+${1:name}(${2:args})"
+		],
+		"description": "Pug mixin call"
+	},
+	"Pug Include": {
+		"prefix": "include",
+		"body": [
+			"include ${1:path/to/file}"
+		],
+		"description": "Pug include"
+	},
+	"Pug Extends": {
+		"prefix": "extends",
+		"body": [
+			"extends ${1:layout}",
+			"",
+			"block ${2:content}",
+			"  $0"
+		],
+		"description": "Pug template inheritance"
+	},
+	"Pug Block": {
+		"prefix": "block",
+		"body": [
+			"block ${1:name}",
+			"  $0"
+		],
+		"description": "Pug block definition"
+	},
+	"Pug Script": {
+		"prefix": "script",
+		"body": [
+			"script(src='${1:app.js}')"
+		],
+		"description": "Pug script tag"
+	},
+	"Pug Inline Script": {
+		"prefix": "scripti",
+		"body": [
+			"script.",
+			"  ${1:// JavaScript code}"
+		],
+		"description": "Pug inline script block"
+	},
+	"Pug Link CSS": {
+		"prefix": "css",
+		"body": [
+			"link(rel='stylesheet', href='${1:style.css}')"
+		],
+		"description": "Pug CSS link tag"
+	},
+	"Pug Form": {
+		"prefix": "form",
+		"body": [
+			"form(action='${1:#}', method='${2|get,post|}')",
+			"  input(type='text', name='${3:field}', placeholder='${4:Enter value}')",
+			"  button(type='submit') ${5:Submit}"
+		],
+		"description": "Pug form element"
+	}
+}

--- a/extensions/restructuredtext/package.json
+++ b/extensions/restructuredtext/package.json
@@ -31,6 +31,12 @@
 				"scopeName": "source.rst",
 				"path": "./syntaxes/rst.tmLanguage.json"
 			}
+		],
+		"snippets": [
+			{
+				"language": "restructuredtext",
+				"path": "./snippets/restructuredtext.code-snippets"
+			}
 		]
 	},
 	"repository": {

--- a/extensions/restructuredtext/snippets/restructuredtext.code-snippets
+++ b/extensions/restructuredtext/snippets/restructuredtext.code-snippets
@@ -1,0 +1,198 @@
+{
+	"RST Title": {
+		"prefix": "title",
+		"body": [
+			"${1:Title}",
+			"${1/./=/g}"
+		],
+		"description": "RST document title (overline + underline)"
+	},
+	"RST Heading 1": {
+		"prefix": "h1",
+		"body": [
+			"${1:Heading 1}",
+			"${1/./=/g}"
+		],
+		"description": "RST heading level 1 (= underline)"
+	},
+	"RST Heading 2": {
+		"prefix": "h2",
+		"body": [
+			"${1:Heading 2}",
+			"${1/./\\-/g}"
+		],
+		"description": "RST heading level 2 (- underline)"
+	},
+	"RST Heading 3": {
+		"prefix": "h3",
+		"body": [
+			"${1:Heading 3}",
+			"${1/./~/g}"
+		],
+		"description": "RST heading level 3 (~ underline)"
+	},
+	"RST Bold": {
+		"prefix": "bold",
+		"body": [
+			"**${1:bold text}**"
+		],
+		"description": "RST bold text"
+	},
+	"RST Italic": {
+		"prefix": "italic",
+		"body": [
+			"*${1:italic text}*"
+		],
+		"description": "RST italic text"
+	},
+	"RST Inline Code": {
+		"prefix": "code",
+		"body": [
+			"``${1:code}``"
+		],
+		"description": "RST inline code"
+	},
+	"RST Code Block": {
+		"prefix": "codeblock",
+		"body": [
+			".. code-block:: ${1|python,javascript,typescript,bash,c,cpp,java,ruby,go|}",
+			"",
+			"   $0"
+		],
+		"description": "RST code block directive"
+	},
+	"RST Literal Block": {
+		"prefix": "literal",
+		"body": [
+			"::",
+			"",
+			"   $0"
+		],
+		"description": "RST literal/preformatted block"
+	},
+	"RST Link": {
+		"prefix": "link",
+		"body": [
+			"\`${1:link text} <${2:https://example.com}>\`_"
+		],
+		"description": "RST external hyperlink"
+	},
+	"RST Internal Link": {
+		"prefix": "linkref",
+		"body": [
+			"\`${1:link text}\`_"
+		],
+		"description": "RST internal link reference"
+	},
+	"RST Bullet List": {
+		"prefix": "list",
+		"body": [
+			"* ${1:Item 1}",
+			"* ${2:Item 2}",
+			"* ${3:Item 3}"
+		],
+		"description": "RST bullet list"
+	},
+	"RST Numbered List": {
+		"prefix": "olist",
+		"body": [
+			"#. ${1:Item 1}",
+			"#. ${2:Item 2}",
+			"#. ${3:Item 3}"
+		],
+		"description": "RST auto-numbered list"
+	},
+	"RST Definition List": {
+		"prefix": "deflist",
+		"body": [
+			"${1:term}",
+			"  ${2:definition}"
+		],
+		"description": "RST definition list item"
+	},
+	"RST Note": {
+		"prefix": "note",
+		"body": [
+			".. note::",
+			"",
+			"   $0"
+		],
+		"description": "RST note directive"
+	},
+	"RST Warning": {
+		"prefix": "warning",
+		"body": [
+			".. warning::",
+			"",
+			"   $0"
+		],
+		"description": "RST warning directive"
+	},
+	"RST Tip": {
+		"prefix": "tip",
+		"body": [
+			".. tip::",
+			"",
+			"   $0"
+		],
+		"description": "RST tip directive"
+	},
+	"RST Image": {
+		"prefix": "image",
+		"body": [
+			".. image:: ${1:path/to/image.png}",
+			"   :alt: ${2:image description}",
+			"   :width: ${3:100%}"
+		],
+		"description": "RST image directive"
+	},
+	"RST Figure": {
+		"prefix": "figure",
+		"body": [
+			".. figure:: ${1:path/to/image.png}",
+			"   :alt: ${2:image description}",
+			"",
+			"   ${3:Figure caption}"
+		],
+		"description": "RST figure directive with caption"
+	},
+	"RST Table": {
+		"prefix": "table",
+		"body": [
+			".. list-table:: ${1:Table Title}",
+			"   :header-rows: 1",
+			"",
+			"   * - ${2:Column 1}",
+			"     - ${3:Column 2}",
+			"   * - ${4:Value 1}",
+			"     - ${5:Value 2}"
+		],
+		"description": "RST list-table directive"
+	},
+	"RST TOC Tree": {
+		"prefix": "toctree",
+		"body": [
+			".. toctree::",
+			"   :maxdepth: ${1:2}",
+			"   :caption: ${2:Contents}",
+			"",
+			"   ${3:page1}",
+			"   ${4:page2}"
+		],
+		"description": "RST toctree directive (Sphinx)"
+	},
+	"RST Ref": {
+		"prefix": "ref",
+		"body": [
+			":ref:\`${1:label}\`"
+		],
+		"description": "RST cross-reference (Sphinx)"
+	},
+	"RST Comment": {
+		"prefix": "comment",
+		"body": [
+			".. ${1:comment text}"
+		],
+		"description": "RST comment"
+	}
+}


### PR DESCRIPTION
Add code snippets for Pug (Jade) and reStructuredText files:

**Pug snippets** (`extensions/pug/snippets/pug.code-snippets`):
- `doctype` / `html` — document structure
- `tag` / `tagc` / `tagi` / `taga` — element variations
- `comment` / `commentu` — comments
- `if` / `ife` — conditionals
- `each` / `eachi` — loops
- `mixin` / `+mixin` — mixin definition and call
- `include` / `extends` / `block` — template composition
- `script` / `scripti` / `css` — assets
- `form` — form element template

**reStructuredText snippets** (`extensions/restructuredtext/snippets/restructuredtext.code-snippets`):
- `title` / `h1` / `h2` / `h3` — headings with correct underline chars
- `bold` / `italic` / `code` — inline markup
- `codeblock` / `literal` — code blocks
- `link` / `linkref` — hyperlinks
- `list` / `olist` / `deflist` — list types
- `note` / `warning` / `tip` — admonition directives
- `image` / `figure` — image directives
- `table` — list-table directive
- `toctree` / `ref` — Sphinx-specific directives
- `comment` — RST comment