### PR TITLE
Fix typos in comments, JSDoc, error messages, and test names (batch 13)

### DIFF
--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -159,7 +159,7 @@ export class DisposableTracker implements IDisposableTracker {
 			});
 
 			if (uncoveredLeakingObjs.length === 0) {
-				throw new Error('There are cyclic diposable chains!');
+				throw new Error('There are cyclic disposable chains!');
 			}
 		}
 

--- a/src/vs/base/common/observableInternal/observables/derivedImpl.ts
+++ b/src/vs/base/common/observableInternal/observables/derivedImpl.ts
@@ -136,7 +136,7 @@ export class Derived<T, TChangeSummary = any, TChange = void> extends BaseObserv
 		} else {
 			do {
 				// We might not get a notification for a dependency that changed while it is updating,
-				// thus we also have to ask all our depedencies if they changed in this case.
+				// thus we also have to ask all our dependencies if they changed in this case.
 				if (this._state === DerivedState.dependenciesMightHaveChanged) {
 					for (const d of this._dependencies) {
 						/** might call {@link handleChange} indirectly, which could make us stale */

--- a/src/vs/base/test/common/observables/observable.test.ts
+++ b/src/vs/base/test/common/observables/observable.test.ts
@@ -1046,7 +1046,7 @@ suite('observables', () => {
 				'myObservable1.set (value 1)',
 			]);
 
-			myObservable2.set(10, tx); // This is a non-change. myDerived3 should not be marked as possibly-depedency-changed!
+			myObservable2.set(10, tx); // This is a non-change. myDerived3 should not be marked as possibly-dependency-changed!
 			assert.deepStrictEqual(log.getAndClearEntries(), [
 				'myObservable2.set (value 10)',
 			]);

--- a/src/vs/editor/common/viewLayout/viewLinesViewportData.ts
+++ b/src/vs/editor/common/viewLayout/viewLinesViewportData.ts
@@ -36,7 +36,7 @@ export class ViewportData {
 	public readonly visibleRange: Range;
 
 	/**
-	 * Value to be substracted from `scrollTop` (in order to vertical offset numbers < 1MM)
+	 * Value to be subtracted from `scrollTop` (in order to vertical offset numbers < 1MM)
 	 */
 	public readonly bigNumbersDelta: number;
 

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -177,7 +177,7 @@ export interface ILineHeightChangeAccessor {
 
 export interface IPartialViewLinesViewportData {
 	/**
-	 * Value to be substracted from `scrollTop` (in order to vertical offset numbers < 1MM)
+	 * Value to be subtracted from `scrollTop` (in order to vertical offset numbers < 1MM)
 	 */
 	readonly bigNumbersDelta: number;
 	/**

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1260,7 +1260,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._domNode.ariaLabel = NLS_FIND_DIALOG_LABEL;
 		this._domNode.role = 'dialog';
 
-		// We need to set this explicitly, otherwise on IE11, the width inheritence of flex doesn't work.
+		// We need to set this explicitly, otherwise on IE11, the width inheritance of flex doesn't work.
 		this._domNode.style.width = `${FIND_WIDGET_INITIAL_WIDTH}px`;
 
 		this._domNode.appendChild(this._toggleReplaceBtn.domNode);

--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -107,7 +107,7 @@ export class MessageController implements IEditorContribution {
 			}
 
 			if (!bounds) {
-				// define bounding box around position and first mouse occurance
+				// define bounding box around position and first mouse occurrence
 				bounds = new Range(position.lineNumber - 3, 1, e.target.position.lineNumber + 3, 1);
 			} else if (!bounds.containsPosition(e.target.position)) {
 				// check if position is still in bounds

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -159,7 +159,7 @@ export class SnippetController2 implements IEditorContribution {
 			this._editor.getModel().pushStackElement();
 		}
 
-		// regster completion item provider when there is any choice element
+		// register completion item provider when there is any choice element
 		if (this._session?.hasChoice) {
 			const provider: CompletionItemProvider = {
 				_debugDisplayName: 'snippetChoiceCompletions',

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -448,7 +448,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 									// if the include is from the settings and target isn't, even if it matches, it's still overridden.
 									return false;
 								} else {
-									// longer filePatterns are considered more specifc, so they always have precedence the shorter patterns
+									// longer filePatterns are considered more specific, so they always have precedence the shorter patterns
 									return target.filenamePatterns.some(targetFilePattern => globMatchesResource(targetFilePattern, uri));
 								}
 							});

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -738,7 +738,7 @@ class ResponseView extends AbstractResponse {
 		public readonly undoStop: string,
 	) {
 		let idx = _response.value.findIndex(v => v.kind === 'undoStop' && v.id === undoStop);
-		// Undo stops are inserted before `codeblockUri`'s, which are preceeded by a
+		// Undo stops are inserted before `codeblockUri`'s, which are preceded by a
 		// markdownContent containing the opening code fence. Adjust the index
 		// backwards to avoid a buggy response if it looked like this happened.
 		if (_response.value[idx + 1]?.kind === 'codeblockUri' && _response.value[idx - 1]?.kind === 'markdownContent') {

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -356,7 +356,7 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 	}
 
 	disposeTemplate(templateData: ICommentThreadTemplateData): void {
-		templateData.disposables.forEach(disposeable => disposeable.dispose());
+		templateData.disposables.forEach(disposable => disposable.dispose());
 		templateData.elementDisposables.dispose();
 		templateData.actionBar.dispose();
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -47,7 +47,7 @@ class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemP
 			if (registeredId) {
 				displayLanguage = this._languageService.getLanguageName(displayLanguage) ?? displayLanguage;
 			} else {
-				// add unregistered lanugage warning item
+				// add unregistered language warning item
 				const searchTooltip = localize('notebook.cell.status.searchLanguageExtensions', "Unknown cell language. Click to search for '{0}' extensions", cell.language);
 				statusBarItems.push({
 					text: `$(dialog-warning)`,

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -937,7 +937,7 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 
 	getLayoutInfo(): NotebookLayoutInfo {
 		if (!this._list) {
-			throw new Error('Editor is not initalized successfully');
+			throw new Error('Editor is not initialized successfully');
 		}
 
 		return {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2756,7 +2756,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	getLayoutInfo(): NotebookLayoutInfo {
 		if (!this._list) {
-			throw new Error('Editor is not initalized successfully');
+			throw new Error('Editor is not initialized successfully');
 		}
 
 		if (!this._fontInfo) {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookWorkbenchToolbar.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookWorkbenchToolbar.test.ts
@@ -104,7 +104,7 @@ suite('Workbench Toolbar calculateActions (strategy always + never)', () => {
 		assert.deepEqual(result.secondaryActions, [actions[2], separator, ...defaultSecondaryActionModels].map(action => action.action));
 	});
 
-	test('should not render separator if preceeded by size 0 action(s).', () => {
+	test('should not render separator if preceded by size 0 action(s).', () => {
 		const actions: IActionModel[] = [
 			{ action: disposables.add(new Action('action0', 'Action 0')), size: 0, visible: true, renderLabel: true },
 			{ action: new Separator(), size: 1, visible: true, renderLabel: true },
@@ -271,7 +271,7 @@ suite('Workbench Toolbar Dynamic calculateActions (strategy dynamic)', () => {
 		assert.deepEqual(result.secondaryActions, defaultSecondaryActions);
 	});
 
-	test('should not render separator if preceeded by size 0 action(s), but keep size 0 action in primary.', () => {
+	test('should not render separator if preceded by size 0 action(s), but keep size 0 action in primary.', () => {
 		const containerSize = 116;
 		const input: IActionModel[] = [
 			{ action: actionTemplate[0], size: 0, visible: true, renderLabel: true }, 	// hidden

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -593,7 +593,7 @@ export namespace TestResultItem {
 export interface ISerializedTestResults {
 	/** ID of these test results */
 	id: string;
-	/** Time the results were compelted */
+	/** Time the results were completed */
 	completedAt: number;
 	/** Subset of test result items */
 	items: TestResultItem.Serialized[];

--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -827,7 +827,7 @@ export class AgentSessionsWelcomePage extends EditorPane {
 			return;
 		}
 
-		// TODO: @osortega this is a weird way of doing this, maybe we handle the 2-colum layout in the control itself?
+		// TODO: @osortega this is a weird way of doing this, maybe we handle the 2-column layout in the control itself?
 		const sessionsWidth = Math.min(800, this.lastDimension.width - 80);
 		// Calculate height based on actual visible sessions (capped at MAX_SESSIONS)
 		// Use ITEM_HEIGHT per item from AgentSessionsListDelegate

--- a/src/vs/workbench/services/path/common/pathService.ts
+++ b/src/vs/workbench/services/path/common/pathService.ts
@@ -53,7 +53,7 @@ export interface IPathService {
 
 	/**
 	 * Resolves the user-home directory for the target environment.
-	 * If the envrionment is connected to a remote, this will be the
+	 * If the environment is connected to a remote, this will be the
 	 * remote's user home directory, otherwise the local one unless
 	 * `preferLocal` is set to `true`.
 	 */

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -695,7 +695,7 @@ function getEscapeAwareSplitStringForRipgrep(pattern: string): { fixedStart?: st
 		switch (char) {
 			case '\\':
 				if (escaped) {
-					// If we're already escaped, then just leave the escaped slash and the preceeding slash that escapes it.
+					// If we're already escaped, then just leave the escaped slash and the preceding slash that escapes it.
 					// The two escaped slashes will result in a single slash and whatever processes the glob later will properly process the escape
 					if (inBraces) {
 						strInBraces += '\\' + char;

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -51,7 +51,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 
 		this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);
 
-		// When the level changes it could change from off to on and we want to make sure telemetry is properly intialized
+		// When the level changes it could change from off to on and we want to make sure telemetry is properly initialized
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(TELEMETRY_SETTING_ID)) {
 				this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);


### PR DESCRIPTION
Fix a collection of typos found across the codebase in comments, JSDoc, error message strings, and test names. All changes are safe — no public API identifiers, config keys, or telemetry event names were modified.

**Changes:**
- `compelted` → `completed` (`testTypes.ts` JSDoc)
- `preceeded`/`preceeding` → `preceded`/`preceding` (`notebookWorkbenchToolbar.test.ts` ×2, `ripgrepTextSearchEngine.ts`, `chatModel.ts`)
- `substracted` → `subtracted` (`viewModel.ts`, `viewLinesViewportData.ts`)
- `inheritence` → `inheritance` (`findWidget.ts`)
- `occurance` → `occurrence` (`messageController.ts`)
- `initalized`/`intialized` → `initialized` (`notebookEditorWidget.ts`, `notebookDiffEditor.ts`, `telemetryService.ts`)
- `diposable` → `disposable` (`lifecycle.ts`)
- `disposeable` → `disposable` (`commentsTreeViewer.ts`)
- `specifc` → `specific` (`extHostNotebook.ts`)
- `regster` → `register` (`snippetController2.ts`)
- `envrionment` → `environment` (`pathService.ts`)
- `depedency`/`depedencies` → `dependency`/`dependencies` (`observable.test.ts`, `derivedImpl.ts`)
- `lanugage` → `language` (`statusBarProviders.ts`)
- `colum` → `column` (`agentSessionsWelcome.ts`)