### PR TITLE
Fix: doubled words ('in in', 'be be', 'this this', 'so so') in comments and API docs

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -53,7 +53,7 @@ export const codiconsDerived = {
 } as const;
 
 /**
- * The Codicon library is a set of default icons that are built-in in VS Code.
+ * The Codicon library is a set of default icons that are built-in VS Code.
  *
  * In the product (outside of base) Codicons should only be used as defaults. In order to have all icons in VS Code
  * themeable, component should define new, UI component specific icons using `iconRegistry.registerIcon`.

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -178,7 +178,7 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 	 * Applies the tunnel metadata and factory found in the remote authority
 	 * resolver to the tunnel system.
 	 *
-	 * `managedRemoteAuthority` should be be passed if the resolver returned on.
+	 * `managedRemoteAuthority` should be passed if the resolver returned on.
 	 * If this is the case, the tunnel cannot be connected to via a websocket from
 	 * the share process, so a synethic tunnel factory is used as a default.
 	 */

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -524,7 +524,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const completePromise = new DeferredPromise<void>();
 		const startPromise = new DeferredPromise<void>();
 
-		// Sequence all edits made this this resource in this streaming edits instance,
+		// Sequence all edits made this resource in this streaming edits instance,
 		// and also sequence the resource overall in the rare (currently invalid?) case
 		// that edits are made in parallel to the same resource,
 		const sequencer = new ThrottledSequencer(15, 1000);

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2341,7 +2341,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		});
 
 		// Retain a reference to itself when a request is in progress, so the ChatModel stays alive in the background
-		// only while running a request. TODO also keep it alive for 5min or so so we don't have to dispose/restore too often?
+		// only while running a request. TODO also keep it alive for 5min or so we don't have to dispose/restore too often?
 		if (this.initialLocation === ChatAgentLocation.Chat && !initialModelProps.disableBackgroundKeepAlive) {
 			const selfRef = this._register(new MutableDisposable<IChatModelReference>());
 			this._register(autorun(r => {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3326,7 +3326,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 						}
 					}
 
-					// At this this point there are multiple tasks.
+					// At this point there are multiple tasks.
 					chooseAndRunTask(tasks);
 				});
 			};

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17927,7 +17927,7 @@ declare module 'vscode' {
 		forceNewSession?: boolean | AuthenticationGetSessionPresentationOptions | AuthenticationForceNewSessionOptions;
 
 		/**
-		 * Whether we should show the indication to sign in in the Accounts menu.
+		 * Whether we should show the indication to sign in the Accounts menu.
 		 *
 		 * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
 		 * If true, no indication will be shown.


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed doubled-word typos across 6 files:

| File | Before | After |
|------|--------|-------|
| `codicons.ts` | `"built-in in VS Code"` | `"built-in VS Code"` |
| `extHostTunnelService.ts` | `"should be be passed"` | `"should be passed"` |
| `chatEditingSession.ts` | `"edits made this this resource"` | `"edits made this resource"` |
| `chatModel.ts` | `"5min or so so we don't"` | `"5min or so we don't"` |
| `abstractTaskService.ts` | `"At this this point"` | `"At this point"` |
| `vscode.d.ts` | `"to sign in in the Accounts menu"` | `"to sign in the Accounts menu"` (public API JSDoc) |

The `vscode.d.ts` change is in the public extension API documentation visible to extension authors.

#### Is there anything you'd like reviewers to focus on?

All changes are in code comments or JSDoc — no logic affected.