### PR TITLE
Fix: 'a the result editor' → 'the result editor' in mergeEditor context key description

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
+++ b/src/vs/workbench/contrib/mergeEditor/common/mergeEditor.ts
@@ -9,7 +9,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 export type MergeEditorLayoutKind = 'mixed' | 'columns';
 
 export const ctxIsMergeEditor = new RawContextKey<boolean>('isMergeEditor', false, { type: 'boolean', description: localize('is', 'The editor is a merge editor') });
-export const ctxIsMergeResultEditor = new RawContextKey<boolean>('isMergeResultEditor', false, { type: 'boolean', description: localize('isr', 'The editor is a the result editor of a merge editor.') });
+export const ctxIsMergeResultEditor = new RawContextKey<boolean>('isMergeResultEditor', false, { type: 'boolean', description: localize('isr', 'The editor is the result editor of a merge editor.') });
 export const ctxMergeEditorLayout = new RawContextKey<MergeEditorLayoutKind>('mergeEditorLayout', 'mixed', { type: 'string', description: localize('editorLayout', 'The layout mode of a merge editor') });
 export const ctxMergeEditorShowBase = new RawContextKey<boolean>('mergeEditorShowBase', false, { type: 'boolean', description: localize('showBase', 'If the merge editor shows the base version') });
 export const ctxMergeEditorShowBaseAtTop = new RawContextKey<boolean>('mergeEditorShowBaseAtTop', false, { type: 'boolean', description: localize('showBaseAtTop', 'If base should be shown at the top') });


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed a double-article error in the user-visible description of the `isMergeResultEditor` context key:

```diff
-'The editor is a the result editor of a merge editor.'
+'The editor is the result editor of a merge editor.'
```

The extra `a` before `the` is a grammatical error. This description appears in context key documentation and potentially in keybinding when-clause completion.

#### Is there anything you'd like reviewers to focus on?

Single-word removal in a `localize()` string — no logic affected.