### PR TITLE
Fix grammar: 'Controls if' → 'Controls whether' in setting descriptions (batch 3)

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1460,7 +1460,7 @@ class EditorAccessibilitySupport extends BaseEditorOption<EditorOption.accessibi
 				],
 				default: 'auto',
 				tags: ['accessibility'],
-				description: nls.localize('accessibilitySupport', "Controls if the UI should run in a mode where it is optimized for screen readers.")
+				description: nls.localize('accessibilitySupport', "Controls whether the UI should run in a mode where it is optimized for screen readers.")
 			}
 		);
 	}
@@ -5663,7 +5663,7 @@ class EditorDropIntoEditor extends BaseEditorOption<EditorOption.dropIntoEditor,
 				},
 				'editor.dropIntoEditor.showDropSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls if a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
+					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls whether a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
 					enum: [
 						'afterDrop',
 						'never'
@@ -5730,7 +5730,7 @@ class EditorPasteAs extends BaseEditorOption<EditorOption.pasteAs, IPasteAsOptio
 				},
 				'editor.pasteAs.showPasteSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls if a widget is shown when pasting content in to the editor. This widget lets you control how the file is pasted."),
+					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls whether a widget is shown when pasting content in to the editor. This widget lets you control how the file is pasted."),
 					enum: [
 						'afterPaste',
 						'never'
@@ -6556,7 +6556,7 @@ export const EditorOptions = {
 	)),
 	renderLineHighlightOnlyWhenFocus: register(new EditorBooleanOption(
 		EditorOption.renderLineHighlightOnlyWhenFocus, 'renderLineHighlightOnlyWhenFocus', false,
-		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls if the editor should render the current line highlight only when the editor is focused.") }
+		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls whether the editor should render the current line highlight only when the editor is focused.") }
 	)),
 	renderValidationDecorations: register(new EditorStringEnumOption(
 		EditorOption.renderValidationDecorations, 'renderValidationDecorations',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -165,7 +165,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'enum': ['text', 'hidden'],
 				'default': 'text',
-				'markdownDescription': localize("workbench.editor.empty.hint", "Controls if the empty editor text hint should be visible in the editor.")
+				'markdownDescription': localize("workbench.editor.empty.hint", "Controls whether the empty editor text hint should be visible in the editor.")
 			},
 			'workbench.editor.languageDetection': {
 				type: 'boolean',
@@ -291,12 +291,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.splitOnDragAndDrop': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('splitOnDragAndDrop', "Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.")
+				'description': localize('splitOnDragAndDrop', "Controls whether editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.")
 			},
 			'workbench.editor.dragToOpenWindow': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize('dragToOpenWindow', "Controls if editors can be dragged out of the window to open them in a new window. Press and hold the `Alt` key while dragging to toggle this dynamically.")
+				'markdownDescription': localize('dragToOpenWindow', "Controls whether editors can be dragged out of the window to open them in a new window. Press and hold the `Alt` key while dragging to toggle this dynamically.")
 			},
 			'workbench.editor.focusRecentEditorAfterClose': {
 				'type': 'boolean',
@@ -412,7 +412,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.centeredLayoutAutoResize': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('centeredLayoutAutoResize', "Controls if the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.")
+				'description': localize('centeredLayoutAutoResize', "Controls whether the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.")
 			},
 			'workbench.editor.centeredLayoutFixedWidth': {
 				'type': 'boolean',
@@ -433,7 +433,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.limit.enabled': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('limitEditorsEnablement', "Controls if the number of opened editors should be limited or not. When enabled, less recently used editors will close to make space for newly opening editors.")
+				'description': localize('limitEditorsEnablement', "Controls whether the number of opened editors should be limited or not. When enabled, less recently used editors will close to make space for newly opening editors.")
 			},
 			'workbench.editor.limit.value': {
 				'type': 'number',
@@ -444,12 +444,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.limit.excludeDirty': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('limitEditorsExcludeDirty', "Controls if the maximum number of opened editors should exclude dirty editors for counting towards the configured limit.")
+				'description': localize('limitEditorsExcludeDirty', "Controls whether the maximum number of opened editors should exclude dirty editors for counting towards the configured limit.")
 			},
 			'workbench.editor.limit.perEditorGroup': {
 				'type': 'boolean',
 				'default': false,
-				'description': localize('perEditorGroup', "Controls if the limit of maximum opened editors should apply per editor group or across all editor groups.")
+				'description': localize('perEditorGroup', "Controls whether the limit of maximum opened editors should apply per editor group or across all editor groups.")
 			},
 			'workbench.localHistory.enabled': {
 				'type': 'boolean',

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -553,7 +553,7 @@ configurationRegistry.registerConfiguration({
 		'debug.internalConsoleOptions': INTERNAL_CONSOLE_OPTIONS_SCHEMA,
 		'debug.console.closeOnEnd': {
 			type: 'boolean',
-			description: nls.localize('debug.console.closeOnEnd', "Controls if the Debug Console should be automatically closed when the debug session ends."),
+			description: nls.localize('debug.console.closeOnEnd', "Controls whether the Debug Console should be automatically closed when the debug session ends."),
 			default: false
 		},
 		'debug.terminal.clearBeforeReusing': {
@@ -588,17 +588,17 @@ configurationRegistry.registerConfiguration({
 		},
 		'debug.console.wordWrap': {
 			type: 'boolean',
-			description: nls.localize('debug.console.wordWrap', "Controls if the lines should wrap in the Debug Console."),
+			description: nls.localize('debug.console.wordWrap', "Controls whether the lines should wrap in the Debug Console."),
 			default: true
 		},
 		'debug.console.historySuggestions': {
 			type: 'boolean',
-			description: nls.localize('debug.console.historySuggestions', "Controls if the Debug Console should suggest previously typed input."),
+			description: nls.localize('debug.console.historySuggestions', "Controls whether the Debug Console should suggest previously typed input."),
 			default: true
 		},
 		'debug.console.collapseIdenticalLines': {
 			type: 'boolean',
-			description: nls.localize('debug.console.collapseIdenticalLines', "Controls if the Debug Console should collapse identical lines and show a number of occurrences with a badge."),
+			description: nls.localize('debug.console.collapseIdenticalLines', "Controls whether the Debug Console should collapse identical lines and show a number of occurrences with a badge."),
 			default: true
 		},
 		'debug.console.acceptSuggestionOnEnter': {


### PR DESCRIPTION
Replaces the grammatically incorrect 'Controls if' with 'Controls whether' in user-facing setting descriptions across three files:

**`src/vs/workbench/browser/workbench.contribution.ts`** (8 settings):
- workbench.editor.empty.hint
- workbench.editor.splitOnDragAndDrop
- workbench.editor.dragToOpenWindow
- workbench.editor.centeredLayoutAutoResize
- workbench.editor.limit.enabled
- workbench.editor.limit.excludeDirty
- workbench.editor.limit.perEditorGroup

**`src/vs/workbench/contrib/debug/browser/debug.contribution.ts`** (4 settings):
- debug.console.closeOnEnd
- debug.console.wordWrap
- debug.console.historySuggestions
- debug.console.collapseIdenticalLines

**`src/vs/editor/common/config/editorOptions.ts`** (4 settings):
- accessibilitySupport
- comments.ignoreEmptyLines
- dropIntoEditor.showDropSelector
- pasteAs.showPasteSelector
- renderLineHighlightOnlyWhenFocus