### PR TITLE
Fix: typos 'descendent' → 'descendant' and 'dependant' → 'dependent' in JSDoc and comments

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1145,7 +1145,7 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	setHiddenAreas(ranges: IRange[], source?: unknown): void;
 
 	/**
-	 * Sets the editor aria options, primarily the active descendent.
+	 * Sets the editor aria options, primarily the active descendant.
 	 * @internal
 	 */
 	setAriaOptions(options: IEditorAriaOptions): void;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2089,7 +2089,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	updateEditorFocus() {
 		// Note - focus going to the webview will fire 'blur', but the webview element will be
-		// a descendent of the notebook editor root.
+		// a descendant of the notebook editor root.
 		this._focusTracker.refreshState();
 		const focused = this.editorHasDomFocus();
 		this._editorFocus.set(focused);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2001,7 +2001,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					.filter(d => d.entrypoint.extends === this.data.id);
 
 				if (dependantRenderers.length) {
-					this.postDebugMessage('Activating dependant renderers', { dependents: dependantRenderers.map(x => x.id).join(', ') });
+					this.postDebugMessage('Activating dependent renderers', { dependents: dependantRenderers.map(x => x.id).join(', ') });
 				}
 
 				// Load all renderers that extend this renderer
@@ -2017,7 +2017,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 						// Squash any errors extends errors. They won't prevent the renderer
 						// itself from working, so just log them.
 						console.error(e);
-						this.postDebugMessage('Activating dependant renderer failed', { dependent: d.id, error: e + '' });
+						this.postDebugMessage('Activating dependent renderer failed', { dependent: d.id, error: e + '' });
 						return undefined;
 					}
 				}));

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -8297,7 +8297,7 @@ declare module 'vscode' {
 		 * Provide decorations for a given uri.
 		 *
 		 * *Note* that this function is only called when a file gets rendered in the UI.
-		 * This means a decoration from a descendent that propagates upwards must be signaled
+		 * This means a decoration from a descendant that propagates upwards must be signaled
 		 * to the editor via the {@link FileDecorationProvider.onDidChangeFileDecorations onDidChangeFileDecorations}-event.
 		 *
 		 * @param uri The uri of the file to provide a decoration for.


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed two related spelling errors across 4 files:

**'descendent' → 'descendant'** (correct English spelling):
- `editorBrowser.ts`: `// primarily the active descendent` (JSDoc)
- `notebookEditorWidget.ts`: `// a descendent of the notebook editor root`
- `vscode.d.ts`: `a decoration from a descendent that propagates upwards` (public API JSDoc)

**'dependant' → 'dependent'** (British 'dependant' is a noun, 'dependent' is the correct adjective):
- `webviewPreloads.ts`: `'Activating dependant renderers'` and `'Activating dependant renderer failed'` (debug messages)

The `vscode.d.ts` change is in a public API comment visible to extension authors.

#### Is there anything you'd like reviewers to focus on?

All changes are in comments and JSDoc — no logic affected. The `vscode.d.ts` fix is the most impactful as it appears in the public extension API documentation.