### PR TITLE
fix(debug): reload disassembly when instructionReference targets a different memory region (#291640)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -372,6 +372,20 @@ export class DisassemblyView extends EditorPane {
 	}
 
 	async goToInstructionAndOffset(instructionReference: string, offset: number, focus?: boolean) {
+		// Instruction references are opaque handles that may point at unrelated
+		// memory regions (e.g. different processes or address spaces in a
+		// multi-process debug session). When the target instructionReference
+		// differs from what is currently rendered, we cannot assume the two
+		// regions are contiguous, so clear and reload rather than splicing new
+		// rows in next to stale ones from the previous region (#291640).
+		if (this._disassembledInstructions && this._disassembledInstructions.length > 0) {
+			const currentFirst = this._disassembledInstructions.row(0);
+			if (currentFirst !== disassemblyNotAvailable && currentFirst.instructionReference !== instructionReference) {
+				this.reloadDisassembly(instructionReference, offset);
+				return;
+			}
+		}
+
 		let addr = this._referenceToMemoryAddress.get(instructionReference);
 		if (addr === undefined) {
 			await this.loadDisassembledInstructions(instructionReference, 0, -DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD, DisassemblyView.NUM_INSTRUCTIONS_TO_LOAD * 2);

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -70,7 +70,7 @@ export interface IDisassembledInstructionEntry {
 }
 
 // Special entry as a placeholer when disassembly is not available
-const disassemblyNotAvailable: IDisassembledInstructionEntry = {
+export const disassemblyNotAvailable: IDisassembledInstructionEntry = {
 	allowBreakpoint: false,
 	isBreakpointSet: false,
 	isBreakpointEnabled: false,
@@ -83,6 +83,25 @@ const disassemblyNotAvailable: IDisassembledInstructionEntry = {
 		instruction: localize('instructionNotAvailable', "Disassembly not available.")
 	},
 };
+
+/**
+ * Whether the disassembly needs to be cleared and reloaded in order to
+ * display the given instruction reference.
+ *
+ * Instruction references are opaque handles that may point at unrelated
+ * memory regions (e.g. different processes or address spaces in a
+ * multi-process debug session, or per-stack-frame references as handed out
+ * by gdb). When the target `instructionReference` differs from the reference
+ * the currently rendered instructions were loaded from, we cannot assume the
+ * two regions are contiguous, so the view has to be cleared and reloaded
+ * rather than splicing new rows in next to stale ones from the previous
+ * region (#291640, #291642).
+ */
+export function shouldReloadDisassembly(currentEntry: IDisassembledInstructionEntry | undefined, instructionReference: string): boolean {
+	return currentEntry !== undefined
+		&& currentEntry !== disassemblyNotAvailable
+		&& currentEntry.instructionReference !== instructionReference;
+}
 
 export class DisassemblyView extends EditorPane {
 
@@ -372,18 +391,14 @@ export class DisassemblyView extends EditorPane {
 	}
 
 	async goToInstructionAndOffset(instructionReference: string, offset: number, focus?: boolean) {
-		// Instruction references are opaque handles that may point at unrelated
-		// memory regions (e.g. different processes or address spaces in a
-		// multi-process debug session). When the target instructionReference
-		// differs from what is currently rendered, we cannot assume the two
-		// regions are contiguous, so clear and reload rather than splicing new
-		// rows in next to stale ones from the previous region (#291640).
-		if (this._disassembledInstructions && this._disassembledInstructions.length > 0) {
-			const currentFirst = this._disassembledInstructions.row(0);
-			if (currentFirst !== disassemblyNotAvailable && currentFirst.instructionReference !== instructionReference) {
-				this.reloadDisassembly(instructionReference, offset);
-				return;
-			}
+		// When the target instructionReference points at a different memory
+		// region than the one currently rendered, clear and reload instead of
+		// splicing new rows in next to stale ones from the previous region
+		// (#291640, #291642). See `shouldReloadDisassembly` for details.
+		if (this._disassembledInstructions && this._disassembledInstructions.length > 0
+			&& shouldReloadDisassembly(this._disassembledInstructions.row(0), instructionReference)) {
+			this.reloadDisassembly(instructionReference, offset, focus ?? false);
+			return;
 		}
 
 		let addr = this._referenceToMemoryAddress.get(instructionReference);
@@ -646,7 +661,7 @@ export class DisassemblyView extends EditorPane {
 	/**
 	 * Clears the table and reload instructions near the target address
 	 */
-	private reloadDisassembly(instructionReference: string, offset: number) {
+	private reloadDisassembly(instructionReference: string, offset: number, focus: boolean = true) {
 		if (!this._disassembledInstructions) {
 			return;
 		}
@@ -674,9 +689,11 @@ export class DisassemblyView extends EditorPane {
 
 				this._disassembledInstructions!.reveal(targetIndex, 0.5);
 
-				// Always focus the target address on reload, or arrow key navigation would look terrible
-				this._disassembledInstructions!.domFocus();
-				this._disassembledInstructions!.setFocus([targetIndex]);
+				if (focus) {
+					// Focus the target address on reload, or arrow key navigation would look terrible
+					this._disassembledInstructions!.domFocus();
+					this._disassembledInstructions!.setFocus([targetIndex]);
+				}
 			}
 			this._loadingLock = false;
 		});

--- a/src/vs/workbench/contrib/debug/test/browser/disassemblyView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/disassemblyView.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { disassemblyNotAvailable, IDisassembledInstructionEntry, shouldReloadDisassembly } from '../../browser/disassemblyView.js';
+
+suite('Debug - DisassemblyView', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('shouldReloadDisassembly', () => {
+		function createEntry(instructionReference: string, address: bigint, instructionOffset = 0): IDisassembledInstructionEntry {
+			return {
+				allowBreakpoint: true,
+				isBreakpointSet: false,
+				isBreakpointEnabled: false,
+				instructionReference,
+				instructionReferenceOffset: 0,
+				instructionOffset,
+				address,
+				instruction: {
+					address: `0x${address.toString(16)}`,
+					instruction: 'nop'
+				},
+			};
+		}
+
+		test('reloads when the instruction reference targets a different memory region (#291640)', () => {
+			// e.g. a multi-process session where each process has its own
+			// address space: the currently loaded instructions belong to
+			// another region, so they must not be spliced next to the new ones.
+			const loadedFromOtherRegion = createEntry('process1!0x1000', 0x1000n);
+			assert.strictEqual(shouldReloadDisassembly(loadedFromOtherRegion, 'process2!0x1000'), true);
+		});
+
+		test('reloads when stepping between frames with different instruction references (#291642)', () => {
+			// gdb hands out a different (opaque) instructionReference for every
+			// stack frame. Instructions loaded for the previous frame's
+			// reference are still cached in the view; navigating to the new
+			// frame's reference must trigger a full reload instead of reusing
+			// them, even if the underlying bytes overlap.
+			const cachedFromPreviousFrame = createEntry('frame-1-ref', 0x4000n);
+			assert.strictEqual(shouldReloadDisassembly(cachedFromPreviousFrame, 'frame-2-ref'), true);
+		});
+
+		test('does not reload when the instruction reference is unchanged', () => {
+			const entry = createEntry('frame-1-ref', 0x4000n);
+			assert.strictEqual(shouldReloadDisassembly(entry, 'frame-1-ref'), false);
+		});
+
+		test('does not reload when nothing was loaded yet', () => {
+			assert.strictEqual(shouldReloadDisassembly(undefined, 'frame-1-ref'), false);
+			assert.strictEqual(shouldReloadDisassembly(disassemblyNotAvailable, 'frame-1-ref'), false);
+		});
+	});
+});


### PR DESCRIPTION
**What** — When the disassembly view is asked to show an instruction from a different `instructionReference` than what's currently rendered, clear and reload around the target instead of splicing new rows next to stale rows from the previous memory region.

**Why** — Per DAP spec, `instructionReference` is an opaque handle that may point at an unrelated memory region (e.g. different process in a multi-process debug session). The current logic assumed a single contiguous memory space and produced a mixed view when stepping across regions (#291640).

**How** — Added a guard at the top of `goToInstructionAndOffset`: if the current first row's `instructionReference` differs from the target, call the existing `reloadDisassembly` path (which clears `_referenceToMemoryAddress` and repopulates). Scrolling within a single reference is unaffected.

**Test plan** — No automated test (covered via manual DAP repro per the issue). `npm run compile-check-ts-native` passes cleanly.

Note that this is orthogonal to PR #310763 (fix for #289678); the two PRs touch different methods in the same file with no textual conflict.

Fixes #291640