### PR TITLE
Fix: variable name typo 'paramterLabel' → 'parameterLabel' in parameterHintsModel test

### DIFF
--- a/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
+++ b/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
@@ -401,7 +401,7 @@ suite('ParameterHintsModel', () => {
 		const triggerChar = 'a';
 		const firstProviderId = 'firstProvider';
 		const secondProviderId = 'secondProvider';
-		const paramterLabel = 'parameter';
+		const parameterLabel = 'parameter';
 
 		const editor = createMockEditor('');
 		const model = disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -423,7 +423,7 @@ suite('ParameterHintsModel', () => {
 								signatures: [{
 									label: firstProviderId,
 									parameters: [
-										{ label: paramterLabel }
+										{ label: parameterLabel }
 									]
 								}]
 							},
@@ -468,12 +468,12 @@ suite('ParameterHintsModel', () => {
 			const firstHint = (await getNextHint(model))!.value;
 			assert.strictEqual(firstHint.signatures[0].label, firstProviderId);
 			assert.strictEqual(firstHint.activeSignature, 0);
-			assert.strictEqual(firstHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(firstHint.signatures[0].parameters[0].label, parameterLabel);
 
 			const secondHint = (await getNextHint(model))!.value;
 			assert.strictEqual(secondHint.signatures[0].label, secondProviderId);
 			assert.strictEqual(secondHint.activeSignature, 1);
-			assert.strictEqual(secondHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(secondHint.signatures[0].parameters[0].label, parameterLabel);
 		});
 	});
 


### PR DESCRIPTION
Fixes a variable name misspelling in the parameter hints model test:

**`editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts`**
- Renamed local variable `paramterLabel` → `parameterLabel` (×4 uses)