### PR TITLE
Fix: correct misspellings deafult, dependant, descendent in comments

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1145,7 +1145,7 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	setHiddenAreas(ranges: IRange[], source?: unknown): void;
 
 	/**
-	 * Sets the editor aria options, primarily the active descendent.
+	 * Sets the editor aria options, primarily the active descendant.
 	 * @internal
 	 */
 	setAriaOptions(options: IEditorAriaOptions): void;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2089,7 +2089,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	updateEditorFocus() {
 		// Note - focus going to the webview will fire 'blur', but the webview element will be
-		// a descendent of the notebook editor root.
+		// a descendant of the notebook editor root.
 		this._focusTracker.refreshState();
 		const focused = this.editorHasDomFocus();
 		this._editorFocus.set(focused);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2001,7 +2001,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					.filter(d => d.entrypoint.extends === this.data.id);
 
 				if (dependantRenderers.length) {
-					this.postDebugMessage('Activating dependant renderers', { dependents: dependantRenderers.map(x => x.id).join(', ') });
+					this.postDebugMessage('Activating dependent renderers', { dependents: dependantRenderers.map(x => x.id).join(', ') });
 				}
 
 				// Load all renderers that extend this renderer
@@ -2017,7 +2017,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 						// Squash any errors extends errors. They won't prevent the renderer
 						// itself from working, so just log them.
 						console.error(e);
-						this.postDebugMessage('Activating dependant renderer failed', { dependent: d.id, error: e + '' });
+						this.postDebugMessage('Activating dependent renderer failed', { dependent: d.id, error: e + '' });
 						return undefined;
 					}
 				}));

--- a/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
@@ -1453,7 +1453,7 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 		const buffer = terminal.buffer.active;
 
 		// Detect programs like git log/less that use the normal buffer but don't
-		// take input by deafult (fixes #109541)
+		// take input by default (fixes #109541)
 		if (buffer.cursorX === 1 && buffer.cursorY === terminal.rows - 1) {
 			if (buffer.getLine(buffer.cursorY + buffer.baseY)?.getCell(0)?.getChars() === ':') {
 				return;

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -8297,7 +8297,7 @@ declare module 'vscode' {
 		 * Provide decorations for a given uri.
 		 *
 		 * *Note* that this function is only called when a file gets rendered in the UI.
-		 * This means a decoration from a descendent that propagates upwards must be signaled
+		 * This means a decoration from a descendant that propagates upwards must be signaled
 		 * to the editor via the {@link FileDecorationProvider.onDidChangeFileDecorations onDidChangeFileDecorations}-event.
 		 *
 		 * @param uri The uri of the file to provide a decoration for.


### PR DESCRIPTION
Corrects five misspelled words in comments and JSDoc strings. No runtime behaviour is affected.

## Changes

| File | Before | After |
|------|--------|-------|
| `src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts` | `deafult` | `default` |
| `src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts` (×2) | `dependant` | `dependent` |
| `src/vscode-dts/vscode.d.ts` | `descendent` | `descendant` |
| `src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts` | `descendent` | `descendant` |
| `src/vs/editor/browser/editorBrowser.ts` | `descendent` | `descendant` |

Note: `descendant` (not `descendent`) is the standard spelling for a child/offspring node in a hierarchy.