### PR TITLE
Fix grammar: 'on the an individual' and doubled 'but but' in comments

### DIFF
--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -296,7 +296,7 @@ const apiMenus: IAPIMenu[] = [
 	{
 		key: 'comments/commentThread/comment/context',
 		id: MenuId.CommentThreadCommentContext,
-		description: localize('comment.commentContext', "The contributed comment context menu, rendered as a right click menu on the an individual comment in the comment thread's peek view."),
+		description: localize('comment.commentContext', "The contributed comment context menu, rendered as a right click menu on an individual comment in the comment thread's peek view."),
 		proposed: 'contribCommentPeekContext'
 	},
 	{

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -117,7 +117,7 @@ export interface IChatSentiment {
 	 * User signals intent to disable Chat.
 	 *
 	 * Note: in contrast to `hidden`, this should not hide
-	 * Chat but but disable its functionality.
+	 * Chat but disable its functionality.
 	 */
 	disabled?: boolean;
 


### PR DESCRIPTION
Two grammar fixes in comments and localized strings:

- `menusExtensionPoint.ts`: `"on the an individual comment"` → `"on an individual comment"` — user-visible localized description for the comment context menu contribution point
- `chatEntitlementService.ts`: `"Chat but but disable"` → `"Chat but disable"` — doubled word in JSDoc

No logic changes.