### PR TITLE
Fix typo: proprety → property in configurations.ts

### DIFF
--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -170,11 +170,11 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 		const wasEmpty = this._configurationModel.isEmpty();
 
 		for (const key of keys) {
-			const proprety = configurationProperties[key] ?? excludedConfigurationProperties[key];
-			const policyName = proprety?.policy?.name;
+			const property = configurationProperties[key] ?? excludedConfigurationProperties[key];
+			const policyName = property?.policy?.name;
 			if (policyName) {
 				let policyValue: PolicyValue | ParsedType | undefined = this.policyService.getPolicyValue(policyName);
-				if (isString(policyValue) && proprety.type !== 'string') {
+				if (isString(policyValue) && property.type !== 'string') {
 					try {
 						policyValue = this.parse(policyValue);
 					} catch (e) {


### PR DESCRIPTION
Renames the local variable `proprety` (a misspelling) to `property` in `PolicyConfiguration` in `configurations.ts`. The variable was used in three lines.