### PR TITLE
feat: add code snippets for Go, Rust, Dart, and Python extensions

### DIFF
--- a/extensions/dart/package.json
+++ b/extensions/dart/package.json
@@ -1,38 +1,44 @@
 {
-	"name": "dart",
-	"displayName": "%displayName%",
-	"description": "%description%",
-	"version": "10.0.0",
-	"publisher": "vscode",
-	"license": "MIT",
-	"engines": {
-		"vscode": "0.10.x"
-	},
-	"scripts": {
-		"update-grammar": "node ../node_modules/vscode-grammar-updater/bin dart-lang/dart-syntax-highlight grammars/dart.json ./syntaxes/dart.tmLanguage.json"
-	},
-	"categories": [
-		"Programming Languages"
-	],
-	"contributes": {
-		"languages": [
-			{
-				"id": "dart",
-				"extensions": [
-					".dart"
-				],
-				"aliases": [
-					"Dart"
-				],
-				"configuration": "./language-configuration.json"
-			}
-		],
-		"grammars": [
-			{
-				"language": "dart",
-				"scopeName": "source.dart",
-				"path": "./syntaxes/dart.tmLanguage.json"
-			}
-		]
-	}
+  "name": "dart",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "10.0.0",
+  "publisher": "vscode",
+  "license": "MIT",
+  "engines": {
+    "vscode": "0.10.x"
+  },
+  "scripts": {
+    "update-grammar": "node ../node_modules/vscode-grammar-updater/bin dart-lang/dart-syntax-highlight grammars/dart.json ./syntaxes/dart.tmLanguage.json"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "dart",
+        "extensions": [
+          ".dart"
+        ],
+        "aliases": [
+          "Dart"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "dart",
+        "scopeName": "source.dart",
+        "path": "./syntaxes/dart.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "dart",
+        "path": "./snippets/dart.code-snippets"
+      }
+    ]
+  }
 }

--- a/extensions/dart/snippets/dart.code-snippets
+++ b/extensions/dart/snippets/dart.code-snippets
@@ -1,0 +1,190 @@
+{
+	"Dart Main Function": {
+		"prefix": "main",
+		"body": [
+			"void main() {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart main function"
+	},
+	"Dart Function": {
+		"prefix": "fn",
+		"body": [
+			"${1:void} ${2:name}(${3:params}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart function declaration"
+	},
+	"Dart Class": {
+		"prefix": "class",
+		"body": [
+			"class ${1:Name} {",
+			"\t${2:Type} ${3:field};",
+			"",
+			"\t${1:Name}(${4:this.${3:field}});",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart class with constructor"
+	},
+	"Dart Abstract Class": {
+		"prefix": "abclass",
+		"body": [
+			"abstract class ${1:Name} {",
+			"\t${2:void} ${3:method}();",
+			"}"
+		],
+		"description": "Dart abstract class"
+	},
+	"Dart Mixin": {
+		"prefix": "mixin",
+		"body": [
+			"mixin ${1:Name} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart mixin declaration"
+	},
+	"Dart Extension": {
+		"prefix": "ext",
+		"body": [
+			"extension ${1:Name} on ${2:Type} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart extension method"
+	},
+	"Dart Print": {
+		"prefix": "print",
+		"body": [
+			"print(${1:value});"
+		],
+		"description": "Dart print statement"
+	},
+	"Dart For Each": {
+		"prefix": "foreach",
+		"body": [
+			"${1:list}.forEach((${2:item}) {",
+			"\t$0",
+			"});"
+		],
+		"description": "Dart forEach loop"
+	},
+	"Dart For Loop": {
+		"prefix": "forl",
+		"body": [
+			"for (var ${1:i} = 0; ${1:i} < ${2:length}; ${1:i}++) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart for loop"
+	},
+	"Dart For-in Loop": {
+		"prefix": "forin",
+		"body": [
+			"for (final ${1:item} in ${2:list}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart for-in loop"
+	},
+	"Dart Async Function": {
+		"prefix": "async",
+		"body": [
+			"Future<${1:void}> ${2:name}(${3:params}) async {",
+			"\t$0",
+			"}"
+		],
+		"description": "Dart async function"
+	},
+	"Dart Await": {
+		"prefix": "await",
+		"body": [
+			"final ${1:result} = await ${2:future};"
+		],
+		"description": "Dart await expression"
+	},
+	"Dart Try-Catch": {
+		"prefix": "try",
+		"body": [
+			"try {",
+			"\t$0",
+			"} catch (${1:e}) {",
+			"\tprint(${1:e});",
+			"}"
+		],
+		"description": "Dart try-catch block"
+	},
+	"Dart Named Constructor": {
+		"prefix": "namedctor",
+		"body": [
+			"${1:ClassName}.${2:named}(${3:params}) : ${4:field = value};"
+		],
+		"description": "Dart named constructor"
+	},
+	"Dart Getter": {
+		"prefix": "get",
+		"body": [
+			"${1:Type} get ${2:name} => ${3:_field};"
+		],
+		"description": "Dart getter"
+	},
+	"Dart Setter": {
+		"prefix": "set",
+		"body": [
+			"set ${1:name}(${2:Type} value) => ${3:_field} = value;"
+		],
+		"description": "Dart setter"
+	},
+	"Dart List": {
+		"prefix": "list",
+		"body": [
+			"final ${1:list} = <${2:Type}>[${3}];"
+		],
+		"description": "Dart typed list"
+	},
+	"Dart Map": {
+		"prefix": "map",
+		"body": [
+			"final ${1:map} = <${2:String}, ${3:dynamic}>{",
+			"\t'${4:key}': ${5:value},",
+			"};"
+		],
+		"description": "Dart map literal"
+	},
+	"Dart Null Check": {
+		"prefix": "null",
+		"body": [
+			"${1:value} ?? ${2:defaultValue}"
+		],
+		"description": "Dart null-coalescing operator"
+	},
+	"Dart Assertion": {
+		"prefix": "assert",
+		"body": [
+			"assert(${1:condition}, '${2:message}');"
+		],
+		"description": "Dart assert statement"
+	},
+	"Dart Stream": {
+		"prefix": "stream",
+		"body": [
+			"Stream<${1:Type}> ${2:name}() async* {",
+			"\tyield ${3:value};",
+			"}"
+		],
+		"description": "Dart async generator / stream"
+	},
+	"Dart Enum": {
+		"prefix": "enum",
+		"body": [
+			"enum ${1:Name} {",
+			"\t${2:value1},",
+			"\t${3:value2},",
+			"}"
+		],
+		"description": "Dart enum"
+	}
+}

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin worlpaker/go-syntax syntaxes/go.tmLanguage.json ./syntaxes/go.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -36,7 +38,13 @@
       "[go]": {
         "editor.insertSpaces": false
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "go",
+        "path": "./snippets/go.code-snippets"
+      }
+    ]
   },
   "repository": {
     "type": "git",

--- a/extensions/go/snippets/go.code-snippets
+++ b/extensions/go/snippets/go.code-snippets
@@ -1,0 +1,214 @@
+{
+	"Go Package Declaration": {
+		"prefix": "pkg",
+		"body": [
+			"package ${1:main}"
+		],
+		"description": "Go package declaration"
+	},
+	"Go Import": {
+		"prefix": "import",
+		"body": [
+			"import (",
+			"\t\"${1:fmt}\"",
+			")"
+		],
+		"description": "Go import block"
+	},
+	"Go Main Function": {
+		"prefix": "main",
+		"body": [
+			"func main() {",
+			"\t$0",
+			"}"
+		],
+		"description": "Go main function"
+	},
+	"Go Function": {
+		"prefix": "func",
+		"body": [
+			"func ${1:name}(${2:params}) ${3:returnType} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Go function declaration"
+	},
+	"Go Function with Error Return": {
+		"prefix": "funce",
+		"body": [
+			"func ${1:name}(${2:params}) (${3:returnType}, error) {",
+			"\t$0",
+			"\treturn ${4:value}, nil",
+			"}"
+		],
+		"description": "Go function returning a value and error"
+	},
+	"Go Struct": {
+		"prefix": "struct",
+		"body": [
+			"type ${1:Name} struct {",
+			"\t${2:Field} ${3:Type}",
+			"}"
+		],
+		"description": "Go struct declaration"
+	},
+	"Go Interface": {
+		"prefix": "iface",
+		"body": [
+			"type ${1:Name} interface {",
+			"\t${2:Method}(${3:params}) ${4:returnType}",
+			"}"
+		],
+		"description": "Go interface declaration"
+	},
+	"Go Method": {
+		"prefix": "method",
+		"body": [
+			"func (${1:r} *${2:Receiver}) ${3:Method}(${4:params}) ${5:returnType} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Go method on a type"
+	},
+	"Go Error Check": {
+		"prefix": "iferr",
+		"body": [
+			"if err != nil {",
+			"\treturn ${1:nil, }err",
+			"}"
+		],
+		"description": "Go idiomatic error check"
+	},
+	"Go For Range": {
+		"prefix": "forr",
+		"body": [
+			"for ${1:i}, ${2:v} := range ${3:collection} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Go for-range loop"
+	},
+	"Go Goroutine": {
+		"prefix": "go",
+		"body": [
+			"go func() {",
+			"\t$0",
+			"}()"
+		],
+		"description": "Go goroutine with anonymous function"
+	},
+	"Go Channel": {
+		"prefix": "chan",
+		"body": [
+			"${1:ch} := make(chan ${2:Type}, ${3:0})"
+		],
+		"description": "Go channel creation"
+	},
+	"Go Select": {
+		"prefix": "select",
+		"body": [
+			"select {",
+			"case ${1:v} := <-${2:ch}:",
+			"\t$0",
+			"case <-${3:done}:",
+			"\treturn",
+			"}"
+		],
+		"description": "Go select statement"
+	},
+	"Go Defer": {
+		"prefix": "defer",
+		"body": [
+			"defer ${1:func}()"
+		],
+		"description": "Go defer statement"
+	},
+	"Go Map": {
+		"prefix": "map",
+		"body": [
+			"${1:m} := map[${2:string}]${3:any}{",
+			"\t\"${4:key}\": ${5:value},",
+			"}"
+		],
+		"description": "Go map literal"
+	},
+	"Go Slice": {
+		"prefix": "slice",
+		"body": [
+			"${1:s} := []${2:Type}{${3}}",
+			""
+		],
+		"description": "Go slice literal"
+	},
+	"Go Test Function": {
+		"prefix": "test",
+		"body": [
+			"func Test${1:Name}(t *testing.T) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Go test function"
+	},
+	"Go Benchmark": {
+		"prefix": "bench",
+		"body": [
+			"func Benchmark${1:Name}(b *testing.B) {",
+			"\tfor i := 0; i < b.N; i++ {",
+			"\t\t$0",
+			"\t}",
+			"}"
+		],
+		"description": "Go benchmark function"
+	},
+	"Go Println": {
+		"prefix": "println",
+		"body": [
+			"fmt.Println(${1})"
+		],
+		"description": "Go fmt.Println"
+	},
+	"Go Printf": {
+		"prefix": "printf",
+		"body": [
+			"fmt.Printf(\"${1:%s}\\n\", ${2:value})"
+		],
+		"description": "Go fmt.Printf"
+	},
+	"Go Errorf": {
+		"prefix": "errorf",
+		"body": [
+			"fmt.Errorf(\"${1:message}: %w\", ${2:err})"
+		],
+		"description": "Go fmt.Errorf with wrapping"
+	},
+	"Go Context": {
+		"prefix": "ctx",
+		"body": [
+			"ctx, cancel := context.WithTimeout(context.Background(), ${1:5}*time.Second)",
+			"defer cancel()"
+		],
+		"description": "Go context with timeout"
+	},
+	"Go WaitGroup": {
+		"prefix": "wg",
+		"body": [
+			"var wg sync.WaitGroup",
+			"wg.Add(${1:1})",
+			"go func() {",
+			"\tdefer wg.Done()",
+			"\t$0",
+			"}()",
+			"wg.Wait()"
+		],
+		"description": "Go WaitGroup pattern"
+	},
+	"Go Mutex": {
+		"prefix": "mutex",
+		"body": [
+			"var mu sync.Mutex",
+			"mu.Lock()",
+			"defer mu.Unlock()"
+		],
+		"description": "Go mutex lock/unlock"
+	}
+}

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "vscode": "*"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -52,7 +54,13 @@
         "diffEditor.ignoreTrimWhitespace": false,
         "editor.defaultColorDecorators": "never"
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "python",
+        "path": "./snippets/python.code-snippets"
+      }
+    ]
   },
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin MagicStack/MagicPython grammars/MagicPython.tmLanguage ./syntaxes/MagicPython.tmLanguage.json grammars/MagicRegExp.tmLanguage ./syntaxes/MagicRegExp.tmLanguage.json"

--- a/extensions/python/snippets/python.code-snippets
+++ b/extensions/python/snippets/python.code-snippets
@@ -1,0 +1,233 @@
+{
+	"Python Main Guard": {
+		"prefix": "main",
+		"body": [
+			"if __name__ == '__main__':",
+			"\t$0"
+		],
+		"description": "Python main guard"
+	},
+	"Python Function": {
+		"prefix": "def",
+		"body": [
+			"def ${1:name}(${2:params}):",
+			"\t$0"
+		],
+		"description": "Python function definition"
+	},
+	"Python Function with Docstring": {
+		"prefix": "defd",
+		"body": [
+			"def ${1:name}(${2:params}):",
+			"\t\"\"\"${3:Description.}\"\"\"",
+			"\t$0"
+		],
+		"description": "Python function with docstring"
+	},
+	"Python Async Function": {
+		"prefix": "async",
+		"body": [
+			"async def ${1:name}(${2:params}):",
+			"\t$0"
+		],
+		"description": "Python async function"
+	},
+	"Python Class": {
+		"prefix": "class",
+		"body": [
+			"class ${1:Name}:",
+			"\tdef __init__(self${2:, params}):",
+			"\t\t$0"
+		],
+		"description": "Python class with __init__"
+	},
+	"Python Dataclass": {
+		"prefix": "dataclass",
+		"body": [
+			"from dataclasses import dataclass",
+			"",
+			"@dataclass",
+			"class ${1:Name}:",
+			"\t${2:field}: ${3:str}"
+		],
+		"description": "Python dataclass"
+	},
+	"Python Property": {
+		"prefix": "property",
+		"body": [
+			"@property",
+			"def ${1:name}(self):",
+			"\treturn self._${1:name}",
+			"",
+			"@${1:name}.setter",
+			"def ${1:name}(self, value):",
+			"\tself._${1:name} = value"
+		],
+		"description": "Python property with getter and setter"
+	},
+	"Python List Comprehension": {
+		"prefix": "lc",
+		"body": [
+			"[${1:expr} for ${2:item} in ${3:iterable}${4: if ${5:condition}}]"
+		],
+		"description": "Python list comprehension"
+	},
+	"Python Dict Comprehension": {
+		"prefix": "dc",
+		"body": [
+			"{${1:key}: ${2:value} for ${3:item} in ${4:iterable}}"
+		],
+		"description": "Python dict comprehension"
+	},
+	"Python Generator": {
+		"prefix": "gen",
+		"body": [
+			"(${1:expr} for ${2:item} in ${3:iterable})"
+		],
+		"description": "Python generator expression"
+	},
+	"Python Lambda": {
+		"prefix": "lambda",
+		"body": [
+			"lambda ${1:params}: ${2:expr}"
+		],
+		"description": "Python lambda function"
+	},
+	"Python Try-Except": {
+		"prefix": "try",
+		"body": [
+			"try:",
+			"\t$0",
+			"except ${1:Exception} as e:",
+			"\t${2:raise}"
+		],
+		"description": "Python try-except block"
+	},
+	"Python Try-Except-Finally": {
+		"prefix": "tryf",
+		"body": [
+			"try:",
+			"\t$0",
+			"except ${1:Exception} as e:",
+			"\t${2:raise}",
+			"finally:",
+			"\t${3:pass}"
+		],
+		"description": "Python try-except-finally"
+	},
+	"Python With Statement": {
+		"prefix": "with",
+		"body": [
+			"with ${1:open('${2:file}', '${3|r,w,a|}') as ${4:f}}:",
+			"\t$0"
+		],
+		"description": "Python with statement"
+	},
+	"Python Assert": {
+		"prefix": "assert",
+		"body": [
+			"assert ${1:condition}, '${2:message}'"
+		],
+		"description": "Python assert statement"
+	},
+	"Python Type Hint Function": {
+		"prefix": "deft",
+		"body": [
+			"def ${1:name}(${2:param}: ${3:type}) -> ${4:ReturnType}:",
+			"\t$0"
+		],
+		"description": "Python function with type hints"
+	},
+	"Python Enumerate": {
+		"prefix": "enum",
+		"body": [
+			"for ${1:i}, ${2:item} in enumerate(${3:iterable}):",
+			"\t$0"
+		],
+		"description": "Python enumerate loop"
+	},
+	"Python Zip": {
+		"prefix": "zip",
+		"body": [
+			"for ${1:a}, ${2:b} in zip(${3:iter1}, ${4:iter2}):",
+			"\t$0"
+		],
+		"description": "Python zip loop"
+	},
+	"Python Argparse": {
+		"prefix": "argparse",
+		"body": [
+			"import argparse",
+			"",
+			"parser = argparse.ArgumentParser(description='${1:Description}')",
+			"parser.add_argument('${2:arg}', help='${3:help text}')",
+			"args = parser.parse_args()"
+		],
+		"description": "Python argparse setup"
+	},
+	"Python Logging Setup": {
+		"prefix": "logging",
+		"body": [
+			"import logging",
+			"",
+			"logging.basicConfig(",
+			"\tlevel=logging.${1|DEBUG,INFO,WARNING,ERROR|},",
+			"\tformat='%(asctime)s - %(name)s - %(levelname)s - %(message)s'",
+			")",
+			"logger = logging.getLogger(__name__)"
+		],
+		"description": "Python logging setup"
+	},
+	"Python Unittest TestCase": {
+		"prefix": "unittest",
+		"body": [
+			"import unittest",
+			"",
+			"class ${1:Test}(unittest.TestCase):",
+			"\tdef test_${2:name}(self):",
+			"\t\tself.assertEqual(${3:actual}, ${4:expected})",
+			"",
+			"if __name__ == '__main__':",
+			"\tunittest.main()"
+		],
+		"description": "Python unittest TestCase"
+	},
+	"Python Pytest Function": {
+		"prefix": "pytest",
+		"body": [
+			"def test_${1:name}():",
+			"\t${2:result} = ${3:call}",
+			"\tassert ${2:result} == ${4:expected}"
+		],
+		"description": "Python pytest test function"
+	},
+	"Python Context Manager": {
+		"prefix": "contextmanager",
+		"body": [
+			"from contextlib import contextmanager",
+			"",
+			"@contextmanager",
+			"def ${1:name}(${2:params}):",
+			"\ttry:",
+			"\t\t$0",
+			"\t\tyield",
+			"\tfinally:",
+			"\t\t${3:pass}"
+		],
+		"description": "Python context manager using contextlib"
+	},
+	"Python Decorator": {
+		"prefix": "decorator",
+		"body": [
+			"from functools import wraps",
+			"",
+			"def ${1:decorator}(func):",
+			"\t@wraps(func)",
+			"\tdef wrapper(*args, **kwargs):",
+			"\t\t$0",
+			"\t\treturn func(*args, **kwargs)",
+			"\treturn wrapper"
+		],
+		"description": "Python function decorator"
+	}
+}

--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ./build/update-grammar.mjs"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -31,6 +33,12 @@
         "language": "rust",
         "path": "./syntaxes/rust.tmLanguage.json",
         "scopeName": "source.rust"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "rust",
+        "path": "./snippets/rust.code-snippets"
       }
     ]
   },

--- a/extensions/rust/snippets/rust.code-snippets
+++ b/extensions/rust/snippets/rust.code-snippets
@@ -1,0 +1,202 @@
+{
+	"Rust Main Function": {
+		"prefix": "main",
+		"body": [
+			"fn main() {",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust main function"
+	},
+	"Rust Function": {
+		"prefix": "fn",
+		"body": [
+			"fn ${1:name}(${2:params}) -> ${3:ReturnType} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust function declaration"
+	},
+	"Rust Function with Result": {
+		"prefix": "fnr",
+		"body": [
+			"fn ${1:name}(${2:params}) -> Result<${3:T}, ${4:E}> {",
+			"\t$0",
+			"\tOk(${5:value})",
+			"}"
+		],
+		"description": "Rust function returning Result"
+	},
+	"Rust Struct": {
+		"prefix": "struct",
+		"body": [
+			"struct ${1:Name} {",
+			"\t${2:field}: ${3:Type},",
+			"}"
+		],
+		"description": "Rust struct declaration"
+	},
+	"Rust Impl Block": {
+		"prefix": "impl",
+		"body": [
+			"impl ${1:Type} {",
+			"\tfn ${2:new}(${3:params}) -> Self {",
+			"\t\t${4:Self {}}",
+			"\t}",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust impl block"
+	},
+	"Rust Trait": {
+		"prefix": "trait",
+		"body": [
+			"trait ${1:Name} {",
+			"\tfn ${2:method}(&self)${3: -> ${4:ReturnType}};",
+			"}"
+		],
+		"description": "Rust trait declaration"
+	},
+	"Rust Enum": {
+		"prefix": "enum",
+		"body": [
+			"enum ${1:Name} {",
+			"\t${2:Variant1},",
+			"\t${3:Variant2}(${4:Type}),",
+			"}"
+		],
+		"description": "Rust enum declaration"
+	},
+	"Rust Match": {
+		"prefix": "match",
+		"body": [
+			"match ${1:expr} {",
+			"\t${2:pattern} => ${3:result},",
+			"\t_ => ${4:default},",
+			"}"
+		],
+		"description": "Rust match expression"
+	},
+	"Rust If Let": {
+		"prefix": "iflet",
+		"body": [
+			"if let ${1:Some(val)} = ${2:expr} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust if let pattern"
+	},
+	"Rust While Let": {
+		"prefix": "whilelet",
+		"body": [
+			"while let ${1:Some(val)} = ${2:expr} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust while let pattern"
+	},
+	"Rust For Loop": {
+		"prefix": "forr",
+		"body": [
+			"for ${1:item} in ${2:collection} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Rust for loop"
+	},
+	"Rust Closure": {
+		"prefix": "closure",
+		"body": [
+			"|${1:params}| ${2:{ $0 }}"
+		],
+		"description": "Rust closure"
+	},
+	"Rust Vec": {
+		"prefix": "vec",
+		"body": [
+			"vec![${1}]"
+		],
+		"description": "Rust vec! macro"
+	},
+	"Rust HashMap": {
+		"prefix": "hashmap",
+		"body": [
+			"let mut ${1:map} = std::collections::HashMap::new();",
+			"${1:map}.insert(${2:key}, ${3:value});"
+		],
+		"description": "Rust HashMap creation"
+	},
+	"Rust Derive": {
+		"prefix": "derive",
+		"body": [
+			"#[derive(${1:Debug, Clone, PartialEq})]"
+		],
+		"description": "Rust derive attribute"
+	},
+	"Rust Option Unwrap": {
+		"prefix": "unwrap",
+		"body": [
+			"${1:expr}.unwrap_or(${2:default})"
+		],
+		"description": "Rust Option unwrap_or"
+	},
+	"Rust Question Mark": {
+		"prefix": "qmark",
+		"body": [
+			"${1:expr}?"
+		],
+		"description": "Rust ? operator for error propagation"
+	},
+	"Rust Println": {
+		"prefix": "println",
+		"body": [
+			"println!(\"${1}\", ${2});"
+		],
+		"description": "Rust println! macro"
+	},
+	"Rust Eprintln": {
+		"prefix": "eprintln",
+		"body": [
+			"eprintln!(\"${1:error}: {}\", ${2:err});"
+		],
+		"description": "Rust eprintln! macro for stderr"
+	},
+	"Rust Test Module": {
+		"prefix": "testmod",
+		"body": [
+			"#[cfg(test)]",
+			"mod tests {",
+			"\tuse super::*;",
+			"",
+			"\t#[test]",
+			"\tfn ${1:test_name}() {",
+			"\t\t$0",
+			"\t}",
+			"}"
+		],
+		"description": "Rust test module with a test function"
+	},
+	"Rust Assert Equal": {
+		"prefix": "assert",
+		"body": [
+			"assert_eq!(${1:left}, ${2:right});"
+		],
+		"description": "Rust assert_eq! macro"
+	},
+	"Rust Spawn Thread": {
+		"prefix": "spawn",
+		"body": [
+			"std::thread::spawn(move || {",
+			"\t$0",
+			"});"
+		],
+		"description": "Rust thread spawn"
+	},
+	"Rust Arc Mutex": {
+		"prefix": "arcmutex",
+		"body": [
+			"let ${1:shared} = std::sync::Arc::new(std::sync::Mutex::new(${2:value}));"
+		],
+		"description": "Rust Arc<Mutex<T>> pattern for shared mutable state"
+	}
+}


### PR DESCRIPTION
Adds productivity code snippets to four built-in language extensions that currently have no snippets.

## Motivation

Users working with Go, Rust, Dart, and Python in VS Code have no built-in snippet support from these extensions. Common patterns (error handling, goroutines, struct/impl declarations, async/await, dataclasses) require typing from scratch every time. This PR adds curated, idiomatic snippets for each language.

## Changes

### Go (`extensions/go/snippets/go.code-snippets`) — 23 snippets
- Package/import boilerplate, `main`, `func`, `funce` (func with error)
- `struct`, `iface`, `method`
- `iferr` — idiomatic `if err != nil { return err }` pattern
- Concurrency: `go` (goroutine), `chan`, `select`, `wg` (WaitGroup), `mutex`
- `forr` (for-range), `defer`, `map`, `slice`
- Testing: `test`, `bench`
- `println`, `printf`, `errorf`, `ctx` (context with timeout)

### Rust (`extensions/rust/snippets/rust.code-snippets`) — 23 snippets
- `main`, `fn`, `fnr` (fn returning Result), `struct`, `impl`, `trait`, `enum`
- `match`, `iflet`, `whilelet`, `forr`, `closure`
- `vec!`, `hashmap`, `derive` attribute
- `unwrap` (unwrap_or), `qmark` (? operator)
- `println!`, `eprintln!`, `testmod`, `assert_eq!`
- `spawn` (thread), `arcmutex` (Arc<Mutex<T>>)

### Dart (`extensions/dart/snippets/dart.code-snippets`) — 22 snippets
- `main`, `fn`, `class`, `abclass`, `mixin`, `ext` (extension method)
- `foreach`, `forl`, `forin`
- `async` (async function), `await`, `stream` (async generator)
- `try`, `namedctor`, `get`, `set`
- `list`, `map`, `null` (??), `assert`, `enum`

### Python (`extensions/python/snippets/python.code-snippets`) — 24 snippets
- `main` guard, `def`, `defd` (with docstring), `async`, `class`, `dataclass`
- `property` (with getter/setter), `decorator`, `contextmanager`
- `lc` (list comprehension), `dc` (dict comprehension), `gen` (generator)
- `lambda`, `try`, `tryf`, `with`
- `deft` (typed function), `enum` (enumerate loop), `zip`
- `argparse`, `logging`, `unittest`, `pytest`

All snippets use tab stops for fast navigation, choice syntax where appropriate, and follow the same JSON format as existing VS Code snippets.