### PR TITLE
Fix: double-word typos in localized strings ('for for', 'using using')

### DIFF
--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -359,7 +359,7 @@
 	"github.copilot.config.projectLabels.inline": "Add project labels in inline edit requests.",
 	"github.copilot.config.workspace.maxLocalIndexSize": "Maximum size of the local workspace index.",
 	"github.copilot.config.workspace.enableCodeSearch": "Enable code search in workspace context.",
-	"github.copilot.config.workspace.maxDiffSizeBeforeUsingExternalIngest": "Maximum number of local changes before we start using using external ingest.",
+	"github.copilot.config.workspace.maxDiffSizeBeforeUsingExternalIngest": "Maximum number of local changes before we start using external ingest.",
 	"github.copilot.config.workspace.preferredEmbeddingsModel": "Preferred embeddings model for semantic search.",
 	"github.copilot.config.workspace.prototypeAdoCodeSearchEndpointOverride": "Override endpoint for Azure DevOps code search prototype.",
 	"github.copilot.config.feedback.onChange": "Enable feedback collection on configuration changes.",

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},


### PR DESCRIPTION
Removes duplicated words in two localized setting descriptions.

**Changes:**

1. `src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts` (line 981):
   - Before: `"Configure the cell toolbar position for for specific file types"`
   - After: `"Configure the cell toolbar position for specific file types"`

2. `extensions/copilot/package.nls.json` (line 362):
   - Before: `"Maximum number of local changes before we start using using external ingest."`
   - After: `"Maximum number of local changes before we start using external ingest."`

Fixes #310522