### PR TITLE
fix: handle quoted ID values in /etc/os-release parsing

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID="$(. /etc/os-release && echo "$ID")"
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## Problem
The `check-requirements-linux.sh` script fails to parse `/etc/os-release` on Rocky Linux 8.5 (and potentially other distros that quote their ID values).

The script uses:
```sh
OS_ID="ubuntu"
```

This regex `ID=([^"]+)` only matches **unquoted** values. However, Rocky Linux 8.5 uses:
```
ID="rocky"
```

With quotes, the grep fails to match, resulting in an empty `OS_ID`, which causes the script to exit with code 1.

## Solution
Use POSIX-compliant `. /etc/os-release && echo "$ID"` to source the file directly. This approach:
- Works with both quoted (`ID="rocky"`) and unquoted (`ID=ubuntu`) values
- Is POSIX-compatible (uses `.` not `source`)
- Creates a subshell so no variables leak into the parent environment

## Testing
Verified with simulated Rocky Linux `/etc/os-release` (quoted) and Ubuntu/Alpine (unquoted) - all parse correctly.

## Fixes
Fixes #232159

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof