### PR TITLE
Fix typos: receieve → receive, implictly → implicitly

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantTelemetry.ts
@@ -928,7 +928,7 @@ export class InlineChatTelemetry extends ChatTelemetry<IDocumentContext> {
 				"messageTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens are in the rest of the query, without the command." },
 				"promptTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens are in the overall prompt." },
 				"responseTokenCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many tokens were in the response." },
-				"implicitCommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the command was implictly detected or provided by the user." },
+				"implicitCommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether the command was implicitly detected or provided by the user." },
 				"attemptCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many times the user has retried." },
 				"selectionLineCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many lines are in the current selection." },
 				"wholeRangeLineCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "How many lines are in the expanded whole range." },

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -159,7 +159,7 @@ export interface IStartupMetrics {
 	 */
 	readonly timers: {
 		/**
-		 * The time it took to receieve the [`ready`](https://electronjs.org/docs/api/app#event-ready)-event. Measured from the first line
+		 * The time it took to receive the [`ready`](https://electronjs.org/docs/api/app#event-ready)-event. Measured from the first line
 		 * of JavaScript code till receiving that event.
 		 *
 		 * * Happens in the main-process


### PR DESCRIPTION
Fix two typos in JSDoc and telemetry comments:

- `receieve` → `receive` in `timerService.ts` JSDoc (line 162)
- `implictly` → `implicitly` in `chatParticipantTelemetry.ts` telemetry comment (line 931)

All changes are in comments only — no logic changes.