### PR TITLE
Fix: typos 'acessible' → 'accessible' and 'inacessable' → 'inaccessible' in localize key names

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -871,7 +871,7 @@ export class AccessibleView extends Disposable {
 
 	private _disableVerbosityHint(provider: AccesibleViewContentProvider): string {
 		if (provider.options.type === AccessibleViewType.Help && this._verbosityEnabled()) {
-			return localize('acessibleViewDisableHint', "\nDisable accessibility verbosity for this feature{0}.", `<keybinding:${AccessibilityCommandId.DisableVerbosityHint}>`);
+			return localize('accessibleViewDisableHint', "\nDisable accessibility verbosity for this feature{0}.", `<keybinding:${AccessibilityCommandId.DisableVerbosityHint}>`);
 		}
 		return '';
 	}
@@ -965,9 +965,9 @@ export class AccessibleViewService extends Disposable implements IAccessibleView
 		const keybinding = this._keybindingService.lookupKeybinding(AccessibilityCommandId.OpenAccessibleView)?.getAriaLabel();
 		let hint = null;
 		if (keybinding) {
-			hint = localize('acessibleViewHint', "Inspect this in the accessible view with {0}", keybinding);
+			hint = localize('accessibleViewHint', "Inspect this in the accessible view with {0}", keybinding);
 		} else {
-			hint = localize('acessibleViewHintNoKbEither', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.");
+			hint = localize('accessibleViewHintNoKbEither', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.");
 		}
 		return hint;
 	}

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -664,7 +664,7 @@ class TunnelItem implements ITunnelItem {
 				description += ` (${this.pid})`;
 			}
 		} else if (this.hasRunningProcess) {
-			description = nls.localize('tunnelView.runningProcess.inacessable', "Process information unavailable");
+			description = nls.localize('tunnelView.runningProcess.inaccessible', "Process information unavailable");
 		}
 
 		return description;


### PR DESCRIPTION
Fixes misspelled key names in `localize()` calls. Localization key names are used for string lookup and should match the feature name correctly.

**`workbench/contrib/accessibility/browser/accessibleView.ts`**
- `'acessibleViewDisableHint'` → `'accessibleViewDisableHint'`
- `'acessibleViewHint'` → `'accessibleViewHint'`
- `'acessibleViewHintNoKbEither'` → `'accessibleViewHintNoKbEither'`

**`workbench/contrib/remote/browser/tunnelView.ts`**
- `'tunnelView.runningProcess.inacessable'` → `'tunnelView.runningProcess.inaccessible'`