### PR TITLE
fix(debug): fire removed event when breakpoints are deduped to avoid ghost entries (#276096)

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1800,10 +1800,16 @@ export class DebugModel extends Disposable implements IDebugModel {
 		});
 		this.breakpoints = this.breakpoints.concat(newBreakpoints);
 		this.breakpointsActivated = true;
-		this.sortAndDeDup();
+		const removedByDedup = this.sortAndDeDup();
 
 		if (fireEvent) {
-			this._onDidChangeBreakpoints.fire({ added: newBreakpoints, sessionOnly: false });
+			const droppedIds = new Set(removedByDedup.map(bp => bp.getId()));
+			const added = droppedIds.size === 0 ? newBreakpoints : newBreakpoints.filter(bp => !droppedIds.has(bp.getId()));
+			this._onDidChangeBreakpoints.fire({
+				added,
+				removed: removedByDedup.length > 0 ? removedByDedup : undefined,
+				sessionOnly: false
+			});
 		}
 
 		return newBreakpoints;
@@ -1823,8 +1829,14 @@ export class DebugModel extends Disposable implements IDebugModel {
 				updated.push(bp);
 			}
 		});
-		this.sortAndDeDup();
-		this._onDidChangeBreakpoints.fire({ changed: updated, sessionOnly: false });
+		const removedByDedup = this.sortAndDeDup();
+		const droppedIds = new Set(removedByDedup.map(bp => bp.getId()));
+		const changed = droppedIds.size === 0 ? updated : updated.filter(bp => !droppedIds.has(bp.getId()));
+		this._onDidChangeBreakpoints.fire({
+			changed,
+			removed: removedByDedup.length > 0 ? removedByDedup : undefined,
+			sessionOnly: false
+		});
 	}
 
 	setBreakpointSessionData(sessionId: string, capabilites: DebugProtocol.Capabilities, data: Map<string, DebugProtocol.Breakpoint> | undefined): void {
@@ -1923,7 +1935,12 @@ export class DebugModel extends Disposable implements IDebugModel {
 		}
 	}
 
-	private sortAndDeDup(): void {
+	/**
+	 * Sorts breakpoints and removes duplicates (same uri / lineNumber / column).
+	 * @returns the breakpoints that were dropped by deduplication, so that callers
+	 *          can surface them as removed in the `onDidChangeBreakpoints` event.
+	 */
+	private sortAndDeDup(): Breakpoint[] {
 		this.breakpoints = this.breakpoints.sort((first, second) => {
 			if (first.uri.toString() !== second.uri.toString()) {
 				return resources.basenameOrAuthority(first.uri).localeCompare(resources.basenameOrAuthority(second.uri));
@@ -1937,7 +1954,20 @@ export class DebugModel extends Disposable implements IDebugModel {
 
 			return first.lineNumber - second.lineNumber;
 		});
-		this.breakpoints = distinct(this.breakpoints, bp => `${bp.uri.toString()}:${bp.lineNumber}:${bp.column}`);
+		const seen = new Set<string>();
+		const kept: Breakpoint[] = [];
+		const removed: Breakpoint[] = [];
+		for (const bp of this.breakpoints) {
+			const key = `${bp.uri.toString()}:${bp.lineNumber}:${bp.column}`;
+			if (seen.has(key)) {
+				removed.push(bp);
+			} else {
+				seen.add(key);
+				kept.push(bp);
+			}
+		}
+		this.breakpoints = kept;
+		return removed;
 	}
 
 	setEnablement(element: IEnablement, enable: boolean): void {

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -19,7 +19,7 @@ import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { createBreakpointDecorations } from '../../browser/breakpointEditorContribution.js';
 import { getBreakpointMessageAndIcon, getExpandedBodySize } from '../../browser/breakpointsView.js';
-import { DataBreakpointSetType, IBreakpointData, IBreakpointUpdateData, IDebugService, State } from '../../common/debug.js';
+import { DataBreakpointSetType, IBreakpoint, IBreakpointData, IBreakpointUpdateData, IDebugService, State } from '../../common/debug.js';
 import { Breakpoint, DebugModel } from '../../common/debugModel.js';
 import { createTestSession } from './callStack.test.js';
 import { createMockDebugModel, mockUriIdentityService } from './mockDebugModel.js';
@@ -79,6 +79,72 @@ suite('Debug - Breakpoints', () => {
 		model.removeBreakpoints(model.getBreakpoints());
 		assert.strictEqual(eventCount, 1);
 		assert.strictEqual(model.getBreakpoints().length, 0);
+	});
+
+	test('updateBreakpoints dedupes collisions and fires removed event (issue #276096)', () => {
+		const modelUri = uri.file('/myfolder/myfile.js');
+
+		// Put two breakpoints on adjacent lines; deleting the line between them forces
+		// the lower breakpoint to shift onto the same line as the upper one.
+		const bps = addBreakpointsAndCheckEvents(model, modelUri, [{ lineNumber: 20, enabled: true }, { lineNumber: 21, enabled: true }]);
+		assert.strictEqual(model.getBreakpoints().length, 2);
+
+		const removedEvents: IBreakpoint[][] = [];
+		const changedEvents: IBreakpoint[][] = [];
+		disposables.add(model.onDidChangeBreakpoints(e => {
+			if (e?.removed) {
+				removedEvents.push(e.removed as IBreakpoint[]);
+			}
+			if (e?.changed) {
+				changedEvents.push(e.changed as IBreakpoint[]);
+			}
+		}));
+
+		// Simulate the editor contribution pushing updated positions after a content
+		// change that collapsed line 21 onto line 20.
+		const update = new Map<string, IBreakpointUpdateData>();
+		update.set(bps[0].getId(), { lineNumber: 20 });
+		update.set(bps[1].getId(), { lineNumber: 20 });
+		model.updateBreakpoints(update);
+
+		// The model itself must keep only one breakpoint per (uri, line, column).
+		assert.strictEqual(model.getBreakpoints().length, 1, 'internal model should dedupe colliding breakpoints');
+
+		// And the `onDidChangeBreakpoints` event must announce the dropped duplicate
+		// so that consumers (notably the extension host's `vscode.debug.breakpoints`)
+		// can drop their stale reference instead of keeping a ghost entry.
+		const totalRemoved = removedEvents.reduce((n, list) => n + list.length, 0);
+		assert.strictEqual(totalRemoved, 1, 'should fire removed event for deduped breakpoint');
+
+		// The duplicate must not leak into the `changed` array either.
+		const totalChanged = changedEvents.reduce((n, list) => n + list.length, 0);
+		assert.strictEqual(totalChanged, 1, 'should only report the surviving breakpoint as changed');
+	});
+
+	test('addBreakpoints dedupes collisions and fires removed event (issue #276096)', () => {
+		const modelUri = uri.file('/myfolder/myfile.js');
+
+		addBreakpointsAndCheckEvents(model, modelUri, [{ lineNumber: 5, enabled: true }]);
+		assert.strictEqual(model.getBreakpoints().length, 1);
+
+		let addedCount = 0;
+		let removedCount = 0;
+		disposables.add(model.onDidChangeBreakpoints(e => {
+			if (e?.added) {
+				addedCount += e.added.length;
+			}
+			if (e?.removed) {
+				removedCount += e.removed.length;
+			}
+		}));
+
+		// Adding a second breakpoint at the same location must not grow the model
+		// and must surface the dedupe as a `removed` event.
+		model.addBreakpoints(modelUri, [{ lineNumber: 5, enabled: true }]);
+
+		assert.strictEqual(model.getBreakpoints().length, 1, 'internal model should dedupe colliding breakpoints');
+		assert.strictEqual(removedCount, 1, 'should fire removed event for the deduped duplicate');
+		assert.strictEqual(addedCount, 0, 'duplicate must not be reported as added');
 	});
 
 	test('toggling', () => {


### PR DESCRIPTION
**What** — When two breakpoints collide on the same `(uri, line, column)` — for example after deleting the lines between them — the surviving one now fires a `removed` event for the dropped duplicate so the extension host's breakpoint map doesn't retain a ghost entry.

**Why** — `vscode.debug.breakpoints` returned duplicate `SourceBreakpoint` entries after deleting code blocks, because `DebugModel.sortAndDeDup()` silently dropped duplicates from the internal array without surfacing them as `removed` to listeners (#276096).

**How** — `sortAndDeDup()` now returns the dropped duplicates; `addBreakpoints` / `updateBreakpoints` include them in the fired event's `removed` field and filter them out of `added`/`changed`. When nothing is deduped, `removed` is `undefined` — preserving the pre-existing event shape for non-collision paths.

**Test plan** — Two new tests in `breakpoints.test.ts` exercise collisions on both the add path and the update path, asserting the model shrinks to one entry, a `removed` event fires with the dropped breakpoint, and the surviving one is reported via `added`/`changed` (never both). `npm run compile-check-ts-native` passes cleanly.

Fixes #276096