### PR TITLE
Fix spelling: 'normalise'/'synchronise' -> 'normalize'/'synchronize'

### DIFF
--- a/src/vs/platform/files/common/watcher.ts
+++ b/src/vs/platform/files/common/watcher.ts
@@ -385,7 +385,7 @@ class EventCoalescer {
 			return event.resource.fsPath;
 		}
 
-		return event.resource.fsPath.toLowerCase(); // normalise to file system case sensitivity
+		return event.resource.fsPath.toLowerCase(); // normalize to file system case sensitivity
 	}
 
 	processEvent(event: IFileChange): void {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -407,7 +407,7 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
 								promises.push(Event.toPromise(Event.filter(userDataSyncService.onDidChangeStatus, status => status !== SyncStatus.Syncing)));
 							}
 
-							// If user chose the sync service then synchronise the store type option in insiders service, so that other clients using insiders service are also updated.
+							// If user chose the sync service then synchronize the store type option in insiders service, so that other clients using insiders service are also updated.
 							if (isSwitchingToInsiders && userDataSyncStoreType) {
 								promises.push(userDataSyncWorkbenchService.synchroniseUserDataSyncStoreType());
 							}


### PR DESCRIPTION
Replace two instances of British `-ise` spelling with American `-ize`:

- `watcher.ts`: `// normalise to file system case sensitivity` → `normalize`
- `update.ts`: `// synchronise the store type option` → `synchronize`

No logic changes — comments only.