### PR TITLE
Fix typos: curren, disposeable, diposable, shoudl

### DIFF
--- a/extensions/copilot/src/platform/notebook/common/alternativeContentProvider.xml.ts
+++ b/extensions/copilot/src/platform/notebook/common/alternativeContentProvider.xml.ts
@@ -158,7 +158,7 @@ export class AlternativeXmlNotebookContentProvider extends BaseAlternativeNotebo
 			} else if (index >= 0) {
 				if (previousLineEndedWithEndCellMarker && previousLine) {
 					// Some how we have two subsequent lines that end with the cell marker,
-					// Weird, shoudl not happen, if it does, yield the previous line.
+					// Weird, should not happen, if it does, yield the previous line.
 					yield previousLine;
 					previousLine = undefined;
 				}

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -159,7 +159,7 @@ export class DisposableTracker implements IDisposableTracker {
 			});
 
 			if (uncoveredLeakingObjs.length === 0) {
-				throw new Error('There are cyclic diposable chains!');
+				throw new Error('There are cyclic disposable chains!');
 			}
 		}
 

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -240,7 +240,7 @@ export const enum CustomTitleBarVisibility {
 }
 
 export function hasCustomTitlebar(configurationService: IConfigurationService, titleBarStyle?: TitlebarStyle): boolean {
-	// Returns if it possible to have a custom title bar in the curren session
+	// Returns if it possible to have a custom title bar in the current session
 	// Does not imply that the title bar is visible
 	return true;
 }

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -356,7 +356,7 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 	}
 
 	disposeTemplate(templateData: ICommentThreadTemplateData): void {
-		templateData.disposables.forEach(disposeable => disposeable.dispose());
+		templateData.disposables.forEach(disposable => disposable.dispose());
 		templateData.elementDisposables.dispose();
 		templateData.actionBar.dispose();
 	}

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfilesEditor.ts
@@ -1149,7 +1149,7 @@ class UseForCurrentWindowPropertyRenderer extends ProfilePropertyRenderer {
 		let profileElement: ProfileTreeElement | undefined;
 
 		const useForCurrentWindowContainer = append(parent, $('.profile-row-container'));
-		append(useForCurrentWindowContainer, $('.profile-label-element', undefined, localize('use for curren window', "Use for Current Window")));
+		append(useForCurrentWindowContainer, $('.profile-label-element', undefined, localize('use for current window', "Use for Current Window")));
 		const useForCurrentWindowValueContainer = append(useForCurrentWindowContainer, $('.profile-use-for-current-container'));
 		const useForCurrentWindowTitle = localize('enable for current window', "Use this profile for the current window");
 		const useForCurrentWindowCheckbox = disposables.add(new Checkbox(useForCurrentWindowTitle, false, defaultCheckboxStyles));


### PR DESCRIPTION
Fix five small typos:

| Typo | Correction | File |
|------|------------|------|
| `curren session` | `current session` | window.ts (comment) |
| `use for curren window` | `use for current window` | userDataProfilesEditor.ts (localize key string) |
| `disposeable` | `disposable` | commentsTreeViewer.ts (local variable name) |
| `diposable` | `disposable` | lifecycle.ts (error message string) |
| `shoudl` | `should` | alternativeContentProvider.xml.ts (comment) |