### PR TITLE
Fix spelling typos in comments, JSDoc, and local variables (batch 21)

### DIFF
--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -50,13 +50,13 @@ suite('Arrays', () => {
 
 	test('quickSelect', () => {
 
-		function assertMedian(expexted: number, data: number[], nth: number = Math.floor(data.length / 2)) {
+		function assertMedian(expected: number, data: number[], nth: number = Math.floor(data.length / 2)) {
 			const compare = (a: number, b: number) => a - b;
 			const actual1 = arrays.quickSelect(nth, data, compare);
-			assert.strictEqual(actual1, expexted);
+			assert.strictEqual(actual1, expected);
 
 			const actual2 = data.slice().sort(compare)[nth];
-			assert.strictEqual(actual2, expexted);
+			assert.strictEqual(actual2, expected);
 		}
 
 		assertMedian(5, [9, 1, 0, 2, 3, 4, 6, 8, 7, 10, 5]);

--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -128,7 +128,7 @@ export class ContextMenuController implements IEditorContribution {
 			}
 		}
 
-		// Unless the user triggerd the context menu through Shift+F10, use the mouse position as menu position
+		// Unless the user triggered the context menu through Shift+F10, use the mouse position as menu position
 		let anchor: IMouseEvent | null = null;
 		if (e.target.type !== MouseTargetType.TEXTAREA) {
 			anchor = e.event;

--- a/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
@@ -338,7 +338,7 @@ export abstract class AbstractExtensionsProfileScannerService extends Disposable
 					if (Array.isArray(parsedData) && parsedData.every(candidate => isStoredProfileExtension(candidate))) {
 						storedProfileExtensions = parsedData;
 					} else {
-						this.logService.warn('Skipping migrating from old default profile locaiton: Found invalid data', parsedData);
+						this.logService.warn('Skipping migrating from old default profile location: Found invalid data', parsedData);
 					}
 				} catch (error) {
 					/* Ignore */

--- a/src/vs/platform/extensionManagement/node/extensionDownloader.ts
+++ b/src/vs/platform/extensionManagement/node/extensionDownloader.ts
@@ -174,7 +174,7 @@ export class ExtensionsDownloader extends Disposable {
 			return;
 		}
 
-		// Download directly if locaiton is not file scheme
+		// Download directly if location is not file scheme
 		if (location.scheme !== Schemas.file) {
 			await downloadFn(location);
 			return;

--- a/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
+++ b/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
@@ -32,7 +32,7 @@ export class NodeJSFileWatcherLibrary extends Disposable {
 	// Same delay as used for the recursive watcher.
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 
-	// Reduce likelyhood of spam from file events via throttling.
+	// Reduce likelihood of spam from file events via throttling.
 	// These numbers are a bit more aggressive compared to the
 	// recursive watcher because we can have many individual
 	// node.js watchers per request.

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -172,11 +172,11 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// Note: since Parcel 2.0.7, the very first event is
 	// emitted without delay if no events occured over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 
-	// Reduce likelyhood of spam from file events via throttling.
+	// Reduce likelihood of spam from file events via throttling.
 	// (https://github.com/microsoft/vscode/issues/124723)
 	private readonly throttledFileChangesEmitter = this._register(new ThrottledWorker<IFileChange>(
 		{

--- a/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/statusBarExtensionPoint.ts
@@ -124,7 +124,7 @@ class ExtensionStatusBarItemService implements IExtensionStatusBarItemService {
 			if (typeof extensionId === 'string') {
 				// We cannot enforce unique priorities across all extensions, so we
 				// use the extension identifier as a secondary sort key to reduce
-				// the likelyhood of collisions.
+				// the likelihood of collisions.
 				// See https://github.com/microsoft/vscode/issues/177835
 				// See https://github.com/microsoft/vscode/issues/123827
 				entryPriority = { primary: priority, secondary: hash(extensionId) };

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -2111,7 +2111,7 @@ export class SCMHistoryViewPane extends ViewPane {
 
 			const historyItemRefMenuItems = MenuRegistry.getMenuItems(MenuId.SCMHistoryItemRefContext).filter(item => isIMenuItem(item));
 
-			// If there are any history item references we have to add a submenu item for each orignal action,
+			// If there are any history item references we have to add a submenu item for each original action,
 			// and a menu item for each history item ref that matches the `when` clause of the original action.
 			if (historyItemRefMenuItems.length > 0 && element.historyItemViewModel.historyItem.references?.length) {
 				const historyItemRefActions = new Map<string, ISCMHistoryItemRef[]>();

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
@@ -52,7 +52,7 @@ export class LspTerminalModelContentProvider extends Disposable implements ILspT
 
 	/**
 	 * Sets or updates content for a terminal virtual document.
-	 * This is when user has executed succesful command in terminal.
+	 * This is when user has executed successful command in terminal.
 	 * Transfer the content to virtual document, and relocate delimiter to get terminal prompt ready for next prompt.
 	 */
 	setContent(content: string): void {

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -695,7 +695,7 @@ function getEscapeAwareSplitStringForRipgrep(pattern: string): { fixedStart?: st
 		switch (char) {
 			case '\\':
 				if (escaped) {
-					// If we're already escaped, then just leave the escaped slash and the preceeding slash that escapes it.
+					// If we're already escaped, then just leave the escaped slash and the preceding slash that escapes it.
 					// The two escaped slashes will result in a single slash and whatever processes the glob later will properly process the escape
 					if (inBraces) {
 						strInBraces += '\\' + char;

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -905,7 +905,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).

--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -375,7 +375,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 			this.setDirty(this.hasAssociatedFilePath || !!hasBackup || !!this.initialValue);
 
 			// If we have initial contents, make sure to emit this
-			// as the appropiate events to the outside.
+			// as the appropriate events to the outside.
 			if (hasBackup || this.initialValue) {
 				this._onDidChangeContent.fire();
 			}

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -1007,7 +1007,7 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 			}
 
 			// We have to protect against being disposed at this point. It could be that the save() operation
-			// was triggerd followed by a dispose() operation right after without waiting. Typically we cannot
+			// was triggered followed by a dispose() operation right after without waiting. Typically we cannot
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/microsoft/vscode/issues/50942).


### PR DESCRIPTION
Fixes spelling typos in comments, JSDoc blocks, and local variable names across various source files.

**Changes:**
- `untitledTextEditorModel.ts`: `appropiate` → `appropriate` in comment
- `extensionDownloader.ts`: `locaiton` → `location` in comment
- `extensionsProfileScannerService.ts`: `locaiton` → `location` in log message
- `scmHistoryViewPane.ts`: `orignal` → `original` in comment
- `lspTerminalModelContentProvider.ts`: `succesful` → `successful` in JSDoc
- `storedFileWorkingCopy.ts`: `triggerd` → `triggered` in comment
- `textFileEditorModel.ts`: `triggerd` → `triggered` in comment
- `contextmenu.ts`: `triggerd` → `triggered` in comment
- `arrays.test.ts`: `expexted` → `expected` (local variable, ×3)
- `ripgrepTextSearchEngine.ts`: `preceeding` → `preceding` in comment
- `parcelWatcher.ts`: `coleasing` → `coalescing` and `likelyhood` → `likelihood` in comments
- `nodejsWatcherLib.ts`: `likelyhood` → `likelihood` in comment
- `statusBarExtensionPoint.ts`: `likelyhood` → `likelihood` in comment