### PR TITLE
Breadcrumbs: add missing comma in symbol type filter descriptions

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -176,157 +176,157 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.file', "When enabled breadcrumbs show `file`-symbols.")
+			markdownDescription: localize('filteredTypes.file', "When enabled, breadcrumbs show `file`-symbols.")
 		},
 		'breadcrumbs.showModules': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.module', "When enabled breadcrumbs show `module`-symbols.")
+			markdownDescription: localize('filteredTypes.module', "When enabled, breadcrumbs show `module`-symbols.")
 		},
 		'breadcrumbs.showNamespaces': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.namespace', "When enabled breadcrumbs show `namespace`-symbols.")
+			markdownDescription: localize('filteredTypes.namespace', "When enabled, breadcrumbs show `namespace`-symbols.")
 		},
 		'breadcrumbs.showPackages': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.package', "When enabled breadcrumbs show `package`-symbols.")
+			markdownDescription: localize('filteredTypes.package', "When enabled, breadcrumbs show `package`-symbols.")
 		},
 		'breadcrumbs.showClasses': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.class', "When enabled breadcrumbs show `class`-symbols.")
+			markdownDescription: localize('filteredTypes.class', "When enabled, breadcrumbs show `class`-symbols.")
 		},
 		'breadcrumbs.showMethods': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.method', "When enabled breadcrumbs show `method`-symbols.")
+			markdownDescription: localize('filteredTypes.method', "When enabled, breadcrumbs show `method`-symbols.")
 		},
 		'breadcrumbs.showProperties': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.property', "When enabled breadcrumbs show `property`-symbols.")
+			markdownDescription: localize('filteredTypes.property', "When enabled, breadcrumbs show `property`-symbols.")
 		},
 		'breadcrumbs.showFields': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.field', "When enabled breadcrumbs show `field`-symbols.")
+			markdownDescription: localize('filteredTypes.field', "When enabled, breadcrumbs show `field`-symbols.")
 		},
 		'breadcrumbs.showConstructors': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.constructor', "When enabled breadcrumbs show `constructor`-symbols.")
+			markdownDescription: localize('filteredTypes.constructor', "When enabled, breadcrumbs show `constructor`-symbols.")
 		},
 		'breadcrumbs.showEnums': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.enum', "When enabled breadcrumbs show `enum`-symbols.")
+			markdownDescription: localize('filteredTypes.enum', "When enabled, breadcrumbs show `enum`-symbols.")
 		},
 		'breadcrumbs.showInterfaces': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.interface', "When enabled breadcrumbs show `interface`-symbols.")
+			markdownDescription: localize('filteredTypes.interface', "When enabled, breadcrumbs show `interface`-symbols.")
 		},
 		'breadcrumbs.showFunctions': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.function', "When enabled breadcrumbs show `function`-symbols.")
+			markdownDescription: localize('filteredTypes.function', "When enabled, breadcrumbs show `function`-symbols.")
 		},
 		'breadcrumbs.showVariables': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.variable', "When enabled breadcrumbs show `variable`-symbols.")
+			markdownDescription: localize('filteredTypes.variable', "When enabled, breadcrumbs show `variable`-symbols.")
 		},
 		'breadcrumbs.showConstants': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.constant', "When enabled breadcrumbs show `constant`-symbols.")
+			markdownDescription: localize('filteredTypes.constant', "When enabled, breadcrumbs show `constant`-symbols.")
 		},
 		'breadcrumbs.showStrings': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.string', "When enabled breadcrumbs show `string`-symbols.")
+			markdownDescription: localize('filteredTypes.string', "When enabled, breadcrumbs show `string`-symbols.")
 		},
 		'breadcrumbs.showNumbers': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.number', "When enabled breadcrumbs show `number`-symbols.")
+			markdownDescription: localize('filteredTypes.number', "When enabled, breadcrumbs show `number`-symbols.")
 		},
 		'breadcrumbs.showBooleans': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.boolean', "When enabled breadcrumbs show `boolean`-symbols.")
+			markdownDescription: localize('filteredTypes.boolean', "When enabled, breadcrumbs show `boolean`-symbols.")
 		},
 		'breadcrumbs.showArrays': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.array', "When enabled breadcrumbs show `array`-symbols.")
+			markdownDescription: localize('filteredTypes.array', "When enabled, breadcrumbs show `array`-symbols.")
 		},
 		'breadcrumbs.showObjects': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.object', "When enabled breadcrumbs show `object`-symbols.")
+			markdownDescription: localize('filteredTypes.object', "When enabled, breadcrumbs show `object`-symbols.")
 		},
 		'breadcrumbs.showKeys': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.key', "When enabled breadcrumbs show `key`-symbols.")
+			markdownDescription: localize('filteredTypes.key', "When enabled, breadcrumbs show `key`-symbols.")
 		},
 		'breadcrumbs.showNull': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.null', "When enabled breadcrumbs show `null`-symbols.")
+			markdownDescription: localize('filteredTypes.null', "When enabled, breadcrumbs show `null`-symbols.")
 		},
 		'breadcrumbs.showEnumMembers': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.enumMember', "When enabled breadcrumbs show `enumMember`-symbols.")
+			markdownDescription: localize('filteredTypes.enumMember', "When enabled, breadcrumbs show `enumMember`-symbols.")
 		},
 		'breadcrumbs.showStructs': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.struct', "When enabled breadcrumbs show `struct`-symbols.")
+			markdownDescription: localize('filteredTypes.struct', "When enabled, breadcrumbs show `struct`-symbols.")
 		},
 		'breadcrumbs.showEvents': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.event', "When enabled breadcrumbs show `event`-symbols.")
+			markdownDescription: localize('filteredTypes.event', "When enabled, breadcrumbs show `event`-symbols.")
 		},
 		'breadcrumbs.showOperators': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.operator', "When enabled breadcrumbs show `operator`-symbols.")
+			markdownDescription: localize('filteredTypes.operator', "When enabled, breadcrumbs show `operator`-symbols.")
 		},
 		'breadcrumbs.showTypeParameters': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: localize('filteredTypes.typeParameter', "When enabled breadcrumbs show `typeParameter`-symbols.")
+			markdownDescription: localize('filteredTypes.typeParameter', "When enabled, breadcrumbs show `typeParameter`-symbols.")
 		}
 	}
 });


### PR DESCRIPTION
Fixes #310451

## What

Added a missing comma after "When enabled" in all 26 `breadcrumbs.showXxx` configuration descriptions.

**Before:** `"When enabled breadcrumbs show \`file\`-symbols."`  
**After:** `"When enabled, breadcrumbs show \`file\`-symbols."`

## Why

"When enabled" is an adverbial introductory clause. In English, introductory clauses should be followed by a comma before the main clause. Without the comma, the sentence is ambiguous — "When enabled breadcrumbs" could be misread as a compound noun phrase rather than "When [this setting is] enabled, breadcrumbs [will] show..."

The same pattern is used correctly in many other VS Code configuration descriptions (e.g., `"When enabled, shows the current problem in the status bar."`).