### PR TITLE
Fix British spelling: behaviour → behavior across codebase

### DIFF
--- a/src/vs/base/browser/ui/dropdown/dropdown.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdown.ts
@@ -56,7 +56,7 @@ export class BaseDropdown extends ActionRunner {
 		}
 
 		for (const event of [EventType.CLICK, EventType.MOUSE_DOWN, GestureEventType.Tap]) {
-			this._register(addDisposableListener(this.element, event, e => EventHelper.stop(e, true))); // prevent default click behaviour to trigger
+			this._register(addDisposableListener(this.element, event, e => EventHelper.stop(e, true))); // prevent default click behavior to trigger
 		}
 
 		for (const event of [EventType.MOUSE_DOWN, GestureEventType.Tap]) {

--- a/src/vs/base/common/buffer.ts
+++ b/src/vs/base/common/buffer.ts
@@ -136,7 +136,7 @@ export class VSBuffer {
 	slice(start?: number, end?: number): VSBuffer {
 		// IMPORTANT: use subarray instead of slice because TypedArray#slice
 		// creates shallow copy and NodeBuffer#slice doesn't. The use of subarray
-		// ensures the same, performance, behaviour.
+		// ensures the same, performance, behavior.
 		return new VSBuffer(this.buffer.subarray(start, end));
 	}
 

--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -355,7 +355,7 @@ function parsePattern(arg1: string | IRelativePattern, options: IGlobOptions): P
 		...options,
 		equals: ignoreCase ? equalsIgnoreCase : (a: string, b: string) => a === b,
 		endsWith: ignoreCase ? endsWithIgnoreCase : (str: string, candidate: string) => str.endsWith(candidate),
-		isEqualOrParent: (base: string, candidate: string) => isEqualOrParent(base, candidate, options.ignoreCase ?? !isLinux /* preserve old behaviour for when option is not adopted */)
+		isEqualOrParent: (base: string, candidate: string) => isEqualOrParent(base, candidate, options.ignoreCase ?? !isLinux /* preserve old behavior for when option is not adopted */)
 	};
 
 	// Check cache

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -496,7 +496,7 @@ function ensureWriteOptions(options?: IWriteFileOptions): IEnsuredWriteFileOptio
  */
 async function rename(source: string, target: string, windowsRetryTimeout: number | false = 60000): Promise<void> {
 	if (source === target) {
-		return;  // simulate node.js behaviour here and do a no-op if paths match
+		return;  // simulate node.js behavior here and do a no-op if paths match
 	}
 
 	try {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -415,7 +415,7 @@ export interface IEditorOptions {
 	 */
 	colorDecoratorsLimit?: number;
 	/**
-	 * Control the behaviour of comments in the editor.
+	 * Control the behavior of comments in the editor.
 	 */
 	comments?: IEditorCommentsOptions;
 	/**
@@ -458,7 +458,7 @@ export interface IEditorOptions {
 	 */
 	multiCursorMergeOverlapping?: boolean;
 	/**
-	 * Configure the behaviour when pasting a text with the line count equal to the cursor count.
+	 * Configure the behavior when pasting a text with the line count equal to the cursor count.
 	 * Defaults to 'spread'.
 	 */
 	multiCursorPaste?: 'spread' | 'full';
@@ -552,7 +552,7 @@ export interface IEditorOptions {
 	 */
 	autoIndentOnPasteWithinString?: boolean;
 	/**
-	 * Emulate selection behaviour of tab characters when using spaces for indentation.
+	 * Emulate selection behavior of tab characters when using spaces for indentation.
 	 * This means selection will stick to tab stops.
 	 */
 	stickyTabStops?: boolean;

--- a/src/vs/editor/common/cursor/cursorAtomicMoveOperations.ts
+++ b/src/vs/editor/common/cursor/cursorAtomicMoveOperations.ts
@@ -56,7 +56,7 @@ export class AtomicTabMoveOperations {
 	 * nearest tab, if atomic tabs are enabled. Left and right are used for the
 	 * arrow key movements, nearest is used for mouse selection. It returns
 	 * -1 if atomic tabs are not relevant and you should fall back to normal
-	 * behaviour.
+	 * behavior.
 	 *
 	 * **Note**: `position` and the return value are 0-based.
 	 */

--- a/src/vs/editor/common/model/intervalTree.ts
+++ b/src/vs/editor/common/model/intervalTree.ts
@@ -410,7 +410,7 @@ function adjustMarkerBeforeColumn(markerOffset: number, markerStickToPreviousCha
 }
 
 /**
- * This is a lot more complicated than strictly necessary to maintain the same behaviour
+ * This is a lot more complicated than strictly necessary to maintain the same behavior
  * as when decorations were implemented using two markers.
  */
 export function nodeAcceptEdit(node: IntervalNode, start: number, end: number, textLength: number, forceMoveMarkers: boolean): void {

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -37,8 +37,8 @@ export const Context = {
 	MultipleSuggestions: new RawContextKey<boolean>('suggestWidgetMultipleSuggestions', false, localize('suggestWidgetMultipleSuggestions', "Whether there are multiple suggestions to pick from")),
 	MakesTextEdit: new RawContextKey<boolean>('suggestionMakesTextEdit', true, localize('suggestionMakesTextEdit', "Whether inserting the current suggestion yields in a change or has everything already been typed")),
 	AcceptSuggestionsOnEnter: new RawContextKey<boolean>('acceptSuggestionOnEnter', true, localize('acceptSuggestionOnEnter', "Whether suggestions are inserted when pressing Enter")),
-	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behaviour")),
-	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behaviour is to insert or replace") }),
+	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behavior")),
+	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behavior is to insert or replace") }),
 	CanResolve: new RawContextKey<boolean>('suggestionCanResolve', false, localize('suggestionCanResolve', "Whether the current suggestion supports to resolve further details")),
 };
 

--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -189,7 +189,7 @@ export interface IEditorOptions {
 	 * Tells the editor to not receive keyboard focus when the editor is being opened.
 	 *
 	 * Will also not activate the group the editor opens in unless the group is already
-	 * the active one. This behaviour can be overridden via the `activation` option.
+	 * the active one. This behavior can be overridden via the `activation` option.
 	 */
 	preserveFocus?: boolean;
 
@@ -248,7 +248,7 @@ export interface IEditorOptions {
 	 * in the background without loading its contents.
 	 *
 	 * Will also not activate the group the editor opens in unless the group is already
-	 * the active one. This behaviour can be overridden via the `activation` option.
+	 * the active one. This behavior can be overridden via the `activation` option.
 	 */
 	inactive?: boolean;
 

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -816,7 +816,7 @@ export class FileService extends Disposable implements IFileService {
 
 	private async doMoveCopy(sourceProvider: IFileSystemProvider, source: URI, targetProvider: IFileSystemProvider, target: URI, mode: 'move' | 'copy', overwrite: boolean): Promise<'move' | 'copy'> {
 		if (source.toString() === target.toString()) {
-			return mode; // simulate node.js behaviour here and do a no-op if paths match
+			return mode; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		// validation

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -672,7 +672,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		const toFilePath = this.toFilePath(to);
 
 		if (fromFilePath === toFilePath) {
-			return; // simulate node.js behaviour here and do a no-op if paths match
+			return; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		try {
@@ -699,7 +699,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		const toFilePath = this.toFilePath(to);
 
 		if (fromFilePath === toFilePath) {
-			return; // simulate node.js behaviour here and do a no-op if paths match
+			return; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		try {

--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -292,7 +292,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 							mapPathToStatDisposable.delete(changedFileName);
 
 							// Depending on the OS the watcher runs on, there
-							// is different behaviour for when the watched
+							// is different behavior for when the watched
 							// folder path is being deleted:
 							//
 							// -   macOS: not reported but events continue to
@@ -376,7 +376,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 					if (type === 'rename' || !isEqual(changedFileName, pathBasename, !isLinux)) {
 
 						// Depending on the OS the watcher runs on, there
-						// is different behaviour for when the watched
+						// is different behavior for when the watched
 						// file path is being deleted:
 						//
 						// -   macOS: "rename" event is reported and events

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -70,11 +70,11 @@ export class LaunchMainService implements ILaunchMainService {
 			return;
 		}
 
-		// macOS: Electron > 7.x changed its behaviour to not
+		// macOS: Electron > 7.x changed its behavior to not
 		// bring the application to the foreground when a window
 		// is focused programmatically. Only via `app.focus` and
 		// the option `steal: true` can you get the previous
-		// behaviour back. The only reason to use this option is
+		// behavior back. The only reason to use this option is
 		// when a window is getting focused while the application
 		// is not in the foreground and since we got instructed
 		// to open a new window from another instance, we ensure

--- a/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
+++ b/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
@@ -611,7 +611,7 @@ export class LifecycleMainService extends Disposable implements ILifecycleMainSe
 			if (!veto && willRestart) {
 				// Windows: we are about to restart and as such we need to restore the original
 				// current working directory we had on startup to get the exact same startup
-				// behaviour. As such, we briefly change back to that directory and then when
+				// behavior. As such, we briefly change back to that directory and then when
 				// Code starts it will set it back to the installation directory again.
 				try {
 					if (isWindows) {

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -386,7 +386,7 @@ export class Menubar extends Disposable {
 		// so we need to unset it there.
 		//
 		// This is a bit ugly but `setApplicationMenu()` has some nice
-		// behaviour we want:
+		// behavior we want:
 		// - on macOS it is required because menus are application set
 		// - we use `getApplicationMenu()` to access the current state
 		// - new windows immediately get the same menu when opening

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1019,7 +1019,7 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 					this.handleAccept(false);
 				}
 				// Unset quick navigate after press. It is only valid once
-				// and should not result in any behaviour change afterwards
+				// and should not result in any behavior change afterwards
 				// if the picker remains open because there was no active item
 				this._quickNavigate = undefined;
 			}

--- a/src/vs/server/node/serverLifetimeService.ts
+++ b/src/vs/server/node/serverLifetimeService.ts
@@ -11,7 +11,7 @@ export const IServerLifetimeService = createDecorator<IServerLifetimeService>('s
 
 export const SHUTDOWN_TIMEOUT = 5 * 60 * 1000;
 
-/** Options controlling the auto-shutdown behaviour. */
+/** Options controlling the auto-shutdown behavior. */
 export interface IServerLifetimeOptions {
 	/** When `false` (default), the server never auto-shuts down. */
 	readonly enableAutoShutdown?: boolean;

--- a/src/vs/sessions/contrib/chat/browser/variableCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/variableCompletions.ts
@@ -105,7 +105,7 @@ function computeRange(model: ITextModel, position: Position, reg: RegExp): IComp
  * following the same pattern as {@link SlashCommandHandler}.
  *
  * Completions are scoped to the workspace selected in the workspace picker dropdown,
- * matching the behaviour of the "Add Context..." attach button.
+ * matching the behavior of the "Add Context..." attach button.
  * For local/remote workspaces the search service is used; for virtual filesystems
  * (e.g. `github-remote-file://`) the file service tree is walked directly.
  */

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -246,7 +246,7 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 			preserveFocus: options.preserveFocus,
 			pinned: options.pinned,
 			selection: options.selection,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: options.preserveFocus ? EditorActivation.RESTORE : undefined,
 			override: EditorResolution.EXCLUSIVE_ONLY

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -102,7 +102,7 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 			preserveFocus: options.preserveFocus,
 			pinned: options.pinned,
 			// selection: options.selection,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: options.preserveFocus ? EditorActivation.RESTORE : undefined,
 			label: options.label,

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -334,11 +334,11 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	private doFindGroupByDirection(direction: GroupDirection, source: IEditorGroupView | GroupIdentifier, wrap?: boolean): IEditorGroupView | undefined {
 		const sourceGroupView = this.assertGroupView(source);
 
-		// Find neighbours and sort by our MRU list
-		const neighbours = this.gridWidget.getNeighborViews(sourceGroupView, this.toGridViewDirection(direction), wrap);
-		neighbours.sort(((n1, n2) => this.mostRecentActiveGroups.indexOf(n1.id) - this.mostRecentActiveGroups.indexOf(n2.id)));
+		// Find neighbors and sort by our MRU list
+		const neighbors = this.gridWidget.getNeighborViews(sourceGroupView, this.toGridViewDirection(direction), wrap);
+		neighbors.sort(((n1, n2) => this.mostRecentActiveGroups.indexOf(n1.id) - this.mostRecentActiveGroups.indexOf(n2.id)));
 
-		return neighbours[0];
+		return neighbors[0];
 	}
 
 	private doFindGroupByLocation(location: GroupLocation, source: IEditorGroupView | GroupIdentifier, wrap?: boolean): IEditorGroupView | undefined {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -414,7 +414,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 				return;  // need at least 2 open editors
 			}
 
-			// Shift-key enables or disables this behaviour depending on the setting
+			// Shift-key enables or disables this behavior depending on the setting
 			if (this.groupsView.partOptions.scrollToSwitchTabs === true) {
 				if (e.shiftKey) {
 					return; // 'on': only enable this when Shift-key is not pressed

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -83,7 +83,7 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 		// This is technically not 100% correct, because 'api' can also be
 		// set as source if a model is resolved as text first and then
 		// transitions into the resolved language. But to preserve the current
-		// behaviour, we do not change this property. Rather, `languageChangeSource`
+		// behavior, we do not change this property. Rather, `languageChangeSource`
 		// can be used to get more fine grained information.
 		return typeof this._languageChangeSource === 'string';
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1170,7 +1170,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 					target: Target.GitHubCopilot,
 				});
 			} else {
-				// Core: use the default core behaviour
+				// Core: use the default core behavior
 				await this.instantiationService.invokeFunction(showConfigureHooksQuickPick, {
 					openEditor: async (resource) => {
 						await this.showEmbeddedEditor(resource, basename(resource), PromptsType.hook, PromptsStorage.local, true);

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
@@ -298,7 +298,7 @@ const enum Step {
 }
 
 /**
- * Optional callbacks and settings for customizing the hook creation and opening behaviour.
+ * Optional callbacks and settings for customizing the hook creation and opening behavior.
  * The agentic editor passes these to open hooks in the embedded editor and
  * track worktree files for auto-commit.
  */

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
@@ -30,7 +30,7 @@ import { PromptsStorage } from '../../common/promptSyntax/service/promptsService
 import { getTarget } from '../../common/promptSyntax/languageProviders/promptFileAttributes.js';
 
 /**
- * Options to override the default folder-picker and editor-open behaviour
+ * Options to override the default folder-picker and editor-open behavior
  * of the new-prompt-file actions. The agentic editor passes these to open
  * files in the embedded editor and pre-resolve the target folder.
  */

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -852,7 +852,7 @@ export function parsePluginSource(
 		return { kind: PluginSourceKind.RelativePath, path: resolved };
 	}
 
-	// String source → legacy relative-path behaviour.
+	// String source → legacy relative-path behavior.
 	if (typeof rawSource === 'string') {
 		const resolved = resolvePluginSource(pluginRoot, rawSource);
 		if (resolved === undefined) {

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -287,7 +287,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		if (items) {
 			await Promise.all(items.map(async item => {
 				const model = item.diffEditorViewModel.model;
-				const handleOriginal = model.original.uri.scheme !== Schemas.untitled && this._textFileService.isDirty(model.original.uri); // match diff editor behaviour
+				const handleOriginal = model.original.uri.scheme !== Schemas.untitled && this._textFileService.isDirty(model.original.uri); // match diff editor behavior
 
 				await Promise.all([
 					handleOriginal ? mode === 'save' ? this._textFileService.save(model.original.uri, options) : this._textFileService.revert(model.original.uri, options) : Promise.resolve(),

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -358,7 +358,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 				});
 			}
 			run(accessor: ServicesAccessor, args?: string | IOpenSettingsActionOptions) {
-				// Match the behaviour of workbench.action.openSettings
+				// Match the behavior of workbench.action.openSettings
 				args = typeof args === 'string' ? { query: args } : sanitizeOpenSettingsArgs(args);
 				return accessor.get(IPreferencesService).openWorkspaceSettings(args);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1825,7 +1825,7 @@ class SettingTextRenderer extends AbstractSettingTextRenderer implements ITreeRe
 		const template = super.renderTemplate(_container, false);
 
 		// TODO@9at8: listWidget filters out all key events from input boxes, so we need to come up with a better way
-		// Disable ArrowUp and ArrowDown behaviour in favor of list navigation
+		// Disable ArrowUp and ArrowDown behavior in favor of list navigation
 		template.toDispose.add(DOM.addStandardDisposableListener(template.inputBox.inputElement, DOM.EventType.KEY_DOWN, e => {
 			if (e.equals(KeyCode.UpArrow) || e.equals(KeyCode.DownArrow)) {
 				e.preventDefault();

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -131,7 +131,7 @@ export class SCMViewService implements ISCMViewService {
 	readonly didFinishLoadingRepositories = observableValue<boolean>(this, false);
 
 	get visibleRepositories(): ISCMRepository[] {
-		// In order to match the legacy behaviour, when the repositories are sorted by discovery time,
+		// In order to match the legacy behavior, when the repositories are sorted by discovery time,
 		// the visible repositories are sorted by the selection index instead of the discovery time.
 		if (this._repositoriesSortKey === ISCMRepositorySortKey.DiscoveryTime) {
 			return this._repositories

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -253,9 +253,9 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 	private registerEditorListeners() {
 		this._register(this.searchResultEditor.onMouseUp(e => {
 			if (e.event.detail === 1) {
-				const behaviour = this.searchConfig.searchEditor.singleClickBehaviour;
+				const behavior = this.searchConfig.searchEditor.singleClickBehaviour;
 				const position = e.target.position;
-				if (position && behaviour === 'peekDefinition') {
+				if (position && behavior === 'peekDefinition') {
 					const line = this.searchResultEditor.getModel()?.getLineContent(position.lineNumber) ?? '';
 					if (line.match(FILE_LINE_REGEX) || line.match(RESULT_LINE_REGEX)) {
 						this.searchResultEditor.setSelection(Range.fromPositions(position));
@@ -263,13 +263,13 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 					}
 				}
 			} else if (e.event.detail === 2) {
-				const behaviour = this.searchConfig.searchEditor.doubleClickBehaviour;
+				const behavior = this.searchConfig.searchEditor.doubleClickBehaviour;
 				const position = e.target.position;
-				if (position && behaviour !== 'selectWord') {
+				if (position && behavior !== 'selectWord') {
 					const line = this.searchResultEditor.getModel()?.getLineContent(position.lineNumber) ?? '';
 					if (line.match(RESULT_LINE_REGEX)) {
 						this.searchResultEditor.setSelection(Range.fromPositions(position));
-						this.commandService.executeCommand(behaviour === 'goToLocation' ? 'editor.action.goToDeclaration' : 'editor.action.openDeclarationToTheSide');
+						this.commandService.executeCommand(behavior === 'goToLocation' ? 'editor.action.goToDeclaration' : 'editor.action.openDeclarationToTheSide');
 					} else if (line.match(FILE_LINE_REGEX)) {
 						this.searchResultEditor.setSelection(Range.fromPositions(position));
 						this.commandService.executeCommand('editor.action.peekDefinition');

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
@@ -283,7 +283,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 		this._editorService.openEditor(webviewInput, {
 			pinned: true,
 			preserveFocus: showOptions.preserveFocus,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: showOptions.preserveFocus ? EditorActivation.RESTORE : undefined
 		}, showOptions.group);
@@ -299,7 +299,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 
 		this._editorService.openEditor(topLevelEditor, {
 			preserveFocus,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: preserveFocus ? EditorActivation.RESTORE : undefined
 		}, group);

--- a/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
+++ b/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
@@ -252,7 +252,7 @@ class NativeContextMenuService extends Disposable implements IContextMenuService
 				enabled: !!entry.enabled,
 				click: event => {
 
-					// To preserve pre-electron-2.x behaviour, we first trigger
+					// To preserve pre-electron-2.x behavior, we first trigger
 					// the onHide callback and then the action.
 					// Fixes https://github.com/microsoft/vscode/issues/45601
 					onHide();

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -425,7 +425,7 @@ export interface IEditorGroupsContainer {
 
 	/**
 	 * Merge the editors of a group into a target group. By default, all editors will
-	 * move and the source group will close. This behaviour can be configured via the
+	 * move and the source group will close. This behavior can be configured via the
 	 * `IMergeGroupOptions` options.
 	 *
 	 * @param group the group to merge

--- a/src/vs/workbench/services/lifecycle/common/lifecycle.ts
+++ b/src/vs/workbench/services/lifecycle/common/lifecycle.ts
@@ -296,7 +296,7 @@ export interface ILifecycleService {
 
 	/**
 	 * Triggers a shutdown of the workbench. Depending on native or web, this can have
-	 * different implementations and behaviour.
+	 * different implementations and behavior.
 	 *
 	 * **Note:** this should normally not be called. See related methods in `IHostService`
 	 * and `INativeHostService` to close a window or quit the application.

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -69,7 +69,7 @@ export interface IFileWorkingCopyModel extends IDisposable {
 
 	/**
 	 * Optional additional configuration for the model that drives
-	 * some of the working copy behaviour.
+	 * some of the working copy behavior.
 	 */
 	readonly configuration?: IFileWorkingCopyModelConfiguration;
 

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -60,7 +60,7 @@ export interface IFileWorkingCopyManager<S extends IStoredFileWorkingCopyModel, 
 	 * disposed.
 	 *
 	 * Use the `IStoredFileWorkingCopyResolveOptions.reload` option to control the
-	 * behaviour for when a stored file working copy was previously already resolved
+	 * behavior for when a stored file working copy was previously already resolved
 	 * with regards to resolving it again from the underlying file resource
 	 * or not.
 	 *

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager.ts
@@ -87,7 +87,7 @@ export interface IStoredFileWorkingCopyManager<M extends IStoredFileWorkingCopyM
 	 * disposed.
 	 *
 	 * Use the `IStoredFileWorkingCopyResolveOptions.reload` option to control the
-	 * behaviour for when a stored file working copy was previously already resolved
+	 * behavior for when a stored file working copy was previously already resolved
 	 * with regards to resolving it again from the underlying file resource
 	 * or not.
 	 *


### PR DESCRIPTION
Replace British English `behaviour`/`behaviours` with American English `behavior`/`behaviors` in comments, JSDoc, and local variable names across 39 files.

**Preserves** public API identifiers such as `singleClickBehaviour` and `doubleClickBehaviour` configuration keys.

**Affected areas:**
- Base utilities (`glob.ts`, `buffer.ts`, `pfs.ts`, `dropdown.ts`)
- Platform files, editor, launch, lifecycle, quickinput, menubar
- Workbench editor/API/chat/preferences/SCM/search/webview/working-copy
- Editor suggestion context key descriptions (`suggest.ts`)
- Server lifecycle

This is a pure text fix — no logic changes.