### PR TITLE
Fix British spelling: favour → favor in comments and log messages

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsScannerService.ts
@@ -385,12 +385,12 @@ export abstract class AbstractExtensionsScannerService extends Disposable implem
 			}
 			if (existing.isValid === extension.isValid) {
 				if (pickLatest && semver.gt(existing.manifest.version, extension.manifest.version)) {
-					this.logService.debug(`Skipping extension ${extension.location.path} with lower version ${extension.manifest.version} in favour of ${existing.location.path} with version ${existing.manifest.version}`);
+					this.logService.debug(`Skipping extension ${extension.location.path} with lower version ${extension.manifest.version} in favor of ${existing.location.path} with version ${existing.manifest.version}`);
 					return false;
 				}
 				if (semver.eq(existing.manifest.version, extension.manifest.version)) {
 					if (existing.type === ExtensionType.System) {
-						this.logService.debug(`Skipping extension ${extension.location.path} in favour of system extension ${existing.location.path} with same version`);
+						this.logService.debug(`Skipping extension ${extension.location.path} in favor of system extension ${existing.location.path} with same version`);
 						return false;
 					}
 					if (existing.targetPlatform === targetPlatform) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -769,7 +769,7 @@ export class PromptValidator {
 		if (!attribute) {
 			return;
 		}
-		report(toMarker(localize('promptValidator.inferDeprecated', "The 'infer' attribute is deprecated in favour of 'user-invocable' and 'disable-model-invocation'."), attribute.value.range, MarkerSeverity.Error));
+		report(toMarker(localize('promptValidator.inferDeprecated', "The 'infer' attribute is deprecated in favor of 'user-invocable' and 'disable-model-invocation'."), attribute.value.range, MarkerSeverity.Error));
 	}
 
 	private validateTarget(attributes: IHeaderAttribute[], report: (markers: IMarkerData) => void): undefined {

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -93,7 +93,7 @@ function findEditor(model: ITextModel, codeEditorService: ICodeEditorService): I
 		for (const editor of codeEditorService.listCodeEditors()) {
 			if (editor.hasModel() && editor.getModel() === model) {
 				if (editor.hasTextFocus()) {
-					return editor; // favour focused editor if there are multiple
+					return editor; // favor focused editor if there are multiple
 				}
 
 				candidate = editor;

--- a/src/vs/workbench/services/extensions/common/extensionsUtil.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsUtil.ts
@@ -24,7 +24,7 @@ export function dedupExtensions(system: IExtensionDescription[], user: IExtensio
 		if (extension) {
 			if (extension.isBuiltin) {
 				if (semver.gte(extension.version, userExtension.version)) {
-					logService.warn(`Skipping extension ${userExtension.extensionLocation.path} in favour of the builtin extension ${extension.extensionLocation.path}.`);
+					logService.warn(`Skipping extension ${userExtension.extensionLocation.path} in favor of the builtin extension ${extension.extensionLocation.path}.`);
 					return;
 				}
 				// Overwriting a builtin extension inherits the `isBuiltin` property and it doesn't show a warning


### PR DESCRIPTION
Replaces British English spelling 'favour' with American English 'favor' in comments and log messages.

**Files changed:**
- `src/vs/platform/extensionManagement/common/extensionsScannerService.ts`: two debug log messages with 'in favour of'
- `src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts`: user-visible localized deprecation message
- `src/vs/workbench/services/extensions/common/extensionsUtil.ts`: warning log message
- `src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts`: inline comment