### PR TITLE
Fix: guard against null model in inline edits view render computations

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -76,7 +76,8 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 			const maxPrefixTrim = prefixTrim.prefixTrim;
 			const modifiedBubbles = rangesToBubbleRanges(edit.replacements.map(r => r.modifiedRange)).map(r => new Range(r.startLineNumber, r.startColumn - maxPrefixTrim, r.endLineNumber, r.endColumn - maxPrefixTrim));
 
-			const textModel = this._editor.model.get()!;
+			const textModel = this._editor.model.get();
+			if (!textModel) { return undefined; }
 			const startLineNumber = edit.modifiedRange.startLineNumber;
 			for (let i = 0; i < edit.modifiedRange.length; i++) {
 				const line = document.createElement('div');

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -95,7 +95,8 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 			return this._userInteractionService.createHoverTracker(elem.element, reader.store).read(reader);
 		});
 		this._renderTextEffect = derived(this, _reader => {
-			const tm = this._editor.model.get()!;
+			const tm = this._editor.model.get();
+			if (!tm) { return; }
 			const origLine = tm.getLineContent(this._viewData.edit.range.startLineNumber);
 
 			const edit = StringReplacement.replace(new OffsetRange(this._viewData.edit.range.startColumn - 1, this._viewData.edit.range.endColumn - 1), this._viewData.edit.text);


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Two inline edits view files used the non-null assertion operator (`!`) when accessing `this._editor.model.get()`, which would throw a runtime crash if the model is `null` (e.g., when the editor is disposed or detached):

**`inlineEditsLineReplacementView.ts`** (line 79):
```ts
// Before (unsafe):
const textModel = this._editor.model.get()!;

// After (safe):
const textModel = this._editor.model.get();
if (!textModel) { return undefined; }
```

**`inlineEditsWordReplacementView.ts`** (line 98):
```ts
// Before (unsafe):
const tm = this._editor.model.get()!;

// After (safe):
const tm = this._editor.model.get();
if (!tm) { return; }
```

These are both inside `derived()` reactive computations. When the editor model is null (editor disposed during async operations), the non-null assertion would cause a crash. The null guard early-returns the derived computation cleanly instead.

#### Is there anything you'd like reviewers to focus on?

Both changes follow the existing pattern in the codebase of guarding against null before accessing the model. The return types of the derived functions already support `undefined`/`void`, so the early return is type-safe.