### PR TITLE
Fix spelling typos in comments and strings (batch 15)

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
+++ b/src/vs/editor/contrib/codelens/browser/codeLensCache.ts
@@ -69,7 +69,7 @@ export class CodeLensCache implements ICodeLensCache {
 
 	put(model: ITextModel, data: CodeLensModel): void {
 		// create a copy of the model that is without command-ids
-		// but with comand-labels
+		// but with command-labels
 		const copyItems = data.lenses.map((item): CodeLens => {
 			return {
 				range: item.symbol.range,

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -330,7 +330,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 					return offsetDigits[i].usableWidthLeftOfLineNumber;
 				}
 			}
-			throw new BugIndicatingError('Could not find avilable width for icon');
+			throw new BugIndicatingError('Could not find available width for icon');
 		};
 	});
 

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2527,7 +2527,7 @@ export class ToggleEditorTypeAction extends Action2 {
 			return;
 		}
 
-		// Replace the current editor with the next avaiable editor type
+		// Replace the current editor with the next available editor type
 		await editorService.replaceEditors([
 			{
 				editor: activeEditorPane.input,

--- a/src/vs/workbench/contrib/notebook/common/services/notebookWebWorker.ts
+++ b/src/vs/workbench/contrib/notebook/common/services/notebookWebWorker.ts
@@ -279,7 +279,7 @@ export class NotebookWorker implements IWebWorkerServerRequestHandler, IDisposab
 			 *
 			 * LCS has no notion of similarity, it only knows about equality.
 			 * We can use other algorithms to find similarity.
-			 * So if we eliminate A, B, we are left with C, D, E, F and we need to find what they map to in `e, F` in modifed document.
+			 * So if we eliminate A, B, we are left with C, D, E, F and we need to find what they map to in `e, F` in modified document.
 			 * We can use a similarity algorithm to find that.
 			 *
 			 * The purpose of using LCS first is to find the cells that have not changed.

--- a/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-browser/remoteTunnel.contribution.ts
@@ -195,7 +195,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 							key: 'recommend.remoteExtension',
 							comment: ['{0} will be a tunnel name, {1} will the link address to the web UI, {6} an extension name. [label](command:commandId) is a markdown link. Only translate the label, do not modify the format']
 						},
-						"Tunnel '{0}' is avaiable for remote access. The {1} extension can be used to connect to it.",
+						"Tunnel '{0}' is available for remote access. The {1} extension can be used to connect to it.",
 						usedOnHost, remoteExtension.friendlyName
 					),
 				actions: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -24,7 +24,7 @@ import { isMacintosh } from '../../../../../../base/common/platform.js';
  * shell integration, here are some problems that are expected:
  *
  * - `133;C` command executed may not happen.
- * - `633;E` comamnd line reporting will likely not happen, so the command line contained in the
+ * - `633;E` command line reporting will likely not happen, so the command line contained in the
  *   execution start and end events will be of low confidence and chances are it will be wrong.
  * - Execution tracking may be incorrect, particularly when `executeCommand` calls are overlapped,
  *   such as Python activating the environment at the same time as Copilot executing a command. So

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -98,7 +98,7 @@ class CachedDecorations {
 		const key = testIds.sort().join('\0\0');
 		return this.runByIdKey.get(key);
 	}
-	/** Adds a new test run decroation */
+	/** Adds a new test run decoration */
 	public addTest(d: RunTestDecoration) {
 		const key = d.testIds.sort().join('\0\0');
 		this.runByIdKey.set(key, d);

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -92,7 +92,7 @@ export interface ITestRunProfileReference {
 }
 
 /**
- * A fully-resolved request to run tests, passsed between the main thread
+ * A fully-resolved request to run tests, passed between the main thread
  * and extension host.
  */
 export interface ResolvedTestRunRequest {
@@ -593,7 +593,7 @@ export namespace TestResultItem {
 export interface ISerializedTestResults {
 	/** ID of these test results */
 	id: string;
-	/** Time the results were compelted */
+	/** Time the results were completed */
 	completedAt: number;
 	/** Subset of test result items */
 	items: TestResultItem.Serialized[];


### PR DESCRIPTION
Fixes spelling typos in comments, JSDoc, error strings, and localized UI strings. All changes are in non-public-API code paths.

**Changes:**
- `avilable` → `available` in `gutterIndicatorView.ts` (BugIndicatingError string)
- `avaiable` → `available` in `editorActions.ts` (comment) and `remoteTunnel.contribution.ts` (localized UI string)
- `comamnd` → `command` in `basicExecuteStrategy.ts` (comment)
- `comand` → `command` in `codeLensCache.ts` (comment)
- `modifed` → `modified` in `notebookWebWorker.ts` (comment)
- `decroation` → `decoration` in `testingDecorations.ts` (JSDoc)
- `passsed` → `passed`, `trigged` → `triggered`, `compelted` → `completed` in `testTypes.ts` (JSDoc)

No functional changes — comments, JSDoc, error strings, and localized strings only.