### PR TITLE
Fix spelling: 'behaviour' -> 'behavior' in copilot extension comments

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -201,7 +201,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	/**
 	 * Entry point for every chat request against this session.
 	 *
-	 * **Steering behaviour**: if the session is already busy (`InProgress` or
+	 * **Steering behavior**: if the session is already busy (`InProgress` or
 	 * `NeedsInput`), the incoming message is treated as a *steering* request.
 	 * Steering sends the new prompt to the SDK with `mode: 'immediate'` so it is
 	 * injected into the running conversation as additional context. The steering

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostTextStrategy.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/ghostText/ghostTextStrategy.ts
@@ -80,7 +80,7 @@ export async function getGhostTextStrategy(
 		case BlockMode.ParsingAndServer:
 		case BlockMode.MoreMultiline:
 		default: {
-			// we shouldn't drop through to here, but in case we do, be explicit about the behaviour
+			// we shouldn't drop through to here, but in case we do, be explicit about the behavior
 			let requestMultiline: MultilineDetermination;
 			try {
 				requestMultiline = await instantiationService.invokeFunction(shouldRequestMultiline,

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
@@ -201,7 +201,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 }
 
 // If the model thinks we are at the end of a line, do we want to offer a completion
-// for the next line? For now (05 Oct 2021) we leave it as false to minimise behaviour
+// for the next line? For now (05 Oct 2021) we leave it as false to minimise behavior
 // changes between parsing and indentation mode.
 const OfferNextLineCompletion = false;
 

--- a/extensions/copilot/src/extension/completions/common/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions/common/parseBlock.ts
@@ -169,7 +169,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 }
 
 // If the model thinks we are at the end of a line, do we want to offer a completion
-// for the next line? For now (05 Oct 2021) we leave it as false to minimise behaviour
+// for the next line? For now (05 Oct 2021) we leave it as false to minimise behavior
 // changes between parsing and indentation mode.
 const OfferNextLineCompletion = false;
 

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/parts/vscodeWorkspace.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/parts/vscodeWorkspace.ts
@@ -341,7 +341,7 @@ export class VSCodeWorkspace extends ObservableWorkspace implements IDisposable 
 		const notebookDocs = this._notebookDocsWithShouldTrackFlag.read(reader);
 		notebookDocs.forEach(d => {
 			map.set(d.doc.uri.toString(), d);
-			// Markdown cells will be treated as standalone text documents (old behaviour).
+			// Markdown cells will be treated as standalone text documents (old behavior).
 			d.doc.getCells().filter(cell => cell.kind === NotebookCellKind.Code).forEach(cell => map.set(cell.document.uri.toString(), d));
 		});
 		return map;

--- a/extensions/copilot/src/util/vs/base/common/buffer.ts
+++ b/extensions/copilot/src/util/vs/base/common/buffer.ts
@@ -138,7 +138,7 @@ export class VSBuffer {
 	slice(start?: number, end?: number): VSBuffer {
 		// IMPORTANT: use subarray instead of slice because TypedArray#slice
 		// creates shallow copy and NodeBuffer#slice doesn't. The use of subarray
-		// ensures the same, performance, behaviour.
+		// ensures the same, performance, behavior.
 		return new VSBuffer(this.buffer.subarray(start, end));
 	}
 


### PR DESCRIPTION
Replace British `behaviour` with American `behavior` in code comments across 6 copilot extension files:

- `buffer.ts`: performance comment
- `vscodeWorkspace.ts`: markdown cell treatment comment
- `ghostTextStrategy.ts`: explicit fallthrough comment
- `parseBlock.ts` (×2 files): minimize behaviour change comment  
- `copilotcliSession.ts`: JSDoc for steering behavior

No logic changes — comments only.