### PR TITLE
Fix: typo 'registraion' → 'registration' in mainThreadNotebookKernels

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -114,9 +114,9 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 	private readonly _editors = new DisposableMap<INotebookEditor>();
 	private readonly _disposables = new DisposableStore();
 
-	private readonly _kernels = new Map<number, [kernel: MainThreadKernel, registraion: IDisposable]>();
-	private readonly _kernelDetectionTasks = new Map<number, [task: MainThreadKernelDetectionTask, registraion: IDisposable]>();
-	private readonly _kernelSourceActionProviders = new Map<number, [provider: IKernelSourceActionProvider, registraion: IDisposable]>();
+	private readonly _kernels = new Map<number, [kernel: MainThreadKernel, registration: IDisposable]>();
+	private readonly _kernelDetectionTasks = new Map<number, [task: MainThreadKernelDetectionTask, registration: IDisposable]>();
+	private readonly _kernelSourceActionProviders = new Map<number, [provider: IKernelSourceActionProvider, registration: IDisposable]>();
 	private readonly _kernelSourceActionProvidersEventRegistrations = new Map<number, IDisposable>();
 
 	private readonly _proxy: ExtHostNotebookKernelsShape;


### PR DESCRIPTION
Fixes a repeated spelling mistake in JSDoc comments:

**`workbench/api/browser/mainThreadNotebookKernels.ts`**
- `registraion` → `registration` appears 3 times in JSDoc describing kernel cell execution provider registration