### PR TITLE
Fix: 'can not' → 'cannot' and article errors in extension point error messages

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -56,7 +56,7 @@ export class JSONValidationExtensionPoint {
 				const extensionLocation = extension.description.extensionLocation;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be a array"));
+					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be an array"));
 					return;
 				}
 				extensionValue.forEach(extension => {

--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -115,7 +115,7 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 			delta.added.forEach(added => {
 				added.value.forEach(rawAdapter => {
 					if (!rawAdapter.type || (typeof rawAdapter.type !== 'string')) {
-						added.collector.error(nls.localize('debugNoType', "Debugger 'type' can not be omitted and must be of type 'string'."));
+						added.collector.error(nls.localize('debugNoType', "Debugger 'type' cannot be omitted and must be of type 'string'."));
 					}
 
 					if (rawAdapter.type !== '*') {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -598,7 +598,7 @@ export class DebugService implements IDebugService {
 				if (err && err.message) {
 					await this.showError(err.message);
 				} else if (this.contextService.getWorkbenchState() === WorkbenchState.EMPTY) {
-					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file can not be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
+					await this.showError(nls.localize('noFolderWorkspaceDebugError', "The active file cannot be debugged. Make sure it is saved and that you have a debug extension installed for that file type."));
 				}
 				if (launch && !initCancellationToken.token.isCancellationRequested) {
 					await launch.openConfigFile({ preserveFocus: true }, initCancellationToken.token);

--- a/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
@@ -37,7 +37,7 @@ const configurationExtPoint = ExtensionsRegistry.registerExtensionPoint<IColorEx
 					type: 'string',
 					description: nls.localize('contributes.color.id', 'The identifier of the themable color'),
 					pattern: colorIdPattern,
-					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and can not start with a dot'),
+					patternErrorMessage: nls.localize('contributes.color.id.format', 'Identifiers must only contain letters, digits and dots and cannot start with a dot'),
 				},
 				description: {
 					type: 'string',
@@ -95,7 +95,7 @@ export class ColorExtensionPoint {
 				const collector = extension.collector;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be a array"));
+					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be an array"));
 					return;
 				}
 				const parseColorValue = (s: string, name: string) => {
@@ -112,15 +112,15 @@ export class ColorExtensionPoint {
 
 				for (const colorContribution of extensionValue) {
 					if (typeof colorContribution.id !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.id', "'configuration.colors.id' must be defined and cannot be empty"));
 						return;
 					}
 					if (!colorContribution.id.match(colorIdPattern)) {
-						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot"));
+						collector.error(nls.localize('invalid.id.format', "'configuration.colors.id' must only contain letters, digits and dots and cannot start with a dot"));
 						return;
 					}
 					if (typeof colorContribution.description !== 'string' || colorContribution.id.length === 0) {
-						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.description', "'configuration.colors.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaults = colorContribution.defaults;

--- a/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
@@ -90,7 +90,7 @@ export class IconExtensionPoint {
 					}
 					const iconContribution = extensionValue[id];
 					if (typeof iconContribution.description !== 'string' || iconContribution.description.length === 0) {
-						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and can not be empty"));
+						collector.error(nls.localize('invalid.icons.description', "'configuration.icons.description' must be defined and cannot be empty"));
 						return;
 					}
 					const defaultIcon = iconContribution.default;

--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -109,7 +109,7 @@ export class TokenClassificationExtensionPoints {
 	constructor() {
 		function validateTypeOrModifier(contribution: ITokenTypeExtensionPoint | ITokenModifierExtensionPoint, extensionPoint: string, collector: ExtensionMessageCollector): boolean {
 			if (typeof contribution.id !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.id', "'configuration.{0}.id' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			if (!contribution.id.match(typeAndModifierIdPattern)) {
@@ -122,7 +122,7 @@ export class TokenClassificationExtensionPoints {
 				return false;
 			}
 			if (typeof contribution.description !== 'string' || contribution.id.length === 0) {
-				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and can not be empty", extensionPoint));
+				collector.error(nls.localize('invalid.description', "'configuration.{0}.description' must be defined and cannot be empty", extensionPoint));
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Fixes user-facing error messages in debug and theme extension points that use the two-word form 'can not' instead of the standard one-word 'cannot'. Also fixes article agreement errors ('a array' → 'an array').

**Changes:**
- `debugAdapterManager.ts`: "can not be omitted" → "cannot be omitted"
- `debugService.ts`: "can not be debugged" → "cannot be debugged"
- `colorExtensionPoint.ts`: 3× "can not" → "cannot"; "a array" → "an array"
- `iconExtensionPoint.ts`: "can not be empty" → "cannot be empty"
- `tokenClassificationExtensionPoint.ts`: 2× "can not" → "cannot"
- `jsonValidationExtensionPoint.ts`: "must be a array" → "must be an array"

Fixes #310489