### PR TITLE
Notebook: fix duplicate word in cell toolbar location setting description

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},


### PR DESCRIPTION
Fixes #310445

## What

Removed the duplicate word "for" from the `notebook.cellToolbarLocation` additional property description.

**Before:** `"Configure the cell toolbar position for for specific file types"`  
**After:** `"Configure the cell toolbar position for specific file types"`

## Why

The description was mistakenly written with the word "for" repeated twice. This appears in the Settings UI when hovering over the `notebook.cellToolbarLocation` object's additional properties.