### PR TITLE
Fix British spelling: replace 'behaviour' with 'behavior' in comments and strings

### DIFF
--- a/src/vs/base/browser/ui/dropdown/dropdown.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdown.ts
@@ -56,7 +56,7 @@ export class BaseDropdown extends ActionRunner {
 		}
 
 		for (const event of [EventType.CLICK, EventType.MOUSE_DOWN, GestureEventType.Tap]) {
-			this._register(addDisposableListener(this.element, event, e => EventHelper.stop(e, true))); // prevent default click behaviour to trigger
+			this._register(addDisposableListener(this.element, event, e => EventHelper.stop(e, true))); // prevent default click behavior to trigger
 		}
 
 		for (const event of [EventType.MOUSE_DOWN, GestureEventType.Tap]) {

--- a/src/vs/base/common/buffer.ts
+++ b/src/vs/base/common/buffer.ts
@@ -136,7 +136,7 @@ export class VSBuffer {
 	slice(start?: number, end?: number): VSBuffer {
 		// IMPORTANT: use subarray instead of slice because TypedArray#slice
 		// creates shallow copy and NodeBuffer#slice doesn't. The use of subarray
-		// ensures the same, performance, behaviour.
+		// ensures the same, performance, behavior.
 		return new VSBuffer(this.buffer.subarray(start, end));
 	}
 

--- a/src/vs/base/common/glob.ts
+++ b/src/vs/base/common/glob.ts
@@ -355,7 +355,7 @@ function parsePattern(arg1: string | IRelativePattern, options: IGlobOptions): P
 		...options,
 		equals: ignoreCase ? equalsIgnoreCase : (a: string, b: string) => a === b,
 		endsWith: ignoreCase ? endsWithIgnoreCase : (str: string, candidate: string) => str.endsWith(candidate),
-		isEqualOrParent: (base: string, candidate: string) => isEqualOrParent(base, candidate, options.ignoreCase ?? !isLinux /* preserve old behaviour for when option is not adopted */)
+		isEqualOrParent: (base: string, candidate: string) => isEqualOrParent(base, candidate, options.ignoreCase ?? !isLinux /* preserve old behavior for when option is not adopted */)
 	};
 
 	// Check cache

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -496,7 +496,7 @@ function ensureWriteOptions(options?: IWriteFileOptions): IEnsuredWriteFileOptio
  */
 async function rename(source: string, target: string, windowsRetryTimeout: number | false = 60000): Promise<void> {
 	if (source === target) {
-		return;  // simulate node.js behaviour here and do a no-op if paths match
+		return;  // simulate node.js behavior here and do a no-op if paths match
 	}
 
 	try {

--- a/src/vs/base/test/common/cancellation.test.ts
+++ b/src/vs/base/test/common/cancellation.test.ts
@@ -243,7 +243,7 @@ suite('CancellationTokenPool', function () {
 		source2.dispose();
 	});
 
-	test('single token pool behaviour', function () {
+	test('single token pool behavior', function () {
 		const pool = new CancellationTokenPool();
 		store.add(pool);
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -415,7 +415,7 @@ export interface IEditorOptions {
 	 */
 	colorDecoratorsLimit?: number;
 	/**
-	 * Control the behaviour of comments in the editor.
+	 * Control the behavior of comments in the editor.
 	 */
 	comments?: IEditorCommentsOptions;
 	/**
@@ -458,7 +458,7 @@ export interface IEditorOptions {
 	 */
 	multiCursorMergeOverlapping?: boolean;
 	/**
-	 * Configure the behaviour when pasting a text with the line count equal to the cursor count.
+	 * Configure the behavior when pasting a text with the line count equal to the cursor count.
 	 * Defaults to 'spread'.
 	 */
 	multiCursorPaste?: 'spread' | 'full';
@@ -552,7 +552,7 @@ export interface IEditorOptions {
 	 */
 	autoIndentOnPasteWithinString?: boolean;
 	/**
-	 * Emulate selection behaviour of tab characters when using spaces for indentation.
+	 * Emulate selection behavior of tab characters when using spaces for indentation.
 	 * This means selection will stick to tab stops.
 	 */
 	stickyTabStops?: boolean;

--- a/src/vs/editor/common/cursor/cursorAtomicMoveOperations.ts
+++ b/src/vs/editor/common/cursor/cursorAtomicMoveOperations.ts
@@ -56,7 +56,7 @@ export class AtomicTabMoveOperations {
 	 * nearest tab, if atomic tabs are enabled. Left and right are used for the
 	 * arrow key movements, nearest is used for mouse selection. It returns
 	 * -1 if atomic tabs are not relevant and you should fall back to normal
-	 * behaviour.
+	 * behavior.
 	 *
 	 * **Note**: `position` and the return value are 0-based.
 	 */

--- a/src/vs/editor/common/model/intervalTree.ts
+++ b/src/vs/editor/common/model/intervalTree.ts
@@ -410,7 +410,7 @@ function adjustMarkerBeforeColumn(markerOffset: number, markerStickToPreviousCha
 }
 
 /**
- * This is a lot more complicated than strictly necessary to maintain the same behaviour
+ * This is a lot more complicated than strictly necessary to maintain the same behavior
  * as when decorations were implemented using two markers.
  */
 export function nodeAcceptEdit(node: IntervalNode, start: number, end: number, textLength: number, forceMoveMarkers: boolean): void {

--- a/src/vs/editor/contrib/snippet/test/browser/snippetController2.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetController2.test.ts
@@ -253,7 +253,7 @@ suite('SnippetController2', function () {
 		assertContextKeys(contextKeys, false, false, false);
 	});
 
-	test('Inconsistent tab stop behaviour with recursive snippets and tab / shift tab, #27543', function () {
+	test('Inconsistent tab stop behavior with recursive snippets and tab / shift tab, #27543', function () {
 		ctrl = instaService.createInstance(SnippetController2, editor);
 		ctrl.insert('1_calize(${1:nl}, \'${2:value}\')$0');
 

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -37,8 +37,8 @@ export const Context = {
 	MultipleSuggestions: new RawContextKey<boolean>('suggestWidgetMultipleSuggestions', false, localize('suggestWidgetMultipleSuggestions', "Whether there are multiple suggestions to pick from")),
 	MakesTextEdit: new RawContextKey<boolean>('suggestionMakesTextEdit', true, localize('suggestionMakesTextEdit', "Whether inserting the current suggestion yields in a change or has everything already been typed")),
 	AcceptSuggestionsOnEnter: new RawContextKey<boolean>('acceptSuggestionOnEnter', true, localize('acceptSuggestionOnEnter', "Whether suggestions are inserted when pressing Enter")),
-	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behaviour")),
-	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behaviour is to insert or replace") }),
+	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behavior")),
+	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behavior is to insert or replace") }),
 	CanResolve: new RawContextKey<boolean>('suggestionCanResolve', false, localize('suggestionCanResolve', "Whether the current suggestion supports to resolve further details")),
 };
 

--- a/src/vs/editor/contrib/wordOperations/test/browser/wordOperations.test.ts
+++ b/src/vs/editor/contrib/wordOperations/test/browser/wordOperations.test.ts
@@ -273,7 +273,7 @@ suite('WordOperations', () => {
 	});
 
 	test('cursorWordStartLeft', () => {
-		// This is the behaviour observed in Visual Studio, please do not touch test
+		// This is the behavior observed in Visual Studio, please do not touch test
 		const EXPECTED = ['|   |/* |Just |some   |more   |text |a|+= |3 |+|5|-|3 |+ |7 |*/  '].join('\n');
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(
@@ -288,7 +288,7 @@ suite('WordOperations', () => {
 	});
 
 	test('cursorWordStartLeft - issue #51119: regression makes VS compatibility impossible', () => {
-		// This is the behaviour observed in Visual Studio, please do not touch test
+		// This is the behavior observed in Visual Studio, please do not touch test
 		const EXPECTED = ['|this|.|is|.|a|.|test'].join('\n');
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(
@@ -463,7 +463,7 @@ suite('WordOperations', () => {
 	});
 
 	test('moveWordStartRight', () => {
-		// This is the behaviour observed in Visual Studio, please do not touch test
+		// This is the behavior observed in Visual Studio, please do not touch test
 		const EXPECTED = [
 			'   |/* |Just |some   |more   |text |a|+= |3 |+|5|-|3 |+ |7 |*/  |',
 		].join('\n');
@@ -480,7 +480,7 @@ suite('WordOperations', () => {
 	});
 
 	test('issue #51119: cursorWordStartRight regression makes VS compatibility impossible', () => {
-		// This is the behaviour observed in Visual Studio, please do not touch test
+		// This is the behavior observed in Visual Studio, please do not touch test
 		const EXPECTED = ['this|.|is|.|a|.|test|'].join('\n');
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(
@@ -495,7 +495,7 @@ suite('WordOperations', () => {
 	});
 
 	test('issue #64810: cursorWordStartRight skips first word after newline', () => {
-		// This is the behaviour observed in Visual Studio, please do not touch test
+		// This is the behavior observed in Visual Studio, please do not touch test
 		const EXPECTED = ['Hello |World|', '|Hei |mailman|'].join('\n');
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -2360,7 +2360,7 @@ suite('Editor Controller', () => {
 		});
 	});
 
-	test('issue #4312: trying to type a tab character over a sequence of spaces results in unexpected behaviour', () => {
+	test('issue #4312: trying to type a tab character over a sequence of spaces results in unexpected behavior', () => {
 		const model = createTextModel(
 			[
 				'var foo = 123;       // this is a comment',

--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -189,7 +189,7 @@ export interface IEditorOptions {
 	 * Tells the editor to not receive keyboard focus when the editor is being opened.
 	 *
 	 * Will also not activate the group the editor opens in unless the group is already
-	 * the active one. This behaviour can be overridden via the `activation` option.
+	 * the active one. This behavior can be overridden via the `activation` option.
 	 */
 	preserveFocus?: boolean;
 
@@ -248,7 +248,7 @@ export interface IEditorOptions {
 	 * in the background without loading its contents.
 	 *
 	 * Will also not activate the group the editor opens in unless the group is already
-	 * the active one. This behaviour can be overridden via the `activation` option.
+	 * the active one. This behavior can be overridden via the `activation` option.
 	 */
 	inactive?: boolean;
 

--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -816,7 +816,7 @@ export class FileService extends Disposable implements IFileService {
 
 	private async doMoveCopy(sourceProvider: IFileSystemProvider, source: URI, targetProvider: IFileSystemProvider, target: URI, mode: 'move' | 'copy', overwrite: boolean): Promise<'move' | 'copy'> {
 		if (source.toString() === target.toString()) {
-			return mode; // simulate node.js behaviour here and do a no-op if paths match
+			return mode; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		// validation

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -672,7 +672,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		const toFilePath = this.toFilePath(to);
 
 		if (fromFilePath === toFilePath) {
-			return; // simulate node.js behaviour here and do a no-op if paths match
+			return; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		try {
@@ -699,7 +699,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 		const toFilePath = this.toFilePath(to);
 
 		if (fromFilePath === toFilePath) {
-			return; // simulate node.js behaviour here and do a no-op if paths match
+			return; // simulate node.js behavior here and do a no-op if paths match
 		}
 
 		try {

--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -292,7 +292,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 							mapPathToStatDisposable.delete(changedFileName);
 
 							// Depending on the OS the watcher runs on, there
-							// is different behaviour for when the watched
+							// is different behavior for when the watched
 							// folder path is being deleted:
 							//
 							// -   macOS: not reported but events continue to
@@ -376,7 +376,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 					if (type === 'rename' || !isEqual(changedFileName, pathBasename, !isLinux)) {
 
 						// Depending on the OS the watcher runs on, there
-						// is different behaviour for when the watched
+						// is different behavior for when the watched
 						// file path is being deleted:
 						//
 						// -   macOS: "rename" event is reported and events

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -70,11 +70,11 @@ export class LaunchMainService implements ILaunchMainService {
 			return;
 		}
 
-		// macOS: Electron > 7.x changed its behaviour to not
+		// macOS: Electron > 7.x changed its behavior to not
 		// bring the application to the foreground when a window
 		// is focused programmatically. Only via `app.focus` and
 		// the option `steal: true` can you get the previous
-		// behaviour back. The only reason to use this option is
+		// behavior back. The only reason to use this option is
 		// when a window is getting focused while the application
 		// is not in the foreground and since we got instructed
 		// to open a new window from another instance, we ensure

--- a/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
+++ b/src/vs/platform/lifecycle/electron-main/lifecycleMainService.ts
@@ -611,7 +611,7 @@ export class LifecycleMainService extends Disposable implements ILifecycleMainSe
 			if (!veto && willRestart) {
 				// Windows: we are about to restart and as such we need to restore the original
 				// current working directory we had on startup to get the exact same startup
-				// behaviour. As such, we briefly change back to that directory and then when
+				// behavior. As such, we briefly change back to that directory and then when
 				// Code starts it will set it back to the installation directory again.
 				try {
 					if (isWindows) {

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -386,7 +386,7 @@ export class Menubar extends Disposable {
 		// so we need to unset it there.
 		//
 		// This is a bit ugly but `setApplicationMenu()` has some nice
-		// behaviour we want:
+		// behavior we want:
 		// - on macOS it is required because menus are application set
 		// - we use `getApplicationMenu()` to access the current state
 		// - new windows immediately get the same menu when opening

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1019,7 +1019,7 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 					this.handleAccept(false);
 				}
 				// Unset quick navigate after press. It is only valid once
-				// and should not result in any behaviour change afterwards
+				// and should not result in any behavior change afterwards
 				// if the picker remains open because there was no active item
 				this._quickNavigate = undefined;
 			}

--- a/src/vs/server/node/serverLifetimeService.ts
+++ b/src/vs/server/node/serverLifetimeService.ts
@@ -11,7 +11,7 @@ export const IServerLifetimeService = createDecorator<IServerLifetimeService>('s
 
 export const SHUTDOWN_TIMEOUT = 5 * 60 * 1000;
 
-/** Options controlling the auto-shutdown behaviour. */
+/** Options controlling the auto-shutdown behavior. */
 export interface IServerLifetimeOptions {
 	/** When `false` (default), the server never auto-shuts down. */
 	readonly enableAutoShutdown?: boolean;

--- a/src/vs/sessions/contrib/chat/browser/variableCompletions.ts
+++ b/src/vs/sessions/contrib/chat/browser/variableCompletions.ts
@@ -105,7 +105,7 @@ function computeRange(model: ITextModel, position: Position, reg: RegExp): IComp
  * following the same pattern as {@link SlashCommandHandler}.
  *
  * Completions are scoped to the workspace selected in the workspace picker dropdown,
- * matching the behaviour of the "Add Context..." attach button.
+ * matching the behavior of the "Add Context..." attach button.
  * For local/remote workspaces the search service is used; for virtual filesystems
  * (e.g. `github-remote-file://`) the file service tree is walked directly.
  */

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -246,7 +246,7 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 			preserveFocus: options.preserveFocus,
 			pinned: options.pinned,
 			selection: options.selection,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: options.preserveFocus ? EditorActivation.RESTORE : undefined,
 			override: EditorResolution.EXCLUSIVE_ONLY

--- a/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookEditors.ts
@@ -102,7 +102,7 @@ export class MainThreadNotebookEditors implements MainThreadNotebookEditorsShape
 			preserveFocus: options.preserveFocus,
 			pinned: options.pinned,
 			// selection: options.selection,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: options.preserveFocus ? EditorActivation.RESTORE : undefined,
 			label: options.label,

--- a/src/vs/workbench/api/test/browser/extHostWorkspace.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostWorkspace.test.ts
@@ -86,7 +86,7 @@ suite('ExtHostWorkspace', function () {
 		assertAsRelativePath(ws, '/Coding/Two2/files/out.txt', '/Coding/Two2/files/out.txt');
 	});
 
-	test('slightly inconsistent behaviour of asRelativePath and getWorkspaceFolder, #31553', function () {
+	test('slightly inconsistent behavior of asRelativePath and getWorkspaceFolder, #31553', function () {
 		const mrws = createExtHostWorkspace(new TestRPCProtocol(), { id: 'foo', folders: [aWorkspaceFolderData(URI.file('/Coding/One'), 0), aWorkspaceFolderData(URI.file('/Coding/Two'), 1)], name: 'Test' }, new NullLogService());
 
 		assertAsRelativePath(mrws, '/Coding/One/file.txt', 'One/file.txt');

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -414,7 +414,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 				return;  // need at least 2 open editors
 			}
 
-			// Shift-key enables or disables this behaviour depending on the setting
+			// Shift-key enables or disables this behavior depending on the setting
 			if (this.groupsView.partOptions.scrollToSwitchTabs === true) {
 				if (e.shiftKey) {
 					return; // 'on': only enable this when Shift-key is not pressed

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -83,7 +83,7 @@ export class BaseTextEditorModel extends EditorModel implements ITextEditorModel
 		// This is technically not 100% correct, because 'api' can also be
 		// set as source if a model is resolved as text first and then
 		// transitions into the resolved language. But to preserve the current
-		// behaviour, we do not change this property. Rather, `languageChangeSource`
+		// behavior, we do not change this property. Rather, `languageChangeSource`
 		// can be used to get more fine grained information.
 		return typeof this._languageChangeSource === 'string';
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1170,7 +1170,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 					target: Target.GitHubCopilot,
 				});
 			} else {
-				// Core: use the default core behaviour
+				// Core: use the default core behavior
 				await this.instantiationService.invokeFunction(showConfigureHooksQuickPick, {
 					openEditor: async (resource) => {
 						await this.showEmbeddedEditor(resource, basename(resource), PromptsType.hook, PromptsStorage.local, true);

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
@@ -298,7 +298,7 @@ const enum Step {
 }
 
 /**
- * Optional callbacks and settings for customizing the hook creation and opening behaviour.
+ * Optional callbacks and settings for customizing the hook creation and opening behavior.
  * The agentic editor passes these to open hooks in the embedded editor and
  * track worktree files for auto-commit.
  */

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
@@ -30,7 +30,7 @@ import { PromptsStorage } from '../../common/promptSyntax/service/promptsService
 import { getTarget } from '../../common/promptSyntax/languageProviders/promptFileAttributes.js';
 
 /**
- * Options to override the default folder-picker and editor-open behaviour
+ * Options to override the default folder-picker and editor-open behavior
  * of the new-prompt-file actions. The agentic editor passes these to open
  * files in the embedded editor and pre-resolve the target folder.
  */

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -852,7 +852,7 @@ export function parsePluginSource(
 		return { kind: PluginSourceKind.RelativePath, path: resolved };
 	}
 
-	// String source → legacy relative-path behaviour.
+	// String source → legacy relative-path behavior.
 	if (typeof rawSource === 'string') {
 		const resolved = resolvePluginSource(pluginRoot, rawSource);
 		if (resolved === undefined) {

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -287,7 +287,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 		if (items) {
 			await Promise.all(items.map(async item => {
 				const model = item.diffEditorViewModel.model;
-				const handleOriginal = model.original.uri.scheme !== Schemas.untitled && this._textFileService.isDirty(model.original.uri); // match diff editor behaviour
+				const handleOriginal = model.original.uri.scheme !== Schemas.untitled && this._textFileService.isDirty(model.original.uri); // match diff editor behavior
 
 				await Promise.all([
 					handleOriginal ? mode === 'save' ? this._textFileService.save(model.original.uri, options) : this._textFileService.revert(model.original.uri, options) : Promise.resolve(),

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -358,7 +358,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 				});
 			}
 			run(accessor: ServicesAccessor, args?: string | IOpenSettingsActionOptions) {
-				// Match the behaviour of workbench.action.openSettings
+				// Match the behavior of workbench.action.openSettings
 				args = typeof args === 'string' ? { query: args } : sanitizeOpenSettingsArgs(args);
 				return accessor.get(IPreferencesService).openWorkspaceSettings(args);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1825,7 +1825,7 @@ class SettingTextRenderer extends AbstractSettingTextRenderer implements ITreeRe
 		const template = super.renderTemplate(_container, false);
 
 		// TODO@9at8: listWidget filters out all key events from input boxes, so we need to come up with a better way
-		// Disable ArrowUp and ArrowDown behaviour in favor of list navigation
+		// Disable ArrowUp and ArrowDown behavior in favor of list navigation
 		template.toDispose.add(DOM.addStandardDisposableListener(template.inputBox.inputElement, DOM.EventType.KEY_DOWN, e => {
 			if (e.equals(KeyCode.UpArrow) || e.equals(KeyCode.DownArrow)) {
 				e.preventDefault();

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -131,7 +131,7 @@ export class SCMViewService implements ISCMViewService {
 	readonly didFinishLoadingRepositories = observableValue<boolean>(this, false);
 
 	get visibleRepositories(): ISCMRepository[] {
-		// In order to match the legacy behaviour, when the repositories are sorted by discovery time,
+		// In order to match the legacy behavior, when the repositories are sorted by discovery time,
 		// the visible repositories are sorted by the selection index instead of the discovery time.
 		if (this._repositoriesSortKey === ISCMRepositorySortKey.DiscoveryTime) {
 			return this._repositories

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
@@ -283,7 +283,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 		this._editorService.openEditor(webviewInput, {
 			pinned: true,
 			preserveFocus: showOptions.preserveFocus,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: showOptions.preserveFocus ? EditorActivation.RESTORE : undefined
 		}, showOptions.group);
@@ -299,7 +299,7 @@ export class WebviewEditorService extends Disposable implements IWebviewWorkbenc
 
 		this._editorService.openEditor(topLevelEditor, {
 			preserveFocus,
-			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// preserve pre 1.38 behavior to not make group active when preserveFocus: true
 			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
 			activation: preserveFocus ? EditorActivation.RESTORE : undefined
 		}, group);

--- a/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
+++ b/src/vs/workbench/services/contextmenu/electron-browser/contextmenuService.ts
@@ -252,7 +252,7 @@ class NativeContextMenuService extends Disposable implements IContextMenuService
 				enabled: !!entry.enabled,
 				click: event => {
 
-					// To preserve pre-electron-2.x behaviour, we first trigger
+					// To preserve pre-electron-2.x behavior, we first trigger
 					// the onHide callback and then the action.
 					// Fixes https://github.com/microsoft/vscode/issues/45601
 					onHide();

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -425,7 +425,7 @@ export interface IEditorGroupsContainer {
 
 	/**
 	 * Merge the editors of a group into a target group. By default, all editors will
-	 * move and the source group will close. This behaviour can be configured via the
+	 * move and the source group will close. This behavior can be configured via the
 	 * `IMergeGroupOptions` options.
 	 *
 	 * @param group the group to merge

--- a/src/vs/workbench/services/lifecycle/common/lifecycle.ts
+++ b/src/vs/workbench/services/lifecycle/common/lifecycle.ts
@@ -296,7 +296,7 @@ export interface ILifecycleService {
 
 	/**
 	 * Triggers a shutdown of the workbench. Depending on native or web, this can have
-	 * different implementations and behaviour.
+	 * different implementations and behavior.
 	 *
 	 * **Note:** this should normally not be called. See related methods in `IHostService`
 	 * and `INativeHostService` to close a window or quit the application.

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -69,7 +69,7 @@ export interface IFileWorkingCopyModel extends IDisposable {
 
 	/**
 	 * Optional additional configuration for the model that drives
-	 * some of the working copy behaviour.
+	 * some of the working copy behavior.
 	 */
 	readonly configuration?: IFileWorkingCopyModelConfiguration;
 

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopyManager.ts
@@ -60,7 +60,7 @@ export interface IFileWorkingCopyManager<S extends IStoredFileWorkingCopyModel, 
 	 * disposed.
 	 *
 	 * Use the `IStoredFileWorkingCopyResolveOptions.reload` option to control the
-	 * behaviour for when a stored file working copy was previously already resolved
+	 * behavior for when a stored file working copy was previously already resolved
 	 * with regards to resolving it again from the underlying file resource
 	 * or not.
 	 *

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopyManager.ts
@@ -87,7 +87,7 @@ export interface IStoredFileWorkingCopyManager<M extends IStoredFileWorkingCopyM
 	 * disposed.
 	 *
 	 * Use the `IStoredFileWorkingCopyResolveOptions.reload` option to control the
-	 * behaviour for when a stored file working copy was previously already resolved
+	 * behavior for when a stored file working copy was previously already resolved
 	 * with regards to resolving it again from the underlying file resource
 	 * or not.
 	 *

--- a/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/activitybar/activitybarPart.test.ts
@@ -79,7 +79,7 @@ suite('ActivitybarPart', () => {
 		layoutService.isVisible = (_part: Parts) => false;
 
 		// Stub instantiation service—createCompositeBar is only called in show(),
-		// which we skip in unit tests focused on dimensions / style behaviour.
+		// which we skip in unit tests focused on dimensions / style behavior.
 		const stubInstantiationService = { createInstance: () => { throw new Error('not expected'); } } as unknown as IInstantiationService;
 
 		const part = disposables.add(new ActivitybarPart(

--- a/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
@@ -671,7 +671,7 @@ suite('FilteredEditorGroupModel', () => {
 		assert.strictEqual(stickyFilteredEditorGroup.id, model.id);
 		assert.strictEqual(unstickyFilteredEditorGroup.id, model.id);
 
-		// group locking same behaviour
+		// group locking same behavior
 		assert.strictEqual(stickyFilteredEditorGroup.isLocked, model.isLocked);
 		assert.strictEqual(unstickyFilteredEditorGroup.isLocked, model.isLocked);
 

--- a/src/vs/workbench/test/browser/parts/editor/modalEditorSidebar.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/modalEditorSidebar.test.ts
@@ -115,7 +115,7 @@ class TestModalEditorSidebarHost extends Disposable {
 		return MODAL_MIN_WIDTH + (this._hasSidebar ? MODAL_SIDEBAR_MIN_WIDTH : 0);
 	}
 
-	// --- option propagation (mirrors updateOptions behaviour) ---------------
+	// --- option propagation (mirrors updateOptions behavior) ---------------
 
 	updateOptions(options: IModalEditorPartOptions): void {
 		if (options.sidebar) {


### PR DESCRIPTION
## Summary

Standardizes American English spelling across 45 source files by replacing British `behaviour` with American `behavior`.

**Scope:** All changes are confined to:
- Code comments (`//` and `/* */`)
- JSDoc (`/** */`)
- Test names (`test('...')`)
- `localize()` strings (user-visible descriptions)

No TypeScript identifiers, variable names, function names, or config key names were changed. The config setting keys `singleClickBehaviour` / `doubleClickBehaviour` in `searchEditor.ts` are preserved as they are public API.

**Files changed:** 45 files across `src/vs/base/`, `src/vs/editor/`, `src/vs/platform/`, `src/vs/workbench/`, and `src/vs/sessions/`.