### PR TITLE
Editor: respect isRegex when using addSelectionToNextFindMatch

### DIFF
--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -286,7 +286,7 @@ export class MultiCursorSession {
 		//  - and the search string is non-empty
 		if (!editor.hasTextFocus() && findState.isRevealed && findState.searchString.length > 0) {
 			// Find widget owns what is searched for
-			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, null);
+			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, findState.isRegex, null);
 		}
 
 		// Otherwise, the selection gives the search text, and the find widget gives the search settings
@@ -294,14 +294,17 @@ export class MultiCursorSession {
 		let isDisconnectedFromFindController = false;
 		let wholeWord: boolean;
 		let matchCase: boolean;
+		let isRegex: boolean;
 		const selections = editor.getSelections();
 		if (selections.length === 1 && selections[0].isEmpty()) {
 			isDisconnectedFromFindController = true;
 			wholeWord = true;
 			matchCase = true;
+			isRegex = false;
 		} else {
 			wholeWord = findState.wholeWord;
 			matchCase = findState.matchCase;
+			isRegex = findState.isRegex;
 		}
 
 		// Selection owns what is searched for
@@ -322,7 +325,7 @@ export class MultiCursorSession {
 			searchText = editor.getModel().getValueInRange(s).replace(/\r\n/g, '\n');
 		}
 
-		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, currentMatch);
+		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, isRegex, currentMatch);
 	}
 
 	constructor(
@@ -332,6 +335,7 @@ export class MultiCursorSession {
 		public readonly searchText: string,
 		public readonly wholeWord: boolean,
 		public readonly matchCase: boolean,
+		public readonly isRegex: boolean,
 		public currentMatch: Selection | null
 	) { }
 
@@ -378,7 +382,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!nextMatch) {
 			return null;
@@ -429,7 +433,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!previousMatch) {
 			return null;
@@ -446,9 +450,9 @@ export class MultiCursorSession {
 
 		const editorModel = this._editor.getModel();
 		if (searchScope) {
-			return editorModel.findMatches(this.searchText, searchScope, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+			return editorModel.findMatches(this.searchText, searchScope, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 		}
-		return editorModel.findMatches(this.searchText, true, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+		return editorModel.findMatches(this.searchText, true, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 	}
 }
 

--- a/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
@@ -593,4 +593,78 @@ suite('Multicursor selection', () => {
 		});
 
 	});
+
+	suite('issue #107090: AddSelectionToNextFindMatch with isRegex', () => {
+
+		test('AddSelectionToNextFindMatchAction respects isRegex from find widget', () => {
+			// When the find widget has regex mode ON, Ctrl+D should treat the
+			// search string as a regex, not as a literal.
+			const text = [
+				'foo123',
+				'foo456',
+				'foo789',
+			];
+			testMulticursor(text, (editor, findController) => {
+				const action = new AddSelectionToNextFindMatchAction();
+
+				// Put focus in find widget so the find state drives the search
+				findController.getState().change({ searchString: 'foo\\d+', isRegex: true, isRevealed: true }, false);
+
+				// Click into the editor (simulate editor focus so the first Ctrl+D
+				// picks the first match driven by the find state)
+				editor.setSelection(new Selection(1, 1, 1, 1));
+
+				action.run(null!, editor);
+				// Should select the first regex match 'foo123'
+				assert.deepStrictEqual(editor.getSelections(), [
+					new Selection(1, 1, 1, 7),
+				]);
+
+				action.run(null!, editor);
+				// Should add 'foo456'
+				assert.deepStrictEqual(editor.getSelections(), [
+					new Selection(1, 1, 1, 7),
+					new Selection(2, 1, 2, 7),
+				]);
+
+				action.run(null!, editor);
+				// Should add 'foo789'
+				assert.deepStrictEqual(editor.getSelections(), [
+					new Selection(1, 1, 1, 7),
+					new Selection(2, 1, 2, 7),
+					new Selection(3, 1, 3, 7),
+				]);
+			});
+		});
+
+		test('SelectHighlightsAction respects isRegex from find widget', () => {
+			// "Select All Occurrences" (Ctrl+Shift+L) should also honour isRegex.
+			const text = [
+				'foo123',
+				'foo456',
+				'foo789',
+				'notfoo',
+			];
+			withTestCodeEditor(text, { serviceCollection: serviceCollection }, (editor) => {
+				const findController = editor.registerAndInstantiateContribution(CommonFindController.ID, CommonFindController);
+				const multiCursorSelectController = editor.registerAndInstantiateContribution(MultiCursorSelectionController.ID, MultiCursorSelectionController);
+				const action = new SelectHighlightsAction();
+
+				editor.setSelection(new Selection(1, 1, 1, 1));
+				findController.getState().change({ searchString: 'foo\\d+', isRegex: true, isRevealed: true }, false);
+
+				action.run(null!, editor);
+				assert.deepStrictEqual(editor.getSelections()!.map(fromRange), [
+					[1, 1, 1, 7],
+					[2, 1, 2, 7],
+					[3, 1, 3, 7],
+				]);
+
+				multiCursorSelectController.dispose();
+				findController.dispose();
+			});
+		});
+
+	});
+
 });


### PR DESCRIPTION
Fixes #107090

## What

When the find widget has **regex mode enabled**, pressing `Ctrl+D` (`addSelectionToNextFindMatch`) would always search with `isRegex: false`, treating the regex pattern as a literal string. This meant Ctrl+D produced no additional selections when the search string was a regex pattern.

The same problem affected:
- `addSelectionToPreviousFindMatch`
- `moveSelectionToNextFindMatch` / `moveSelectionToPreviousFindMatch`  
- `selectAll` (Select All Occurrences)

## Root Cause

`MultiCursorSession` never stored the `isRegex` flag from `FindState`, and every call to `findNextMatch`, `findPreviousMatch`, and `findMatches` hardcoded `false` for the `isRegex` argument.

## Fix

1. Added `isRegex: boolean` to `MultiCursorSession` constructor.
2. In `MultiCursorSession.create()`, read `findState.isRegex` when the session is connected to the find controller. When disconnected (word-expansion mode), `isRegex` is always `false` since we search for a literal word.
3. Replaced the three hardcoded `false` arguments in `_getNextMatch`, `_getPreviousMatch`, and `selectAll` with `this.isRegex`.

## How to Test

1. Open any file with repeated content, e.g.:
   ```
   foo123
   foo456
   foo789
   ```
2. Open the Find widget (`Ctrl+F`) and enable **regex mode**.
3. Type `foo\d+` in the search box.
4. Click into the editor. Press `Ctrl+D` repeatedly.
5. **Before fix:** no additional selections are made.
6. **After fix:** each `Ctrl+D` selects the next `foo\d+` match.