### PR TITLE
Fix: normalize 'E.g' → 'e.g.' abbreviation in localize strings

### DIFF
--- a/src/vs/platform/extensions/common/extensionValidator.ts
+++ b/src/vs/platform/extensions/common/extensionValidator.ts
@@ -404,13 +404,13 @@ function isVersionValid(currentVersion: string, date: ProductDate, requestedVers
 	if (desiredVersion.majorBase === 0) {
 		// force that major and minor must be specific
 		if (!desiredVersion.majorMustEqual || !desiredVersion.minorMustEqual) {
-			notices.push(nls.localize('versionSpecificity1', "Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions before 1.0.0, please define at a minimum the major and minor desired version. E.g. ^0.10.0, 0.10.x, 0.11.0, etc.", requestedVersion));
+			notices.push(nls.localize('versionSpecificity1', "Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions before 1.0.0, please define at a minimum the major and minor desired version. e.g. ^0.10.0, 0.10.x, 0.11.0, etc.", requestedVersion));
 			return false;
 		}
 	} else {
 		// force that major must be specific
 		if (!desiredVersion.majorMustEqual) {
-			notices.push(nls.localize('versionSpecificity2', "Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions after 1.0.0, please define at a minimum the major desired version. E.g. ^1.10.0, 1.10.x, 1.x.x, 2.x.x, etc.", requestedVersion));
+			notices.push(nls.localize('versionSpecificity2', "Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions after 1.0.0, please define at a minimum the major desired version. e.g. ^1.10.0, 1.10.x, 1.x.x, 2.x.x, etc.", requestedVersion));
 			return false;
 		}
 	}

--- a/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
@@ -616,11 +616,11 @@ export class BaseIssueReporterService extends Disposable {
 			// eslint-disable-next-line no-restricted-syntax
 			const descriptionTextArea = <HTMLInputElement>this.getElementById('issue-title');
 			if (value === IssueSource.VSCode) {
-				descriptionTextArea.placeholder = localize('vscodePlaceholder', "E.g Workbench is missing problems panel");
+				descriptionTextArea.placeholder = localize('vscodePlaceholder', "e.g. Workbench is missing problems panel");
 			} else if (value === IssueSource.Extension) {
-				descriptionTextArea.placeholder = localize('extensionPlaceholder', "E.g. Missing alt text on extension readme image");
+				descriptionTextArea.placeholder = localize('extensionPlaceholder', "e.g. Missing alt text on extension readme image");
 			} else if (value === IssueSource.Marketplace) {
-				descriptionTextArea.placeholder = localize('marketplacePlaceholder', "E.g Cannot disable installed extension");
+				descriptionTextArea.placeholder = localize('marketplacePlaceholder', "e.g. Cannot disable installed extension");
 			} else {
 				descriptionTextArea.placeholder = localize('undefinedPlaceholder', "Please enter a title");
 			}


### PR DESCRIPTION
Fixes #310484

## What

Normalizes the `e.g.` abbreviation to use lowercase and include the trailing period consistently across 5 localization strings.

## Changes

**`platform/extensions/common/extensionValidator.ts`** (2 instances):
```
E.g. ^0.10.0  →  e.g. ^0.10.0
E.g. ^1.10.0  →  e.g. ^1.10.0
```

**`contrib/issue/browser/baseIssueReporterService.ts`** (3 placeholder texts):
```
"E.g Workbench is missing problems panel"    →  "e.g. Workbench is missing problems panel"
"E.g. Missing alt text on extension readme"  →  "e.g. Missing alt text on extension readme"
"E.g Cannot disable installed extension"     →  "e.g. Cannot disable installed extension"
```

All changes are in `nls.localize()` / `localize()` calls. No runtime behavior is affected.