### PR TITLE
Fix spelling: 'behaviour' -> 'behavior' in monaco.d.ts public API docs

### DIFF
--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3570,7 +3570,7 @@ declare namespace monaco.editor {
 		 */
 		colorDecoratorsLimit?: number;
 		/**
-		 * Control the behaviour of comments in the editor.
+		 * Control the behavior of comments in the editor.
 		 */
 		comments?: IEditorCommentsOptions;
 		/**
@@ -3613,7 +3613,7 @@ declare namespace monaco.editor {
 		 */
 		multiCursorMergeOverlapping?: boolean;
 		/**
-		 * Configure the behaviour when pasting a text with the line count equal to the cursor count.
+		 * Configure the behavior when pasting a text with the line count equal to the cursor count.
 		 * Defaults to 'spread'.
 		 */
 		multiCursorPaste?: 'spread' | 'full';
@@ -3707,7 +3707,7 @@ declare namespace monaco.editor {
 		 */
 		autoIndentOnPasteWithinString?: boolean;
 		/**
-		 * Emulate selection behaviour of tab characters when using spaces for indentation.
+		 * Emulate selection behavior of tab characters when using spaces for indentation.
 		 * This means selection will stick to tab stops.
 		 */
 		stickyTabStops?: boolean;


### PR DESCRIPTION
Replace three instances of British `behaviour` with American `behavior` in `monaco.d.ts`, which is the public API documentation for Monaco Editor used by many external consumers.

Changed properties:
- `IEditorOptions.comments`: `"Control the behaviour of comments"` → `"behavior"`
- `IEditorOptions.multiCursorPaste`: `"Configure the behaviour when pasting"` → `"behavior"`
- `IEditorOptions.stickyTabStops`: `"Emulate selection behaviour of tab characters"` → `"behavior"`

No logic changes — JSDoc strings only.