### PR TITLE
Fix British spellings: maximised → maximized, serialised → serialized in comments

### DIFF
--- a/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
+++ b/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
@@ -379,7 +379,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 				if (startupEditor !== 'agentSessionsWelcomePage' && (auxiliaryBarDefaultVisibility === 'visible' || auxiliaryBarDefaultVisibility === 'visibleInWorkspace')) {
 					auxiliaryBarWidth = override.layoutInfo.auxiliaryBarWidth || partSplash.layoutInfo.auxiliaryBarWidth || ThemeMainService.DEFAULT_BAR_WIDTH;
 				} else if (startupEditor !== 'agentSessionsWelcomePage' && (auxiliaryBarDefaultVisibility === 'maximized' || auxiliaryBarDefaultVisibility === 'maximizedInWorkspace')) {
-					auxiliaryBarWidth = Number.MAX_SAFE_INTEGER; // marker for a maximised auxiliary bar
+					auxiliaryBarWidth = Number.MAX_SAFE_INTEGER; // marker for a maximized auxiliary bar
 				} else {
 					auxiliaryBarWidth = 0;
 				}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1643,7 +1643,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				if (!this.inMaximizedAuxiliaryBarTransition) {
 
 					// skip reacting when we are transitioning
-					// in or out of maximised auxiliary bar to prevent
+					// in or out of maximized auxiliary bar to prevent
 					// stepping on each other toes because this
 					// transition is already dealing with all parts
 					// visibility efficiently.
@@ -1846,7 +1846,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	private setEditorHidden(hidden: boolean): void {
 		if (!hidden && this.setAuxiliaryBarMaximized(false) && this.isVisible(Parts.EDITOR_PART)) {
-			return; // return: leaving maximised auxiliary bar made this part visible
+			return; // return: leaving maximized auxiliary bar made this part visible
 		}
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN, hidden);
@@ -1882,7 +1882,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	private setSideBarHidden(hidden: boolean): void {
 		if (!hidden && this.setAuxiliaryBarMaximized(false) && this.isVisible(Parts.SIDEBAR_PART)) {
-			return; // return: leaving maximised auxiliary bar made this part visible
+			return; // return: leaving maximized auxiliary bar made this part visible
 		}
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN, hidden);
@@ -2021,7 +2021,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		if (!hidden && this.setAuxiliaryBarMaximized(false) && this.isVisible(Parts.PANEL_PART)) {
-			return; // return: leaving maximised auxiliary bar made this part visible
+			return; // return: leaving maximized auxiliary bar made this part visible
 		}
 
 		const wasHidden = !this.isVisible(Parts.PANEL_PART);
@@ -2220,7 +2220,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	private setAuxiliaryBarHidden(hidden: boolean, skipLayout?: boolean): void {
 		if (hidden && this.setAuxiliaryBarMaximized(false) && !this.isVisible(Parts.AUXILIARYBAR_PART)) {
-			return; // return: leaving maximised auxiliary bar made this part hidden
+			return; // return: leaving maximized auxiliary bar made this part hidden
 		}
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.AUXILIARYBAR_HIDDEN, hidden);

--- a/src/vs/workbench/contrib/chat/common/plugins/fileBackedInstalledPluginsStore.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/fileBackedInstalledPluginsStore.ts
@@ -23,7 +23,7 @@ const LEGACY_INSTALLED_PLUGINS_STORAGE_KEY = 'chat.plugins.installed.v1';
 const LEGACY_MARKETPLACE_INDEX_STORAGE_KEY = 'chat.plugins.marketplaces.index.v1';
 
 /**
- * Minimal entry stored in `installed.json`. URIs are serialised as strings
+ * Minimal entry stored in `installed.json`. URIs are serialized as strings
  * so that external tools can read and write the file without depending on
  * VS Code internal URI representations.
  */

--- a/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts
@@ -54,7 +54,7 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 		super(window, container, stylesHaveLoaded, configurationService, hostService, environmentService, contextMenuService, layoutService);
 
 		if (!isMacintosh) {
-			// For now, limit this to platforms that have clear maximised
+			// For now, limit this to platforms that have clear maximized
 			// transitions (Windows, Linux) via window buttons.
 			this.handleMaximizedState();
 		}

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -1031,7 +1031,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 
 		// We want to merge the opened editors from the last
 		// session with the stored editors from the last
-		// session. Because not all editors can be serialised
+		// session. Because not all editors can be serialized
 		// we want to make sure to include all opened editors
 		// too.
 		// Opened editors should always be first in the history


### PR DESCRIPTION
Replaces British English spellings in inline comments across five files:

**maximised → maximized:**
- `src/vs/workbench/browser/layout.ts` (5 occurrences in comments)
- `src/vs/platform/theme/electron-main/themeMainServiceImpl.ts` (1 in comment)
- `src/vs/workbench/services/auxiliaryWindow/electron-browser/auxiliaryWindowService.ts` (1 in comment)

**serialised → serialized:**
- `src/vs/workbench/contrib/chat/common/plugins/fileBackedInstalledPluginsStore.ts` (1 in JSDoc)
- `src/vs/workbench/services/history/browser/historyService.ts` (1 in comment)