### PR TITLE
Fix: 'Controls if' → 'Controls whether' in setting descriptions for consistency

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1460,7 +1460,7 @@ class EditorAccessibilitySupport extends BaseEditorOption<EditorOption.accessibi
 				],
 				default: 'auto',
 				tags: ['accessibility'],
-				description: nls.localize('accessibilitySupport', "Controls if the UI should run in a mode where it is optimized for screen readers.")
+				description: nls.localize('accessibilitySupport', "Controls whether the UI should run in a mode where it is optimized for screen readers.")
 			}
 		);
 	}
@@ -5663,7 +5663,7 @@ class EditorDropIntoEditor extends BaseEditorOption<EditorOption.dropIntoEditor,
 				},
 				'editor.dropIntoEditor.showDropSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls if a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
+					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls whether a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
 					enum: [
 						'afterDrop',
 						'never'
@@ -5730,7 +5730,7 @@ class EditorPasteAs extends BaseEditorOption<EditorOption.pasteAs, IPasteAsOptio
 				},
 				'editor.pasteAs.showPasteSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls if a widget is shown when pasting content in to the editor. This widget lets you control how the file is pasted."),
+					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls whether a widget is shown when pasting content in to the editor. This widget lets you control how the file is pasted."),
 					enum: [
 						'afterPaste',
 						'never'
@@ -6556,7 +6556,7 @@ export const EditorOptions = {
 	)),
 	renderLineHighlightOnlyWhenFocus: register(new EditorBooleanOption(
 		EditorOption.renderLineHighlightOnlyWhenFocus, 'renderLineHighlightOnlyWhenFocus', false,
-		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls if the editor should render the current line highlight only when the editor is focused.") }
+		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls whether the editor should render the current line highlight only when the editor is focused.") }
 	)),
 	renderValidationDecorations: register(new EditorStringEnumOption(
 		EditorOption.renderValidationDecorations, 'renderValidationDecorations',

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -48,7 +48,7 @@ const argsSchema = {
 		'preferred': {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('args.schema.preferred', "Controls if only preferred code actions should be returned."),
+			description: nls.localize('args.schema.preferred', "Controls whether only preferred code actions should be returned."),
 		}
 	}
 } as const satisfies IJSONSchema;

--- a/src/vs/platform/keyboardLayout/common/keyboardConfig.ts
+++ b/src/vs/platform/keyboardLayout/common/keyboardConfig.ts
@@ -45,7 +45,7 @@ const keyboardConfiguration: IConfigurationNode = {
 			scope: ConfigurationScope.APPLICATION,
 			type: 'boolean',
 			default: false,
-			markdownDescription: nls.localize('mapAltGrToCtrlAlt', "Controls if the AltGraph+ modifier should be treated as Ctrl+Alt+."),
+			markdownDescription: nls.localize('mapAltGrToCtrlAlt', "Controls whether the AltGraph+ modifier should be treated as Ctrl+Alt+."),
 			included: OS === OperatingSystem.Windows
 		}
 	}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -165,7 +165,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'enum': ['text', 'hidden'],
 				'default': 'text',
-				'markdownDescription': localize("workbench.editor.empty.hint", "Controls if the empty editor text hint should be visible in the editor.")
+				'markdownDescription': localize("workbench.editor.empty.hint", "Controls whether the empty editor text hint should be visible in the editor.")
 			},
 			'workbench.editor.languageDetection': {
 				type: 'boolean',
@@ -291,12 +291,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.splitOnDragAndDrop': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('splitOnDragAndDrop', "Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.")
+				'description': localize('splitOnDragAndDrop', "Controls whether editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.")
 			},
 			'workbench.editor.dragToOpenWindow': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize('dragToOpenWindow', "Controls if editors can be dragged out of the window to open them in a new window. Press and hold the `Alt` key while dragging to toggle this dynamically.")
+				'markdownDescription': localize('dragToOpenWindow', "Controls whether editors can be dragged out of the window to open them in a new window. Press and hold the `Alt` key while dragging to toggle this dynamically.")
 			},
 			'workbench.editor.focusRecentEditorAfterClose': {
 				'type': 'boolean',
@@ -412,7 +412,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.centeredLayoutAutoResize': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('centeredLayoutAutoResize', "Controls if the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.")
+				'description': localize('centeredLayoutAutoResize', "Controls whether the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.")
 			},
 			'workbench.editor.centeredLayoutFixedWidth': {
 				'type': 'boolean',
@@ -433,7 +433,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.limit.enabled': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('limitEditorsEnablement', "Controls if the number of opened editors should be limited or not. When enabled, less recently used editors will close to make space for newly opening editors.")
+				'description': localize('limitEditorsEnablement', "Controls whether the number of opened editors should be limited or not. When enabled, less recently used editors will close to make space for newly opening editors.")
 			},
 			'workbench.editor.limit.value': {
 				'type': 'number',
@@ -444,12 +444,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.limit.excludeDirty': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('limitEditorsExcludeDirty', "Controls if the maximum number of opened editors should exclude dirty editors for counting towards the configured limit.")
+				'description': localize('limitEditorsExcludeDirty', "Controls whether the maximum number of opened editors should exclude dirty editors for counting towards the configured limit.")
 			},
 			'workbench.editor.limit.perEditorGroup': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('perEditorGroup', "Controls if the limit of maximum opened editors should apply per editor group or across all editor groups.")
+				'description': localize('perEditorGroup', "Controls whether the limit of maximum opened editors should apply per editor group or across all editor groups.")
 			},
 			'workbench.localHistory.enabled': {
 				'type': 'boolean',

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -328,7 +328,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 	id: 'files',
 	properties: {
 		[autoSaveSetting]: {
-			description: localize('refactoring.autoSave', "Controls if files that were part of a refactoring are saved automatically"),
+			description: localize('refactoring.autoSave', "Controls whether files that were part of a refactoring are saved automatically"),
 			default: true,
 			type: 'boolean'
 		}

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -553,7 +553,7 @@ configurationRegistry.registerConfiguration({
 		'debug.internalConsoleOptions': INTERNAL_CONSOLE_OPTIONS_SCHEMA,
 		'debug.console.closeOnEnd': {
 			type: 'boolean',
-			description: nls.localize('debug.console.closeOnEnd', "Controls if the Debug Console should be automatically closed when the debug session ends."),
+			description: nls.localize('debug.console.closeOnEnd', "Controls whether the Debug Console should be automatically closed when the debug session ends."),
 			default: false
 		},
 		'debug.terminal.clearBeforeReusing': {
@@ -588,17 +588,17 @@ configurationRegistry.registerConfiguration({
 		},
 		'debug.console.wordWrap': {
 			type: 'boolean',
-			description: nls.localize('debug.console.wordWrap', "Controls if the lines should wrap in the Debug Console."),
+			description: nls.localize('debug.console.wordWrap', "Controls whether the lines should wrap in the Debug Console."),
 			default: true
 		},
 		'debug.console.historySuggestions': {
 			type: 'boolean',
-			description: nls.localize('debug.console.historySuggestions', "Controls if the Debug Console should suggest previously typed input."),
+			description: nls.localize('debug.console.historySuggestions', "Controls whether the Debug Console should suggest previously typed input."),
 			default: true
 		},
 		'debug.console.collapseIdenticalLines': {
 			type: 'boolean',
-			description: nls.localize('debug.console.collapseIdenticalLines', "Controls if the Debug Console should collapse identical lines and show a number of occurrences with a badge."),
+			description: nls.localize('debug.console.collapseIdenticalLines', "Controls whether the Debug Console should collapse identical lines and show a number of occurrences with a badge."),
 			default: true
 		},
 		'debug.console.acceptSuggestionOnEnter': {

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -167,7 +167,7 @@ export const presentationSchema: IJSONSchema = {
 		hidden: {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('presentation.hidden', "Controls if this configuration should be shown in the configuration dropdown and the command palette.")
+			description: nls.localize('presentation.hidden', "Controls whether this configuration should be shown in the configuration dropdown and the command palette.")
 		},
 		group: {
 			type: 'string',

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -405,7 +405,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize({ key: 'modification', comment: ['This is the description of an option'] }, "Format modifications. Requires source control and a formatter that supports 'Format Selection'."),
 				nls.localize({ key: 'modificationIfAvailable', comment: ['This is the description of an option'] }, "Will attempt to format modifications only (requires source control and a formatter that supports 'Format Selection'). If source control can't be used, then the whole file will be formatted."),
 			],
-			'markdownDescription': nls.localize('formatOnSaveMode', "Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled."),
+			'markdownDescription': nls.localize('formatOnSaveMode', "Controls whether format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
 		},
 	}

--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -16,7 +16,7 @@ export const enum TerminalInitialHintSettingId {
 export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalInitialHintSettingId.Enabled]: {
 		restricted: true,
-		markdownDescription: localize('terminal.integrated.initialHint', "Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
+		markdownDescription: localize('terminal.integrated.initialHint', "Controls whether the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
 		type: 'boolean',
 		default: true
 	},

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -210,7 +210,7 @@ import product from '../../platform/product/common/product.js';
 			'window.zoomPerWindow': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize({ comment: ['{0} will be a setting name rendered as a link'], key: 'zoomPerWindow' }, "Controls if the 'Zoom In' and 'Zoom Out' commands apply the zoom level to all windows or only the active window. See {0} for configuring a default zoom level for all windows.", '`#window.zoomLevel#`'),
+				'markdownDescription': localize({ comment: ['{0} will be a setting name rendered as a link'], key: 'zoomPerWindow' }, "Controls whether the 'Zoom In' and 'Zoom Out' commands apply the zoom level to all windows or only the active window. See {0} for configuring a default zoom level for all windows.", '`#window.zoomLevel#`'),
 				tags: ['accessibility']
 			},
 			'window.newWindowDimensions': {
@@ -302,7 +302,7 @@ import product from '../../platform/product/common/product.js';
 			'window.nativeFullScreen': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('window.nativeFullScreen', "Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen."),
+				'description': localize('window.nativeFullScreen', "Controls whether native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen."),
 				'scope': ConfigurationScope.APPLICATION,
 				'included': isMacintosh
 			},

--- a/src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts
+++ b/src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts
@@ -46,7 +46,7 @@ export const inputsSchema: IJSONSchema = {
 							},
 							password: {
 								type: 'boolean',
-								description: nls.localize('JsonSchema.input.password', "Controls if a password input is shown. Password input hides the typed text."),
+								description: nls.localize('JsonSchema.input.password', "Controls whether a password input is shown. Password input hides the typed text."),
 							},
 						}
 					},

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -62,7 +62,7 @@ const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoin
 						},
 						tildify: {
 							type: 'boolean',
-							description: localize('vscode.extension.contributes.resourceLabelFormatters.tildify', "Controls if the start of the uri label should be tildified when possible.")
+							description: localize('vscode.extension.contributes.resourceLabelFormatters.tildify', "Controls whether the start of the uri label should be tildified when possible.")
 						},
 						workspaceSuffix: {
 							type: 'string',


### PR DESCRIPTION
Fixes #310518

## What changed

Replaced 25 instances of `"Controls if "` with `"Controls whether "` across 12 files to make setting descriptions consistent with the rest of the codebase.

## Context

VS Code setting descriptions use "Controls whether" as the standard phrasing (376 occurrences), but 25 settings inconsistently use "Controls if". This PR fixes those 25 instances.

## Grammar note

When introducing a noun clause expressing doubt or alternative choices (i.e., "whether X is true or false"), "whether" is preferred over "if" in formal writing. "If" is typically reserved for conditional clauses.

## Files changed

- `src/vs/platform/keyboardLayout/common/keyboardConfig.ts` (1)
- `src/vs/workbench/browser/workbench.contribution.ts` (7)
- `src/vs/workbench/contrib/files/browser/files.contribution.ts` (1)
- `src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts` (1)
- `src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts` (1)
- `src/vs/workbench/contrib/debug/browser/debug.contribution.ts` (4)
- `src/vs/workbench/contrib/debug/common/debugSchemas.ts` (1)
- `src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts` (1)
- `src/vs/workbench/services/label/common/labelService.ts` (1)
- `src/vs/workbench/electron-browser/desktop.contribution.ts` (2)
- `src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts` (1)
- `src/vs/editor/common/config/editorOptions.ts` (4)