### PR TITLE
Fix: typos 'likelyhood' → 'likelihood', 'dependant' → 'dependent' in file watchers and notebook

### DIFF
--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -32,7 +32,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 	// Same delay as used for the recursive watcher.
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 
-	// Reduce likelyhood of spam from file events via throttling.
+	// Reduce likelihood of spam from file events via throttling.
 	// These numbers are a bit more aggressive compared to the
 	// recursive watcher because we can have many individual
 	// node.js watchers per request.

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -176,7 +176,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 
-	// Reduce likelyhood of spam from file events via throttling.
+	// Reduce likelihood of spam from file events via throttling.
 	// (https://github.com/microsoft/vscode/issues/124723)
 	private readonly throttledFileChangesEmitter = this._register(new ThrottledWorker<IFileChange>(
 		{

--- a/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
@@ -124,7 +124,7 @@ class ExtensionStatusBarItemService implements IExtensionStatusBarItemService {
 			if (typeof extensionId === 'string') {
 				// We cannot enforce unique priorities across all extensions, so we
 				// use the extension identifier as a secondary sort key to reduce
-				// the likelyhood of collisions.
+				// the likelihood of collisions.
 				// See https://github.com/microsoft/vscode/issues/177835
 				// See https://github.com/microsoft/vscode/issues/123827
 				entryPriority = { primary: priority, secondary: hash(extensionId) };

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1997,15 +1997,15 @@ async function webviewPreloads(ctx: PreloadContext) {
 				this._api = await module.activate(this.createRendererContext());
 				this.postDebugMessage('Activated renderer', { duration: `${performance.now() - importStart}ms` });
 
-				const dependantRenderers = ctx.rendererData
+				const dependentRenderers = ctx.rendererData
 					.filter(d => d.entrypoint.extends === this.data.id);
 
-				if (dependantRenderers.length) {
-					this.postDebugMessage('Activating dependant renderers', { dependents: dependantRenderers.map(x => x.id).join(', ') });
+				if (dependentRenderers.length) {
+					this.postDebugMessage('Activating dependent renderers', { dependents: dependentRenderers.map(x => x.id).join(', ') });
 				}
 
 				// Load all renderers that extend this renderer
-				await Promise.all(dependantRenderers.map(async d => {
+				await Promise.all(dependentRenderers.map(async d => {
 					const renderer = renderers.getRenderer(d.id);
 					if (!renderer) {
 						throw new Error(`Could not find extending renderer: ${d.id}`);
@@ -2017,7 +2017,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 						// Squash any errors extends errors. They won't prevent the renderer
 						// itself from working, so just log them.
 						console.error(e);
-						this.postDebugMessage('Activating dependant renderer failed', { dependent: d.id, error: e + '' });
+						this.postDebugMessage('Activating dependent renderer failed', { dependent: d.id, error: e + '' });
 						return undefined;
 					}
 				}));


### PR DESCRIPTION
Fixes spelling mistakes across file watcher and notebook source files:

**`platform/files/node/watcher/nodejs/nodejsWatcherLib.ts`**
- `likelyhood` → `likelihood` in a comment about file event throttling

**`platform/files/node/watcher/parcel/parcelWatcher.ts`**
- `likelyhood` → `likelihood` in a comment about file event throttling

**`workbench/api/browser/statusBarExtensionPoint.ts`**
- `likelyhood` → `likelihood` in a comment about extension priority collisions

**`workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts`**
- Renamed local variable `dependantRenderers` → `dependentRenderers` (×4 occurrences)
- `'Activating dependant renderers'` → `'Activating dependent renderers'` in debug message
- `'Activating dependant renderer failed'` → `'Activating dependent renderer failed'` in debug message