### PR TITLE
Fix typos: occured → occurred, occurences → occurrences in comments

### DIFF
--- a/src/vs/editor/standalone/common/monarch/monarchCompile.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchCompile.ts
@@ -88,7 +88,7 @@ function createKeywordMatcher(arr: string[], caseInsensitive: boolean = false): 
  */
 function compileRegExp<S extends true | false>(lexer: monarchCommon.ILexerMin, str: string, handleSn: S): S extends true ? RegExp | DynamicRegExp : RegExp;
 function compileRegExp(lexer: monarchCommon.ILexerMin, str: string, handleSn: true | false): RegExp | DynamicRegExp {
-	// @@ must be interpreted as a literal @, so we replace all occurences of @@ with a placeholder character
+	// @@ must be interpreted as a literal @, so we replace all occurrences of @@ with a placeholder character
 	str = str.replace(/@@/g, `\x01`);
 
 	let n = 0;

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//


### PR DESCRIPTION
Fixes two spelling errors in code comments:

- `src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts`: `occured` → `occurred` in timeout comment
- `src/vs/editor/standalone/common/monarch/monarchCompile.ts`: `occurences` → `occurrences` in @@ replacement comment