### PR TITLE
Fix grammar: 'can not' → 'cannot' in comments and error messages (batch 3)

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1875,7 +1875,7 @@ class StickyScrollWidget<T, TFilterData, TRef> implements IDisposable {
 			container.setAttribute('aria-level', `${ariaLevel}`);
 		}
 
-		// Sticky Scroll elements can not be selected
+		// Sticky Scroll elements cannot be selected
 		container.setAttribute('aria-selected', String(false));
 
 		return result;
@@ -2103,7 +2103,7 @@ class StickyScrollFocus<T, TFilterData, TRef> extends Disposable {
 
 	private setFocus(newFocusIndex: number): void {
 		if (0 > newFocusIndex) {
-			throw new Error('addFocus() can not remove focus');
+			throw new Error('addFocus() cannot remove focus');
 		}
 		if (!this.state && newFocusIndex >= 0) {
 			throw new Error('Cannot set focus index when state is undefined');

--- a/src/vs/editor/common/cursor/cursor.ts
+++ b/src/vs/editor/common/cursor/cursor.ts
@@ -991,7 +991,7 @@ export class CommandExecutor {
 			return -(Range.compareRangesUsingEnds(a.range, b.range));
 		});
 
-		// Operations can not overlap!
+		// Operations cannot overlap!
 		const loserCursorsMap: { [index: string]: boolean } = {};
 
 		for (let i = 1; i < operations.length; i++) {

--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -134,7 +134,7 @@ export function getInheritIndentForLine(
 			line: precedingUnIgnoredLine
 		};
 	} else {
-		// precedingUnIgnoredLine can not be ignored.
+		// precedingUnIgnoredLine cannot be ignored.
 		// it doesn't increase indent of following lines
 		// it doesn't increase just next line
 		// so current line is not affect by precedingUnIgnoredLine

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -86,7 +86,7 @@ export interface LanguageConfiguration {
 	/**
 	 * Defines what characters must be after the cursor for bracket or quote autoclosing to occur when using the \'languageDefined\' autoclosing setting.
 	 *
-	 * This is typically the set of characters which can not start an expression, such as whitespace, closing brackets, non-unary operators, etc.
+	 * This is typically the set of characters which cannot start an expression, such as whitespace, closing brackets, non-unary operators, etc.
 	 */
 	autoCloseBefore?: string;
 

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -192,7 +192,7 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 			if (!stdinFilePath) {
 				stdinFilePath = getStdinFilePath();
 				const readFromStdinDone = new DeferredPromise<void>();
-				await readFromStdin(stdinFilePath, verbose, () => readFromStdinDone.complete()); // throws error if file can not be written
+				await readFromStdin(stdinFilePath, verbose, () => readFromStdinDone.complete()); // throws error if file cannot be written
 				if (!parsedArgs.wait) {
 					// if `--wait` is not provided, we keep this process alive
 					// for at least as long as the stdin stream is open to

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -338,7 +338,7 @@ export abstract class MenubarControl extends Disposable {
 
 				return this.hostService.openWindow([openable], {
 					forceNewWindow: !!openInNewWindow,
-					remoteAuthority: remoteAuthority || null // local window if remoteAuthority is not set or can not be deducted from the openable
+					remoteAuthority: remoteAuthority || null // local window if remoteAuthority is not set or cannot be deducted from the openable
 				});
 			}
 		});

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -244,7 +244,7 @@ export class DiffEditorInput extends SideBySideEditorInput implements IDiffEdito
 	override dispose(): void {
 
 		// Free the diff editor model but do not propagate the dispose() call to the two inputs
-		// We never created the two inputs (original and modified) so we can not dispose
+		// We never created the two inputs (original and modified) so we cannot dispose
 		// them without sideeffects.
 		if (this.cachedModel) {
 			this.cachedModel.dispose();

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -245,7 +245,7 @@ export class DiffEditorInput extends SideBySideEditorInput implements IDiffEdito
 
 		// Free the diff editor model but do not propagate the dispose() call to the two inputs
 		// We never created the two inputs (original and modified) so we cannot dispose
-		// them without sideeffects.
+		// them without side effects.
 		if (this.cachedModel) {
 			this.cachedModel.dispose();
 			this.cachedModel = undefined;

--- a/src/vs/workbench/common/editor/diffEditorModel.ts
+++ b/src/vs/workbench/common/editor/diffEditorModel.ts
@@ -39,7 +39,7 @@ export class DiffEditorModel extends EditorModel {
 	override dispose(): void {
 
 		// Do not propagate the dispose() call to the two models inside. We never created the two models
-		// (original and modified) so we can not dispose them without sideeffects. Rather rely on the
+		// (original and modified) so we cannot dispose them without sideeffects. Rather rely on the
 		// models getting disposed when their related inputs get disposed from the diffEditorInput.
 
 		super.dispose();

--- a/src/vs/workbench/common/editor/diffEditorModel.ts
+++ b/src/vs/workbench/common/editor/diffEditorModel.ts
@@ -39,7 +39,7 @@ export class DiffEditorModel extends EditorModel {
 	override dispose(): void {
 
 		// Do not propagate the dispose() call to the two models inside. We never created the two models
-		// (original and modified) so we cannot dispose them without sideeffects. Rather rely on the
+		// (original and modified) so we cannot dispose them without side effects. Rather rely on the
 		// models getting disposed when their related inputs get disposed from the diffEditorInput.
 
 		super.dispose();

--- a/src/vs/workbench/common/editor/textDiffEditorModel.ts
+++ b/src/vs/workbench/common/editor/textDiffEditorModel.ts
@@ -69,7 +69,7 @@ export class TextDiffEditorModel extends DiffEditorModel {
 
 		// Free the diff editor model but do not propagate the dispose() call to the two models
 		// inside. We never created the two models (original and modified) so we cannot dispose
-		// them without sideeffects. Rather rely on the models getting disposed when their related
+		// them without side effects. Rather rely on the models getting disposed when their related
 		// inputs get disposed from the diffEditorInput.
 		this._textDiffEditorModel = undefined;
 

--- a/src/vs/workbench/common/editor/textDiffEditorModel.ts
+++ b/src/vs/workbench/common/editor/textDiffEditorModel.ts
@@ -68,7 +68,7 @@ export class TextDiffEditorModel extends DiffEditorModel {
 	override dispose(): void {
 
 		// Free the diff editor model but do not propagate the dispose() call to the two models
-		// inside. We never created the two models (original and modified) so we can not dispose
+		// inside. We never created the two models (original and modified) so we cannot dispose
 		// them without sideeffects. Rather rely on the models getting disposed when their related
 		// inputs get disposed from the diffEditorInput.
 		this._textDiffEditorModel = undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatSelectedTools.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatSelectedTools.ts
@@ -204,7 +204,7 @@ export class ChatSelectedTools extends Disposable {
 				this.updateCustomModeTools(mode.uri.get(), enablementMap);
 				return;
 			} else {
-				// can not write to extensions, store
+				// cannot write to extensions, store
 				this._sessionStates.set(mode.id, ToolEnablementStates.fromMap(enablementMap));
 				return;
 			}

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -790,7 +790,7 @@ class InlineBreakpointWidget implements IContentWidget, IDisposable {
 		if (!this.range) {
 			return null;
 		}
-		// Workaround: since the content widget can not be placed before the first column we need to force the left position
+		// Workaround: since the content widget cannot be placed before the first column we need to force the left position
 		this.domNode.classList.toggle('line-start', this.range.startColumn === 1);
 
 		return {

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -304,7 +304,7 @@ export class LinkDetector implements ILinkDetector {
 			}
 			this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
 		}).catch(() => {
-			// If the uri cannot be resolved we should not spam the console with error, remain quite #86587
+			// If the uri cannot be resolved we should not spam the console with error, remain quiet #86587
 		});
 		return link;
 	}

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -304,7 +304,7 @@ export class LinkDetector implements ILinkDetector {
 			}
 			this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
 		}).catch(() => {
-			// If the uri can not be resolved we should not spam the console with error, remain quite #86587
+			// If the uri cannot be resolved we should not spam the console with error, remain quite #86587
 		});
 		return link;
 	}

--- a/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
+++ b/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
@@ -1861,7 +1861,7 @@ declare namespace DebugProtocol {
 		description?: string;
 		/** Initial value of the filter option. If not specified a value false is assumed. */
 		default?: boolean;
-		/** Controls whether a condition can be specified for this filter option. If false or missing, a condition can not be set. */
+		/** Controls whether a condition can be specified for this filter option. If false or missing, a condition cannot be set. */
 		supportsCondition?: boolean;
 		/** A help text providing information about the condition. This string is shown as the placeholder text for a text box and can be translated. */
 		conditionDescription?: string;
@@ -1956,7 +1956,7 @@ declare namespace DebugProtocol {
 		*/
 		path?: string;
 		/** If the value > 0 the contents of the source must be retrieved through the `source` request (even if a path is specified).
-			Since a `sourceReference` is only valid for a session, it can not be used to persist a source.
+			Since a `sourceReference` is only valid for a session, it cannot be used to persist a source.
 			The value should be less than or equal to 2147483647 (2^31-1).
 		*/
 		sourceReference?: number;
@@ -2329,7 +2329,7 @@ declare namespace DebugProtocol {
 		length?: number;
 		/** Determines the start of the new selection after the text has been inserted (or replaced). `selectionStart` is measured in UTF-16 code units and must be in the range 0 and length of the completion text. If omitted the selection starts at the end of the completion text. */
 		selectionStart?: number;
-		/** Determines the length of the new selection after the text has been inserted (or replaced) and it is measured in UTF-16 code units. The selection can not extend beyond the bounds of the completion text. If omitted the length is assumed to be 0. */
+		/** Determines the length of the new selection after the text has been inserted (or replaced) and it is measured in UTF-16 code units. The selection cannot extend beyond the bounds of the completion text. If omitted the length is assumed to be 0. */
 		selectionLength?: number;
 	}
 


### PR DESCRIPTION
Replaces `can not` with `cannot` in comments and error messages across 13 files, completing the cleanup:

- `base/browser/ui/tree/abstractTree.ts`: sticky scroll / focus error comments
- `editor/common/cursor/cursor.ts`: overlap check comment
- `editor/common/languages/autoIndent.ts`: indent rule comment
- `editor/common/languages/languageConfiguration.ts`: autoclosing chars description
- `server/node/server.cli.ts`: stdin file-write comment
- `workbench/browser/parts/titlebar/menubarControl.ts`: remote authority comment
- `workbench/common/editor/diffEditorInput.ts`, `diffEditorModel.ts`, `textDiffEditorModel.ts`: dispose comments
- `workbench/contrib/chat/browser/widget/input/chatSelectedTools.ts`: extension write comment
- `workbench/contrib/debug/browser/breakpointEditorContribution.ts`: content widget workaround
- `workbench/contrib/debug/browser/linkDetector.ts`: URI resolution comment
- `workbench/contrib/debug/common/debugProtocol.d.ts`: sourceReference and completion text JSDoc