### PR TITLE
Fix missing comma after "When enabled" in localize strings

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -475,7 +475,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		'notebook.navigation.allowNavigateToSurroundingCells': {
 			type: 'boolean',
 			default: true,
-			markdownDescription: localize('notebook.navigation.allowNavigateToSurroundingCells', "When enabled cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line.")
+			markdownDescription: localize('notebook.navigation.allowNavigateToSurroundingCells', "When enabled, cursor can navigate to the next/previous cell when the current cursor in the cell editor is at the first/last line.")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/remote/electron-browser/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-browser/remote.contribution.ts
@@ -209,7 +209,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		properties: {
 			'remote.downloadExtensionsLocally': {
 				type: 'boolean',
-				markdownDescription: nls.localize('remote.downloadExtensionsLocally', "When enabled extensions are downloaded locally and installed on remote."),
+				markdownDescription: nls.localize('remote.downloadExtensionsLocally', "When enabled, extensions are downloaded locally and installed on remote."),
 				default: false
 			},
 		}


### PR DESCRIPTION
Fixes #310453

## What

Two `localize()` user-facing description strings were missing a comma after the introductory dependent clause "When enabled".

### `src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts`

```diff
-"When enabled cursor can navigate to the next/previous cell..."
+"When enabled, cursor can navigate to the next/previous cell..."
```

### `src/vs/workbench/contrib/remote/electron-browser/remote.contribution.ts`

```diff
-"When enabled extensions are downloaded locally and installed on remote."
+"When enabled, extensions are downloaded locally and installed on remote."
```

## Why

"When enabled" is an introductory dependent clause. Standard English grammar requires a comma before the main clause that follows. These strings appear in VS Code settings UI descriptions visible to all users.