### PR TITLE
Fix doubled words in comments: 'this this', 'that that'

### DIFF
--- a/src/vs/base/browser/cssValue.ts
+++ b/src/vs/base/browser/cssValue.ts
@@ -76,7 +76,7 @@ export function className(value: string, escapingExpected = false): CssFragment 
 type InlineCssTemplateValue = CssFragment | Color;
 
 /**
- * Template string tag that that constructs a CSS fragment.
+ * Template string tag that constructs a CSS fragment.
  *
  * All expressions in the template must be css safe values.
  */

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -524,7 +524,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const completePromise = new DeferredPromise<void>();
 		const startPromise = new DeferredPromise<void>();
 
-		// Sequence all edits made this this resource in this streaming edits instance,
+		// Sequence all edits made this resource in this streaming edits instance,
 		// and also sequence the resource overall in the rare (currently invalid?) case
 		// that edits are made in parallel to the same resource,
 		const sequencer = new ThrottledSequencer(15, 1000);

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3326,7 +3326,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 						}
 					}
 
-					// At this this point there are multiple tasks.
+					// At this point there are multiple tasks.
 					chooseAndRunTask(tasks);
 				});
 			};


### PR DESCRIPTION
Removes duplicate words from three inline comments:

- `src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts`: `At this this point` → `At this point`
- `src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts`: `made this this resource` → `made this resource`
- `src/vs/base/browser/cssValue.ts`: `tag that that constructs` → `tag that constructs`