### PR TITLE
Fix: typo 'avaiable' → 'available' in editor action comment and remote tunnel notification

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2527,7 +2527,7 @@ export class ToggleEditorTypeAction extends Action2 {
 			return;
 		}
 
-		// Replace the current editor with the next avaiable editor type
+		// Replace the current editor with the next available editor type
 		await editorService.replaceEditors([
 			{
 				editor: activeEditorPane.input,

--- a/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
@@ -195,7 +195,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 							key: 'recommend.remoteExtension',
 							comment: ['{0} will be a tunnel name, {1} will the link address to the web UI, {6} an extension name. [label](command:commandId) is a markdown link. Only translate the label, do not modify the format']
 						},
-						"Tunnel '{0}' is avaiable for remote access. The {1} extension can be used to connect to it.",
+						"Tunnel '{0}' is available for remote access. The {1} extension can be used to connect to it.",
 						usedOnHost, remoteExtension.friendlyName
 					),
 				actions: {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed two occurrences of the spelling typo 'avaiable' → 'available':

1. **`editorActions.ts`** (comment): `// Replace the current editor with the next avaiable editor type`
2. **`remoteTunnel.contribution.ts`** (user-visible localized string): `"Tunnel '{0}' is avaiable for remote access."` — this one is shown in a notification to users when a tunnel becomes accessible.

#### Is there anything you'd like reviewers to focus on?

The `remoteTunnel.contribution.ts` change fixes a typo in a user-visible notification message. The `editorActions.ts` change is in a code comment only.