### PR TITLE
Fix: remove doubled words in comments and doc strings (batch 4)

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -53,7 +53,7 @@ export const codiconsDerived = {
 } as const;
 
 /**
- * The Codicon library is a set of default icons that are built-in in VS Code.
+ * The Codicon library is a set of default icons that are built-in VS Code.
  *
  * In the product (outside of base) Codicons should only be used as defaults. In order to have all icons in VS Code
  * themeable, component should define new, UI component specific icons using `iconRegistry.registerIcon`.

--- a/src/vs/platform/userDataSync/common/userDataSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncService.ts
@@ -784,7 +784,7 @@ class ProfileSynchronizer extends Disposable {
 						throw userDataSyncError;
 					}
 
-					// Log and and continue
+					// Log and continue
 					this.logService.error(e);
 					this.logService.error(`${synchroniser.resource}: ${toErrorMessage(e)}`);
 					syncErrors.push([synchroniser.resource, userDataSyncError]);

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -178,7 +178,7 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 	 * Applies the tunnel metadata and factory found in the remote authority
 	 * resolver to the tunnel system.
 	 *
-	 * `managedRemoteAuthority` should be be passed if the resolver returned on.
+	 * `managedRemoteAuthority` should be passed if the resolver returned on.
 	 * If this is the case, the tunnel cannot be connected to via a websocket from
 	 * the share process, so a synethic tunnel factory is used as a default.
 	 */

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -524,7 +524,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const completePromise = new DeferredPromise<void>();
 		const startPromise = new DeferredPromise<void>();
 
-		// Sequence all edits made this this resource in this streaming edits instance,
+		// Sequence all edits made this resource in this streaming edits instance,
 		// and also sequence the resource overall in the rare (currently invalid?) case
 		// that edits are made in parallel to the same resource,
 		const sequencer = new ThrottledSequencer(15, 1000);

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2341,7 +2341,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		});
 
 		// Retain a reference to itself when a request is in progress, so the ChatModel stays alive in the background
-		// only while running a request. TODO also keep it alive for 5min or so so we don't have to dispose/restore too often?
+		// only while running a request. TODO also keep it alive for 5min or so we don't have to dispose/restore too often?
 		if (this.initialLocation === ChatAgentLocation.Chat && !initialModelProps.disableBackgroundKeepAlive) {
 			const selfRef = this._register(new MutableDisposable<IChatModelReference>());
 			this._register(autorun(r => {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -984,7 +984,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			rootFiles.push({ fileName: CLAUDE_LOCAL_MD_FILENAME, type: AgentInstructionFileType.claudeMd }); // CLAUDE.local.md in workspace root
 
 			promises.push(this.fileLocator.findFilesInRoots(rootFolders, CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in .claude folder under workspace root
-			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in in ~/.claude folder
+			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in ~/.claude folder
 		}
 		const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
 		if (!useCopilotInstructionsFiles) {

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -314,7 +314,7 @@ export class SearchView extends ViewPane {
 
 		this._refreshResultsScheduler = this._register(new RunOnceScheduler(this._updateResults.bind(this), 80));
 
-		// storage service listener for for roaming changes
+		// storage service listener for roaming changes
 		this._register(this.storageService.onWillSaveState(() => {
 			this._saveSearchHistoryService();
 		}));

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3326,7 +3326,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 						}
 					}
 
-					// At this this point there are multiple tasks.
+					// At this point there are multiple tasks.
 					chooseAndRunTask(tasks);
 				});
 			};

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -101,7 +101,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 
 		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions'];
 		this._register(this._remoteTerminalChannel.onExecuteCommand(async e => {
-			// Ensure this request for for this window
+			// Ensure this request for this window
 			const pty = this._ptys.get(e.persistentProcessId);
 			if (!pty) {
 				return;

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17927,7 +17927,7 @@ declare module 'vscode' {
 		forceNewSession?: boolean | AuthenticationGetSessionPresentationOptions | AuthenticationForceNewSessionOptions;
 
 		/**
-		 * Whether we should show the indication to sign in in the Accounts menu.
+		 * Whether we should show the indication to sign in the Accounts menu.
 		 *
 		 * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
 		 * If true, no indication will be shown.


### PR DESCRIPTION
Removes accidental word repetitions found in comments and JSDoc strings across multiple files.

## Changes

| File | Before | After |
|------|--------|-------|
| `src/vscode-dts/vscode.d.ts` | `sign in in the Accounts menu` | `sign in the Accounts menu` |
| `src/vs/base/common/codicons.ts` | `built-in in VS Code` | `built-in VS Code` |
| `src/vs/platform/userDataSync/common/userDataSyncService.ts` | `Log and and continue` (×2) | `Log and continue` |
| `src/vs/workbench/api/common/extHostTunnelService.ts` | `should be be passed` | `should be passed` |
| `src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts` | `position for for specific` | `position for specific` |
| `src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts` | `At this this point` | `At this point` |
| `src/vs/workbench/contrib/search/browser/searchView.ts` | `listener for for roaming` | `listener for roaming` |
| `src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts` | `request for for this` | `request for this` |
| `src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts` | `made this this resource` | `made this resource` |
| `src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts` | `CLAUDE.md in in ~/.claude` | `CLAUDE.md in ~/.claude` |
| `src/vs/workbench/contrib/chat/common/model/chatModel.ts` | `5min or so so we` | `5min or so we` |

All changes are in comments/JSDoc only — no runtime behaviour affected.