### PR TITLE
Fix: typo 'occurrance' → 'occurrence' in replViewer localize comment

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -423,7 +423,7 @@ export class ReplAccessibilityProvider implements IListAccessibilityProvider<IRe
 			return localize('replVariableAriaLabel', "Variable {0}, value {1}", element.name, element.value);
 		}
 		if (element instanceof ReplOutputElement || element instanceof ReplEvaluationInput || element instanceof ReplEvaluationResult) {
-			return element.value + (element instanceof ReplOutputElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrance count.'] },
+			return element.value + (element instanceof ReplOutputElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrence count.'] },
 				", occurred {0} times", element.count) : '');
 		}
 		if (element instanceof RawObjectReplElement) {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in a localize comment annotation in `replViewer.ts`:

```diff
-comment: ['... represents occurrance count.']
+comment: ['... represents occurrence count.']
```

'occurrance' → 'occurrence'. The comment is a translation hint for localization tools, not user-visible text.

#### Is there anything you'd like reviewers to focus on?

Comment annotation change only — no logic or visible text affected.