### PR TITLE
Fix: extra space before period and missing comma in localized error/setting strings

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -934,7 +934,7 @@ export abstract class AbstractExtensionManagementService extends CommontExtensio
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name, dependents[1].manifest.displayName || dependents[1].manifest.name);
 		}
 		if (dependents.length === 1) {
-			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension . It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
+			return nls.localize('singleIndirectDependentError', "Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
 				extensionToUninstall.manifest.displayName || extensionToUninstall.manifest.name, dependingExtension.manifest.displayName
 			|| dependingExtension.manifest.name, dependents[0].manifest.displayName || dependents[0].manifest.name);
 		}

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -425,7 +425,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.openEditors.minVisible': {
 			'type': 'number',
-			'description': nls.localize({ key: 'openEditorsVisibleMin', comment: ['Open is an adjective'] }, "The minimum number of editor slots pre-allocated in the Open Editors pane. If set to 0 the Open Editors pane will dynamically resize based on the number of editors."),
+			'description': nls.localize({ key: 'openEditorsVisibleMin', comment: ['Open is an adjective'] }, "The minimum number of editor slots pre-allocated in the Open Editors pane. If set to 0, the Open Editors pane will dynamically resize based on the number of editors."),
 			'default': 0,
 			'minimum': 0
 		},


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Two punctuation fixes in user-visible localized strings:

1. **`abstractExtensionManagementService.ts`**: `"extension . It includes"` → `"extension. It includes"` — removes extra space before the period in an extension uninstall error message shown to users.

2. **`files.contribution.ts`** (`openEditorsVisibleMin` setting): `"If set to 0 the Open Editors pane"` → `"If set to 0, the Open Editors pane"` — adds missing comma after the conditional clause in a setting description.

Both changes are in user-visible `nls.localize()` strings.

#### Is there anything you'd like reviewers to focus on?

Pure punctuation fixes in localized strings — no logic changes.