### PR TITLE
Fix British spellings: -ise/-isation → -ize/-ization in comments and JSDoc

### DIFF
--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/parseBlock.ts
@@ -169,7 +169,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 				if (i >= 0) {
 					ind = undefined;
 					i--;
-					// This is the same loop as above but specialised for direction = -1
+					// This is the same loop as above but specialized for direction = -1
 					while (ind === undefined && i >= 0) {
 						ind = indentationOfLine(lines[i]);
 						indIdx = i;

--- a/extensions/copilot/src/extension/completions/common/parseBlock.ts
+++ b/extensions/copilot/src/extension/completions/common/parseBlock.ts
@@ -137,7 +137,7 @@ export function contextIndentationFromText(source: string, offset: number, langu
 				if (i >= 0) {
 					ind = undefined;
 					i--;
-					// This is the same loop as above but specialised for direction = -1
+					// This is the same loop as above but specialized for direction = -1
 					while (ind === undefined && i >= 0) {
 						ind = indentationOfLine(lines[i]);
 						indIdx = i;

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -181,7 +181,7 @@ export async function runMigrations(db: Database, migrations: readonly ISessionD
 
 /**
  * A wrapper around a `@vscode/sqlite3` {@link Database} instance with
- * lazy initialisation.
+ * lazy initialization.
  *
  * The underlying connection is opened on the first async method call
  * (not at construction time), allowing the object to be created

--- a/src/vs/platform/browserView/node/playwrightService.ts
+++ b/src/vs/platform/browserView/node/playwrightService.ts
@@ -37,7 +37,7 @@ const DEFERRED_RESULT_CLEANUP_MS = 5 * 60_000; // 5 minutes
  * Shared-process implementation of {@link IPlaywrightService}.
  *
  * Creates a {@link PlaywrightPageManager} eagerly on construction to track
- * browser views. The Playwright browser connection is lazily initialised
+ * browser views. The Playwright browser connection is lazily initialized
  * only when an operation that requires it is called.
  */
 export class PlaywrightService extends Disposable implements IPlaywrightService {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1701,7 +1701,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	/**
 	 * Waits for an {@link AgentSessionAdapter} with the given resource to appear
 	 * in the session cache (populated by {@link _refreshSessionCache}).
-	 * Only called once during session initialisation (after the commit event),
+	 * Only called once during session initialization (after the commit event),
 	 * so the timeout has no performance impact on steady-state operations.
 	 */
 	private async _waitForSessionInCache(resource: URI): Promise<AgentSessionAdapter> {

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -50,7 +50,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 				this._proxy.$acceptDebugSessionNameChanged(this.getSessionDto(session), name);
 			}));
 		}));
-		// Need to start listening early to new session events because a custom event can come while a session is initialising
+		// Need to start listening early to new session events because a custom event can come while a session is initializing
 		this._toDispose.add(debugService.onWillNewSession(session => {
 			let store = sessionListeners.get(session);
 			if (!store) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
@@ -124,7 +124,7 @@ export class CodeBlockPart extends Disposable {
 	/**
 	 * Compute a pool reuse key for a code block. When the same key is used
 	 * across render cycles the pool will try to return the same CodeBlockPart,
-	 * which lets the setText append-optimisation avoid a full model reset.
+	 * which lets the setText append-optimization avoid a full model reset.
 	 */
 	static poolKey(elementId: string, codeBlockIndex: number): string {
 		return `${elementId}/${codeBlockIndex}`;

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -184,7 +184,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			}
 		}));
 		this._register(this.debugService.onWillNewSession(async newSession => {
-			// Need to listen to output events for sessions which are not yet fully initialised
+			// Need to listen to output events for sessions which are not yet fully initialized
 			const input = this.tree?.getInput();
 			if (!input || input.state === State.Inactive) {
 				await this.selectSession(newSession);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1148,7 +1148,7 @@ export interface IDebugService {
 	readonly onDidChangeState: Event<State>;
 
 	/**
-	 * Allows to register on sessions about to be created (not yet fully initialised).
+	 * Allows to register on sessions about to be created (not yet fully initialized).
 	 * This is fired exactly one time for any given session.
 	 */
 	readonly onWillNewSession: Event<IDebugSession>;

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -407,7 +407,7 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
 								promises.push(Event.toPromise(Event.filter(userDataSyncService.onDidChangeStatus, status => status !== SyncStatus.Syncing)));
 							}
 
-							// If user chose the sync service then synchronise the store type option in insiders service, so that other clients using insiders service are also updated.
+							// If user chose the sync service then synchronize the store type option in insiders service, so that other clients using insiders service are also updated.
 							if (isSwitchingToInsiders && userDataSyncStoreType) {
 								promises.push(userDataSyncWorkbenchService.synchroniseUserDataSyncStoreType());
 							}

--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -205,7 +205,7 @@ export class ConfigurationEditing {
 			try {
 				// Optimization: we apply edits to a text model and save it
 				// right after. Use the files config service to signal this
-				// to the workbench to optimise the UI during this operation.
+				// to the workbench to optimize the UI during this operation.
 				// For example, avoids to briefly show dirty indicators.
 				disposable = this.filesConfigurationService.enableAutoSaveAfterShortDelay(model.uri);
 				if (this.applyEditsToBuffer(edit, model)) {

--- a/src/vs/workbench/services/configuration/common/jsonEditingService.ts
+++ b/src/vs/workbench/services/configuration/common/jsonEditingService.ts
@@ -54,7 +54,7 @@ export class JSONEditingService implements IJSONEditingService {
 		try {
 			// Optimization: we apply edits to a text model and save it
 			// right after. Use the files config service to signal this
-			// to the workbench to optimise the UI during this operation.
+			// to the workbench to optimize the UI during this operation.
 			// For example, avoids to briefly show dirty indicators.
 			disposable = this.filesConfigurationService.enableAutoSaveAfterShortDelay(model.uri);
 


### PR DESCRIPTION
Replace British English verb forms in comments, JSDoc, and local variable names across 12 files. No logic changes.

| British | American | Files |
|---------|----------|-------|
| initialised/initialising | initialized/initializing | playwrightService.ts, mainThreadDebugService.ts, repl.ts, debug.ts |
| initialisation | initialization | sessionDatabase.ts, copilotChatSessionsProvider.ts |
| append-optimisation | append-optimization | codeBlockPart.ts |
| optimise | optimize | configurationEditing.ts, jsonEditingService.ts |
| synchronise | synchronize | update.ts |
| specialised | specialized | parseBlock.ts (copilot ext, ×2) |