### PR TITLE
Fix: spelling typos across 8 source files (globaly, exectued, concurent, acurate, etc.)

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -131,7 +131,7 @@ export class OneSnippet {
 
 		} else {
 			// the selection of the current placeholder might
-			// not acurate any more -> simply restore it
+			// not accurate any more -> simply restore it
 		}
 
 		const newSelections = this._editor.getModel().changeDecorations(accessor => {

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -350,7 +350,7 @@ export namespace WindowStateValidator {
 				logService.trace('window#validateWindowState: restoring fullscreen to previous display');
 
 				const defaults = defaultWindowState(WindowMode.Fullscreen); // make sure we have good values when the user restores the window
-				defaults.x = display.bounds.x; // carefull to use displays x/y position so that the window ends up on the correct monitor
+				defaults.x = display.bounds.x; // careful to use displays x/y position so that the window ends up on the correct monitor
 				defaults.y = display.bounds.y;
 
 				return defaults;

--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -868,7 +868,7 @@ export class EditorParts extends MultiWindowParts<EditorPart, IEditorPartsMement
 
 	bind<T extends ContextKeyValue>(contextKey: RawContextKey<T>, group: IEditorGroupView): IContextKey<T> {
 
-		// Ensure we only bind to the same context key once globaly
+		// Ensure we only bind to the same context key once globally
 		let globalContextKey = this.globalContextKeys.get(contextKey.key);
 		if (!globalContextKey) {
 			globalContextKey = contextKey.bindTo(this.contextKeyService);

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1686,7 +1686,7 @@ class ExceptionBreakpointInputRenderer implements ICompressibleTreeRenderer<IExc
 			}
 		}));
 		toDispose.add(dom.addDisposableListener(inputBox.inputElement, 'blur', () => {
-			// Need to react with a timeout on the blur event due to possible concurent splices #56443
+			// Need to react with a timeout on the blur event due to possible concurrent splices #56443
 			setTimeout(() => {
 				wrapUp(true);
 			});

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -321,8 +321,8 @@ function findNextVisibleFrame(down: boolean, callStack: readonly IStackFrame[], 
 }
 
 // These commands are used in call stack context menu, call stack inline actions, command palette, debug toolbar, mac native touch bar
-// When the command is exectued in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
-// Otherwise when it is executed "globaly"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
+// When the command is executed in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
+// Otherwise when it is executed "globally"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
 // Same for stackFrame commands and session commands.
 CommandsRegistry.registerCommand({
 	id: COPY_STACK_TRACE_ID,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -469,7 +469,7 @@ export class GettingStartedPage extends EditorPane {
 				this.hideCategory(argument);
 				break;
 			}
-			// Use selectTask over selectStep to keep telemetry consistant:https://github.com/microsoft/vscode/issues/122256
+			// Use selectTask over selectStep to keep telemetry consistent: https://github.com/microsoft/vscode/issues/122256
 			case 'selectTask': {
 				this.selectStep(argument);
 				break;

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -709,7 +709,7 @@ function getEscapeAwareSplitStringForRipgrep(pattern: string): { fixedStart?: st
 				break;
 			case '{':
 				if (escaped) {
-					// if we escaped this opening bracket, then it is to be taken literally. Remove the `\` because we've acknowleged it and add the `{` to the appropriate string
+					// if we escaped this opening bracket, then it is to be taken literally. Remove the `\` because we've acknowledged it and add the `{` to the appropriate string
 					if (inBraces) {
 						strInBraces += char;
 					} else {

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -375,7 +375,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 			this.setDirty(this.hasAssociatedFilePath || !!hasBackup || !!this.initialValue);
 
 			// If we have initial contents, make sure to emit this
-			// as the appropiate events to the outside.
+			// as the appropriate events to the outside.
 			if (hasBackup || this.initialValue) {
 				this._onDidChangeContent.fire();
 			}


### PR DESCRIPTION
Fixes spelling mistakes in code comments across multiple files:

**`workbench/browser/parts/editor/editorParts.ts`**
- `globaly` → `globally` in a comment about context key binding

**`workbench/contrib/debug/browser/debugCommands.ts`**
- `exectued` → `executed` and `globaly` → `globally` in a comment about thread context

**`workbench/contrib/debug/browser/breakpointsView.ts`**
- `concurent` → `concurrent` in a comment about blur event handling (#56443)

**`editor/contrib/snippet/browser/snippetSession.ts`**
- `acurate` → `accurate` in a comment about placeholder selection restoration

**`workbench/services/untitled/common/untitledTextEditorModel.ts`**
- `appropiate` → `appropriate` in a comment about initial content events

**`workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts`**
- `consistant` → `consistent` in a comment about telemetry key consistency

**`platform/windows/electron-main/windows.ts`**
- `carefull` → `careful` in a comment about display position restoration

**`workbench/services/search/node/ripgrepTextSearchEngine.ts`**
- `acknowleged` → `acknowledged` in a comment about escaped bracket handling