### PR TITLE
fix(debug): snapshot active file at F5 to prevent ${file} from resolving to a later focused editor (#278130)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -28,9 +28,12 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keyb
 import { IListService } from '../../../../platform/list/browser/listService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
 import { ActiveEditorContext, PanelFocusContext, ResourceContextKey } from '../../../common/contextkeys.js';
 import { ViewContainerLocation } from '../../../common/views.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
 import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
@@ -768,11 +771,21 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_STATE.isEqualTo('inactive')),
 	handler: async (accessor: ServicesAccessor, debugStartOptions?: { config?: Partial<IConfig>; noDebug?: boolean }) => {
 		const debugService = accessor.get(IDebugService);
-		await saveAllBeforeDebugStart(accessor.get(IConfigurationService), accessor.get(IEditorService));
+		const editorService = accessor.get(IEditorService);
+		const pathService = accessor.get(IPathService);
+		// Snapshot the active editor resource synchronously before any `await`. The
+		// subsequent `saveAllBeforeDebugStart` and debugger bootstrapping can yield
+		// for long enough that a user shifting focus causes `${file}` to resolve to
+		// a different editor than what was active when F5 was pressed. See #278130.
+		const activeFileOverride = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, {
+			supportSideBySide: SideBySideEditor.PRIMARY,
+			filterByScheme: [Schemas.file, Schemas.vscodeUserData, pathService.defaultUriScheme]
+		});
+		await saveAllBeforeDebugStart(accessor.get(IConfigurationService), editorService);
 		const { launch, name, getConfig } = debugService.getConfigurationManager().selectedConfiguration;
 		const config = await getConfig();
 		const configOrName = config ? Object.assign(deepClone(config), debugStartOptions?.config) : name;
-		await debugService.startDebugging(launch, configOrName, { noDebug: debugStartOptions?.noDebug, startedByUser: true }, false);
+		await debugService.startDebugging(launch, configOrName, { noDebug: debugStartOptions?.noDebug, startedByUser: true, activeFileOverride }, false);
 	}
 });
 

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -32,8 +32,11 @@ import { IQuickInputService } from '../../../../platform/quickinput/common/quick
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
-import { EditorsOrder } from '../../../common/editor.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { EditorResourceAccessor, EditorsOrder, SideBySideEditor } from '../../../common/editor.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
+import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../common/views.js';
 import { IActivityService, NumberBadge } from '../../../services/activity/common/activity.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -114,6 +117,8 @@ export class DebugService implements IDebugService {
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ITestService private readonly testService: ITestService,
+		@IConfigurationResolverService private readonly configurationResolverService: IConfigurationResolverService,
+		@IPathService private readonly pathService: IPathService,
 	) {
 		this.breakpointsToSendOnResourceSaved = new Set<URI>();
 
@@ -351,6 +356,26 @@ export class DebugService implements IDebugService {
 	 * properly manages compounds, checks for errors and handles the initializing state.
 	 */
 	async startDebugging(launch: ILaunch | undefined, configOrName?: IConfig | string, options?: IDebugSessionOptions, saveBeforeStart = !options?.parentSession): Promise<boolean> {
+		// Snapshot the active editor resource synchronously so that ${file} (and related
+		// file variables) resolve against whatever file the user was looking at when they
+		// triggered debugging, rather than against whichever editor happens to be active
+		// later, after awaits such as workspace trust, save-all and preLaunchTask. Without
+		// this snapshot, quickly shifting focus right after pressing F5 could cause the
+		// wrong program to be launched. See https://github.com/microsoft/vscode/issues/278130.
+		// Callers that already captured the resource (e.g. the F5 keybinding handler,
+		// which captures before awaiting `saveAllBeforeDebugStart`) may supply it via
+		// `options.activeFileOverride`; otherwise we fall back to a best-effort capture
+		// at the time `startDebugging` is entered.
+		if (options?.parentSession === undefined && options?.activeFileOverride === undefined) {
+			const captured = EditorResourceAccessor.getOriginalUri(this.editorService.activeEditor, {
+				supportSideBySide: SideBySideEditor.PRIMARY,
+				filterByScheme: [Schemas.file, Schemas.vscodeUserData, this.pathService.defaultUriScheme]
+			});
+			if (captured) {
+				options = { ...options, activeFileOverride: captured };
+			}
+		}
+
 		const message = options && options.noDebug ? nls.localize('runTrust', "Running executes build tasks and program code from your workspace.") : nls.localize('debugTrust', "Debugging executes build tasks and program code from your workspace.");
 		const trust = await this.workspaceTrustRequestService.requestWorkspaceTrust({ message });
 		if (!trust) {
@@ -453,6 +478,19 @@ export class DebugService implements IDebugService {
 	 * gets the debugger for the type, resolves configurations by providers, substitutes variables and runs prelaunch tasks
 	 */
 	private async createSession(launch: ILaunch | undefined, config: IConfig | undefined, options?: IDebugSessionOptions): Promise<boolean> {
+		// If the caller snapshotted the active file at trigger time (see #278130),
+		// keep that snapshot in effect for the entire resolution + variable-substitution
+		// phase so that `${file}` et al. resolve against the originally-active editor
+		// even if focus changed during the intervening async work.
+		if (options?.activeFileOverride) {
+			return this.configurationResolverService.withActiveFileOverride(
+				options.activeFileOverride,
+				() => this.createSessionInternal(launch, config, options));
+		}
+		return this.createSessionInternal(launch, config, options);
+	}
+
+	private async createSessionInternal(launch: ILaunch | undefined, config: IConfig | undefined, options?: IDebugSessionOptions): Promise<boolean> {
 		// We keep the debug type in a separate variable 'type' so that a no-folder config has no attributes.
 		// Storing the type in the config would break extensions that assume that the no-folder case is indicated by an empty config.
 		let type: string | undefined;

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -251,6 +251,15 @@ export interface IDebugSessionOptions {
 	 * the session will instead stop/restart the test run.
 	 */
 	testRun?: IDebugTestRunReference;
+	/**
+	 * The active file URI at the moment the user triggered debugging. When set,
+	 * variables like `${file}` and `${fileDirname}` will resolve against this
+	 * snapshot instead of the live `activeEditor`. This is set by callers such
+	 * as the F5 command handler so that async work (saving files, activating
+	 * extensions, running preLaunch tasks) between the keystroke and variable
+	 * resolution does not cause the wrong file to be launched. See #278130.
+	 */
+	activeFileOverride?: URI;
 }
 
 export interface IDataBreakpointInfoResponse {

--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -35,6 +35,16 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 
 	private userInputAccessQueue = new Queue<string | IQuickPickItem | undefined>();
 
+	/**
+	 * Stack of active-file URI overrides. When non-empty, the top value is used
+	 * as the "active editor" resource for `${file}` and related variables instead
+	 * of `editorService.activeEditor`. This lets callers (e.g. the debug service
+	 * when handling F5) snapshot the active file at the time the user initiated
+	 * the operation so that later async work which changes focus does not affect
+	 * the resolution. See https://github.com/microsoft/vscode/issues/278130.
+	 */
+	private readonly activeFileOverrides: (uri | undefined)[] = [];
+
 	constructor(
 		context: {
 			getAppRoot: () => string | undefined;
@@ -51,6 +61,15 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 		extensionService: IExtensionService,
 		private readonly storageService: IStorageService,
 	) {
+		const getActiveFileResource = (): uri | undefined => {
+			if (this.activeFileOverrides.length > 0) {
+				return this.activeFileOverrides[this.activeFileOverrides.length - 1];
+			}
+			return EditorResourceAccessor.getOriginalUri(editorService.activeEditor, {
+				supportSideBySide: SideBySideEditor.PRIMARY,
+				filterByScheme: [Schemas.file, Schemas.vscodeUserData, this.pathService.defaultUriScheme]
+			});
+		};
 		super({
 			getFolderUri: (folderName: string): uri | undefined => {
 				const folder = workspaceContextService.getWorkspace().folders.filter(f => f.name === folderName).pop();
@@ -69,20 +88,14 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				return context.getExecPath();
 			},
 			getFilePath: (): string | undefined => {
-				const fileResource = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, {
-					supportSideBySide: SideBySideEditor.PRIMARY,
-					filterByScheme: [Schemas.file, Schemas.vscodeUserData, this.pathService.defaultUriScheme]
-				});
+				const fileResource = getActiveFileResource();
 				if (!fileResource) {
 					return undefined;
 				}
 				return this.labelService.getUriLabel(fileResource, { noPrefix: true });
 			},
 			getWorkspaceFolderPathForFile: (): string | undefined => {
-				const fileResource = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, {
-					supportSideBySide: SideBySideEditor.PRIMARY,
-					filterByScheme: [Schemas.file, Schemas.vscodeUserData, this.pathService.defaultUriScheme]
-				});
+				const fileResource = getActiveFileResource();
 				if (!fileResource) {
 					return undefined;
 				}
@@ -141,6 +154,28 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 
 		this.resolvableVariables.add('command');
 		this.resolvableVariables.add('input');
+	}
+
+	/**
+	 * Runs `fn` with the `${file}` (and related `file*`) variables bound to the given
+	 * URI instead of the current active editor. This is used to capture the active
+	 * file at the moment the user initiates an operation (e.g. pressing F5) so that
+	 * later async work which changes the active editor does not cause variables to
+	 * resolve to a different file.
+	 *
+	 * If `resource` is `undefined`, the active editor lookup is short-circuited so
+	 * file variables will report "no editor open" rather than picking up whichever
+	 * editor happens to be active when substitution actually runs.
+	 *
+	 * Overrides are stacked: nested calls respect the most recently pushed value.
+	 */
+	public override async withActiveFileOverride<T>(resource: uri | undefined, fn: () => Promise<T>): Promise<T> {
+		this.activeFileOverrides.push(resource);
+		try {
+			return await fn();
+		} finally {
+			this.activeFileOverrides.pop();
+		}
 	}
 
 	override async resolveWithInteractionReplace(folder: IWorkspaceFolderData | undefined, config: unknown, section?: string, variables?: IStringDictionary<string>, target?: ConfigurationTarget): Promise<unknown> {

--- a/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts
@@ -6,6 +6,7 @@
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { ErrorNoTelemetry } from '../../../../base/common/errors.js';
 import { IProcessEnvironment } from '../../../../base/common/platform.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
@@ -47,6 +48,21 @@ export interface IConfigurationResolverService {
 	 * and resolveWithInteractionReplace will have contributed variables resolved.
 	 */
 	contributeVariable(variable: string, resolution: () => Promise<string | undefined>): void;
+
+	/**
+	 * Runs `fn` while pinning the `${file}` (and related `file*`) variables to the
+	 * given URI rather than the current active editor. Callers use this to capture
+	 * the active file at the moment a user action is triggered (e.g. F5) so that
+	 * later asynchronous work which changes the active editor does not alter
+	 * variable resolution.
+	 *
+	 * Passing `undefined` pins the resolver to "no active editor", which will make
+	 * file variables throw the usual "please open an editor" error instead of
+	 * silently picking up a different editor that happened to become active.
+	 *
+	 * Overrides are stacked: nested calls respect the most recently pushed value.
+	 */
+	withActiveFileOverride<T>(resource: URI | undefined, fn: () => Promise<T>): Promise<T>;
 }
 
 interface PromptStringInputInfo {

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -110,6 +110,15 @@ export abstract class AbstractVariableResolverService implements IConfigurationR
 		}
 	}
 
+	/**
+	 * Default implementation is a no-op passthrough. Subclasses that back `${file}`
+	 * with an editor service (see `BaseConfigurationResolverService`) override this
+	 * to honor the snapshot.
+	 */
+	public withActiveFileOverride<T>(_resource: uri | undefined, fn: () => Promise<T>): Promise<T> {
+		return fn();
+	}
+
 	private fsPath(displayUri: uri): string {
 		return this._labelService ? this._labelService.getUriLabel(displayUri, { noPrefix: true }) : displayUri.fsPath;
 	}

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -208,6 +208,36 @@ suite('Configuration Resolver Service', () => {
 		assert.rejects(async () => await configurationResolverService!.resolveAsync(undefined, 'abc ${relativeFile:invalidLocation} xyz'));
 	});
 
+	// #278130: the active file must be captured at the moment the user triggers
+	// debugging, not re-read whenever variable resolution runs. If the active
+	// editor changes between the F5 keystroke and the call to the resolver, the
+	// override should still produce the originally-captured path so the correct
+	// program is launched.
+	test('withActiveFileOverride pins ${file} to the captured resource even if activeEditor changes', async () => {
+		let currentResource = URI.parse('file:///VSCode/workspaceLocation/originalFile');
+		const editorService: any = {
+			get activeEditor() { return { get resource() { return currentResource; } }; },
+			get activeTextEditorControl() { return undefined; },
+		};
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), editorService, new MockInputsConfigurationService(), mockCommandService, new TestContextService(containingWorkspace), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
+
+		const captured = currentResource;
+		// Simulate focus moving to a different editor after F5 was pressed but
+		// before variables are resolved (the exact race described in #278130).
+		currentResource = URI.parse('file:///VSCode/workspaceLocation/otherFile');
+
+		const resolved = await service.withActiveFileOverride(captured, () =>
+			service.resolveAsync(workspace, '${file}'));
+
+		const expected = normalize(captured.fsPath);
+		assert.strictEqual(resolved, expected);
+
+		// Without the override, the live active editor wins, proving the race
+		// we are guarding against is real in this test setup.
+		const withoutOverride = await service.resolveAsync(workspace, '${file}');
+		assert.strictEqual(withoutOverride, normalize(currentResource.fsPath));
+	});
+
 	test('substitute many', async () => {
 		if (platform.isWindows) {
 			assert.strictEqual(await configurationResolverService!.resolveAsync(workspace, '${workspaceFolder} - ${workspaceFolder}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation');


### PR DESCRIPTION
**What** — When the user presses F5, VS Code now snapshots the active editor resource synchronously and pins `${file}` / `${fileDirname}` / related variables to it for the duration of debug-configuration resolution, so focus changes during the async bootstrap phase don't silently substitute the wrong file.

**Why** — F5 performs multiple awaits before resolving variables (`saveAllBeforeDebugStart`, `activateByEvent('onDebug')`, workspace-trust, configured-debugger provider resolution, etc.). Because `getFilePath()` read `editorService.activeEditor` live at substitution time, a focus change during those awaits caused `${file}` to resolve to a different editor than the one active when F5 was pressed (#278130).

**How** — `debugCommands.ts` captures `editorService.activeEditor` synchronously and passes it via a new `IDebugSessionOptions.activeFileOverride`. `DebugService.startDebugging` captures the active editor up-front for callers that didn't supply one. `DebugService.createSession` wraps the resolution+substitution phase in a new `IConfigurationResolverService.withActiveFileOverride(uri, fn)` method, which pushes the URI onto an override stack consulted by `getFilePath`/`getWorkspaceFolderPathForFile`. A no-op default sits on `AbstractVariableResolverService` so `CustomVariableResolver` / `ExtHostVariableResolverService` don't need updates.

**Scope note** — The fix touches 7 files but only 3 carry real logic: `debugCommands.ts` (snapshot point), `debugService.ts` (passthrough + wrap), and `baseConfigurationResolverService.ts` (stack). The other four are mechanical: one interface method on `IConfigurationResolverService`, its no-op implementation in `AbstractVariableResolverService`, an options field on `IDebugSessionOptions`, and the regression test. Happy to collapse the interface additions and cast internally if the reviewer prefers a tighter API surface.

**Test plan** — Added `configurationResolverService.test.ts` regression test directly exercising the override mechanism (asserts `${file}` resolves to the captured URI even after `editorService.activeEditor` changes, with a sibling assertion confirming the race it guards against is real). `npm run compile-check-ts-native` passes cleanly.

Fixes #278130