### PR TITLE
Fix missing opening single quote in semanticTokenScopes selector error message

### DIFF
--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -200,7 +200,7 @@ export class TokenClassificationExtensionPoints {
 							const selector = tokenClassificationRegistry.parseTokenSelector(selectorString, contribution.language);
 							tokenClassificationRegistry.registerTokenStyleDefault(selector, { scopesToProbe: tmScopes.map(s => s.split(' ')) });
 						} catch (e) {
-							collector.error(nls.localize('invalid.semanticTokenScopes.scopes.selector', "configuration.semanticTokenScopes.scopes': Problems parsing selector {0}.", selectorString));
+							collector.error(nls.localize('invalid.semanticTokenScopes.scopes.selector', "'configuration.semanticTokenScopes.scopes': Problems parsing selector {0}.", selectorString));
 							// invalid selector, ignore
 						}
 					}


### PR DESCRIPTION
Fixes #310469

## What

The error message for selector parsing in `tokenClassificationExtensionPoint.ts` (line 203) was missing the opening single quote around the configuration key name.

```diff
-"configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
+"'configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
```

## Why

All other similar error messages in the same file consistently wrap the configuration key in single quotes:
- `'configuration.{0}.id' must be defined`
- `'configuration.semanticTokenScopes.language' must be a string`
- `'configuration.semanticTokenScopes.scopes' values must be an array of strings`

The missing opening quote made this error message appear malformed compared to all others in the file.