### PR TITLE
Fix: typos 'paramter'/'ParamterListParts' → 'parameter'/'ParameterListParts' in TypeScript extension

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts
@@ -33,22 +33,22 @@ function appendJoinedPlaceholders(
 	joiner: string
 ) {
 	for (let i = 0; i < parts.length; ++i) {
-		const paramterPart = parts[i];
-		snippet.appendPlaceholder(paramterPart.text);
+		const parameterPart = parts[i];
+		snippet.appendPlaceholder(parameterPart.text);
 		if (i !== parts.length - 1) {
 			snippet.appendText(joiner);
 		}
 	}
 }
 
-interface ParamterListParts {
+interface ParameterListParts {
 	readonly parts: ReadonlyArray<Proto.SymbolDisplayPart>;
 	readonly hasOptionalParameters: boolean;
 }
 
 function getParameterListParts(
 	displayParts: ReadonlyArray<Proto.SymbolDisplayPart>
-): ParamterListParts {
+): ParameterListParts {
 	const parts: Proto.SymbolDisplayPart[] = [];
 	let optionalParams: Proto.SymbolDisplayPart[] = [];
 	let isInMethod = false;


### PR DESCRIPTION
Fixes variable and interface name spelling mistakes in the TypeScript language features extension:

**`extensions/typescript-language-features/src/languageFeatures/util/snippetForFunctionCall.ts`**
- Renamed local variable `paramterPart` → `parameterPart`
- Renamed interface `ParamterListParts` → `ParameterListParts` (×2 references)