### PR TITLE
Extensions: fix typo and plural in uninstall dependency error messages

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -930,11 +930,11 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				return nls.localize('twoDependentsError', "Cannot uninstall '{0}' extension. '{1}' and '{2}' extensions depend on this.",
 					extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name, dependents[1].manifest.displayName || dependents[1].manifest.name);
 			}
-			return nls.localize('multipleDependentsError', "Cannot uninstall '{0}' extension. '{1}', '{2}' and other extension depend on this.",
+			return nls.localize('multipleDependentsError', "Cannot uninstall '{0}' extension. '{1}', '{2}' and other extensions depend on this.",
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name, dependents[1].manifest.displayName || dependents[1].manifest.name);
 		}
 		if (dependents.length === 1) {
-			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension . It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
+			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependingExtension.manifest.displayName
 			|| dependingExtension.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name);
 		}


### PR DESCRIPTION
Fixes #310443

## What

Two string fixes in `src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts`:

1. **Extra space before period** (line 937): `"extension . It"` → `"extension. It"`
2. **Wrong plural** (line 933): `"other extension depend"` → `"other extensions depend"`

## Why

- Bug 1: There is a spurious space character before the period in `singleIndirectDependentError`. The two-dependent (`twoIndirectDependentsError`) and many-dependent (`multipleIndirectDependentsError`) cases do not have this space.
- Bug 2: `multipleDependentsError` uses the singular "extension" where it should use "extensions" to agree with "other [extensions]". The two-dependent case (`twoDependentsError`) correctly uses "extensions" (plural), making this an inconsistency.

## Testing

These strings appear in error dialogs when a user tries to uninstall an extension that other extensions depend on. Verified by reading the code path — no behavioral change, only string correction.