### PR TITLE
Fix grammar and British spelling in editor option descriptions and comments

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -232,7 +232,7 @@ export interface IEditorOptions {
 	 */
 	overviewRulerLanes?: number;
 	/**
-	 * Controls if a border should be drawn around the overview ruler.
+	 * Controls whether a border should be drawn around the overview ruler.
 	 * Defaults to `true`.
 	 */
 	overviewRulerBorder?: boolean;
@@ -572,7 +572,7 @@ export interface IEditorOptions {
 	 */
 	doubleClickSelectsBlock?: boolean;
 	/**
-	 * Controls if the editor should allow to move selections via drag and drop.
+	 * Controls whether the editor should allow to move selections via drag and drop.
 	 * Defaults to false.
 	 */
 	dragAndDrop?: boolean;
@@ -1724,11 +1724,11 @@ export interface IEditorFindOptions {
 	 */
 	findOnType?: boolean;
 	/**
-	 * Controls if we seed search string in the Find Widget with editor selection.
+	 * Controls whether we seed search string in the Find Widget with editor selection.
 	 */
 	seedSearchStringFromSelection?: 'never' | 'always' | 'selection';
 	/**
-	 * Controls if Find in Selection flag is turned on in the editor.
+	 * Controls whether Find in Selection flag is turned on in the editor.
 	 */
 	autoFindInSelection?: 'never' | 'always' | 'multiline';
 	/*
@@ -1737,7 +1737,7 @@ export interface IEditorFindOptions {
 	addExtraSpaceOnTop?: boolean;
 	/**
 	 * @internal
-	 * Controls if the Find Widget should read or modify the shared find clipboard on macOS
+	 * Controls whether the Find Widget should read or modify the shared find clipboard on macOS
 	 */
 	globalFindClipboard?: boolean;
 	/**
@@ -5638,7 +5638,7 @@ export interface IDropIntoEditorOptions {
 	enabled?: boolean;
 
 	/**
-	 * Controls if a widget is shown after a drop.
+	 * Controls whether a widget is shown after a drop.
 	 * Defaults to 'afterDrop'.
 	 */
 	showDropSelector?: 'afterDrop' | 'never';
@@ -5663,7 +5663,7 @@ class EditorDropIntoEditor extends BaseEditorOption<EditorOption.dropIntoEditor,
 				},
 				'editor.dropIntoEditor.showDropSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls if a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
+					markdownDescription: nls.localize('dropIntoEditor.showDropSelector', "Controls whether a widget is shown when dropping files into the editor. This widget lets you control how the file is dropped."),
 					enum: [
 						'afterDrop',
 						'never'
@@ -5705,7 +5705,7 @@ export interface IPasteAsOptions {
 	enabled?: boolean;
 
 	/**
-	 * Controls if a widget is shown after a drop.
+	 * Controls whether a widget is shown after a drop.
 	 * Defaults to 'afterPaste'.
 	 */
 	showPasteSelector?: 'afterPaste' | 'never';
@@ -5730,7 +5730,7 @@ class EditorPasteAs extends BaseEditorOption<EditorOption.pasteAs, IPasteAsOptio
 				},
 				'editor.pasteAs.showPasteSelector': {
 					type: 'string',
-					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls if a widget is shown when pasting content in to the editor. This widget lets you control how the file is pasted."),
+					markdownDescription: nls.localize('pasteAs.showPasteSelector', "Controls whether a widget is shown when pasting content into the editor. This widget lets you control how the file is pasted."),
 					enum: [
 						'afterPaste',
 						'never'
@@ -6556,7 +6556,7 @@ export const EditorOptions = {
 	)),
 	renderLineHighlightOnlyWhenFocus: register(new EditorBooleanOption(
 		EditorOption.renderLineHighlightOnlyWhenFocus, 'renderLineHighlightOnlyWhenFocus', false,
-		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls if the editor should render the current line highlight only when the editor is focused.") }
+		{ description: nls.localize('renderLineHighlightOnlyWhenFocus', "Controls whether the editor should render the current line highlight only when the editor is focused.") }
 	)),
 	renderValidationDecorations: register(new EditorStringEnumOption(
 		EditorOption.renderValidationDecorations, 'renderValidationDecorations',

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -87,7 +87,7 @@ export abstract class BaseWindow extends Disposable {
 			// to focus the window which can take care of bringin the
 			// window to the front.
 			//
-			// To minimise disruption by bringing windows to the front
+			// To minimize disruption by bringing windows to the front
 			// by accident, we only do this if the window is not already
 			// focused and the active window is not the target window
 			// but has focus. This is an indication that multiple windows

--- a/src/vs/workbench/contrib/debug/browser/debugColors.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugColors.ts
@@ -125,7 +125,7 @@ export function registerColors() {
 		const toolbarHoverBackgroundColor = theme.getColor(toolbarHoverBackground);
 
 		collector.addRule(`
-			/* Text colour of the call stack row's filename */
+			/* Text color of the call stack row's filename */
 			.debug-pane .debug-call-stack .monaco-list-row:not(.selected) .stack-frame > .file .file-name {
 				color: ${listDeemphasizedForegroundColor}
 			}

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -174,12 +174,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 30; i <= 37; i++) {
 			const customClassName: string = 'code-foreground-colored';
 
-			// Foreground colour class
+			// Foreground color class
 			assertSingleSequenceElement('\x1b[' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom foreground class not found on element after foreground ANSI code #${i}.`);
 			});
 
-			// Cancellation code removes colour class
+			// Cancellation code removes color class
 			assertSingleSequenceElement('\x1b[' + i + ';39m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom foreground class still found after foreground cancellation code.');
 				assertInlineColor(child, 'foreground', undefined, 'Custom color style still found after foreground cancellation code.');
@@ -189,12 +189,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 40; i <= 47; i++) {
 			const customClassName: string = 'code-background-colored';
 
-			// Foreground colour class
+			// Foreground color class
 			assertSingleSequenceElement('\x1b[' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom background class not found on element after background ANSI code #${i}.`);
 			});
 
-			// Cancellation code removes colour class
+			// Cancellation code removes color class
 			assertSingleSequenceElement('\x1b[' + i + ';49m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom background class still found after background cancellation code.');
 				assertInlineColor(child, 'foreground', undefined, 'Custom color style still found after background cancellation code.');
@@ -205,12 +205,12 @@ suite('Debug - ANSI Handling', () => {
 		for (let i = 0; i <= 255; i++) {
 			const customClassName: string = 'code-underline-colored';
 
-			// Underline colour class
+			// Underline color class
 			assertSingleSequenceElement('\x1b[58;5;' + i + 'm', (child) => {
 				assert(child.classList.contains(customClassName), `Custom underline color class not found on element after underline color ANSI code 58;5;${i}m.`);
 			});
 
-			// Cancellation underline color code removes colour class
+			// Cancellation underline color code removes color class
 			assertSingleSequenceElement('\x1b[58;5;' + i + 'm\x1b[59m', (child) => {
 				assert(child.classList.contains(customClassName) === false, 'Custom underline color class still found after underline color cancellation code 59m.');
 				assertInlineColor(child, 'underline', undefined, 'Custom underline color style still found after underline color cancellation code 59m.');
@@ -994,7 +994,7 @@ suite('Debug - ANSI Handling', () => {
 	test('Empty sequence output', () => {
 
 		const sequences: string[] = [
-			// No colour codes
+			// No color codes
 			'',
 			'\x1b[;m',
 			'\x1b[1;;m',

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -1673,7 +1673,7 @@ suite('EditorService', () => {
 		assert.strictEqual(service.isVisible(input1), true);
 		assert.strictEqual(service.isOpened(input1), true);
 
-		// Open to the side uses existing neighbour group if any
+		// Open to the side uses existing neighbor group if any
 		editor = await service.openEditor(input2, { pinned: true, preserveFocus: true }, SIDE_GROUP);
 		assert.strictEqual(part.activeGroup, rootGroup);
 		assert.strictEqual(part.count, 2);


### PR DESCRIPTION
## Summary

- Replace `Controls if` with `Controls whether` in `editorOptions.ts` setting descriptions and JSDoc (8 occurrences) — _whether_ is grammatically correct for yes/no conditions
- Fix British spelling `colour` → `color` in CSS comment (`debugColors.ts`) and test comments (`debugANSIHandling.test.ts`, 7 occurrences)
- Fix British spelling `minimise` → `minimize` in `window.ts` comment
- Fix British spelling `neighbour` → `neighbor` in `editorService.test.ts` comment

No functional changes — only comment/description text is affected.