### PR TITLE
Fix typos in comments, JSDoc, test names, and UI strings (batch 14)

### DIFF
--- a/src/vs/base/test/common/glob.test.ts
+++ b/src/vs/base/test/common/glob.test.ts
@@ -801,7 +801,7 @@ suite('Glob', () => {
 		assert.strictEqual(glob.parse(expr)('bar.js', undefined, hasSibling), null);
 	});
 
-	test('expression with multipe basename globs', function () {
+	test('expression with multiple basename globs', function () {
 		const expr = {
 			'**/bar': true,
 			'{**/baz,**/foo}': true

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -6619,7 +6619,7 @@ export const EditorOptions = {
 	selectionHighlightMaxLength: register(new EditorIntOption(
 		EditorOption.selectionHighlightMaxLength, 'selectionHighlightMaxLength',
 		200, 0, Constants.MAX_SAFE_SMALL_INTEGER,
-		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similiar matches are not highlighted. Set to zero for unlimited.") }
+		{ description: nls.localize('selectionHighlightMaxLength', "Controls how many characters can be in the selection before similar matches are not highlighted. Set to zero for unlimited.") }
 	)),
 	selectionHighlightMultiline: register(new EditorBooleanOption(
 		EditorOption.selectionHighlightMultiline, 'selectionHighlightMultiline', false,

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -797,7 +797,7 @@ suite('TextModelSearch', () => {
 	});
 
 	test('issue #100134. Zero-length matches should properly step over surrogate pairs', () => {
-		// 1[Laptop]1 - there shoud be no matches inside of [Laptop] emoji
+		// 1[Laptop]1 - there should be no matches inside of [Laptop] emoji
 		assertFindMatches('1\uD83D\uDCBB1', '()', true, false, null,
 			[
 				[1, 1, 1, 1],
@@ -807,8 +807,8 @@ suite('TextModelSearch', () => {
 
 			]
 		);
-		// 1[Hacker Cat]1 = 1[Cat Face][ZWJ][Laptop]1 - there shoud be matches between emoji and ZWJ
-		// there shoud be no matches inside of [Cat Face] and [Laptop] emoji
+		// 1[Hacker Cat]1 = 1[Cat Face][ZWJ][Laptop]1 - there should be matches between emoji and ZWJ
+		// there should be no matches inside of [Cat Face] and [Laptop] emoji
 		assertFindMatches('1\uD83D\uDC31\u200D\uD83D\uDCBB1', '()', true, false, null,
 			[
 				[1, 1, 1, 1],

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -271,7 +271,7 @@ export class DiskFileSystemProvider extends AbstractDiskFileSystemProvider imple
 	private async doWriteFileAtomic(resource: URI, tempResource: URI, content: Uint8Array, opts: IFileWriteOptions): Promise<void> {
 
 		// Ensure to create locks for all resources involved
-		// since atomic write involves mutiple disk operations
+		// since atomic write involves multiple disk operations
 		// and resources.
 
 		const locks = new DisposableStore();

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -312,7 +312,7 @@ export class KeybindingResolver {
 	}
 
 	/**
-	 * Looks up a keybinding trigged as a result of pressing a sequence of chords - `[...currentChords, keypress]`
+	 * Looks up a keybinding triggered as a result of pressing a sequence of chords - `[...currentChords, keypress]`
 	 *
 	 * Example: resolving 3 chords pressed sequentially - `cmd+k cmd+p cmd+i`:
 	 * 	`currentChords = [ 'cmd+k' , 'cmd+p' ]` and `keypress = `cmd+i` - last pressed chord

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -174,7 +174,7 @@ export class NotebookEditor extends EditorPane implements INotebookEditorPane, I
 		if (!visible) {
 			this._saveEditorViewState(this.input);
 			if (this.input && this._widget.value) {
-				// the widget is not transfered to other editor inputs
+				// the widget is not transferred to other editor inputs
 				this._widget.value.onWillHide();
 			}
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1329,7 +1329,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		// select cells if options tell to do so
 		// todo@rebornix https://github.com/microsoft/vscode/issues/118108 support selections not just focus
-		// todo@rebornix support multipe selections
+		// todo@rebornix support multiple selections
 		if (options?.cellSelections) {
 			const focusCellIndex = options.cellSelections[0].start;
 			const focusedCell = this.viewModel.cellAt(focusCellIndex);

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -529,7 +529,7 @@ export class TestingDecorations extends Disposable implements IEditorContributio
 			for await (const _tests of testsInFile(this.testService, this.uriIdentityService, uri, false)) {
 				// consume the iterator so that all tests in the file get expanded. Or
 				// at least until the URI changes. If new items are requested, changes
-				// will be trigged in the `onDidProcessDiff` callback.
+				// will be triggered in the `onDidProcessDiff` callback.
 				if (this._currentUri !== uri) {
 					break;
 				}

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -361,7 +361,7 @@ export interface AmbiguousRunTestsRequest {
 	exclude?: InternalTestItem[];
 	/** Whether this was triggered from an auto run. */
 	continuous?: boolean;
-	/** Whether this was trigged by a user action in UI. Default=true */
+	/** Whether this was triggered by a user action in UI. Default=true */
 	preserveFocus?: boolean;
 }
 

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -105,7 +105,7 @@ export interface ResolvedTestRunRequest {
 	exclude?: string[];
 	/** Whether this is a continuous test run */
 	continuous?: boolean;
-	/** Whether this was trigged by a user action in UI. Default=true */
+	/** Whether this was triggered by a user action in UI. Default=true */
 	preserveFocus?: boolean;
 }
 

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -905,7 +905,7 @@ suite('ExtensionEnablementService Test', () => {
 		assert.deepStrictEqual(testObject.getEnablementState(webExtension), EnablementState.EnabledGlobally);
 	});
 
-	test('test state of multipe extensions', async () => {
+	test('test state of multiple extensions', async () => {
 		installed.push(...[aLocalExtension('pub.a'), aLocalExtension('pub.b'), aLocalExtension('pub.c'), aLocalExtension('pub.d'), aLocalExtension('pub.e')]);
 		testObject = disposableStore.add(new TestExtensionEnablementService(instantiationService));
 		await (<TestExtensionEnablementService>testObject).waitUntilInitialized();

--- a/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
@@ -227,7 +227,7 @@ suite('RPCProtocol', () => {
 		});
 	});
 
-	test('SerializableObjectWithBuffers is correctly transfered', function (done) {
+	test('SerializableObjectWithBuffers is correctly transferred', function (done) {
 		delegate = (a1: SerializableObjectWithBuffers<{ string: string; buff: VSBuffer }>, a2: number) => {
 			return new SerializableObjectWithBuffers({ string: a1.value.string + ' world', buff: a1.value.buff });
 		};

--- a/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -194,7 +194,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 			// let score = matchedKeyboardLayout.score;
 
 			// Due to https://bugs.chromium.org/p/chromium/issues/detail?id=977609, any key after a dead key will generate a wrong mapping,
-			// we shoud avoid yielding the false error.
+			// we should avoid yielding the false error.
 			// if (keymap && score < 0) {
 			// const donotAskUpdateKey = 'missing.keyboardlayout.donotask';
 			// if (this._storageService.getBoolean(donotAskUpdateKey, StorageScope.APPLICATION)) {

--- a/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
+++ b/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
@@ -217,7 +217,7 @@ suite('ViewContainerModel', () => {
 		assert.deepStrictEqual(target.elements, [view3]);
 
 		testObject.setVisible('view3', false);
-		assert.deepStrictEqual(testObject.visibleViewDescriptors, [], 'view3 shoud hide');
+		assert.deepStrictEqual(testObject.visibleViewDescriptors, [], 'view3 should hide');
 		assert.deepStrictEqual(target.elements, []);
 
 		testObject.setVisible('view1', true);


### PR DESCRIPTION
Fix a collection of typos found across the codebase in comments, JSDoc, UI description strings, and test names. All changes are safe — no public API identifiers, config keys, or telemetry event names were modified.

**Changes:**
- `trigged` → `triggered` (`testTypes.ts`, `testService.ts`, `testingDecorations.ts`, `keybindingResolver.ts`)
- `transfered` → `transferred` (`rpcProtocol.test.ts`, `notebookEditor.ts`)
- `multipe` → `multiple` (`glob.test.ts`, `diskFileSystemProvider.ts`, `extensionEnablementService.test.ts`, `notebookEditorWidget.ts`)
- `similiar` → `similar` (`editorOptions.ts` UI description string)
- `shoud` → `should` (`textModelSearch.test.ts` ×3, `viewContainerModel.test.ts`, `keyboardLayoutService.ts`)