### PR TITLE
Fix typos: comand, explictly, registraion

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
+++ b/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
@@ -69,7 +69,7 @@ export class CodeLensCache implements ICodeLensCache {
 
 	put(model: ITextModel, data: CodeLensModel): void {
 		// create a copy of the model that is without command-ids
-		// but with comand-labels
+		// but with command-labels
 		const copyItems = data.lenses.map((item): CodeLens => {
 			return {
 				range: item.symbol.range,

--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -114,9 +114,9 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 	private readonly _editors = new DisposableMap<INotebookEditor>();
 	private readonly _disposables = new DisposableStore();
 
-	private readonly _kernels = new Map<number, [kernel: MainThreadKernel, registraion: IDisposable]>();
-	private readonly _kernelDetectionTasks = new Map<number, [task: MainThreadKernelDetectionTask, registraion: IDisposable]>();
-	private readonly _kernelSourceActionProviders = new Map<number, [provider: IKernelSourceActionProvider, registraion: IDisposable]>();
+	private readonly _kernels = new Map<number, [kernel: MainThreadKernel, registration: IDisposable]>();
+	private readonly _kernelDetectionTasks = new Map<number, [task: MainThreadKernelDetectionTask, registration: IDisposable]>();
+	private readonly _kernelSourceActionProviders = new Map<number, [provider: IKernelSourceActionProvider, registration: IDisposable]>();
 	private readonly _kernelSourceActionProvidersEventRegistrations = new Map<number, IDisposable>();
 
 	private readonly _proxy: ExtHostNotebookKernelsShape;

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -151,7 +151,7 @@ export class VariablesView extends ViewPane implements IDebugViewWithVariables {
 				return;
 			}
 
-			// Refresh the tree immediately if the user explictly changed stack frames.
+			// Refresh the tree immediately if the user explicitly changed stack frames.
 			// Otherwise postpone the refresh until user stops stepping.
 			const timeout = sf.explicit ? 0 : undefined;
 			this.updateTreeScheduler.schedule(timeout);


### PR DESCRIPTION
Fix three spelling mistakes in comments and type label names:

- `src/vs/editor/contrib/codelens/browser/codeLensCache.ts`: `comand` → `command`
- `src/vs/workbench/contrib/debug/browser/variablesView.ts`: `explictly` → `explicitly`
- `src/vs/workbench/api/browser/mainThreadNotebookKernels.ts`: `registraion` → `registration` (three tuple label names)