### PR TITLE
Fix grammar: 'allow to' → 'allow you to' in setting descriptions and API docs

### DIFF
--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3727,7 +3727,7 @@ declare namespace monaco.editor {
 		 */
 		doubleClickSelectsBlock?: boolean;
 		/**
-		 * Controls if the editor should allow to move selections via drag and drop.
+		 * Controls whether the editor should allow you to move selections via drag and drop.
 		 * Defaults to false.
 		 */
 		dragAndDrop?: boolean;

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -477,7 +477,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',
-			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer."),
+			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow you to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer."),
 			'default': true
 		},
 		'explorer.confirmDragAndDrop': {

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -477,7 +477,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',
-			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow you to move files and folders via drag and drop. This setting only effects drag and drop from inside the Explorer."),
+			'description': nls.localize('enableDragAndDrop', "Controls whether the Explorer should allow you to move files and folders via drag and drop. This setting only affects drag and drop from inside the Explorer."),
 			'default': true
 		},
 		'explorer.confirmDragAndDrop': {


### PR DESCRIPTION
Fixes grammatically incorrect 'allow to' phrases in user-visible setting descriptions and public API documentation:

- `src/vs/workbench/contrib/files/browser/files.contribution.ts`: Explorer drag-and-drop setting — 'should allow to move files' → 'should allow you to move files'
- `src/vs/monaco.d.ts`: Public API JSDoc — 'Controls if the editor should allow to move selections' → 'Controls whether the editor should allow you to move selections'