### PR TITLE
Fix: typos 'genrating', 'notebooke', 'regster' in snippet and chat editing comments

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -159,7 +159,7 @@ export class SnippetController2 implements IEditorContribution {
 			this._editor.getModel().pushStackElement();
 		}
 
-		// regster completion item provider when there is any choice element
+		// register completion item provider when there is any choice element
 		if (this._session?.hasChoice) {
 			const provider: CompletionItemProvider = {
 				_debugDisplayName: 'snippetChoiceCompletions',

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNewNotebookContentEdits.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNewNotebookContentEdits.ts
@@ -14,12 +14,12 @@ import { INotebookService } from '../../../../notebook/common/notebookService.js
  * When asking LLM to generate a new notebook, LLM might end up generating the notebook
  * using the raw file format.
  * E.g. assume we ask LLM to generate a new Github Issues notebook, LLM might end up
- * genrating the notebook using the JSON format of github issues file.
+ * generating the notebook using the JSON format of github issues file.
  * Such a format is not known to copilot extension and those are sent over as regular
  * text edits for the Notebook URI.
  *
  * In such cases we should accumulate all of the edits, generate the content and deserialize the content
- * into a notebook, then generate notebooke edits to insert these cells.
+ * into a notebook, then generate notebook edits to insert these cells.
  */
 export class ChatEditingNewNotebookContentEdits {
 	private readonly textEdits: TextEdit[] = [];


### PR DESCRIPTION
Fixes spelling mistakes in code comments:

**`editor/contrib/snippet/browser/snippetController2.ts`**
- `regster` → `register` in a comment about completion item provider registration

**`workbench/contrib/chat/browser/chatEditing/notebook/chatEditingNewNotebookContentEdits.ts`**
- `genrating` → `generating` in a JSDoc description
- `notebooke` → `notebook` in a JSDoc description