### PR TITLE
Fix incorrect indefinite article "a" before vowel-starting nouns in localize strings

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -56,7 +56,7 @@ export class JSONValidationExtensionPoint {
 				const extensionLocation = extension.description.extensionLocation;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be a array"));
+					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be an array"));
 					return;
 				}
 				extensionValue.forEach(extension => {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -385,7 +385,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.editor.restoreViewState': {
 				'type': 'boolean',
-				'markdownDescription': localize('restoreViewState', "Restores the last editor view state (such as scroll position) when re-opening editors after they have been closed. Editor view state is stored per editor group and discarded when a group closes. Use the {0} setting to use the last known view state across all editor groups in case no previous view state was found for a editor group.", '`#workbench.editor.sharedViewState#`'),
+				'markdownDescription': localize('restoreViewState', "Restores the last editor view state (such as scroll position) when re-opening editors after they have been closed. Editor view state is stored per editor group and discarded when a group closes. Use the {0} setting to use the last known view state across all editor groups in case no previous view state was found for an editor group.", '`#workbench.editor.sharedViewState#`'),
 				'default': true,
 				'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
 			},

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -33,7 +33,7 @@ export const RemoteNameContext = new RawContextKey<string>('remoteName', '', loc
 export const VirtualWorkspaceContext = new RawContextKey<string>('virtualWorkspace', '', localize('virtualWorkspace', "The scheme of the current workspace is from a virtual file system or an empty string."));
 export const TemporaryWorkspaceContext = new RawContextKey<boolean>('temporaryWorkspace', false, localize('temporaryWorkspace', "The scheme of the current workspace is from a temporary file system."));
 
-export const IsSessionsWindowContext = new RawContextKey<boolean>('isSessionsWindow', false, localize('isSessionsWindow', "Whether the current window is a agent sessions window."));
+export const IsSessionsWindowContext = new RawContextKey<boolean>('isSessionsWindow', false, localize('isSessionsWindow', "Whether the current window is an agent sessions window."));
 
 export const HasWebFileSystemAccess = new RawContextKey<boolean>('hasWebFileSystemAccess', false, true); // Support for FileSystemAccess web APIs (https://wicg.github.io/file-system-access)
 

--- a/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
@@ -95,7 +95,7 @@ export class ColorExtensionPoint {
 				const collector = extension.collector;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be a array"));
+					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be an array"));
 					return;
 				}
 				const parseColorValue = (s: string, name: string) => {

--- a/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
@@ -119,7 +119,7 @@ export class IconExtensionPoint {
 							}
 						}, iconContribution.description);
 					} else {
-						collector.error(nls.localize('invalid.icons.default', "'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontPath` and `fontCharacter`."));
+						collector.error(nls.localize('invalid.icons.default', "'configuration.icons.default' must be either a reference to the id of another theme icon (string) or an icon definition (object) with properties `fontPath` and `fontCharacter`."));
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #310456

## What

Five `nls.localize()` user-facing strings used the incorrect indefinite article `"a"` before nouns starting with a vowel sound. English grammar requires `"an"` in these positions.

### Changes

**`src/vs/workbench/api/common/jsonValidationExtensionPoint.ts`**
```diff
-"'configuration.jsonValidation' must be a array"
+"'configuration.jsonValidation' must be an array"
```

**`src/vs/workbench/services/themes/common/colorExtensionPoint.ts`**
```diff
-"'configuration.colors' must be a array"
+"'configuration.colors' must be an array"
```

**`src/vs/workbench/common/contextkeys.ts`**
```diff
-"Whether the current window is a agent sessions window."
+"Whether the current window is an agent sessions window."
```

**`src/vs/workbench/browser/workbench.contribution.ts`**
```diff
-"...no previous view state was found for a editor group."
+"...no previous view state was found for an editor group."
```

**`src/vs/workbench/services/themes/common/iconExtensionPoint.ts`**
```diff
-"...must be either a reference to the id of an other theme icon (string) or a icon definition..."
+"...must be either a reference to the id of another theme icon (string) or an icon definition..."
```