### PR TITLE
Remove dead serverToolCalls / IServerToolCall code

### DIFF
--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -39,7 +39,7 @@ import { Mutable } from '../../../util/vs/base/common/types';
 import { URI } from '../../../util/vs/base/common/uri';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { ChatResponsePullRequestPart, LanguageModelDataPart2, LanguageModelPartAudience, LanguageModelTextPart, LanguageModelToolResult2, MarkdownString } from '../../../vscodeTypes';
+import { ChatResponsePullRequestPart, LanguageModelDataPart2, LanguageModelPartAudience, LanguageModelToolResult2, MarkdownString } from '../../../vscodeTypes';
 import { InteractionOutcomeComputer } from '../../inlineChat/node/promptCraftingTypes';
 import { ChatVariablesCollection } from '../../prompt/common/chatVariablesCollection';
 import { AnthropicTokenUsageMetadata, Conversation, IResultMetadata, ResponseStreamParticipant, TurnStatus } from '../../prompt/common/conversation';
@@ -1317,14 +1317,6 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						id: this.createInternalToolCallId(call.id),
 						arguments: call.arguments === '' ? '{}' : call.arguments
 					})));
-				}
-				if (delta.serverToolCalls) {
-					for (const serverCall of delta.serverToolCalls) {
-						const result: LanguageModelToolResult2 = {
-							content: [new LanguageModelTextPart(JSON.stringify(serverCall.result, undefined, 2))]
-						};
-						this._requestLogger.logServerToolCall(serverCall.id, serverCall.name, serverCall.args, result);
-					}
 				}
 				if (delta.statefulMarker) {
 					statefulMarker = delta.statefulMarker;

--- a/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -372,20 +372,6 @@ export class RequestLogger extends AbstractRequestLogger {
 		));
 	}
 
-	public override logServerToolCall(id: string, name: string, args: unknown, result: LanguageModelToolResult2): void {
-		this._addEntry(new LoggedToolCall(
-			id,
-			`${name} [server]`,
-			args,
-			result,
-			this.currentRequest,
-			Date.now(),
-			undefined, // thinking
-			undefined, // edits
-			undefined  // toolMetadata
-		));
-	}
-
 	/** Start tracking edits made to the workspace for every tool call. */
 	public override enableWorkspaceEditTracing(): void {
 		if (!this._workspaceEditRecorder) {

--- a/extensions/copilot/src/platform/networking/common/fetch.ts
+++ b/extensions/copilot/src/platform/networking/common/fetch.ts
@@ -89,17 +89,6 @@ export interface ICopilotToolCall {
 	id: string;
 }
 
-export interface IServerToolCall {
-	/** Indicates this is a server-side tool call (e.g., tool_search, websearch) - not validated/executed by client */
-	isServer: true;
-	name: string;
-	id: string;
-	/** The parsed input arguments for this tool call */
-	args?: unknown;
-	/** The parsed result returned by the server for this tool call */
-	result?: unknown;
-}
-
 export interface ICopilotToolCallStreamUpdate {
 	name: string;
 	arguments: string;
@@ -162,8 +151,6 @@ export interface IResponseDelta {
 	statefulMarker?: string;
 	/** Context management information from Anthropic Messages API */
 	contextManagement?: ContextManagementResponse | OpenAIContextManagementResponse;
-	/** Server-side tool calls (e.g., tool_search) - reported for logging but not validated/executed */
-	serverToolCalls?: IServerToolCall[];
 }
 
 export function isOpenAIContextManagementResponse(value: ContextManagementResponse | OpenAIContextManagementResponse): value is OpenAIContextManagementResponse {

--- a/extensions/copilot/src/platform/requestLogger/common/requestLogger.ts
+++ b/extensions/copilot/src/platform/requestLogger/common/requestLogger.ts
@@ -153,8 +153,6 @@ export interface IRequestLogger {
 
 	logToolCall(id: string, name: string, args: unknown, response: LanguageModelToolResult2, thinking?: ThinkingData): void;
 
-	logServerToolCall(id: string, name: string, args: unknown, result: LanguageModelToolResult2): void;
-
 	logModelListCall(requestId: string, requestMetadata: RequestMetadata, models: IModelAPIResponse[]): void;
 
 	logContentExclusionRules(repos: string[], rules: { patterns: string[]; ifAnyMatch: string[]; ifNoneMatch: string[] }[], durationMs: number): void;

--- a/extensions/copilot/src/platform/requestLogger/node/nullRequestLogger.ts
+++ b/extensions/copilot/src/platform/requestLogger/node/nullRequestLogger.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { RequestMetadata } from '@vscode/copilot-api';
-import type { LanguageModelToolResult, LanguageModelToolResult2 } from 'vscode';
+import type { LanguageModelToolResult2 } from 'vscode';
 import { ILoggedRequestInfo, LoggedRequest } from '../../../platform/requestLogger/common/requestLogger';
 import { AbstractRequestLogger } from '../../../platform/requestLogger/node/requestLogger';
 import { Event } from '../../../util/vs/base/common/event';
@@ -24,9 +24,7 @@ export class NullRequestLogger extends AbstractRequestLogger {
 	public override logModelListCall(id: string, requestMetadata: RequestMetadata, models: IModelAPIResponse[]): void {
 
 	}
-	public override logToolCall(name: string | undefined, args: unknown, response: LanguageModelToolResult): void {
-	}
-	public override logServerToolCall(id: string, name: string, args: unknown, result: LanguageModelToolResult2): void {
+	public override logToolCall(_id: string, _name: string | undefined, _args: unknown, _response: LanguageModelToolResult2): void {
 	}
 	override onDidChangeRequests: Event<void> = Event.None;
 }

--- a/extensions/copilot/src/platform/requestLogger/node/requestLogger.ts
+++ b/extensions/copilot/src/platform/requestLogger/node/requestLogger.ts
@@ -77,7 +77,6 @@ export abstract class AbstractRequestLogger extends Disposable implements IReque
 
 	public abstract logModelListCall(id: string, requestMetadata: RequestMetadata, models: IModelAPIResponse[]): void;
 	public abstract logToolCall(id: string, name: string | undefined, args: unknown, response: LanguageModelToolResult2): void;
-	public abstract logServerToolCall(id: string, name: string, args: unknown, result: LanguageModelToolResult2): void;
 
 	public logContentExclusionRules(_repos: string[], _rules: { patterns: string[]; ifAnyMatch: string[]; ifNoneMatch: string[] }[], _durationMs: number): void {
 		// no-op by default; concrete implementations can override

--- a/extensions/copilot/src/platform/requestLogger/test/node/testRequestLogger.ts
+++ b/extensions/copilot/src/platform/requestLogger/test/node/testRequestLogger.ts
@@ -59,11 +59,6 @@ export class TestRequestLogger extends AbstractRequestLogger {
 		this._onDidChangeRequests.fire();
 	}
 
-	public override logServerToolCall(id: string, name: string, args: unknown, result: LanguageModelToolResult2): void {
-		this._entries.push(new TestLoggedToolCall(id, name, args, result, this.currentRequest, Date.now()));
-		this._onDidChangeRequests.fire();
-	}
-
 	/**
 	 * Clear all logged entries (useful between tests).
 	 */


### PR DESCRIPTION
Follow-up to #310343.

After removing server-side tool search, the `serverToolCalls` / `IServerToolCall` types and `logServerToolCall` methods became dead code — nothing produces `serverToolCalls` anymore.

