### PR TITLE
Fix grammar: 'Controls if' → 'Controls whether' in mergeEditor setting

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
@@ -56,7 +56,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'mergeEditor.showDeletionMarkers': {
 			type: 'boolean',
 			default: true,
-			description: 'Controls if deletions in base or one of the inputs should be indicated by a vertical bar.',
+			description: 'Controls whether deletions in base or one of the inputs should be indicated by a vertical bar.',
 		},
 	}
 });


### PR DESCRIPTION
Corrects `Controls if` to `Controls whether` in the description of the merge editor deletion indicator setting in `mergeEditor.contribution.ts`.