### PR TITLE
Fix spelling typos in comments, JSDoc, and local variables (batch 20)

### DIFF
--- a/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
+++ b/src/vs/base/parts/sandbox/electron-browser/electronTypes.ts
@@ -183,7 +183,7 @@ export interface WebUtils {
 	 * where the File object passed in was constructed in JS and is not backed by a
 	 * file on disk an empty string is returned.
 	 *
-	 * This method superceded the previous augmentation to the `File` object with the
+	 * This method superseded the previous augmentation to the `File` object with the
 	 * `path` property.  An example is included below.
 	 */
 	getPathForFile(file: File): string;

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1260,7 +1260,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._domNode.ariaLabel = NLS_FIND_DIALOG_LABEL;
 		this._domNode.role = 'dialog';
 
-		// We need to set this explicitly, otherwise on IE11, the width inheritence of flex doesn't work.
+		// We need to set this explicitly, otherwise on IE11, the width inheritance of flex doesn't work.
 		this._domNode.style.width = `${FIND_WIDGET_INITIAL_WIDTH}px`;
 
 		this._domNode.appendChild(this._toggleReplaceBtn.domNode);

--- a/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
+++ b/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
@@ -401,7 +401,7 @@ suite('ParameterHintsModel', () => {
 		const triggerChar = 'a';
 		const firstProviderId = 'firstProvider';
 		const secondProviderId = 'secondProvider';
-		const paramterLabel = 'parameter';
+		const parameterLabel = 'parameter';
 
 		const editor = createMockEditor('');
 		const model = disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -423,7 +423,7 @@ suite('ParameterHintsModel', () => {
 								signatures: [{
 									label: firstProviderId,
 									parameters: [
-										{ label: paramterLabel }
+										{ label: parameterLabel }
 									]
 								}]
 							},
@@ -468,12 +468,12 @@ suite('ParameterHintsModel', () => {
 			const firstHint = (await getNextHint(model))!.value;
 			assert.strictEqual(firstHint.signatures[0].label, firstProviderId);
 			assert.strictEqual(firstHint.activeSignature, 0);
-			assert.strictEqual(firstHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(firstHint.signatures[0].parameters[0].label, parameterLabel);
 
 			const secondHint = (await getNextHint(model))!.value;
 			assert.strictEqual(secondHint.signatures[0].label, secondProviderId);
 			assert.strictEqual(secondHint.activeSignature, 1);
-			assert.strictEqual(secondHint.signatures[0].parameters[0].label, paramterLabel);
+			assert.strictEqual(secondHint.signatures[0].parameters[0].label, parameterLabel);
 		});
 	});
 

--- a/src/vs/editor/test/common/model/textModelSearch.test.ts
+++ b/src/vs/editor/test/common/model/textModelSearch.test.ts
@@ -797,7 +797,7 @@ suite('TextModelSearch', () => {
 	});
 
 	test('issue #100134. Zero-length matches should properly step over surrogate pairs', () => {
-		// 1[Laptop]1 - there shoud be no matches inside of [Laptop] emoji
+		// 1[Laptop]1 - there should be no matches inside of [Laptop] emoji
 		assertFindMatches('1\uD83D\uDCBB1', '()', true, false, null,
 			[
 				[1, 1, 1, 1],
@@ -807,8 +807,8 @@ suite('TextModelSearch', () => {
 
 			]
 		);
-		// 1[Hacker Cat]1 = 1[Cat Face][ZWJ][Laptop]1 - there shoud be matches between emoji and ZWJ
-		// there shoud be no matches inside of [Cat Face] and [Laptop] emoji
+		// 1[Hacker Cat]1 = 1[Cat Face][ZWJ][Laptop]1 - there should be matches between emoji and ZWJ
+		// there should be no matches inside of [Cat Face] and [Laptop] emoji
 		assertFindMatches('1\uD83D\uDC31\u200D\uD83D\uDCBB1', '()', true, false, null,
 			[
 				[1, 1, 1, 1],

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -170,11 +170,11 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 		const wasEmpty = this._configurationModel.isEmpty();
 
 		for (const key of keys) {
-			const proprety = configurationProperties[key] ?? excludedConfigurationProperties[key];
-			const policyName = proprety?.policy?.name;
+			const property = configurationProperties[key] ?? excludedConfigurationProperties[key];
+			const policyName = property?.policy?.name;
 			if (policyName) {
 				let policyValue: PolicyValue | ParsedType | undefined = this.policyService.getPolicyValue(policyName);
-				if (isString(policyValue) && proprety.type !== 'string') {
+				if (isString(policyValue) && property?.type !== 'string') {
 					try {
 						policyValue = this.parse(policyValue);
 					} catch (e) {

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -389,7 +389,7 @@ class MainThreadChatSessionItemController extends Disposable implements IChatSes
 		this._proxy = proxy;
 		this._handle = handle;
 
-		// Update the chat session item based on on the actual model state
+		// Update the chat session item based on the actual model state
 		// TODO: This should be based on the chat session content provider instead of the chat models directly
 		// or bed moved into the chat session service so that all controllers get the same behavior.
 		const addModelListeners = async (model: IChatModel) => {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -290,7 +290,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 					} else if (isShiftPressed) {
 						breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!enabled, bp));
 					} else if (!env.isLinux && breakpoints.some(bp => !!bp.condition || !!bp.logMessage || !!bp.hitCondition || !!bp.triggeredBy)) {
-						// Show the dialog if there is a potential condition to be accidently lost.
+						// Show the dialog if there is a potential condition to be accidentally lost.
 						// Do not show dialog on linux due to electron issue freezing the mouse #50026
 						const logPoint = breakpoints.every(bp => !!bp.logMessage);
 						const breakpointType = logPoint ? nls.localize('logPoint', "Logpoint") : nls.localize('breakpoint', "Breakpoint");

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -727,7 +727,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(listenerDisposables);
 
 		const sessionRunningScheduler = listenerDisposables.add(new RunOnceScheduler(() => {
-			// Do not immediatly defocus the stack frame if the session is running
+			// Do not immediately defocus the stack frame if the session is running
 			if (session.state === State.Running && this.viewModel.focusedSession === session) {
 				this.viewModel.setFocus(undefined, this.viewModel.focusedThread, session, false);
 			}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;

--- a/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -194,7 +194,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 			// let score = matchedKeyboardLayout.score;
 
 			// Due to https://bugs.chromium.org/p/chromium/issues/detail?id=977609, any key after a dead key will generate a wrong mapping,
-			// we shoud avoid yielding the false error.
+			// we should avoid yielding the false error.
 			// if (keymap && score < 0) {
 			// const donotAskUpdateKey = 'missing.keyboardlayout.donotask';
 			// if (this._storageService.getBoolean(donotAskUpdateKey, StorageScope.APPLICATION)) {

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -51,7 +51,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 
 		this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);
 
-		// When the level changes it could change from off to on and we want to make sure telemetry is properly intialized
+		// When the level changes it could change from off to on and we want to make sure telemetry is properly initialized
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(TELEMETRY_SETTING_ID)) {
 				this.impl = this.initializeService(environmentService, loggerService, configurationService, storageService, productService, remoteAgentService, meteredConnectionService);

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -462,7 +462,7 @@ export interface ITimerService {
 	/**
 	 * Return the duration between two marks.
 	 * @param from from mark name
-	 * @param to to mark name
+	 * @param to mark name
 	 */
 	getDuration(from: string, to: string): number;
 

--- a/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
+++ b/src/vs/workbench/services/views/test/browser/viewContainerModel.test.ts
@@ -217,7 +217,7 @@ suite('ViewContainerModel', () => {
 		assert.deepStrictEqual(target.elements, [view3]);
 
 		testObject.setVisible('view3', false);
-		assert.deepStrictEqual(testObject.visibleViewDescriptors, [], 'view3 shoud hide');
+		assert.deepStrictEqual(testObject.visibleViewDescriptors, [], 'view3 should hide');
 		assert.deepStrictEqual(target.elements, []);
 
 		testObject.setVisible('view1', true);


### PR DESCRIPTION
Fixes spelling typos in comments, JSDoc blocks, and local variable names across various source files.

**Changes:**
- `mainThreadChatSessions.ts`: `on on` → `on` in comment
- `electronTypes.ts`: `superceded` → `superseded` in JSDoc
- `extHostTypes.ts`: `seperate` → `separate` in comment
- `timerService.ts` (browser): `@param to to mark name` → `@param to mark name` in JSDoc
- `parameterHintsModel.test.ts`: `paramterLabel` → `parameterLabel` (local variable, ×4)
- `configurations.ts`: `proprety` → `property` (local variable, ×3)
- `findWidget.ts`: `inheritence` → `inheritance` in comment
- `parcelWatcher.ts`: `occured` → `occurred` in comment
- `viewContainerModel.test.ts`: `shoud` → `should` in assert message
- `keyboardLayoutService.ts`: `shoud` → `should` in comment
- `textModelSearch.test.ts`: `shoud` → `should` in comments (×3)
- `telemetryService.ts`: `intialized` → `initialized` in comment
- `breakpointEditorContribution.ts`: `accidently` → `accidentally` in comment
- `debugSession.ts`: `immediatly` → `immediately` in comment
- `debugService.ts`: `immediatly` → `immediately` in comment