### PR TITLE
Fix: 'allow to' and 'effects' (wrong verb) in Explorer drag-and-drop setting description

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -477,7 +477,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',
-			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer."),
+			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow you to move files and folders via drag and drop. This setting only affects drag and drop from inside the Explorer."),
 			'default': true
 		},
 		'explorer.confirmDragAndDrop': {


### PR DESCRIPTION
Fixes two grammar errors in the `explorer.enableDragAndDrop` setting description.

**File:** `src/vs/workbench/contrib/files/browser/files.contribution.ts` (line 480)

**Changes:**
- `"should allow to move"` → `"should allow you to move"` — "allow to" without a subject is ungrammatical
- `"only effects drag and drop"` → `"only affects drag and drop"` — "effect" as a verb means "to bring about"; "affect" means "to influence/apply to"

Fixes #310528