### PR TITLE
Fix: double article errors ('a the', 'the an') in localized context descriptions

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
@@ -9,7 +9,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 export type MergeEditorLayoutKind = 'mixed' | 'columns';
 
 export const ctxIsMergeEditor = new RawContextKey<boolean>('isMergeEditor', false, { type: 'boolean', description: localize('is', 'The editor is a merge editor') });
-export const ctxIsMergeResultEditor = new RawContextKey<boolean>('isMergeResultEditor', false, { type: 'boolean', description: localize('isr', 'The editor is a the result editor of a merge editor.') });
+export const ctxIsMergeResultEditor = new RawContextKey<boolean>('isMergeResultEditor', false, { type: 'boolean', description: localize('isr', 'The editor is the result editor of a merge editor.') });
 export const ctxMergeEditorLayout = new RawContextKey<MergeEditorLayoutKind>('mergeEditorLayout', 'mixed', { type: 'string', description: localize('editorLayout', 'The layout mode of a merge editor') });
 export const ctxMergeEditorShowBase = new RawContextKey<boolean>('mergeEditorShowBase', false, { type: 'boolean', description: localize('showBase', 'If the merge editor shows the base version') });
 export const ctxMergeEditorShowBaseAtTop = new RawContextKey<boolean>('mergeEditorShowBaseAtTop', false, { type: 'boolean', description: localize('showBaseAtTop', 'If base should be shown at the top') });

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -296,7 +296,7 @@ const apiMenus: IAPIMenu[] = [
 	{
 		key: 'comments/commentThread/comment/context',
 		id: MenuId.CommentThreadCommentContext,
-		description: localize('comment.commentContext', "The contributed comment context menu, rendered as a right click menu on the an individual comment in the comment thread's peek view."),
+		description: localize('comment.commentContext', "The contributed comment context menu, rendered as a right click menu on an individual comment in the comment thread's peek view."),
 		proposed: 'contribCommentPeekContext'
 	},
 	{


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute).
- [x] The pull request title follows our guidelines.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixes two localized strings with double article errors:

**1. `src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts` (line 12)**
- Before: `'The editor is a the result editor of a merge editor.'`
- After: `'The editor is the result editor of a merge editor.'`

**2. `src/vs/workbench/services/actions/common/menusExtensionPoint.ts` (line 299)**
- Before: `'...rendered as a right click menu on the an individual comment...'`
- After: `'...rendered as a right click menu on an individual comment...'`

Both descriptions appear in developer-facing tooling (context key docs, extension API docs).

Fixes #310538