### PR TITLE
feat: add code snippets for CSS, Less, and SCSS extensions

### DIFF
--- a/extensions/css/package.json
+++ b/extensions/css/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin microsoft/vscode-css grammars/css.cson ./syntaxes/css.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -37,6 +39,12 @@
         "tokenTypes": {
           "meta.function.url string.quoted": "other"
         }
+      }
+    ],
+    "snippets": [
+      {
+        "language": "css",
+        "path": "./snippets/css.code-snippets"
       }
     ]
   },

--- a/extensions/css/snippets/css.code-snippets
+++ b/extensions/css/snippets/css.code-snippets
@@ -1,0 +1,175 @@
+{
+	"CSS Rule": {
+		"prefix": "rule",
+		"body": [
+			"${1:selector} {",
+			"\t${2:property}: ${3:value};",
+			"}"
+		],
+		"description": "CSS rule block"
+	},
+	"CSS Flexbox Container": {
+		"prefix": "flex",
+		"body": [
+			"display: flex;",
+			"flex-direction: ${1|row,column,row-reverse,column-reverse|};",
+			"justify-content: ${2|flex-start,flex-end,center,space-between,space-around,space-evenly|};",
+			"align-items: ${3|stretch,flex-start,flex-end,center,baseline|};"
+		],
+		"description": "CSS flexbox container properties"
+	},
+	"CSS Grid Container": {
+		"prefix": "grid",
+		"body": [
+			"display: grid;",
+			"grid-template-columns: ${1:repeat(3, 1fr)};",
+			"grid-template-rows: ${2:auto};",
+			"gap: ${3:1rem};"
+		],
+		"description": "CSS grid container properties"
+	},
+	"CSS Media Query": {
+		"prefix": "mq",
+		"body": [
+			"@media (${1|max-width,min-width|}: ${2:768px}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "CSS media query"
+	},
+	"CSS Custom Property": {
+		"prefix": "var",
+		"body": [
+			"--${1:name}: ${2:value};"
+		],
+		"description": "CSS custom property (variable) declaration"
+	},
+	"CSS Variable Usage": {
+		"prefix": "use",
+		"body": [
+			"var(--${1:name})"
+		],
+		"description": "CSS var() usage"
+	},
+	"CSS :root Variables": {
+		"prefix": "root",
+		"body": [
+			":root {",
+			"\t--${1:color-primary}: ${2:#007acc};",
+			"\t--${3:font-size-base}: ${4:16px};",
+			"}"
+		],
+		"description": "CSS :root custom properties block"
+	},
+	"CSS Transition": {
+		"prefix": "trans",
+		"body": [
+			"transition: ${1:all} ${2:0.3s} ${3|ease,ease-in,ease-out,ease-in-out,linear|};"
+		],
+		"description": "CSS transition shorthand"
+	},
+	"CSS Animation": {
+		"prefix": "anim",
+		"body": [
+			"animation: ${1:name} ${2:1s} ${3|ease,ease-in,ease-out,linear|} ${4:infinite};"
+		],
+		"description": "CSS animation shorthand"
+	},
+	"CSS Keyframes": {
+		"prefix": "keyframes",
+		"body": [
+			"@keyframes ${1:name} {",
+			"\tfrom {",
+			"\t\t${2:property}: ${3:from-value};",
+			"\t}",
+			"\tto {",
+			"\t\t${4:property}: ${5:to-value};",
+			"\t}",
+			"}"
+		],
+		"description": "CSS @keyframes animation"
+	},
+	"CSS Box Shadow": {
+		"prefix": "shadow",
+		"body": [
+			"box-shadow: ${1:0} ${2:2px} ${3:4px} ${4:rgba(0, 0, 0, 0.2)};"
+		],
+		"description": "CSS box-shadow"
+	},
+	"CSS Border Radius": {
+		"prefix": "radius",
+		"body": [
+			"border-radius: ${1:4px};"
+		],
+		"description": "CSS border-radius"
+	},
+	"CSS Position Absolute Center": {
+		"prefix": "center",
+		"body": [
+			"position: absolute;",
+			"top: 50%;",
+			"left: 50%;",
+			"transform: translate(-50%, -50%);"
+		],
+		"description": "CSS absolute center an element"
+	},
+	"CSS Truncate Text": {
+		"prefix": "truncate",
+		"body": [
+			"overflow: hidden;",
+			"text-overflow: ellipsis;",
+			"white-space: nowrap;"
+		],
+		"description": "CSS text truncation with ellipsis"
+	},
+	"CSS Aspect Ratio": {
+		"prefix": "aspect",
+		"body": [
+			"aspect-ratio: ${1:16} / ${2:9};"
+		],
+		"description": "CSS aspect-ratio"
+	},
+	"CSS Pseudo Class": {
+		"prefix": "pseudo",
+		"body": [
+			"${1:selector}:${2|hover,focus,active,visited,first-child,last-child,nth-child(n),not(selector)|} {",
+			"\t$0",
+			"}"
+		],
+		"description": "CSS pseudo-class selector"
+	},
+	"CSS Pseudo Element": {
+		"prefix": "psel",
+		"body": [
+			"${1:selector}::${2|before,after,first-line,first-letter,placeholder,selection|} {",
+			"\tcontent: '${3}';",
+			"\t$0",
+			"}"
+		],
+		"description": "CSS pseudo-element"
+	},
+	"CSS Import": {
+		"prefix": "import",
+		"body": [
+			"@import url('${1:path/to/file.css}');"
+		],
+		"description": "CSS @import"
+	},
+	"CSS Container Query": {
+		"prefix": "cq",
+		"body": [
+			"@container ${1:name} (${2|min-width,max-width|}: ${3:600px}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "CSS container query"
+	},
+	"CSS Scroll Behavior": {
+		"prefix": "scroll",
+		"body": [
+			"scroll-behavior: ${1|smooth,auto|};",
+			"overflow: ${2|auto,scroll,hidden|};"
+		],
+		"description": "CSS scroll properties"
+	}
+}

--- a/extensions/less/package.json
+++ b/extensions/less/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ./build/update-grammar.js"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -51,6 +53,12 @@
           "line": 3,
           "column": 4
         }
+      }
+    ],
+    "snippets": [
+      {
+        "language": "less",
+        "path": "./snippets/less.code-snippets"
       }
     ]
   },

--- a/extensions/less/snippets/less.code-snippets
+++ b/extensions/less/snippets/less.code-snippets
@@ -1,0 +1,111 @@
+{
+	"Less Variable": {
+		"prefix": "var",
+		"body": [
+			"@${1:name}: ${2:value};"
+		],
+		"description": "Less variable declaration"
+	},
+	"Less Mixin": {
+		"prefix": "mixin",
+		"body": [
+			".${1:mixin-name}(${2:@param: value}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Less mixin declaration"
+	},
+	"Less Mixin Call": {
+		"prefix": "call",
+		"body": [
+			".${1:mixin-name}(${2:arg});"
+		],
+		"description": "Less mixin call"
+	},
+	"Less Nesting": {
+		"prefix": "nest",
+		"body": [
+			"${1:parent} {",
+			"\t${2:property}: ${3:value};",
+			"",
+			"\t&:${4|hover,focus,active|} {",
+			"\t\t$0",
+			"\t}",
+			"}"
+		],
+		"description": "Less nested rule with parent reference"
+	},
+	"Less Extend": {
+		"prefix": "extend",
+		"body": [
+			"&:extend(.${1:class});"
+		],
+		"description": "Less extend"
+	},
+	"Less Import": {
+		"prefix": "import",
+		"body": [
+			"@import '${1:path/to/file}';"
+		],
+		"description": "Less import"
+	},
+	"Less Color Function": {
+		"prefix": "colorfn",
+		"body": [
+			"${1|lighten,darken,saturate,desaturate,mix|}(@${2:color}, ${3:10%})"
+		],
+		"description": "Less color manipulation function"
+	},
+	"Less Media Query": {
+		"prefix": "mq",
+		"body": [
+			"@${1:breakpoint}: ~\"(${2|max-width,min-width|}: ${3:768px})\";",
+			"",
+			"@media @${1:breakpoint} {",
+			"\t$0",
+			"}"
+		],
+		"description": "Less media query with variable"
+	},
+	"Less Loop": {
+		"prefix": "loop",
+		"body": [
+			".loop(${1:@n}) when (@${1:n} > 0) {",
+			"\t.loop(@${1:n} - 1);",
+			"\t.item-@{${1:n}} { $0 }",
+			"}",
+			".loop(${2:5});"
+		],
+		"description": "Less recursive mixin loop"
+	},
+	"Less Guard": {
+		"prefix": "when",
+		"body": [
+			".${1:mixin}(@${2:param}) when (${3:@${2:param} > 0}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "Less mixin guard (conditional)"
+	},
+	"Less Flexbox": {
+		"prefix": "flex",
+		"body": [
+			"display: flex;",
+			"flex-direction: ${1|row,column|};",
+			"justify-content: ${2|flex-start,center,space-between|};",
+			"align-items: ${3|stretch,center,flex-start|};"
+		],
+		"description": "Less flexbox container"
+	},
+	"Less Namespace": {
+		"prefix": "ns",
+		"body": [
+			"#${1:namespace} {",
+			"\t.${2:mixin}() {",
+			"\t\t$0",
+			"\t}",
+			"}"
+		],
+		"description": "Less namespace"
+	}
+}

--- a/extensions/scss/package.json
+++ b/extensions/scss/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin atom/language-sass grammars/scss.cson ./syntaxes/scss.tmLanguage.json grammars/sassdoc.cson ./syntaxes/sassdoc.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -77,6 +79,12 @@
             "regexp": "^}$"
           }
         ]
+      }
+    ],
+    "snippets": [
+      {
+        "language": "scss",
+        "path": "./snippets/scss.code-snippets"
       }
     ]
   },

--- a/extensions/scss/snippets/scss.code-snippets
+++ b/extensions/scss/snippets/scss.code-snippets
@@ -1,0 +1,163 @@
+{
+	"SCSS Variable": {
+		"prefix": "var",
+		"body": [
+			"\\$${1:name}: ${2:value};"
+		],
+		"description": "SCSS variable declaration"
+	},
+	"SCSS Mixin": {
+		"prefix": "mixin",
+		"body": [
+			"@mixin ${1:name}(${2:\\$params}) {",
+			"\t$0",
+			"}"
+		],
+		"description": "SCSS mixin declaration"
+	},
+	"SCSS Include": {
+		"prefix": "include",
+		"body": [
+			"@include ${1:mixin-name}(${2:args});"
+		],
+		"description": "SCSS @include mixin"
+	},
+	"SCSS Extend": {
+		"prefix": "extend",
+		"body": [
+			"@extend ${1:%placeholder};"
+		],
+		"description": "SCSS @extend"
+	},
+	"SCSS Placeholder": {
+		"prefix": "placeholder",
+		"body": [
+			"%${1:name} {",
+			"\t$0",
+			"}"
+		],
+		"description": "SCSS placeholder selector"
+	},
+	"SCSS Nesting": {
+		"prefix": "nest",
+		"body": [
+			"${1:parent} {",
+			"\t${2:property}: ${3:value};",
+			"",
+			"\t&:${4|hover,focus,active|} {",
+			"\t\t$0",
+			"\t}",
+			"",
+			"\t&__${5:element} {",
+			"\t\t${6}",
+			"\t}",
+			"}"
+		],
+		"description": "SCSS BEM-style nesting"
+	},
+	"SCSS Import": {
+		"prefix": "import",
+		"body": [
+			"@use '${1:path/to/module}';",
+			""
+		],
+		"description": "SCSS @use (modern import)"
+	},
+	"SCSS Forward": {
+		"prefix": "forward",
+		"body": [
+			"@forward '${1:path/to/module}'${2: with (\\$${3:var}: ${4:value})};"
+		],
+		"description": "SCSS @forward"
+	},
+	"SCSS Function": {
+		"prefix": "fn",
+		"body": [
+			"@function ${1:name}(${2:\\$params}) {",
+			"\t@return ${3:value};",
+			"}"
+		],
+		"description": "SCSS function"
+	},
+	"SCSS Each Loop": {
+		"prefix": "each",
+		"body": [
+			"@each \\$${1:item} in ${2:list} {",
+			"\t$0",
+			"}"
+		],
+		"description": "SCSS @each loop"
+	},
+	"SCSS For Loop": {
+		"prefix": "for",
+		"body": [
+			"@for \\$${1:i} from ${2:1} through ${3:10} {",
+			"\t$0",
+			"}"
+		],
+		"description": "SCSS @for loop"
+	},
+	"SCSS While Loop": {
+		"prefix": "while",
+		"body": [
+			"@while ${1:\\$condition} {",
+			"\t$0",
+			"}"
+		],
+		"description": "SCSS @while loop"
+	},
+	"SCSS If-Else": {
+		"prefix": "if",
+		"body": [
+			"@if ${1:condition} {",
+			"\t$0",
+			"} @else {",
+			"\t${2}",
+			"}"
+		],
+		"description": "SCSS @if-@else"
+	},
+	"SCSS Map": {
+		"prefix": "map",
+		"body": [
+			"\\$${1:map}: (",
+			"\t'${2:key}': ${3:value},",
+			");"
+		],
+		"description": "SCSS map variable"
+	},
+	"SCSS Map Get": {
+		"prefix": "mapget",
+		"body": [
+			"map.get(\\$${1:map}, '${2:key}')"
+		],
+		"description": "SCSS map.get()"
+	},
+	"SCSS Responsive Mixin": {
+		"prefix": "respond",
+		"body": [
+			"@mixin respond-to(\\$breakpoint) {",
+			"\t@if \\$breakpoint == '${1:sm}' {",
+			"\t\t@media (max-width: ${2:576px}) { @content; }",
+			"\t} @else if \\$breakpoint == '${3:md}' {",
+			"\t\t@media (max-width: ${4:768px}) { @content; }",
+			"\t} @else if \\$breakpoint == '${5:lg}' {",
+			"\t\t@media (max-width: ${6:992px}) { @content; }",
+			"\t}",
+			"}"
+		],
+		"description": "SCSS responsive mixin with breakpoints"
+	},
+	"SCSS Flexbox Mixin": {
+		"prefix": "flex",
+		"body": [
+			"@mixin flex(\\$direction: row, \\$justify: flex-start, \\$align: stretch) {",
+			"\tdisplay: flex;",
+			"\tflex-direction: \\$direction;",
+			"\tjustify-content: \\$justify;",
+			"\talign-items: \\$align;",
+			"}"
+		],
+		"description": "SCSS flexbox mixin"
+	}
+}


### PR DESCRIPTION
Adds productivity snippets to three built-in stylesheet language extensions that currently have no snippets.

## Motivation

CSS, Less, and SCSS users type common patterns repeatedly. Snippets for flexbox, grid, media queries, transitions, and preprocessor features (mixins, variables, loops) reduce boilerplate and improve discoverability of advanced CSS features.

## Changes

### CSS (`extensions/css/snippets/css.code-snippets`) — 20 snippets
`rule`, `flex` (flexbox container), `grid`, `mq` (media query), `var` (custom property), `use` (var()), `root` (:root block), `trans` (transition), `anim` (animation), `keyframes`, `shadow`, `radius`, `center` (absolute center), `truncate` (text ellipsis), `aspect` (aspect-ratio), `pseudo`, `psel` (pseudo-element), `import`, `cq` (container query), `scroll`

### Less (`extensions/less/snippets/less.code-snippets`) — 12 snippets
`var`, `mixin`, `call`, `nest`, `extend`, `import`, `colorfn`, `mq`, `loop` (recursive), `when` (guard), `flex`, `ns` (namespace)

### SCSS (`extensions/scss/snippets/scss.code-snippets`) — 17 snippets
`var`, `mixin`, `include`, `extend`, `placeholder`, `nest` (BEM), `import` (@use), `forward`, `fn` (function), `each`, `for`, `while`, `if`, `map`, `mapget`, `respond` (responsive mixin), `flex` (flexbox mixin)

All snippets use tab stops with choice syntax where appropriate.