### PR TITLE
fix: consider wco on the left side

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -321,13 +321,13 @@
 	background-color: transparent;
 }
 
-/* Window Controls Container Web: Apply WCO environment variables (https://developer.mozilla.org/en-US/docs/Web/CSS/env#titlebar-area-x) */
-.monaco-workbench.web .part.titlebar .titlebar-right .window-controls-container {
+/* Window Controls Container: Apply WCO environment variables (https://developer.mozilla.org/en-US/docs/Web/CSS/env#titlebar-area-x) */
+.monaco-workbench:not(.mac) .part.titlebar .titlebar-right .window-controls-container {
 	width: calc(100vw - env(titlebar-area-width, 100vw) - env(titlebar-area-x, 0px));
 	height: env(titlebar-area-height, 35px);
 }
 
-.monaco-workbench.web .part.titlebar .titlebar-left .window-controls-container {
+.monaco-workbench:not(.mac) .part.titlebar .titlebar-left .window-controls-container {
 	width: env(titlebar-area-x, 0px);
 	height: env(titlebar-area-height, 35px);
 }
@@ -338,15 +338,6 @@
 
 .monaco-workbench.web.mac .part.titlebar .titlebar-right .window-controls-container {
 	order: 1;
-}
-
-/* Window Controls Container Desktop: apply zoom friendly size */
-.monaco-workbench:not(.web):not(.mac) .part.titlebar .window-controls-container {
-	width: calc(138px / var(--zoom-factor, 1));
-}
-
-.monaco-workbench:not(.web):not(.mac) .part.titlebar .titlebar-container.counter-zoom .window-controls-container {
-	width: 138px;
 }
 
 .monaco-workbench.linux:not(.web) .part.titlebar .window-controls-container.wco-enabled {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -530,11 +530,10 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				// Linux/Windows: controls are explicitly disabled
 			} else {
 				this.windowControlsContainer = append(primaryWindowControlsLocation === 'left' ? this.leftContent : this.rightContent, $('div.window-controls-container'));
-				if (isWeb) {
-					// Web: its possible to have control overlays on both sides, for example on macOS
-					// with window controls on the left and PWA controls on the right.
-					append(primaryWindowControlsLocation === 'left' ? this.rightContent : this.leftContent, $('div.window-controls-container'));
-				}
+				// Its possible to have control overlays on both sides, for example on macOS
+				// with window controls on the left and PWA controls on the right or Linux with
+				// custom window controls settings.
+				append(primaryWindowControlsLocation === 'left' ? this.rightContent : this.leftContent, $('div.window-controls-container'));
 
 				if (isWCOEnabled()) {
 					this.windowControlsContainer.classList.add('wco-enabled');


### PR DESCRIPTION
Updated style to make titlebar layout properly consider WCO variables for both left and right side. Even though upstream Electron never exposes `env(titlebar-area-x)` with non-zero value, this may change in future. I made PR to electron codebase that makes it consider system settings and position controls on the left side: https://github.com/electron/electron/pull/51010

Overall - this was already supported on web - my changes to code just align web and non-web code into one.

Before/after:
<img width="1261" height="617" alt="image" src="https://github.com/user-attachments/assets/d602e0e2-7254-4a25-87aa-fb1109124c21" />
