### PR TITLE
Fix ${relativeFile} using backslashes in WSL

### DIFF
--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IStringDictionary } from '../../../../base/common/collections.js';
+import { hasDriveLetter } from '../../../../base/common/extpath.js';
 import { normalizeDriveLetter } from '../../../../base/common/labels.js';
 import * as paths from '../../../../base/common/path.js';
 import { IProcessEnvironment, isWindows } from '../../../../base/common/platform.js';
@@ -112,6 +113,36 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 
 	private fsPath(displayUri: uri): string {
 		return this._labelService ? this._labelService.getUriLabel(displayUri, { noPrefix: true }) : displayUri.fsPath;
+	}
+
+	/**
+	 * Picks the path library that matches the target file system's separators.
+	 *
+	 * `paths` is bound to the host platform (win32 on Windows, posix otherwise), but
+	 * when resolving variables for a remote workspace (e.g. WSL on a Windows host)
+	 * the file paths produced via the label service already use the remote's
+	 * separators. Operating on them with win32 helpers then emits backslashes in
+	 * the output (see microsoft/vscode#172099). Fall back to posix helpers only
+	 * when all supplied paths clearly use posix separators so Windows-host
+	 * behavior (including drive letters, UNC paths and plain backslash-separated
+	 * paths) is preserved.
+	 */
+	private pathsFor(...pathValues: string[]): paths.IPath {
+		if (!isWindows) {
+			return paths;
+		}
+		for (const p of pathValues) {
+			if (!p) {
+				continue;
+			}
+			// Any indicator of a Windows-style path keeps us on the native
+			// (win32) helpers: a drive letter, UNC prefix, or a backslash
+			// separator anywhere in the path.
+			if (hasDriveLetter(p) || p.startsWith('\\\\') || p.includes('\\')) {
+				return paths;
+			}
+		}
+		return paths.posix;
 	}
 
 	protected async evaluateSingleVariable(replacement: Replacement, folderUri: uri | undefined, processEnvironment?: IProcessEnvironment, commandValueMapping?: IStringDictionary<IResolvedValue>): Promise<IResolvedValue | string | undefined> {
@@ -268,16 +299,21 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 					case 'fileWorkspaceFolderBasename':
 						return paths.basename(getFolderPathForFile(VariableKind.FileWorkspaceFolderBasename));
 
-					case 'relativeFile':
+					case 'relativeFile': {
+						const filePath = getFilePath(VariableKind.RelativeFile);
 						if (folderUri || argument) {
-							return paths.relative(this.fsPath(getFolderUri(VariableKind.RelativeFile)), getFilePath(VariableKind.RelativeFile));
+							const folderPath = this.fsPath(getFolderUri(VariableKind.RelativeFile));
+							return this.pathsFor(filePath, folderPath).relative(folderPath, filePath);
 						}
-						return getFilePath(VariableKind.RelativeFile);
+						return filePath;
+					}
 
 					case 'relativeFileDirname': {
-						const dirname = paths.dirname(getFilePath(VariableKind.RelativeFileDirname));
+						const filePath = getFilePath(VariableKind.RelativeFileDirname);
+						const dirname = this.pathsFor(filePath).dirname(filePath);
 						if (folderUri || argument) {
-							const relative = paths.relative(this.fsPath(getFolderUri(VariableKind.RelativeFileDirname)), dirname);
+							const folderPath = this.fsPath(getFolderUri(VariableKind.RelativeFileDirname));
+							const relative = this.pathsFor(filePath, folderPath).relative(folderPath, dirname);
 							return relative.length === 0 ? '.' : relative;
 						}
 						return dirname;

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -56,6 +56,20 @@ class TestConfigurationResolverService extends BaseConfigurationResolverService 
 
 }
 
+class TestEditorServiceWithRemoteActiveEditor extends TestEditorServiceWithActiveEditor {
+	constructor(private readonly _remoteResource: URI) {
+		super();
+	}
+	override get activeEditor(): any {
+		const resource = this._remoteResource;
+		return {
+			get resource(): URI {
+				return resource;
+			}
+		};
+	}
+}
+
 const nullContext = {
 	getAppRoot: () => undefined,
 	getExecPath: () => undefined
@@ -206,6 +220,22 @@ suite('Configuration Resolver Service', () => {
 
 	test('relative file with invalid argument and undefined workspace folder', () => {
 		assert.rejects(async () => await configurationResolverService!.resolveAsync(undefined, 'abc ${relativeFile:invalidLocation} xyz'));
+	});
+
+	// https://github.com/microsoft/vscode/issues/172099
+	test('relative file uses posix separators when paths look posix (WSL on Windows)', async () => {
+		const remoteUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'wsl+ubuntu', path: '/home/user/project/src/app.ts' });
+		const remoteFolderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'wsl+ubuntu', path: '/home/user/project' });
+		const remoteEditorService = disposables.add(new TestEditorServiceWithRemoteActiveEditor(remoteUri));
+		const remoteLabelService = new MockRemoteLabelService();
+		const remotePathService = new MockPathService();
+		remotePathService.defaultUriScheme = Schemas.vscodeRemote;
+		const remoteContainingWorkspace = testWorkspace(remoteFolderUri);
+		const remoteWorkspace = remoteContainingWorkspace.folders[0];
+		const remoteContext = new TestContextService(remoteContainingWorkspace);
+		const resolver = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), remoteEditorService, new MockInputsConfigurationService(), mockCommandService, remoteContext, quickInputService, remoteLabelService, remotePathService, extensionService, disposables.add(new TestStorageService()));
+		assert.strictEqual(await resolver.resolveAsync(remoteWorkspace, '${relativeFile}'), 'src/app.ts');
+		assert.strictEqual(await resolver.resolveAsync(remoteWorkspace, '${relativeFileDirname}'), 'src');
 	});
 
 	test('substitute many', async () => {
@@ -834,6 +864,14 @@ class MockLabelService implements ILabelService {
 		throw new Error('Method not implemented.');
 	}
 	readonly onDidChangeFormatters: Event<IFormatterChangeEvent> = new Emitter<IFormatterChangeEvent>().event;
+}
+
+class MockRemoteLabelService extends MockLabelService {
+	// Simulates a remote label formatter (e.g. WSL) that always uses posix
+	// separators regardless of the host operating system.
+	override getUriLabel(resource: URI): string {
+		return resource.path;
+	}
 }
 
 class MockPathService implements IPathService {


### PR DESCRIPTION
## Summary

Fixes #172099 — the `${relativeFile}` and `${relativeFileDirname}` variables were emitting Windows backslashes when resolved against a WSL (or other remote-posix) workspace on a Windows host. That breaks workflows like:

```json
{
  "key": "ctrl+shift+p",
  "command": "workbench.action.terminal.sendSequence",
  "args": { "text": "${relativeFile}" }
}
```

where the sequence sent to a WSL shell needs forward slashes (`config/code/settings.json`) but we were sending `config\code\settings.json`.

## Root cause

`AbstractVariableResolverService` in `src/vs/workbench/services/configurationResolver/common/variableResolver.ts` computes the relative path with `paths.relative(...)` / `paths.dirname(...)`. `paths` from `base/common/path.ts` is bound to the host platform — `win32` on Windows, `posix` elsewhere. The file/folder paths themselves come out of the label service in the remote's format (WSL → forward slashes), so on Windows we end up passing posix-style strings into win32 helpers and getting backslashes in the result.

## The fix

Pick the path library that matches the *paths*, not the host OS. On non-Windows hosts nothing changes. On Windows, `${relativeFile}` / `${relativeFileDirname}` keep using the win32 helpers as long as any of the inputs looks like a Windows path (has a drive letter, starts with a UNC prefix, or contains a backslash separator); otherwise the posix helpers are used. This keeps drive-letter / UNC / mixed paths working on Windows while producing forward slashes for remote posix workspaces.

Concretely this only changes two `case` arms in the resolver plus a small `pathsFor(...)` helper. No other resolver behavior is touched.

## Why not the "resolve in extension host" approach

@alexr00 suggested (https://github.com/microsoft/vscode/issues/172099#issuecomment-2558050000) that the ideal fix is to have the terminal resolve variables in the extension host like tasks/debug do, so the remote's path library is used directly. That would be the correct long-term answer, but it requires plumbing a new resolution path through `workbench.action.terminal.sendSequence` / the terminal send flow, which is a much larger change than this drive-by PR warrants. This change targets the exact symptom reported in the issue without disturbing callers.

Pointers from @Tyriar on this same issue: https://github.com/microsoft/vscode/issues/172099#issuecomment-2481550828 — the relevant `variableResolver.ts` arms are exactly what's touched here.

## Test plan

- [x] Added unit test `relative file uses posix separators when paths look posix (WSL on Windows)` in `configurationResolverService.test.ts` that drives the resolver with a `vscode-remote://wsl+ubuntu/...` URI and an `ILabelService` that returns posix-formatted labels; asserts `${relativeFile}` → `src/app.ts` and `${relativeFileDirname}` → `src`.
- [x] Existing `relative file` / `relative file with argument` / `relative file with undefined workspace folder` tests continue to exercise the Windows-path branch (paths contain `\`, so the win32 helpers are still selected).
- [ ] Manual: open a WSL window on a Windows host, bind `workbench.action.terminal.sendSequence` with `"text": "${relativeFile}\n"`, trigger it in an open file — expect `src/app.ts` instead of `src\app.ts`.