### PR TITLE
Fix British spellings: colour → color, customised → customized, a HTML → an HTML

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
@@ -381,7 +381,7 @@ function attributeArrayToRecord(attributes: string[]): Record<string, string> {
 	return record;
 }
 
-/** Slightly customised CDP debugger inspect highlight colours. */
+/** Slightly customized CDP debugger inspect highlight colors. */
 const inspectHighlightConfig = {
 	showInfo: true,
 	showRulers: false,

--- a/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
+++ b/src/vs/platform/theme/electron-main/themeMainServiceImpl.ts
@@ -148,7 +148,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 		}
 
 		// high contrast is set if one of shouldUseInvertedColorScheme or shouldUseHighContrastColors is set,
-		// reflecting the 'Invert colours' and `Increase contrast` settings in MacOS
+		// reflecting the 'Invert colors' and `Increase contrast` settings in MacOS
 		else if (isMacintosh) {
 			if (electron.nativeTheme.shouldUseInvertedColorScheme || electron.nativeTheme.shouldUseHighContrastColors) {
 				return { dark: electron.nativeTheme.shouldUseDarkColors, highContrast: true };

--- a/src/vs/workbench/contrib/debug/browser/debugColors.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugColors.ts
@@ -113,7 +113,7 @@ export function registerColors() {
 	}, localize('debugIcon.stepBackForeground', "Debug toolbar icon for step back."));
 
 	registerThemingParticipant((theme, collector) => {
-		// All these colours provide a default value so they will never be undefined, hence the `!`
+		// All these colors provide a default value so they will never be undefined, hence the `!`
 		const badgeBackgroundColor = theme.getColor(badgeBackground)!;
 		const badgeForegroundColor = theme.getColor(badgeForeground)!;
 		const listDeemphasizedForegroundColor = theme.getColor(listDeemphasizedForeground)!;
@@ -125,7 +125,7 @@ export function registerColors() {
 		const toolbarHoverBackgroundColor = theme.getColor(toolbarHoverBackground);
 
 		collector.addRule(`
-			/* Text colour of the call stack row's filename */
+			/* Text color of the call stack row's filename */
 			.debug-pane .debug-call-stack .monaco-list-row:not(.selected) .stack-frame > .file .file-name {
 				color: ${listDeemphasizedForegroundColor}
 			}

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -174,12 +174,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 30; i <= 37; i++) {
 			const customClassName: string = 'code-foreground-colored';
 
-			// Foreground colour class
+			// Foreground color class
 			assertSingleSequenceElement('\x1b[' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom foreground class not found on element after foreground ANSI code #${i}.`);
 			});
 
-			// Cancellation code removes colour class
+			// Cancellation code removes color class
 			assertSingleSequenceElement('\x1b[' + i + ';39m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom foreground class still found after foreground cancellation code.');
 				assertInlineColor(child, 'foreground', undefined, 'Custom color style still found after foreground cancellation code.');
@@ -189,12 +189,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 40; i <= 47; i++) {
 			const customClassName: string = 'code-background-colored';
 
-			// Foreground colour class
+			// Foreground color class
 			assertSingleSequenceElement('\x1b[' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom background class not found on element after background ANSI code #${i}.`);
 			});
 
-			// Cancellation code removes colour class
+			// Cancellation code removes color class
 			assertSingleSequenceElement('\x1b[' + i + ';49m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom background class still found after background cancellation code.');
 				assertInlineColor(child, 'foreground', undefined, 'Custom color style still found after background cancellation code.');
@@ -205,12 +205,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 0; i <= 255; i++) {
 			const customClassName: string = 'code-underline-colored';
 
-			// Underline colour class
+			// Underline color class
 			assertSingleSequenceElement('\x1b[58;5;' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom underline color class not found on element after underline color ANSI code 58;5;${i}m.`);
 			});
 
-			// Cancellation underline color code removes colour class
+			// Cancellation underline color code removes color class
 			assertSingleSequenceElement('\x1b[58;5;' + i + 'm\x1b[59m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom underline color class still found after underline color cancellation code 59m.');
 				assertInlineColor(child, 'underline', undefined, 'Custom underline color style still found after underline color cancellation code 59m.');
@@ -994,7 +994,7 @@ suite('Debug - ANSI Handling', () => {
 	test('Empty sequence output', () => {
 
 		const sequences: string[] = [
-			// No colour codes
+			// No color codes
 			'',
 			'\x1b[;m',
 			'\x1b[1;;m',

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -278,7 +278,7 @@ export interface IWebview extends IDisposable {
  */
 export interface IWebviewElement extends IWebview {
 	/**
-	 * Append the webview to a HTML element.
+	 * Append the webview to an HTML element.
 	 *
 	 * Note that the webview content will be destroyed if any part of the parent hierarchy
 	 * changes. You can avoid this by using a {@link IOverlayWebview} instead.


### PR DESCRIPTION
Fix British English spellings in comments and JSDoc across 5 files:

- `browserViewElementInspector.ts`: `customised`/`colours` → `customized`/`colors` in JSDoc comment
- `debugColors.ts`: `colours` → `colors` in code comments
- `debugANSIHandling.test.ts`: `colour` → `color` in test comments
- `themeMainServiceImpl.ts`: `'Invert colours'` → `'Invert colors'` in comment (macOS setting reference — the actual macOS name uses US English "Colors")
- `webview.ts`: `a HTML element` → `an HTML element` in JSDoc (article fix)

All changes are in comments/JSDoc only — no logic changes.