### PR TITLE
Fix: double spaces in localized setting description strings

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -79,7 +79,7 @@ export class JSONValidationExtensionPoint {
 							collector.error(nls.localize('invalid.url.fileschema', "'configuration.jsonValidation.url' is an invalid relative URL: {0}", e.message));
 						}
 					} else if (!/^[^:/?#]+:\/\//.test(uri)) {
-						collector.error(nls.localize('invalid.url.schema', "'configuration.jsonValidation.url' must be an absolute URL or start with './'  to reference schemas located in the extension."));
+						collector.error(nls.localize('invalid.url.schema', "'configuration.jsonValidation.url' must be an absolute URL or start with './' to reference schemas located in the extension."));
 						return;
 					}
 				});

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -325,7 +325,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'workbench.editor.closeOnFileDelete': {
 				'type': 'boolean',
-				'description': localize('closeOnFileDelete', "Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that editors with unsaved changes will never close to preserve your data."),
+				'description': localize('closeOnFileDelete', "Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open on such an event. Note that deleting from within the application will always close the editor and that editors with unsaved changes will never close to preserve your data."),
 				'default': false
 			},
 			'workbench.editor.openPositioning': {

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -258,7 +258,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				patternProperties: {
 					'(^\\d+(-\\d+)?$)|(.+)': {
 						type: 'object',
-						description: localize('remote.portsAttributes.port', "A port, range of ports (ex. \"40000-55000\"), host and port (ex. \"db:1234\"), or regular expression (ex. \".+\\\\/server.js\").  For a port number or range, the attributes will apply to that port number or range of port numbers. Attributes which use a regular expression will apply to ports whose associated process command line matches the expression."),
+						description: localize('remote.portsAttributes.port', "A port, range of ports (ex. \"40000-55000\"), host and port (ex. \"db:1234\"), or regular expression (ex. \".+\\\\/server.js\"). For a port number or range, the attributes will apply to that port number or range of port numbers. Attributes which use a regular expression will apply to ports whose associated process command line matches the expression."),
 						properties: {
 							'onAutoForward': {
 								type: 'string',


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed double spaces in three localized user-visible setting descriptions:

- `jsonValidationExtensionPoint.ts`: `'./'  to reference` → `'./' to reference` (extra space after `'./'`)
- `workbench.contribution.ts`: `open  on such an event` → `open on such an event` (extra space)
- `remote.contribution.ts`: `regular expression (ex. \".+\\\\/server.js\").  For` → `(ex. \".+\\\\/server.js\"). For` (double space after sentence)

All three changes are in user-visible `localize()` strings. Double spaces render as single spaces in most UI contexts but are inconsistent and could cause issues in accessibility tools or plain-text rendering.

#### Is there anything you'd like reviewers to focus on?

All changes are purely whitespace corrections in localized strings — no logic changes.