### PR TITLE
Fix: spelling typos 'seperately', 'occurences/occurence', 'languafe' across 4 files

### DIFF
--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -153,8 +153,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 		const oldDecorations: string[] = [];
 		const keys = Object.keys(this.currentOccurrences);
 		for (const decorationId of keys) {
-			const occurence = this.currentOccurrences[decorationId];
-			oldDecorations.push(occurence.decorationId);
+			const occurrence = this.currentOccurrences[decorationId];
+			oldDecorations.push(occurrence.decorationId);
 		}
 
 		const newDecorations: IModelDeltaDecoration[] = [];
@@ -171,8 +171,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 			this.currentOccurrences = {};
 			this.activeLinkDecorationId = null;
 			for (let i = 0, len = decorations.length; i < len; i++) {
-				const occurence = new LinkOccurrence(links[i], decorations[i]);
-				this.currentOccurrences[occurence.decorationId] = occurence;
+				const occurrence = new LinkOccurrence(links[i], decorations[i]);
+				this.currentOccurrences[occurrence.decorationId] = occurrence;
 			}
 		});
 	}

--- a/src/vs/editor/standalone/common/monarch/monarchCompile.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchCompile.ts
@@ -88,7 +88,7 @@ function createKeywordMatcher(arr: string[], caseInsensitive: boolean = false): 
  */
 function compileRegExp<S extends true | false>(lexer: monarchCommon.ILexerMin, str: string, handleSn: S): S extends true ? RegExp | DynamicRegExp : RegExp;
 function compileRegExp(lexer: monarchCommon.ILexerMin, str: string, handleSn: true | false): RegExp | DynamicRegExp {
-	// @@ must be interpreted as a literal @, so we replace all occurences of @@ with a placeholder character
+	// @@ must be interpreted as a literal @, so we replace all occurrences of @@ with a placeholder character
 	str = str.replace(/@@/g, `\x01`);
 
 	let n = 0;

--- a/src/vs/platform/theme/common/tokenClassificationRegistry.ts
+++ b/src/vs/platform/theme/common/tokenClassificationRegistry.ts
@@ -212,7 +212,7 @@ export interface ITokenClassificationRegistry {
 	/**
 	 * Parses a token selector from a selector string.
 	 * @param selectorString selector string in the form (*|type)(.modifier)*
-	 * @param language language to which the selector applies or undefined if the selector is for all languafe
+	 * @param language language to which the selector applies or undefined if the selector is for all language
 	 * @returns the parsesd selector
 	 * @throws an error if the string is not a valid selector
 	 */

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typos across 4 files:

| File | Typo | Fix |
|------|------|-----|
| `explorerViewer.ts` | `"handled seperately"` | `"handled separately"` (comment) |
| `monarchCompile.ts` | `"all occurences of @@"` | `"all occurrences of @@"` (comment) |
| `tokenClassificationRegistry.ts` | `"for all languafe"` | `"for all language"` (JSDoc) |
| `links.ts` | local variable `occurence` (×4 uses) | `occurrence` |

The `links.ts` change renames a local variable `occurence` → `occurrence` in two local scopes within `LinkDetector`. The class field `currentOccurrences` (which is already spelled correctly) is unchanged.

#### Is there anything you'd like reviewers to focus on?

The `links.ts` change renames a local variable — please verify both usages in each scope are correctly updated (they are). The other 3 changes are comment/JSDoc only.