### PR TITLE
feat: add code snippets for Lua, Perl, R, and PowerShell extensions

### DIFF
--- a/extensions/lua/package.json
+++ b/extensions/lua/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin sumneko/lua.tmbundle Syntaxes/Lua.plist ./syntaxes/lua.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -34,6 +36,12 @@
         "tokenTypes": {
           "comment.line.double-dash.doc.lua": "other"
         }
+      }
+    ],
+    "snippets": [
+      {
+        "language": "lua",
+        "path": "./snippets/lua.code-snippets"
       }
     ]
   },

--- a/extensions/lua/snippets/lua.code-snippets
+++ b/extensions/lua/snippets/lua.code-snippets
@@ -1,0 +1,188 @@
+{
+	"Lua Function": {
+		"prefix": "fn",
+		"body": [
+			"function ${1:name}(${2:params})",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua function declaration"
+	},
+	"Lua Local Function": {
+		"prefix": "lfn",
+		"body": [
+			"local function ${1:name}(${2:params})",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua local function declaration"
+	},
+	"Lua Local Variable": {
+		"prefix": "local",
+		"body": [
+			"local ${1:name} = ${2:value}"
+		],
+		"description": "Lua local variable"
+	},
+	"Lua If Statement": {
+		"prefix": "if",
+		"body": [
+			"if ${1:condition} then",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua if statement"
+	},
+	"Lua If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if ${1:condition} then",
+			"\t$0",
+			"else",
+			"\t${2}",
+			"end"
+		],
+		"description": "Lua if-else statement"
+	},
+	"Lua If-Elseif-Else": {
+		"prefix": "ifeif",
+		"body": [
+			"if ${1:condition} then",
+			"\t$0",
+			"elseif ${2:condition} then",
+			"\t${3}",
+			"else",
+			"\t${4}",
+			"end"
+		],
+		"description": "Lua if-elseif-else"
+	},
+	"Lua While Loop": {
+		"prefix": "while",
+		"body": [
+			"while ${1:condition} do",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua while loop"
+	},
+	"Lua Repeat-Until Loop": {
+		"prefix": "repeat",
+		"body": [
+			"repeat",
+			"\t$0",
+			"until ${1:condition}"
+		],
+		"description": "Lua repeat-until loop"
+	},
+	"Lua Numeric For Loop": {
+		"prefix": "forn",
+		"body": [
+			"for ${1:i} = ${2:1}, ${3:10} do",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua numeric for loop"
+	},
+	"Lua Generic For Loop": {
+		"prefix": "forg",
+		"body": [
+			"for ${1:k}, ${2:v} in ${3:pairs(${4:t})} do",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua generic for loop"
+	},
+	"Lua Table": {
+		"prefix": "table",
+		"body": [
+			"local ${1:t} = {",
+			"\t${2:key} = ${3:value},",
+			"}"
+		],
+		"description": "Lua table constructor"
+	},
+	"Lua Array Table": {
+		"prefix": "array",
+		"body": [
+			"local ${1:t} = { ${2} }"
+		],
+		"description": "Lua array-like table"
+	},
+	"Lua Class Pattern": {
+		"prefix": "class",
+		"body": [
+			"local ${1:ClassName} = {}",
+			"${1:ClassName}.__index = ${1:ClassName}",
+			"",
+			"function ${1:ClassName}.new(${2:params})",
+			"\tlocal self = setmetatable({}, ${1:ClassName})",
+			"\t$0",
+			"\treturn self",
+			"end",
+			"",
+			"return ${1:ClassName}"
+		],
+		"description": "Lua OOP class pattern"
+	},
+	"Lua Method": {
+		"prefix": "method",
+		"body": [
+			"function ${1:ClassName}:${2:methodName}(${3:params})",
+			"\t$0",
+			"end"
+		],
+		"description": "Lua method (colon syntax)"
+	},
+	"Lua Require": {
+		"prefix": "require",
+		"body": [
+			"local ${1:module} = require('${2:module_name}')"
+		],
+		"description": "Lua require statement"
+	},
+	"Lua Print": {
+		"prefix": "print",
+		"body": [
+			"print(${1:value})"
+		],
+		"description": "Lua print statement"
+	},
+	"Lua String Format": {
+		"prefix": "format",
+		"body": [
+			"string.format('${1:%s}', ${2:value})"
+		],
+		"description": "Lua string.format"
+	},
+	"Lua Error": {
+		"prefix": "error",
+		"body": [
+			"error('${1:message}', ${2:2})"
+		],
+		"description": "Lua error with level"
+	},
+	"Lua Protected Call": {
+		"prefix": "pcall",
+		"body": [
+			"local ${1:ok}, ${2:err} = pcall(function()",
+			"\t$0",
+			"end)",
+			"if not ${1:ok} then",
+			"\terror(${2:err})",
+			"end"
+		],
+		"description": "Lua pcall error handling"
+	},
+	"Lua Module Pattern": {
+		"prefix": "module",
+		"body": [
+			"local M = {}",
+			"",
+			"$0",
+			"",
+			"return M"
+		],
+		"description": "Lua module pattern"
+	}
+}

--- a/extensions/perl/package.json
+++ b/extensions/perl/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin textmate/perl.tmbundle Syntaxes/Perl.plist ./syntaxes/perl.tmLanguage.json Syntaxes/Perl%206.tmLanguage ./syntaxes/perl6.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -65,6 +67,16 @@
         "language": "raku",
         "scopeName": "source.perl.6",
         "path": "./syntaxes/perl6.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "perl",
+        "path": "./snippets/perl.code-snippets"
+      },
+      {
+        "language": "raku",
+        "path": "./snippets/perl.code-snippets"
       }
     ]
   },

--- a/extensions/perl/snippets/perl.code-snippets
+++ b/extensions/perl/snippets/perl.code-snippets
@@ -1,0 +1,184 @@
+{
+	"Perl Shebang": {
+		"prefix": "shebang",
+		"body": [
+			"#!/usr/bin/env perl",
+			"use strict;",
+			"use warnings;",
+			"",
+			"$0"
+		],
+		"description": "Perl script header with strict and warnings"
+	},
+	"Perl Subroutine": {
+		"prefix": "sub",
+		"body": [
+			"sub ${1:name} {",
+			"\tmy (${2:\\$params}) = @_;",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl subroutine"
+	},
+	"Perl If Statement": {
+		"prefix": "if",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl if statement"
+	},
+	"Perl If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"} else {",
+			"\t${2}",
+			"}"
+		],
+		"description": "Perl if-else"
+	},
+	"Perl Unless": {
+		"prefix": "unless",
+		"body": [
+			"unless (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl unless statement"
+	},
+	"Perl For Loop": {
+		"prefix": "for",
+		"body": [
+			"for my \\$${1:i} (0 .. ${2:9}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl for loop"
+	},
+	"Perl Foreach": {
+		"prefix": "foreach",
+		"body": [
+			"foreach my \\$${1:item} (@${2:array}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl foreach loop"
+	},
+	"Perl While Loop": {
+		"prefix": "while",
+		"body": [
+			"while (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl while loop"
+	},
+	"Perl Array": {
+		"prefix": "array",
+		"body": [
+			"my @${1:array} = (${2});"
+		],
+		"description": "Perl array declaration"
+	},
+	"Perl Hash": {
+		"prefix": "hash",
+		"body": [
+			"my %${1:hash} = (",
+			"\t'${2:key}' => '${3:value}',",
+			");"
+		],
+		"description": "Perl hash declaration"
+	},
+	"Perl Print": {
+		"prefix": "print",
+		"body": [
+			"print \"${1:message}\\n\";"
+		],
+		"description": "Perl print statement"
+	},
+	"Perl Say": {
+		"prefix": "say",
+		"body": [
+			"say \"${1:message}\";"
+		],
+		"description": "Perl say (print with newline)"
+	},
+	"Perl Die": {
+		"prefix": "die",
+		"body": [
+			"die \"${1:error message}: $!\\n\";"
+		],
+		"description": "Perl die statement"
+	},
+	"Perl Regex Match": {
+		"prefix": "match",
+		"body": [
+			"if (\\$${1:str} =~ /${2:pattern}/) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Perl regex match"
+	},
+	"Perl Regex Substitute": {
+		"prefix": "subst",
+		"body": [
+			"\\$${1:str} =~ s/${2:pattern}/${3:replacement}/g;"
+		],
+		"description": "Perl regex substitution"
+	},
+	"Perl Open File": {
+		"prefix": "open",
+		"body": [
+			"open(my \\$${1:fh}, '<', '${2:file}') or die \"Cannot open: $!\\n\";",
+			"while (my \\$${3:line} = <\\$${1:fh}>) {",
+			"\tchomp \\$${3:line};",
+			"\t$0",
+			"}",
+			"close(\\$${1:fh});"
+		],
+		"description": "Perl open and read file"
+	},
+	"Perl Module": {
+		"prefix": "module",
+		"body": [
+			"package ${1:Module::Name};",
+			"",
+			"use strict;",
+			"use warnings;",
+			"",
+			"sub new {",
+			"\tmy (\\$class, %args) = @_;",
+			"\treturn bless {%args}, \\$class;",
+			"}",
+			"",
+			"$0",
+			"",
+			"1;"
+		],
+		"description": "Perl module/package with constructor"
+	},
+	"Perl Use Module": {
+		"prefix": "use",
+		"body": [
+			"use ${1:Module}${2: qw(${3:func})};"
+		],
+		"description": "Perl use statement"
+	},
+	"Perl Map": {
+		"prefix": "map",
+		"body": [
+			"my @${1:result} = map { ${2:\\$_} } @${3:array};"
+		],
+		"description": "Perl map function"
+	},
+	"Perl Grep": {
+		"prefix": "grep",
+		"body": [
+			"my @${1:result} = grep { ${2:\\$_ =~ /${3:pattern}/} } @${4:array};"
+		],
+		"description": "Perl grep function"
+	}
+}

--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "vscode": "*"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -36,6 +38,12 @@
         "language": "powershell",
         "scopeName": "source.powershell",
         "path": "./syntaxes/powershell.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "powershell",
+        "path": "./snippets/powershell.code-snippets"
       }
     ]
   },

--- a/extensions/powershell/snippets/powershell.code-snippets
+++ b/extensions/powershell/snippets/powershell.code-snippets
@@ -1,0 +1,208 @@
+{
+	"PowerShell Function": {
+		"prefix": "fn",
+		"body": [
+			"function ${1:Verb-Noun} {",
+			"\t[CmdletBinding()]",
+			"\tparam(",
+			"\t\t[Parameter(Mandatory=\\$${2|true,false|})]",
+			"\t\t[${3:string}]\\$${4:Param}",
+			"\t)",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell function with CmdletBinding"
+	},
+	"PowerShell Simple Function": {
+		"prefix": "sfn",
+		"body": [
+			"function ${1:Name} {",
+			"\tparam(${2:\\$Param})",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell simple function"
+	},
+	"PowerShell If Statement": {
+		"prefix": "if",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell if statement"
+	},
+	"PowerShell If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"} else {",
+			"\t${2}",
+			"}"
+		],
+		"description": "PowerShell if-else"
+	},
+	"PowerShell Switch": {
+		"prefix": "switch",
+		"body": [
+			"switch (\\$${1:variable}) {",
+			"\t'${2:value1}' { ${3:action1} }",
+			"\t'${4:value2}' { ${5:action2} }",
+			"\tDefault { ${6:default} }",
+			"}"
+		],
+		"description": "PowerShell switch statement"
+	},
+	"PowerShell ForEach-Object": {
+		"prefix": "foreach",
+		"body": [
+			"\\$${1:collection} | ForEach-Object {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell ForEach-Object pipeline"
+	},
+	"PowerShell For Loop": {
+		"prefix": "for",
+		"body": [
+			"for (\\$${1:i} = 0; \\$${1:i} -lt ${2:10}; \\$${1:i}++) {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell for loop"
+	},
+	"PowerShell While Loop": {
+		"prefix": "while",
+		"body": [
+			"while (${1:\\$condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell while loop"
+	},
+	"PowerShell Try-Catch": {
+		"prefix": "try",
+		"body": [
+			"try {",
+			"\t$0",
+			"} catch {",
+			"\tWrite-Error \\$_.Exception.Message",
+			"}"
+		],
+		"description": "PowerShell try-catch"
+	},
+	"PowerShell Try-Catch-Finally": {
+		"prefix": "tryf",
+		"body": [
+			"try {",
+			"\t$0",
+			"} catch {",
+			"\tWrite-Error \\$_.Exception.Message",
+			"} finally {",
+			"\t${2:# cleanup}",
+			"}"
+		],
+		"description": "PowerShell try-catch-finally"
+	},
+	"PowerShell Write-Host": {
+		"prefix": "wh",
+		"body": [
+			"Write-Host \"${1:message}\""
+		],
+		"description": "PowerShell Write-Host"
+	},
+	"PowerShell Write-Output": {
+		"prefix": "wo",
+		"body": [
+			"Write-Output \"${1:message}\""
+		],
+		"description": "PowerShell Write-Output"
+	},
+	"PowerShell Write-Verbose": {
+		"prefix": "wv",
+		"body": [
+			"Write-Verbose \"${1:message}\""
+		],
+		"description": "PowerShell Write-Verbose"
+	},
+	"PowerShell Where-Object": {
+		"prefix": "where",
+		"body": [
+			"\\$${1:collection} | Where-Object { \\$_.${2:Property} -${3|eq,ne,gt,lt,like,match|} '${4:value}' }"
+		],
+		"description": "PowerShell Where-Object filter"
+	},
+	"PowerShell Select-Object": {
+		"prefix": "select",
+		"body": [
+			"\\$${1:collection} | Select-Object ${2:Property1}, ${3:Property2}"
+		],
+		"description": "PowerShell Select-Object"
+	},
+	"PowerShell Get-ChildItem": {
+		"prefix": "gci",
+		"body": [
+			"Get-ChildItem -Path '${1:.}' -Filter '${2:*}' -Recurse"
+		],
+		"description": "PowerShell Get-ChildItem"
+	},
+	"PowerShell Test-Path": {
+		"prefix": "tp",
+		"body": [
+			"if (Test-Path '${1:path}') {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell Test-Path check"
+	},
+	"PowerShell Hashtable": {
+		"prefix": "hash",
+		"body": [
+			"\\$${1:hash} = @{",
+			"\t${2:Key} = '${3:Value}'",
+			"}"
+		],
+		"description": "PowerShell hashtable"
+	},
+	"PowerShell Array": {
+		"prefix": "array",
+		"body": [
+			"\\$${1:arr} = @(${2:'item1', 'item2'})"
+		],
+		"description": "PowerShell array"
+	},
+	"PowerShell Script Block": {
+		"prefix": "sb",
+		"body": [
+			"\\$${1:sb} = {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell script block"
+	},
+	"PowerShell Invoke-Command": {
+		"prefix": "ic",
+		"body": [
+			"Invoke-Command -ComputerName ${1:server} -ScriptBlock {",
+			"\t$0",
+			"}"
+		],
+		"description": "PowerShell Invoke-Command"
+	},
+	"PowerShell Module": {
+		"prefix": "module",
+		"body": [
+			"#Requires -Version ${1:5.1}",
+			"",
+			"function ${2:Verb-Noun} {",
+			"\t[CmdletBinding()]",
+			"\tparam()",
+			"\t$0",
+			"}",
+			"",
+			"Export-ModuleMember -Function ${2:Verb-Noun}"
+		],
+		"description": "PowerShell module template"
+	}
+}

--- a/extensions/r/package.json
+++ b/extensions/r/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin REditorSupport/vscode-R-syntax syntaxes/r.json ./syntaxes/r.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -34,6 +36,12 @@
         "language": "r",
         "scopeName": "source.r",
         "path": "./syntaxes/r.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "r",
+        "path": "./snippets/r.code-snippets"
       }
     ]
   },

--- a/extensions/r/snippets/r.code-snippets
+++ b/extensions/r/snippets/r.code-snippets
@@ -1,0 +1,184 @@
+{
+	"R Function": {
+		"prefix": "fn",
+		"body": [
+			"${1:name} <- function(${2:params}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "R function declaration"
+	},
+	"R Function with Return": {
+		"prefix": "fnr",
+		"body": [
+			"${1:name} <- function(${2:params}) {",
+			"\t$0",
+			"\treturn(${3:value})",
+			"}"
+		],
+		"description": "R function with return value"
+	},
+	"R For Loop": {
+		"prefix": "for",
+		"body": [
+			"for (${1:i} in ${2:1:10}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "R for loop"
+	},
+	"R While Loop": {
+		"prefix": "while",
+		"body": [
+			"while (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "R while loop"
+	},
+	"R If Statement": {
+		"prefix": "if",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "R if statement"
+	},
+	"R If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if (${1:condition}) {",
+			"\t$0",
+			"} else {",
+			"\t${2}",
+			"}"
+		],
+		"description": "R if-else"
+	},
+	"R Apply": {
+		"prefix": "apply",
+		"body": [
+			"${1:result} <- apply(${2:X}, ${3|1,2|}, function(${4:x}) {",
+			"\t$0",
+			"})"
+		],
+		"description": "R apply function"
+	},
+	"R Lapply": {
+		"prefix": "lapply",
+		"body": [
+			"${1:result} <- lapply(${2:list}, function(${3:x}) {",
+			"\t$0",
+			"})"
+		],
+		"description": "R lapply function"
+	},
+	"R Sapply": {
+		"prefix": "sapply",
+		"body": [
+			"${1:result} <- sapply(${2:vector}, function(${3:x}) {",
+			"\t$0",
+			"})"
+		],
+		"description": "R sapply function"
+	},
+	"R Vector": {
+		"prefix": "vec",
+		"body": [
+			"${1:v} <- c(${2})"
+		],
+		"description": "R vector with c()"
+	},
+	"R List": {
+		"prefix": "list",
+		"body": [
+			"${1:l} <- list(${2:name} = ${3:value})"
+		],
+		"description": "R named list"
+	},
+	"R Data Frame": {
+		"prefix": "df",
+		"body": [
+			"${1:df} <- data.frame(",
+			"\t${2:col1} = ${3:c()},",
+			"\t${4:col2} = ${5:c()},",
+			"\tstringsAsFactors = FALSE",
+			")"
+		],
+		"description": "R data frame creation"
+	},
+	"R Print": {
+		"prefix": "print",
+		"body": [
+			"print(${1:value})"
+		],
+		"description": "R print statement"
+	},
+	"R Cat": {
+		"prefix": "cat",
+		"body": [
+			"cat(${1:\"message\"}, \"\\n\")"
+		],
+		"description": "R cat output"
+	},
+	"R Sprintf": {
+		"prefix": "sprintf",
+		"body": [
+			"sprintf(\"${1:%s}\", ${2:value})"
+		],
+		"description": "R sprintf for formatted strings"
+	},
+	"R TryCatch": {
+		"prefix": "try",
+		"body": [
+			"tryCatch({",
+			"\t$0",
+			"}, error = function(e) {",
+			"\tmessage('Error: ', e\\$message)",
+			"})"
+		],
+		"description": "R tryCatch error handling"
+	},
+	"R Library": {
+		"prefix": "lib",
+		"body": [
+			"library(${1:package})"
+		],
+		"description": "R library import"
+	},
+	"R ggplot2 Basic": {
+		"prefix": "ggplot",
+		"body": [
+			"library(ggplot2)",
+			"ggplot(${1:data}, aes(x = ${2:x}, y = ${3:y})) +",
+			"\tgeom_${4|point,line,bar,histogram|}() +",
+			"\tlabs(title = '${5:Title}', x = '${6:X}', y = '${7:Y}')"
+		],
+		"description": "R ggplot2 basic plot"
+	},
+	"R dplyr Pipe": {
+		"prefix": "pipe",
+		"body": [
+			"${1:data} |>",
+			"\tdplyr::filter(${2:condition}) |>",
+			"\tdplyr::select(${3:columns}) |>",
+			"\tdplyr::mutate(${4:new_col} = ${5:expr})"
+		],
+		"description": "R dplyr pipe chain"
+	},
+	"R Read CSV": {
+		"prefix": "readcsv",
+		"body": [
+			"${1:df} <- read.csv('${2:file.csv}', stringsAsFactors = FALSE)"
+		],
+		"description": "R read CSV file"
+	},
+	"R Write CSV": {
+		"prefix": "writecsv",
+		"body": [
+			"write.csv(${1:df}, '${2:file.csv}', row.names = FALSE)"
+		],
+		"description": "R write CSV file"
+	}
+}


### PR DESCRIPTION
Adds productivity code snippets to four built-in language extensions that currently have no snippets.

## Motivation

Lua, Perl, R, and PowerShell all have syntax that is verbose or non-obvious to type from scratch. Adding idiomatic snippets lets users scaffold common patterns instantly with tab stops.

## Changes

### Lua (`extensions/lua/snippets/lua.code-snippets`) — 20 snippets
`fn`, `lfn`, `local`, `if`, `ife`, `ifeif`, `while`, `repeat`, `forn`, `forg`, `table`, `array`, `class` (OOP pattern), `method`, `require`, `print`, `format`, `error`, `pcall`, `module`

### Perl (`extensions/perl/snippets/perl.code-snippets`) — 20 snippets
`shebang` (with strict/warnings), `sub`, `if`, `ife`, `unless`, `for`, `foreach`, `while`, `array`, `hash`, `print`, `say`, `die`, `match`, `subst` (s///), `open` (file loop), `module`, `use`, `map`, `grep`

Also registered for the `raku` language id.

### R (`extensions/r/snippets/r.code-snippets`) — 21 snippets
`fn`, `fnr`, `for`, `while`, `if`, `ife`, `apply`, `lapply`, `sapply`, `vec`, `list`, `df` (data frame), `print`, `cat`, `sprintf`, `try` (tryCatch), `lib`, `ggplot`, `pipe` (dplyr), `readcsv`, `writecsv`

### PowerShell (`extensions/powershell/snippets/powershell.code-snippets`) — 22 snippets
`fn` (CmdletBinding), `sfn`, `if`, `ife`, `switch`, `foreach`, `for`, `while`, `try`, `tryf`, `wh`, `wo`, `wv`, `where`, `select`, `gci`, `tp`, `hash`, `array`, `sb`, `ic`, `module`

All snippets use proper tab stops, choice syntax where applicable, and match the JSON format of existing VS Code snippets.