### PR TITLE
Fix: typos 'non-recurive' → 'non-recursive' and 'psuedo' → 'pseudo' in watcher and history

### DIFF
--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -148,7 +148,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 		if (isDirectory) {
 			// Recursive watcher re-use is currently not enabled for when
 			// folders are watched. this is because the dispatching in the
-			// recursive watcher for non-recurive requests is optimized for
+			// recursive watcher for non-recursive requests is optimized for
 			// file changes  where we really only match on the exact path
 			// and not child paths.
 			return false;

--- a/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
@@ -465,7 +465,7 @@ export async function fetchFishHistory(accessor: ServicesAccessor): Promise<IShe
 
 	/**
 	 * These apply to `fish` v3.5.1:
-	 * - It looks like YAML but it's not. It's, quoting, *"a broken psuedo-YAML"*.
+	 * - It looks like YAML but it's not. It's, quoting, *"a broken pseudo-YAML"*.
 	 *   See these discussions for more details:
 	 *   - https://github.com/fish-shell/fish-shell/pull/6493
 	 *   - https://github.com/fish-shell/fish-shell/issues/3341


### PR DESCRIPTION
Fixes spelling mistakes in code comments:

**`platform/files/node/watcher/nodejs/nodejsWatcherLib.ts`**
- `non-recurive` → `non-recursive` in a comment about watcher request optimization

**`workbench/contrib/terminalContrib/history/common/history.ts`**
- `psuedo` → `pseudo` in a comment describing fish shell's history file format (quoting the fish-shell maintainers)