### PR TITLE
feat: add code snippets for Julia and HLSL extensions

### DIFF
--- a/extensions/hlsl/package.json
+++ b/extensions/hlsl/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin tgjones/shaders-tmLanguage grammars/hlsl.json ./syntaxes/hlsl.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -38,6 +40,12 @@
         "language": "hlsl",
         "path": "./syntaxes/hlsl.tmLanguage.json",
         "scopeName": "source.hlsl"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "hlsl",
+        "path": "./snippets/hlsl.code-snippets"
       }
     ]
   },

--- a/extensions/hlsl/snippets/hlsl.code-snippets
+++ b/extensions/hlsl/snippets/hlsl.code-snippets
@@ -1,0 +1,173 @@
+{
+	"HLSL Vertex Shader": {
+		"prefix": "vs",
+		"body": [
+			"struct VSInput {",
+			"\tfloat4 position : POSITION;",
+			"\tfloat2 uv : TEXCOORD0;",
+			"};",
+			"",
+			"struct VSOutput {",
+			"\tfloat4 position : SV_Position;",
+			"\tfloat2 uv : TEXCOORD0;",
+			"};",
+			"",
+			"VSOutput ${1:VSMain}(VSInput input) {",
+			"\tVSOutput output;",
+			"\toutput.position = ${2:mul(input.position, WorldViewProjection)};",
+			"\toutput.uv = input.uv;",
+			"\treturn output;",
+			"}"
+		],
+		"description": "HLSL vertex shader template"
+	},
+	"HLSL Pixel Shader": {
+		"prefix": "ps",
+		"body": [
+			"Texture2D ${1:diffuseTexture} : register(t0);",
+			"SamplerState ${2:samplerState} : register(s0);",
+			"",
+			"float4 ${3:PSMain}(float2 uv : TEXCOORD0) : SV_Target {",
+			"\treturn ${1:diffuseTexture}.Sample(${2:samplerState}, uv);",
+			"}"
+		],
+		"description": "HLSL pixel shader template"
+	},
+	"HLSL Compute Shader": {
+		"prefix": "cs",
+		"body": [
+			"RWTexture2D<float4> ${1:output} : register(u0);",
+			"",
+			"[numthreads(${2:8}, ${3:8}, 1)]",
+			"void ${4:CSMain}(uint3 id : SV_DispatchThreadID) {",
+			"\t$0",
+			"\t${1:output}[id.xy] = float4(1, 0, 0, 1);",
+			"}"
+		],
+		"description": "HLSL compute shader template"
+	},
+	"HLSL Constant Buffer": {
+		"prefix": "cbuffer",
+		"body": [
+			"cbuffer ${1:PerFrame} : register(b${2:0}) {",
+			"\tfloat4x4 ${3:WorldViewProjection};",
+			"\t$0",
+			"};"
+		],
+		"description": "HLSL constant buffer"
+	},
+	"HLSL Struct": {
+		"prefix": "struct",
+		"body": [
+			"struct ${1:Name} {",
+			"\t${2:float4} ${3:position} : ${4:SV_Position};",
+			"};"
+		],
+		"description": "HLSL struct with semantic"
+	},
+	"HLSL Texture Sample": {
+		"prefix": "sample",
+		"body": [
+			"${1:texture}.Sample(${2:sampler}, ${3:uv})"
+		],
+		"description": "HLSL texture sample"
+	},
+	"HLSL Texture Sample Level": {
+		"prefix": "sampleLevel",
+		"body": [
+			"${1:texture}.SampleLevel(${2:sampler}, ${3:uv}, ${4:0})"
+		],
+		"description": "HLSL texture sample with mip level"
+	},
+	"HLSL Matrix Multiply": {
+		"prefix": "mul",
+		"body": [
+			"mul(${1:vector}, ${2:matrix})"
+		],
+		"description": "HLSL matrix multiply"
+	},
+	"HLSL Lerp": {
+		"prefix": "lerp",
+		"body": [
+			"lerp(${1:a}, ${2:b}, ${3:t})"
+		],
+		"description": "HLSL lerp"
+	},
+	"HLSL Saturate": {
+		"prefix": "sat",
+		"body": [
+			"saturate(${1:value})"
+		],
+		"description": "HLSL saturate (clamp to 0-1)"
+	},
+	"HLSL Normalize": {
+		"prefix": "norm",
+		"body": [
+			"normalize(${1:vector})"
+		],
+		"description": "HLSL normalize"
+	},
+	"HLSL Dot Product": {
+		"prefix": "dot",
+		"body": [
+			"dot(${1:a}, ${2:b})"
+		],
+		"description": "HLSL dot product"
+	},
+	"HLSL Cross Product": {
+		"prefix": "cross",
+		"body": [
+			"cross(${1:a}, ${2:b})"
+		],
+		"description": "HLSL cross product"
+	},
+	"HLSL Length": {
+		"prefix": "len",
+		"body": [
+			"length(${1:vector})"
+		],
+		"description": "HLSL vector length"
+	},
+	"HLSL Float4": {
+		"prefix": "f4",
+		"body": [
+			"float4(${1:x}, ${2:y}, ${3:z}, ${4:w})"
+		],
+		"description": "HLSL float4 constructor"
+	},
+	"HLSL Float3": {
+		"prefix": "f3",
+		"body": [
+			"float3(${1:x}, ${2:y}, ${3:z})"
+		],
+		"description": "HLSL float3 constructor"
+	},
+	"HLSL Float2": {
+		"prefix": "f2",
+		"body": [
+			"float2(${1:x}, ${2:y})"
+		],
+		"description": "HLSL float2 constructor"
+	},
+	"HLSL Register Texture": {
+		"prefix": "tex",
+		"body": [
+			"Texture${1|2D,3D,2DArray,Cube|}< float4> ${2:texName} : register(t${3:0});"
+		],
+		"description": "HLSL texture register"
+	},
+	"HLSL Register Sampler": {
+		"prefix": "samp",
+		"body": [
+			"SamplerState ${1:sampName} : register(s${2:0});"
+		],
+		"description": "HLSL sampler register"
+	},
+	"HLSL Numthreads": {
+		"prefix": "numthreads",
+		"body": [
+			"[numthreads(${1:8}, ${2:8}, ${3:1})]"
+		],
+		"description": "HLSL numthreads attribute"
+	}
+}

--- a/extensions/julia/package.json
+++ b/extensions/julia/package.json
@@ -1,60 +1,72 @@
 {
-	"name": "julia",
-	"displayName": "%displayName%",
-	"description": "%description%",
-	"version": "10.0.0",
-	"publisher": "vscode",
-	"license": "MIT",
-	"engines": {
-		"vscode": "0.10.x"
-	},
+  "name": "julia",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "10.0.0",
+  "publisher": "vscode",
+  "license": "MIT",
+  "engines": {
+    "vscode": "0.10.x"
+  },
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin JuliaEditorSupport/atom-language-julia variants/julia_vscode.json ./syntaxes/julia.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
-	"contributes": {
-		"languages": [
-			{
-					"id": "julia",
-					"aliases": [
-							"Julia",
-							"julia"
-					],
-					"extensions": [
-							".jl"
-					],
-					"firstLine": "^#!\\s*/.*\\bjulia[0-9.-]*\\b",
-					"configuration": "./language-configuration.json"
-			},
-			{
-					"id": "juliamarkdown",
-					"aliases": [
-							"Julia Markdown",
-							"juliamarkdown"
-					],
-					"extensions": [
-							".jmd"
-					]
-			}
-		],
-		"grammars": [
-			{
-					"language": "julia",
-					"scopeName": "source.julia",
-					"path": "./syntaxes/julia.tmLanguage.json",
-					"embeddedLanguages": {
-							"meta.embedded.inline.cpp": "cpp",
-							"meta.embedded.inline.javascript": "javascript",
-							"meta.embedded.inline.python": "python",
-							"meta.embedded.inline.r": "r",
-							"meta.embedded.inline.sql": "sql"
-					}
-			}
-		],
-		"configurationDefaults": {
-			"[julia]": {
-				"editor.defaultColorDecorators": "never"
-			}
-		}
-	}
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "julia",
+        "aliases": [
+          "Julia",
+          "julia"
+        ],
+        "extensions": [
+          ".jl"
+        ],
+        "firstLine": "^#!\\s*/.*\\bjulia[0-9.-]*\\b",
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "juliamarkdown",
+        "aliases": [
+          "Julia Markdown",
+          "juliamarkdown"
+        ],
+        "extensions": [
+          ".jmd"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "julia",
+        "scopeName": "source.julia",
+        "path": "./syntaxes/julia.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.inline.cpp": "cpp",
+          "meta.embedded.inline.javascript": "javascript",
+          "meta.embedded.inline.python": "python",
+          "meta.embedded.inline.r": "r",
+          "meta.embedded.inline.sql": "sql"
+        }
+      }
+    ],
+    "configurationDefaults": {
+      "[julia]": {
+        "editor.defaultColorDecorators": "never"
+      }
+    },
+    "snippets": [
+      {
+        "language": "julia",
+        "path": "./snippets/julia.code-snippets"
+      },
+      {
+        "language": "juliamarkdown",
+        "path": "./snippets/julia.code-snippets"
+      }
+    ]
+  }
 }

--- a/extensions/julia/snippets/julia.code-snippets
+++ b/extensions/julia/snippets/julia.code-snippets
@@ -1,0 +1,182 @@
+{
+	"Julia Function": {
+		"prefix": "fn",
+		"body": [
+			"function ${1:name}(${2:args})",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia function definition"
+	},
+	"Julia Function with Return Type": {
+		"prefix": "fnr",
+		"body": [
+			"function ${1:name}(${2:args})::${3:ReturnType}",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia function with return type annotation"
+	},
+	"Julia Anonymous Function": {
+		"prefix": "anon",
+		"body": [
+			"${1:x} -> ${2:x^2}"
+		],
+		"description": "Julia anonymous function"
+	},
+	"Julia Struct": {
+		"prefix": "struct",
+		"body": [
+			"struct ${1:Name}",
+			"\t${2:field}::${3:Type}",
+			"end"
+		],
+		"description": "Julia struct (immutable)"
+	},
+	"Julia Mutable Struct": {
+		"prefix": "mstruct",
+		"body": [
+			"mutable struct ${1:Name}",
+			"\t${2:field}::${3:Type}",
+			"end"
+		],
+		"description": "Julia mutable struct"
+	},
+	"Julia Abstract Type": {
+		"prefix": "abstract",
+		"body": [
+			"abstract type ${1:Name} end"
+		],
+		"description": "Julia abstract type"
+	},
+	"Julia If Statement": {
+		"prefix": "if",
+		"body": [
+			"if ${1:condition}",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia if statement"
+	},
+	"Julia If-Else": {
+		"prefix": "ife",
+		"body": [
+			"if ${1:condition}",
+			"\t$0",
+			"else",
+			"\t${2}",
+			"end"
+		],
+		"description": "Julia if-else statement"
+	},
+	"Julia For Loop": {
+		"prefix": "for",
+		"body": [
+			"for ${1:i} in ${2:1:10}",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia for loop"
+	},
+	"Julia While Loop": {
+		"prefix": "while",
+		"body": [
+			"while ${1:condition}",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia while loop"
+	},
+	"Julia Try-Catch": {
+		"prefix": "try",
+		"body": [
+			"try",
+			"\t$0",
+			"catch ${1:e}",
+			"\t${2:@error e}",
+			"end"
+		],
+		"description": "Julia try-catch block"
+	},
+	"Julia Module": {
+		"prefix": "module",
+		"body": [
+			"module ${1:Name}",
+			"",
+			"$0",
+			"",
+			"end  # module ${1:Name}"
+		],
+		"description": "Julia module definition"
+	},
+	"Julia Using": {
+		"prefix": "using",
+		"body": [
+			"using ${1:Package}"
+		],
+		"description": "Julia using statement"
+	},
+	"Julia Import": {
+		"prefix": "import",
+		"body": [
+			"import ${1:Package}: ${2:function}"
+		],
+		"description": "Julia import with specific names"
+	},
+	"Julia List Comprehension": {
+		"prefix": "comp",
+		"body": [
+			"[${1:expr} for ${2:x} in ${3:collection}]"
+		],
+		"description": "Julia list comprehension"
+	},
+	"Julia Dict Comprehension": {
+		"prefix": "dcomp",
+		"body": [
+			"Dict(${1:k} => ${2:v} for (${1:k}, ${2:v}) in ${3:pairs})"
+		],
+		"description": "Julia dict comprehension"
+	},
+	"Julia Println": {
+		"prefix": "print",
+		"body": [
+			"println(${1:value})"
+		],
+		"description": "Julia println"
+	},
+	"Julia String Interpolation": {
+		"prefix": "str",
+		"body": [
+			"\"${1:text} \\$(${2:expr})\""
+		],
+		"description": "Julia string interpolation"
+	},
+	"Julia Macro": {
+		"prefix": "macro",
+		"body": [
+			"macro ${1:name}(${2:args})",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia macro definition"
+	},
+	"Julia Test Module": {
+		"prefix": "testset",
+		"body": [
+			"using Test",
+			"",
+			"@testset \"${1:Test Suite Name}\" begin",
+			"\t@test ${2:1 + 1 == 2}",
+			"\t$0",
+			"end"
+		],
+		"description": "Julia @testset"
+	},
+	"Julia Broadcast": {
+		"prefix": "broadcast",
+		"body": [
+			"${1:f}.(${2:args})"
+		],
+		"description": "Julia broadcasting (dot notation)"
+	}
+}


### PR DESCRIPTION
Adds productivity snippets to two built-in language extensions that currently have no snippets.

## Motivation

Julia is increasingly popular for scientific computing and data science. HLSL is the primary shader language for DirectX development. Both languages have verbose boilerplate that snippets can eliminate.

## Changes

### Julia (`extensions/julia/snippets/julia.code-snippets`) — 21 snippets
`fn`, `fnr` (with return type), `anon`, `struct`, `mstruct` (mutable), `abstract`, `if`, `ife`, `for`, `while`, `try`, `module`, `using`, `import`, `comp` (list comprehension), `dcomp` (dict), `print`, `str` (string interpolation), `macro`, `testset`, `broadcast`

Registered for both `julia` and `juliamarkdown` language IDs.

### HLSL (`extensions/hlsl/snippets/hlsl.code-snippets`) — 20 snippets
`vs` (vertex shader template), `ps` (pixel shader), `cs` (compute shader), `cbuffer`, `struct`, `sample`, `sampleLevel`, `mul`, `lerp`, `sat`, `norm`, `dot`, `cross`, `len`, `f4/f3/f2` (constructors), `tex`, `samp`, `numthreads`

All snippets use tab stops with choice syntax where applicable.