### PR TITLE
Fix: 'allow to' → 'allow you to' and 'effects' → 'affects' in explorer drag-and-drop setting

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -477,7 +477,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',
-			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer."),
+			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow you to move files and folders via drag and drop. This setting only affects drag and drop from inside the Explorer."),
 			'default': true
 		},
 		'explorer.confirmDragAndDrop': {


### PR DESCRIPTION
Fixes two grammar mistakes in a user-visible setting description:

**`workbench/contrib/files/browser/files.contribution.ts`** — `explorer.enableDragAndDrop`
- `allow to move` → `allow you to move` (missing pronoun)
- `only effects drag` → `only affects drag` ('effects' as a verb means "to bring about"; 'affects' is the correct verb here meaning "to have an impact on")