### PR TITLE
Fix spelling: 'analyse' -> 'analyze' in profiler comments

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsAutoProfiler.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsAutoProfiler.ts
@@ -111,12 +111,12 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 				await timeout(5e3, cts.token);
 			} catch {
 				// can throw cancellation error. that is
-				// OK, we stop profiling and analyse the
+				// OK, we stop profiling and analyze the
 				// profile anyways
 			}
 
 			try {
-				// stop profiling and analyse results
+				// stop profiling and analyze results
 				this._processCpuProfile(await session.stop());
 			} catch (err) {
 				onUnexpectedError(err);
@@ -145,7 +145,7 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 			);
 		}
 
-		// analyse profile by extension-category
+		// analyze profile by extension-category
 		const categories: [location: URI, id: string][] = this._extensionService.extensions
 			.filter(e => e.extensionLocation.scheme === Schemas.file)
 			.map(e => [e.extensionLocation, ExtensionIdentifier.toKey(e.identifier)]);

--- a/src/vs/workbench/contrib/performance/electron-browser/rendererAutoProfiler.ts
+++ b/src/vs/workbench/contrib/performance/electron-browser/rendererAutoProfiler.ts
@@ -71,7 +71,7 @@ export class RendererProfiling {
 				// pause observation, we'll take a detailed look
 				obs.disconnect();
 
-				// profile renderer for 5secs, analyse, and take action depending on the result
+				// profile renderer for 5secs, analyze, and take action depending on the result
 				for (let i = 0; i < 3; i++) {
 
 					try {


### PR DESCRIPTION
Replace British `analyse` with American `analyze` in code comments (not in function/method names) in two profiler files:

- `rendererAutoProfiler.ts`: `// profile renderer for 5secs, analyse, and take action` → `analyze`
- `extensionsAutoProfiler.ts`: three comment lines using `analyse` → `analyze`

Note: the `analyseBottomUp` and `analyseByLocation` method names on `_profileAnalysisService` are not changed here, as they are external API identifiers.

No logic changes — comments only.