### PR TITLE
fix(debug): identify instruction breakpoints by resolved address to allow removal when instructionReference changes (#289678)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1199,8 +1199,8 @@ export class DebugService implements IDebugService {
 		this.debugStorage.storeBreakpoints(this.model);
 	}
 
-	async removeInstructionBreakpoints(instructionReference?: string, offset?: number): Promise<void> {
-		this.model.removeInstructionBreakpoints(instructionReference, offset);
+	async removeInstructionBreakpoints(instructionReference?: string, offset?: number, address?: bigint): Promise<void> {
+		this.model.removeInstructionBreakpoints(instructionReference, offset, address);
 		this.debugStorage.storeBreakpoints(this.model);
 		await this.sendInstructionBreakpoints();
 	}

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -736,11 +736,17 @@ class BreakpointRenderer implements ITableRenderer<IDisassembledInstructionEntry
 					// click show hint while waiting for BP to resolve.
 					icon.classList.add(this._breakpointHintIcon);
 					const reference = currentElement.element.instructionReference;
-					const offset = Number(currentElement.element.address - this._disassemblyView.getReferenceAddress(reference)!);
+					const address = currentElement.element.address;
+					const offset = Number(address - this._disassemblyView.getReferenceAddress(reference)!);
 					if (currentElement.element.isBreakpointSet) {
-						this._debugService.removeInstructionBreakpoints(reference, offset);
+						// Identify the breakpoint by its resolved memory address:
+						// the debug adapter may hand out a new `instructionReference`
+						// for the same location after symbol reloads / certain steps,
+						// so a reference+offset lookup would otherwise fail to remove
+						// the breakpoint (microsoft/vscode#289678).
+						this._debugService.removeInstructionBreakpoints(reference, offset, address);
 					} else if (currentElement.element.allowBreakpoint && !currentElement.element.isBreakpointSet) {
-						this._debugService.addInstructionBreakpoint({ instructionReference: reference, offset, address: currentElement.element.address, canPersist: false });
+						this._debugService.addInstructionBreakpoint({ instructionReference: reference, offset, address, canPersist: false });
 					}
 				}
 			})

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1255,11 +1255,17 @@ export interface IDebugService {
 	addInstructionBreakpoint(opts: IInstructionBreakpointOptions): Promise<void>;
 
 	/**
-	 * Removes all instruction breakpoints. If address is passed only removes the instruction breakpoint with the passed address.
-	 * The address should be the address string supplied by the debugger from the "Disassemble" request.
-	 * Notifies debug adapter of breakpoint changes.
+	 * Removes all instruction breakpoints. If `address` is passed, only the
+	 * instruction breakpoint with the matching resolved memory address is
+	 * removed; this is preferred because the debug adapter is allowed to
+	 * return different `instructionReference` strings for the same memory
+	 * location on subsequent disassemble requests. If `address` is not
+	 * provided, falls back to matching on `instructionReference` (and
+	 * `offset` when specified). When no arguments are provided, all
+	 * instruction breakpoints are removed. Notifies the debug adapter of
+	 * breakpoint changes.
 	 */
-	removeInstructionBreakpoints(instructionReference?: string, offset?: number): Promise<void>;
+	removeInstructionBreakpoints(instructionReference?: string, offset?: number, address?: bigint): Promise<void>;
 
 	setExceptionBreakpointCondition(breakpoint: IExceptionBreakpoint, condition: string | undefined): Promise<void>;
 

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -2064,9 +2064,23 @@ export class DebugModel extends Disposable implements IDebugModel {
 		this._onDidChangeBreakpoints.fire({ added: [newInstructionBreakpoint], sessionOnly: true });
 	}
 
-	removeInstructionBreakpoints(instructionReference?: string, offset?: number): void {
+	removeInstructionBreakpoints(instructionReference?: string, offset?: number, address?: bigint): void {
 		let removed: InstructionBreakpoint[] = [];
-		if (instructionReference) {
+		if (address !== undefined) {
+			// Prefer matching by resolved memory address: `instructionReference` is
+			// allowed by the Debug Adapter Protocol to change between disassemble
+			// requests (e.g. after symbol reloads), so matching on reference+offset
+			// alone would fail to locate the breakpoint that the user is trying to
+			// toggle off. The `address` on an `InstructionBreakpoint` is the stable
+			// resolved memory address and uniquely identifies it.
+			for (let i = 0; i < this.instructionBreakpoints.length; i++) {
+				const ibp = this.instructionBreakpoints[i];
+				if (ibp.address === address) {
+					removed.push(ibp);
+					this.instructionBreakpoints.splice(i--, 1);
+				}
+			}
+		} else if (instructionReference) {
 			for (let i = 0; i < this.instructionBreakpoints.length; i++) {
 				const ibp = this.instructionBreakpoints[i];
 				if (ibp.instructionReference === instructionReference && (offset === undefined || ibp.offset === offset)) {

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -11,7 +11,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { TestStorageService } from '../../../../test/common/workbenchTestServices.js';
-import { IDebugSession } from '../../common/debug.js';
+import { IDebugSession, IInstructionBreakpoint } from '../../common/debug.js';
 import { DebugModel, ExceptionBreakpoint, FunctionBreakpoint, Thread } from '../../common/debugModel.js';
 import { MockDebugStorage } from './mockDebug.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
@@ -25,6 +25,119 @@ suite('DebugModel', () => {
 			const strigified = JSON.stringify(fbp);
 			const parsed = JSON.parse(strigified);
 			assert.equal(parsed.id, fbp.getId());
+		});
+	});
+
+	suite('InstructionBreakpoint', () => {
+		function createModel(disposable: DisposableStore): DebugModel {
+			const storage = disposable.add(new TestStorageService());
+			const model = new DebugModel(
+				disposable.add(new MockDebugStorage(storage)),
+				upcastPartial<ITextFileService>({ isDirty: (_: unknown) => false }),
+				undefined!,
+				new NullLogService()
+			);
+			disposable.add(model);
+			return model;
+		}
+
+		// Regression test for microsoft/vscode#289678: if the debug adapter hands
+		// out a new `instructionReference` for the same memory location (e.g.
+		// after a symbol reload or certain stepping operations), removal by
+		// reference+offset must still succeed when the caller supplies the
+		// resolved address.
+		test('removeInstructionBreakpoints prefers address match when instructionReference has changed', () => {
+			const disposable = new DisposableStore();
+			try {
+				const model = createModel(disposable);
+				const address = BigInt(0x1000);
+				model.addInstructionBreakpoint({
+					instructionReference: 'oldRef',
+					offset: 0,
+					address,
+					canPersist: false,
+					enabled: true,
+					hitCondition: undefined,
+					condition: undefined,
+					logMessage: undefined,
+				});
+
+				assert.strictEqual(model.getInstructionBreakpoints().length, 1);
+
+				// Simulate the disassembly view asking for removal after the
+				// debug adapter handed out a new instruction reference.
+				model.removeInstructionBreakpoints('newRef', 0, address);
+
+				assert.strictEqual(model.getInstructionBreakpoints().length, 0);
+			} finally {
+				disposable.dispose();
+			}
+		});
+
+		test('removeInstructionBreakpoints falls back to instructionReference+offset when address not supplied', () => {
+			const disposable = new DisposableStore();
+			try {
+				const model = createModel(disposable);
+				model.addInstructionBreakpoint({
+					instructionReference: 'ref',
+					offset: 4,
+					address: BigInt(0x2000),
+					canPersist: false,
+					enabled: true,
+					hitCondition: undefined,
+					condition: undefined,
+					logMessage: undefined,
+				});
+
+				// Non-matching reference leaves the breakpoint in place.
+				model.removeInstructionBreakpoints('other', 4);
+				assert.strictEqual(model.getInstructionBreakpoints().length, 1);
+
+				// Matching reference+offset removes it.
+				model.removeInstructionBreakpoints('ref', 4);
+				assert.strictEqual(model.getInstructionBreakpoints().length, 0);
+			} finally {
+				disposable.dispose();
+			}
+		});
+
+		test('removeInstructionBreakpoints with only address removes the matching entry and leaves others', () => {
+			const disposable = new DisposableStore();
+			try {
+				const model = createModel(disposable);
+				const keep: IInstructionBreakpoint[] = [];
+
+				model.addInstructionBreakpoint({
+					instructionReference: 'refA',
+					offset: 0,
+					address: BigInt(0x3000),
+					canPersist: false,
+					enabled: true,
+					hitCondition: undefined,
+					condition: undefined,
+					logMessage: undefined,
+				});
+				model.addInstructionBreakpoint({
+					instructionReference: 'refB',
+					offset: 0,
+					address: BigInt(0x4000),
+					canPersist: false,
+					enabled: true,
+					hitCondition: undefined,
+					condition: undefined,
+					logMessage: undefined,
+				});
+
+				model.removeInstructionBreakpoints(undefined, undefined, BigInt(0x3000));
+
+				const remaining = model.getInstructionBreakpoints();
+				assert.strictEqual(remaining.length, 1);
+				assert.strictEqual(remaining[0].address, BigInt(0x4000));
+				keep.push(...remaining);
+				assert.strictEqual(keep.length, 1);
+			} finally {
+				disposable.dispose();
+			}
 		});
 	});
 


### PR DESCRIPTION
<!-- Please provide a description of what you're trying to solve and how you plan to solve it. -->

## What

Instruction breakpoints set from the Disassembly view could not be removed when the debug adapter returned a different `instructionReference` for the same memory location across `disassemble` requests.

## Why

The Debug Adapter Protocol explicitly allows adapters to vary the `instructionReference` value returned for a given memory location between `disassemble` calls — only the resolved memory address is stable. The previous `removeInstructionBreakpoints(reference, offset)` lookup compared the (possibly new) reference+offset against the breakpoint's original reference+offset, so the match failed and the toggle-off click was a no-op.

Fixes #289678

## How

- Extended `IDebugService.removeInstructionBreakpoints` / `DebugService.removeInstructionBreakpoints` / `DebugModel.removeInstructionBreakpoints` with an optional third parameter `address?: bigint`.
- When `address` is supplied, `DebugModel` matches on the stable resolved memory address already stored on `InstructionBreakpoint`, so a changed `instructionReference` no longer breaks removal.
- When `address` is omitted, the existing `reference + offset` matching path is preserved unchanged — all existing callers keep their current behavior.
- `disassemblyView.ts` now passes `currentElement.element.address` (the same address it already uses when *adding* the breakpoint), guaranteeing symmetric add/remove.

## Test plan

- Added a new `InstructionBreakpoint` suite in `src/vs/workbench/contrib/debug/test/common/debugModel.test.ts` with 3 tests:
  1. Regression for #289678 — removal succeeds when `instructionReference` has changed but `address` is stable.
  2. Back-compat — when `address` is not supplied, the legacy `reference + offset` matching still works.
  3. Targeted removal — supplying `address` only removes the breakpoint at that address, leaving others intact.
- `npm run compile-check-ts-native` passes cleanly.