### PR TITLE
Fix: typo 'occured' → 'occurred' in parcelWatcher comment

### DIFF
--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//


### PR DESCRIPTION
Fixes a spelling typo in a code comment:

**`platform/files/node/watcher/parcel/parcelWatcher.ts`**
- `occured` → `occurred` in a description of Parcel's event emission behavior