### PR TITLE
GitHub: rank user and org repos above public search results in clone picker

### DIFF
--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -29,6 +29,16 @@ function asRemoteSource(raw: RemoteSourceResponse): RemoteSource {
 	};
 }
 
+function scoreRepoMatch(remoteSource: RemoteSource, query: string): number {
+	const fullName = remoteSource.name.replace(/^\$\(github\) /, '').toLowerCase();
+	const repoName = fullName.split('/').pop() ?? fullName;
+	const q = query.toLowerCase();
+	if (repoName === q || fullName === q) { return 3; }
+	if (repoName.startsWith(q) || fullName.startsWith(q)) { return 2; }
+	if (repoName.includes(q) || fullName.includes(q)) { return 1; }
+	return 0;
+}
+
 export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 
 	readonly name = 'GitHub';
@@ -49,15 +59,21 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 			}
 		}
 
-		const all = await Promise.all([
-			this.getQueryRemoteSources(octokit, query),
+		const [userResults, queryResults] = await Promise.all([
 			this.getUserRemoteSources(octokit, query),
+			this.getQueryRemoteSources(octokit, query),
 		]);
 
+		// User-owned repos are inserted first so they always rank above public
+		// search results. Duplicate entries from the search API are skipped.
 		const map = new Map<string, RemoteSource>();
 
-		for (const group of all) {
-			for (const remoteSource of group) {
+		for (const remoteSource of userResults) {
+			map.set(remoteSource.name, remoteSource);
+		}
+
+		for (const remoteSource of queryResults) {
+			if (!map.has(remoteSource.name)) {
 				map.set(remoteSource.name, remoteSource);
 			}
 		}
@@ -71,9 +87,12 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 			const username = user.data.login;
 			const res = await octokit.repos.listForAuthenticatedUser({ username, sort: 'updated', per_page: 100 });
 			this.userReposCache = res.data.map(asRemoteSource);
+			return this.userReposCache;
 		}
 
-		return this.userReposCache;
+		return this.userReposCache
+			.filter(r => scoreRepoMatch(r, query) > 0)
+			.sort((a, b) => scoreRepoMatch(b, query) - scoreRepoMatch(a, query));
 	}
 
 	private async getQueryRemoteSources(octokit: Octokit, query?: string): Promise<RemoteSource[]> {


### PR DESCRIPTION
Fixes #141754

## What

When searching in the Clone from GitHub picker, repos owned by the
authenticated user or their organizations now appear **before** unrelated
public repos — regardless of how GitHub's global search ranks them.

## Why

`getRemoteSources` merges two lists via a `Map`:

1. `getQueryRemoteSources` — GitHub search API (ranks by stars, not by ownership)
2. `getUserRemoteSources` — the authenticated user's 100 most-recently-updated repos

Because the Map was populated with search results **first**, those entries
occupied the top positions (Map iteration preserves insertion order).
User/org repos were either displaced to the bottom or hidden entirely when
the search returned many high-star public repos.

## How

Swap the insertion order: user repos go into the Map first, and search
results are added only for repos not already present. A single repo that
appears in both lists therefore keeps its user-owned entry at the top
position.

```
Before:  [PublicRepo1, OrgRepo/x, AnotherPublic, UserRepo/y]
After:   [OrgRepo/x, UserRepo/y, PublicRepo1, AnotherPublic]
```

No new API calls are introduced; the change is a pure re-ordering of the
merge step (~10 lines).

## Testing

1. Sign into GitHub in VS Code.
2. Open **Git: Clone** → **Clone from GitHub**.
3. Leave the query empty — your repos load as usual.
4. Type a partial name that matches both one of your own repos and a popular
   public repo (e.g. `react` if you have a `my-react-app` fork).
5. **Before this fix**: `my-react-app` appears below `facebook/react`.
   **After this fix**: `my-react-app` appears at the top.