### PR TITLE
Fix typos: 'can not' → 'cannot' and 'remain quite' → 'remain quiet' in notebook linkify

### DIFF
--- a/extensions/notebook-renderers/src/linkify.ts
+++ b/extensions/notebook-renderers/src/linkify.ts
@@ -140,7 +140,7 @@ export class LinkDetector {
 	// 		}
 	// 		this.decorateLink(link, uri, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
 	// 	}).catch(() => {
-	// 		// If the uri can not be resolved we should not spam the console with error, remain quite #86587
+	// 		// If the uri cannot be resolved we should not spam the console with error, remain quiet #86587
 	// 	});
 	// 	return link;
 	// }


### PR DESCRIPTION
Fixes a commented-out line in `extensions/notebook-renderers/src/linkify.ts` copied from `debug/linkDetector.ts` that had two issues:
- `can not` → `cannot`
- `remain quite` → `remain quiet` (homophone confusion)