### PR TITLE
Fix: typo 'retreive' → 'retrieve' in betterSecretStorage JSDoc

### DIFF
--- a/extensions/microsoft-authentication/src/betterSecretStorage.ts
+++ b/extensions/microsoft-authentication/src/betterSecretStorage.ts
@@ -28,7 +28,7 @@ export class BetterTokenStorage<T> {
 	/**
 	 *
 	 * @param keylistKey The key in the secret storage that will hold the list of keys associated with this instance of BetterTokenStorage
-	 * @param context the vscode Context used to register disposables and retreive the vscode.SecretStorage for this instance of VS Code
+	 * @param context the vscode Context used to register disposables and retrieve the vscode.SecretStorage for this instance of VS Code
 	 */
 	constructor(private keylistKey: string, context: ExtensionContext) {
 		this._secretStorage = context.secrets;


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in a JSDoc comment in the Microsoft Authentication extension:

```diff
-// retreive
+// retrieve
```

'retreive' → 'retrieve' (transposed 'ie' → 'ie' correction).

#### Is there anything you'd like reviewers to focus on?

Comment-only change, no logic affected.