### PR TITLE
Fix doubled words and spelling typos in comments (batch 17)

### DIFF
--- a/src/vs/base/common/jsonc.ts
+++ b/src/vs/base/common/jsonc.ts
@@ -26,7 +26,7 @@ export function stripComments(content: string): string {
 			// A block comment. Replace with nothing
 			return '';
 		} else if (m4) {
-			// Since m4 is a single line comment is is at least of length 2 (e.g. //)
+			// Since m4 is a single line comment it is at least of length 2 (e.g. //)
 			// If it ends in \r?\n then keep it.
 			const length = m4.length;
 			if (m4[length - 1] === '\n') {

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -178,9 +178,9 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 	 * Applies the tunnel metadata and factory found in the remote authority
 	 * resolver to the tunnel system.
 	 *
-	 * `managedRemoteAuthority` should be be passed if the resolver returned on.
+	 * `managedRemoteAuthority` should be passed if the resolver returned on.
 	 * If this is the case, the tunnel cannot be connected to via a websocket from
-	 * the share process, so a synethic tunnel factory is used as a default.
+	 * the share process, so a synthetic tunnel factory is used as a default.
 	 */
 	async setTunnelFactory(provider: vscode.RemoteAuthorityResolver | undefined, managedRemoteAuthority: vscode.ManagedResolvedAuthority | undefined): Promise<IDisposable> {
 		// Do not wait for any of the proxy promises here.

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -524,7 +524,7 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 		const completePromise = new DeferredPromise<void>();
 		const startPromise = new DeferredPromise<void>();
 
-		// Sequence all edits made this this resource in this streaming edits instance,
+		// Sequence all edits made to this resource in this streaming edits instance,
 		// and also sequence the resource overall in the rare (currently invalid?) case
 		// that edits are made in parallel to the same resource,
 		const sequencer = new ThrottledSequencer(15, 1000);

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -366,7 +366,7 @@ class AttachedHistory extends Disposable {
 
 	/**
 	 * Pushes an history item that is tied to the last text edit (or an extension of it).
-	 * When the last text edit is undone/redone, so is is this history item.
+	 * When the last text edit is undone/redone, so is this history item.
 	 */
 	public pushAttachedHistoryElement(element: IAttachedHistoryElement): void {
 		this.attachedHistory.push({ altId: this.model.getAlternativeVersionId(), element });

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -978,7 +978,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('notebook.cellToolbarLocation.description', "Where the cell toolbar should be shown, or whether it should be hidden."),
 			type: 'object',
 			additionalProperties: {
-				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for for specific file types"),
+				markdownDescription: nls.localize('notebook.cellToolbarLocation.viewType', "Configure the cell toolbar position for specific file types"),
 				type: 'string',
 				enum: ['left', 'right', 'hidden']
 			},

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -314,7 +314,7 @@ export class SearchView extends ViewPane {
 
 		this._refreshResultsScheduler = this._register(new RunOnceScheduler(this._updateResults.bind(this), 80));
 
-		// storage service listener for for roaming changes
+		// storage service listener for roaming changes
 		this._register(this.storageService.onWillSaveState(() => {
 			this._saveSearchHistoryService();
 		}));

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3326,7 +3326,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 						}
 					}
 
-					// At this this point there are multiple tasks.
+					// At this point there are multiple tasks.
 					chooseAndRunTask(tasks);
 				});
 			};

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -101,7 +101,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 
 		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions'];
 		this._register(this._remoteTerminalChannel.onExecuteCommand(async e => {
-			// Ensure this request for for this window
+			// Ensure this request for this window
 			const pty = this._ptys.get(e.persistentProcessId);
 			if (!pty) {
 				return;

--- a/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalStatusList.ts
@@ -42,7 +42,7 @@ export interface ITerminalStatusList {
 	/**
 	 * Adds a status to the list.
 	 * @param status The status object. Ideally a single status object that does not change will be
-	 * shared as this call will no-op if the status is already set (checked by by object reference).
+	 * shared as this call will no-op if the status is already set (checked by object reference).
 	 * @param duration An optional duration in milliseconds of the status, when specified the status
 	 * will remove itself when the duration elapses unless the status gets re-added.
 	 */

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
@@ -190,7 +190,7 @@ registerTerminalAction({
 	],
 	run: async (c, accessor) => {
 		let activeInstance = c.service.activeInstance;
-		// If an instanec doesn't exist, create one and wait for shell type to be set
+		// If an instance doesn't exist, create one and wait for shell type to be set
 		if (!activeInstance) {
 			const newInstance = activeInstance = await c.service.getActiveOrCreateInstance();
 			await c.service.revealActiveTerminal();

--- a/src/vs/workbench/services/label/test/browser/label.test.ts
+++ b/src/vs/workbench/services/label/test/browser/label.test.ts
@@ -98,7 +98,7 @@ suite('URI Label', () => {
 		assert.strictEqual(labelService.getUriBasenameLabel(uri1), 'END');
 	});
 
-	test('mulitple authority', function () {
+	test('multiple authority', function () {
 		labelService.registerFormatter({
 			scheme: 'vscode',
 			authority: 'not_matching_but_long',


### PR DESCRIPTION
Fixes doubled words and spelling typos in comments, JSDoc, test names, and localized strings.

**Doubled words fixed:**
- `for for` → `for` in `notebook.contribution.ts` (localized UI description string)
- `is is` → `is` in `viewModel.ts` JSDoc
- `for for` → `for` in `searchView.ts` comment
- `for for` → `for` in `remoteTerminalBackend.ts` comment
- `by by` → `by` in `terminalStatusList.ts` JSDoc
- `is is at least` → `it is at least` in `jsonc.ts` comment
- `be be` → `be` in `extHostTunnelService.ts` JSDoc
- `this this` → `this` in `abstractTaskService.ts` comment
- `this this` → `to this` in `chatEditingSession.ts` comment

**Spelling typos fixed:**
- `synethic` → `synthetic` in `extHostTunnelService.ts` JSDoc
- `instanec` → `instance` in `terminal.history.contribution.ts` comment
- `mulitple` → `multiple` in `label.test.ts` test name

No functional changes — all changes are in comments, JSDoc, test names, and localized strings.