### PR TITLE
feat: add code snippets for LaTeX and Makefile extensions

### DIFF
--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ./build/update-grammars.js"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -110,6 +112,16 @@
         "language": "cpp_embedded_latex",
         "scopeName": "source.cpp.embedded.latex",
         "path": "./syntaxes/cpp-grammar-bailout.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "latex",
+        "path": "./snippets/latex.code-snippets"
+      },
+      {
+        "language": "tex",
+        "path": "./snippets/latex.code-snippets"
       }
     ]
   },

--- a/extensions/latex/snippets/latex.code-snippets
+++ b/extensions/latex/snippets/latex.code-snippets
@@ -1,0 +1,224 @@
+{
+	"LaTeX Article Document": {
+		"prefix": "article",
+		"body": [
+			"\\\\documentclass[${1:12pt,a4paper}]{article}",
+			"",
+			"\\\\usepackage[utf8]{inputenc}",
+			"\\\\usepackage[T1]{fontenc}",
+			"\\\\usepackage{amsmath, amssymb}",
+			"\\\\usepackage{graphicx}",
+			"\\\\usepackage{hyperref}",
+			"",
+			"\\\\title{${2:Title}}",
+			"\\\\author{${3:Author}}",
+			"\\\\date{${4:\\\\today}}",
+			"",
+			"\\\\begin{document}",
+			"\\\\maketitle",
+			"",
+			"$0",
+			"",
+			"\\\\end{document}"
+		],
+		"description": "LaTeX article document template"
+	},
+	"LaTeX Beamer Presentation": {
+		"prefix": "beamer",
+		"body": [
+			"\\\\documentclass{beamer}",
+			"\\\\usetheme{${1:Madrid}}",
+			"",
+			"\\\\title{${2:Title}}",
+			"\\\\author{${3:Author}}",
+			"\\\\date{${4:\\\\today}}",
+			"",
+			"\\\\begin{document}",
+			"\\\\begin{frame}",
+			"\\\\titlepage",
+			"\\\\end{frame}",
+			"",
+			"\\\\begin{frame}{${5:Frame Title}}",
+			"\t$0",
+			"\\\\end{frame}",
+			"",
+			"\\\\end{document}"
+		],
+		"description": "LaTeX Beamer presentation template"
+	},
+	"LaTeX Section": {
+		"prefix": "sec",
+		"body": [
+			"\\\\section{${1:Section Title}}",
+			"$0"
+		],
+		"description": "LaTeX section"
+	},
+	"LaTeX Subsection": {
+		"prefix": "sub",
+		"body": [
+			"\\\\subsection{${1:Subsection Title}}",
+			"$0"
+		],
+		"description": "LaTeX subsection"
+	},
+	"LaTeX Equation": {
+		"prefix": "eq",
+		"body": [
+			"\\\\begin{equation}",
+			"\t${1:f(x) = ax^2 + bx + c}",
+			"\\\\label{eq:${2:label}}",
+			"\\\\end{equation}"
+		],
+		"description": "LaTeX numbered equation"
+	},
+	"LaTeX Align": {
+		"prefix": "align",
+		"body": [
+			"\\\\begin{align}",
+			"\t${1:a} &= ${2:b} \\\\\\\\",
+			"\t${3:c} &= ${4:d}",
+			"\\\\end{align}"
+		],
+		"description": "LaTeX align environment"
+	},
+	"LaTeX Inline Math": {
+		"prefix": "math",
+		"body": [
+			"\\$${1:expression}\\$"
+		],
+		"description": "LaTeX inline math"
+	},
+	"LaTeX Display Math": {
+		"prefix": "dmath",
+		"body": [
+			"\\\\[",
+			"\t${1:expression}",
+			"\\\\]"
+		],
+		"description": "LaTeX display math"
+	},
+	"LaTeX Figure": {
+		"prefix": "fig",
+		"body": [
+			"\\\\begin{figure}[${1|h,t,b,H|}]",
+			"\t\\\\centering",
+			"\t\\\\includegraphics[width=${2:0.8}\\\\textwidth]{${3:image}}",
+			"\t\\\\caption{${4:Caption}}",
+			"\t\\\\label{fig:${5:label}}",
+			"\\\\end{figure}"
+		],
+		"description": "LaTeX figure with caption"
+	},
+	"LaTeX Table": {
+		"prefix": "table",
+		"body": [
+			"\\\\begin{table}[${1|h,t,b|}]",
+			"\t\\\\centering",
+			"\t\\\\begin{tabular}{${2:lll}}",
+			"\t\t\\\\hline",
+			"\t\t${3:Col1} & ${4:Col2} & ${5:Col3} \\\\\\\\",
+			"\t\t\\\\hline",
+			"\t\t${6:data1} & ${7:data2} & ${8:data3} \\\\\\\\",
+			"\t\t\\\\hline",
+			"\t\\\\end{tabular}",
+			"\t\\\\caption{${9:Caption}}",
+			"\t\\\\label{tab:${10:label}}",
+			"\\\\end{table}"
+		],
+		"description": "LaTeX table environment"
+	},
+	"LaTeX Itemize": {
+		"prefix": "items",
+		"body": [
+			"\\\\begin{itemize}",
+			"\t\\\\item ${1:First item}",
+			"\t\\\\item ${2:Second item}",
+			"\\\\end{itemize}"
+		],
+		"description": "LaTeX itemize list"
+	},
+	"LaTeX Enumerate": {
+		"prefix": "enum",
+		"body": [
+			"\\\\begin{enumerate}",
+			"\t\\\\item ${1:First item}",
+			"\t\\\\item ${2:Second item}",
+			"\\\\end{enumerate}"
+		],
+		"description": "LaTeX enumerate list"
+	},
+	"LaTeX Environment": {
+		"prefix": "env",
+		"body": [
+			"\\\\begin{${1:environment}}",
+			"\t$0",
+			"\\\\end{${1:environment}}"
+		],
+		"description": "LaTeX generic environment"
+	},
+	"LaTeX Bold": {
+		"prefix": "bf",
+		"body": [
+			"\\\\textbf{${1:text}}"
+		],
+		"description": "LaTeX bold text"
+	},
+	"LaTeX Italic": {
+		"prefix": "it",
+		"body": [
+			"\\\\textit{${1:text}}"
+		],
+		"description": "LaTeX italic text"
+	},
+	"LaTeX Reference": {
+		"prefix": "ref",
+		"body": [
+			"\\\\ref{${1:label}}"
+		],
+		"description": "LaTeX cross-reference"
+	},
+	"LaTeX Citation": {
+		"prefix": "cite",
+		"body": [
+			"\\\\cite{${1:key}}"
+		],
+		"description": "LaTeX citation"
+	},
+	"LaTeX Footnote": {
+		"prefix": "fn",
+		"body": [
+			"\\\\footnote{${1:text}}"
+		],
+		"description": "LaTeX footnote"
+	},
+	"LaTeX URL": {
+		"prefix": "url",
+		"body": [
+			"\\\\url{${1:https://example.com}}"
+		],
+		"description": "LaTeX URL"
+	},
+	"LaTeX Package": {
+		"prefix": "pkg",
+		"body": [
+			"\\\\usepackage[${1:options}]{${2:package}}"
+		],
+		"description": "LaTeX usepackage"
+	},
+	"LaTeX New Command": {
+		"prefix": "newcmd",
+		"body": [
+			"\\\\newcommand{\\\\${1:name}}[${2:0}]{${3:definition}}"
+		],
+		"description": "LaTeX newcommand"
+	},
+	"LaTeX Bibliography": {
+		"prefix": "bib",
+		"body": [
+			"\\\\bibliographystyle{${1|plain,alpha,abbrv,ieeetr,apalike|}}",
+			"\\\\bibliography{${2:references}}"
+		],
+		"description": "LaTeX bibliography"
+	}
+}

--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin fadeevab/make.tmbundle Syntaxes/Makefile.plist ./syntaxes/make.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -48,7 +50,13 @@
       "[makefile]": {
         "editor.insertSpaces": false
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "makefile",
+        "path": "./snippets/makefile.code-snippets"
+      }
+    ]
   },
   "repository": {
     "type": "git",

--- a/extensions/make/snippets/makefile.code-snippets
+++ b/extensions/make/snippets/makefile.code-snippets
@@ -1,0 +1,126 @@
+{
+	"Makefile Basic Rule": {
+		"prefix": "rule",
+		"body": [
+			"${1:target}: ${2:deps}",
+			"\t${3:command}"
+		],
+		"description": "Makefile rule"
+	},
+	"Makefile Phony Target": {
+		"prefix": "phony",
+		"body": [
+			".PHONY: ${1:all clean}",
+			"",
+			"${1:all}: ${2:deps}",
+			"\t$0"
+		],
+		"description": "Makefile .PHONY target"
+	},
+	"Makefile Variable": {
+		"prefix": "var",
+		"body": [
+			"${1:VAR} := ${2:value}"
+		],
+		"description": "Makefile variable assignment"
+	},
+	"Makefile Conditional Variable": {
+		"prefix": "cvar",
+		"body": [
+			"${1:VAR} ?= ${2:default}"
+		],
+		"description": "Makefile conditional variable (set if not already defined)"
+	},
+	"Makefile Default Goal": {
+		"prefix": "default",
+		"body": [
+			".DEFAULT_GOAL := ${1:all}"
+		],
+		"description": "Makefile default goal"
+	},
+	"Makefile Pattern Rule": {
+		"prefix": "pattern",
+		"body": [
+			"%.${1:o}: %.${2:c}",
+			"\t\\$(${3:CC}) \\$(${4:CFLAGS}) -c -o \\$@ \\$<"
+		],
+		"description": "Makefile pattern rule"
+	},
+	"Makefile All Clean": {
+		"prefix": "allclean",
+		"body": [
+			"CC := ${1:gcc}",
+			"CFLAGS := ${2:-Wall -O2}",
+			"SRC := ${3:\\$(wildcard *.c)}",
+			"OBJ := ${4:\\$(SRC:.c=.o)}",
+			"TARGET := ${5:app}",
+			"",
+			".PHONY: all clean",
+			"",
+			"all: \\$(TARGET)",
+			"",
+			"\\$(TARGET): \\$(OBJ)",
+			"\t\\$(CC) \\$(CFLAGS) -o \\$@ \\$^",
+			"",
+			"%.o: %.c",
+			"\t\\$(CC) \\$(CFLAGS) -c -o \\$@ \\$<",
+			"",
+			"clean:",
+			"\trm -f \\$(OBJ) \\$(TARGET)"
+		],
+		"description": "Makefile C project template with all and clean"
+	},
+	"Makefile Wildcard": {
+		"prefix": "wild",
+		"body": [
+			"\\$(wildcard ${1:*.c})"
+		],
+		"description": "Makefile wildcard function"
+	},
+	"Makefile Subst": {
+		"prefix": "subst",
+		"body": [
+			"\\$(patsubst ${1:%.c}, ${2:%.o}, \\$(${3:SOURCES}))"
+		],
+		"description": "Makefile patsubst for file extension substitution"
+	},
+	"Makefile Echo": {
+		"prefix": "echo",
+		"body": [
+			"\t@echo \"${1:message}\""
+		],
+		"description": "Makefile silent echo"
+	},
+	"Makefile Mkdir": {
+		"prefix": "mkdir",
+		"body": [
+			"\t@mkdir -p ${1:build}"
+		],
+		"description": "Makefile mkdir with -p"
+	},
+	"Makefile Include": {
+		"prefix": "include",
+		"body": [
+			"-include ${1:config.mk}"
+		],
+		"description": "Makefile include (with - to ignore errors)"
+	},
+	"Makefile ifeq": {
+		"prefix": "ifeq",
+		"body": [
+			"ifeq (\\$(${1:OS}), ${2:Windows_NT})",
+			"\t${3:PLATFORM := windows}",
+			"else",
+			"\t${4:PLATFORM := linux}",
+			"endif"
+		],
+		"description": "Makefile ifeq conditional"
+	},
+	"Makefile Auto Variables": {
+		"prefix": "auto",
+		"body": [
+			"# \\$@ = target, \\$< = first dep, \\$^ = all deps, \\$* = stem"
+		],
+		"description": "Makefile automatic variable reference comment"
+	}
+}


### PR DESCRIPTION
Adds productivity snippets to two built-in language extensions that currently have no snippets.

## Motivation

LaTeX and Makefile have verbose, hard-to-memorize syntax. Snippets for common document structures, math environments, build patterns, and conditional blocks greatly reduce the friction of working in these languages.

## Changes

### LaTeX (`extensions/latex/snippets/latex.code-snippets`) — 22 snippets
`article` (full document template), `beamer` (presentation template), `sec`, `sub`, `eq` (numbered equation), `align`, `math` (inline), `dmath` (display), `fig` (figure+caption), `table`, `items` (itemize), `enum` (enumerate), `env` (generic), `bf`, `it`, `ref`, `cite`, `fn` (footnote), `url`, `pkg` (usepackage), `newcmd`, `bib` (bibliography)

Registered for both `latex` and `tex` language IDs.

### Makefile (`extensions/make/snippets/makefile.code-snippets`) — 14 snippets
`rule`, `phony` (.PHONY), `var` (:= assignment), `cvar` (?= conditional), `default` (.DEFAULT_GOAL), `pattern` (%.o: %.c), `allclean` (full C project template), `wild` (wildcard), `subst` (patsubst), `echo` (@echo), `mkdir`, `include`, `ifeq`, `auto` (automatic variable comment)

All snippets use tab stops and choice syntax where applicable.