### PR TITLE
Fix: typo 'comand-labels' → 'command-labels' in codeLensCache comment

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
+++ b/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
@@ -69,7 +69,7 @@ export class CodeLensCache implements ICodeLensCache {
 
 	put(model: ITextModel, data: CodeLensModel): void {
 		// create a copy of the model that is without command-ids
-		// but with comand-labels
+		// but with command-labels
 		const copyItems = data.lenses.map((item): CodeLens => {
 			return {
 				range: item.symbol.range,


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in a code comment in `codeLensCache.ts`:

```diff
-// but with comand-labels
+// but with command-labels
```

'comand' → 'command' (missing 'm').

#### Is there anything you'd like reviewers to focus on?

Comment-only change, no logic affected.