### PR TITLE
Fix spelling: 'minimise' -> 'minimize' in comments

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
@@ -201,7 +201,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 }
 
 // If the model thinks we are at the end of a line, do we want to offer a completion
-// for the next line? For now (05 Oct 2021) we leave it as false to minimise behaviour
+// for the next line? For now (05 Oct 2021) we leave it as false to minimize behaviour
 // changes between parsing and indentation mode.
 const OfferNextLineCompletion = false;
 

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/telemetry.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/telemetry.ts
@@ -196,7 +196,7 @@ export class TelemetryData {
 			// We want to keep including these properties in enhanced telemetry.
 			return map;
 		}
-		// deliberately written in the same style as `sanitizeKeys` to minimise risk
+		// deliberately written in the same style as `sanitizeKeys` to minimize risk
 		const returnValue: { [key: string]: string } = {};
 		for (const key in map) {
 			if (!TelemetryData.keysToRemoveFromStandardTelemetry.includes(key)) {

--- a/extensions/copilot/src/extension/completions/common/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions/common/parseBlock.ts
@@ -169,7 +169,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 }
 
 // If the model thinks we are at the end of a line, do we want to offer a completion
-// for the next line? For now (05 Oct 2021) we leave it as false to minimise behaviour
+// for the next line? For now (05 Oct 2021) we leave it as false to minimize behaviour
 // changes between parsing and indentation mode.
 const OfferNextLineCompletion = false;
 

--- a/extensions/copilot/src/platform/telemetry/common/telemetryData.ts
+++ b/extensions/copilot/src/platform/telemetry/common/telemetryData.ts
@@ -129,7 +129,7 @@ export class TelemetryData {
 			// We want to keep including these properties in secure/enhanced telemetry.
 			return map;
 		}
-		// deliberately written in the same style as `sanitizeKeys` to minimise risk
+		// deliberately written in the same style as `sanitizeKeys` to minimize risk
 		const returnValue: { [key: string]: any } = {};
 		for (const key in map) {
 			if (!TelemetryData.keysToRemoveFromStandardTelemetry.includes(key)) {

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -87,7 +87,7 @@ export abstract class BaseWindow extends Disposable {
 			// to focus the window which can take care of bringin the
 			// window to the front.
 			//
-			// To minimise disruption by bringing windows to the front
+			// To minimize disruption by bringing windows to the front
 			// by accident, we only do this if the window is not already
 			// focused and the active window is not the target window
 			// but has focus. This is an indication that multiple windows


### PR DESCRIPTION
Replace British `minimise` with American `minimize` in code comments across 5 files:

- `window.ts`: `// To minimise disruption by bringing windows to the front`
- `telemetryData.ts`, `telemetry.ts`: comments about minimizing risk in telemetry sanitization
- `parseBlock.ts` (×2): comments about minimizing behavior changes

No logic changes — comments only.