### PR TITLE
Fix: 'can not' → 'cannot' in 5 more localize string instances

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -905,10 +905,10 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			this.dialogMainService.showMessageBox({
 				type: 'info',
 				buttons: [localize({ key: 'ok', comment: ['&& denotes a mnemonic'] }, "&&OK")],
-				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI can not be opened"),
+				message: uri.scheme === Schemas.file ? localize('pathNotExistTitle', "Path does not exist") : localize('uriInvalidTitle', "URI cannot be opened"),
 				detail: uri.scheme === Schemas.file ?
 					localize('pathNotExistDetail', "The path '{0}' does not exist on this computer.", getPathLabel(uri, { os: OS, tildify: this.environmentMainService })) :
-					localize('uriInvalidDetail', "The URI '{0}' is not valid and can not be opened.", uri.toString(true))
+					localize('uriInvalidDetail', "The URI '{0}' is not valid and cannot be opened.", uri.toString(true))
 			}, BrowserWindow.getFocusedWindow() ?? undefined);
 
 			return undefined;

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -610,7 +610,7 @@ const schema: IJSONSchema = {
 		},
 		autoCloseBefore: {
 			default: ';:.,=}])> \n\t',
-			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which can not start an expression.'),
+			description: nls.localize('schema.autoCloseBefore', 'Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting. This is typically the set of characters which cannot start an expression.'),
 			type: 'string',
 		},
 		surroundingPairs: {

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -196,7 +196,7 @@ export class DebugTaskRunner implements IDisposable {
 			return Promise.resolve(null);
 		}
 		if (!root) {
-			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
+			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' cannot be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
 		}
 		// run a task before starting a debug session
 		const task = await this.taskService.getTask(root, taskId);

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -267,7 +267,7 @@ export class RawDebugSession implements IDisposable {
 	 */
 	async start(): Promise<void> {
 		if (!this.debugAdapter) {
-			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, can not start debug session.")));
+			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, cannot start debug session.")));
 		}
 
 		await this.debugAdapter.startSession();


### PR DESCRIPTION
Fixes #310486

## What

Replaces the two-word form 'can not' with the preferred one-word form 'cannot' in 5 more localization strings.

## Changes

| File | Before | After |
|------|--------|-------|
| `debug/browser/debugTaskRunner.ts:199` | `Task '{0}' can not be referenced` | `cannot be referenced` |
| `debug/browser/rawDebugSession.ts:270` | `can not start debug session` | `cannot start debug session` |
| `codeEditor/common/languageConfigurationExtensionPoint.ts:613` | `characters which can not start` | `which cannot start` |
| `platform/windows/electron-main/windowsMainService.ts:908` | `URI can not be opened` | `cannot be opened` |
| `platform/windows/electron-main/windowsMainService.ts:911` | `is not valid and can not be opened` | `cannot be opened` |

All changes are in `nls.localize()` / `localize()` calls. No runtime behavior is affected.