### PR TITLE
Fix: Missing comma after 'When enabled/disabled' in IntelliSense suggest settings

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5210,152 +5210,152 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 				'editor.suggest.showMethods': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showMethods', "When enabled IntelliSense shows `method`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showMethods', "When enabled, IntelliSense shows `method`-suggestions.")
 				},
 				'editor.suggest.showFunctions': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showFunctions', "When enabled IntelliSense shows `function`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showFunctions', "When enabled, IntelliSense shows `function`-suggestions.")
 				},
 				'editor.suggest.showConstructors': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showConstructors', "When enabled IntelliSense shows `constructor`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showConstructors', "When enabled, IntelliSense shows `constructor`-suggestions.")
 				},
 				'editor.suggest.showDeprecated': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showDeprecated', "When enabled IntelliSense shows `deprecated`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showDeprecated', "When enabled, IntelliSense shows `deprecated`-suggestions.")
 				},
 				'editor.suggest.matchOnWordStartOnly': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.matchOnWordStartOnly', "When enabled IntelliSense filtering requires that the first character matches on a word start. For example, `c` on `Console` or `WebContext` but _not_ on `description`. When disabled IntelliSense will show more results but still sorts them by match quality.")
+					markdownDescription: nls.localize('editor.suggest.matchOnWordStartOnly', "When enabled, IntelliSense filtering requires that the first character matches on a word start. For example, `c` on `Console` or `WebContext` but _not_ on `description`. When disabled, IntelliSense will show more results but still sorts them by match quality.")
 				},
 				'editor.suggest.showFields': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showFields', "When enabled IntelliSense shows `field`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showFields', "When enabled, IntelliSense shows `field`-suggestions.")
 				},
 				'editor.suggest.showVariables': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showVariables', "When enabled IntelliSense shows `variable`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showVariables', "When enabled, IntelliSense shows `variable`-suggestions.")
 				},
 				'editor.suggest.showClasses': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showClasss', "When enabled IntelliSense shows `class`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showClasss', "When enabled, IntelliSense shows `class`-suggestions.")
 				},
 				'editor.suggest.showStructs': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showStructs', "When enabled IntelliSense shows `struct`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showStructs', "When enabled, IntelliSense shows `struct`-suggestions.")
 				},
 				'editor.suggest.showInterfaces': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showInterfaces', "When enabled IntelliSense shows `interface`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showInterfaces', "When enabled, IntelliSense shows `interface`-suggestions.")
 				},
 				'editor.suggest.showModules': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showModules', "When enabled IntelliSense shows `module`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showModules', "When enabled, IntelliSense shows `module`-suggestions.")
 				},
 				'editor.suggest.showProperties': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showPropertys', "When enabled IntelliSense shows `property`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showPropertys', "When enabled, IntelliSense shows `property`-suggestions.")
 				},
 				'editor.suggest.showEvents': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showEvents', "When enabled IntelliSense shows `event`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showEvents', "When enabled, IntelliSense shows `event`-suggestions.")
 				},
 				'editor.suggest.showOperators': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showOperators', "When enabled IntelliSense shows `operator`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showOperators', "When enabled, IntelliSense shows `operator`-suggestions.")
 				},
 				'editor.suggest.showUnits': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showUnits', "When enabled IntelliSense shows `unit`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showUnits', "When enabled, IntelliSense shows `unit`-suggestions.")
 				},
 				'editor.suggest.showValues': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showValues', "When enabled IntelliSense shows `value`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showValues', "When enabled, IntelliSense shows `value`-suggestions.")
 				},
 				'editor.suggest.showConstants': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showConstants', "When enabled IntelliSense shows `constant`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showConstants', "When enabled, IntelliSense shows `constant`-suggestions.")
 				},
 				'editor.suggest.showEnums': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showEnums', "When enabled IntelliSense shows `enum`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showEnums', "When enabled, IntelliSense shows `enum`-suggestions.")
 				},
 				'editor.suggest.showEnumMembers': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showEnumMembers', "When enabled IntelliSense shows `enumMember`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showEnumMembers', "When enabled, IntelliSense shows `enumMember`-suggestions.")
 				},
 				'editor.suggest.showKeywords': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showKeywords', "When enabled IntelliSense shows `keyword`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showKeywords', "When enabled, IntelliSense shows `keyword`-suggestions.")
 				},
 				'editor.suggest.showWords': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showTexts', "When enabled IntelliSense shows `text`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showTexts', "When enabled, IntelliSense shows `text`-suggestions.")
 				},
 				'editor.suggest.showColors': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showColors', "When enabled IntelliSense shows `color`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showColors', "When enabled, IntelliSense shows `color`-suggestions.")
 				},
 				'editor.suggest.showFiles': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showFiles', "When enabled IntelliSense shows `file`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showFiles', "When enabled, IntelliSense shows `file`-suggestions.")
 				},
 				'editor.suggest.showReferences': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showReferences', "When enabled IntelliSense shows `reference`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showReferences', "When enabled, IntelliSense shows `reference`-suggestions.")
 				},
 				'editor.suggest.showCustomcolors': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showCustomcolors', "When enabled IntelliSense shows `customcolor`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showCustomcolors', "When enabled, IntelliSense shows `customcolor`-suggestions.")
 				},
 				'editor.suggest.showFolders': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showFolders', "When enabled IntelliSense shows `folder`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showFolders', "When enabled, IntelliSense shows `folder`-suggestions.")
 				},
 				'editor.suggest.showTypeParameters': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showTypeParameters', "When enabled IntelliSense shows `typeParameter`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showTypeParameters', "When enabled, IntelliSense shows `typeParameter`-suggestions.")
 				},
 				'editor.suggest.showSnippets': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showSnippets', "When enabled IntelliSense shows `snippet`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showSnippets', "When enabled, IntelliSense shows `snippet`-suggestions.")
 				},
 				'editor.suggest.showUsers': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showUsers', "When enabled IntelliSense shows `user`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showUsers', "When enabled, IntelliSense shows `user`-suggestions.")
 				},
 				'editor.suggest.showIssues': {
 					type: 'boolean',
 					default: true,
-					markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled IntelliSense shows `issues`-suggestions.")
+					markdownDescription: nls.localize('editor.suggest.showIssues', "When enabled, IntelliSense shows `issues`-suggestions.")
 				}
 			}
 		);


### PR DESCRIPTION
Fixes #310501

## What changed

Added missing commas after introductory clauses in 30 `markdownDescription` strings in `src/vs/editor/common/config/editorOptions.ts`.

All `editor.suggest.show*` settings and `editor.suggest.matchOnWordStartOnly` were missing a comma after `When enabled` and `When disabled` respectively.

## Examples

**Before:**
```
"When enabled IntelliSense shows `method`-suggestions."
"When disabled IntelliSense will show more results but still sorts them by match quality."
```

**After:**
```
"When enabled, IntelliSense shows `method`-suggestions."
"When disabled, IntelliSense will show more results but still sorts them by match quality."
```

## Grammar rule

An introductory participial phrase at the start of a sentence requires a comma before the main clause. "When enabled" is a shorthand for "When this setting is enabled" — an introductory adverbial clause modifying the subject "IntelliSense". A comma is required.

This is consistent with other VS Code settings strings that already use this pattern correctly.