### PR TITLE
Fix: doubled word 'set to to default' → 'set to default' in colorThemeData comment

### DIFF
--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -767,7 +767,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			// new JSON color themes format
 			for (const colorId in colors) {
 				const colorVal = colors[colorId];
-				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to to default
+				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to default
 					delete result.colors[colorId];
 				} else if (typeof colorVal === 'string') {
 					result.colors[colorId] = Color.fromHex(colors[colorId]);


### PR DESCRIPTION
Fixes a doubled word in a code comment:

**`workbench/services/themes/common/colorThemeData.ts`**
- `colors that are set to to default` → `colors that are set to default` — removes the extra "to" in an inline comment about default color handling