### PR TITLE
Fix: missing commas after introductory 'When X' clauses in localized strings

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5968,7 +5968,7 @@ export const EditorOptions = {
 	accessibilitySupport: register(new EditorAccessibilitySupport()),
 	accessibilityPageSize: register(new EditorIntOption(EditorOption.accessibilityPageSize, 'accessibilityPageSize', 500, 1, Constants.MAX_SAFE_SMALL_INTEGER,
 		{
-			description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
+			description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader, we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
 			tags: ['accessibility']
 		}
 	)),

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -568,7 +568,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'debug.showSubSessionsInToolBar': {
 			type: 'boolean',
-			description: nls.localize({ comment: ['This is the description for a setting'], key: 'showSubSessionsInToolBar' }, "Controls whether the debug sub-sessions are shown in the debug tool bar. When this setting is false the stop command on a sub-session will also stop the parent session."),
+			description: nls.localize({ comment: ['This is the description for a setting'], key: 'showSubSessionsInToolBar' }, "Controls whether the debug sub-sessions are shown in the debug tool bar. When this setting is false, the stop command on a sub-session will also stop the parent session."),
 			default: false
 		},
 		'debug.console.fontSize': {

--- a/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
@@ -36,7 +36,7 @@ export const TERMINAL_SELECTION_FOREGROUND_COLOR = registerColor('terminal.selec
 	dark: null,
 	hcDark: '#000000',
 	hcLight: '#ffffff'
-}, nls.localize('terminal.selectionForeground', 'The selection foreground color of the terminal. When this is null the selection foreground will be retained and have the minimum contrast ratio feature applied.'));
+}, nls.localize('terminal.selectionForeground', 'The selection foreground color of the terminal. When this is null, the selection foreground will be retained and have the minimum contrast ratio feature applied.'));
 export const TERMINAL_COMMAND_DECORATION_DEFAULT_BACKGROUND_COLOR = registerColor('terminalCommandDecoration.defaultBackground', {
 	light: '#00000040',
 	dark: '#ffffff40',


### PR DESCRIPTION
Adds missing commas after introductory dependent 'When' clauses in three setting descriptions. A comma is required between the introductory clause and the main clause.

**Changes:**

1. `src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts` (line 39):
   - Before: `"...When this is null the selection foreground will be retained..."`
   - After: `"...When this is null, the selection foreground will be retained..."`

2. `src/vs/workbench/contrib/debug/browser/debug.contribution.ts` (line 571):
   - Before: `"...When this setting is false the stop command on a sub-session will also stop the parent session."`
   - After: `"...When this setting is false, the stop command on a sub-session..."`

3. `src/vs/editor/common/config/editorOptions.ts` (line 5971):
   - Before: `"...When we detect a screen reader we automatically set the default to be 500."`
   - After: `"...When we detect a screen reader, we automatically set the default to be 500."`

Fixes #310524