### PR TITLE
Fix: doubled words a a, to to, of of, that that in comments

### DIFF
--- a/src/vs/base/browser/cssValue.ts
+++ b/src/vs/base/browser/cssValue.ts
@@ -76,7 +76,7 @@ export function className(value: string, escapingExpected = false): CssFragment 
 type InlineCssTemplateValue = CssFragment | Color;
 
 /**
- * Template string tag that that constructs a CSS fragment.
+ * Template string tag that constructs a CSS fragment.
  *
  * All expressions in the template must be css safe values.
  */

--- a/src/vs/editor/common/core/ranges/lineRange.ts
+++ b/src/vs/editor/common/core/ranges/lineRange.ts
@@ -46,7 +46,7 @@ export class LineRange {
 	}
 
 	/**
-	 * @param lineRanges An array of arrays of of sorted line ranges.
+	 * @param lineRanges An array of arrays of sorted line ranges.
 	 */
 	public static joinMany(lineRanges: readonly (readonly LineRange[])[]): readonly LineRange[] {
 		if (lineRanges.length === 0) {

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -51,7 +51,7 @@ export interface ICommandActionToggleInfo {
 	tooltip?: string;
 
 	/**
-	 * The title that goes well with a a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
+	 * The title that goes well with a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
 	 */
 	title?: string;
 

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -767,7 +767,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			// new JSON color themes format
 			for (const colorId in colors) {
 				const colorVal = colors[colorId];
-				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to to default
+				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to default
 					delete result.colors[colorId];
 				} else if (typeof colorVal === 'string') {
 					result.colors[colorId] = Color.fromHex(colors[colorId]);


### PR DESCRIPTION
Fix four doubled-word typos in comments:

- `a a check mark` → `a check mark` in `action.ts`
- `set to to default` → `set to default` in `colorThemeData.ts`
- `arrays of of sorted` → `arrays of sorted` in `lineRange.ts`
- `tag that that constructs` → `tag that constructs` in `cssValue.ts`