### PR TITLE
Issue reporter: show insiders-build prompt for stable users

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
@@ -172,6 +172,13 @@ export class BaseIssueReporterService extends Disposable {
 			show(this.getElementById('english'));
 		}
 
+		// Prompt stable users to verify the issue exists in VS Code Insiders before reporting,
+		// since many stable bugs are already fixed in the Insiders build.
+		if (product.quality === 'stable') {
+			// eslint-disable-next-line no-restricted-syntax
+			show(this.getElementById('insiders-banner'));
+		}
+
 		const codiconStyleSheet = createStyleSheet();
 		codiconStyleSheet.id = 'codiconStyles';
 

--- a/src/vs/workbench/contrib/issue/browser/issueReporterPage.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterPage.ts
@@ -13,6 +13,16 @@ const sendExtensionsLabel = escape(localize('sendExtensions', "Include my enable
 const sendExperimentsLabel = escape(localize('sendExperiments', "Include A/B experiment info"));
 const sendExtensionData = escape(localize('sendExtensionData', "Include additional extension info"));
 const acknowledgementsLabel = escape(localize('acknowledgements', "I acknowledge that my VS Code version is not updated and this issue may be closed."));
+const insidersBannerLabel = localize( // intentionally not escaped because of its embedded link
+	{
+		key: 'insidersBannerLabel',
+		comment: [
+			'{Locked="<a href=\"https://aka.ms/vscode-insiders\" id=\"insiders-link\" target=\"_blank\">"}',
+			'{Locked="</a>"}'
+		]
+	},
+	'Before reporting, please test your issue in the latest <a href="https://aka.ms/vscode-insiders" id="insiders-link" target="_blank">VS Code Insiders</a> build — many bugs in stable are already fixed there.'
+);
 const reviewGuidanceLabel = localize( // intentionally not escaped because of its embedded tags
 	{
 		key: 'reviewGuidanceLabel',
@@ -29,6 +39,9 @@ export default (): string => `
 	<span class="update-banner-text" id="update-banner-text">
 		<!-- To be dynamically filled -->
 	</span>
+</div>
+<div id="insiders-banner" class="issue-reporter-update-banner hidden">
+	${insidersBannerLabel}
 </div>
 <div class="issue-reporter" id="issue-reporter">
 	<div id="english" class="input-group hidden">${escape(localize('completeInEnglish', "Please complete the form in English."))}</div>


### PR DESCRIPTION
Fixes #52210

## What

Adds a sticky banner at the top of the issue reporter form, shown only when the user is running **VS Code stable** (`product.quality === 'stable'`). The banner reads:

> Before reporting, please test your issue in the latest [VS Code Insiders](https://aka.ms/vscode-insiders) build — many bugs in stable are already fixed there.

## Why

Many issues filed against VS Code stable have already been fixed in the Insiders build. Prompting users to verify on Insiders before filing reduces duplicate and stale issues and saves triage effort.

## Design

- Reuses the existing `.issue-reporter-update-banner` CSS class — no new styles needed.
- Hidden by default (`hidden` class). Revealed in `BaseIssueReporterService` constructor when `product.quality === 'stable'`.
- The prompt is non-blocking: users can still file the issue immediately. It is informational only.
- The link uses `https://aka.ms/vscode-insiders` (the existing alias used elsewhere in the codebase).

## How to Test

1. Run VS Code stable (or set `product.quality = 'stable'` in a dev build).
2. Open **Help > Report Issue**.
3. Confirm the blue/highlighted banner appears at the top with the Insiders link.
4. Run VS Code Insiders — confirm the banner is **not** shown.