### PR TITLE
Fix hydration of external-source plugins after reload (#308504)

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -610,7 +610,19 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 				const plugins = await this._readPluginsFromDirectory(repoDir, reference);
 				const match = plugins.find(p => {
 					const installUri = this._pluginRepositoryService.getPluginInstallUri(p);
-					return isEqual(installUri, entry.pluginUri);
+					if (isEqual(installUri, entry.pluginUri)) {
+						return true;
+					}
+					// External-source plugins (GitHub, GitUrl, Npm, Pip) are stored
+					// with a URI from getPluginSourceInstallUri() which resolves to a
+					// separate cache directory, not the marketplace-relative path that
+					// getPluginInstallUri() returns. Fall back to comparing against the
+					// source install URI for these plugins. (#308504)
+					if (p.sourceDescriptor.kind !== PluginSourceKind.RelativePath) {
+						const sourceInstallUri = this._pluginRepositoryService.getPluginSourceInstallUri(p.sourceDescriptor);
+						return isEqual(sourceInstallUri, entry.pluginUri);
+					}
+					return false;
 				});
 				if (match) {
 					this._pluginMetadata.set(key, match);

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { timeout } from '../../../../../../base/common/async.js';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IFileService, IFileSystemWatcher } from '../../../../../../platform/files/common/files.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IRequestService } from '../../../../../../platform/request/common/request.js';
@@ -520,5 +522,266 @@ suite('getPluginSourceLabel', () => {
 
 	test('formats pip source with version', () => {
 		assert.strictEqual(getPluginSourceLabel({ kind: PluginSourceKind.Pip, package: 'my-plugin', version: '2.0' }), 'my-plugin==2.0');
+	});
+});
+
+/**
+ * Minimal in-memory file service used to simulate `installed.json` and
+ * marketplace definition files on disk during hydration tests.
+ */
+class HydrationTestFileService {
+	private readonly _files = new Map<string, string>();
+	private readonly _folders = new Set<string>();
+
+	async exists(resource: URI): Promise<boolean> {
+		const key = resource.toString();
+		return this._files.has(key) || this._folders.has(key);
+	}
+
+	async readFile(resource: URI): Promise<{ value: VSBuffer }> {
+		const key = resource.toString();
+		const value = this._files.get(key);
+		if (value === undefined) {
+			throw new Error(`Missing file: ${key}`);
+		}
+		return { value: VSBuffer.fromString(value) };
+	}
+
+	async writeFile(_resource: URI, _content: VSBuffer): Promise<unknown> {
+		// Writes are not needed for hydration tests; swallow them.
+		return {};
+	}
+
+	async createFolder(resource: URI): Promise<unknown> {
+		this._folders.add(resource.toString());
+		return {};
+	}
+
+	createWatcher(): IFileSystemWatcher {
+		return { onDidChange: Event.None, dispose: () => { } };
+	}
+
+	setFile(resource: URI, content: string): void {
+		this._files.set(resource.toString(), content);
+	}
+}
+
+suite('PluginMarketplaceService - hydration of installed plugins', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	const agentPluginsHome = URI.file('/agent-plugins');
+	const installedJsonUri = URI.joinPath(agentPluginsHome, 'installed.json');
+	const marketplaceRepoDir = URI.file('/agent-plugins/github.com/sugeryp/marketplace-plugins-test');
+	const marketplaceRef = parseMarketplaceReference('sugeryp/marketplace-plugins-test')!;
+
+	interface ICreateServiceOptions {
+		installedEntries: { pluginUri: URI; marketplace: string }[];
+		marketplaceJsonPath: string;
+		marketplaceJsonContent: object;
+		/** URI returned by getPluginInstallUri for a plugin, keyed by plugin name. */
+		installUrisByName: Map<string, URI>;
+		/** URI returned by getPluginSourceInstallUri, keyed by source kind. */
+		sourceInstallUrisByKind: Map<PluginSourceKind, URI>;
+	}
+
+	function createService(options: ICreateServiceOptions): PluginMarketplaceService {
+		const fileService = new HydrationTestFileService();
+
+		// Seed installed.json so FileBackedInstalledPluginsStore picks up the
+		// stored entries at construction time, simulating a restart with
+		// pre-existing installed plugins.
+		fileService.setFile(installedJsonUri, JSON.stringify({
+			version: 1,
+			installed: options.installedEntries.map(e => ({
+				pluginUri: e.pluginUri.toString(),
+				marketplace: e.marketplace,
+			})),
+		}));
+
+		// Seed the marketplace.json inside the (mock) cloned repo directory so
+		// _readPluginsFromDirectory can parse it during hydration.
+		fileService.setFile(
+			URI.joinPath(marketplaceRepoDir, options.marketplaceJsonPath),
+			JSON.stringify(options.marketplaceJsonContent),
+		);
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService({
+			[ChatConfiguration.PluginMarketplaces]: ['sugeryp/marketplace-plugins-test'],
+			[ChatConfiguration.PluginsEnabled]: true,
+		}));
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
+		instantiationService.stub(IFileService, fileService as unknown as IFileService);
+		instantiationService.stub(IAgentPluginRepositoryService, {
+			agentPluginsHome,
+			getRepositoryUri: () => marketplaceRepoDir,
+			getPluginInstallUri: (plugin: IMarketplacePlugin) => {
+				return options.installUrisByName.get(plugin.name)
+					// Default: marketplace-relative path (mirrors production behaviour).
+					?? URI.joinPath(marketplaceRepoDir, plugin.source || plugin.name);
+			},
+			getPluginSourceInstallUri: (descriptor: { kind: PluginSourceKind }) => {
+				const uri = options.sourceInstallUrisByKind.get(descriptor.kind);
+				if (!uri) {
+					throw new Error(`No source install URI stubbed for ${descriptor.kind}`);
+				}
+				return uri;
+			},
+		} as unknown as IAgentPluginRepositoryService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IRequestService, {} as unknown as IRequestService);
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+		instantiationService.stub(IWorkspacePluginSettingsService, {
+			extraMarketplaces: observableValue('test.extraMarketplaces', []),
+			enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+		instantiationService.stub(IWorkspaceTrustManagementService, {
+			isWorkspaceTrusted: () => true,
+			onDidChangeTrust: Event.None,
+		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
+
+		return store.add(instantiationService.createInstance(PluginMarketplaceService));
+	}
+
+	async function waitForHydration(service: PluginMarketplaceService, expectedCount: number): Promise<void> {
+		for (let i = 0; i < 50; i++) {
+			if (service.installedPlugins.get().length >= expectedCount) {
+				return;
+			}
+			await timeout(10);
+		}
+	}
+
+	test('hydrates metadata for inline RelativePath plugins after restart', async () => {
+		// installed.json entry for an inline plugin uses the marketplace-relative URI,
+		// which matches getPluginInstallUri() directly.
+		const inlineInstallUri = URI.joinPath(marketplaceRepoDir, 'plugins/hello-sample');
+
+		const service = createService({
+			installedEntries: [{ pluginUri: inlineInstallUri, marketplace: marketplaceRef.displayLabel }],
+			marketplaceJsonPath: '.claude-plugin/marketplace.json',
+			marketplaceJsonContent: {
+				name: 'sugeryp/marketplace-plugins-test',
+				owner: { name: 'sugeryp' },
+				plugins: [
+					{
+						name: 'hello-sample',
+						source: './plugins/hello-sample',
+						description: 'inline sample plugin',
+						version: '0.1.0',
+					},
+				],
+			},
+			installUrisByName: new Map([['hello-sample', inlineInstallUri]]),
+			sourceInstallUrisByKind: new Map(),
+		});
+
+		await waitForHydration(service, 1);
+
+		const installed = service.installedPlugins.get();
+		assert.strictEqual(installed.length, 1, 'inline plugin should be hydrated on restart');
+		assert.strictEqual(installed[0].plugin.name, 'hello-sample');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.RelativePath);
+	});
+
+	test('hydrates metadata for GitHub-source plugins after restart (#308504)', async () => {
+		// External-source plugins are stored in installed.json with the URI
+		// returned by getPluginSourceInstallUri(), which points to a separate
+		// cache directory — NOT the marketplace-relative path that
+		// getPluginInstallUri() would return. Prior to #308504 the hydration
+		// path only compared against getPluginInstallUri(), so the match always
+		// failed and the plugin appeared uninstalled after reload.
+		const githubSourceInstallUri = URI.file('/agent-plugins/github.com/sugeryp/edge-tag');
+		const marketplaceRelativeUri = URI.joinPath(marketplaceRepoDir, 'edge-tag');
+
+		const service = createService({
+			installedEntries: [{ pluginUri: githubSourceInstallUri, marketplace: marketplaceRef.displayLabel }],
+			marketplaceJsonPath: '.claude-plugin/marketplace.json',
+			marketplaceJsonContent: {
+				name: 'sugeryp/marketplace-plugins-test',
+				owner: { name: 'sugeryp' },
+				plugins: [
+					{
+						name: 'edge-tag',
+						description: 'github-source plugin',
+						version: '0.1.0',
+						source: { source: 'github', repo: 'sugeryp/edge-tag', ref: 'plugin-test' },
+					},
+				],
+			},
+			installUrisByName: new Map([['edge-tag', marketplaceRelativeUri]]),
+			sourceInstallUrisByKind: new Map([[PluginSourceKind.GitHub, githubSourceInstallUri]]),
+		});
+
+		await waitForHydration(service, 1);
+
+		const installed = service.installedPlugins.get();
+		assert.strictEqual(installed.length, 1, 'external-source plugin should be hydrated on restart');
+		assert.strictEqual(installed[0].plugin.name, 'edge-tag');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitHub);
+		assert.strictEqual(installed[0].pluginUri.toString(), githubSourceInstallUri.toString());
+	});
+
+	test('hydrates metadata for npm-source plugins after restart (#308504)', async () => {
+		const npmSourceInstallUri = URI.file('/agent-plugins/npm/@acme/my-plugin');
+		const marketplaceRelativeUri = URI.joinPath(marketplaceRepoDir, 'my-npm-plugin');
+
+		const service = createService({
+			installedEntries: [{ pluginUri: npmSourceInstallUri, marketplace: marketplaceRef.displayLabel }],
+			marketplaceJsonPath: '.claude-plugin/marketplace.json',
+			marketplaceJsonContent: {
+				name: 'sugeryp/marketplace-plugins-test',
+				owner: { name: 'sugeryp' },
+				plugins: [
+					{
+						name: 'my-npm-plugin',
+						description: 'npm-source plugin',
+						version: '1.0.0',
+						source: { source: 'npm', package: '@acme/my-plugin' },
+					},
+				],
+			},
+			installUrisByName: new Map([['my-npm-plugin', marketplaceRelativeUri]]),
+			sourceInstallUrisByKind: new Map([[PluginSourceKind.Npm, npmSourceInstallUri]]),
+		});
+
+		await waitForHydration(service, 1);
+
+		const installed = service.installedPlugins.get();
+		assert.strictEqual(installed.length, 1, 'npm-source plugin should be hydrated on restart');
+		assert.strictEqual(installed[0].plugin.name, 'my-npm-plugin');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.Npm);
+	});
+
+	test('does not hydrate when neither install URI matches', async () => {
+		const service = createService({
+			installedEntries: [{
+				pluginUri: URI.file('/agent-plugins/unrelated/path'),
+				marketplace: marketplaceRef.displayLabel,
+			}],
+			marketplaceJsonPath: '.claude-plugin/marketplace.json',
+			marketplaceJsonContent: {
+				name: 'sugeryp/marketplace-plugins-test',
+				owner: { name: 'sugeryp' },
+				plugins: [
+					{
+						name: 'edge-tag',
+						description: 'github-source plugin',
+						version: '0.1.0',
+						source: { source: 'github', repo: 'sugeryp/edge-tag' },
+					},
+				],
+			},
+			installUrisByName: new Map([['edge-tag', URI.joinPath(marketplaceRepoDir, 'edge-tag')]]),
+			sourceInstallUrisByKind: new Map([[PluginSourceKind.GitHub, URI.file('/agent-plugins/github.com/sugeryp/edge-tag')]]),
+		});
+
+		// Give the async hydration a chance to run — it should find no match
+		// and leave installedPlugins empty.
+		for (let i = 0; i < 10; i++) {
+			await timeout(10);
+		}
+
+		assert.strictEqual(service.installedPlugins.get().length, 0, 'unrelated URI must not be matched against any plugin');
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -7,12 +7,15 @@ import assert from 'assert';
 import { timeout } from '../../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Event } from '../../../../../../base/common/event.js';
+import { Schemas } from '../../../../../../base/common/network.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IFileService, IFileSystemWatcher } from '../../../../../../platform/files/common/files.js';
+import { FileService } from '../../../../../../platform/files/common/fileService.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IRequestService } from '../../../../../../platform/request/common/request.js';
@@ -525,53 +528,12 @@ suite('getPluginSourceLabel', () => {
 	});
 });
 
-/**
- * Minimal in-memory file service used to simulate `installed.json` and
- * marketplace definition files on disk during hydration tests.
- */
-class HydrationTestFileService {
-	private readonly _files = new Map<string, string>();
-	private readonly _folders = new Set<string>();
-
-	async exists(resource: URI): Promise<boolean> {
-		const key = resource.toString();
-		return this._files.has(key) || this._folders.has(key);
-	}
-
-	async readFile(resource: URI): Promise<{ value: VSBuffer }> {
-		const key = resource.toString();
-		const value = this._files.get(key);
-		if (value === undefined) {
-			throw new Error(`Missing file: ${key}`);
-		}
-		return { value: VSBuffer.fromString(value) };
-	}
-
-	async writeFile(_resource: URI, _content: VSBuffer): Promise<unknown> {
-		// Writes are not needed for hydration tests; swallow them.
-		return {};
-	}
-
-	async createFolder(resource: URI): Promise<unknown> {
-		this._folders.add(resource.toString());
-		return {};
-	}
-
-	createWatcher(): IFileSystemWatcher {
-		return { onDidChange: Event.None, dispose: () => { } };
-	}
-
-	setFile(resource: URI, content: string): void {
-		this._files.set(resource.toString(), content);
-	}
-}
-
 suite('PluginMarketplaceService - hydration of installed plugins', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	const agentPluginsHome = URI.file('/agent-plugins');
+	const agentPluginsHome = URI.from({ scheme: Schemas.inMemory, path: '/agent-plugins' });
 	const installedJsonUri = URI.joinPath(agentPluginsHome, 'installed.json');
-	const marketplaceRepoDir = URI.file('/agent-plugins/github.com/sugeryp/marketplace-plugins-test');
+	const marketplaceRepoDir = URI.joinPath(agentPluginsHome, 'github.com/sugeryp/marketplace-plugins-test');
 	const marketplaceRef = parseMarketplaceReference('sugeryp/marketplace-plugins-test')!;
 
 	interface ICreateServiceOptions {
@@ -584,25 +546,28 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 		sourceInstallUrisByKind: Map<PluginSourceKind, URI>;
 	}
 
-	function createService(options: ICreateServiceOptions): PluginMarketplaceService {
-		const fileService = new HydrationTestFileService();
+	async function createService(options: ICreateServiceOptions): Promise<PluginMarketplaceService> {
+		const logService = new NullLogService();
+		const fileService = store.add(new FileService(logService));
+		store.add(fileService.registerProvider(Schemas.inMemory, store.add(new InMemoryFileSystemProvider())));
 
 		// Seed installed.json so FileBackedInstalledPluginsStore picks up the
 		// stored entries at construction time, simulating a restart with
 		// pre-existing installed plugins.
-		fileService.setFile(installedJsonUri, JSON.stringify({
+		await fileService.createFolder(agentPluginsHome);
+		await fileService.writeFile(installedJsonUri, VSBuffer.fromString(JSON.stringify({
 			version: 1,
 			installed: options.installedEntries.map(e => ({
 				pluginUri: e.pluginUri.toString(),
 				marketplace: e.marketplace,
 			})),
-		}));
+		})));
 
 		// Seed the marketplace.json inside the (mock) cloned repo directory so
 		// _readPluginsFromDirectory can parse it during hydration.
-		fileService.setFile(
+		await fileService.writeFile(
 			URI.joinPath(marketplaceRepoDir, options.marketplaceJsonPath),
-			JSON.stringify(options.marketplaceJsonContent),
+			VSBuffer.fromString(JSON.stringify(options.marketplaceJsonContent)),
 		);
 
 		const instantiationService = store.add(new TestInstantiationService());
@@ -610,8 +575,8 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 			[ChatConfiguration.PluginMarketplaces]: ['sugeryp/marketplace-plugins-test'],
 			[ChatConfiguration.PluginsEnabled]: true,
 		}));
-		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as Partial<IEnvironmentService> as IEnvironmentService);
-		instantiationService.stub(IFileService, fileService as unknown as IFileService);
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.from({ scheme: Schemas.inMemory, path: '/cache' }) } as Partial<IEnvironmentService> as IEnvironmentService);
+		instantiationService.stub(IFileService, fileService);
 		instantiationService.stub(IAgentPluginRepositoryService, {
 			agentPluginsHome,
 			getRepositoryUri: () => marketplaceRepoDir,
@@ -628,7 +593,7 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 				return uri;
 			},
 		} as unknown as IAgentPluginRepositoryService);
-		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ILogService, logService);
 		instantiationService.stub(IRequestService, {} as unknown as IRequestService);
 		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
 		instantiationService.stub(IWorkspacePluginSettingsService, {
@@ -657,7 +622,7 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 		// which matches getPluginInstallUri() directly.
 		const inlineInstallUri = URI.joinPath(marketplaceRepoDir, 'plugins/hello-sample');
 
-		const service = createService({
+		const service = await createService({
 			installedEntries: [{ pluginUri: inlineInstallUri, marketplace: marketplaceRef.displayLabel }],
 			marketplaceJsonPath: '.claude-plugin/marketplace.json',
 			marketplaceJsonContent: {
@@ -691,10 +656,10 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 		// getPluginInstallUri() would return. Prior to #308504 the hydration
 		// path only compared against getPluginInstallUri(), so the match always
 		// failed and the plugin appeared uninstalled after reload.
-		const githubSourceInstallUri = URI.file('/agent-plugins/github.com/sugeryp/edge-tag');
+		const githubSourceInstallUri = URI.joinPath(agentPluginsHome, 'github.com/sugeryp/edge-tag');
 		const marketplaceRelativeUri = URI.joinPath(marketplaceRepoDir, 'edge-tag');
 
-		const service = createService({
+		const service = await createService({
 			installedEntries: [{ pluginUri: githubSourceInstallUri, marketplace: marketplaceRef.displayLabel }],
 			marketplaceJsonPath: '.claude-plugin/marketplace.json',
 			marketplaceJsonContent: {
@@ -722,41 +687,46 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 		assert.strictEqual(installed[0].pluginUri.toString(), githubSourceInstallUri.toString());
 	});
 
-	test('hydrates metadata for npm-source plugins after restart (#308504)', async () => {
-		const npmSourceInstallUri = URI.file('/agent-plugins/npm/@acme/my-plugin');
-		const marketplaceRelativeUri = URI.joinPath(marketplaceRepoDir, 'my-npm-plugin');
+	test('hydrates metadata for GitUrl-source plugins after restart (#308504)', async () => {
+		// `source: { source: "url", url: "..." }` in a marketplace manifest
+		// parses to a GitUrl source descriptor and installs into a cache
+		// directory outside the marketplace clone — same class of hydration
+		// failure as the GitHub case.
+		const gitUrlSourceInstallUri = URI.joinPath(agentPluginsHome, 'git-url/example.com/org/repo');
+		const marketplaceRelativeUri = URI.joinPath(marketplaceRepoDir, 'url-plugin');
 
-		const service = createService({
-			installedEntries: [{ pluginUri: npmSourceInstallUri, marketplace: marketplaceRef.displayLabel }],
+		const service = await createService({
+			installedEntries: [{ pluginUri: gitUrlSourceInstallUri, marketplace: marketplaceRef.displayLabel }],
 			marketplaceJsonPath: '.claude-plugin/marketplace.json',
 			marketplaceJsonContent: {
 				name: 'sugeryp/marketplace-plugins-test',
 				owner: { name: 'sugeryp' },
 				plugins: [
 					{
-						name: 'my-npm-plugin',
-						description: 'npm-source plugin',
-						version: '1.0.0',
-						source: { source: 'npm', package: '@acme/my-plugin' },
+						name: 'url-plugin',
+						description: 'git-url source plugin',
+						version: '0.1.0',
+						source: { source: 'url', url: 'https://example.com/org/repo.git' },
 					},
 				],
 			},
-			installUrisByName: new Map([['my-npm-plugin', marketplaceRelativeUri]]),
-			sourceInstallUrisByKind: new Map([[PluginSourceKind.Npm, npmSourceInstallUri]]),
+			installUrisByName: new Map([['url-plugin', marketplaceRelativeUri]]),
+			sourceInstallUrisByKind: new Map([[PluginSourceKind.GitUrl, gitUrlSourceInstallUri]]),
 		});
 
 		await waitForHydration(service, 1);
 
 		const installed = service.installedPlugins.get();
-		assert.strictEqual(installed.length, 1, 'npm-source plugin should be hydrated on restart');
-		assert.strictEqual(installed[0].plugin.name, 'my-npm-plugin');
-		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.Npm);
+		assert.strictEqual(installed.length, 1, 'git-url source plugin should be hydrated on restart');
+		assert.strictEqual(installed[0].plugin.name, 'url-plugin');
+		assert.strictEqual(installed[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitUrl);
+		assert.strictEqual(installed[0].pluginUri.toString(), gitUrlSourceInstallUri.toString());
 	});
 
 	test('does not hydrate when neither install URI matches', async () => {
-		const service = createService({
+		const service = await createService({
 			installedEntries: [{
-				pluginUri: URI.file('/agent-plugins/unrelated/path'),
+				pluginUri: URI.from({ scheme: Schemas.inMemory, path: '/agent-plugins/unrelated/path' }),
 				marketplace: marketplaceRef.displayLabel,
 			}],
 			marketplaceJsonPath: '.claude-plugin/marketplace.json',
@@ -773,7 +743,7 @@ suite('PluginMarketplaceService - hydration of installed plugins', () => {
 				],
 			},
 			installUrisByName: new Map([['edge-tag', URI.joinPath(marketplaceRepoDir, 'edge-tag')]]),
-			sourceInstallUrisByKind: new Map([[PluginSourceKind.GitHub, URI.file('/agent-plugins/github.com/sugeryp/edge-tag')]]),
+			sourceInstallUrisByKind: new Map([[PluginSourceKind.GitHub, URI.joinPath(agentPluginsHome, 'github.com/sugeryp/edge-tag')]]),
 		});
 
 		// Give the async hydration a chance to run — it should find no match


### PR DESCRIPTION
## Summary

Fixes #308504.

Installed agent plugins whose source is not a marketplace-relative path (i.e. `github`, `url`, `npm`, `pip`, or a subdir-via-`source`-object) disappear from the Installed list every time the window is reloaded, even though `installed.json` still has the entry. Re-installing brings them back, but the state is lost again on the next reload.

## Root cause

`PluginMarketplaceService._hydratePluginMetadata()` re-reads each marketplace on startup and tries to match every installed entry against the freshly parsed plugins. The match only compared against `IAgentPluginRepositoryService.getPluginInstallUri(plugin)`, which returns the *marketplace-relative* install path.

External-source plugins (anything whose `sourceDescriptor.kind` is not `RelativePath`) are installed into a separate cache directory, so their persisted `pluginUri` comes from `getPluginSourceInstallUri(sourceDescriptor)` and never equals the marketplace-relative path. The match fell through, the entry was dropped from `_pluginMetadata`, and the UI rendered the plugin as uninstalled.

## Fix

Fall back to comparing against `getPluginSourceInstallUri()` when the plugin's source descriptor is not `RelativePath`:

```ts
const match = plugins.find(p => {
    const installUri = this._pluginRepositoryService.getPluginInstallUri(p);
    if (isEqual(installUri, entry.pluginUri)) {
        return true;
    }
    if (p.sourceDescriptor.kind !== PluginSourceKind.RelativePath) {
        const sourceInstallUri = this._pluginRepositoryService.getPluginSourceInstallUri(p.sourceDescriptor);
        return isEqual(sourceInstallUri, entry.pluginUri);
    }
    return false;
});
```

## Test plan

- [x] Added a new `PluginMarketplaceService - hydration of installed plugins` suite in `pluginMarketplaceService.test.ts` (using a real `FileService` backed by `InMemoryFileSystemProvider`, mirroring the existing `workspacePluginSettingsService.test.ts` setup) with four cases:
  - RelativePath plugin hydrates against `getPluginInstallUri()` (regression guard)
  - GitHub-source plugin hydrates against `getPluginSourceInstallUri()`
  - GitUrl-source (`source: { source: 'url', ... }`) plugin hydrates against `getPluginSourceInstallUri()` — the original repro scenario in #308504
  - Entries that match neither URI are left un-hydrated
- [x] `npm run compile-check-ts-native` — clean
- [x] Full unit-test suite — 8931 passing, 0 failing
- [x] Manual verification in a local build:
  1. Install an external-source plugin (`source: url` pointing at a GitHub branch) via Extensions → `@agentPlugins`
  2. Confirm the skill fires
  3. Developer: Reload Window
  4. Before the fix: plugin shows as Uninstalled, skill no longer fires
  5. After the fix: plugin stays Installed & Enabled, skill continues to fire