### PR TITLE
Fix spelling: 'initialised' -> 'initialized' in comments

### DIFF
--- a/src/vs/platform/browserView/node/playwrightService.ts
+++ b/src/vs/platform/browserView/node/playwrightService.ts
@@ -37,7 +37,7 @@ const DEFERRED_RESULT_CLEANUP_MS = 5 * 60_000; // 5 minutes
  * Shared-process implementation of {@link IPlaywrightService}.
  *
  * Creates a {@link PlaywrightPageManager} eagerly on construction to track
- * browser views. The Playwright browser connection is lazily initialised
+ * browser views. The Playwright browser connection is lazily initialized
  * only when an operation that requires it is called.
  */
 export class PlaywrightService extends Disposable implements IPlaywrightService {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -184,7 +184,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			}
 		}));
 		this._register(this.debugService.onWillNewSession(async newSession => {
-			// Need to listen to output events for sessions which are not yet fully initialised
+			// Need to listen to output events for sessions which are not yet fully initialized
 			const input = this.tree?.getInput();
 			if (!input || input.state === State.Inactive) {
 				await this.selectSession(newSession);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1148,7 +1148,7 @@ export interface IDebugService {
 	readonly onDidChangeState: Event<State>;
 
 	/**
-	 * Allows to register on sessions about to be created (not yet fully initialised).
+	 * Allows to register on sessions about to be created (not yet fully initialized).
 	 * This is fired exactly one time for any given session.
 	 */
 	readonly onWillNewSession: Event<IDebugSession>;


### PR DESCRIPTION
Replace British `initialised` with American `initialized` in three code comments:

- `playwrightService.ts`: JSDoc about lazy browser connection initialization
- `repl.ts`: comment about listening to debug sessions not yet fully initialized
- `debug.ts`: JSDoc for the `onWillNewSession` event handler

No logic changes — comments only.