### PR TITLE
Fix: Missing comma after 'Instead' as transitional adverb in editor settings

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5670,7 +5670,7 @@ class EditorDropIntoEditor extends BaseEditorOption<EditorOption.dropIntoEditor,
 					],
 					enumDescriptions: [
 						nls.localize('dropIntoEditor.showDropSelector.afterDrop', "Show the drop selector widget after a file is dropped into the editor."),
-						nls.localize('dropIntoEditor.showDropSelector.never', "Never show the drop selector widget. Instead the default drop provider is always used."),
+						nls.localize('dropIntoEditor.showDropSelector.never', "Never show the drop selector widget. Instead, the default drop provider is always used."),
 					],
 					default: 'afterDrop',
 				},
@@ -5737,7 +5737,7 @@ class EditorPasteAs extends BaseEditorOption<EditorOption.pasteAs, IPasteAsOptio
 					],
 					enumDescriptions: [
 						nls.localize('pasteAs.showPasteSelector.afterPaste', "Show the paste selector widget after content is pasted into the editor."),
-						nls.localize('pasteAs.showPasteSelector.never', "Never show the paste selector widget. Instead the default pasting behavior is always used."),
+						nls.localize('pasteAs.showPasteSelector.never', "Never show the paste selector widget. Instead, the default pasting behavior is always used."),
 					],
 					default: 'afterPaste',
 				},


### PR DESCRIPTION
Fixes #310513

## What changed

Added missing commas after `Instead` in 2 localized strings in `src/vs/editor/common/config/editorOptions.ts`.

## Examples

**Before:**
```
"Never show the drop selector widget. Instead the default drop provider is always used."
"Never show the paste selector widget. Instead the default pasting behavior is always used."
```

**After:**
```
"Never show the drop selector widget. Instead, the default drop provider is always used."
"Never show the paste selector widget. Instead, the default pasting behavior is always used."
```

## Grammar rule

When "Instead" is used as a transitional adverb to begin a new clause (following a period), it requires a comma after it before the main clause begins.