### PR TITLE
Fix typo "languge" → "language" in semanticTokenScopes description

### DIFF
--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -85,7 +85,7 @@ const tokenStyleDefaultsExtPoint = ExtensionsRegistry.registerExtensionPoint<ITo
 			type: 'object',
 			properties: {
 				language: {
-					description: nls.localize('contributes.semanticTokenScopes.languages', 'Lists the languge for which the defaults are.'),
+					description: nls.localize('contributes.semanticTokenScopes.languages', 'Lists the language for which the defaults are.'),
 					type: 'string'
 				},
 				scopes: {


### PR DESCRIPTION
Fixes #310472

## What

Fixes a typo in `src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts` line 88:

```diff
-'Lists the languge for which the defaults are.'
+'Lists the language for which the defaults are.'
```

This string is the description for the `language` property in the `semanticTokenScopes` contribution point schema, shown to extension authors.