### PR TITLE
copilotcli: Enhance permission handling in Copilot CLI

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -20,7 +20,6 @@ import { CancellationToken } from '../../../../util/vs/base/common/cancellation'
 import { Codicon } from '../../../../util/vs/base/common/codicons';
 import { Emitter } from '../../../../util/vs/base/common/event';
 import { DisposableStore, IDisposable, toDisposable } from '../../../../util/vs/base/common/lifecycle';
-import { extUriBiasedIgnorePathCase, isEqual } from '../../../../util/vs/base/common/resources';
 import { truncate } from '../../../../util/vs/base/common/strings';
 import { ThemeIcon } from '../../../../util/vs/base/common/themables';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
@@ -29,12 +28,11 @@ import { IToolsService } from '../../../tools/common/toolsService';
 import { IChatSessionMetadataStore } from '../../common/chatSessionMetadataStore';
 import { ExternalEditTracker } from '../../common/externalEditTracker';
 import { getWorkingDirectory, isIsolationEnabled, IWorkspaceInfo } from '../../common/workspaceInfo';
-import { enrichToolInvocationWithSubagentMetadata, getAffectedUrisForEditTool, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, processToolExecutionComplete, processToolExecutionStart, ToolCall, updateTodoList } from '../common/copilotCLITools';
-import { getCopilotCLISessionStateDir } from './cliHelpers';
+import { enrichToolInvocationWithSubagentMetadata, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, processToolExecutionComplete, processToolExecutionStart, ToolCall, updateTodoList } from '../common/copilotCLITools';
 import type { CopilotCliBridgeSpanProcessor } from './copilotCliBridgeSpanProcessor';
 import { ICopilotCLIImageSupport } from './copilotCLIImageSupport';
 import { handleExitPlanMode } from './exitPlanModeHandler';
-import { PermissionRequest, requestPermission, requiresFileEditconfirmation } from './permissionHelpers';
+import { handleMcpPermission, handleReadPermission, handleShellPermission, handleWritePermission, type PermissionRequest, type PermissionRequestResult, showInteractivePermissionPrompt } from './permissionHelpers';
 import { IQuestion, IUserQuestionHandler } from './userInputHelpers';
 
 /**
@@ -429,20 +427,56 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			disposables.add(toDisposable(this._sdkSession.on('permission.requested', async (event) => {
 				const permissionRequest = event.data.permissionRequest;
 				const requestId = event.data.requestId;
-				const response = await this.requestPermission(permissionRequest, editTracker,
-					(toolCallId: string) => {
-						const toolData = toolCalls.get(toolCallId);
-						if (!toolData) {
-							return undefined;
-						}
-						const data = pendingToolInvocations.get(toolCallId);
-						if (data) {
-							return [toolData, data[2]] as const;
-						}
-						return [toolData, undefined] as const;
-					},
-					token
-				);
+
+				// Auto-approve all requests when the permission level allows it.
+				if (this._permissionLevel === 'autoApprove' || this._permissionLevel === 'autopilot') {
+					this.logService.trace(`[CopilotCLISession] Auto Approving ${permissionRequest.kind} request (permission level: ${this._permissionLevel})`);
+					this._sdkSession.respondToPermission(requestId, { kind: 'approved' });
+					return;
+				}
+
+				// Resolve tool call data for the permission request.
+				const toolData = permissionRequest.toolCallId ? toolCalls.get(permissionRequest.toolCallId) : undefined;
+				const pendingData = permissionRequest.toolCallId ? pendingToolInvocations.get(permissionRequest.toolCallId) : undefined;
+				const toolParentCallId = pendingData ? pendingData[2] : undefined;
+				const toolInvocationToken = this._toolInvocationToken as unknown as never;
+
+				let response: PermissionRequestResult;
+				switch (permissionRequest.kind) {
+					case 'read':
+						response = await handleReadPermission(
+							this.sessionId, permissionRequest, toolParentCallId,
+							this.attachments, this._imageSupport, this.workspace, this.workspaceService,
+							this._toolsService, toolInvocationToken, this.logService, token,
+						);
+						break;
+					case 'write':
+						response = await handleWritePermission(
+							this.sessionId, permissionRequest, toolData, toolParentCallId,
+							this._stream, editTracker, this.workspace, this.workspaceService,
+							this.instantiationService, this._toolsService, toolInvocationToken, this.logService, token,
+						);
+						break;
+					case 'shell':
+						response = await handleShellPermission(
+							permissionRequest, toolParentCallId,
+							this.workspace, this._toolsService, toolInvocationToken, this.logService, token,
+						);
+						break;
+					case 'mcp':
+						response = await handleMcpPermission(
+							permissionRequest, toolParentCallId,
+							this._toolsService, toolInvocationToken, this.logService, token,
+						);
+						break;
+					default:
+						response = await showInteractivePermissionPrompt(
+							permissionRequest, toolParentCallId,
+							this._toolsService, toolInvocationToken, this.logService, token,
+						);
+						break;
+				}
+
 				flushPendingInvocationMessageForToolCallId(permissionRequest.toolCallId);
 
 				this._requestLogger.addEntry({
@@ -866,132 +900,6 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 
 	public getSelectedModelId() {
 		return this._sdkSession.getSelectedModel();
-	}
-
-	private isFileFromSessionWorkspace(file: Uri): boolean {
-		const workingDirectory = getWorkingDirectory(this.workspace);
-		if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(file, workingDirectory)) {
-			return true;
-		}
-		if (this.workspace.folder && extUriBiasedIgnorePathCase.isEqualOrParent(file, this.workspace.folder)) {
-			return true;
-		}
-		// Only if we have a worktree should we check the repository.
-		// As this means the user created a worktree and we have a repository.
-		// & if the worktree is automatically trusted, then so is the repository as we created the worktree from that.
-		if (this.workspace.worktree && this.workspace.repository && extUriBiasedIgnorePathCase.isEqualOrParent(file, this.workspace.repository)) {
-			return true;
-		}
-
-		return false;
-	}
-	private async requestPermission(
-		permissionRequest: PermissionRequest,
-		editTracker: ExternalEditTracker,
-		getToolCall: (toolCallId: string) => undefined | [ToolCall, parentToolCallId: string | undefined],
-		token: vscode.CancellationToken
-	): Promise<{ kind: 'approved' } | { kind: 'denied-interactively-by-user' }> {
-		if (this._permissionLevel === 'autoApprove' || this._permissionLevel === 'autopilot') {
-			this.logService.trace(`[CopilotCLISession] Auto Approving ${permissionRequest.kind} request (permission level: ${this._permissionLevel})`);
-			return { kind: 'approved' };
-		}
-
-		const workingDirectory = getWorkingDirectory(this.workspace);
-
-		if (permissionRequest.kind === 'read') {
-			// If user is reading a file in the working directory or workspace, auto-approve
-			// read requests. Outside workspace reads (e.g., /etc/passwd) will still require
-			// approval.
-			const data = Uri.file(permissionRequest.path);
-
-			if (this._imageSupport.isTrustedImage(data)) {
-				return { kind: 'approved' };
-			}
-
-			if (this.isFileFromSessionWorkspace(data)) {
-				this.logService.trace(`[CopilotCLISession] Auto Approving request to read file in session workspace ${permissionRequest.path}`);
-				return { kind: 'approved' };
-			}
-
-			if (this.workspaceService.getWorkspaceFolder(data)) {
-				this.logService.trace(`[CopilotCLISession] Auto Approving request to read workspace file ${permissionRequest.path}`);
-				return { kind: 'approved' };
-			}
-
-			// If reading a file from session directory, e.g. plan.md, then auto approve it, this is internal file to Cli.
-			const sessionDir = Uri.joinPath(Uri.file(getCopilotCLISessionStateDir()), this.sessionId);
-			if (extUriBiasedIgnorePathCase.isEqualOrParent(data, sessionDir)) {
-				this.logService.trace(`[CopilotCLISession] Auto Approving request to read Copilot CLI session resource ${permissionRequest.path}`);
-				return { kind: 'approved' };
-			}
-
-			// If model is trying to read the contents of a file thats attached, then auto-approve it, as this is an explicit action by the user to share the file with the model.
-			if (this.attachments.some(attachment => attachment.type === 'file' && isEqual(Uri.file(attachment.path), data))) {
-				this.logService.trace(`[CopilotCLISession] Auto Approving request to read attached file ${permissionRequest.path}`);
-				return { kind: 'approved' };
-			}
-		}
-
-		// Get hold of file thats being edited if this is a edit tool call (requiring write permissions).
-		const toolData = permissionRequest.toolCallId ? getToolCall(permissionRequest.toolCallId) : undefined;
-		const toolCall = toolData ? toolData[0] : undefined;
-		const toolParentCallId = toolData ? toolData[1] : undefined;
-		const editFiles = toolCall ? getAffectedUrisForEditTool(toolCall) : undefined;
-		// Sometimes we don't get a tool call id for the edit permission request
-		const editFile = permissionRequest.kind === 'write' ? (editFiles && editFiles.length ? editFiles[0] : (permissionRequest.fileName ? Uri.file(permissionRequest.fileName) : undefined)) : undefined;
-		if (workingDirectory && permissionRequest.kind === 'write' && editFile) {
-			const isWorkspaceFile = this.workspaceService.getWorkspaceFolder(editFile);
-			const isWorkingDirectoryFile = !this.workspaceService.getWorkspaceFolder(workingDirectory) && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, workingDirectory);
-
-			let autoApprove = false;
-			// If isolation is enabled, we only auto-approve writes within the working directory.
-			if (isIsolationEnabled(this.workspace) && isWorkingDirectoryFile) {
-				autoApprove = true;
-			}
-			// If its a workspace file, and not editing protected files, we auto-approve.
-			if (!autoApprove && isWorkspaceFile && !(await requiresFileEditconfirmation(this.instantiationService, permissionRequest, toolCall))) {
-				autoApprove = true;
-			}
-			// If we're working in the working directory (non-isolation), and not editing protected files, we auto-approve.
-			if (!autoApprove && isWorkingDirectoryFile && !(await requiresFileEditconfirmation(this.instantiationService, permissionRequest, toolCall, workingDirectory))) {
-				autoApprove = true;
-			}
-
-			if (autoApprove) {
-				this.logService.trace(`[CopilotCLISession] Auto Approving request ${editFile.fsPath}`);
-
-				// If we're editing a file, start tracking the edit & wait for core to acknowledge it.
-				if (toolCall && this._stream) {
-					this.logService.trace(`[CopilotCLISession] Starting to track edit for toolCallId ${toolCall.toolCallId} & file ${editFile.fsPath}`);
-					await editTracker.trackEdit(toolCall.toolCallId, [editFile], this._stream);
-				}
-
-				return { kind: 'approved' };
-			}
-		}
-		// If reading a file from session directory, e.g. plan.md, then auto approve it, this is internal file to Cli.
-		const sessionDir = Uri.joinPath(Uri.file(getCopilotCLISessionStateDir()), this.sessionId);
-		if (permissionRequest.kind === 'write' && editFile && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, sessionDir)) {
-			this.logService.trace(`[CopilotCLISession] Auto Approving request to write to Copilot CLI session resource ${editFile.fsPath}`);
-			return { kind: 'approved' };
-		}
-
-		try {
-			if (await requestPermission(this.instantiationService, permissionRequest, toolCall, getWorkingDirectory(this.workspace), this._toolsService, this._toolInvocationToken as unknown as never, toolParentCallId, token)) {
-				// If we're editing a file, start tracking the edit & wait for core to acknowledge it.
-				if (editFile && toolCall && this._stream) {
-					this.logService.trace(`[CopilotCLISession] Starting to track edit for toolCallId ${toolCall.toolCallId} & file ${editFile.fsPath}`);
-					await editTracker.trackEdit(toolCall.toolCallId, [editFile], this._stream);
-				}
-				return { kind: 'approved' };
-			}
-		} catch (error) {
-			this.logService.error(`[CopilotCLISession] Permission request error: ${error}`);
-		} finally {
-			this._permissionRequested = undefined;
-		}
-
-		return { kind: 'denied-interactively-by-user' };
 	}
 
 	private _logRequest(userPrompt: string, modelId: string, attachments: Attachment[], startTimeMs: number): void {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -443,39 +443,44 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 
 				try {
 					let response: PermissionRequestResult;
-					switch (permissionRequest.kind) {
-						case 'read':
-							response = await handleReadPermission(
-								this.sessionId, permissionRequest, toolParentCallId,
-								this.attachments, this._imageSupport, this.workspace, this.workspaceService,
-								this._toolsService, toolInvocationToken, this.logService, token,
-							);
-							break;
-						case 'write':
-							response = await handleWritePermission(
-								this.sessionId, permissionRequest, toolData, toolParentCallId,
-								this._stream, editTracker, this.workspace, this.workspaceService,
-								this.instantiationService, this._toolsService, toolInvocationToken, this.logService, token,
-							);
-							break;
-						case 'shell':
-							response = await handleShellPermission(
-								permissionRequest, toolParentCallId,
-								this.workspace, this._toolsService, toolInvocationToken, this.logService, token,
-							);
-							break;
-						case 'mcp':
-							response = await handleMcpPermission(
-								permissionRequest, toolParentCallId,
-								this._toolsService, toolInvocationToken, this.logService, token,
-							);
-							break;
-						default:
-							response = await showInteractivePermissionPrompt(
-								permissionRequest, toolParentCallId,
-								this._toolsService, toolInvocationToken, this.logService, token,
-							);
-							break;
+					if (this._permissionLevel === 'autoApprove' || this._permissionLevel === 'autopilot') {
+						this.logService.trace(`[CopilotCLISession] Auto Approving ${permissionRequest.kind} request (permission level: ${this._permissionLevel})`);
+						response = { kind: 'approved' };
+					} else {
+						switch (permissionRequest.kind) {
+							case 'read':
+								response = await handleReadPermission(
+									this.sessionId, permissionRequest, toolParentCallId,
+									this.attachments, this._imageSupport, this.workspace, this.workspaceService,
+									this._toolsService, toolInvocationToken, this.logService, token,
+								);
+								break;
+							case 'write':
+								response = await handleWritePermission(
+									this.sessionId, permissionRequest, toolData, toolParentCallId,
+									this._stream, editTracker, this.workspace, this.workspaceService,
+									this.instantiationService, this._toolsService, toolInvocationToken, this.logService, token,
+								);
+								break;
+							case 'shell':
+								response = await handleShellPermission(
+									permissionRequest, toolParentCallId,
+									this.workspace, this._toolsService, toolInvocationToken, this.logService, token,
+								);
+								break;
+							case 'mcp':
+								response = await handleMcpPermission(
+									permissionRequest, toolParentCallId,
+									this._toolsService, toolInvocationToken, this.logService, token,
+								);
+								break;
+							default:
+								response = await showInteractivePermissionPrompt(
+									permissionRequest, toolParentCallId,
+									this._toolsService, toolInvocationToken, this.logService, token,
+								);
+								break;
+						}
 					}
 
 					flushPendingInvocationMessageForToolCallId(permissionRequest.toolCallId);

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -441,54 +441,61 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				const toolParentCallId = pendingData ? pendingData[2] : undefined;
 				const toolInvocationToken = this._toolInvocationToken as unknown as never;
 
-				let response: PermissionRequestResult;
-				switch (permissionRequest.kind) {
-					case 'read':
-						response = await handleReadPermission(
-							this.sessionId, permissionRequest, toolParentCallId,
-							this.attachments, this._imageSupport, this.workspace, this.workspaceService,
-							this._toolsService, toolInvocationToken, this.logService, token,
-						);
-						break;
-					case 'write':
-						response = await handleWritePermission(
-							this.sessionId, permissionRequest, toolData, toolParentCallId,
-							this._stream, editTracker, this.workspace, this.workspaceService,
-							this.instantiationService, this._toolsService, toolInvocationToken, this.logService, token,
-						);
-						break;
-					case 'shell':
-						response = await handleShellPermission(
-							permissionRequest, toolParentCallId,
-							this.workspace, this._toolsService, toolInvocationToken, this.logService, token,
-						);
-						break;
-					case 'mcp':
-						response = await handleMcpPermission(
-							permissionRequest, toolParentCallId,
-							this._toolsService, toolInvocationToken, this.logService, token,
-						);
-						break;
-					default:
-						response = await showInteractivePermissionPrompt(
-							permissionRequest, toolParentCallId,
-							this._toolsService, toolInvocationToken, this.logService, token,
-						);
-						break;
+				try {
+					let response: PermissionRequestResult;
+					switch (permissionRequest.kind) {
+						case 'read':
+							response = await handleReadPermission(
+								this.sessionId, permissionRequest, toolParentCallId,
+								this.attachments, this._imageSupport, this.workspace, this.workspaceService,
+								this._toolsService, toolInvocationToken, this.logService, token,
+							);
+							break;
+						case 'write':
+							response = await handleWritePermission(
+								this.sessionId, permissionRequest, toolData, toolParentCallId,
+								this._stream, editTracker, this.workspace, this.workspaceService,
+								this.instantiationService, this._toolsService, toolInvocationToken, this.logService, token,
+							);
+							break;
+						case 'shell':
+							response = await handleShellPermission(
+								permissionRequest, toolParentCallId,
+								this.workspace, this._toolsService, toolInvocationToken, this.logService, token,
+							);
+							break;
+						case 'mcp':
+							response = await handleMcpPermission(
+								permissionRequest, toolParentCallId,
+								this._toolsService, toolInvocationToken, this.logService, token,
+							);
+							break;
+						default:
+							response = await showInteractivePermissionPrompt(
+								permissionRequest, toolParentCallId,
+								this._toolsService, toolInvocationToken, this.logService, token,
+							);
+							break;
+					}
+
+					flushPendingInvocationMessageForToolCallId(permissionRequest.toolCallId);
+
+					this._requestLogger.addEntry({
+						type: LoggedRequestKind.MarkdownContentRequest,
+						debugName: `Permission Request`,
+						startTimeMs: Date.now(),
+						icon: Codicon.question,
+						markdownContent: this._renderPermissionToMarkdown(permissionRequest, response.kind),
+						isConversationRequest: true
+					});
+
+					this._sdkSession.respondToPermission(requestId, response);
 				}
-
-				flushPendingInvocationMessageForToolCallId(permissionRequest.toolCallId);
-
-				this._requestLogger.addEntry({
-					type: LoggedRequestKind.MarkdownContentRequest,
-					debugName: `Permission Request`,
-					startTimeMs: Date.now(),
-					icon: Codicon.question,
-					markdownContent: this._renderPermissionToMarkdown(permissionRequest, response.kind),
-					isConversationRequest: true
-				});
-
-				this._sdkSession.respondToPermission(requestId, response);
+				catch (error) {
+					this.logService.error(error, `[CopilotCLISession] Error handling permission request of kind ${permissionRequest.kind}`);
+					flushPendingInvocationMessageForToolCallId(permissionRequest.toolCallId);
+					this._sdkSession.respondToPermission(requestId, { kind: 'denied-interactively-by-user' });
+				}
 			})));
 			if (shouldHandleExitPlanModeRequests) {
 				disposables.add(toDisposable(this._sdkSession.on('exit_plan_mode.requested', async (event) => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -567,7 +567,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 			const session = this.createCopilotSession(sdkSession, options.workspace, options.agent?.name, sessionManager);
 			session.object.add(mcpGateway);
-			await sessionManager.loadDeferredRepoHooks(sdkSession);
 			void this._chatSessionMetadataStore.setSessionOrigin(session.object.sessionId);
 			return session;
 		}
@@ -752,7 +751,6 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 				const session = this.createCopilotSession(sdkSession, options.workspace, options.agent?.name, sessionManager);
 				session.object.add(mcpGateway);
-				await sessionManager.loadDeferredRepoHooks(sdkSession);
 				return session;
 			}
 			catch (error) {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -567,6 +567,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 			const session = this.createCopilotSession(sdkSession, options.workspace, options.agent?.name, sessionManager);
 			session.object.add(mcpGateway);
+			await sessionManager.loadDeferredRepoHooks(sdkSession);
 			void this._chatSessionMetadataStore.setSessionOrigin(session.object.sessionId);
 			return session;
 		}
@@ -751,6 +752,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 
 				const session = this.createCopilotSession(sdkSession, options.workspace, options.agent?.name, sessionManager);
 				session.object.add(mcpGateway);
+				await sessionManager.loadDeferredRepoHooks(sdkSession);
 				return session;
 			}
 			catch (error) {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
@@ -285,7 +285,7 @@ async function invokeConfirmationTool(
 			return { kind: 'approved' };
 		}
 	} catch (error) {
-		logService.error(`[CopilotCLISession] Permission request error: ${error}`);
+		logService.error(error, `[CopilotCLISession] Permission request error`);
 	}
 	return { kind: 'denied-interactively-by-user' };
 }
@@ -343,7 +343,7 @@ async function trackEditIfNeeded(editTracker: ExternalEditTracker, toolCall: Too
 		try {
 			await editTracker.trackEdit(toolCall.toolCallId, [editFile], stream);
 		} catch (error) {
-			logService.error(`[CopilotCLISession] Failed to track edit for toolCallId ${toolCall.toolCallId}: ${error}`);
+			logService.error(error, `[CopilotCLISession] Failed to track edit for toolCallId ${toolCall.toolCallId}`);
 		}
 	}
 }

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
@@ -3,18 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { PermissionRequestedEvent } from '@github/copilot/sdk';
+import type { Attachment, PermissionRequestedEvent } from '@github/copilot/sdk';
 import { platform } from 'node:os';
-import type { CancellationToken, ChatParticipantToolToken } from 'vscode';
+import type { CancellationToken, ChatParticipantToolToken, ChatResponseStream } from 'vscode';
+import { ILogService } from '../../../../platform/log/common/logService';
 import { IWorkspaceService } from '../../../../platform/workspace/common/workspaceService';
-import { extUriBiasedIgnorePathCase } from '../../../../util/vs/base/common/resources';
+import { extUriBiasedIgnorePathCase, isEqual } from '../../../../util/vs/base/common/resources';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { IInstantiationService, ServicesAccessor } from '../../../../util/vs/platform/instantiation/common/instantiation';
-import { LanguageModelTextPart } from '../../../../vscodeTypes';
+import { LanguageModelTextPart, Uri } from '../../../../vscodeTypes';
 import { ToolName } from '../../../tools/common/toolNames';
 import { IToolsService } from '../../../tools/common/toolsService';
 import { createEditConfirmation, formatDiffAsUnified } from '../../../tools/node/editFileToolUtils';
+import { ExternalEditTracker } from '../../common/externalEditTracker';
+import { getWorkingDirectory, isIsolationEnabled, IWorkspaceInfo } from '../../common/workspaceInfo';
 import { getAffectedUrisForEditTool, getCdPresentationOverrides, ToolCall } from '../common/copilotCLITools';
+import { getCopilotCLISessionStateDir } from './cliHelpers';
+import { ICopilotCLIImageSupport } from './copilotCLIImageSupport';
 
 type CoreTerminalConfirmationToolParams = {
 	tool: ToolName.CoreTerminalConfirmationTool;
@@ -34,26 +39,313 @@ type CoreConfirmationToolParams = {
 	};
 }
 
-export async function requestPermission(
-	instaService: IInstantiationService,
-	permissionRequest: PermissionRequest,
-	toolCall: ToolCall | undefined,
-	workingDirectory: URI | undefined,
+/**
+ * The result of requesting permissions — the full union accepted by `Session.respondToPermission`.
+ * Extracted from the SDK's second parameter type to stay in sync automatically.
+ */
+export type PermissionRequestResult = Parameters<import('@github/copilot/sdk').Session['respondToPermission']>[1];
+
+/**
+ * Handles `read` permission requests.
+ * Auto-approves reads for workspace files, session resources, trusted images, and attached files.
+ * Falls back to interactive confirmation for out-of-workspace reads.
+ */
+export async function handleReadPermission(
+	sessionId: string,
+	permissionRequest: Extract<PermissionRequest, { kind: 'read' }>,
+	toolParentCallId: string | undefined,
+	attachments: readonly Attachment[],
+	imageSupport: ICopilotCLIImageSupport,
+	workspaceInfo: IWorkspaceInfo,
+	workspaceService: IWorkspaceService,
 	toolsService: IToolsService,
 	toolInvocationToken: ChatParticipantToolToken,
-	toolParentCallId: string | undefined,
+	logService: ILogService,
 	token: CancellationToken,
-): Promise<boolean> {
+): Promise<PermissionRequestResult> {
+	const file = Uri.file(permissionRequest.path);
 
-	const toolParams = await getConfirmationToolParams(instaService, permissionRequest, toolCall, workingDirectory);
+	if (imageSupport.isTrustedImage(file)) {
+		return { kind: 'approved' };
+	}
+
+	if (isFileFromSessionWorkspace(file, workspaceInfo)) {
+		logService.trace(`[CopilotCLISession] Auto Approving request to read file in session workspace ${permissionRequest.path}`);
+		return { kind: 'approved' };
+	}
+
+	if (workspaceService.getWorkspaceFolder(file)) {
+		logService.trace(`[CopilotCLISession] Auto Approving request to read workspace file ${permissionRequest.path}`);
+		return { kind: 'approved' };
+	}
+
+	// Auto-approve reads of internal session resources (e.g. plan.md).
+	const sessionDir = Uri.joinPath(Uri.file(getCopilotCLISessionStateDir()), sessionId);
+	if (extUriBiasedIgnorePathCase.isEqualOrParent(file, sessionDir)) {
+		logService.trace(`[CopilotCLISession] Auto Approving request to read Copilot CLI session resource ${permissionRequest.path}`);
+		return { kind: 'approved' };
+	}
+
+	// Auto-approve if the file was explicitly attached by the user.
+	if (attachments.some(attachment => attachment.type === 'file' && isEqual(Uri.file(attachment.path), file))) {
+		logService.trace(`[CopilotCLISession] Auto Approving request to read attached file ${permissionRequest.path}`);
+		return { kind: 'approved' };
+	}
+
+	const toolParams: CoreConfirmationToolParams = {
+		tool: ToolName.CoreConfirmationTool,
+		input: {
+			title: 'Read file(s)',
+			message: permissionRequest.intention || permissionRequest.path || codeBlock(permissionRequest),
+			confirmationType: 'basic'
+		}
+	};
+	return invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
+}
+
+/**
+ * Handles `write` permission requests.
+ * Auto-approves writes within workspace/working directory (respecting isolation mode
+ * and protected-file checks). Tracks edits via `ExternalEditTracker` when auto-approving.
+ * Falls back to interactive confirmation for writes outside the workspace or to protected files.
+ */
+export async function handleWritePermission(
+	sessionId: string,
+	permissionRequest: Extract<PermissionRequest, { kind: 'write' }>,
+	toolCall: ToolCall | undefined,
+	toolParentCallId: string | undefined,
+	stream: ChatResponseStream | undefined,
+	editTracker: ExternalEditTracker,
+	workspaceInfo: IWorkspaceInfo,
+	workspaceService: IWorkspaceService,
+	instantiationService: IInstantiationService,
+	toolsService: IToolsService,
+	toolInvocationToken: ChatParticipantToolToken,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<PermissionRequestResult> {
+	const workingDirectory = getWorkingDirectory(workspaceInfo);
+	const editFile = getFileBeingEdited(permissionRequest, toolCall);
+
+	// Auto-approve writes within the workspace/working directory when appropriate.
+	if (workingDirectory && editFile) {
+		const isWorkspaceFile = workspaceService.getWorkspaceFolder(editFile);
+		const isWorkingDirectoryFile = !workspaceService.getWorkspaceFolder(workingDirectory) && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, workingDirectory);
+
+		let autoApprove = false;
+		// If isolation is enabled, we only auto-approve writes within the working directory.
+		if (isIsolationEnabled(workspaceInfo) && isWorkingDirectoryFile) {
+			autoApprove = true;
+		}
+		// If its a workspace file, and not editing protected files, we auto-approve.
+		if (!autoApprove && isWorkspaceFile && !(await requiresFileEditconfirmation(instantiationService, permissionRequest, toolCall))) {
+			autoApprove = true;
+		}
+		// If we're working in the working directory (non-isolation), and not editing protected files, we auto-approve.
+		if (!autoApprove && isWorkingDirectoryFile && !(await requiresFileEditconfirmation(instantiationService, permissionRequest, toolCall, workingDirectory))) {
+			autoApprove = true;
+		}
+
+		if (autoApprove) {
+			logService.trace(`[CopilotCLISession] Auto Approving request ${editFile.fsPath}`);
+			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+			return { kind: 'approved' };
+		}
+	}
+
+	// Auto-approve writes to internal session resources (e.g. plan.md).
+	const sessionDir = Uri.joinPath(Uri.file(getCopilotCLISessionStateDir()), sessionId);
+	if (editFile && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, sessionDir)) {
+		logService.trace(`[CopilotCLISession] Auto Approving request to write to Copilot CLI session resource ${editFile.fsPath}`);
+		return { kind: 'approved' };
+	}
+
+	// Fall back to interactive confirmation. If approved, track the edit.
+	let workspaceFolderForFile: URI | undefined;
+	if (editFile) {
+		workspaceFolderForFile = workspaceService.getWorkspaceFolder(editFile);
+		if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, workingDirectory)) {
+			workspaceFolderForFile = workingDirectory;
+		}
+	}
+	const toolParams = await getFileEditConfirmationToolParams(instantiationService, permissionRequest, toolCall, workspaceFolderForFile);
 	if (!toolParams) {
+		// No confirmation needed (e.g. no file to edit) — auto-approve.
+		if (editFile) {
+			await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+		}
+		return { kind: 'approved' };
+	}
+	const result = await invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
+	if (result.kind === 'approved' && editFile) {
+		await trackEditIfNeeded(editTracker, toolCall, editFile, stream, logService);
+	}
+	return result;
+}
+
+/**
+ * Handles `shell` permission requests.
+ * Builds a terminal confirmation prompt with the command text and intention,
+ * stripping `cd` prefixes that match the working directory for cleaner display.
+ */
+export async function handleShellPermission(
+	permissionRequest: Extract<PermissionRequest, { kind: 'shell' }>,
+	toolParentCallId: string | undefined,
+	workspaceInfo: IWorkspaceInfo,
+	toolsService: IToolsService,
+	toolInvocationToken: ChatParticipantToolToken,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<PermissionRequestResult> {
+	const toolParams = buildShellConfirmationParams(permissionRequest, getWorkingDirectory(workspaceInfo));
+	return invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
+}
+
+/**
+ * Builds the terminal confirmation tool params for a shell permission request.
+ * Pure function — no side effects, easy to test.
+ */
+export function buildShellConfirmationParams(
+	permissionRequest: Extract<PermissionRequest, { kind: 'shell' }>,
+	workingDirectory: URI | undefined,
+	isWindows?: boolean,
+): CoreTerminalConfirmationToolParams {
+	isWindows = typeof isWindows === 'boolean' ? isWindows : platform() === 'win32';
+	const isPowershell = isWindows;
+	const fullCommandText = permissionRequest.fullCommandText || '';
+	const userFriendlyCommand = fullCommandText ? getCdPresentationOverrides(fullCommandText, isPowershell, workingDirectory)?.commandLine : undefined;
+	const command = userFriendlyCommand ?? fullCommandText;
+
+	return {
+		tool: ToolName.CoreTerminalConfirmationTool,
+		input: {
+			message: permissionRequest.intention || command || codeBlock(permissionRequest),
+			command,
+			isBackground: false
+		}
+	};
+}
+
+/**
+ * Handles `mcp` permission requests.
+ * Shows a confirmation dialog with the MCP server name, tool name, and arguments.
+ */
+export async function handleMcpPermission(
+	permissionRequest: Extract<PermissionRequest, { kind: 'mcp' }>,
+	toolParentCallId: string | undefined,
+	toolsService: IToolsService,
+	toolInvocationToken: ChatParticipantToolToken,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<PermissionRequestResult> {
+	const toolParams = buildMcpConfirmationParams(permissionRequest);
+	return invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
+}
+
+/**
+ * Builds the confirmation tool params for an MCP permission request.
+ * Pure function — no side effects, easy to test.
+ */
+export function buildMcpConfirmationParams(
+	permissionRequest: Extract<PermissionRequest, { kind: 'mcp' }>,
+): CoreConfirmationToolParams {
+	const serverName = permissionRequest.serverName as string | undefined;
+	const toolTitle = permissionRequest.toolTitle as string | undefined;
+	const toolName = permissionRequest.toolName as string | undefined;
+	const args = permissionRequest.args;
+
+	return {
+		tool: ToolName.CoreConfirmationTool,
+		input: {
+			title: toolTitle || `MCP Tool: ${toolName || 'Unknown'}`,
+			message: serverName
+				? `Server: ${serverName}\n\`\`\`json\n${JSON.stringify(args, null, 2)}\n\`\`\``
+				: `\`\`\`json\n${JSON.stringify(permissionRequest, null, 2)}\n\`\`\``,
+			confirmationType: 'basic'
+		}
+	};
+}
+
+/**
+ * Invokes a confirmation tool and returns a `PermissionRequestResult` based on the user's response.
+ */
+async function invokeConfirmationTool(
+	toolParams: CoreTerminalConfirmationToolParams | CoreConfirmationToolParams,
+	toolParentCallId: string | undefined,
+	toolsService: IToolsService,
+	toolInvocationToken: ChatParticipantToolToken,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<PermissionRequestResult> {
+	try {
+		const { tool, input } = toolParams;
+		const result = await toolsService.invokeTool(tool, { input, toolInvocationToken, subAgentInvocationId: toolParentCallId }, token);
+		const firstResultPart = result.content.at(0);
+		if (firstResultPart instanceof LanguageModelTextPart && typeof firstResultPart.value === 'string' && firstResultPart.value.toLowerCase() === 'yes') {
+			return { kind: 'approved' };
+		}
+	} catch (error) {
+		logService.error(`[CopilotCLISession] Permission request error: ${error}`);
+	}
+	return { kind: 'denied-interactively-by-user' };
+}
+
+/**
+ * Shows a generic interactive permission prompt to the user.
+ * Used as the fallback for permission kinds without a dedicated handler (url, memory, custom-tool, hook).
+ */
+export async function showInteractivePermissionPrompt(
+	permissionRequest: PermissionRequest,
+	toolParentCallId: string | undefined,
+	toolsService: IToolsService,
+	toolInvocationToken: ChatParticipantToolToken,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<PermissionRequestResult> {
+	const toolParams: CoreConfirmationToolParams = {
+		tool: ToolName.CoreConfirmationTool,
+		input: {
+			title: 'Copilot CLI Permission Request',
+			message: codeBlock(permissionRequest),
+			confirmationType: 'basic'
+		}
+	};
+	return invokeConfirmationTool(toolParams, toolParentCallId, toolsService, toolInvocationToken, logService, token);
+}
+
+/**
+ * Checks whether a file belongs to the session's workspace, working directory,
+ * or repository (when using worktrees).
+ */
+export function isFileFromSessionWorkspace(file: URI, workspaceInfo: IWorkspaceInfo): boolean {
+	const workingDirectory = getWorkingDirectory(workspaceInfo);
+	if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(file, workingDirectory)) {
 		return true;
 	}
-	const { tool, input } = toolParams;
-	const result = await toolsService.invokeTool(tool, { input, toolInvocationToken, subAgentInvocationId: toolParentCallId }, token);
+	if (workspaceInfo.folder && extUriBiasedIgnorePathCase.isEqualOrParent(file, workspaceInfo.folder)) {
+		return true;
+	}
+	// Only if we have a worktree should we check the repository.
+	// As this means the user created a worktree and we have a repository.
+	// & if the worktree is automatically trusted, then so is the repository as we created the worktree from that.
+	if (workspaceInfo.worktree && workspaceInfo.repository && extUriBiasedIgnorePathCase.isEqualOrParent(file, workspaceInfo.repository)) {
+		return true;
+	}
+	return false;
+}
 
-	const firstResultPart = result.content.at(0);
-	return (firstResultPart instanceof LanguageModelTextPart && firstResultPart.value === 'yes');
+/**
+ * Starts edit tracking if we have a tool call and a stream.
+ * This ensures the UI shows the edit-in-progress indicator and waits for core to acknowledge the edit.
+ */
+async function trackEditIfNeeded(editTracker: ExternalEditTracker, toolCall: ToolCall | undefined, editFile: URI, stream: ChatResponseStream | undefined, logService: ILogService): Promise<void> {
+	if (toolCall && stream) {
+		try {
+			await editTracker.trackEdit(toolCall.toolCallId, [editFile], stream);
+		} catch (error) {
+			logService.error(`[CopilotCLISession] Failed to track edit for toolCallId ${toolCall.toolCallId}: ${error}`);
+		}
+	}
 }
 
 export async function requiresFileEditconfirmation(instaService: IInstantiationService, permissionRequest: PermissionRequest, toolCall?: ToolCall | undefined, workingDirectory?: URI): Promise<boolean> {
@@ -124,90 +416,13 @@ async function getDetailsForFileEditPermissionRequest(accessor: ServicesAccessor
 	}
 }
 
-export function getFileBeingEdited(permissionRequest: PermissionRequest, toolCall?: ToolCall) {
-	if (permissionRequest.kind !== 'write') {
-		return;
-	}
+export function getFileBeingEdited(permissionRequest: Extract<PermissionRequest, { kind: 'write' }>, toolCall?: ToolCall) {
 	// Get hold of file thats being edited if this is a edit tool call (requiring write permissions).
 	const editFiles = toolCall ? getAffectedUrisForEditTool(toolCall) : undefined;
 	// Sometimes we don't get a tool call id for the edit permission request
 	const editFile = editFiles && editFiles.length ? editFiles[0] : (permissionRequest.fileName ? URI.file(permissionRequest.fileName) : undefined);
 	return editFile;
 }
-/**
- * Pure function mapping a Copilot CLI permission request -> tool invocation params.
- * Keeps logic out of session class for easier unit testing.
- */
-export async function getConfirmationToolParams(instaService: IInstantiationService, permissionRequest: PermissionRequest, toolCall?: ToolCall, workingDirectory?: URI, isWindows?: boolean): Promise<CoreTerminalConfirmationToolParams | CoreConfirmationToolParams | undefined> {
-	if (permissionRequest.kind === 'shell') {
-		isWindows = typeof isWindows === 'boolean' ? isWindows : platform() === 'win32';
-		const isPowershell = isWindows;
-		const fullCommandText = permissionRequest.fullCommandText || '';
-		const userFriendlyCommand = fullCommandText ? getCdPresentationOverrides(fullCommandText, isPowershell, workingDirectory)?.commandLine : undefined;
-		const command = userFriendlyCommand ?? fullCommandText;
-		return {
-			tool: ToolName.CoreTerminalConfirmationTool,
-			input: {
-				message: permissionRequest.intention || command || codeBlock(permissionRequest),
-				command,
-				isBackground: false
-			}
-		};
-	}
-
-	if (permissionRequest.kind === 'write') {
-		const workspaceService = instaService.invokeFunction(accessor => accessor.get(IWorkspaceService));
-		const editFile = getFileBeingEdited(permissionRequest, toolCall);
-
-		// Determine the working/workspace folder this file belongs to.
-		let workspaceFolderForFileBeingEdited: URI | undefined;
-		if (editFile) {
-			workspaceFolderForFileBeingEdited = workspaceService.getWorkspaceFolder(editFile);
-			if (workingDirectory && extUriBiasedIgnorePathCase.isEqualOrParent(editFile, workingDirectory)) {
-				workspaceFolderForFileBeingEdited = workingDirectory;
-			}
-		}
-		return getFileEditConfirmationToolParams(instaService, permissionRequest, toolCall, workspaceFolderForFileBeingEdited);
-	}
-
-	if (permissionRequest.kind === 'mcp') {
-		const serverName = permissionRequest.serverName as string | undefined;
-		const toolTitle = permissionRequest.toolTitle as string | undefined;
-		const toolName = permissionRequest.toolName as string | undefined;
-		const args = permissionRequest.args;
-		return {
-			tool: ToolName.CoreConfirmationTool,
-			input: {
-				title: toolTitle || `MCP Tool: ${toolName || 'Unknown'}`,
-				message: serverName
-					? `Server: ${serverName}\n\`\`\`json\n${JSON.stringify(args, null, 2)}\n\`\`\``
-					: `\`\`\`json\n${JSON.stringify(permissionRequest, null, 2)}\n\`\`\``,
-				confirmationType: 'basic'
-			}
-		};
-	}
-
-	if (permissionRequest.kind === 'read' && typeof permissionRequest.intention === 'string' && permissionRequest.intention) {
-		return {
-			tool: ToolName.CoreConfirmationTool,
-			input: {
-				title: 'Read file(s)',
-				message: permissionRequest.intention,
-				confirmationType: 'basic'
-			}
-		};
-	}
-
-	return {
-		tool: ToolName.CoreConfirmationTool,
-		input: {
-			title: 'Copilot CLI Permission Request',
-			message: codeBlock(permissionRequest),
-			confirmationType: 'basic'
-		}
-	};
-}
-
 function codeBlock(obj: Record<string, unknown>): string {
 	return `\n\n\`\`\`\n${JSON.stringify(obj, null, 2)}\n\`\`\``;
 }

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { assert } from '../../../../../util/vs/base/common/assert';
 import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { ToolName } from '../../../../tools/common/toolNames';
-import { getConfirmationToolParams, PermissionRequest, requiresFileEditconfirmation } from '../permissionHelpers';
+import { buildMcpConfirmationParams, buildShellConfirmationParams, PermissionRequest, requiresFileEditconfirmation } from '../permissionHelpers';
 
 
 describe('CopilotCLI permissionHelpers', () => {
@@ -25,332 +24,171 @@ describe('CopilotCLI permissionHelpers', () => {
 		disposables.clear();
 	});
 
-	describe('getConfirmationToolParams', () => {
-		it('shell: uses intention over command text and sets terminal confirmation tool', async () => {
-			const req: PermissionRequest = { kind: 'shell', intention: 'List workspace files', fullCommandText: 'ls -la' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+	describe('buildShellConfirmationParams', () => {
+		it('shell: uses intention over command text and sets terminal confirmation tool', () => {
+			const req = { kind: 'shell', intention: 'List workspace files', fullCommandText: 'ls -la' } as any;
+			const result = buildShellConfirmationParams(req, undefined);
 			expect(result.tool).toBe(ToolName.CoreTerminalConfirmationTool);
 			expect(result.input.message).toBe('List workspace files');
 			expect(result.input.command).toBe('ls -la');
 			expect(result.input.isBackground).toBe(false);
 		});
 
-		it('shell: falls back to fullCommandText when no intention', async () => {
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: 'echo "hi"' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+		it('shell: falls back to fullCommandText when no intention', () => {
+			const req = { kind: 'shell', fullCommandText: 'echo "hi"' } as any;
+			const result = buildShellConfirmationParams(req, undefined);
 			expect(result.tool).toBe(ToolName.CoreTerminalConfirmationTool);
 			expect(result.input.message).toBe('echo "hi"');
 			expect(result.input.command).toBe('echo "hi"');
 		});
 
-		it('shell: falls back to codeBlock when neither intention nor command text provided', async () => {
-			const req: PermissionRequest = { kind: 'shell' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+		it('shell: falls back to codeBlock when neither intention nor command text provided', () => {
+			const req = { kind: 'shell' } as any;
+			const result = buildShellConfirmationParams(req, undefined);
 			expect(result.tool).toBe(ToolName.CoreTerminalConfirmationTool);
 			// codeBlock starts with two newlines then ```
 			expect(result.input.message).toMatch(/^\n\n```/);
 		});
 
-		it('shell: strips cd prefix from command when matching workingDirectory on bash', async () => {
+		it('shell: strips cd prefix from command when matching workingDirectory on bash', () => {
 			const workingDirectory = URI.file('/workspace');
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: `cd ${workingDirectory.fsPath} && npm test` } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText: `cd ${workingDirectory.fsPath} && npm test` } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, false);
 			expect(result.input.command).toBe('npm test');
 			expect(result.input.message).toBe('npm test');
 		});
 
-		it('shell: keeps full command when cd prefix does not match workingDirectory on bash', async () => {
+		it('shell: keeps full command when cd prefix does not match workingDirectory on bash', () => {
 			const fullCommandText = `cd ${URI.file('/other').fsPath} && npm test`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: fullCommandText } as any;
+			const req = { kind: 'shell', fullCommandText: fullCommandText } as any;
 			const workingDirectory = URI.file('/workspace');
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const result = buildShellConfirmationParams(req, workingDirectory, false);
 			expect(result.input.command).toBe(fullCommandText);
 			expect(result.input.message).toBe(fullCommandText);
 		});
 
-		it('shell: keeps full command with cd prefix when no workingDirectory', async () => {
+		it('shell: keeps full command with cd prefix when no workingDirectory', () => {
 			const fullCommandText = 'cd /workspace && npm test';
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, undefined, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText: fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, undefined, false);
 			expect(result.input.command).toBe(fullCommandText);
 			expect(result.input.message).toBe(fullCommandText);
 		});
 
-		it('shell: plain command without cd prefix is unchanged', async () => {
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: 'npm test' } as any;
+		it('shell: plain command without cd prefix is unchanged', () => {
+			const req = { kind: 'shell', fullCommandText: 'npm test' } as any;
 			const workingDirectory = URI.file('/workspace');
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const result = buildShellConfirmationParams(req, workingDirectory, false);
 			expect(result.input.command).toBe('npm test');
 			expect(result.input.message).toBe('npm test');
 		});
 
-		it('shell: intention takes priority in message even when cd prefix is stripped', async () => {
+		it('shell: intention takes priority in message even when cd prefix is stripped', () => {
 			const workingDirectory = URI.file('/workspace');
 			const fullCommandText = `cd ${workingDirectory.fsPath} && npm test`;
-			const req: PermissionRequest = { kind: 'shell', intention: 'Run unit tests', fullCommandText: fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', intention: 'Run unit tests', fullCommandText: fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, false);
 			expect(result.input.message).toBe('Run unit tests');
 			expect(result.input.command).toBe('npm test');
 		});
 
-		it('shell: strips Set-Location prefix when matching workingDirectory on Windows', async () => {
+		it('shell: strips Set-Location prefix when matching workingDirectory on Windows', () => {
 			const workingDirectory = URI.file('C:\\workspace');
 			const fullCommandText = `Set-Location ${workingDirectory.fsPath}; npm test`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, true);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText: fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, true);
 			expect(result.input.command).toBe('npm test');
 			expect(result.input.message).toBe('npm test');
 		});
 
-		it('shell: strips cd /d prefix when matching workingDirectory on Windows', async () => {
+		it('shell: strips cd /d prefix when matching workingDirectory on Windows', () => {
 			const workingDirectory = URI.file('C:\\project');
 			const fullCommandText = `cd /d ${workingDirectory.fsPath} && npm start`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, true);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, true);
 			expect(result.input.command).toBe('npm start');
 			expect(result.input.message).toBe('npm start');
 		});
 
-		it('shell: strips Set-Location -Path prefix when matching workingDirectory on Windows', async () => {
+		it('shell: strips Set-Location -Path prefix when matching workingDirectory on Windows', () => {
 			const workingDirectory = URI.file('C:\\project');
 			const fullCommandText = `Set-Location -Path ${workingDirectory.fsPath} && npm start`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, true);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, true);
 			expect(result.input.command).toBe('npm start');
 			expect(result.input.message).toBe('npm start');
 		});
 
-		it('shell: bash cd prefix not recognized when isWindows is true', async () => {
+		it('shell: bash cd prefix not recognized when isWindows is true', () => {
 			// On Windows, isPowershell=true, so bash-style `cd /workspace &&` may not match the powershell regex
 			const workingDirectory = URI.file('/workspace');
 			const fullCommandText = `cd ${workingDirectory.fsPath} && npm test`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, true);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, true);
 			// Powershell regex does match `cd <dir> &&` pattern (cd without /d), so stripping still happens
 			expect(result.input.command).toBe('npm test');
 		});
 
-		it('shell: Windows Set-Location not recognized when isWindows is false', async () => {
+		it('shell: Windows Set-Location not recognized when isWindows is false', () => {
 			// On non-Windows, isPowershell=false, so Set-Location is not recognized
 			const workingDirectory = URI.file('C:\\workspace');
 			const fullCommandText = `Set-Location -Path ${workingDirectory.fsPath}; npm test`;
-			const req: PermissionRequest = { kind: 'shell', fullCommandText } as any;
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory, false);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreTerminalConfirmationTool) {
-				expect.fail('Expected CoreTerminalConfirmationTool');
-			}
+			const req = { kind: 'shell', fullCommandText } as any;
+			const result = buildShellConfirmationParams(req, workingDirectory, false);
 			// Bash regex doesn't recognize Set-Location, so full command is kept
 			expect(result.input.command).toBe(fullCommandText);
 		});
+	});
 
-		it('write: uses intention as title and fileName for message', async () => {
-			const req: PermissionRequest = { kind: 'write', intention: 'Modify configuration', fileName: 'config.json' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
+	describe('buildMcpConfirmationParams', () => {
+		it('mcp: formats with serverName, toolTitle and args JSON', () => {
+			const req = { kind: 'mcp', serverName: 'files', toolTitle: 'List Files', toolName: 'list', args: { path: '/tmp' } } as any;
+			const result = buildMcpConfirmationParams(req as Extract<PermissionRequest, { kind: 'mcp' }>);
 			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-			expect(result.input.title).toBe('Allow edits to sensitive files?');
-			expect(result.input.message).toContain(`The model wants to edit`);
-			expect(result.input.confirmationType).toBe('basic');
-		});
-
-		it('write: falls back to default title and codeBlock message when no intention and no fileName', async () => {
-			const req: PermissionRequest = { kind: 'write' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			expect(result).toBeUndefined();
-		});
-
-		it('write: no confirmation when workingDirectory covers the file', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/workspace/src/foo.ts').fsPath, diff: '', intention: '' } as any;
-			const workingDirectory = URI.file('/workspace');
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory);
-			expect(result).toBeUndefined();
-		});
-
-		it('write: requires confirmation when workingDirectory does not cover the file', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/other/path/foo.ts').fsPath, diff: '', intention: '' } as any;
-			const workingDirectory = URI.file('/workspace');
-			const result = await getConfirmationToolParams(instaService, req, undefined, workingDirectory);
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-		});
-
-		it('write: requires confirmation when no workingDirectory and file is outside workspace', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/some/external/file.ts').fsPath, diff: '', intention: '' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-		});
-
-		it('mcp: formats with serverName, toolTitle and args JSON', async () => {
-			const req: PermissionRequest = { kind: 'mcp', serverName: 'files', toolTitle: 'List Files', toolName: 'list', args: { path: '/tmp' } } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
 			expect(result.input.title).toBe('List Files');
 			expect(result.input.message).toContain('Server: files');
 			expect(result.input.message).toContain('"path": "/tmp"');
 		});
 
-		it('mcp: falls back to generated title and full JSON when no serverName', async () => {
-			const req: PermissionRequest = { kind: 'mcp', toolName: 'info', args: { detail: true } } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
+		it('mcp: falls back to generated title and full JSON when no serverName', () => {
+			const req = { kind: 'mcp', toolName: 'info', args: { detail: true } } as any;
+			const result = buildMcpConfirmationParams(req as Extract<PermissionRequest, { kind: 'mcp' }>);
 			expect(result.input.title).toBe('MCP Tool: info');
 			expect(result.input.message).toMatch(/```json/);
 			expect(result.input.message).toContain('"detail": true');
 		});
 
-		it('mcp: uses Unknown when neither toolTitle nor toolName provided', async () => {
-			const req: PermissionRequest = { kind: 'mcp', args: {} } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
+		it('mcp: uses Unknown when neither toolTitle nor toolName provided', () => {
+			const req = { kind: 'mcp', args: {} } as any;
+			const result = buildMcpConfirmationParams(req as Extract<PermissionRequest, { kind: 'mcp' }>);
 			expect(result.input.title).toBe('MCP Tool: Unknown');
-		});
-
-		it('read: returns specialized title and intention message', async () => {
-			const req: PermissionRequest = { kind: 'read', intention: 'Read 2 files', path: '/tmp/a' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
-			expect(result.input.title).toBe('Read file(s)');
-			expect(result.input.message).toBe('Read 2 files');
-		});
-
-		it('read: falls through to default when intention empty string', async () => {
-			const req: PermissionRequest = { kind: 'read', intention: '', path: '/tmp/a' } as any;
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
-			expect(result.input.title).toBe('Copilot CLI Permission Request');
-			expect(result.input.message).toMatch(/"kind": "read"/);
-		});
-
-		it('default: unknown kind uses generic confirmation and wraps JSON in code block', async () => {
-			const req: any = { kind: 'some_new_kind', extra: 1 };
-			const result = await getConfirmationToolParams(instaService, req);
-			assert(!!result);
-			if (result.tool !== ToolName.CoreConfirmationTool) {
-				expect.fail('Expected CoreConfirmationTool');
-			}
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-			expect(result.input.title).toBe('Copilot CLI Permission Request');
-			expect(result.input.message).toMatch(/^\n\n```/);
-			expect(result.input.message).toContain('"some_new_kind"');
-		});
-	});
-
-	describe('getConfirmationToolParams', () => {
-		it('maps shell requests to terminal confirmation tool', async () => {
-			const result = await getConfirmationToolParams(instaService, { kind: 'shell', fullCommandText: 'rm -rf /tmp/test', canOfferSessionApproval: true, commands: [], hasWriteFileRedirection: true, intention: '', possiblePaths: [], possibleUrls: [] });
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreTerminalConfirmationTool);
-		});
-
-		it('maps write requests with filename', async () => {
-			const result = await getConfirmationToolParams(instaService, { kind: 'write', fileName: 'foo.ts', diff: '', intention: '' });
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
-			const input = result.input as any;
-			expect(input.message).toContain('The model wants to edit');
-		});
-
-		it('maps mcp requests', async () => {
-			const result = await getConfirmationToolParams(instaService, { kind: 'mcp', serverName: 'srv', toolTitle: 'Tool', toolName: 'run', args: { a: 1 }, readOnly: false });
-			assert(!!result);
-			expect(result.tool).toBe(ToolName.CoreConfirmationTool);
 		});
 	});
 
 	describe('requiresFileEditconfirmation', () => {
 		it('returns false for non-write requests', async () => {
-			const req: PermissionRequest = { kind: 'shell', fullCommandText: 'ls' } as any;
+			const req = { kind: 'shell', fullCommandText: 'ls' } as any;
 			expect(await requiresFileEditconfirmation(instaService, req)).toBe(false);
 		});
 
 		it('returns false when no fileName is provided', async () => {
-			const req: PermissionRequest = { kind: 'write', intention: 'edit' } as any;
+			const req = { kind: 'write', intention: 'edit' } as any;
 			expect(await requiresFileEditconfirmation(instaService, req)).toBe(false);
 		});
 
 		it('requires confirmation for file outside workspace when no workingDirectory', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/some/path/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const req = { kind: 'write', fileName: URI.file('/some/path/foo.ts').fsPath, diff: '', intention: '' } as any;
 			expect(await requiresFileEditconfirmation(instaService, req)).toBe(true);
 		});
 
 		it('does not require confirmation when workingDirectory covers the file', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/workspace/src/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const req = { kind: 'write', fileName: URI.file('/workspace/src/foo.ts').fsPath, diff: '', intention: '' } as any;
 			const workingDirectory = URI.file('/workspace');
 			expect(await requiresFileEditconfirmation(instaService, req, undefined, workingDirectory)).toBe(false);
 		});
 
 		it('does not require confirmation when workingDirectory is provided', async () => {
-			const req: PermissionRequest = { kind: 'write', fileName: URI.file('/workspace/other/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const req = { kind: 'write', fileName: URI.file('/workspace/other/foo.ts').fsPath, diff: '', intention: '' } as any;
 			const workingDirectory = URI.file('/workspace');
 			// workingDirectory callback always returns the same folder, treating all files as in-workspace
 			expect(await requiresFileEditconfirmation(instaService, req, undefined, workingDirectory)).toBe(false);

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/permissionHelpers.spec.ts
@@ -3,13 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CancellationToken, ChatParticipantToolToken } from 'vscode';
+import { ILogService } from '../../../../../platform/log/common/logService';
+import { IWorkspaceService } from '../../../../../platform/workspace/common/workspaceService';
+import { CancellationTokenSource } from '../../../../../util/vs/base/common/cancellation';
 import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { URI } from '../../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
+import { LanguageModelTextPart, LanguageModelToolResult2 } from '../../../../../vscodeTypes';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
 import { ToolName } from '../../../../tools/common/toolNames';
-import { buildMcpConfirmationParams, buildShellConfirmationParams, PermissionRequest, requiresFileEditconfirmation } from '../permissionHelpers';
+import { IToolsService } from '../../../../tools/common/toolsService';
+import { ExternalEditTracker } from '../../../common/externalEditTracker';
+import { IWorkspaceInfo } from '../../../common/workspaceInfo';
+import { ICopilotCLIImageSupport } from '../copilotCLIImageSupport';
+import { buildMcpConfirmationParams, buildShellConfirmationParams, handleReadPermission, handleWritePermission, isFileFromSessionWorkspace, PermissionRequest, requiresFileEditconfirmation, showInteractivePermissionPrompt } from '../permissionHelpers';
 
 
 describe('CopilotCLI permissionHelpers', () => {
@@ -192,6 +201,389 @@ describe('CopilotCLI permissionHelpers', () => {
 			const workingDirectory = URI.file('/workspace');
 			// workingDirectory callback always returns the same folder, treating all files as in-workspace
 			expect(await requiresFileEditconfirmation(instaService, req, undefined, workingDirectory)).toBe(false);
+		});
+	});
+
+	describe('isFileFromSessionWorkspace', () => {
+		it('returns true for file inside the working directory (folder)', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: URI.file('/workspace'),
+				repository: undefined,
+				worktree: undefined,
+				worktreeProperties: undefined,
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/workspace/src/foo.ts'), workspaceInfo)).toBe(true);
+		});
+
+		it('returns false for file outside all known directories', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: URI.file('/workspace'),
+				repository: undefined,
+				worktree: undefined,
+				worktreeProperties: undefined,
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/other/path/foo.ts'), workspaceInfo)).toBe(false);
+		});
+
+		it('returns true for file inside the worktree', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: URI.file('/workspace'),
+				repository: URI.file('/repo'),
+				worktree: URI.file('/worktree'),
+				worktreeProperties: { autoCommit: true, baseCommit: 'abc', branchName: 'test', repositoryPath: '/repo', worktreePath: '/worktree', version: 1 },
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/worktree/src/foo.ts'), workspaceInfo)).toBe(true);
+		});
+
+		it('returns true for file inside repository when worktree exists', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: URI.file('/workspace'),
+				repository: URI.file('/repo'),
+				worktree: URI.file('/worktree'),
+				worktreeProperties: { autoCommit: true, baseCommit: 'abc', branchName: 'test', repositoryPath: '/repo', worktreePath: '/worktree', version: 1 },
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/repo/src/foo.ts'), workspaceInfo)).toBe(true);
+		});
+
+		it('returns false for file inside repository when no worktree exists', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: URI.file('/workspace'),
+				repository: URI.file('/repo'),
+				worktree: undefined,
+				worktreeProperties: undefined,
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/repo/src/foo.ts'), workspaceInfo)).toBe(false);
+		});
+
+		it('returns false when workspaceInfo has no folder, no repository, no worktree', () => {
+			const workspaceInfo: IWorkspaceInfo = {
+				folder: undefined,
+				repository: undefined,
+				worktree: undefined,
+				worktreeProperties: undefined,
+			};
+			expect(isFileFromSessionWorkspace(URI.file('/any/file.ts'), workspaceInfo)).toBe(false);
+		});
+	});
+
+	describe('handleReadPermission', () => {
+		let logService: ILogService;
+		let token: CancellationToken;
+		let tokenSource: CancellationTokenSource;
+
+		beforeEach(() => {
+			const services = disposables.add(createExtensionUnitTestingServices());
+			const accessor = services.createTestingAccessor();
+			logService = accessor.get(ILogService);
+			tokenSource = new CancellationTokenSource();
+			token = tokenSource.token;
+		});
+
+		afterEach(() => {
+			tokenSource.dispose();
+		});
+
+		function makeWorkspaceInfo(folder?: URI, worktree?: URI, repository?: URI): IWorkspaceInfo {
+			return {
+				folder,
+				repository,
+				worktree,
+				worktreeProperties: worktree ? { autoCommit: true, baseCommit: 'abc', branchName: 'test', repositoryPath: repository?.fsPath ?? '', worktreePath: worktree.fsPath, version: 1 } : undefined,
+			};
+		}
+
+		function makeImageSupport(trusted: boolean): ICopilotCLIImageSupport {
+			return { _serviceBrand: undefined, storeImage: vi.fn(), isTrustedImage: () => trusted };
+		}
+
+		function makeWorkspaceService(folders: URI[]): IWorkspaceService {
+			return { getWorkspaceFolder: (resource: URI) => folders.find(f => resource.fsPath.startsWith(f.fsPath)) } as unknown as IWorkspaceService;
+		}
+
+		function makeToolsService(response: string): IToolsService {
+			return {
+				invokeTool: vi.fn(async () => new LanguageModelToolResult2([new LanguageModelTextPart(response)])),
+			} as unknown as IToolsService;
+		}
+
+		it('auto-approves trusted images', async () => {
+			const req = { kind: 'read', path: '/images/cat.png' } as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(true),
+				makeWorkspaceInfo(), makeWorkspaceService([]), makeToolsService('no'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('auto-approves files in session workspace (folder)', async () => {
+			const req = { kind: 'read', path: '/workspace/src/file.ts' } as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(URI.file('/workspace')), makeWorkspaceService([]),
+				makeToolsService('no'), undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('auto-approves files in a VS Code workspace folder', async () => {
+			const req = { kind: 'read', path: '/vscode-ws/src/file.ts' } as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(URI.file('/other')), makeWorkspaceService([URI.file('/vscode-ws')]),
+				makeToolsService('no'), undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('auto-approves attached files', async () => {
+			const filePath = '/external/attached.ts';
+			const req = { kind: 'read', path: filePath } as any;
+			const attachments = [{ type: 'file', path: filePath }] as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, attachments, makeImageSupport(false),
+				makeWorkspaceInfo(), makeWorkspaceService([]),
+				makeToolsService('no'), undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('falls back to confirmation tool for out-of-workspace reads and approves on "yes"', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'read', path: '/external/secret.txt', intention: 'Read config' } as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(URI.file('/workspace')), makeWorkspaceService([]),
+				toolsService, undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+			expect(toolsService.invokeTool).toHaveBeenCalled();
+		});
+
+		it('denies when confirmation tool returns non-"yes"', async () => {
+			const toolsService = makeToolsService('no');
+			const req = { kind: 'read', path: '/external/secret.txt' } as any;
+			const result = await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(URI.file('/workspace')), makeWorkspaceService([]),
+				toolsService, undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('denied-interactively-by-user');
+		});
+
+		it('uses intention as message when available', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'read', path: '/external/file.txt', intention: 'Read 3 config files' } as any;
+			await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(), makeWorkspaceService([]),
+				toolsService, undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			const callArgs = (toolsService.invokeTool as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(callArgs[0]).toBe(ToolName.CoreConfirmationTool);
+			expect(callArgs[1].input.message).toBe('Read 3 config files');
+		});
+
+		it('falls back to path when no intention', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'read', path: '/external/file.txt' } as any;
+			await handleReadPermission(
+				'session-1', req, undefined, [], makeImageSupport(false),
+				makeWorkspaceInfo(), makeWorkspaceService([]),
+				toolsService, undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			const callArgs = (toolsService.invokeTool as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(callArgs[1].input.message).toBe('/external/file.txt');
+		});
+	});
+
+	describe('handleWritePermission', () => {
+		let logService: ILogService;
+		let token: CancellationToken;
+		let tokenSource: CancellationTokenSource;
+		let editTracker: ExternalEditTracker;
+
+		beforeEach(() => {
+			const services = disposables.add(createExtensionUnitTestingServices());
+			const accessor = services.createTestingAccessor();
+			logService = accessor.get(ILogService);
+			tokenSource = new CancellationTokenSource();
+			token = tokenSource.token;
+			editTracker = new ExternalEditTracker();
+			editTracker.trackEdit = vi.fn(async () => { });
+		});
+
+		afterEach(() => {
+			tokenSource.dispose();
+		});
+
+		function makeWorkspaceInfo(opts: { folder?: URI; worktree?: URI; repository?: URI; worktreeProperties?: any } = {}): IWorkspaceInfo {
+			return {
+				folder: opts.folder,
+				repository: opts.repository,
+				worktree: opts.worktree,
+				worktreeProperties: opts.worktreeProperties,
+			};
+		}
+
+		function makeWorkspaceService(folders: URI[]): IWorkspaceService {
+			return { getWorkspaceFolder: (resource: URI) => folders.find(f => resource.fsPath.startsWith(f.fsPath)) } as unknown as IWorkspaceService;
+		}
+
+		function makeToolsService(response: string): IToolsService {
+			return {
+				invokeTool: vi.fn(async () => new LanguageModelToolResult2([new LanguageModelTextPart(response)])),
+			} as unknown as IToolsService;
+		}
+
+		it('auto-approves writes in workspace folder for non-protected files', async () => {
+			const wsFolder = URI.file('/workspace');
+			const req = { kind: 'write', fileName: URI.file('/workspace/src/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const result = await handleWritePermission(
+				'session-1', req, undefined, undefined, undefined, editTracker,
+				makeWorkspaceInfo({ folder: wsFolder }),
+				makeWorkspaceService([wsFolder]),
+				instaService, makeToolsService('no'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('auto-approves writes in working directory when isolation is enabled', async () => {
+			const worktree = URI.file('/worktree');
+			const req = { kind: 'write', fileName: URI.file('/worktree/src/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const result = await handleWritePermission(
+				'session-1', req, undefined, undefined, undefined, editTracker,
+				makeWorkspaceInfo({
+					folder: URI.file('/workspace'),
+					worktree,
+					worktreeProperties: { autoCommit: true, baseCommit: 'abc', branchName: 'test', repositoryPath: '/repo', worktreePath: '/worktree', version: 1 },
+				}),
+				makeWorkspaceService([]),
+				instaService, makeToolsService('no'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+		});
+
+		it('falls back to confirmation for writes outside workspace', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'write', fileName: URI.file('/external/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const result = await handleWritePermission(
+				'session-1', req, undefined, undefined, undefined, editTracker,
+				makeWorkspaceInfo({ folder: URI.file('/workspace') }),
+				makeWorkspaceService([URI.file('/workspace')]),
+				instaService, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+			expect(toolsService.invokeTool).toHaveBeenCalled();
+		});
+
+		it('denies writes outside workspace when user declines confirmation', async () => {
+			const toolsService = makeToolsService('no');
+			const req = { kind: 'write', fileName: URI.file('/external/foo.ts').fsPath, diff: '', intention: '' } as any;
+			const result = await handleWritePermission(
+				'session-1', req, undefined, undefined, undefined, editTracker,
+				makeWorkspaceInfo({ folder: URI.file('/workspace') }),
+				makeWorkspaceService([URI.file('/workspace')]),
+				instaService, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('denied-interactively-by-user');
+		});
+
+		it('auto-approves when no file can be determined (no fileName, no toolCall)', async () => {
+			const req = { kind: 'write', intention: 'some write' } as any;
+			const result = await handleWritePermission(
+				'session-1', req, undefined, undefined, undefined, editTracker,
+				makeWorkspaceInfo({ folder: URI.file('/workspace') }),
+				makeWorkspaceService([URI.file('/workspace')]),
+				instaService, makeToolsService('no'),
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			// No file => getFileEditConfirmationToolParams returns undefined => auto-approve
+			expect(result.kind).toBe('approved');
+		});
+	});
+
+	describe('showInteractivePermissionPrompt', () => {
+		let logService: ILogService;
+		let token: CancellationToken;
+		let tokenSource: CancellationTokenSource;
+
+		beforeEach(() => {
+			const services = disposables.add(createExtensionUnitTestingServices());
+			const accessor = services.createTestingAccessor();
+			logService = accessor.get(ILogService);
+			tokenSource = new CancellationTokenSource();
+			token = tokenSource.token;
+		});
+
+		afterEach(() => {
+			tokenSource.dispose();
+		});
+
+		function makeToolsService(response: string): IToolsService {
+			return {
+				invokeTool: vi.fn(async () => new LanguageModelToolResult2([new LanguageModelTextPart(response)])),
+			} as unknown as IToolsService;
+		}
+
+		it('approves when user confirms with "yes"', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'url', url: 'https://example.com' } as any;
+			const result = await showInteractivePermissionPrompt(
+				req, undefined, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
+			const callArgs = (toolsService.invokeTool as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(callArgs[0]).toBe(ToolName.CoreConfirmationTool);
+			expect(callArgs[1].input.title).toBe('Copilot CLI Permission Request');
+		});
+
+		it('denies when user declines', async () => {
+			const toolsService = makeToolsService('no');
+			const req = { kind: 'url', url: 'https://example.com' } as any;
+			const result = await showInteractivePermissionPrompt(
+				req, undefined, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('denied-interactively-by-user');
+		});
+
+		it('denies when invokeTool throws', async () => {
+			const toolsService = {
+				invokeTool: vi.fn(async () => { throw new Error('tool failure'); }),
+			} as unknown as IToolsService;
+			const req = { kind: 'url', url: 'https://example.com' } as any;
+			const result = await showInteractivePermissionPrompt(
+				req, undefined, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('denied-interactively-by-user');
+		});
+
+		it('passes toolParentCallId as subAgentInvocationId', async () => {
+			const toolsService = makeToolsService('yes');
+			const req = { kind: 'url', url: 'https://example.com' } as any;
+			await showInteractivePermissionPrompt(
+				req, 'parent-123', toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			const callArgs = (toolsService.invokeTool as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(callArgs[1].subAgentInvocationId).toBe('parent-123');
+		});
+
+		it('approves with case-insensitive "Yes"', async () => {
+			const toolsService = makeToolsService('Yes');
+			const req = { kind: 'url', url: 'https://example.com' } as any;
+			const result = await showInteractivePermissionPrompt(
+				req, undefined, toolsService,
+				undefined as unknown as ChatParticipantToolToken, logService, token,
+			);
+			expect(result.kind).toBe('approved');
 		});
 	});
 });


### PR DESCRIPTION
Improve permission handling by ensuring deferred repository hooks are loaded during session creation in the Copilot CLI. This change enhances the overall functionality and responsiveness of the CLI. Testing can be done by initiating sessions and verifying that the hooks are correctly loaded.

