### PR TITLE
Fix typo: perference → preference in notebookKernelService JSDoc

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -139,7 +139,7 @@ export interface INotebookKernelService {
 	preselectKernelForNotebook(kernel: INotebookKernel, notebook: INotebookTextModelLike): void;
 
 	/**
-	 * Set a perference of a kernel for a certain notebook. Higher values win, `undefined` removes the preference
+	 * Set a preference of a kernel for a certain notebook. Higher values win, `undefined` removes the preference
 	 */
 	updateKernelNotebookAffinity(kernel: INotebookKernel, notebook: URI, preference: number | undefined): void;
 


### PR DESCRIPTION
Corrects the misspelling `perference` to `preference` in the JSDoc comment for `setKernelNotebookAffinity` in `notebookKernelService.ts`.