### PR TITLE
Fix: typos 'fullfilled', 'refrence', 'initialze', 'disposeable', 'transfered' in comments

### DIFF
--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -182,7 +182,7 @@ export interface ISplitViewOptions<TLayoutContext = undefined, TView extends IVi
 
 	/**
 	 * An initial description of this {@link SplitView} instance, allowing
-	 * to initialze all views within the ctor.
+	 * to initialize all views within the ctor.
 	 */
 	readonly descriptor?: ISplitViewDescriptor<TLayoutContext, TView>;
 

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -266,7 +266,7 @@ export class InstantiationService implements IInstantiationService {
 			for (const { data } of roots) {
 				// Repeat the check for this still being a service sync descriptor. That's because
 				// instantiating a dependency might have side-effect and recursively trigger instantiation
-				// so that some dependencies are now fullfilled already.
+				// so that some dependencies are now fulfilled already.
 				const instanceOrDesc = this._getServiceInstanceOrDescriptor(data.id);
 				if (instanceOrDesc instanceof SyncDescriptor) {
 					// create instance and overwrite the service collections

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -356,7 +356,7 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 	}
 
 	disposeTemplate(templateData: ICommentThreadTemplateData): void {
-		templateData.disposables.forEach(disposeable => disposeable.dispose());
+		templateData.disposables.forEach(disposable => disposable.dispose());
 		templateData.elementDisposables.dispose();
 		templateData.actionBar.dispose();
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -174,7 +174,7 @@ export class NotebookEditor extends EditorPane implements INotebookEditorPane, I
 		if (!visible) {
 			this._saveEditorViewState(this.input);
 			if (this.input && this._widget.value) {
-				// the widget is not transfered to other editor inputs
+				// the widget is not transferred to other editor inputs
 				this._widget.value.onWillHide();
 			}
 		}

--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -48,7 +48,7 @@ export interface IQuickDiffModelService {
 
 	/**
 	 * Returns `undefined` if the editor model is not resolved.
-	 * Model refrence has to be disposed once not needed anymore.
+	 * Model reference has to be disposed once not needed anymore.
 	 * @param resource
 	 * @param options
 	 */


### PR DESCRIPTION
Fixes spelling mistakes in code and JSDoc comments across multiple files:

**`base/browser/ui/splitview/splitview.ts`**
- `initialze` → `initialize` in JSDoc describing `descriptor` option

**`platform/instantiation/common/instantiationService.ts`**
- `fullfilled` → `fulfilled` in a comment about dependency instantiation side-effects

**`workbench/contrib/comments/browser/commentsTreeViewer.ts`**
- Renamed parameter `disposeable` → `disposable` in `disposeTemplate` method

**`workbench/contrib/notebook/browser/notebookEditor.ts`**
- `transfered` → `transferred` in a comment about widget visibility

**`workbench/contrib/scm/browser/quickDiffModel.ts`**
- `refrence` → `reference` in JSDoc describing model reference disposal