### PR TITLE
Fix: Article errors ('a HTTP', 'a HTML') and 'setup' used as verb in localized strings

### DIFF
--- a/extensions/html-language-features/schemas/package.schema.json
+++ b/extensions/html-language-features/schemas/package.schema.json
@@ -10,7 +10,7 @@
 					"markdownDescription": "A list of relative file paths pointing to JSON files following the [custom data format](https://github.com/microsoft/vscode-html-languageservice/blob/master/docs/customData.md).\n\nVS Code loads custom data on startup to enhance its HTML support for the custom HTML tags, attributes and attribute values you specify in the JSON files.\n\nThe file paths are relative to workspace and only workspace folder settings are considered.",
 					"items": {
 						"type": "string",
-						"description": "Relative path to a HTML custom data file"
+						"description": "Relative path to an HTML custom data file"
 					}
 				},
 				"htmlLanguageParticipants": {

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -281,7 +281,7 @@ export const schema: IJSONSchema = {
 					},
 					{
 						label: 'onDebug',
-						description: nls.localize('vscode.extension.activationEvents.onDebug', 'An activation event emitted whenever a user is about to start debugging or about to setup debug configurations.'),
+						description: nls.localize('vscode.extension.activationEvents.onDebug', 'An activation event emitted whenever a user is about to start debugging or about to set up debug configurations.'),
 						body: 'onDebug'
 					},
 					{
@@ -598,7 +598,7 @@ export const schema: IJSONSchema = {
 			],
 			properties: {
 				'url': {
-					description: nls.localize('vscode.extension.contributes.sponsor.url', "URL from where users can sponsor your extension. It must be a valid URL with a HTTP or HTTPS protocol. Example value: https://github.com/sponsors/nvaccess"),
+					description: nls.localize('vscode.extension.contributes.sponsor.url', "URL from where users can sponsor your extension. It must be a valid URL with an HTTP or HTTPS protocol. Example value: https://github.com/sponsors/nvaccess"),
 					type: 'string',
 				}
 			}


### PR DESCRIPTION
Fixes #310511

## What changed

Fixed 3 grammar errors in user-facing localized strings across 2 files.

## Files changed

### `src/vs/workbench/services/extensions/common/extensionsRegistry.ts`

- Line 601: `'a HTTP or HTTPS protocol'` → `'an HTTP or HTTPS protocol'`
- Line 284: `'about to setup debug configurations'` → `'about to set up debug configurations'`

### `extensions/html-language-features/schemas/package.schema.json`

- Line 13: `'Relative path to a HTML custom data file'` → `'Relative path to an HTML custom data file'`

## Grammar rules

**Article agreement**: The article "an" is required before words starting with a vowel *sound*. Acronyms like HTTP ("aitch-tee-tee-pee") and HTML ("aitch-tee-em-ell") begin with "H" which is pronounced "aitch" — a vowel sound. So "an HTTP" and "an HTML" are correct.

**setup vs set up**: "setup" is a noun ("a one-time setup"). The two-word form "set up" is the verb phrase ("to set up a configuration"). Using "setup" as a verb is a common but incorrect usage.