### PR TITLE
Fix: typo 'triggerd' → 'triggered' in working copy and context menu comments

### DIFF
--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -128,7 +128,7 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}
 
-		// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position
+		// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position
 		let anchor: IMouseEvent | null = null;
 		if (e.target.type !== MouseTargetType.TEXTAREA) {
 			anchor = e.event;

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -905,7 +905,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -1007,7 +1007,7 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).


### PR DESCRIPTION
Fixes a spelling mistake in code comments:

**`workbench/services/textfile/common/textFileEditorModel.ts`**
- `triggerd` → `triggered` in a comment about save operations

**`workbench/services/workingCopy/common/storedFileWorkingCopy.ts`**
- `triggerd` → `triggered` in a comment about content changes