### PR TITLE
Fix: 'drop down' → 'dropdown' in debug compound configuration description

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -219,7 +219,7 @@ export const launchSchema: IJSONSchema = {
 				properties: {
 					name: {
 						type: 'string',
-						description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration drop down menu.")
+						description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration dropdown menu.")
 					},
 					presentation: presentationSchema,
 					configurations: {
@@ -235,7 +235,7 @@ export const launchSchema: IJSONSchema = {
 								properties: {
 									name: {
 										enum: [],
-										description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration drop down menu.")
+										description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration dropdown menu.")
 									},
 									folder: {
 										enum: [],


### PR DESCRIPTION
Fixes inconsistent spacing in the launch configuration compound name description.

**File:** `src/vs/workbench/contrib/debug/common/debugSchemas.ts` (lines 222 and 238)

**Change:** `"launch configuration drop down menu"` → `"launch configuration dropdown menu"`

The rest of the file (lines 165, 175, 180) and the VS Code codebase consistently uses `"dropdown"` as a single word. The two-word form `"drop down"` at lines 222 and 238 was inconsistent.

Fixes #310531