### PR TITLE
Fix double space before "setting" in git extension branchProtection description

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -184,7 +184,7 @@
 	"config.checkoutType.remote": "Remote branches",
 	"config.defaultBranchName": "The name of the default branch (example: main, trunk, development) when initializing a new Git repository. When set to empty, the default branch name configured in Git will be used. **Note:** Requires Git version `2.28.0` or later.",
 	"config.branchPrefix": "Prefix used when creating a new branch.",
-	"config.branchProtection": "List of protected branches. By default, a prompt is shown before changes are committed to a protected branch. The prompt can be controlled using the `#git.branchProtectionPrompt#`  setting.",
+	"config.branchProtection": "List of protected branches. By default, a prompt is shown before changes are committed to a protected branch. The prompt can be controlled using the `#git.branchProtectionPrompt#` setting.",
 	"config.branchProtectionPrompt": "Controls whether a prompt is being shown before changes are committed to a protected branch.",
 	"config.branchProtectionPrompt.alwaysCommit": "Always commit changes to the protected branch.",
 	"config.branchProtectionPrompt.alwaysCommitToNewBranch": "Always commit changes to a new branch.",


### PR DESCRIPTION
Fixes #310460

## What

`extensions/git/package.nls.json` line 187 had an accidental double space in the `config.branchProtection` setting description, visible in the VS Code Settings UI.

```diff
-"...The prompt can be controlled using the `#git.branchProtectionPrompt#`  setting."
+"...The prompt can be controlled using the `#git.branchProtectionPrompt#` setting."
```