### PR TITLE
Fix: typo 'accomodate' → 'accommodate' in extensionRunningLocationTracker comment

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
+++ b/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
@@ -163,7 +163,7 @@ export class ExtensionRunningLocationTracker {
 		// When doing extension host debugging, we will ignore the configured affinity
 		// because we can currently debug a single extension host
 		if (!this._environmentService.isExtensionDevelopment) {
-			// Go through each configured affinity and try to accomodate it
+			// Go through each configured affinity and try to accommodate it
 			const configuredAffinities = this._configurationService.getValue<{ [extensionId: string]: number } | undefined>('extensions.experimental.affinity') || {};
 			const configuredExtensionIds = Object.keys(configuredAffinities);
 			const configuredAffinityToResultingAffinity = new Map<number, number>();


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in a comment in `extensionRunningLocationTracker.ts`:

```diff
-// Go through each configured affinity and try to accomodate it
+// Go through each configured affinity and try to accommodate it
```

'accomodate' → 'accommodate' (missing 'c' in the double-c spelling).

#### Is there anything you'd like reviewers to focus on?

Comment-only change, no logic affected.