### PR TITLE
Fix spelling: explictly, immediatly, succesful in comments

### DIFF
--- a/extensions/microsoft-authentication/src/common/telemetryReporter.ts
+++ b/extensions/microsoft-authentication/src/common/telemetryReporter.ts
@@ -38,7 +38,7 @@ export class MicrosoftAuthenticationTelemetryReporter implements IExperimentatio
 
 	sendActivatedWithMsalNoBrokerEvent(): void {
 		/* __GDPR__
-			"activatingMsalNoBroker" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users use the msal-no-broker login flow. This only fires if the user explictly opts in to this." }
+			"activatingMsalNoBroker" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users use the msal-no-broker login flow. This only fires if the user explicitly opts in to this." }
 		*/
 		this._telemetryReporter.sendTelemetryEvent('activatingmsalnobroker');
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -727,7 +727,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(listenerDisposables);
 
 		const sessionRunningScheduler = listenerDisposables.add(new RunOnceScheduler(() => {
-			// Do not immediatly defocus the stack frame if the session is running
+			// Do not immediately defocus the stack frame if the session is running
 			if (session.state === State.Running && this.viewModel.focusedSession === session) {
 				this.viewModel.setFocus(undefined, this.viewModel.focusedThread, session, false);
 			}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -151,7 +151,7 @@ export class VariablesView extends ViewPane implements IDebugViewWithVariables {
 				return;
 			}
 
-			// Refresh the tree immediately if the user explictly changed stack frames.
+			// Refresh the tree immediately if the user explicitly changed stack frames.
 			// Otherwise postpone the refresh until user stops stepping.
 			const timeout = sf.explicit ? 0 : undefined;
 			this.updateTreeScheduler.schedule(timeout);

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
@@ -52,7 +52,7 @@ export class LspTerminalModelContentProvider extends Disposable implements ILspT
 
 	/**
 	 * Sets or updates content for a terminal virtual document.
-	 * This is when user has executed succesful command in terminal.
+	 * This is when user has executed successful command in terminal.
 	 * Transfer the content to virtual document, and relocate delimiter to get terminal prompt ready for next prompt.
 	 */
 	setContent(content: string): void {


### PR DESCRIPTION
Fix three common misspellings found in code comments and telemetry annotations:

- `explictly` → `explicitly` in `variablesView.ts`, `debugSession.ts`, `debugService.ts`, `telemetryReporter.ts`
- `immediatly` → `immediately` in `debugSession.ts` and `debugService.ts`
- `succesful` → `successful` in `lspTerminalModelContentProvider.ts`

No logic changes — comments and documentation only.