### PR TITLE
Fix: typo 'destory' → 'destroy' in notebook service comments and log messages

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -836,7 +836,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		}
 	}
 
-	// --- notebook documents: create, destory, retrieve, enumerate
+	// --- notebook documents: create, destroy, retrieve, enumerate
 
 	async createNotebookTextModel(viewType: string, uri: URI, stream?: VSBufferReadableStream): Promise<NotebookTextModel> {
 		if (this._models.has(uri)) {

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -148,7 +148,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 				this._modelListener.delete(model);
 				model.dispose();
 			} catch (err) {
-				this._notebookLoggingService.error('NotebookModelCollection', 'FAILED to destory notebook - ' + err);
+				this._notebookLoggingService.error('NotebookModelCollection', 'FAILED to destroy notebook - ' + err);
 			} finally {
 				this.modelsToDispose.delete(key); // Untrack as being disposed
 			}


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo 'destory' → 'destroy' in two notebook-related files:

1. **`notebookServiceImpl.ts`**: `// --- notebook documents: create, destory, retrieve, enumerate`
2. **`notebookEditorModelResolverServiceImpl.ts`**: `'FAILED to destory notebook - '` (in an error log message)

'destory' → 'destroy' (transposed letters).

#### Is there anything you'd like reviewers to focus on?

Comment and log string changes only — no logic affected.