### PR TITLE
Fix: typos 'overide' → 'override' and 'accomodate' → 'accommodate' in comments

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -103,7 +103,7 @@ export class WorkbenchToolBar extends ToolBar {
 			getKeyBinding: (action) => _keybindingService.lookupKeybinding(action.id) ?? undefined,
 			// options (override defaults)
 			..._options,
-			// mandatory (overide options)
+			// mandatory (override options)
 			allowContextMenu: true,
 			skipTelemetry: typeof _options?.telemetrySource === 'string',
 		});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1042,7 +1042,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentLanguageModel.set(model, undefined);
 
 		if (this.cachedWidth) {
-			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
+			// For quick chat and editor chat, relayout because the input may need to shrink to accommodate the model name
 			this.layout(this.cachedWidth);
 		}
 

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -198,7 +198,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move


### PR DESCRIPTION
Fixes spelling mistakes in code comments:

**`workbench/contrib/chat/browser/widget/input/chatInputPart.ts`**
- `accomodate` → `accommodate` in a layout comment

**`workbench/contrib/files/browser/explorerViewlet.ts`**
- `overide` → `override` in a method comment