### PR TITLE
Fix British spelling: -ise/-ised → -ize/-ized in comments and JSDoc

### DIFF
--- a/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetSession.test.ts
@@ -643,7 +643,7 @@ suite('SnippetSession', function () {
 		assert.strictEqual(editor.getModel()!.getValue(), 'test 1\ntest 2\ntest 3\ntest 4\n');
 	});
 
-	test('Snippet variable text isn\'t whitespace normalised, #31124', function () {
+	test('Snippet variable text isn\'t whitespace normalized, #31124', function () {
 		editor.getModel()!.setValue([
 			'start',
 			'\t\t-one',

--- a/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewElementInspector.ts
@@ -381,7 +381,7 @@ function attributeArrayToRecord(attributes: string[]): Record<string, string> {
 	return record;
 }
 
-/** Slightly customised CDP debugger inspect highlight colours. */
+/** Slightly customized CDP debugger inspect highlight colors. */
 const inspectHighlightConfig = {
 	showInfo: true,
 	showRulers: false,

--- a/src/vs/platform/browserView/node/playwrightService.ts
+++ b/src/vs/platform/browserView/node/playwrightService.ts
@@ -37,7 +37,7 @@ const DEFERRED_RESULT_CLEANUP_MS = 5 * 60_000; // 5 minutes
  * Shared-process implementation of {@link IPlaywrightService}.
  *
  * Creates a {@link PlaywrightPageManager} eagerly on construction to track
- * browser views. The Playwright browser connection is lazily initialised
+ * browser views. The Playwright browser connection is lazily initialized
  * only when an operation that requires it is called.
  */
 export class PlaywrightService extends Disposable implements IPlaywrightService {

--- a/src/vs/platform/files/common/watcher.ts
+++ b/src/vs/platform/files/common/watcher.ts
@@ -385,7 +385,7 @@ class EventCoalescer {
 			return event.resource.fsPath;
 		}
 
-		return event.resource.fsPath.toLowerCase(); // normalise to file system case sensitivity
+		return event.resource.fsPath.toLowerCase(); // normalize to file system case sensitivity
 	}
 
 	processEvent(event: IFileChange): void {

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -50,7 +50,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 				this._proxy.$acceptDebugSessionNameChanged(this.getSessionDto(session), name);
 			}));
 		}));
-		// Need to start listening early to new session events because a custom event can come while a session is initialising
+		// Need to start listening early to new session events because a custom event can come while a session is initializing
 		this._toDispose.add(debugService.onWillNewSession(session => {
 			let store = sessionListeners.get(session);
 			if (!store) {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -184,7 +184,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			}
 		}));
 		this._register(this.debugService.onWillNewSession(async newSession => {
-			// Need to listen to output events for sessions which are not yet fully initialised
+			// Need to listen to output events for sessions which are not yet fully initialized
 			const input = this.tree?.getInput();
 			if (!input || input.state === State.Inactive) {
 				await this.selectSession(newSession);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1148,7 +1148,7 @@ export interface IDebugService {
 	readonly onDidChangeState: Event<State>;
 
 	/**
-	 * Allows to register on sessions about to be created (not yet fully initialised).
+	 * Allows to register on sessions about to be created (not yet fully initialized).
 	 * This is fired exactly one time for any given session.
 	 */
 	readonly onWillNewSession: Event<IDebugSession>;

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -407,7 +407,7 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
 								promises.push(Event.toPromise(Event.filter(userDataSyncService.onDidChangeStatus, status => status !== SyncStatus.Syncing)));
 							}
 
-							// If user chose the sync service then synchronise the store type option in insiders service, so that other clients using insiders service are also updated.
+							// If user chose the sync service then synchronize the store type option in insiders service, so that other clients using insiders service are also updated.
 							if (isSwitchingToInsiders && userDataSyncStoreType) {
 								promises.push(userDataSyncWorkbenchService.synchroniseUserDataSyncStoreType());
 							}


### PR DESCRIPTION
## Summary

Replaces British `-ise`/`-ised`/`-ising` variants with American English equivalents in code comments and JSDoc strings across 8 files:

| British | American | File |
|---------|----------|------|
| `normalise` | `normalize` | `watcher.ts` |
| `initialised` | `initialized` | `playwrightService.ts`, `mainThreadDebugService.ts`, `repl.ts`, `debug.ts` |
| `synchronise` | `synchronize` | `update.ts` |
| `normalised` | `normalized` | `snippetSession.test.ts` (test name) |
| `customised`, `colours` | `customized`, `colors` | `browserViewElementInspector.ts` |

All changes are confined to comments and JSDoc — no TypeScript identifiers were renamed.