### PR TITLE
Fix: word duplication and truncation typos in localize strings

### DIFF
--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -359,7 +359,7 @@
 	"github.copilot.config.projectLabels.inline": "Add project labels in inline edit requests.",
 	"github.copilot.config.workspace.maxLocalIndexSize": "Maximum size of the local workspace index.",
 	"github.copilot.config.workspace.enableCodeSearch": "Enable code search in workspace context.",
-	"github.copilot.config.workspace.maxDiffSizeBeforeUsingExternalIngest": "Maximum number of local changes before we start using using external ingest.",
+	"github.copilot.config.workspace.maxDiffSizeBeforeUsingExternalIngest": "Maximum number of local changes before we start using external ingest.",
 	"github.copilot.config.workspace.preferredEmbeddingsModel": "Preferred embeddings model for semantic search.",
 	"github.copilot.config.workspace.prototypeAdoCodeSearchEndpointOverride": "Override endpoint for Azure DevOps code search prototype.",
 	"github.copilot.config.feedback.onChange": "Enable feedback collection on configuration changes.",

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},

--- a/src/vs/workbench/contrib/testing/browser/icons.ts
+++ b/src/vs/workbench/contrib/testing/browser/icons.ts
@@ -32,7 +32,7 @@ export const testingUpdateProfiles = registerIcon('testing-update-profiles', Cod
 export const testingRefreshTests = registerIcon('testing-refresh-tests', Codicon.refresh, localize('testingRefreshTests', 'Icon on the button to refresh tests.'));
 export const testingTurnContinuousRunOn = registerIcon('testing-turn-continuous-run-on', Codicon.eye, localize('testingTurnContinuousRunOn', 'Icon to turn continuous test runs on.'));
 export const testingTurnContinuousRunOff = registerIcon('testing-turn-continuous-run-off', Codicon.eyeClosed, localize('testingTurnContinuousRunOff', 'Icon to turn continuous test runs off.'));
-export const testingContinuousIsOn = registerIcon('testing-continuous-is-on', Codicon.eye, localize('testingTurnContinuousRunIsOn', 'Icon when continuous run is on for a test ite,.'));
+export const testingContinuousIsOn = registerIcon('testing-continuous-is-on', Codicon.eye, localize('testingTurnContinuousRunIsOn', 'Icon when continuous run is on for a test item.'));
 export const testingCancelRefreshTests = registerIcon('testing-cancel-refresh-tests', Codicon.stop, localize('testingCancelRefreshTests', 'Icon on the button to cancel refreshing tests.'));
 
 export const testingCoverageReport = registerIcon('testing-coverage', Codicon.coverage, localize('testingCoverage', 'Icon representing test coverage'));


### PR DESCRIPTION
Fixes #310476

## What

Corrects three word-level typos in user-facing localization strings.

## Changes

| File | Before | After |
|------|--------|-------|
| `notebook/browser/notebook.contribution.ts:981` | `position for for specific file types` | `position for specific file types` |
| `testing/browser/icons.ts:35` | `on for a test ite,.` | `on for a test item.` |
| `copilot/package.nls.json:362` | `we start using using external ingest` | `we start using external ingest` |

All are within `nls.localize()` / JSON value strings visible to end users. No runtime behavior is affected.