### PR TITLE
Fix spelling: 'locaiton' -> 'location' in extensionManagement

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
@@ -338,7 +338,7 @@ export abstract class AbstractExtensionsProfileScannerService extends Disposable
 					if (Array.isArray(parsedData) && parsedData.every(candidate => isStoredProfileExtension(candidate))) {
 						storedProfileExtensions = parsedData;
 					} else {
-						this.logService.warn('Skipping migrating from old default profile locaiton: Found invalid data', parsedData);
+						this.logService.warn('Skipping migrating from old default profile location: Found invalid data', parsedData);
 					}
 				} catch (error) {
 					/* Ignore */

--- a/src/vs/platform/extensionManagement/node/extensionDownloader.ts
+++ b/src/vs/platform/extensionManagement/node/extensionDownloader.ts
@@ -174,7 +174,7 @@ export class ExtensionsDownloader extends Disposable {
 			return;
 		}
 
-		// Download directly if locaiton is not file scheme
+		// Download directly if location is not file scheme
 		if (location.scheme !== Schemas.file) {
 			await downloadFn(location);
 			return;


### PR DESCRIPTION
Fix typo `locaiton` → `location` in two files:

- `extensionDownloader.ts` line 177: comment for download location scheme check
- `extensionsProfileScannerService.ts` line 341: warning log message about profile migration location

No logic changes — comments and log strings only.