### PR TITLE
Fix British spelling: focussed → focused in debug comments

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -322,7 +322,7 @@ function findNextVisibleFrame(down: boolean, callStack: readonly IStackFrame[], 
 
 // These commands are used in call stack context menu, call stack inline actions, command palette, debug toolbar, mac native touch bar
 // When the command is exectued in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
-// Otherwise when it is executed "globaly"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
+// Otherwise when it is executed "globaly"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focused thread
 // Same for stackFrame commands and session commands.
 CommandsRegistry.registerCommand({
 	id: COPY_STACK_TRACE_ID,

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -1051,7 +1051,7 @@ registerAction2(class extends ViewAction<Repl> {
 			session = resolveChildSession(session, debugService.getModel().getSessions());
 			await debugService.focusStackFrame(undefined, undefined, session, { explicit: true });
 		}
-		// Need to select the session in the view since the focussed session might not have changed
+		// Need to select the session in the view since the focused session might not have changed
 		await view.selectSession(session);
 	}
 });


### PR DESCRIPTION
Replaces the British English spelling 'focussed' (double-s) with the American English 'focused' (single-s) in two inline comments in the debug module:

- `repl.ts`: 'since the focussed session might not have changed'
- `debugCommands.ts`: 'whatever is the focussed thread'