### PR TITLE
Fix: doubled words and grammar errors in code comments across 5 files

### DIFF
--- a/src/vs/platform/storage/common/storage.ts
+++ b/src/vs/platform/storage/common/storage.ts
@@ -381,7 +381,7 @@ export abstract class AbstractStorageService extends Disposable implements IStor
 				// In the browser we do not have support for long running unload sequences. As such,
 				// we cannot ask for saving state in that moment, because that would result in a
 				// long running operation.
-				// Instead, periodically ask customers to save save. The library will be clever enough
+				// Instead, periodically ask customers to save. The library will be clever enough
 				// to only save state that has actually changed.
 				this.flushWhenIdleScheduler.schedule();
 			})();

--- a/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
@@ -293,7 +293,7 @@ export class MainThreadQuickOpen implements MainThreadQuickOpenShape {
 			return;
 		} else if (ThemeIcon.isThemeIcon(icon)) {
 			// TODO: Since IQuickPickItem and IQuickInputButton do not support ThemeIcon directly, the color ID is lost here.
-			// We should consider changing changing iconPath/iconClass to IconPath in both interfaces.
+			// We should consider changing iconPath/iconClass to IconPath in both interfaces.
 			// Request for color support: https://github.com/microsoft/vscode/issues/185356..
 			target.iconClass = ThemeIcon.asClassName(icon);
 		} else if (isUriComponents(icon)) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart.ts
@@ -107,7 +107,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 	}
 
 	hasSameContent(other: IChatRendererContent, followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {
-		// Progress parts render render until some other content shows up, then they hide.
+		// Progress parts render until some other content shows up, then they hide.
 		// When some other content shows up, need to signal to be rerendered as hidden.
 		if (followingContent.some(part => part.kind !== 'progressMessage') && !this.isHidden) {
 			return false;

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/listProjection.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/listProjection.ts
@@ -18,7 +18,7 @@ import { ITestService } from '../../common/testService.js';
 import { ITestItemUpdate, InternalTestItem, TestDiffOpType, TestItemExpandState, TestResultState, TestsDiff, applyTestItemUpdate } from '../../common/testTypes.js';
 
 /**
- * Test tree element element that groups be hierarchy.
+ * Test tree element that groups by hierarchy.
  */
 class ListTestItemElement extends TestItemTreeElement {
 	private errorChild?: TestTreeErrorMessage;

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
@@ -38,7 +38,7 @@ const computedStateAccessor: IComputedStateAndDurationAccessor<TreeTestItemEleme
 };
 
 /**
- * Test tree element element that groups be hierarchy.
+ * Test tree element that groups by hierarchy.
  */
 class TreeTestItemElement extends TestItemTreeElement {
 	/**


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed doubled-word typos and grammar errors in code comments across 5 files:

| File | Before | After |
|------|--------|-------|
| `storage.ts` | `"periodically ask customers to save save."` | `"periodically ask customers to save."` |
| `mainThreadQuickOpen.ts` | `"consider changing changing iconPath"` | `"consider changing iconPath"` |
| `chatProgressContentPart.ts` | `"Progress parts render render until"` | `"Progress parts render until"` |
| `listProjection.ts` | `"element element that groups be hierarchy"` | `"element that groups by hierarchy"` |
| `treeProjection.ts` | `"element element that groups be hierarchy"` | `"element that groups by hierarchy"` |

The last two also fix a grammar error: `"groups be"` → `"groups by"`.

#### Is there anything you'd like reviewers to focus on?

All changes are in code comments — no logic affected.