### PR TITLE
Fix: typo 'implictly' → 'implicitly' in chatParticipantTelemetry telemetry comment

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -928,7 +928,7 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 				"messageTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens are in the rest of the query, without the command." },
 				"promptTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens are in the overall prompt." },
 				"responseTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens were in the response." },
-				"implicitCommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the command was implictly detected or provided by the user." },
+				"implicitCommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the command was implicitly detected or provided by the user." },
 				"attemptCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many times the user has retried." },
 				"selectionLineCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many lines are in the current selection." },
 				"wholeRangeLineCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many lines are in the expanded whole range." },


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make?

Fixed a spelling typo in a telemetry property comment in `extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts`:

```diff
-"comment": "Whether the command was implictly detected or provided by the user."
+"comment": "Whether the command was implicitly detected or provided by the user."
```

'implictly' → 'implicitly' (missing 'i').

#### Is there anything you'd like reviewers to focus on?

Comment-only change inside a telemetry property definition — no logic or telemetry data affected.