### PR TITLE
Fix: correct indefinite article 'a' → 'an' before vowel-initial words in localize strings

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -583,7 +583,7 @@ const schema: IJSONSchema = {
 		},
 		autoClosingPairs: {
 			default: [['(', ')'], ['[', ']'], ['{', '}']],
-			description: nls.localize('schema.autoClosingPairs', 'Defines the bracket pairs. When a opening bracket is entered, the closing bracket is inserted automatically.'),
+			description: nls.localize('schema.autoClosingPairs', 'Defines the bracket pairs. When an opening bracket is entered, the closing bracket is inserted automatically.'),
 			type: 'array',
 			items: {
 				oneOf: [{

--- a/src/vs/workbench/contrib/extensions/browser/extensionsIcons.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsIcons.ts
@@ -32,10 +32,10 @@ export const starFullIcon = registerIcon('extensions-star-full', Codicon.starFul
 export const starHalfIcon = registerIcon('extensions-star-half', Codicon.starHalf, localize('starHalfIcon', 'Half star icon used for the rating in the extensions editor.'));
 export const starEmptyIcon = registerIcon('extensions-star-empty', Codicon.starEmpty, localize('starEmptyIcon', 'Empty star icon used for the rating in the extensions editor.'));
 
-export const errorIcon = registerIcon('extensions-error-message', Codicon.error, localize('errorIcon', 'Icon shown with a error message in the extensions editor.'));
+export const errorIcon = registerIcon('extensions-error-message', Codicon.error, localize('errorIcon', 'Icon shown with an error message in the extensions editor.'));
 export const warningIcon = registerIcon('extensions-warning-message', Codicon.warning, localize('warningIcon', 'Icon shown with a warning message in the extensions editor.'));
 export const infoIcon = registerIcon('extensions-info-message', Codicon.info, localize('infoIcon', 'Icon shown with an info message in the extensions editor.'));
 
 export const trustIcon = registerIcon('extension-workspace-trust', Codicon.shield, localize('trustIcon', 'Icon shown with a workspace trust message in the extension editor.'));
-export const activationTimeIcon = registerIcon('extension-activation-time', Codicon.history, localize('activationtimeIcon', 'Icon shown with a activation time message in the extension editor.'));
+export const activationTimeIcon = registerIcon('extension-activation-time', Codicon.history, localize('activationtimeIcon', 'Icon shown with an activation time message in the extension editor.'));
 export const restartRequiredIcon = registerIcon('extension-restart-required', Codicon.refresh, localize('restartRequiredIcon', 'Icon shown when an extension requires a restart in the extensions view.'));

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -287,7 +287,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				throw new TaskError(Severity.Error, error.message, TaskErrors.UnknownError);
 			} else {
 				this._log(error.toString());
-				throw new TaskError(Severity.Error, nls.localize('TerminalTaskSystem.unknownError', 'A unknown error has occurred while executing a task. See task output log for details.'), TaskErrors.UnknownError);
+				throw new TaskError(Severity.Error, nls.localize('TerminalTaskSystem.unknownError', 'An unknown error has occurred while executing a task. See task output log for details.'), TaskErrors.UnknownError);
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/testing/browser/icons.ts
+++ b/src/vs/workbench/contrib/testing/browser/icons.ts
@@ -37,7 +37,7 @@ export const testingCancelRefreshTests = registerIcon('testing-cancel-refresh-te
 
 export const testingCoverageReport = registerIcon('testing-coverage', Codicon.coverage, localize('testingCoverage', 'Icon representing test coverage'));
 export const testingWasCovered = registerIcon('testing-was-covered', Codicon.check, localize('testingWasCovered', 'Icon representing that an element was covered'));
-export const testingCoverageMissingBranch = registerIcon('testing-missing-branch', Codicon.question, localize('testingMissingBranch', 'Icon representing a uncovered block without a range'));
+export const testingCoverageMissingBranch = registerIcon('testing-missing-branch', Codicon.question, localize('testingMissingBranch', 'Icon representing an uncovered block without a range'));
 
 export const testingStatesToIcons = new Map<TestResultState, ThemeIcon>([
 	[TestResultState.Errored, registerIcon('testing-error-icon', Codicon.issues, localize('testingErrorIcon', 'Icon shown for tests that have an error.'))],

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -347,7 +347,7 @@ export const schema: IJSONSchema = {
 					{
 						label: 'onOpenExternalUri',
 						body: 'onOpenExternalUri',
-						description: nls.localize('vscode.extension.activationEvents.onOpenExternalUri', 'An activation event emitted whenever a external uri (such as an http or https link) is being opened.'),
+						description: nls.localize('vscode.extension.activationEvents.onOpenExternalUri', 'An activation event emitted whenever an external uri (such as an http or https link) is being opened.'),
 					},
 					{
 						label: 'onCustomEditor',

--- a/src/vs/workbench/services/language/common/languageService.ts
+++ b/src/vs/workbench/services/language/common/languageService.ts
@@ -97,7 +97,7 @@ export const languagesExtPoint: IExtensionPoint<IRawLanguageExtensionPoint[]> = 
 				},
 				icon: {
 					type: 'object',
-					description: localize('vscode.extension.contributes.languages.icon', 'A icon to use as file icon, if no icon theme provides one for the language.'),
+					description: localize('vscode.extension.contributes.languages.icon', 'An icon to use as file icon, if no icon theme provides one for the language.'),
 					properties: {
 						light: {
 							description: localize('vscode.extension.contributes.languages.icon.light', 'Icon path when a light theme is used'),


### PR DESCRIPTION
Fixes #310474

## What

Corrects 7 instances of the indefinite article 'a' used before words that begin with a vowel sound, where 'an' is grammatically required.

## Changes

| File | Before | After |
|------|--------|-------|
| `testing/browser/icons.ts:40` | `a uncovered block` | `an uncovered block` |
| `tasks/browser/terminalTaskSystem.ts:290` | `A unknown error` | `An unknown error` |
| `extensions/browser/extensionsIcons.ts:35` | `a error message` | `an error message` |
| `extensions/browser/extensionsIcons.ts:40` | `a activation time message` | `an activation time message` |
| `codeEditor/common/languageConfigurationExtensionPoint.ts:586` | `a opening bracket` | `an opening bracket` |
| `services/language/common/languageService.ts:100` | `A icon to use` | `An icon to use` |
| `services/extensions/common/extensionsRegistry.ts:350` | `a external uri` | `an external uri` |

All changes are within `nls.localize()` / `localize()` calls — no runtime behavior is affected.