### PR TITLE
Fix: doubled words ('is is', 'on on', 'in in', 'by by', 'are are') in code comments and API docs

### DIFF
--- a/src/vs/base/common/jsonc.ts
+++ b/src/vs/base/common/jsonc.ts
@@ -26,7 +26,7 @@ export function stripComments(content: string): string {
 			// A block comment. Replace with nothing
 			return '';
 		} else if (m4) {
-			// Since m4 is a single line comment is is at least of length 2 (e.g. //)
+			// Since m4 is a single line comment it is at least of length 2 (e.g. //)
 			// If it ends in \r?\n then keep it.
 			const length = m4.length;
 			if (m4[length - 1] === '\n') {

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -389,7 +389,7 @@ class MainThreadChatSessionItemController extends Disposable implements IChatSes
 		this._proxy = proxy;
 		this._handle = handle;
 
-		// Update the chat session item based on on the actual model state
+		// Update the chat session item based on the actual model state
 		// TODO: This should be based on the chat session content provider instead of the chat models directly
 		// or bed moved into the chat session service so that all controllers get the same behavior.
 		const addModelListeners = async (model: IChatModel) => {

--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -233,7 +233,7 @@ export class MainThreadFileSystemEventService implements MainThreadFileSystemEve
 		}
 
 		// Correlated file watching: use an exclusive `createWatcher()`
-		// Note: currently not enabled for extensions (but leaving in in case of future usage)
+		// Note: currently not enabled for extensions (but leaving in case of future usage)
 		if (correlate && !opts.recursive) {
 			this._logService.trace(`MainThreadFileSystemEventService#$watch(): request to start watching correlated (extension: ${extensionId}, path: ${uri.toString(true)}, recursive: ${opts.recursive}, session: ${session}, excludes: ${JSON.stringify(opts.excludes)}, includes: ${JSON.stringify(opts.includes)})`);
 

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -366,7 +366,7 @@ class AttachedHistory extends Disposable {
 
 	/**
 	 * Pushes an history item that is tied to the last text edit (or an extension of it).
-	 * When the last text edit is undone/redone, so is is this history item.
+	 * When the last text edit is undone/redone, so is this history item.
 	 */
 	public pushAttachedHistoryElement(element: IAttachedHistoryElement): void {
 		this.attachedHistory.push({ altId: this.model.getAlternativeVersionId(), element });

--- a/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
@@ -42,7 +42,7 @@ export interface ITerminalStatusList {
 	/**
 	 * Adds a status to the list.
 	 * @param status The status object. Ideally a single status object that does not change will be
-	 * shared as this call will no-op if the status is already set (checked by by object reference).
+	 * shared as this call will no-op if the status is already set (checked by object reference).
 	 * @param duration An optional duration in milliseconds of the status, when specified the status
 	 * will remove itself when the duration elapses unless the status gets re-added.
 	 */

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -14405,7 +14405,7 @@ declare module 'vscode' {
 		 * files change on disk, e.g triggered by another application, or when using the
 		 * {@linkcode FileSystem workspace.fs}-api.
 		 *
-		 * *Note 2:* When this event is fired, edits to files that are are being created cannot be applied.
+		 * *Note 2:* When this event is fired, edits to files that are being created cannot be applied.
 		 */
 		export const onWillCreateFiles: Event<FileWillCreateEvent>;
 


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed doubled-word typos in 6 files:

| File | Before | After |
|------|--------|-------|
| `jsonc.ts` | `"comment is is at least of length 2"` | `"comment it is at least of length 2"` |
| `mainThreadChatSessions.ts` | `"based on on the actual model state"` | `"based on the actual model state"` |
| `mainThreadFileSystemEventService.ts` | `"(but leaving in in case of future usage)"` | `"(but leaving in case of future usage)"` |
| `mergeEditor/view/viewModel.ts` | `"so is is this history item"` | `"so is this history item"` |
| `terminalStatusList.ts` | `"(checked by by object reference)"` | `"(checked by object reference)"` |
| `vscode.d.ts` | `"files that are are being created"` | `"files that are being created"` (public API JSDoc) |

The `vscode.d.ts` change is in the public extension API documentation.

#### Is there anything you'd like reviewers to focus on?

All changes are in code comments or JSDoc — no logic affected. The `jsonc.ts` fix also corrects the grammar from `"comment is is"` to `"comment it is"` (not just removing a duplicate word).