### PR TITLE
Fix: rename 'continousMatchingGlobPattern' → 'continuousMatchingGlobPattern' in searchChatContext

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchChatContext.ts
+++ b/src/vs/workbench/contrib/search/browser/searchChatContext.ts
@@ -236,7 +236,7 @@ export async function searchFilesAndFolders(
 	configurationService: IConfigurationService,
 	searchService: ISearchService
 ): Promise<{ folders: URI[]; files: URI[] }> {
-	const segmentMatchPattern = fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continousMatchingGlobPattern(pattern);
+	const segmentMatchPattern = fuzzyMatch ? fuzzyMatchingGlobPattern(pattern) : continuousMatchingGlobPattern(pattern);
 
 	const searchExcludePattern = getExcludes(configurationService.getValue<ISearchConfiguration>({ resource: workspace })) || {};
 	const searchOptions: IFileQuery = {
@@ -278,7 +278,7 @@ function fuzzyMatchingGlobPattern(pattern: string): string {
 	return '*' + pattern.split('').join('*') + '*';
 }
 
-function continousMatchingGlobPattern(pattern: string): string {
+function continuousMatchingGlobPattern(pattern: string): string {
 	if (!pattern) {
 		return '*';
 	}


### PR DESCRIPTION
Fixes a function name spelling mistake:

**`workbench/contrib/search/browser/searchChatContext.ts`**
- Renamed function `continousMatchingGlobPattern` → `continuousMatchingGlobPattern` (×2 — declaration and call site)