### PR TITLE
fix: handle quoted ID values in check-requirements-linux.sh

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo "$ID")
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

The previous grep-based approach failed to parse ID values surrounded by quotes (e.g., `ID=\"rocky\"` on Rocky Linux 8.5), resulting in an empty `OS_ID` and exit code 1.

This fix uses `source /etc/os-release && echo \"$ID\"` to properly parse shell-compatible variable assignments, which correctly handles both quoted and unquoted values.

Fixes #232159

## Verification
- Tested with quoted format (`ID=\"rocky\"`): correctly returns `rocky`
- Tested with unquoted format (`ID=ubuntu`): correctly returns `ubuntu`
- The `source` approach is a standard shell idiom for reading `/etc/os-release`

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof