### PR TITLE
Fix: typo 'occurences' → 'occurrences' in chatParticipantTelemetry comments

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -321,7 +321,7 @@ export abstract class ChatTelemetry<C extends IDocumentContext | undefined = IDo
 	protected _editCount: number = 0;
 	protected _editLineCount: number = 0;
 
-	// todo@connor4312: temporary event to track occurences of patches in response
+	// todo@connor4312: temporary event to track occurrences of patches in response
 	// text, ref https://github.com/microsoft/vscode-copilot/issues/16608
 	private _didSeePatchInResponse = false;
 	private _lastMarkdownLine = '';
@@ -448,7 +448,7 @@ export abstract class ChatTelemetry<C extends IDocumentContext | undefined = IDo
 		this._sendResponseInternalTelemetryEvent(responseType, response);
 
 
-		// todo@connor4312: temporary event to track occurences of patches in response
+		// todo@connor4312: temporary event to track occurrences of patches in response
 		// text, ref https://github.com/microsoft/vscode-copilot/issues/16608
 		if (this._didSeePatchInResponse) {
 			/* __GDPR__


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo in two TODO comments in `extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts`:

```diff
-// todo@connor4312: temporary event to track occurences of patches in response
+// todo@connor4312: temporary event to track occurrences of patches in response
```

'occurences' → 'occurrences' (missing 'r' and double 'c'). Fixed in two places (lines 324 and 451).

#### Is there anything you'd like reviewers to focus on?

Comment-only changes, no logic affected.