### PR TITLE
Fix grammar: 'controls if' → 'controls whether' in localized strings

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3806,7 +3806,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 				}
 			],
 			default: defaults,
-			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget. Also be aware of the {0}-setting which controls if suggestions are triggered by special characters.", '`#editor.suggestOnTriggerCharacters#`'),
+			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget. Also be aware of the {0}-setting which controls whether suggestions are triggered by special characters.", '`#editor.suggestOnTriggerCharacters#`'),
 			experiment: {
 				mode: 'auto'
 			}

--- a/src/vs/workbench/contrib/codeEditor/browser/diffEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/diffEditorAccessibilityHelp.ts
@@ -37,7 +37,7 @@ export class DiffEditorAccessibilityHelp implements IAccessibleViewImplementatio
 		}
 
 		const switchSides = localize('msg3', "Run the command Diff Editor: Switch Side{0} to toggle between the original and modified editors.", '<keybinding:diffEditor.switchSide>');
-		const diffEditorActiveAnnouncement = localize('msg5', "The setting, accessibility.verbosity.diffEditorActive, controls if a diff editor announcement is made when it becomes the active editor.");
+		const diffEditorActiveAnnouncement = localize('msg5', "The setting, accessibility.verbosity.diffEditorActive, controls whether a diff editor announcement is made when it becomes the active editor.");
 
 		const keys = ['accessibility.signals.diffLineDeleted', 'accessibility.signals.diffLineInserted', 'accessibility.signals.diffLineModified'];
 		const content = [

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorAccessibilityHelp.ts
@@ -48,7 +48,7 @@ function getAccessibilityHistoryHelpText(): string {
 		localize('replEditor.historyOverview', 'You are in a REPL History which is a list of cells that have been executed in the REPL. Each cell has an input, an output, and the cell container.'),
 		localize('replEditor.focusCellEditor', 'The Edit Cell command{0} will move focus to the read-only editor for the input of the cell.', '<keybinding:notebook.cell.edit>'),
 		localize('replEditor.cellNavigation', 'The Quit Edit command{0} will move focus to the cell container, where the up and down arrows will also move focus between cells in the history.', '<keybinding:notebook.cell.quitEdit>'),
-		localize('replEditor.accessibilityView', 'Run the Open Accessbility View command{0} while navigating the history for an accessible view of the item\'s output.', '<keybinding:editor.action.accessibleView>'),
+		localize('replEditor.accessibilityView', 'Run the Open Accessibility View command{0} while navigating the history for an accessible view of the item\'s output.', '<keybinding:editor.action.accessibleView>'),
 		localize('replEditor.focusInOutput', 'The Focus Output command{0} will set focus on the output when focused on a previously executed item.', '<keybinding:notebook.cell.focusInOutput>'),
 		localize('replEditor.focusReplInputFromHistory', 'The Focus Input Editor command{0} will move focus to the REPL input box.', '<keybinding:repl.input.focus>'),
 		localize('replEditor.focusLastItemAdded', 'The Focus Last executed command{0} will move focus to the last executed item in the REPL history.', '<keybinding:repl.focusLastItemExecuted>'),

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorAccessibilityHelp.ts
@@ -25,10 +25,10 @@ function getAccessibilityInputHelpText(): string {
 	return [
 		localize('replEditor.inputOverview', 'You are in a REPL Editor Input box which will accept code to be executed in the REPL.'),
 		localize('replEditor.execute', 'The Execute command{0} will evaluate the expression in the input box.', '<keybinding:repl.execute>'),
-		localize('replEditor.configReadExecution', 'The setting `accessibility.replEditor.readLastExecutionOutput` controls if output will be automatically read when execution completes.'),
-		localize('replEditor.autoFocusRepl', 'The setting `accessibility.replEditor.autoFocusReplExecution` controls if focus will automatically move to the REPL after executing code.'),
+		localize('replEditor.configReadExecution', 'The setting `accessibility.replEditor.readLastExecutionOutput` controls whether output will be automatically read when execution completes.'),
+		localize('replEditor.autoFocusRepl', 'The setting `accessibility.replEditor.autoFocusReplExecution` controls whether focus will automatically move to the REPL after executing code.'),
 		localize('replEditor.focusLastItemAdded', 'The Focus Last executed command{0} will move focus to the last executed item in the REPL history.', '<keybinding:repl.focusLastItemExecuted>'),
-		localize('replEditor.inputAccessibilityView', 'When you run the Open Accessbility View command{0} from this input box, the output from the last execution will be shown in the accessibility view.', '<keybinding:editor.action.accessibleView>'),
+		localize('replEditor.inputAccessibilityView', 'When you run the Open Accessibility View command{0} from this input box, the output from the last execution will be shown in the accessibility view.', '<keybinding:editor.action.accessibleView>'),
 		localize('replEditor.focusReplInput', 'The Focus Input Editor command{0} will bring the focus back to this editor.', '<keybinding:repl.input.focus>'),
 	].join('\n');
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/common/terminalSuggestConfiguration.ts
@@ -95,7 +95,7 @@ export const terminalSuggestConfiguration: IStringDictionary<IConfigurationPrope
 	},
 	[TerminalSuggestSettingId.QuickSuggestions]: {
 		restricted: true,
-		markdownDescription: localize('suggest.quickSuggestions', "Controls whether suggestions should automatically show up while typing. Also be aware of the {0}-setting which controls if suggestions are triggered by special characters.", `\`#${TerminalSuggestSettingId.SuggestOnTriggerCharacters}#\``),
+		markdownDescription: localize('suggest.quickSuggestions', "Controls whether suggestions should automatically show up while typing. Also be aware of the {0}-setting which controls whether suggestions are triggered by special characters.", `\`#${TerminalSuggestSettingId.SuggestOnTriggerCharacters}#\``),
 		type: 'object',
 		properties: {
 			commands: {


### PR DESCRIPTION
Fix grammatically incorrect `controls if` (should be `controls whether`) in user-visible localized strings, plus one `Accessbility` typo.

| File | Change |
|------|--------|
| `editorOptions.ts` | `controls if suggestions are triggered` → `controls whether suggestions are triggered` |
| `diffEditorAccessibilityHelp.ts` | `controls if a diff editor announcement` → `controls whether a diff editor announcement` |
| `replEditorAccessibilityHelp.ts` | Two `controls if` → `controls whether` fixes + `Accessbility` → `Accessibility` |
| `terminalSuggestConfiguration.ts` | `controls if suggestions are triggered` → `controls whether suggestions are triggered` |

"Whether" is the correct word for yes/no questions; "if" introduces conditional clauses.