### PR TITLE
Fix: typos 'explicilty'/'explictly' → 'explicitly' in notebook and debug view comments

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -151,7 +151,7 @@ export class VariablesView extends ViewPane implements IDebugViewWithVariables {
 				return;
 			}
 
-			// Refresh the tree immediately if the user explictly changed stack frames.
+			// Refresh the tree immediately if the user explicitly changed stack frames.
 			// Otherwise postpone the refresh until user stops stepping.
 			const timeout = sf.explicit ? 0 : undefined;
 			this.updateTreeScheduler.schedule(timeout);

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -271,7 +271,7 @@ abstract class KernelPickerStrategyBase implements IKernelPickerStrategy {
 				this._productService.quality !== 'stable'
 			);
 		} else if (isSourcePick(pick)) {
-			// selected explicilty, it should trigger the execution?
+			// selected explicitly, it should trigger the execution?
 			pick.action.runAction();
 		}
 
@@ -624,7 +624,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 				await this._selectOneKernel(notebook, selectedKernelPickItem.label, selectedKernelPickItem.kernels);
 				return true;
 			} else if (isSourcePick(selectedKernelPickItem)) {
-				// selected explicilty, it should trigger the execution?
+				// selected explicitly, it should trigger the execution?
 				try {
 					await selectedKernelPickItem.action.runAction();
 					return true;


### PR DESCRIPTION
Fixes spelling mistakes in code comments:

**`workbench/contrib/debug/browser/variablesView.ts`**
- `explictly` → `explicitly` in a comment about tree refresh behavior on stack frame change

**`workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts`**
- `explicilty` → `explicitly` in two comments about kernel pick selection (×2)