### PR TITLE
Fix missing period after "e.g" in suggest.selectionMode description

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5172,7 +5172,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 						nls.localize('suggest.insertMode.whenQuickSuggestion', "Select a suggestion only when triggering IntelliSense as you type."),
 					],
 					default: defaults.selectionMode,
-					markdownDescription: nls.localize('suggest.selectionMode', "Controls whether a suggestion is selected when the widget shows. Note that this only applies to automatically triggered suggestions ({0} and {1}) and that a suggestion is always selected when explicitly invoked, e.g via `Ctrl+Space`.", '`#editor.quickSuggestions#`', '`#editor.suggestOnTriggerCharacters#`')
+					markdownDescription: nls.localize('suggest.selectionMode', "Controls whether a suggestion is selected when the widget shows. Note that this only applies to automatically triggered suggestions ({0} and {1}) and that a suggestion is always selected when explicitly invoked, e.g. via `Ctrl+Space`.", '`#editor.quickSuggestions#`', '`#editor.suggestOnTriggerCharacters#`')
 				},
 				'editor.suggest.snippetsPreventQuickSuggestions': {
 					type: 'boolean',


### PR DESCRIPTION
Fixes #310462

## What

The `suggest.selectionMode` setting description (visible in the VS Code Settings UI) uses `e.g` without a trailing period.

```diff
-"...that a suggestion is always selected when explicitly invoked, e.g via `Ctrl+Space`."
+"...that a suggestion is always selected when explicitly invoked, e.g. via `Ctrl+Space`."
```

The abbreviation for Latin "exempli gratia" should always be written as `e.g.` with a trailing period.