### PR TITLE
Fix: typos 'minimium' → 'minimum' and 'proprety' → 'property'

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -508,7 +508,7 @@ export class MenuBar extends Disposable {
 		}
 
 
-		// If below minimium menu threshold, show the overflow menu only as hamburger menu
+		// If below minimum menu threshold, show the overflow menu only as hamburger menu
 		if (this.numMenusShown - 1 <= showableMenus.length / 4) {
 			for (const menuBarMenu of showableMenus) {
 				menuBarMenu.buttonElement.style.visibility = 'hidden';

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -170,11 +170,11 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 		const wasEmpty = this._configurationModel.isEmpty();
 
 		for (const key of keys) {
-			const proprety = configurationProperties[key] ?? excludedConfigurationProperties[key];
-			const policyName = proprety?.policy?.name;
+			const property = configurationProperties[key] ?? excludedConfigurationProperties[key];
+			const policyName = property?.policy?.name;
 			if (policyName) {
 				let policyValue: PolicyValue | ParsedType | undefined = this.policyService.getPolicyValue(policyName);
-				if (isString(policyValue) && proprety.type !== 'string') {
+				if (isString(policyValue) && property.type !== 'string') {
 					try {
 						policyValue = this.parse(policyValue);
 					} catch (e) {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typos in 2 files:

1. **`menubar.ts`**: `// If below minimium menu threshold` → `// If below minimum menu threshold`
   - Comment-only change

2. **`configurations.ts`**: Local variable `proprety` → `property` (3 usages in one scope in `PolicyConfiguration`)
   - Renames a misspelled local variable — no behavior change

#### Is there anything you'd like reviewers to focus on?

The `configurations.ts` change renames a local variable. All 3 usages within the same scope are updated consistently.