### PR TITLE
Quick Open: left-truncate long path descriptions to show the distinctive tail

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -47,6 +47,61 @@ import { quickInputButtonsToActionArrays } from './quickInputUtils.js';
 
 const $ = dom.$;
 
+/**
+ * Maximum number of characters to display for a quick-open item description
+ * (typically a file path). Paths longer than this are left-truncated so that
+ * the distinguishing end of the path remains visible, matching the behaviour
+ * of editors such as Sublime Text.
+ */
+const DESCRIPTION_DISPLAY_MAX_LENGTH = 80;
+
+/**
+ * Left-truncate `description` at a path-separator boundary so that the tail
+ * fits within {@link DESCRIPTION_DISPLAY_MAX_LENGTH} characters.
+ *
+ * Also adjusts `matches` (fuzzy-highlight ranges) so they still point to the
+ * correct positions in the truncated string. Match ranges that fall entirely
+ * before the cut point are dropped; ranges that straddle the cut are clamped.
+ *
+ * The full path is preserved in the tooltip/descriptionTitle so hover still
+ * shows the complete path.
+ */
+function leftTruncateDescription(
+	description: string,
+	matches: readonly IMatch[] | undefined
+): { description: string; matches: IMatch[] } {
+	if (description.length <= DESCRIPTION_DISPLAY_MAX_LENGTH) {
+		return { description, matches: matches ? [...matches] : [] };
+	}
+
+	// Find the first path separator in the tail portion so we don't cut mid-segment.
+	const tail = description.slice(description.length - DESCRIPTION_DISPLAY_MAX_LENGTH);
+	const firstSepIdx = tail.search(/[/\\]/);
+	const truncateAt = firstSepIdx >= 0
+		? description.length - DESCRIPTION_DISPLAY_MAX_LENGTH + firstSepIdx
+		: description.length - DESCRIPTION_DISPLAY_MAX_LENGTH;
+
+	const truncated = '\u2026' + description.slice(truncateAt);
+	// After truncation: index 0 = '\u2026', index 1 = description[truncateAt], ...
+	// Original index P  →  new index P - truncateAt + 1
+	const shift = truncateAt - 1;
+
+	const adjustedMatches: IMatch[] = [];
+	if (matches) {
+		for (const m of matches) {
+			if (m.end <= truncateAt) {
+				continue; // entirely before the cut
+			}
+			adjustedMatches.push({
+				start: Math.max(1, m.start - shift),
+				end: m.end - shift,
+			});
+		}
+	}
+
+	return { description: truncated, matches: adjustedMatches };
+}
+
 interface IQuickInputItemLazyParts {
 	readonly saneLabel: string;
 	readonly saneSortLabel: string;
@@ -501,18 +556,26 @@ class QuickPickItemElementRenderer extends BaseQuickInputListRenderer<QuickPickI
 				markdownNotSupportedFallback: element.saneDescription
 			};
 		}
+		// Left-truncate long descriptions (e.g. file paths) so the distinctive
+		// end of the path is always visible. The full path is still shown in the
+		// tooltip (descriptionTitle) set above.
+		const { description: displayDescription, matches: displayDescriptionMatches } =
+			element.saneDescription
+				? leftTruncateDescription(element.saneDescription, descriptionHighlights)
+				: { description: element.saneDescription, matches: [] };
+
 		const options: IIconLabelValueOptions = {
 			matches: labelHighlights || [],
 			// If we have a tooltip, we want that to be shown and not any other hover
 			descriptionTitle,
-			descriptionMatches: descriptionHighlights || [],
+			descriptionMatches: displayDescriptionMatches,
 			labelEscapeNewLines: true
 		};
 		options.extraClasses = mainItem.iconClasses;
 		options.italic = mainItem.italic;
 		options.strikethrough = mainItem.strikethrough;
 		data.entry.classList.remove('quick-input-list-separator-as-item');
-		data.label.setLabel(element.saneLabel, element.saneDescription, options);
+		data.label.setLabel(element.saneLabel, displayDescription, options);
 
 		// Keybinding
 		data.keybinding.set(mainItem.keybinding);


### PR DESCRIPTION
Fixes #143956

## Problem

When multiple files share the same name but live in different directories, the Quick Open (Go to File, `Ctrl+P`) description column is left-truncated by the browser, hiding the portion that distinguishes one file from another:

```
some_project/very/long/shared/path/fruits/apples/Main.js
some_project/very/long/shared/path/fruits/bananas/Main.js
```

Both appear as `some_project/very/long/shared/path/…` — impossible to tell apart without opening each one.

Sublime Text (referenced in the issue) solves this by showing the **right-end** of the path so the distinguishing directory is always visible:
```
…/fruits/apples/Main.js
…/fruits/bananas/Main.js
```

## Solution

Added a `leftTruncateDescription()` helper function in `quickInputList.ts` that:

1. **Trims at a path-separator boundary** — never cuts a directory or file name in the middle.
2. **Prepends `…`** (U+2026) to indicate truncation.
3. **Adjusts fuzzy-match highlight ranges** to match the new positions in the truncated string — ranges entirely before the cut point are dropped; ranges that straddle it are clamped to index 1 (after the ellipsis character).
4. **Preserves the full path** in the `descriptionTitle` tooltip — hovering still shows the complete path for users who need it.

This is a pure TypeScript fix, avoiding previous attempts at CSS `direction: rtl` which visually reorders the inner highlight `<span>` elements and breaks the display of fuzzy-match highlights.

## How to Test

1. Create (or open) a workspace with two files that share a name under different long paths:
   ```
   src/some/very/long/path/feature-a/index.ts
   src/some/very/long/path/feature-b/index.ts
   ```
2. Press `Ctrl+P` and type `index`.
3. **Before:** Both items show the same truncated prefix — indistinguishable.
4. **After:** Both items show `…/feature-a/index.ts` and `…/feature-b/index.ts`.
5. Hovering either item still shows the full path.
6. Fuzzy-match highlights still appear at the correct positions in the truncated description.