### PR TITLE
Fix spelling: 'seperate' -> 'separate' in extHostTypes comment

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;


### PR DESCRIPTION
Fix typo `seperate` → `separate` in a TODO comment in `extHostTypes.ts` about the `ChatResponseMarkdownPart` API proposal.

No logic changes — comment only.