### PR TITLE
Fix: remove trailing spaces in localize string descriptions

### DIFF
--- a/src/vs/platform/theme/common/tokenClassificationRegistry.ts
+++ b/src/vs/platform/theme/common/tokenClassificationRegistry.ts
@@ -570,7 +570,7 @@ function createDefaultTokenClassificationRegistry(): TokenClassificationRegistry
 	registerTokenType('event', nls.localize('event', "Style for events."), [['variable.other.event']]);
 	registerTokenType('decorator', nls.localize('decorator', "Style for decorators & annotations."), [['entity.name.decorator'], ['entity.name.function']]);
 
-	registerTokenType('label', nls.localize('labels', "Style for labels. "), undefined);
+	registerTokenType('label', nls.localize('labels', "Style for labels."), undefined);
 
 	// default token modifiers
 

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -363,7 +363,7 @@ jsonRegistry.registerSchema('vscode://schemas/workspaceConfig', {
 						},
 						name: {
 							type: 'string',
-							description: nls.localize('workspaceConfig.name.description', "An optional name for the folder. ")
+							description: nls.localize('workspaceConfig.name.description', "An optional name for the folder.")
 						}
 					},
 					required: ['path']
@@ -375,7 +375,7 @@ jsonRegistry.registerSchema('vscode://schemas/workspaceConfig', {
 						},
 						name: {
 							type: 'string',
-							description: nls.localize('workspaceConfig.name.description', "An optional name for the folder. ")
+							description: nls.localize('workspaceConfig.name.description', "An optional name for the folder.")
 						}
 					},
 					required: ['uri']


### PR DESCRIPTION
Fixes #310480

## What

Removes unintentional trailing spaces in three localization string descriptions.

## Changes

**`platform/theme/common/tokenClassificationRegistry.ts:573`**
```
"Style for labels. "  →  "Style for labels."
```

**`workbench/api/common/configurationExtensionPoint.ts:366,378`** (same key used twice)
```
"An optional name for the folder. "  →  "An optional name for the folder."
```

All changes are in `nls.localize()` calls. No runtime behavior is affected.