### PR TITLE
Fix typo: accidently → accidentally in breakpointEditorContribution

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -290,7 +290,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					} else if (isShiftPressed) {
 						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition || !!bp.triggeredBy)) {
-						// Show the dialog if there is a potential condition to be accidently lost.
+						// Show the dialog if there is a potential condition to be accidentally lost.
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");


### PR DESCRIPTION
Corrects `accidently` (missing 'al') to `accidentally` in an inline comment in `breakpointEditorContribution.ts`.