### PR TITLE
Fix spelling: 'optimise' -> 'optimize' in configuration service comments

### DIFF
--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -205,7 +205,7 @@ export class ConfigurationEditing {
 			try {
 				// Optimization: we apply edits to a text model and save it
 				// right after. Use the files config service to signal this
-				// to the workbench to optimise the UI during this operation.
+				// to the workbench to optimize the UI during this operation.
 				// For example, avoids to briefly show dirty indicators.
 				disposable = this.filesConfigurationService.enableAutoSaveAfterShortDelay(model.uri);
 				if (this.applyEditsToBuffer(edit, model)) {

--- a/src/vs/workbench/services/configuration/common/jsonEditingService.ts
+++ b/src/vs/workbench/services/configuration/common/jsonEditingService.ts
@@ -54,7 +54,7 @@ export class JSONEditingService implements IJSONEditingService {
 		try {
 			// Optimization: we apply edits to a text model and save it
 			// right after. Use the files config service to signal this
-			// to the workbench to optimise the UI during this operation.
+			// to the workbench to optimize the UI during this operation.
 			// For example, avoids to briefly show dirty indicators.
 			disposable = this.filesConfigurationService.enableAutoSaveAfterShortDelay(model.uri);
 


### PR DESCRIPTION
Replace British `optimise` with American `optimize` in two parallel comments in the configuration service about UI optimization during settings edits:

- `configurationEditing.ts`
- `jsonEditingService.ts`

No logic changes — comments only.