### PR TITLE
Fix: typos 'modifed'/'modifeid' → 'modified' in notebook services comments

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/services/notebookCellMatching.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookCellMatching.ts
@@ -202,7 +202,7 @@ export function matchCellBasedOnSimilarties(modifiedCells: ICell[], originalCell
 				if (matchesForThisOriginalIndex && previousMatchedOriginalIndex < originalIndex) {
 					const betterMatch = Array.from(matchesForThisOriginalIndex).find(([modifiedIndex, value]) => {
 						if (modifiedIndex === i) {
-							// This is the same modifeid entry.
+							// This is the same modified entry.
 							return false;
 						}
 						if (modifiedIndex >= nextMatchedModifiedIndex) {

--- a/src/vs/workbench/contrib/notebook/common/services/notebookWebWorker.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookWebWorker.ts
@@ -279,7 +279,7 @@ export class NotebookWorker implements IWebWorkerServerRequestHandler, IDisposab
 			 *
 			 * LCS has no notion of similarity, it only knows about equality.
 			 * We can use other algorithms to find similarity.
-			 * So if we eliminate A, B, we are left with C, D, E, F and we need to find what they map to in `e, F` in modifed document.
+			 * So if we eliminate A, B, we are left with C, D, E, F and we need to find what they map to in `e, F` in modified document.
 			 * We can use a similarity algorithm to find that.
 			 *
 			 * The purpose of using LCS first is to find the cells that have not changed.


### PR DESCRIPTION
Fixes spelling mistakes in code comments:

**`workbench/contrib/notebook/common/services/notebookCellMatching.ts`**
- `modifeid` → `modified` in a comment about cell matching

**`workbench/contrib/notebook/common/services/notebookWebWorker.ts`**
- `modifed` → `modified` in a comment about LCS algorithm and document diffing