### PR TITLE
sessions: fix TypeError when copilot pickers react to non-copilot sessions

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -41,7 +41,8 @@ export class BranchPicker extends Disposable {
 
 		this._register(autorun(reader => {
 			const session = this.sessionsManagementService.activeSession.read(reader);
-			const providerSession = session ? this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId) : undefined;
+			const provider = session ? this.sessionsProvidersService.getProvider(session.providerId) : undefined;
+			const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
 			if (providerSession) {
 				providerSession.loading.read(reader);
 				providerSession.branches.read(reader);
@@ -57,7 +58,8 @@ export class BranchPicker extends Disposable {
 		if (!session) {
 			return undefined;
 		}
-		return this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId);
+		const provider = this.sessionsProvidersService.getProvider(session.providerId);
+		return provider instanceof CopilotChatSessionsProvider ? provider.getSession(session.sessionId) : undefined;
 	}
 
 	render(container: HTMLElement): void {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -315,7 +315,8 @@ class CopilotActiveSessionContribution extends Disposable implements IWorkbenchC
 		this._register(autorun((reader: IReader) => {
 			const session = sessionsManagementService.activeSession.read(reader);
 			if (session?.providerId === COPILOT_PROVIDER_ID) {
-				const providerSession = sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId);
+				const provider = sessionsProvidersService.getProvider(session.providerId);
+				const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session.sessionId) : undefined;
 				const isLoading = providerSession?.loading.read(reader);
 				hasRepositoryKey.set(!isLoading && !!providerSession?.gitRepository);
 			} else {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -66,7 +66,8 @@ export class IsolationPicker extends Disposable {
 		this._register(autorun(reader => {
 			const session = this.sessionsManagementService.activeSession.read(reader);
 			const isLoading = session?.loading.read(reader);
-			const providerSession = session ? this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId) : undefined;
+			const provider = session ? this.sessionsProvidersService.getProvider(session.providerId) : undefined;
+			const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
 			if (providerSession) {
 				const gitRepo = providerSession.gitRepository;
 				const repoState = gitRepo?.state?.read?.(reader);
@@ -84,7 +85,8 @@ export class IsolationPicker extends Disposable {
 
 	private _getSessionIsolationMode(): IsolationMode {
 		const session = this.sessionsManagementService.activeSession.get();
-		const providerSession = session ? this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId) : undefined;
+		const provider = session ? this.sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
 		return providerSession?.isolationMode.get() ?? 'worktree';
 	}
 
@@ -165,7 +167,8 @@ export class IsolationPicker extends Disposable {
 
 	private _setModeOnSession(mode: IsolationMode): void {
 		const session = this.sessionsManagementService.activeSession.get();
-		const providerSession = session ? this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId) : undefined;
+		const provider = session ? this.sessionsProvidersService.getProvider(session.providerId) : undefined;
+		const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
 		providerSession?.setIsolationMode(mode);
 	}
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -218,7 +218,10 @@ export class ModePicker extends Disposable {
 			return;
 		}
 
-		this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId)?.setMode(mode);
+		const provider = this.sessionsProvidersService.getProvider(session.providerId);
+		if (provider instanceof CopilotChatSessionsProvider) {
+			provider.getSession(session.sessionId)?.setMode(mode);
+		}
 	}
 
 	private _updateTriggerLabel(): void {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
@@ -58,7 +58,8 @@ export class CloudModelPicker extends Disposable {
 
 		this._register(autorun(reader => {
 			const session = sessionsManagementService.activeSession.read(reader);
-			const providerSession = session ? sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId) : undefined;
+			const provider = session ? sessionsProvidersService.getProvider(session.providerId) : undefined;
+			const providerSession = provider instanceof CopilotChatSessionsProvider ? provider.getSession(session!.sessionId) : undefined;
 			if (providerSession instanceof RemoteNewSession) {
 				this._setSession(providerSession);
 			}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -67,7 +67,10 @@ export class PermissionPicker extends Disposable {
 			if (!session) {
 				return;
 			}
-			this.sessionsProvidersService.getProvider<CopilotChatSessionsProvider>(session.providerId)?.getSession(session.sessionId)?.setPermissionLevel(level);
+			const provider = this.sessionsProvidersService.getProvider(session.providerId);
+			if (provider instanceof CopilotChatSessionsProvider) {
+				provider.getSession(session.sessionId)?.setPermissionLevel(level);
+			}
 		}));
 	}
 

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/isolationPicker.test.ts
@@ -16,6 +16,7 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { GitRefType } from '../../../../../workbench/contrib/git/common/gitService.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
+import { CopilotChatSessionsProvider } from '../../browser/copilotChatSessionsProvider.js';
 import { IsolationMode, IsolationPicker } from '../../browser/isolationPicker.js';
 
 interface IIsolationActionItem {
@@ -49,12 +50,12 @@ function createPicker(
 		workingTreeChanges: [],
 		untrackedChanges: [],
 	});
-	const provider = {
+	const provider = Object.assign(Object.create(CopilotChatSessionsProvider.prototype), {
 		getSession: () => ({
 			gitRepository: { state: gitState },
 			isolationMode,
 		}),
-	};
+	});
 
 	instantiationService.stub(IActionWidgetService, {
 		isVisible: false,


### PR DESCRIPTION
The copilot-specific pickers (`BranchPicker`, `IsolationPicker`, `ModePicker`, `ModelPicker`, `PermissionPicker`) use `autorun` observers that react to `activeSession` changes. They called `getProvider<CopilotChatSessionsProvider>()` which is a compile-time-only generic cast — at runtime, when a non-Copilot provider's session becomes active, the returned object doesn't have `getSession()`, causing a TypeError.

## Root cause

These pickers are registered via `actionViewItemService.register` and live for the lifetime of the contribution. Their `autorun` callbacks fire on **every** `activeSession` change regardless of provider type, even though the picker UI is only visible for Copilot sessions (gated by `IsActiveSessionCopilotChatCLI`). The mismatch between visibility gating and autorun execution means the pickers tried to call Copilot-specific methods on non-Copilot providers.

## Fix

Replace all unsafe `getProvider<CopilotChatSessionsProvider>()` generic casts with `instanceof CopilotChatSessionsProvider` runtime checks across 6 files. This makes the pickers safely return `undefined` for non-Copilot providers.

(Written by Copilot)