### PR TITLE
Fix: typo 'superceded' → 'superseded' in electronTypes JSDoc

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;


### PR DESCRIPTION
Fixes a spelling mistake in JSDoc documentation:

**`base/parts/sandbox/electron-browser/electronTypes.ts`**
- `superceded` → `superseded` in a JSDoc comment for `WebUtils.getPathForFile()` explaining it replaced a previous API augmentation to the `File` object