### PR TITLE
Fix typos: placeholer, avilable, excecution, perserve

### DIFF
--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -344,7 +344,7 @@ suite('Indent With Tab - TypeScript/JavaScript', () => {
 		assert.ok(true);
 	});
 
-	test.skip('issue #63388: perserve correct indentation on tab 1', () => {
+	test.skip('issue #63388: preserve correct indentation on tab 1', () => {
 
 		// https://github.com/microsoft/vscode/issues/63388
 
@@ -366,7 +366,7 @@ suite('Indent With Tab - TypeScript/JavaScript', () => {
 		});
 	});
 
-	test.skip('issue #63388: perserve correct indentation on tab 2', () => {
+	test.skip('issue #63388: preserve correct indentation on tab 2', () => {
 
 		// https://github.com/microsoft/vscode/issues/63388
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -330,7 +330,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 					return offsetDigits[i].usableWidthLeftOfLineNumber;
 				}
 			}
-			throw new BugIndicatingError('Could not find avilable width for icon');
+			throw new BugIndicatingError('Could not find available width for icon');
 		};
 	});
 

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -69,7 +69,7 @@ export interface IDisassembledInstructionEntry {
 	address: bigint;
 }
 
-// Special entry as a placeholer when disassembly is not available
+// Special entry as a placeholder when disassembly is not available
 const disassemblyNotAvailable: IDisassembledInstructionEntry = {
 	allowBreakpoint: false,
 	isBreakpointSet: false,

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
@@ -185,7 +185,7 @@ export class NotebookVariablesView extends ViewPane {
 			// new execution state means either new variables or the kernel is busy so we shouldn't ask
 			this.dataSource.cancel();
 
-			// changed === undefined -> excecution ended
+			// changed === undefined -> execution ended
 			if (event.changed === undefined) {
 				this.updateScheduler.schedule();
 			}


### PR DESCRIPTION
Fix four spelling mistakes in comments and error messages:

- `src/vs/workbench/contrib/debug/browser/disassemblyView.ts`: `placeholer` → `placeholder`
- `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts`: `avilable` → `available`
- `src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts`: `excecution` → `execution`
- `src/vs/editor/contrib/indentation/test/browser/indentation.test.ts`: `perserve` → `preserve` (two skipped test names)