### PR TITLE
Fix: typo 'explict' → 'explicit' in chat editing modified entry comments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -269,7 +269,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (!config.autoSave || !this._textFileService.isDirty(this.modifiedURI)) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			try {
 				await this._textFileService.save(this.modifiedURI, {
 					reason: SaveReason.EXPLICIT,

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -421,7 +421,7 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (this.modifiedModel.uri.scheme !== Schemas.untitled && (!config.autoSave || !this.notebookResolver.isDirty(this.modifiedURI))) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			await this._applyEdits(async () => {
 				try {
 					await this.modifiedResourceRef.object.save({


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in code comments in two chat editing entry files:

- `chatEditingModifiedDocumentEntry.ts`: `// trigger explict save` → `// trigger explicit save`
- `chatEditingModifiedNotebookEntry.ts`: `// trigger explict save` → `// trigger explicit save`

'explict' → 'explicit' (missing 'i').

#### Is there anything you'd like reviewers to focus on?

Comment-only changes, no logic affected.