### PR TITLE
Fix: doubled words ('a a', 'in in', 'is is', 'of of') in code and JSDoc comments

### DIFF
--- a/src/vs/editor/common/core/ranges/lineRange.ts
+++ b/src/vs/editor/common/core/ranges/lineRange.ts
@@ -46,7 +46,7 @@ export class LineRange {
 	}
 
 	/**
-	 * @param lineRanges An array of arrays of of sorted line ranges.
+	 * @param lineRanges An array of arrays of sorted line ranges.
 	 */
 	public static joinMany(lineRanges: readonly (readonly LineRange[])[]): readonly LineRange[] {
 		if (lineRanges.length === 0) {

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -51,7 +51,7 @@ export interface ICommandActionToggleInfo {
 	tooltip?: string;
 
 	/**
-	 * The title that goes well with a a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
+	 * The title that goes well with a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
 	 */
 	title?: string;
 

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -233,7 +233,7 @@ export class MainThreadFileSystemEventService implements MainThreadFileSystemEve
 		}
 
 		// Correlated file watching: use an exclusive `createWatcher()`
-		// Note: currently not enabled for extensions (but leaving in in case of future usage)
+		// Note: currently not enabled for extensions (but leaving in case of future usage)
 		if (correlate && !opts.recursive) {
 			this._logService.trace(`MainThreadFileSystemEventService#$watch(): request to start watching correlated (extension: ${extensionId}, path: ${uri.toString(true)}, recursive: ${opts.recursive}, session: ${session}, excludes: ${JSON.stringify(opts.excludes)}, includes: ${JSON.stringify(opts.includes)})`);
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -366,7 +366,7 @@ class AttachedHistory extends Disposable {
 
 	/**
 	 * Pushes an history item that is tied to the last text edit (or an extension of it).
-	 * When the last text edit is undone/redone, so is is this history item.
+	 * When the last text edit is undone/redone, so is this history item.
 	 */
 	public pushAttachedHistoryElement(element: IAttachedHistoryElement): void {
 		this.attachedHistory.push({ altId: this.model.getAlternativeVersionId(), element });


### PR DESCRIPTION
Fixes duplicate word typos in code comments and JSDoc:

**`editor/common/core/ranges/lineRange.ts`**
- `arrays of of sorted` → `arrays of sorted` in JSDoc for `LineRange.joinMany`

**`platform/action/common/action.ts`**
- `well with a a check mark` → `well with a check mark` in JSDoc for `ICommandActionToggleInfo.title`

**`workbench/api/browser/mainThreadFileSystemEventService.ts`**
- `leaving in in case` → `leaving in case` in a comment about correlated file watching

**`workbench/contrib/mergeEditor/browser/view/viewModel.ts`**
- `so is is this` → `so is this` in JSDoc for `pushAttachedHistoryElement`