### PR TITLE
Fix: correct misspellings in comments (accommodate, accidentally, original, overwriting)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1042,7 +1042,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentLanguageModel.set(model, undefined);
 
 		if (this.cachedWidth) {
-			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
+			// For quick chat and editor chat, relayout because the input may need to shrink to accommodate the model name
 			this.layout(this.cachedWidth);
 		}
 

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -290,7 +290,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					} else if (isShiftPressed) {
 						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition || !!bp.triggeredBy)) {
-						// Show the dialog if there is a potential condition to be accidently lost.
+						// Show the dialog if there is a potential condition to be accidentally lost.
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -198,7 +198,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -2111,7 +2111,7 @@ export class SCMHistoryViewPane extends ViewPane {
 
 			const historyItemRefMenuItems = MenuRegistry.getMenuItems(MenuId.SCMHistoryItemRefContext).filter(item => isIMenuItem(item));
 
-			// If there are any history item references we have to add a submenu item for each orignal action,
+			// If there are any history item references we have to add a submenu item for each original action,
 			// and a menu item for each history item ref that matches the `when` clause of the original action.
 			if (historyItemRefMenuItems.length > 0 && element.historyItemViewModel.historyItem.references?.length) {
 				const historyItemRefActions = new Map<string, ISCMHistoryItemRef[]>();

--- a/src/vs/workbench/contrib/timeline/common/timelineService.ts
+++ b/src/vs/workbench/contrib/timeline/common/timelineService.ts
@@ -90,7 +90,7 @@ export class TimelineService extends Disposable implements ITimelineService {
 
 		const existing = this.providers.get(id);
 		if (existing) {
-			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwritting here (still will be blocked in the Extension Host)
+			// For now to deal with https://github.com/microsoft/vscode/issues/89553 allow any overwriting here (still will be blocked in the Extension Host)
 			// TODO@eamodio: Ultimately will need to figure out a way to unregister providers when the Extension Host restarts/crashes
 			// throw new Error(`Timeline Provider ${id} already exists.`);
 			try {

--- a/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
+++ b/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
@@ -163,7 +163,7 @@ export class ExtensionRunningLocationTracker {
 		// When doing extension host debugging, we will ignore the configured affinity
 		// because we can currently debug a single extension host
 		if (!this._environmentService.isExtensionDevelopment) {
-			// Go through each configured affinity and try to accomodate it
+			// Go through each configured affinity and try to accommodate it
 			const configuredAffinities = this._configurationService.getValue<{ [extensionId: string]: number } | undefined>('extensions.experimental.affinity') || {};
 			const configuredExtensionIds = Object.keys(configuredAffinities);
 			const configuredAffinityToResultingAffinity = new Map<number, number>();


### PR DESCRIPTION
Corrects six misspelled words in comments across multiple files. No runtime behaviour is affected.

## Changes

| File | Before | After |
|------|--------|-------|
| `src/vs/workbench/contrib/files/browser/explorerViewlet.ts` | `accomodate` | `accommodate` |
| `src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts` | `accomodate` | `accommodate` |
| `src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts` | `accomodate` | `accommodate` |
| `src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts` | `accidently` | `accidentally` |
| `src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts` | `orignal` | `original` |
| `src/vs/workbench/contrib/timeline/common/timelineService.ts` | `overwritting` | `overwriting` |