### PR TITLE
Fix: typo 'suported' → 'supported' in two service file comments

### DIFF
--- a/src/vs/workbench/services/languageDetection/browser/languageDetectionWebWorker.ts
+++ b/src/vs/workbench/services/languageDetection/browser/languageDetectionWebWorker.ts
@@ -206,7 +206,7 @@ export class LanguageDetectionWorker implements ILanguageDetectionWorker {
 			case 'csv':
 			case 'toml':
 				// Other considerations for negativeConfidenceCorrection that
-				// aren't built in but suported by the model include:
+				// aren't built in but supported by the model include:
 				// * Assembly, TeX - These languages didn't have clear language modes in the community
 				// * Markdown, Dockerfile - These languages are simple but they embed other languages
 				modelResult.confidence -= LanguageDetectionWorker.negativeConfidenceCorrection;

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -436,7 +436,7 @@ export class IndexedDBStorageDatabase extends Disposable implements IIndexedDBSt
 	}
 
 	async optimize(): Promise<void> {
-		// not suported in IndexedDB
+		// not supported in IndexedDB
 	}
 
 	async close(): Promise<void> {


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed spelling typo 'suported' → 'supported' in two files:

1. `languageDetectionWebWorker.ts`: `"aren't built in but suported by the model include:"` → `"supported"`
2. `storageService.ts`: `"// not suported in IndexedDB"` → `"// not supported in IndexedDB"`

Both changes are in code comments — no logic affected.

#### Is there anything you'd like reviewers to focus on?

Comment-only changes.