### PR TITLE
Fix: typo 'initalized' → 'initialized' in notebook editor error messages

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -937,7 +937,7 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 
 	getLayoutInfo(): NotebookLayoutInfo {
 		if (!this._list) {
-			throw new Error('Editor is not initalized successfully');
+			throw new Error('Editor is not initialized successfully');
 		}
 
 		return {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2756,7 +2756,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	getLayoutInfo(): NotebookLayoutInfo {
 		if (!this._list) {
-			throw new Error('Editor is not initalized successfully');
+			throw new Error('Editor is not initialized successfully');
 		}
 
 		if (!this._fontInfo) {


### PR DESCRIPTION
Fixes the same error message misspelling in two notebook editor files:

**`workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts`** (line 940)
**`workbench/contrib/notebook/browser/notebookEditorWidget.ts`** (line 2759)

Both have `throw new Error('Editor is not initalized successfully')` in their `getLayoutInfo()` method. This error is surfaced to users when the editor layout is queried before the list is ready.