### PR TITLE
fix(tasks): add hover description for required property in taskDefinitions contribution schema (#275670)

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -27,6 +27,7 @@ const taskDefinitionSchema: IJSONSchema = {
 		},
 		required: {
 			type: 'array',
+			markdownDescription: nls.localize('TaskDefinition.required', 'The names of the properties from the `properties` object that must be provided for a task of this type to be considered a match. Used by VS Code to associate a `tasks.json` entry with a registered task provider.'),
 			items: {
 				type: 'string'
 			}


### PR DESCRIPTION
**What** — Add `markdownDescription` to the `required` property in the `taskDefinitions` extension-point schema.

**Why** — Hovering the property in an extension's `package.json` previously showed only the schema type with no documentation (#275670).

**How** — Added a localized `nls.localize('TaskDefinition.required', ...)` matching the style of the sibling `when` property's `markdownDescription`.

**Test plan** — Create an extension with a `contributes.taskDefinitions` entry including a `required` array and hover over the `required` key in `package.json` — the hover card now shows the description. `npm run compile-check-ts-native` passes cleanly.

Fixes #275670