### PR TITLE
Fix spelling typos in comments and JSDoc (batch 12)

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -868,7 +868,7 @@ export class EditorParts extends MultiWindowParts<EditorPart, IEditorPartsMement
 
 	bind<T extends ContextKeyValue>(contextKey: RawContextKey<T>, group: IEditorGroupView): IContextKey<T> {
 
-		// Ensure we only bind to the same context key once globaly
+		// Ensure we only bind to the same context key once globally
 		let globalContextKey = this.globalContextKeys.get(contextKey.key);
 		if (!globalContextKey) {
 			globalContextKey = contextKey.bindTo(this.contextKeyService);

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -321,8 +321,8 @@ function findNextVisibleFrame(down: boolean, callStack: readonly IStackFrame[], 
 }
 
 // These commands are used in call stack context menu, call stack inline actions, command palette, debug toolbar, mac native touch bar
-// When the command is exectued in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
-// Otherwise when it is executed "globaly"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focussed thread
+// When the command is executed in the context of a thread(context menu on a thread, inline call stack action) we pass the thread id
+// Otherwise when it is executed "globally"(using the touch bar, debug toolbar, command palette) we do not pass any id and just take whatever is the focused thread
 // Same for stackFrame commands and session commands.
 CommandsRegistry.registerCommand({
 	id: COPY_STACK_TRACE_ID,

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -1051,7 +1051,7 @@ registerAction2(class extends ViewAction<Repl> {
 			session = resolveChildSession(session, debugService.getModel().getSessions());
 			await debugService.focusStackFrame(undefined, undefined, session, { explicit: true });
 		}
-		// Need to select the session in the view since the focussed session might not have changed
+		// Need to select the session in the view since the focused session might not have changed
 		await view.selectSession(session);
 	}
 });

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1690,7 +1690,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {
-					return true; // Can not move anything onto itself excpet for root folders
+					return true; // Can not move anything onto itself except for root folders
 				}
 
 				if (!isCopy && this.uriIdentityService.extUri.isEqual(dirname(source.resource), target.resource)) {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
@@ -98,7 +98,7 @@ export class NotebookOutlineEntryFactory implements INotebookOutlineEntryFactory
 			if (!isMarkdown) {
 				const cached = this.cellOutlineEntryCache[cell.id];
 
-				// Gathering symbols from the model is an async operation, but this provider is syncronous.
+				// Gathering symbols from the model is an async operation, but this provider is synchronous.
 				// So symbols need to be precached before this function is called to get the full list.
 				if (cached) {
 					// push code cell entry that is a parent of cached symbols, always necessary. filtering for quickpick done in that provider.


### PR DESCRIPTION
Fix spelling typos in comments and JSDoc. No logic changes.

**Fixes:**
- `seperate` → `separate` (extHostTypes.ts comment)
- `globaly` → `globally` (editorParts.ts comment, debugCommands.ts comment)
- `exectued` → `executed` (debugCommands.ts comment)
- `focussed` → `focused` (debugCommands.ts comment, repl.ts comment)
- `excpet` → `except` (explorerViewer.ts comment)
- `syncronous` → `synchronous` (notebookOutlineEntryFactory.ts comment)