### PR TITLE
Fix spelling: 'colours' -> 'colors' in two comments

### DIFF
--- a/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
+++ b/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
@@ -148,7 +148,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 		}
 
 		// high contrast is set if one of shouldUseInvertedColorScheme or shouldUseHighContrastColors is set,
-		// reflecting the 'Invert colours' and `Increase contrast` settings in MacOS
+		// reflecting the 'Invert colors' and `Increase contrast` settings in MacOS
 		else if (isMacintosh) {
 			if (electron.nativeTheme.shouldUseInvertedColorScheme || electron.nativeTheme.shouldUseHighContrastColors) {
 				return { dark: electron.nativeTheme.shouldUseDarkColors, highContrast: true };

--- a/src/vs/workbench/contrib/debug/browser/debugColors.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugColors.ts
@@ -113,7 +113,7 @@ export function registerColors() {
 	}, localize('debugIcon.stepBackForeground', "Debug toolbar icon for step back."));
 
 	registerThemingParticipant((theme, collector) => {
-		// All these colours provide a default value so they will never be undefined, hence the `!`
+		// All these colors provide a default value so they will never be undefined, hence the `!`
 		const badgeBackgroundColor = theme.getColor(badgeBackground)!;
 		const badgeForegroundColor = theme.getColor(badgeForeground)!;
 		const listDeemphasizedForegroundColor = theme.getColor(listDeemphasizedForeground)!;


### PR DESCRIPTION
Replace British `colours` with American `colors` in two comment lines:

- `themeMainServiceImpl.ts`: `"Invert colours"` → `"Invert colors"` in comment about macOS settings
- `debugColors.ts`: `"All these colours"` → `"All these colors"` in a theme registration comment

No logic changes — comments only.