### PR TITLE
Fix: remove redundant double 'await' in extHostNotebookDocumentSaveParticipant

### DIFF
--- a/src/vs/workbench/api/common/extHostNotebookDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocumentSaveParticipant.ts
@@ -56,7 +56,7 @@ export class ExtHostNotebookDocumentSaveParticipant implements ExtHostNotebookDo
 
 		await this._onWillSaveNotebookDocumentEvent.fireAsync({ notebook: document.apiNotebook, reason: TextDocumentSaveReason.to(reason) }, token, async (thenable: Promise<unknown>, listener) => {
 			const now = Date.now();
-			const data = await await Promise.resolve(thenable);
+			const data = await Promise.resolve(thenable);
 			if (Date.now() - now > this._thresholds.timeout) {
 				this._logService.warn('onWillSaveNotebookDocument-listener from extension', (<IExtensionListener<NotebookDocumentWillSaveEvent>>listener).extension.identifier);
 			}


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Removed a redundant `await` in `extHostNotebookDocumentSaveParticipant.ts`:

```ts
// Before (redundant double await):
const data = await await Promise.resolve(thenable);

// After (correct):
const data = await Promise.resolve(thenable);
```

`Promise.resolve(thenable)` returns a Promise. The first `await` resolves it to its value. If that value is not a Promise itself, the outer `await` is a no-op (awaiting a non-Promise just returns it). The double `await` pattern is both redundant and potentially confusing.

This matches the pattern used in the sibling file `extHostDocumentSaveParticipant.ts` which uses a single `await`.

#### Is there anything you'd like reviewers to focus on?

The fix is a single-character change (removing one `await `). The behavior is equivalent: the resolved value of `thenable` is assigned to `data` in both cases.