### PR TITLE
Remove double spaces in localize() setting description strings

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -79,7 +79,7 @@ export class JSONValidationExtensionPoint {
 							collector.error(nls.localize('invalid.url.fileschema', "'configuration.jsonValidation.url' is an invalid relative URL: {0}", e.message));
 						}
 					} else if (!/^[^:/?#]+:\/\//.test(uri)) {
-						collector.error(nls.localize('invalid.url.schema', "'configuration.jsonValidation.url' must be an absolute URL or start with './'  to reference schemas located in the extension."));
+						collector.error(nls.localize('invalid.url.schema', "'configuration.jsonValidation.url' must be an absolute URL or start with './' to reference schemas located in the extension."));
 						return;
 					}
 				});

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -325,7 +325,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.editor.closeOnFileDelete': {
 				'type': 'boolean',
-				'description': localize('closeOnFileDelete', "Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that editors with unsaved changes will never close to preserve your data."),
+				'description': localize('closeOnFileDelete', "Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open on such an event. Note that deleting from within the application will always close the editor and that editors with unsaved changes will never close to preserve your data."),
 				'default': false
 			},
 			'workbench.editor.openPositioning': {

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -258,7 +258,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				patternProperties: {
 					'(^\\d+(-\\d+)?$)|(.+)': {
 						type: 'object',
-						description: localize('remote.portsAttributes.port', "A port, range of ports (ex. \"40000-55000\"), host and port (ex. \"db:1234\"), or regular expression (ex. \".+\\\\/server.js\").  For a port number or range, the attributes will apply to that port number or range of port numbers. Attributes which use a regular expression will apply to ports whose associated process command line matches the expression."),
+						description: localize('remote.portsAttributes.port', "A port, range of ports (ex. \"40000-55000\"), host and port (ex. \"db:1234\"), or regular expression (ex. \".+\\\\/server.js\"). For a port number or range, the attributes will apply to that port number or range of port numbers. Attributes which use a regular expression will apply to ports whose associated process command line matches the expression."),
 						properties: {
 							'onAutoForward': {
 								type: 'string',


### PR DESCRIPTION
Fixes #310458

## What

Three `localize()` user-facing setting description strings contained accidental double spaces.

### `src/vs/workbench/browser/workbench.contribution.ts`
```diff
-"...Disabling this will keep the editor open  on such an event..."
+"...Disabling this will keep the editor open on such an event..."
```

### `src/vs/workbench/api/common/jsonValidationExtensionPoint.ts`
```diff
-"...must be an absolute URL or start with './'  to reference schemas..."
+"...must be an absolute URL or start with './' to reference schemas..."
```

### `src/vs/workbench/contrib/remote/common/remote.contribution.ts`
```diff
-"...or regular expression (ex. \".+\\/server.js\").  For a port number..."
+"...or regular expression (ex. \".+\\/server.js\"). For a port number..."
```

These strings are shown in the VS Code Settings UI descriptions.