### PR TITLE
SCM: fix singular/plural condition for quick diff change count label

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
@@ -271,12 +271,12 @@ class QuickDiffWidget extends PeekViewWidget {
 			const label = this.model.quickDiffs
 				.find(quickDiff => quickDiff.id === this._providerId)?.label ?? '';
 
-			detail = this.model.changes.length > 1
+			detail = providerChanges.length > 1
 				? nls.localize('changes', "{0} - {1} of {2} changes", label, providerIndex + 1, providerChanges.length)
 				: nls.localize('change', "{0} - {1} of {2} change", label, providerIndex + 1, providerChanges.length);
 			this.dropdownContainer!.style.display = 'none';
 		} else {
-			detail = this.model.changes.length > 1
+			detail = providerChanges.length > 1
 				? nls.localize('multiChanges', "{0} of {1} changes", providerIndex + 1, providerChanges.length)
 				: nls.localize('multiChange', "{0} of {1} change", providerIndex + 1, providerChanges.length);
 			this.dropdownContainer!.style.display = 'inherit';


### PR DESCRIPTION
Fixes #310441

## What

Changed the condition for singular/plural form of "change" in the quick diff widget from `this.model.changes.length > 1` to `providerChanges.length > 1` in two places (lines 274 and 279).

## Why

The format string displays `providerChanges.length` as the count (`{2}`), but the condition that chose "change" vs "changes" was checking `this.model.changes.length` — the total across **all** providers, not the current provider.

When a file has changes from two providers where Provider A has 2 changes and Provider B has 1 change, navigating to Provider B's change showed **"ProviderB - 1 of 1 changes"** (grammatically wrong plural) instead of **"ProviderB - 1 of 1 change"**.

The condition must match the count being displayed, which is `providerChanges.length`.

## Testing

- Reproduced with two SCM providers, one having 1 change and another having 2+ changes
- After fix: singular "change" is used when `providerChanges.length === 1`, plural "changes" when `providerChanges.length > 1`
- Single-provider scenarios are unaffected (both conditions would agree)