### PR TITLE
Fix: typo 'fo' → 'for' in inlineEditsWordReplacementView comment

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -144,7 +144,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 				alternativeAction = {
 					label: count !== undefined ? (active ? occurrencesLabel : label) : label,
 					tooltip: occurrencesLabel ? `${occurrencesLabel}\n${keybindingTooltip}` : undefined,
-					icon: undefined, //this._viewData.alternativeAction.icon, Do not render icon fo the moment
+					icon: undefined, //this._viewData.alternativeAction.icon, Do not render icon for the moment
 					count,
 					keybinding: this._keybindingService.lookupKeybinding(inlineSuggestCommitAlternativeActionId),
 					active: altModifierActive,


### PR DESCRIPTION
Fixes a missing letter typo in a code comment:

**`editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts`**
- `Do not render icon fo the moment` → `Do not render icon for the moment` (inline comment explaining why an icon prop is set to undefined)