### PR TITLE
Fix redundant phrasing 'built-in in' → 'built-in to' in codicons comment

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -53,7 +53,7 @@ export const codiconsDerived = {
 } as const;
 
 /**
- * The Codicon library is a set of default icons that are built-in in VS Code.
+ * The Codicon library is a set of default icons that are built-in to VS Code.
  *
  * In the product (outside of base) Codicons should only be used as defaults. In order to have all icons in VS Code
  * themeable, component should define new, UI component specific icons using `iconRegistry.registerIcon`.


### PR DESCRIPTION
The JSDoc comment in `codicons.ts` contained the redundant phrase `built-in in VS Code`. Changed to the more idiomatic `built-in to VS Code`.