### PR TITLE
Fix typos: occured/occurence/occurences, seperate/seperately

### DIFF
--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -153,8 +153,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 		const oldDecorations: string[] = [];
 		const keys = Object.keys(this.currentOccurrences);
 		for (const decorationId of keys) {
-			const occurence = this.currentOccurrences[decorationId];
-			oldDecorations.push(occurence.decorationId);
+			const occurrence = this.currentOccurrences[decorationId];
+			oldDecorations.push(occurrence.decorationId);
 		}
 
 		const newDecorations: IModelDeltaDecoration[] = [];
@@ -171,8 +171,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 			this.currentOccurrences = {};
 			this.activeLinkDecorationId = null;
 			for (let i = 0, len = decorations.length; i < len; i++) {
-				const occurence = new LinkOccurrence(links[i], decorations[i]);
-				this.currentOccurrences[occurence.decorationId] = occurence;
+				const occurrence = new LinkOccurrence(links[i], decorations[i]);
+				this.currentOccurrences[occurrence.decorationId] = occurrence;
 			}
 		});
 	}

--- a/src/vs/editor/standalone/common/monarch/monarchCompile.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchCompile.ts
@@ -88,7 +88,7 @@ function createKeywordMatcher(arr: string[], caseInsensitive: boolean = false): 
  */
 function compileRegExp<S extends true | false>(lexer: monarchCommon.ILexerMin, str: string, handleSn: S): S extends true ? RegExp | DynamicRegExp : RegExp;
 function compileRegExp(lexer: monarchCommon.ILexerMin, str: string, handleSn: true | false): RegExp | DynamicRegExp {
-	// @@ must be interpreted as a literal @, so we replace all occurences of @@ with a placeholder character
+	// @@ must be interpreted as a literal @, so we replace all occurrences of @@ with a placeholder character
 	str = str.replace(/@@/g, `\x01`);
 
 	let n = 0;

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {


### PR DESCRIPTION
Fix spelling mistakes in comments and a local variable name:

- `src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts`: `occured` → `occurred`
- `src/vs/editor/standalone/common/monarch/monarchCompile.ts`: `occurences` → `occurrences`
- `src/vs/editor/contrib/links/browser/links.ts`: `occurence` → `occurrence` (local variable, 4 places)
- `src/vs/workbench/api/common/extHostTypes.ts`: `seperate` → `separate`
- `src/vs/workbench/contrib/files/browser/views/explorerViewer.ts`: `seperately` → `separately`