### PR TITLE
Fix: trailing spaces in remote localized notification and tooltip strings

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -442,7 +442,7 @@ class OnAutoForwardedAction extends Disposable {
 	private async basicMessage(tunnel: RemoteTunnel) {
 		const properties = await this.remoteExplorerService.tunnelModel.getAttributes([{ host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort }], false);
 		const label = properties?.get(tunnel.tunnelRemotePort)?.label;
-		return nls.localize('remote.tunnelsView.automaticForward', "Your application{0} running on port {1} is available.  ",
+		return nls.localize('remote.tunnelsView.automaticForward', "Your application{0} running on port {1} is available. ",
 			label ? ` (${label})` : '',
 			tunnel.tunnelRemotePort);
 	}
@@ -467,7 +467,7 @@ class OnAutoForwardedAction extends Disposable {
 
 		if ((tunnel.tunnelLocalPort !== tunnel.tunnelRemotePort) && this.tunnelService.canElevate && this.tunnelService.isPortPrivileged(tunnel.tunnelRemotePort)) {
 			// Privileged ports are not on Windows, so it's safe to use "superuser"
-			message += nls.localize('remote.tunnelsView.elevationMessage', "You'll need to run as superuser to use port {0} locally.  ", tunnel.tunnelRemotePort);
+			message += nls.localize('remote.tunnelsView.elevationMessage', "You'll need to run as superuser to use port {0} locally. ", tunnel.tunnelRemotePort);
 			choices.unshift(this.elevateChoice(tunnel));
 		}
 

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -815,7 +815,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 				if (remoteExtension) {
 					quickPick.items = [];
 					quickPick.busy = true;
-					quickPick.placeholder = nls.localize('remote.startActions.installingExtension', 'Installing extension... ');
+					quickPick.placeholder = nls.localize('remote.startActions.installingExtension', 'Installing extension...');
 
 					try {
 						await this.installExtension(remoteExtension.id, selectedItems[0].label);

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -673,9 +673,9 @@ class TunnelItem implements ITunnelItem {
 	get tooltipPostfix(): string {
 		let information: string;
 		if (this.localAddress) {
-			information = nls.localize('remote.tunnel.tooltipForwarded', "Remote port {0}:{1} forwarded to local address {2}. ", this.remoteHost, this.remotePort, this.localAddress);
+			information = nls.localize('remote.tunnel.tooltipForwarded', "Remote port {0}:{1} forwarded to local address {2}.", this.remoteHost, this.remotePort, this.localAddress);
 		} else {
-			information = nls.localize('remote.tunnel.tooltipCandidate', "Remote port {0}:{1} not forwarded. ", this.remoteHost, this.remotePort);
+			information = nls.localize('remote.tunnel.tooltipCandidate', "Remote port {0}:{1} not forwarded.", this.remoteHost, this.remotePort);
 		}
 
 		return information;


### PR DESCRIPTION
Removes unnecessary trailing whitespace from localized strings used in remote tunnel notifications, tooltip messages, and the extension install placeholder.

**Changes:**
- `remoteExplorer.ts`: "is available.  " → "is available. " (double → single space); "locally.  " → "locally. " (double → single space)
- `tunnelView.ts`: "forwarded to local address {2}. " → "forwarded to local address {2}." (removes trailing space); "not forwarded. " → "not forwarded." (removes trailing space)
- `remoteIndicator.ts`: "Installing extension... " → "Installing extension..." (removes trailing space from placeholder text)

The double trailing spaces in `remoteExplorer.ts` would cause double-space gaps when messages are concatenated.

Fixes #310496