### PR TITLE
Fix: article errors, typo, and missing comma in localized strings

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -160,7 +160,7 @@ const presentation: IJSONSchema = {
 		focus: {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('JsonSchema.tasks.presentation.focus', 'Controls whether the panel takes focus. Default is false. If set to true the panel is revealed as well.')
+			description: nls.localize('JsonSchema.tasks.presentation.focus', 'Controls whether the panel takes focus. Default is false. If set to true, the panel is revealed as well.')
 		},
 		revealProblems: {
 			type: 'string',

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -793,7 +793,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 						result.semanticTokenRules.push(rule);
 					}
 				} catch (e) {
-					return Promise.reject(new Error(nls.localize({ key: 'error.invalidformat.semanticTokenColors', comment: ['{0} will be replaced by a path. Values in quotes should not be translated.'] }, "Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector", themeLocation.toString())));
+					return Promise.reject(new Error(nls.localize({ key: 'error.invalidformat.semanticTokenColors', comment: ['{0} will be replaced by a path. Values in quotes should not be translated.'] }, "Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains an invalid selector", themeLocation.toString())));
 				}
 			}
 		}

--- a/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/iconExtensionPoint.ts
@@ -119,7 +119,7 @@ export class IconExtensionPoint {
 							}
 						}, iconContribution.description);
 					} else {
-						collector.error(nls.localize('invalid.icons.default', "'configuration.icons.default' must be either a reference to the id of an other theme icon (string) or a icon definition (object) with properties `fontPath` and `fontCharacter`."));
+						collector.error(nls.localize('invalid.icons.default', "'configuration.icons.default' must be either a reference to the id of another theme icon (string) or an icon definition (object) with properties `fontPath` and `fontCharacter`."));
 					}
 				}
 			}

--- a/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/tokenClassificationExtensionPoint.ts
@@ -85,7 +85,7 @@ const tokenStyleDefaultsExtPoint = ExtensionsRegistry.registerExtensionPoint<ITo
 			type: 'object',
 			properties: {
 				language: {
-					description: nls.localize('contributes.semanticTokenScopes.languages', 'Lists the languge for which the defaults are.'),
+					description: nls.localize('contributes.semanticTokenScopes.languages', 'Lists the language for which the defaults are.'),
 					type: 'string'
 				},
 				scopes: {


### PR DESCRIPTION
Fixes small grammar and spelling errors in user-facing localized strings.

**Changes:**
- `colorThemeData.ts`: "contains a invalid selector" → "contains an invalid selector"
- `iconExtensionPoint.ts`: "a reference to the id of an other theme icon... or a icon definition" → "another theme icon... or an icon definition"
- `tokenClassificationExtensionPoint.ts`: typo "languge" → "language"
- `jsonSchema_v2.ts`: "If set to true the panel is revealed" → "If set to true, the panel is revealed" (missing comma after introductory conditional)

Fixes #310491