### PR TITLE
Debug: fix missing word spaces in Disassembly View mnemonic titles

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -237,7 +237,7 @@ class OpenDisassemblyViewAction extends Action2 {
 			id: OpenDisassemblyViewAction.ID,
 			title: {
 				...nls.localize2('openDisassemblyView', "Open Disassembly View"),
-				mnemonicTitle: nls.localize({ key: 'miDisassemblyView', comment: ['&& denotes a mnemonic'] }, "&&DisassemblyView"),
+				mnemonicTitle: nls.localize({ key: 'miDisassemblyView', comment: ['&& denotes a mnemonic'] }, "&&Disassembly View"),
 			},
 			precondition: CONTEXT_FOCUSED_STACK_FRAME_HAS_INSTRUCTION_POINTER_REFERENCE,
 			menu: [
@@ -277,7 +277,7 @@ class ToggleDisassemblyViewSourceCodeAction extends Action2 {
 			id: ToggleDisassemblyViewSourceCodeAction.ID,
 			title: {
 				...nls.localize2('toggleDisassemblyViewSourceCode', "Toggle Source Code in Disassembly View"),
-				mnemonicTitle: nls.localize({ key: 'mitogglesource', comment: ['&& denotes a mnemonic'] }, "&&ToggleSource"),
+				mnemonicTitle: nls.localize({ key: 'mitogglesource', comment: ['&& denotes a mnemonic'] }, "&&Toggle Source"),
 			},
 			metadata: {
 				description: nls.localize2('toggleDisassemblyViewSourceCodeDescription', 'Shows or hides source code in disassembly')


### PR DESCRIPTION
Fixes #310447

## What

Fixed two `mnemonicTitle` strings in `debugEditorActions.ts` that were missing spaces between words:

- `"&&DisassemblyView"` → `"&&Disassembly View"` (for `OpenDisassemblyViewAction`)
- `"&&ToggleSource"` → `"&&Toggle Source"` (for `ToggleDisassemblyViewSourceCodeAction`)

## Why

`mnemonicTitle` strings appear in the native OS menu bar on Windows and Linux. Without spaces, they display as CamelCase single words ("DisassemblyView", "ToggleSource") rather than proper two-word phrases.

All other debug mnemonic titles use proper word spacing (e.g., `"Toggle &&Breakpoint"`, `"&&Enable All Breakpoints"`, `"Open &&Configurations"`). These two were inconsistent.