### PR TITLE
Fix British spelling: grey → gray in action.ts JSDoc comment

### DIFF
--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -87,7 +87,7 @@ export interface ICommandAction {
 	source?: ICommandActionSource;
 	/**
 	 * Precondition controls enablement (for example for a menu item, show
-	 * it in grey or for a command, do not allow to invoke it)
+	 * it in gray or for a command, do not allow to invoke it)
 	 */
 	precondition?: ContextKeyExpression;
 


### PR DESCRIPTION
The JSDoc comment for the `precondition` property in `action.ts` used the British English spelling 'grey'. Changed to American English 'gray'.