### PR TITLE
Fix: 'Controls if' → 'Controls whether' and 'drop down' → 'dropdown' in debug schemas

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -167,7 +167,7 @@ export const presentationSchema: IJSONSchema = {
 		hidden: {
 			type: 'boolean',
 			default: false,
-			description: nls.localize('presentation.hidden', "Controls if this configuration should be shown in the configuration dropdown and the command palette.")
+			description: nls.localize('presentation.hidden', "Controls whether this configuration should be shown in the configuration dropdown and the command palette.")
 		},
 		group: {
 			type: 'string',
@@ -219,7 +219,7 @@ export const launchSchema: IJSONSchema = {
 				properties: {
 					name: {
 						type: 'string',
-						description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration drop down menu.")
+						description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration dropdown menu.")
 					},
 					presentation: presentationSchema,
 					configurations: {
@@ -235,7 +235,7 @@ export const launchSchema: IJSONSchema = {
 								properties: {
 									name: {
 										enum: [],
-										description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration drop down menu.")
+										description: nls.localize('app.launch.json.compound.name', "Name of compound. Appears in the launch configuration dropdown menu.")
 									},
 									folder: {
 										enum: [],


### PR DESCRIPTION
Two grammar fixes in debug schema localized descriptions:

- 'Controls if' → 'Controls whether': 'whether' is the correct form for embedded questions about binary choices (setting descriptions)
- 'drop down menu' → 'dropdown menu': 'dropdown' is the standard compound noun in technical writing

Fixes #310544