### PR TITLE
Fix: 'can not' → 'cannot' in debug error messages

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -196,7 +196,7 @@ export class DebugTaskRunner implements IDisposable {
 			return Promise.resolve(null);
 		}
 		if (!root) {
-			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
+			return Promise.reject(new Error(nls.localize('invalidTaskReference', "Task '{0}' cannot be referenced from a launch configuration that is in a different workspace folder.", typeof taskId === 'string' ? taskId : taskId.type)));
 		}
 		// run a task before starting a debug session
 		const task = await this.taskService.getTask(root, taskId);

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -267,7 +267,7 @@ export class RawDebugSession implements IDisposable {
 	 */
 	async start(): Promise<void> {
 		if (!this.debugAdapter) {
-			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, can not start debug session.")));
+			return Promise.reject(new Error(nls.localize('noDebugAdapterStart', "No debug adapter, cannot start debug session.")));
 		}
 
 		await this.debugAdapter.startSession();


### PR DESCRIPTION
'Cannot' (one word) is the standard form in modern English. The two-word 'can not' is only used for emphasis, not for ordinary negation in error messages.

Fixes #310542

- `debugTaskRunner.ts:199`: 'can not be referenced' → 'cannot be referenced'
- `rawDebugSession.ts:270`: 'can not start' → 'cannot start'