### PR TITLE
Fix British spelling: honour → honor in extension comments

### DIFF
--- a/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
+++ b/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
@@ -196,7 +196,7 @@ export class NodeOTelService implements IOTelService {
 
 		// When OTel is enabled only for dbSpanExporter (no OTLP endpoint/file/console configured),
 		// use a noop exporter as the primary span exporter so the pipeline still runs.
-		// If the user also explicitly enabled OTel (via setting or env var), honour their
+		// If the user also explicitly enabled OTel (via setting or env var), honor their
 		// exporter config and don't switch to noop.
 		const dbOnlyMode = config.dbSpanExporter
 			&& !config.enabledExplicitly

--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -152,7 +152,7 @@ export class CommitCommandsCenter {
 
 			if (command === undefined) {
 				// Commit WAS NOT initiated using the action button (ex: keybinding, toolbar action,
-				// command palette) so we have to honour the default post commit command (memento/setting).
+				// command palette) so we have to honor the default post commit command (memento/setting).
 				const primaryCommand = this.getPrimaryCommand();
 				command = primaryCommand.arguments?.length === 2 ? primaryCommand.arguments[1] : null;
 			}


### PR DESCRIPTION
Replaces British English spelling 'honour' with American English 'honor' in two extension comment strings:

- `extensions/git/src/postCommitCommands.ts`: comment about post-commit command handling
- `extensions/copilot/src/platform/otel/node/otelServiceImpl.ts`: comment about OTel setting