### PR TITLE
Fix typo: serialise → serialize in pluginGitCommandService

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-browser/pluginGitCommandService.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/pluginGitCommandService.ts
@@ -15,7 +15,7 @@ import { IPluginGitService } from '../common/plugins/pluginGitService.js';
  * delegate to the git extension (which may be running on a remote host).
  *
  * Cancellation tokens are mapped to operation IDs so that cancel requests
- * survive the IPC boundary to the shared process (tokens don't serialise).
+ * survive the IPC boundary to the shared process (tokens don't serialize).
  */
 export class NativePluginGitCommandService implements IPluginGitService {
 	declare readonly _serviceBrand: undefined;


### PR DESCRIPTION
Fixes British English spelling in a JSDoc comment.

**Change:** `serialise` → `serialize`

**File:** `src/vs/workbench/contrib/chat/electron-browser/pluginGitCommandService.ts`

The comment explaining why cancellation tokens are mapped to operation IDs used the British English spelling 'serialise' instead of American English 'serialize', which is the project standard.