### PR TITLE
Fix: key name capitalization and 'ie.' → 'i.e.' in localized strings

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -274,7 +274,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			'notebook-cell-output-line-height': `${this.options.outputLineHeight}px`,
 			'notebook-cell-output-max-height': `${this.options.outputLineHeight * this.options.outputLineLimit + 2}px`,
 			'notebook-cell-output-font-family': this.options.outputFontFamily || this.options.fontFamily,
-			'notebook-cell-markup-empty-content': nls.localize('notebook.emptyMarkdownPlaceholder', "Empty markdown cell, double-click or press enter to edit."),
+			'notebook-cell-markup-empty-content': nls.localize('notebook.emptyMarkdownPlaceholder', "Empty markdown cell, double-click or press Enter to edit."),
 			'notebook-cell-renderer-not-found-error': nls.localize({
 				key: 'notebook.error.rendererNotFound',
 				comment: ['$0 is a placeholder for the mime type']

--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -166,7 +166,7 @@ export class DefineKeybindingWidget extends Widget {
 		this._domNode.setWidth(DefineKeybindingWidget.WIDTH);
 		this._domNode.setHeight(DefineKeybindingWidget.HEIGHT);
 
-		const message = nls.localize('defineKeybinding.initial', "Press desired key combination and then press ENTER.");
+		const message = nls.localize('defineKeybinding.initial', "Press desired key combination and then press Enter.");
 		dom.append(this._domNode.domNode, dom.$('.message', undefined, message));
 
 		this._domNode.domNode.style.backgroundColor = asCssVariable(editorWidgetBackground);

--- a/src/vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/viewsWelcomeExtensionPoint.ts
@@ -33,7 +33,7 @@ export const ViewIdentifierMap: { [key: string]: string } = {
 
 const viewsWelcomeExtensionPointSchema = Object.freeze<IConfigurationPropertySchema>({
 	type: 'array',
-	description: nls.localize('contributes.viewsWelcome', "Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, ie. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view."),
+	description: nls.localize('contributes.viewsWelcome', "Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, i.e. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view."),
 	items: {
 		type: 'object',
 		description: nls.localize('contributes.viewsWelcome.view', "Contributed welcome content for a specific view."),


### PR DESCRIPTION
Key names in UI strings should use title case (Enter, Escape, Tab). The abbreviation 'i.e.' requires periods after each letter per standard style.

Fixes #310543

- `keybindingWidgets.ts`: 'press ENTER' → 'press Enter'
- `backLayerWebView.ts`: 'press enter' → 'press Enter'
- `viewsWelcomeExtensionPoint.ts`: 'ie.' → 'i.e.'