### PR TITLE
Fix: doubled words ('that that', 'of of', 'a a') in JSDoc comments

### DIFF
--- a/src/vs/base/browser/cssValue.ts
+++ b/src/vs/base/browser/cssValue.ts
@@ -76,7 +76,7 @@ export function className(value: string, escapingExpected = false): CssFragment 
 type InlineCssTemplateValue = CssFragment | Color;
 
 /**
- * Template string tag that that constructs a CSS fragment.
+ * Template string tag that constructs a CSS fragment.
  *
  * All expressions in the template must be css safe values.
  */

--- a/src/vs/editor/common/core/ranges/lineRange.ts
+++ b/src/vs/editor/common/core/ranges/lineRange.ts
@@ -46,7 +46,7 @@ export class LineRange {
 	}
 
 	/**
-	 * @param lineRanges An array of arrays of of sorted line ranges.
+	 * @param lineRanges An array of arrays of sorted line ranges.
 	 */
 	public static joinMany(lineRanges: readonly (readonly LineRange[])[]): readonly LineRange[] {
 		if (lineRanges.length === 0) {

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -51,7 +51,7 @@ export interface ICommandActionToggleInfo {
 	tooltip?: string;
 
 	/**
-	 * The title that goes well with a a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
+	 * The title that goes well with a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
 	 */
 	title?: string;
 


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed three doubled-word typos in code comments/JSDoc across 3 files:

| File | Before | After |
|------|--------|-------|
| `cssValue.ts` | `"Template string tag that that constructs a CSS fragment."` | `"Template string tag that constructs a CSS fragment."` |
| `lineRange.ts` | `"An array of arrays of of sorted line ranges."` | `"An array of arrays of sorted line ranges."` |
| `action.ts` | `"The title that goes well with a a check mark"` | `"The title that goes well with a check mark"` |

All changes are in JSDoc comments — no logic affected.

#### Is there anything you'd like reviewers to focus on?

Comment-only changes.