### PR TITLE
Fix: article errors ('a array', 'a opening') and 'eg.' → 'e.g.' in localized strings

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -56,7 +56,7 @@ export class JSONValidationExtensionPoint {
 				const extensionLocation = extension.description.extensionLocation;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be a array"));
+					collector.error(nls.localize('invalid.jsonValidation', "'configuration.jsonValidation' must be an array"));
 					return;
 				}
 				extensionValue.forEach(extension => {

--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -583,7 +583,7 @@ const schema: IJSONSchema = {
 		},
 		autoClosingPairs: {
 			default: [['(', ')'], ['[', ']'], ['{', '}']],
-			description: nls.localize('schema.autoClosingPairs', 'Defines the bracket pairs. When a opening bracket is entered, the closing bracket is inserted automatically.'),
+			description: nls.localize('schema.autoClosingPairs', 'Defines the bracket pairs. When an opening bracket is entered, the closing bracket is inserted automatically.'),
 			type: 'array',
 			items: {
 				oneOf: [{

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -1173,7 +1173,7 @@ export namespace ForwardPortAction {
 	export const COMMANDPALETTE_ID = 'remote.tunnel.forwardCommandPalette';
 	export const LABEL: ILocalizedString = nls.localize2('remote.tunnel.forward', "Forward a Port");
 	export const TREEITEM_LABEL = nls.localize('remote.tunnel.forwardItem', "Forward Port");
-	const forwardPrompt = nls.localize('remote.tunnel.forwardPrompt', "Port number or address (eg. 3000 or 10.10.10.10:2000).");
+	const forwardPrompt = nls.localize('remote.tunnel.forwardPrompt', "Port number or address (e.g. 3000 or 10.10.10.10:2000).");
 
 	function validateInput(remoteExplorerService: IRemoteExplorerService, tunnelService: ITunnelService, value: string, canElevate: boolean): { content: string; severity: Severity } | null {
 		const parsed = parseAddress(value);

--- a/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
+++ b/src/vs/workbench/services/themes/common/colorExtensionPoint.ts
@@ -95,7 +95,7 @@ export class ColorExtensionPoint {
 				const collector = extension.collector;
 
 				if (!extensionValue || !Array.isArray(extensionValue)) {
-					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be a array"));
+					collector.error(nls.localize('invalid.colorConfiguration', "'configuration.colors' must be an array"));
 					return;
 				}
 				const parseColorValue = (s: string, name: string) => {


### PR DESCRIPTION
Fixes four grammar/style issues in localized strings.

**Changes:**

1. `src/vs/workbench/api/common/jsonValidationExtensionPoint.ts` (line 59):
   - `"'configuration.jsonValidation' must be a array"` → `"must be an array"`

2. `src/vs/workbench/services/themes/common/colorExtensionPoint.ts` (line 98):
   - `"'configuration.colors' must be a array"` → `"must be an array"`

3. `src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts` (line 586):
   - `"When a opening bracket is entered..."` → `"When an opening bracket is entered..."`

4. `src/vs/workbench/contrib/remote/browser/tunnelView.ts` (line 1176):
   - `"Port number or address (eg. 3000 or ...)"` → `"(e.g. 3000 or ...)"` (standard two-dot abbreviation)

Fixes #310523