### PR TITLE
Fix typos: whith → with, fullfilled → fulfilled in comments

### DIFF
--- a/extensions/copilot/src/util/vs/platform/instantiation/common/instantiationService.ts
+++ b/extensions/copilot/src/util/vs/platform/instantiation/common/instantiationService.ts
@@ -268,7 +268,7 @@ export class InstantiationService implements IInstantiationService {
 			for (const { data } of roots) {
 				// Repeat the check for this still being a service sync descriptor. That's because
 				// instantiating a dependency might have side-effect and recursively trigger instantiation
-				// so that some dependencies are now fullfilled already.
+				// so that some dependencies are now fulfilled already.
 				const instanceOrDesc = this._getServiceInstanceOrDescriptor(data.id);
 				if (instanceOrDesc instanceof SyncDescriptor) {
 					// create instance and overwrite the service collections

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -266,7 +266,7 @@ export class InstantiationService implements IInstantiationService {
 			for (const { data } of roots) {
 				// Repeat the check for this still being a service sync descriptor. That's because
 				// instantiating a dependency might have side-effect and recursively trigger instantiation
-				// so that some dependencies are now fullfilled already.
+				// so that some dependencies are now fulfilled already.
 				const instanceOrDesc = this._getServiceInstanceOrDescriptor(data.id);
 				if (instanceOrDesc instanceof SyncDescriptor) {
 					// create instance and overwrite the service collections

--- a/src/vs/workbench/services/timer/electron-browser/timerService.ts
+++ b/src/vs/workbench/services/timer/electron-browser/timerService.ts
@@ -105,7 +105,7 @@ export function didUseCachedData(productService: IProductService, storageService
 	// or subsequent
 	if (typeof _didUseCachedData !== 'boolean') {
 		if (!environmentService.window.isCodeCaching || !productService.commit) {
-			_didUseCachedData = false; // we only produce cached data whith commit and code cache path
+			_didUseCachedData = false; // we only produce cached data with commit and code cache path
 		} else if (storageService.get(lastRunningCommitStorageKey, StorageScope.APPLICATION) === productService.commit) {
 			_didUseCachedData = true; // subsequent start on same commit, assume cached data is there
 		} else {


### PR DESCRIPTION
Fix two typos in code comments:

- `whith` → `with` in `timerService.ts` (line 108)
- `fullfilled` → `fulfilled` in `instantiationService.ts` (line 269) and the copilot extension copy (line 271)

All changes are in comments only — no logic changes.