### PR TITLE
Fix: space before period and missing comma in localized strings

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -934,7 +934,7 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name, dependents[1].manifest.displayName || dependents[1].manifest.name);
 		}
 		if (dependents.length === 1) {
-			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension . It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
+			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependingExtension.manifest.displayName
 			|| dependingExtension.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name);
 		}

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -425,7 +425,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.openEditors.minVisible': {
 			'type': 'number',
-			'description': nls.localize({ key: 'openEditorsVisibleMin', comment: ['Open is an adjective'] }, "The minimum number of editor slots pre-allocated in the Open Editors pane. If set to 0 the Open Editors pane will dynamically resize based on the number of editors."),
+			'description': nls.localize({ key: 'openEditorsVisibleMin', comment: ['Open is an adjective'] }, "The minimum number of editor slots pre-allocated in the Open Editors pane. If set to 0, the Open Editors pane will dynamically resize based on the number of editors."),
 			'default': 0,
 			'minimum': 0
 		},


### PR DESCRIPTION
Two small grammar fixes in user-facing localized strings.

**Space before period (typo):**
- `abstractExtensionManagementService.ts`: "Cannot uninstall '{0}' extension . It includes..." → "extension. It includes..."

**Missing comma after conditional clause:**
- `files.contribution.ts`: "If set to 0 the Open Editors pane will dynamically resize..." → "If set to 0, the Open Editors pane..."

Fixes #310498