### PR TITLE
Fix: doubled words ('and and', 'in in', 'for for', 'to to') in comments and user-visible strings

### DIFF
--- a/src/vs/editor/common/core/ranges/lineRange.ts
+++ b/src/vs/editor/common/core/ranges/lineRange.ts
@@ -46,7 +46,7 @@ export class LineRange {
 	}
 
 	/**
-	 * @param lineRanges An array of arrays of of sorted line ranges.
+	 * @param lineRanges An array of arrays of sorted line ranges.
 	 */
 	public static joinMany(lineRanges: readonly (readonly LineRange[])[]): readonly LineRange[] {
 		if (lineRanges.length === 0) {

--- a/src/vs/platform/userDataSync/common/userDataSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataSyncService.ts
@@ -784,7 +784,7 @@ class ProfileSynchronizer extends Disposable {
 						throw userDataSyncError;
 					}
 
-					// Log and and continue
+					// Log and continue
 					this.logService.error(e);
 					this.logService.error(`${synchroniser.resource}: ${toErrorMessage(e)}`);
 					syncErrors.push([synchroniser.resource, userDataSyncError]);

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -389,7 +389,7 @@ class MainThreadChatSessionItemController extends Disposable implements IChatSes
 		this._proxy = proxy;
 		this._handle = handle;
 
-		// Update the chat session item based on on the actual model state
+		// Update the chat session item based on the actual model state
 		// TODO: This should be based on the chat session content provider instead of the chat models directly
 		// or bed moved into the chat session service so that all controllers get the same behavior.
 		const addModelListeners = async (model: IChatModel) => {

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -233,7 +233,7 @@ export class MainThreadFileSystemEventService implements MainThreadFileSystemEve
 		}
 
 		// Correlated file watching: use an exclusive `createWatcher()`
-		// Note: currently not enabled for extensions (but leaving in in case of future usage)
+		// Note: currently not enabled for extensions (but leaving in case of future usage)
 		if (correlate && !opts.recursive) {
 			this._logService.trace(`MainThreadFileSystemEventService#$watch(): request to start watching correlated (extension: ${extensionId}, path: ${uri.toString(true)}, recursive: ${opts.recursive}, session: ${session}, excludes: ${JSON.stringify(opts.excludes)}, includes: ${JSON.stringify(opts.includes)})`);
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -984,7 +984,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			rootFiles.push({ fileName: CLAUDE_LOCAL_MD_FILENAME, type: AgentInstructionFileType.claudeMd }); // CLAUDE.local.md in workspace root
 
 			promises.push(this.fileLocator.findFilesInRoots(rootFolders, CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in .claude folder under workspace root
-			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in in ~/.claude folder
+			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in ~/.claude folder
 		}
 		const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
 		if (!useCopilotInstructionsFiles) {

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -290,7 +290,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					} else if (isShiftPressed) {
 						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition || !!bp.triggeredBy)) {
-						// Show the dialog if there is a potential condition to be accidently lost.
+						// Show the dialog if there is a potential condition to be accidentally lost.
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -314,7 +314,7 @@ export class SearchView extends ViewPane {
 
 		this._refreshResultsScheduler = this._register(new RunOnceScheduler(this._updateResults.bind(this), 80));
 
-		// storage service listener for for roaming changes
+		// storage service listener for roaming changes
 		this._register(this.storageService.onWillSaveState(() => {
 			this._saveSearchHistoryService();
 		}));

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -101,7 +101,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 
 		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions'];
 		this._register(this._remoteTerminalChannel.onExecuteCommand(async e => {
-			// Ensure this request for for this window
+			// Ensure this request for this window
 			const pty = this._ptys.get(e.persistentProcessId);
 			if (!pty) {
 				return;

--- a/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
@@ -42,7 +42,7 @@ export interface ITerminalStatusList {
 	/**
 	 * Adds a status to the list.
 	 * @param status The status object. Ideally a single status object that does not change will be
-	 * shared as this call will no-op if the status is already set (checked by by object reference).
+	 * shared as this call will no-op if the status is already set (checked by object reference).
 	 * @param duration An optional duration in milliseconds of the status, when specified the status
 	 * will remove itself when the duration elapses unless the status gets re-added.
 	 */

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -767,7 +767,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			// new JSON color themes format
 			for (const colorId in colors) {
 				const colorVal = colors[colorId];
-				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to to default
+				if (colorVal === DEFAULT_COLOR_CONFIG_VALUE) { // ignore colors that are set to default
 					delete result.colors[colorId];
 				} else if (typeof colorVal === 'string') {
 					result.colors[colorId] = Color.fromHex(colors[colorId]);

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -462,7 +462,7 @@ export interface ITimerService {
 	/**
 	 * Return the duration between two marks.
 	 * @param from from mark name
-	 * @param to to mark name
+	 * @param to mark name
 	 */
 	getDuration(from: string, to: string): number;
 


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed doubled-word typos across 7 files — one in a user-visible localized string, the rest in code comments:

| File | Before | After |
|------|--------|-------|
| `userDataSyncService.ts` | `// Log and and continue` | `// Log and continue` |
| `promptsServiceImpl.ts` | `// CLAUDE.md in in ~/.claude folder` | `// CLAUDE.md in ~/.claude folder` |
| `breakpointEditorContribution.ts` | `accidently` → `accidentally` (typo fix in comment) |
| `notebook.contribution.ts` | `"position for for specific file types"` | `"position for specific file types"` (user-visible!) |
| `searchView.ts` | `// listener for for roaming changes` | `// listener for roaming changes` |
| `remoteTerminalBackend.ts` | `// Ensure this request for for this window` | `// Ensure this request for this window` |
| `timerService.ts` | `@param to to mark name` | `@param to mark name` |

The `notebook.contribution.ts` change fixes a user-visible localized string in the cell toolbar position setting description.

#### Is there anything you'd like reviewers to focus on?

The `notebook.contribution.ts` change affects a user-visible `markdownDescription` in a configuration registration. All other changes are in comments/JSDoc only.