### PR TITLE
Replace "can not" with "cannot" in localize() strings for style consistency

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -905,10 +905,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			this.dialogMainService.showMessageBox({
 				type: 'info',
 				buttons: [localize({ key: 'ok', comment: ['&& denotes a mnemonic'] }, "&&OK")],
-				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI can not be opened"),
+				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI cannot be opened"),
 				detail: uri.scheme === Schemas.file ?
 					localize('pathNotExistDetail', "The path '{0}' does not exist on this computer.", getPathLabel(uri, { os: OS, tildify: this.environmentMainService })) :
-					localize('uriInvalidDetail', "The URI '{0}' is not valid and can not be opened.", uri.toString(true))
+					localize('uriInvalidDetail', "The URI '{0}' is not valid and cannot be opened.", uri.toString(true))
 			}, BrowserWindow.getFocusedWindow() ?? undefined);
 
 			return undefined;

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -610,7 +610,7 @@ const schema: IJSONSchema = {
 		},
 		autoCloseBefore: {
 			default: ';:.,=}])> \n\t',
-			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which can not start an expression.'),
+			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which cannot start an expression.'),
 			type: 'string',
 		},
 		surroundingPairs: {

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -115,7 +115,7 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 			delta.added.forEach(added => {
 				added.value.forEach(rawAdapter => {
 					if (!rawAdapter.type || (typeof rawAdapter.type !== 'string')) {
-						added.collector.error(nls.localize('debugNoType', "Debugger 'type' can not be omitted and must be of type 'string'."));
+						added.collector.error(nls.localize('debugNoType', "Debugger 'type' cannot be omitted and must be of type 'string'."));
 					}
 
 					if (rawAdapter.type !== '*') {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -598,7 +598,7 @@ export class DebugService implements IDebugService {
 				if (err && err.message) {
 					await this.showError(err.message);
 				} else if (this.contextService.getWorkbenchState() === WorkbenchState.EMPTY) {
-					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file can not be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
+					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file cannot be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
 				}
 				if (launch && !initCancellationToken.token.isCancellationRequested) {
 					await launch.openConfigFile({ preserveFocus: true }, initCancellationToken.token);

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -394,7 +394,7 @@ export class DebugSession implements IDebugSession {
 	 */
 	async launchOrAttach(config: IConfig): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'launch or attach'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'launch or attach'));
 		}
 		if (this.parentSession && this.parentSession.state === State.Inactive) {
 			throw canceled();
@@ -474,7 +474,7 @@ export class DebugSession implements IDebugSession {
 	 */
 	async restart(): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'restart'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'restart'));
 		}
 
 		this.cancelAllRequests();
@@ -487,7 +487,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendBreakpoints(modelUri: URI, breakpointsToSend: IBreakpoint[], sourceModified: boolean): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'breakpoints'));
 		}
 
 		if (!this.raw.readyForBreakpoints) {
@@ -521,7 +521,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendFunctionBreakpoints(fbpts: IFunctionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'function breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'function breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -538,7 +538,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendExceptionBreakpoints(exbpts: IExceptionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'exception breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'exception breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -579,7 +579,7 @@ export class DebugSession implements IDebugSession {
 
 	private async _dataBreakpointInfo(args: DebugProtocol.DataBreakpointInfoArguments): Promise<{ dataId: string | null; description: string; canPersist?: boolean } | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'data breakpoints info'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'data breakpoints info'));
 		}
 		if (!this.raw.readyForBreakpoints) {
 			throw new Error(localize('sessionNotReadyForBreakpoints', "Session is not ready for breakpoints"));
@@ -591,7 +591,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendDataBreakpoints(dataBreakpoints: IDataBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'data breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'data breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -621,7 +621,7 @@ export class DebugSession implements IDebugSession {
 
 	async sendInstructionBreakpoints(instructionBreakpoints: IInstructionBreakpoint[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'instruction breakpoints'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'instruction breakpoints'));
 		}
 
 		if (this.raw.readyForBreakpoints) {
@@ -638,7 +638,7 @@ export class DebugSession implements IDebugSession {
 
 	async breakpointsLocations(uri: URI, lineNumber: number): Promise<IPosition[]> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'breakpoints locations'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'breakpoints locations'));
 		}
 
 		const source = this.getRawSource(uri);
@@ -658,7 +658,7 @@ export class DebugSession implements IDebugSession {
 
 	customRequest(request: string, args: any): Promise<DebugProtocol.Response | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", request));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", request));
 		}
 
 		return this.raw.custom(request, args);
@@ -666,7 +666,7 @@ export class DebugSession implements IDebugSession {
 
 	stackTrace(threadId: number, startFrame: number, levels: number, token: CancellationToken): Promise<DebugProtocol.StackTraceResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stackTrace'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stackTrace'));
 		}
 
 		const sessionToken = this.getNewCancellationToken(threadId, token);
@@ -675,7 +675,7 @@ export class DebugSession implements IDebugSession {
 
 	async exceptionInfo(threadId: number): Promise<IExceptionInfo | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'exceptionInfo'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'exceptionInfo'));
 		}
 
 		const response = await this.raw.exceptionInfo({ threadId });
@@ -693,7 +693,7 @@ export class DebugSession implements IDebugSession {
 
 	scopes(frameId: number, threadId: number): Promise<DebugProtocol.ScopesResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'scopes'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'scopes'));
 		}
 
 		const token = this.getNewCancellationToken(threadId);
@@ -702,7 +702,7 @@ export class DebugSession implements IDebugSession {
 
 	variables(variablesReference: number, threadId: number | undefined, filter: 'indexed' | 'named' | undefined, start: number | undefined, count: number | undefined): Promise<DebugProtocol.VariablesResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'variables'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'variables'));
 		}
 
 		const token = threadId ? this.getNewCancellationToken(threadId) : undefined;
@@ -711,7 +711,7 @@ export class DebugSession implements IDebugSession {
 
 	evaluate(expression: string, frameId: number, context?: string, location?: { line: number; column: number; source: DebugProtocol.Source }): Promise<DebugProtocol.EvaluateResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'evaluate'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'evaluate'));
 		}
 
 		return this.raw.evaluate({ expression, frameId, context, line: location?.line, column: location?.column, source: location?.source });
@@ -720,7 +720,7 @@ export class DebugSession implements IDebugSession {
 	async restartFrame(frameId: number, threadId: number): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'restartFrame'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'restartFrame'));
 		}
 
 		await this.raw.restartFrame({ frameId }, threadId);
@@ -736,7 +736,7 @@ export class DebugSession implements IDebugSession {
 	async next(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'next'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'next'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -746,7 +746,7 @@ export class DebugSession implements IDebugSession {
 	async stepIn(threadId: number, targetId?: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepIn'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepIn'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -756,7 +756,7 @@ export class DebugSession implements IDebugSession {
 	async stepOut(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepOut'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepOut'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -766,7 +766,7 @@ export class DebugSession implements IDebugSession {
 	async stepBack(threadId: number, granularity?: DebugProtocol.SteppingGranularity): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepBack'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepBack'));
 		}
 
 		this.setLastSteppingGranularity(threadId, granularity);
@@ -776,7 +776,7 @@ export class DebugSession implements IDebugSession {
 	async continue(threadId: number): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'continue'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'continue'));
 		}
 
 		await this.raw.continue({ threadId });
@@ -785,7 +785,7 @@ export class DebugSession implements IDebugSession {
 	async reverseContinue(threadId: number): Promise<void> {
 		await this.waitForTriggeredBreakpoints();
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'reverse continue'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'reverse continue'));
 		}
 
 		await this.raw.reverseContinue({ threadId });
@@ -793,7 +793,7 @@ export class DebugSession implements IDebugSession {
 
 	async pause(threadId: number): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'pause'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'pause'));
 		}
 
 		await this.raw.pause({ threadId });
@@ -801,7 +801,7 @@ export class DebugSession implements IDebugSession {
 
 	async terminateThreads(threadIds?: number[]): Promise<void> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'terminateThreads'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'terminateThreads'));
 		}
 
 		await this.raw.terminateThreads({ threadIds });
@@ -809,7 +809,7 @@ export class DebugSession implements IDebugSession {
 
 	setVariable(variablesReference: number, name: string, value: string): Promise<DebugProtocol.SetVariableResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'setVariable'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'setVariable'));
 		}
 
 		return this.raw.setVariable({ variablesReference, name, value });
@@ -817,7 +817,7 @@ export class DebugSession implements IDebugSession {
 
 	setExpression(frameId: number, expression: string, value: string): Promise<DebugProtocol.SetExpressionResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'setExpression'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'setExpression'));
 		}
 
 		return this.raw.setExpression({ expression, value, frameId });
@@ -825,7 +825,7 @@ export class DebugSession implements IDebugSession {
 
 	gotoTargets(source: DebugProtocol.Source, line: number, column?: number): Promise<DebugProtocol.GotoTargetsResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'gotoTargets'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'gotoTargets'));
 		}
 
 		return this.raw.gotoTargets({ source, line, column });
@@ -833,7 +833,7 @@ export class DebugSession implements IDebugSession {
 
 	goto(threadId: number, targetId: number): Promise<DebugProtocol.GotoResponse | undefined> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'goto'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'goto'));
 		}
 
 		return this.raw.goto({ threadId, targetId });
@@ -841,7 +841,7 @@ export class DebugSession implements IDebugSession {
 
 	loadSource(resource: URI): Promise<DebugProtocol.SourceResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'loadSource')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'loadSource')));
 		}
 
 		const source = this.getSourceForUri(resource);
@@ -859,7 +859,7 @@ export class DebugSession implements IDebugSession {
 
 	async getLoadedSources(): Promise<Source[]> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'getLoadedSources')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'getLoadedSources')));
 		}
 
 		const response = await this.raw.loadedSources({});
@@ -872,7 +872,7 @@ export class DebugSession implements IDebugSession {
 
 	async completions(frameId: number | undefined, threadId: number, text: string, position: Position, token: CancellationToken): Promise<DebugProtocol.CompletionsResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'completions')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'completions')));
 		}
 		const sessionCancelationToken = this.getNewCancellationToken(threadId, token);
 
@@ -886,7 +886,7 @@ export class DebugSession implements IDebugSession {
 
 	async stepInTargets(frameId: number): Promise<{ id: number; label: string }[] | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'stepInTargets')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'stepInTargets')));
 		}
 
 		const response = await this.raw.stepInTargets({ frameId });
@@ -895,7 +895,7 @@ export class DebugSession implements IDebugSession {
 
 	async cancel(progressId: string): Promise<DebugProtocol.CancelResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'cancel')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'cancel')));
 		}
 
 		return this.raw.cancel({ progressId });
@@ -903,7 +903,7 @@ export class DebugSession implements IDebugSession {
 
 	async disassemble(memoryReference: string, offset: number, instructionOffset: number, instructionCount: number): Promise<DebugProtocol.DisassembledInstruction[] | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'disassemble')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'disassemble')));
 		}
 
 		const response = await this.raw.disassemble({ memoryReference, offset, instructionOffset, instructionCount, resolveSymbols: true });
@@ -912,7 +912,7 @@ export class DebugSession implements IDebugSession {
 
 	readMemory(memoryReference: string, offset: number, count: number): Promise<DebugProtocol.ReadMemoryResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'readMemory')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'readMemory')));
 		}
 
 		return this.raw.readMemory({ count, memoryReference, offset });
@@ -920,7 +920,7 @@ export class DebugSession implements IDebugSession {
 
 	writeMemory(memoryReference: string, offset: number, data: string, allowPartial?: boolean): Promise<DebugProtocol.WriteMemoryResponse | undefined> {
 		if (!this.raw) {
-			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'disassemble')));
+			return Promise.reject(new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'disassemble')));
 		}
 
 		return this.raw.writeMemory({ memoryReference, offset, allowPartial, data });
@@ -928,12 +928,12 @@ export class DebugSession implements IDebugSession {
 
 	async resolveLocationReference(locationReference: number): Promise<IDebugLocationReferenced> {
 		if (!this.raw) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'locations'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'locations'));
 		}
 
 		const location = await this.raw.locations({ locationReference });
 		if (!location?.body) {
-			throw new Error(localize('noDebugAdapter', "No debugger available, can not send '{0}'", 'locations'));
+			throw new Error(localize('noDebugAdapter', "No debugger available, cannot send '{0}'", 'locations'));
 		}
 
 		const source = this.getSource(location.body.source);

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -196,7 +196,7 @@ export class DebugTaskRunner implements IDisposable {
 			return Promise.resolve(null);
 		}
 		if (!root) {
-			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
+			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' cannot be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
 		}
 		// run a task before starting a debug session
 		const task = await this.taskService.getTask(root, taskId);

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -267,7 +267,7 @@ export class RawDebugSession implements IDisposable {
 	 */
 	async start(): Promise<void> {
 		if (!this.debugAdapter) {
-			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, can not start debug session.")));
+			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, cannot start debug session.")));
 		}
 
 		await this.debugAdapter.startSession();

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -130,7 +130,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 			if (filePath) {
 				return normalizeDriveLetter(filePath);
 			}
-			throw new VariableError(variableKind, (localize('canNotResolveFile', "Variable {0} can not be resolved. Please open an editor.", replacement.id)));
+			throw new VariableError(variableKind, (localize('canNotResolveFile', "Variable {0} cannot be resolved. Please open an editor.", replacement.id)));
 		};
 
 		// common error handling for all variables that require an open editor
@@ -142,7 +142,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 					return normalizeDriveLetter(folderPath);
 				}
 			}
-			throw new VariableError(variableKind, localize('canNotResolveFolderForFile', "Variable {0}: can not find workspace folder of '{1}'.", replacement.id, paths.basename(filePath)));
+			throw new VariableError(variableKind, localize('canNotResolveFolderForFile', "Variable {0}: cannot find workspace folder of '{1}'.", replacement.id, paths.basename(filePath)));
 		};
 
 		// common error handling for all variables that require an open folder and accept a folder name argument
@@ -152,7 +152,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 				if (folder) {
 					return folder;
 				}
-				throw new VariableError(variableKind, localize('canNotFindFolder', "Variable {0} can not be resolved. No such folder '{1}'.", variableKind, argument));
+				throw new VariableError(variableKind, localize('canNotFindFolder', "Variable {0} cannot be resolved. No such folder '{1}'.", variableKind, argument));
 			}
 
 			if (folderUri) {
@@ -160,9 +160,9 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 			}
 
 			if (this._context.getWorkspaceFolderCount() > 1) {
-				throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolderMultiRoot', "Variable {0} can not be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.", variableKind));
+				throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolderMultiRoot', "Variable {0} cannot be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.", variableKind));
 			}
-			throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolder', "Variable {0} can not be resolved. Please open a folder.", variableKind));
+			throw new VariableError(variableKind, localize('canNotResolveWorkspaceFolder', "Variable {0} cannot be resolved. Please open a folder.", variableKind));
 		};
 
 		switch (variable) {
@@ -176,20 +176,20 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 					}
 					return '';
 				}
-				throw new VariableError(VariableKind.Env, localize('missingEnvVarName', "Variable {0} can not be resolved because no environment variable name is given.", replacement.id));
+				throw new VariableError(VariableKind.Env, localize('missingEnvVarName', "Variable {0} cannot be resolved because no environment variable name is given.", replacement.id));
 
 			case 'config':
 				if (argument) {
 					const config = this._context.getConfigurationValue(folderUri, argument);
 					if (types.isUndefinedOrNull(config)) {
-						throw new VariableError(VariableKind.Config, localize('configNotFound', "Variable {0} can not be resolved because setting '{1}' not found.", replacement.id, argument));
+						throw new VariableError(VariableKind.Config, localize('configNotFound', "Variable {0} cannot be resolved because setting '{1}' not found.", replacement.id, argument));
 					}
 					if (types.isObject(config)) {
-						throw new VariableError(VariableKind.Config, localize('configNoString', "Variable {0} can not be resolved because '{1}' is a structured value.", replacement.id, argument));
+						throw new VariableError(VariableKind.Config, localize('configNoString', "Variable {0} cannot be resolved because '{1}' is a structured value.", replacement.id, argument));
 					}
 					return config;
 				}
-				throw new VariableError(VariableKind.Config, localize('missingConfigName', "Variable {0} can not be resolved because no settings name is given.", replacement.id));
+				throw new VariableError(VariableKind.Config, localize('missingConfigName', "Variable {0} cannot be resolved because no settings name is given.", replacement.id));
 
 			case 'command':
 				return this.resolveFromMap(VariableKind.Command, replacement.id, argument, commandValueMapping, 'command');
@@ -201,11 +201,11 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 				if (argument) {
 					const ext = await this._context.getExtension(argument);
 					if (!ext) {
-						throw new VariableError(VariableKind.ExtensionInstallFolder, localize('extensionNotInstalled', "Variable {0} can not be resolved because the extension {1} is not installed.", replacement.id, argument));
+						throw new VariableError(VariableKind.ExtensionInstallFolder, localize('extensionNotInstalled', "Variable {0} cannot be resolved because the extension {1} is not installed.", replacement.id, argument));
 					}
 					return this.fsPath(ext.extensionLocation);
 				}
-				throw new VariableError(VariableKind.ExtensionInstallFolder, localize('missingExtensionName', "Variable {0} can not be resolved because no extension name is given.", replacement.id));
+				throw new VariableError(VariableKind.ExtensionInstallFolder, localize('missingExtensionName', "Variable {0} cannot be resolved because no extension name is given.", replacement.id));
 
 			default: {
 				switch (variable) {
@@ -233,14 +233,14 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 						if (environment.userHome) {
 							return environment.userHome;
 						}
-						throw new VariableError(VariableKind.UserHome, localize('canNotResolveUserHome', "Variable {0} can not be resolved. UserHome path is not defined", replacement.id));
+						throw new VariableError(VariableKind.UserHome, localize('canNotResolveUserHome', "Variable {0} cannot be resolved. UserHome path is not defined", replacement.id));
 
 					case 'lineNumber': {
 						const lineNumber = this._context.getLineNumber();
 						if (lineNumber) {
 							return lineNumber;
 						}
-						throw new VariableError(VariableKind.LineNumber, localize('canNotResolveLineNumber', "Variable {0} can not be resolved. Make sure to have a line selected in the active editor.", replacement.id));
+						throw new VariableError(VariableKind.LineNumber, localize('canNotResolveLineNumber', "Variable {0} cannot be resolved. Make sure to have a line selected in the active editor.", replacement.id));
 					}
 
 					case 'columnNumber': {
@@ -248,7 +248,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 						if (columnNumber) {
 							return columnNumber;
 						}
-						throw new Error(localize('canNotResolveColumnNumber', "Variable {0} can not be resolved. Make sure to have a column selected in the active editor.", replacement.id));
+						throw new Error(localize('canNotResolveColumnNumber', "Variable {0} cannot be resolved. Make sure to have a column selected in the active editor.", replacement.id));
 					}
 
 					case 'selectedText': {
@@ -256,7 +256,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 						if (selectedText) {
 							return selectedText;
 						}
-						throw new VariableError(VariableKind.SelectedText, localize('canNotResolveSelectedText', "Variable {0} can not be resolved. Make sure to have some text selected in the active editor.", replacement.id));
+						throw new VariableError(VariableKind.SelectedText, localize('canNotResolveSelectedText', "Variable {0} cannot be resolved. Make sure to have some text selected in the active editor.", replacement.id));
 					}
 
 					case 'file':
@@ -338,7 +338,7 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 			if (typeof v === 'string') {
 				return v;
 			}
-			throw new VariableError(variableKind, localize('noValueForCommand', "Variable {0} can not be resolved because the command has no value.", match));
+			throw new VariableError(variableKind, localize('noValueForCommand', "Variable {0} cannot be resolved because the command has no value.", match));
 		}
 		return match;
 	}

--- a/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
@@ -37,7 +37,7 @@ const configurationExtPoint = ExtensionsRegistry.registerExtensionPoint<IColorEx
 					type: 'string',
 					description: nls.localize('contributes.color.id', 'The identifier of the themable color'),
 					pattern: colorIdPattern,
-					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and can not start with a dot'),
+					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and cannot start with a dot'),
 				},
 				description: {
 					type: 'string',
@@ -112,15 +112,15 @@ export class ColorExtensionPoint {
 
 				for (const colorContribution of extensionValue) {
 					if (typeof colorContribution.id !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and cannot be empty"));
 						return;
 					}
 					if (!colorContribution.id.match(colorIdPattern)) {
-						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot"));
+						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and cannot start with a dot"));
 						return;
 					}
 					if (typeof colorContribution.description !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaults = colorContribution.defaults;

--- a/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
@@ -90,7 +90,7 @@ export class IconExtensionPoint {
 					}
 					const iconContribution = extensionValue[id];
 					if (typeof iconContribution.description !== 'string' || iconContribution.description.length === 0) {
-						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaultIcon = iconContribution.default;

--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -109,7 +109,7 @@ export class TokenClassificationExtensionPoints {
 	constructor() {
 		function validateTypeOrModifier(contribution: ITokenTypeExtensionPoint | ITokenModifierExtensionPoint, extensionPoint: string, collector: ExtensionMessageCollector): boolean {
 			if (typeof contribution.id !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			if (!contribution.id.match(typeAndModifierIdPattern)) {
@@ -122,7 +122,7 @@ export class TokenClassificationExtensionPoints {
 				return false;
 			}
 			if (typeof contribution.description !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Fixes #310467

## What

Replaces 68 occurrences of `"can not"` with `"cannot"` in `localize()` user-facing strings across 11 files.

## Why

The VS Code codebase already uses `"cannot"` in ~185 other `localize()` strings, making `"can not"` inconsistent. Style guides (AP, Chicago, VS Code's own existing strings) all prefer `"cannot"` as a single word.

## Files changed

| File | Changes |
|------|---------|
| `debugSession.ts` | 38 occurrences |
| `variableResolver.ts` | 16 occurrences |
| `colorExtensionPoint.ts` | 4 occurrences |
| `tokenClassificationExtensionPoint.ts` | 2 occurrences |
| `windowsMainService.ts` | 2 occurrences |
| Other files (6) | 1 each |

All changes are purely textual in `localize()` string arguments with no functional impact.