### PR TITLE
Fix: 'Controls if' → 'Controls whether' in localized setting descriptions (batch 2)

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -48,7 +48,7 @@ const argsSchema = {
 		'preferred': {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('args.schema.preferred', "Controls if only preferred code actions should be returned."),
+			description: nls.localize('args.schema.preferred', "Controls whether only preferred code actions should be returned."),
 		}
 	}
 } as const satisfies IJSONSchema;

--- a/src/vs/platform/keyboardLayout/common/keyboardConfig.ts
+++ b/src/vs/platform/keyboardLayout/common/keyboardConfig.ts
@@ -45,7 +45,7 @@ const keyboardConfiguration: IConfigurationNode = {
 			scope: ConfigurationScope.APPLICATION,
 			type: 'boolean',
 			default: false,
-			markdownDescription: nls.localize('mapAltGrToCtrlAlt', "Controls if the AltGraph+ modifier should be treated as Ctrl+Alt+."),
+			markdownDescription: nls.localize('mapAltGrToCtrlAlt', "Controls whether the AltGraph+ modifier should be treated as Ctrl+Alt+."),
 			included: OS === OperatingSystem.Windows
 		}
 	}

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts
@@ -328,7 +328,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 	id: 'files',
 	properties: {
 		[autoSaveSetting]: {
-			description: localize('refactoring.autoSave', "Controls if files that were part of a refactoring are saved automatically"),
+			description: localize('refactoring.autoSave', "Controls whether files that were part of a refactoring are saved automatically"),
 			default: true,
 			type: 'boolean'
 		}

--- a/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
+++ b/src/vs/workbench/contrib/customEditor/common/extensionPoint.ts
@@ -60,7 +60,7 @@ const customEditorsContributionSchema = {
 		},
 		[Fields.priority]: {
 			type: 'string',
-			markdownDeprecationMessage: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.'),
+			markdownDeprecationMessage: nls.localize('contributes.priority', 'Controls whether the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.'),
 			enum: [
 				CustomEditorPriority.default,
 				CustomEditorPriority.option,

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -405,7 +405,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize({ key: 'modification', comment: ['This is the description of an option'] }, "Format modifications. Requires source control and a formatter that supports 'Format Selection'."),
 				nls.localize({ key: 'modificationIfAvailable', comment: ['This is the description of an option'] }, "Will attempt to format modifications only (requires source control and a formatter that supports 'Format Selection'). If source control can't be used, then the whole file will be formatted."),
 			],
-			'markdownDescription': nls.localize('formatOnSaveMode', "Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled."),
+			'markdownDescription': nls.localize('formatOnSaveMode', "Controls whether format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled."),
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
 		},
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts
@@ -98,7 +98,7 @@ const notebookProviderContribution: IJSONSchema = {
 			},
 			[NotebookEditorContribution.priority]: {
 				type: 'string',
-				markdownDeprecationMessage: nls.localize('contributes.priority', 'Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.'),
+				markdownDeprecationMessage: nls.localize('contributes.priority', 'Controls whether the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.'),
 				enum: [
 					NotebookEditorPriority.default,
 					NotebookEditorPriority.option,

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -45,7 +45,7 @@ Registry
 		...editorConfigurationBaseNode,
 		'properties': {
 			'editor.snippets.codeActions.enabled': {
-				'description': nls.localize('editor.snippets.codeActions.enabled', 'Controls if surround-with-snippets or file template snippets show as Code Actions.'),
+				'description': nls.localize('editor.snippets.codeActions.enabled', 'Controls whether surround-with-snippets or file template snippets show as Code Actions.'),
 				'type': 'boolean',
 				'default': true
 			}

--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -188,7 +188,7 @@ const presentation: IJSONSchema = {
 			type: 'string',
 			enum: ['shared', 'dedicated', 'new'],
 			default: 'shared',
-			description: nls.localize('JsonSchema.tasks.presentation.instance', 'Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.')
+			description: nls.localize('JsonSchema.tasks.presentation.instance', 'Controls whether the panel is shared between tasks, dedicated to this task or a new one is created on every run.')
 		},
 		showReuseMessage: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1271,7 +1271,7 @@ export namespace Schemas {
 			applyTo: {
 				type: 'string',
 				enum: ['allDocuments', 'openDocuments', 'closedDocuments'],
-				description: localize('ProblemMatcherSchema.applyTo', 'Controls if a problem reported on a text document is applied only to open, closed or all documents.')
+				description: localize('ProblemMatcherSchema.applyTo', 'Controls whether a problem reported on a text document is applied only to open, closed or all documents.')
 			},
 			pattern: PatternType,
 			fileLocation: {

--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -16,7 +16,7 @@ export const enum TerminalInitialHintSettingId {
 export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalInitialHintSettingId.Enabled]: {
 		restricted: true,
-		markdownDescription: localize('terminal.integrated.initialHint', "Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
+		markdownDescription: localize('terminal.integrated.initialHint', "Controls whether the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
 		type: 'boolean',
 		default: true
 	},

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -210,7 +210,7 @@ import product from '../../platform/product/common/product.js';
 			'window.zoomPerWindow': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize({ comment: ['{0} will be a setting name rendered as a link'], key: 'zoomPerWindow' }, "Controls if the 'Zoom In' and 'Zoom Out' commands apply the zoom level to all windows or only the active window. See {0} for configuring a default zoom level for all windows.", '`#window.zoomLevel#`'),
+				'markdownDescription': localize({ comment: ['{0} will be a setting name rendered as a link'], key: 'zoomPerWindow' }, "Controls whether the 'Zoom In' and 'Zoom Out' commands apply the zoom level to all windows or only the active window. See {0} for configuring a default zoom level for all windows.", '`#window.zoomLevel#`'),
 				tags: ['accessibility']
 			},
 			'window.newWindowDimensions': {
@@ -302,7 +302,7 @@ import product from '../../platform/product/common/product.js';
 			'window.nativeFullScreen': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('window.nativeFullScreen', "Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen."),
+				'description': localize('window.nativeFullScreen', "Controls whether native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen."),
 				'scope': ConfigurationScope.APPLICATION,
 				'included': isMacintosh
 			},

--- a/src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts
+++ b/src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts
@@ -46,7 +46,7 @@ export const inputsSchema: IJSONSchema = {
 							},
 							password: {
 								type: 'boolean',
-								description: nls.localize('JsonSchema.input.password', "Controls if a password input is shown. Password input hides the typed text."),
+								description: nls.localize('JsonSchema.input.password', "Controls whether a password input is shown. Password input hides the typed text."),
 							},
 						}
 					},

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -62,7 +62,7 @@ const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoin
 						},
 						tildify: {
 							type: 'boolean',
-							description: localize('vscode.extension.contributes.resourceLabelFormatters.tildify', "Controls if the start of the uri label should be tildified when possible.")
+							description: localize('vscode.extension.contributes.resourceLabelFormatters.tildify', "Controls whether the start of the uri label should be tildified when possible.")
 						},
 						workspaceSuffix: {
 							type: 'string',


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute).
- [x] The pull request title follows our guidelines.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixes 14 instances of 'Controls if' → 'Controls whether' across 13 files.

**Grammar explanation:** 'Controls whether' is the correct form for boolean settings. 'Controls if' introduces an ambiguous conditional clause, whereas 'Controls whether' clearly describes a binary choice. This is consistent with VS Code's existing style used in the vast majority of setting descriptions.

**Files changed:**
- `src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts`
- `src/vs/platform/keyboardLayout/common/keyboardConfig.ts`
- `src/vs/workbench/contrib/bulkEdit/browser/bulkEditService.ts`
- `src/vs/workbench/contrib/customEditor/common/extensionPoint.ts`
- `src/vs/workbench/contrib/files/browser/files.contribution.ts`
- `src/vs/workbench/contrib/notebook/browser/notebookExtensionPoint.ts`
- `src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts`
- `src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts`
- `src/vs/workbench/contrib/tasks/common/problemMatcher.ts`
- `src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts`
- `src/vs/workbench/electron-browser/desktop.contribution.ts`
- `src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts`
- `src/vs/workbench/services/label/common/labelService.ts`

Fixes #310536