### PR TITLE
feat: add code snippets for Clojure, Dockerfile, and Handlebars extensions

### DIFF
--- a/extensions/clojure/package.json
+++ b/extensions/clojure/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin atom/language-clojure grammars/clojure.cson ./syntaxes/clojure.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -42,7 +44,13 @@
       "[clojure]": {
         "diffEditor.ignoreTrimWhitespace": false
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "clojure",
+        "path": "./snippets/clojure.code-snippets"
+      }
+    ]
   },
   "repository": {
     "type": "git",

--- a/extensions/clojure/snippets/clojure.code-snippets
+++ b/extensions/clojure/snippets/clojure.code-snippets
@@ -1,0 +1,185 @@
+{
+	"Clojure Namespace": {
+		"prefix": "ns",
+		"body": [
+			"(ns ${1:my.namespace}",
+			"  (:require [${2:clojure.string :as str}]))"
+		],
+		"description": "Clojure namespace declaration"
+	},
+	"Clojure Defn": {
+		"prefix": "defn",
+		"body": [
+			"(defn ${1:name}",
+			"  \"${2:Docstring.}\"",
+			"  [${3:args}]",
+			"  $0)"
+		],
+		"description": "Clojure function definition"
+	},
+	"Clojure Defn-": {
+		"prefix": "defn-",
+		"body": [
+			"(defn- ${1:name}",
+			"  [${2:args}]",
+			"  $0)"
+		],
+		"description": "Clojure private function definition"
+	},
+	"Clojure Def": {
+		"prefix": "def",
+		"body": [
+			"(def ${1:name} ${2:value})"
+		],
+		"description": "Clojure value definition"
+	},
+	"Clojure Defmacro": {
+		"prefix": "defmacro",
+		"body": [
+			"(defmacro ${1:name}",
+			"  \"${2:Docstring.}\"",
+			"  [${3:args}]",
+			"  $0)"
+		],
+		"description": "Clojure macro definition"
+	},
+	"Clojure Let": {
+		"prefix": "let",
+		"body": [
+			"(let [${1:x} ${2:value}]",
+			"  $0)"
+		],
+		"description": "Clojure let binding"
+	},
+	"Clojure If": {
+		"prefix": "if",
+		"body": [
+			"(if ${1:condition}",
+			"  ${2:then}",
+			"  ${3:else})"
+		],
+		"description": "Clojure if expression"
+	},
+	"Clojure When": {
+		"prefix": "when",
+		"body": [
+			"(when ${1:condition}",
+			"  $0)"
+		],
+		"description": "Clojure when expression"
+	},
+	"Clojure Cond": {
+		"prefix": "cond",
+		"body": [
+			"(cond",
+			"  ${1:condition1} ${2:result1}",
+			"  ${3:condition2} ${4:result2}",
+			"  :else ${5:default})"
+		],
+		"description": "Clojure cond expression"
+	},
+	"Clojure Map": {
+		"prefix": "map",
+		"body": [
+			"(map ${1:#()} ${2:coll})"
+		],
+		"description": "Clojure map function"
+	},
+	"Clojure Filter": {
+		"prefix": "filter",
+		"body": [
+			"(filter ${1:#()} ${2:coll})"
+		],
+		"description": "Clojure filter function"
+	},
+	"Clojure Reduce": {
+		"prefix": "reduce",
+		"body": [
+			"(reduce ${1:+} ${2:0} ${3:coll})"
+		],
+		"description": "Clojure reduce function"
+	},
+	"Clojure Thread First": {
+		"prefix": "->",
+		"body": [
+			"(-> ${1:value}",
+			"    ${2:(fn1)}",
+			"    ${3:(fn2)})"
+		],
+		"description": "Clojure thread-first macro"
+	},
+	"Clojure Thread Last": {
+		"prefix": "->>",
+		"body": [
+			"(->> ${1:coll}",
+			"     ${2:(map #())}",
+			"     ${3:(filter #())})"
+		],
+		"description": "Clojure thread-last macro"
+	},
+	"Clojure Defrecord": {
+		"prefix": "defrecord",
+		"body": [
+			"(defrecord ${1:Name} [${2:fields}]",
+			"  ${3:Protocol}",
+			"  $0)"
+		],
+		"description": "Clojure defrecord"
+	},
+	"Clojure Defprotocol": {
+		"prefix": "defprotocol",
+		"body": [
+			"(defprotocol ${1:Name}",
+			"  (${2:method} [${3:this}]))"
+		],
+		"description": "Clojure defprotocol"
+	},
+	"Clojure Try-Catch": {
+		"prefix": "try",
+		"body": [
+			"(try",
+			"  $0",
+			"  (catch Exception ${1:e}",
+			"    (println \"Error:\" (.getMessage ${1:e}))))"
+		],
+		"description": "Clojure try-catch"
+	},
+	"Clojure Do": {
+		"prefix": "do",
+		"body": [
+			"(do",
+			"  ${1:expr1}",
+			"  $0)"
+		],
+		"description": "Clojure do block"
+	},
+	"Clojure Println": {
+		"prefix": "println",
+		"body": [
+			"(println ${1:value})"
+		],
+		"description": "Clojure println"
+	},
+	"Clojure Atom": {
+		"prefix": "atom",
+		"body": [
+			"(def ${1:state} (atom ${2:initial-value}))"
+		],
+		"description": "Clojure atom"
+	},
+	"Clojure Swap!": {
+		"prefix": "swap!",
+		"body": [
+			"(swap! ${1:atom} ${2:update-fn})"
+		],
+		"description": "Clojure swap!"
+	},
+	"Clojure Fn": {
+		"prefix": "fn",
+		"body": [
+			"(fn [${1:args}]",
+			"  $0)"
+		],
+		"description": "Clojure anonymous function"
+	}
+}

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -8,9 +8,10 @@
   "engines": {
     "vscode": "*"
   },
-  "scripts": {
-  },
-  "categories": ["Programming Languages"],
+  "scripts": {},
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "languages": [
       {
@@ -48,7 +49,13 @@
           "strings": true
         }
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "dockerfile",
+        "path": "./snippets/dockerfile.code-snippets"
+      }
+    ]
   },
   "repository": {
     "type": "git",

--- a/extensions/docker/snippets/dockerfile.code-snippets
+++ b/extensions/docker/snippets/dockerfile.code-snippets
@@ -1,0 +1,167 @@
+{
+	"Dockerfile FROM": {
+		"prefix": "from",
+		"body": [
+			"FROM ${1:ubuntu}:${2:22.04}"
+		],
+		"description": "Dockerfile FROM instruction"
+	},
+	"Dockerfile Node.js App": {
+		"prefix": "node",
+		"body": [
+			"FROM node:${1:20-alpine}",
+			"",
+			"WORKDIR /app",
+			"",
+			"COPY package*.json ./",
+			"RUN npm ci --only=production",
+			"",
+			"COPY . .",
+			"",
+			"EXPOSE ${2:3000}",
+			"CMD [\"node\", \"${3:server.js}\"]"
+		],
+		"description": "Dockerfile Node.js production template"
+	},
+	"Dockerfile Python App": {
+		"prefix": "python",
+		"body": [
+			"FROM python:${1:3.11-slim}",
+			"",
+			"WORKDIR /app",
+			"",
+			"COPY requirements.txt .",
+			"RUN pip install --no-cache-dir -r requirements.txt",
+			"",
+			"COPY . .",
+			"",
+			"EXPOSE ${2:8000}",
+			"CMD [\"python\", \"${3:app.py}\"]"
+		],
+		"description": "Dockerfile Python app template"
+	},
+	"Dockerfile Multi-Stage Build": {
+		"prefix": "multistage",
+		"body": [
+			"# Build stage",
+			"FROM ${1:node}:${2:20-alpine} AS builder",
+			"WORKDIR /app",
+			"COPY package*.json ./",
+			"RUN npm ci",
+			"COPY . .",
+			"RUN npm run build",
+			"",
+			"# Production stage",
+			"FROM ${3:node}:${4:20-alpine}",
+			"WORKDIR /app",
+			"COPY --from=builder /app/${5:dist} ./${5:dist}",
+			"COPY package*.json ./",
+			"RUN npm ci --only=production",
+			"",
+			"EXPOSE ${6:3000}",
+			"CMD [\"node\", \"${5:dist}/${7:index.js}\"]"
+		],
+		"description": "Dockerfile multi-stage build template"
+	},
+	"Dockerfile RUN": {
+		"prefix": "run",
+		"body": [
+			"RUN ${1:command}"
+		],
+		"description": "Dockerfile RUN instruction"
+	},
+	"Dockerfile RUN apt-get": {
+		"prefix": "apt",
+		"body": [
+			"RUN apt-get update && apt-get install -y \\\\",
+			"\t${1:package} \\\\",
+			"\t&& rm -rf /var/lib/apt/lists/*"
+		],
+		"description": "Dockerfile apt-get install with cleanup"
+	},
+	"Dockerfile COPY": {
+		"prefix": "copy",
+		"body": [
+			"COPY ${1:src} ${2:dest}"
+		],
+		"description": "Dockerfile COPY instruction"
+	},
+	"Dockerfile ADD": {
+		"prefix": "add",
+		"body": [
+			"ADD ${1:src} ${2:dest}"
+		],
+		"description": "Dockerfile ADD instruction"
+	},
+	"Dockerfile ENV": {
+		"prefix": "env",
+		"body": [
+			"ENV ${1:KEY}=${2:value}"
+		],
+		"description": "Dockerfile ENV variable"
+	},
+	"Dockerfile ARG": {
+		"prefix": "arg",
+		"body": [
+			"ARG ${1:VAR}=${2:default}"
+		],
+		"description": "Dockerfile ARG build argument"
+	},
+	"Dockerfile EXPOSE": {
+		"prefix": "expose",
+		"body": [
+			"EXPOSE ${1:8080}"
+		],
+		"description": "Dockerfile EXPOSE port"
+	},
+	"Dockerfile CMD": {
+		"prefix": "cmd",
+		"body": [
+			"CMD [\"${1:command}\", \"${2:arg}\"]"
+		],
+		"description": "Dockerfile CMD instruction"
+	},
+	"Dockerfile ENTRYPOINT": {
+		"prefix": "entrypoint",
+		"body": [
+			"ENTRYPOINT [\"${1:executable}\"]"
+		],
+		"description": "Dockerfile ENTRYPOINT instruction"
+	},
+	"Dockerfile WORKDIR": {
+		"prefix": "workdir",
+		"body": [
+			"WORKDIR ${1:/app}"
+		],
+		"description": "Dockerfile WORKDIR instruction"
+	},
+	"Dockerfile USER": {
+		"prefix": "user",
+		"body": [
+			"USER ${1:nonroot}"
+		],
+		"description": "Dockerfile USER instruction"
+	},
+	"Dockerfile VOLUME": {
+		"prefix": "volume",
+		"body": [
+			"VOLUME [\"${1:/data}\"]"
+		],
+		"description": "Dockerfile VOLUME instruction"
+	},
+	"Dockerfile HEALTHCHECK": {
+		"prefix": "healthcheck",
+		"body": [
+			"HEALTHCHECK --interval=${1:30s} --timeout=${2:10s} --retries=${3:3} \\\\",
+			"\tCMD ${4:curl -f http://localhost:${5:8080}/health || exit 1}"
+		],
+		"description": "Dockerfile HEALTHCHECK instruction"
+	},
+	"Dockerfile LABEL": {
+		"prefix": "label",
+		"body": [
+			"LABEL ${1:maintainer}=\"${2:name@example.com}\""
+		],
+		"description": "Dockerfile LABEL instruction"
+	}
+}

--- a/extensions/handlebars/package.json
+++ b/extensions/handlebars/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "update-grammar": "node ../node_modules/vscode-grammar-updater/bin daaain/Handlebars grammars/Handlebars.json ./syntaxes/Handlebars.tmLanguage.json"
   },
-  "categories": ["Programming Languages"],
+  "categories": [
+    "Programming Languages"
+  ],
   "extensionKind": [
     "ui",
     "workspace"
@@ -46,6 +48,12 @@
       {
         "languageId": "handlebars",
         "autoInsert": true
+      }
+    ],
+    "snippets": [
+      {
+        "language": "handlebars",
+        "path": "./snippets/handlebars.code-snippets"
       }
     ]
   },

--- a/extensions/handlebars/snippets/handlebars.code-snippets
+++ b/extensions/handlebars/snippets/handlebars.code-snippets
@@ -1,0 +1,152 @@
+{
+	"Handlebars Expression": {
+		"prefix": "hb",
+		"body": [
+			"{{${1:expression}}}"
+		],
+		"description": "Handlebars expression"
+	},
+	"Handlebars Triple (unescaped)": {
+		"prefix": "hbu",
+		"body": [
+			"{{{${1:expression}}}}"
+		],
+		"description": "Handlebars unescaped expression"
+	},
+	"Handlebars If Block": {
+		"prefix": "if",
+		"body": [
+			"{{#if ${1:condition}}}",
+			"\t$0",
+			"{{/if}}"
+		],
+		"description": "Handlebars {{#if}} block"
+	},
+	"Handlebars If-Else Block": {
+		"prefix": "ife",
+		"body": [
+			"{{#if ${1:condition}}}",
+			"\t$0",
+			"{{else}}",
+			"\t${2}",
+			"{{/if}}"
+		],
+		"description": "Handlebars {{#if}} with {{else}}"
+	},
+	"Handlebars Unless Block": {
+		"prefix": "unless",
+		"body": [
+			"{{#unless ${1:condition}}}",
+			"\t$0",
+			"{{/unless}}"
+		],
+		"description": "Handlebars {{#unless}} block"
+	},
+	"Handlebars Each Block": {
+		"prefix": "each",
+		"body": [
+			"{{#each ${1:items}}}",
+			"\t$0",
+			"{{/each}}"
+		],
+		"description": "Handlebars {{#each}} loop"
+	},
+	"Handlebars Each with Index": {
+		"prefix": "eachi",
+		"body": [
+			"{{#each ${1:items}}}",
+			"\t{{@index}}: {{${2:this}}}",
+			"{{/each}}"
+		],
+		"description": "Handlebars {{#each}} with @index"
+	},
+	"Handlebars With Block": {
+		"prefix": "with",
+		"body": [
+			"{{#with ${1:context}}}",
+			"\t$0",
+			"{{/with}}"
+		],
+		"description": "Handlebars {{#with}} context block"
+	},
+	"Handlebars Partial": {
+		"prefix": "partial",
+		"body": [
+			"{{> ${1:partialName}}}"
+		],
+		"description": "Handlebars partial inclusion"
+	},
+	"Handlebars Partial with Context": {
+		"prefix": "partialctx",
+		"body": [
+			"{{> ${1:partialName} ${2:context}}}"
+		],
+		"description": "Handlebars partial with context"
+	},
+	"Handlebars Helper": {
+		"prefix": "helper",
+		"body": [
+			"{{${1:helperName} ${2:arg}}}"
+		],
+		"description": "Handlebars helper call"
+	},
+	"Handlebars Block Helper": {
+		"prefix": "blockhelper",
+		"body": [
+			"{{#${1:helperName} ${2:arg}}}",
+			"\t$0",
+			"{{/${1:helperName}}}"
+		],
+		"description": "Handlebars block helper"
+	},
+	"Handlebars Comment": {
+		"prefix": "comment",
+		"body": [
+			"{{! ${1:comment} }}"
+		],
+		"description": "Handlebars comment (not rendered in HTML)"
+	},
+	"Handlebars Block Comment": {
+		"prefix": "blockcomment",
+		"body": [
+			"{{!--",
+			" ${1:comment}",
+			"--}}"
+		],
+		"description": "Handlebars block comment"
+	},
+	"Handlebars Lookup": {
+		"prefix": "lookup",
+		"body": [
+			"{{lookup ${1:array} ${2:index}}}"
+		],
+		"description": "Handlebars lookup helper"
+	},
+	"Handlebars Log": {
+		"prefix": "log",
+		"body": [
+			"{{log ${1:value}}}"
+		],
+		"description": "Handlebars log helper for debugging"
+	},
+	"Handlebars HTML Template": {
+		"prefix": "html",
+		"body": [
+			"<!DOCTYPE html>",
+			"<html lang=\"en\">",
+			"<head>",
+			"\t<meta charset=\"UTF-8\">",
+			"\t<title>{{${1:title}}}</title>",
+			"</head>",
+			"<body>",
+			"\t{{> ${2:header}}}",
+			"\t<main>",
+			"\t\t$0",
+			"\t</main>",
+			"\t{{> ${3:footer}}}",
+			"</body>",
+			"</html>"
+		],
+		"description": "Handlebars HTML template with partials"
+	}
+}


### PR DESCRIPTION
Adds productivity snippets to three built-in language extensions that currently have no snippets.

## Motivation

Clojure, Dockerfile, and Handlebars all require users to type verbose or hard-to-remember boilerplate from scratch. Snippets for common patterns (Clojure threading macros, multi-stage Docker builds, Handlebars block helpers) dramatically speed up development.

## Changes

### Clojure (`extensions/clojure/snippets/clojure.code-snippets`) — 22 snippets
`ns`, `defn`, `defn-`, `def`, `defmacro`, `let`, `if`, `when`, `cond`, `map`, `filter`, `reduce`, `->` (thread-first), `->>` (thread-last), `defrecord`, `defprotocol`, `try`, `do`, `println`, `atom`, `swap!`, `fn`

### Dockerfile (`extensions/docker/snippets/dockerfile.code-snippets`) — 18 snippets
`from`, `node` (full Node.js template), `python` (full Python template), `multistage` (multi-stage build), `run`, `apt` (apt-get with cleanup), `copy`, `add`, `env`, `arg`, `expose`, `cmd`, `entrypoint`, `workdir`, `user`, `volume`, `healthcheck`, `label`

### Handlebars (`extensions/handlebars/snippets/handlebars.code-snippets`) — 17 snippets
`hb` (expression), `hbu` (unescaped), `if`, `ife`, `unless`, `each`, `eachi` (with @index), `with`, `partial`, `partialctx`, `helper`, `blockhelper`, `comment`, `blockcomment`, `lookup`, `log`, `html` (full template)

All snippets use tab stops with choice syntax where appropriate.