### PR TITLE
Fix: Missing commas after introductory clauses in task schema and problem matcher descriptions

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/jsonSchemaCommon.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchemaCommon.ts
@@ -20,14 +20,14 @@ const schema: IJSONSchema = {
 			properties: {
 				cwd: {
 					type: 'string',
-					description: nls.localize('JsonSchema.options.cwd', 'The current working directory of the executed program or script. If omitted Code\'s current workspace root is used.')
+					description: nls.localize('JsonSchema.options.cwd', 'The current working directory of the executed program or script. If omitted, Code\'s current workspace root is used.')
 				},
 				env: {
 					type: 'object',
 					additionalProperties: {
 						type: 'string'
 					},
-					description: nls.localize('JsonSchema.options.env', 'The environment of the executed program or shell. If omitted the parent process\' environment is used.')
+					description: nls.localize('JsonSchema.options.env', 'The environment of the executed program or shell. If omitted, the parent process\' environment is used.')
 				}
 			},
 			additionalProperties: {
@@ -166,12 +166,12 @@ const schema: IJSONSchema = {
 				},
 				suppressTaskName: {
 					type: 'boolean',
-					description: nls.localize('JsonSchema.tasks.suppressTaskName', 'Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.'),
+					description: nls.localize('JsonSchema.tasks.suppressTaskName', 'Controls whether the task name is added as an argument to the command. If omitted, the globally defined value is used.'),
 					default: true
 				},
 				showOutput: {
 					$ref: '#/definitions/showOutputType',
-					description: nls.localize('JsonSchema.tasks.showOutput', 'Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.')
+					description: nls.localize('JsonSchema.tasks.showOutput', 'Controls whether the output of the running task is shown or not. If omitted, the globally defined value is used.')
 				},
 				echoCommand: {
 					type: 'boolean',
@@ -230,7 +230,7 @@ const schema: IJSONSchema = {
 				},
 				showOutput: {
 					$ref: '#/definitions/showOutputType',
-					description: nls.localize('JsonSchema.showOutput', 'Controls whether the output of the running task is shown or not. If omitted \'always\' is used.')
+					description: nls.localize('JsonSchema.showOutput', 'Controls whether the output of the running task is shown or not. If omitted, \'always\' is used.')
 				},
 				isWatching: {
 					type: 'boolean',

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1347,7 +1347,7 @@ export namespace Schemas {
 				properties: {
 					activeOnStart: {
 						type: 'boolean',
-						description: localize('ProblemMatcherSchema.background.activeOnStart', 'If set to true the background monitor starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
+						description: localize('ProblemMatcherSchema.background.activeOnStart', 'If set to true, the background monitor starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
 					},
 					beginsPattern: {
 						oneOf: [
@@ -1356,7 +1356,7 @@ export namespace Schemas {
 							},
 							Schemas.WatchingPattern
 						],
-						description: localize('ProblemMatcherSchema.background.beginsPattern', 'If matched in the output the start of a background task is signaled.')
+						description: localize('ProblemMatcherSchema.background.beginsPattern', 'If matched in the output, the start of a background task is signaled.')
 					},
 					endsPattern: {
 						oneOf: [
@@ -1365,7 +1365,7 @@ export namespace Schemas {
 							},
 							Schemas.WatchingPattern
 						],
-						description: localize('ProblemMatcherSchema.background.endsPattern', 'If matched in the output the end of a background task is signaled.')
+						description: localize('ProblemMatcherSchema.background.endsPattern', 'If matched in the output, the end of a background task is signaled.')
 					}
 				}
 			},
@@ -1377,7 +1377,7 @@ export namespace Schemas {
 				properties: {
 					activeOnStart: {
 						type: 'boolean',
-						description: localize('ProblemMatcherSchema.watching.activeOnStart', 'If set to true the watcher starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
+						description: localize('ProblemMatcherSchema.watching.activeOnStart', 'If set to true, the watcher starts in active mode. This is the same as outputting a line that matches beginsPattern when the task starts.')
 					},
 					beginsPattern: {
 						oneOf: [
@@ -1386,7 +1386,7 @@ export namespace Schemas {
 							},
 							Schemas.WatchingPattern
 						],
-						description: localize('ProblemMatcherSchema.watching.beginsPattern', 'If matched in the output the start of a watching task is signaled.')
+						description: localize('ProblemMatcherSchema.watching.beginsPattern', 'If matched in the output, the start of a watching task is signaled.')
 					},
 					endsPattern: {
 						oneOf: [
@@ -1395,7 +1395,7 @@ export namespace Schemas {
 							},
 							Schemas.WatchingPattern
 						],
-						description: localize('ProblemMatcherSchema.watching.endsPattern', 'If matched in the output the end of a watching task is signaled.')
+						description: localize('ProblemMatcherSchema.watching.endsPattern', 'If matched in the output, the end of a watching task is signaled.')
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #310505

## What changed

Added missing commas after introductory conditional clauses in 11 localized strings across 2 files.

## Files changed

### `src/vs/workbench/contrib/tasks/common/problemMatcher.ts` (6 fixes)

- `ProblemMatcherSchema.background.activeOnStart`: `'If set to true the background monitor...'` → `'If set to true, the background monitor...'`
- `ProblemMatcherSchema.background.beginsPattern`: `'If matched in the output the start...'` → `'If matched in the output, the start...'`
- `ProblemMatcherSchema.background.endsPattern`: `'If matched in the output the end...'` → `'If matched in the output, the end...'`
- `ProblemMatcherSchema.watching.activeOnStart`: `'If set to true the watcher starts...'` → `'If set to true, the watcher starts...'`
- `ProblemMatcherSchema.watching.beginsPattern`: `'If matched in the output the start...'` → `'If matched in the output, the start...'`
- `ProblemMatcherSchema.watching.endsPattern`: `'If matched in the output the end...'` → `'If matched in the output, the end...'`

### `src/vs/workbench/contrib/tasks/common/jsonSchemaCommon.ts` (5 fixes)

- `JsonSchema.options.cwd`: `'If omitted Code's current workspace root is used.'` → `'If omitted, Code's...'`
- `JsonSchema.options.env`: `'If omitted the parent process' environment is used.'` → `'If omitted, the parent process'...'`
- `JsonSchema.tasks.suppressTaskName`: `'If omitted the globally defined value is used.'` → `'If omitted, the...'`
- `JsonSchema.tasks.showOutput`: `'If omitted the globally defined value is used.'` → `'If omitted, the...'`
- `JsonSchema.showOutput`: `'If omitted 'always' is used.'` → `'If omitted, 'always'...'`

## Grammar rule

Introductory conditional clauses ("If X") must be followed by a comma before the main clause begins. This is standard English punctuation.