### PR TITLE
Fix doubled words in comments: 'a a', 'be be', 'is is'

### DIFF
--- a/src/vs/base/common/jsonc.ts
+++ b/src/vs/base/common/jsonc.ts
@@ -26,7 +26,7 @@ export function stripComments(content: string): string {
 			// A block comment. Replace with nothing
 			return '';
 		} else if (m4) {
-			// Since m4 is a single line comment is is at least of length 2 (e.g. //)
+			// Since m4 is a single line comment is at least of length 2 (e.g. //)
 			// If it ends in \r?\n then keep it.
 			const length = m4.length;
 			if (m4[length - 1] === '\n') {

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -51,7 +51,7 @@ export interface ICommandActionToggleInfo {
 	tooltip?: string;
 
 	/**
-	 * The title that goes well with a a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
+	 * The title that goes well with a check mark, e.g "(check) Line Numbers" vs "Toggle Line Numbers"
 	 */
 	title?: string;
 

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -178,7 +178,7 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 	 * Applies the tunnel metadata and factory found in the remote authority
 	 * resolver to the tunnel system.
 	 *
-	 * `managedRemoteAuthority` should be be passed if the resolver returned on.
+	 * `managedRemoteAuthority` should be passed if the resolver returned on.
 	 * If this is the case, the tunnel cannot be connected to via a websocket from
 	 * the share process, so a synethic tunnel factory is used as a default.
 	 */

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -366,7 +366,7 @@ class AttachedHistory extends Disposable {
 
 	/**
 	 * Pushes an history item that is tied to the last text edit (or an extension of it).
-	 * When the last text edit is undone/redone, so is is this history item.
+	 * When the last text edit is undone/redone, so is this history item.
 	 */
 	public pushAttachedHistoryElement(element: IAttachedHistoryElement): void {
 		this.attachedHistory.push({ altId: this.model.getAlternativeVersionId(), element });


### PR DESCRIPTION
Removes duplicate words from four JSDoc/inline comments:

- `src/vs/platform/action/common/action.ts`: `a a check mark` → `a check mark`
- `src/vs/workbench/api/common/extHostTunnelService.ts`: `should be be passed` → `should be passed`
- `src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts`: `so is is this history item` → `so is this history item`
- `src/vs/base/common/jsonc.ts`: `comment is is at least` → `comment is at least`