### PR TITLE
workbench: fix workspace folder path handling in settings reader

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -187,7 +187,7 @@ class WorkspaceSettingsReader extends Disposable {
 		const settingsDirs = observableFromEvent(
 			this,
 			workspaceContextService.onDidChangeWorkspaceFolders,
-			() => workspaceContextService.getWorkspace().folders.map(f => joinPath(f.uri, configFolder)),
+			() => workspaceContextService.getWorkspace().folders.map(f => f.uri.path ? joinPath(f.uri, configFolder) : f.uri.with({ path: configFolder })),
 		);
 
 		const watcherStore = this._register(new DisposableStore());

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -187,7 +187,7 @@ class WorkspaceSettingsReader extends Disposable {
 		const settingsDirs = observableFromEvent(
 			this,
 			workspaceContextService.onDidChangeWorkspaceFolders,
-			() => workspaceContextService.getWorkspace().folders.map(f => f.uri.path ? joinPath(f.uri, configFolder) : f.uri.with({ path: configFolder })),
+			() => workspaceContextService.getWorkspace().folders.map(f => f.uri.path ? joinPath(f.uri, configFolder) : joinPath(f.uri.with({ path: '/' }), configFolder)),
 		);
 
 		const watcherStore = this._register(new DisposableStore());


### PR DESCRIPTION
- Fixes handling of workspace folders that have null or undefined URI paths
  in the settings folder observer. Adds fallback path handling using
  URI.with() method for folders without explicit paths.

Fixes #310367

(Commit message generated by Copilot)