### PR TITLE
Fix spelling typos and doubled words in JSDoc and comments (batch 19)

### DIFF
--- a/src/vs/editor/test/common/model/tokensStore.test.ts
+++ b/src/vs/editor/test/common/model/tokensStore.test.ts
@@ -449,7 +449,7 @@ suite('TokensStore', () => {
 	});
 
 
-	test('issue #95949: Identifiers are colored in bold when targetting keywords', () => {
+	test('issue #95949: Identifiers are colored in bold when targeting keywords', () => {
 
 		function createTMMetadata(foreground: number, fontStyle: number, languageId: number): number {
 			return (

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -405,7 +405,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 	 *
 	 * @param handle used to get notebook serializer
 	 * @param textQuery the text query to search using
-	 * @param viewTypeFileTargets the globs (and associated ranks) that are targetting for opening this type of notebook
+	 * @param viewTypeFileTargets the globs (and associated ranks) that are targeting for opening this type of notebook
 	 * @param otherViewTypeFileTargets ranked globs for other editors that we should consider when deciding whether it will open as this notebook
 	 * @param token cancellation token
 	 * @returns `IRawClosedNotebookFileMatch` for every file. Files without matches will just have a `IRawClosedNotebookFileMatch`

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -984,7 +984,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			rootFiles.push({ fileName: CLAUDE_LOCAL_MD_FILENAME, type: AgentInstructionFileType.claudeMd }); // CLAUDE.local.md in workspace root
 
 			promises.push(this.fileLocator.findFilesInRoots(rootFolders, CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in .claude folder under workspace root
-			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in in ~/.claude folder
+			promises.push(this.fileLocator.findFilesInRoots([await this.pathService.userHome()], CLAUDE_CONFIG_FOLDER, [claudeMdFile], token, resolvedAgentFiles)); // CLAUDE.md in ~/.claude folder
 		}
 		const useCopilotInstructionsFiles = this.configurationService.getValue(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES);
 		if (!useCopilotInstructionsFiles) {

--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -48,7 +48,7 @@ export interface IQuickDiffModelService {
 
 	/**
 	 * Returns `undefined` if the editor model is not resolved.
-	 * Model refrence has to be disposed once not needed anymore.
+	 * Model reference has to be disposed once not needed anymore.
 	 * @param resource
 	 * @param options
 	 */

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -9619,7 +9619,7 @@ declare module 'vscode' {
 		 *
 		 * The `excludes` array is used to indicate paths that should be excluded from file
 		 * watching. It is typically derived from the `files.watcherExclude` setting that
-		 * is configurable by the user. Each entry can be be:
+		 * is configurable by the user. Each entry can be:
 		 * - the absolute path to exclude
 		 * - a relative path to exclude (for example `build/output`)
 		 * - a simple glob pattern (for example `**​/build`, `output/**`)
@@ -12613,7 +12613,7 @@ declare module 'vscode' {
 		 * Note writing `\n` will just move the cursor down 1 row, you need to write `\r` as well
 		 * to move the cursor to the left-most cell.
 		 *
-		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+		 * Events fired before {@link Pseudoterminal.open} is called will be ignored.
 		 *
 		 * **Example:** Write red text to the terminal
 		 * ```typescript
@@ -12640,7 +12640,7 @@ declare module 'vscode' {
 		 * bar). Set to `undefined` for the terminal to go back to the regular dimensions (fit to
 		 * the size of the panel).
 		 *
-		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+		 * Events fired before {@link Pseudoterminal.open} is called will be ignored.
 		 *
 		 * **Example:** Override the dimensions of a terminal to 20 columns and 10 rows
 		 * ```typescript
@@ -12664,7 +12664,7 @@ declare module 'vscode' {
 		/**
 		 * An event that when fired will signal that the pty is closed and dispose of the terminal.
 		 *
-		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+		 * Events fired before {@link Pseudoterminal.open} is called will be ignored.
 		 *
 		 * A number can be used to provide an exit code for the terminal. Exit codes must be
 		 * positive and a non-zero exit codes signals failure which shows a notification for a
@@ -12696,7 +12696,7 @@ declare module 'vscode' {
 		/**
 		 * An event that when fired allows changing the name of the terminal.
 		 *
-		 * Events fired before {@link Pseudoterminal.open} is called will be be ignored.
+		 * Events fired before {@link Pseudoterminal.open} is called will be ignored.
 		 *
 		 * **Example:** Change the terminal name to "My new terminal".
 		 * ```typescript
@@ -17927,7 +17927,7 @@ declare module 'vscode' {
 		forceNewSession?: boolean | AuthenticationGetSessionPresentationOptions | AuthenticationForceNewSessionOptions;
 
 		/**
-		 * Whether we should show the indication to sign in in the Accounts menu.
+		 * Whether we should show the indication to sign in the Accounts menu.
 		 *
 		 * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
 		 * If true, no indication will be shown.


### PR DESCRIPTION
Fixes spelling typos and doubled words in JSDoc comments and code comments.

**Doubled words fixed:**
- `can be be:` → `can be:` in `vscode.d.ts` (JSDoc for file watcher excludes)
- `will be be ignored` → `will be ignored` in `vscode.d.ts` (×4, Pseudoterminal JSDoc)
- `sign in in the` → `sign in the` in `vscode.d.ts` (JSDoc)
- `in in ~/.claude` → `in ~/.claude` in `promptsServiceImpl.ts` (comment)

**Spelling typos fixed:**
- `targetting` → `targeting` in `extHostNotebook.ts` (JSDoc `@param`)
- `targetting` → `targeting` in `tokensStore.test.ts` (test name)
- `refrence` → `reference` in `quickDiffModel.ts` (JSDoc)

No functional changes — all changes are in comments, JSDoc, and test names.