### PR TITLE
Fix: typos 'syncronous', 'deafult', 'manualy' in code comments

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -1046,7 +1046,7 @@ registerAction2(class extends ViewAction<Repl> {
 
 	async runInView(accessor: ServicesAccessor, view: Repl, session: IDebugSession | undefined) {
 		const debugService = accessor.get(IDebugService);
-		// If session is already the focused session we need to manualy update the tree since view model will not send a focused change event
+		// If session is already the focused session we need to manually update the tree since view model will not send a focused change event
 		if (session && session.state !== State.Inactive && session !== debugService.getViewModel().focusedSession) {
 			session = resolveChildSession(session, debugService.getModel().getSessions());
 			await debugService.focusStackFrame(undefined, undefined, session, { explicit: true });

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
@@ -98,7 +98,7 @@ export class NotebookOutlineEntryFactory implements INotebookOutlineEntryFactory
 			if (!isMarkdown) {
 				const cached = this.cellOutlineEntryCache[cell.id];
 
-				// Gathering symbols from the model is an async operation, but this provider is syncronous.
+				// Gathering symbols from the model is an async operation, but this provider is synchronous.
 				// So symbols need to be precached before this function is called to get the full list.
 				if (cached) {
 					// push code cell entry that is a parent of cached symbols, always necessary. filtering for quickpick done in that provider.

--- a/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts
@@ -1453,7 +1453,7 @@ export class TypeAheadAddon extends Disposable implements ITerminalAddon {
 		const buffer = terminal.buffer.active;
 
 		// Detect programs like git log/less that use the normal buffer but don't
-		// take input by deafult (fixes #109541)
+		// take input by default (fixes #109541)
 		if (buffer.cursorX === 1 && buffer.cursorY === terminal.rows - 1) {
 			if (buffer.getLine(buffer.cursorY + buffer.baseY)?.getCell(0)?.getChars() === ':') {
 				return;


### PR DESCRIPTION
Fixes three spelling mistakes in code comments:

**`workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts`**
- `syncronous` → `synchronous` in a comment explaining why symbols must be pre-cached

**`workbench/contrib/terminalContrib/typeAhead/browser/terminalTypeAheadAddon.ts`**
- `deafult` → `default` in a comment about programs that use the normal buffer (fixes #109541)

**`workbench/contrib/debug/browser/repl.ts`**
- `manualy` → `manually` in a comment about forcing a tree update for focused debug sessions