### PR TITLE
Fix spelling typos in comments and test names (batch 18)

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
@@ -35,33 +35,33 @@ suite('mockService', () => {
 			assert.strictEqual(
 				mock.bar,
 				'oh hi!',
-				'bar should be overriden',
+				'bar should be overridden',
 			);
 
 			assert.strictEqual(
 				mock.baz,
 				42,
-				'baz should be overriden',
+				'baz should be overridden',
 			);
 
 			assert(
 				!(mock.anotherMethod(490274)),
-				'Must execute overriden method correctly 1.',
+				'Must execute overridden method correctly 1.',
 			);
 
 			assert(
 				mock.anotherMethod(NaN),
-				'Must execute overriden method correctly 2.',
+				'Must execute overridden method correctly 2.',
 			);
 
 			assert.throws(() => {
-				// property is not overriden so must throw
+				// property is not overridden so must throw
 				// eslint-disable-next-line local/code-no-unused-expressions
 				mock.foo;
 			});
 
 			assert.throws(() => {
-				// function is not overriden so must throw
+				// function is not overridden so must throw
 				mock.someMethod(randomBoolean());
 			});
 		});

--- a/src/vs/workbench/contrib/debug/browser/debugQuickAccess.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugQuickAccess.ts
@@ -95,7 +95,7 @@ export class StartDebugQuickAccessProvider extends PickerQuickAccessProvider<IPi
 			picks.push({
 				type: 'separator', label: localize({
 					key: 'contributed',
-					comment: ['contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations.']
+					comment: ['contributed is lower case because it looks better like that in UI. Nothing precedes it. It is a name of the grouping of debug configurations.']
 				}, "contributed")
 			});
 		}

--- a/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
@@ -511,7 +511,7 @@ suite('Terminal history', () => {
 				});
 			});
 
-			suite('local (overriden path)', () => {
+			suite('local (overridden path)', () => {
 				let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 				setup(() => {
 					originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };
@@ -569,7 +569,7 @@ suite('Terminal history', () => {
 			});
 		});
 
-		suite('remote (overriden path)', () => {
+		suite('remote (overridden path)', () => {
 			let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 			setup(() => {
 				originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -962,9 +962,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (
 			// The line didn't end with ghost text
 			(currentPromptInputState.ghostTextIndex === -1 || currentPromptInputState.ghostTextIndex > currentPromptInputState.cursorIndex) &&
-			// There is more than one charatcer
+			// There is more than one character
 			currentPromptInputState.value.length > currentPromptInputState.cursorIndex + 1 &&
-			// THe next character is not a space
+			// The next character is not a space
 			currentPromptInputState.value.at(currentPromptInputState.cursorIndex) !== ' '
 		) {
 			const spaceIndex = currentPromptInputState.value.substring(currentPromptInputState.cursorIndex, currentPromptInputState.ghostTextIndex === -1 ? undefined : currentPromptInputState.ghostTextIndex).indexOf(' ');

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -2482,7 +2482,7 @@ suite('EditorService', () => {
 		const untypedInput1 = input1.toUntyped();
 		assert.ok(untypedInput1);
 
-		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overriden
+		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overridden
 		await service.openEditor(input1);
 		assert.strictEqual(editorCount, 0);
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -695,7 +695,7 @@ function getEscapeAwareSplitStringForRipgrep(pattern: string): { fixedStart?: st
 		switch (char) {
 			case '\\':
 				if (escaped) {
-					// If we're already escaped, then just leave the escaped slash and the preceeding slash that escapes it.
+					// If we're already escaped, then just leave the escaped slash and the preceding slash that escapes it.
 					// The two escaped slashes will result in a single slash and whatever processes the glob later will properly process the escape
 					if (inBraces) {
 						strInBraces += '\\' + char;


### PR DESCRIPTION
Fixes spelling typos in comments, JSDoc comments (in localize calls), and test suite/test names.

**Changes:**
- `overriden` → `overridden` in `history.test.ts` (×2 suite names), `mock.test.ts` (×4 test strings), `editorService.test.ts` (comment)
- `preceeds` → `precedes` in `debugQuickAccess.ts` (localize comment annotation)
- `preceeding` → `preceding` in `ripgrepTextSearchEngine.ts` (comment)
- `charatcer` → `character` in `terminalSuggestAddon.ts` (comment)
- `THe` → `The` in `terminalSuggestAddon.ts` (comment)

No functional changes — all changes are in comments, test names/strings, and localize comment annotations.