### PR TITLE
fix: set isNESForAnotherDoc correctly for cross-file NES

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/inlineCompletionProvider.ts
@@ -354,6 +354,7 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 				const positionToJumpOneBased = suggestionInfo.suggestion.result.jumpToPosition;
 				const jumpToPosition = new Position(positionToJumpOneBased.lineNumber - 1, positionToJumpOneBased.column - 1);
 				const targetDocumentId = suggestionInfo.suggestion.result.targetDocumentId;
+				telemetryBuilder.setIsNESForOtherEditor(!!targetDocumentId && targetDocumentId !== doc.id);
 				const jumpToPositionCompletionItem: NesCompletionItem = {
 					insertText: undefined as unknown as string,
 					info: suggestionInfo,
@@ -388,6 +389,8 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 					resolveDoc = targetObsDoc;
 				} else {
 					logger.trace('no next edit suggestion: cross-file target document not found in workspace');
+					telemetryBuilder.setIsNESForOtherEditor(true);
+					telemetryBuilder.setStatus('noEdit:crossFileTargetNotFound');
 					this.telemetrySender.scheduleSendingEnhancedTelemetry(suggestionInfo.suggestion, telemetryBuilder);
 					return emptyList;
 				}
@@ -396,6 +399,7 @@ export class InlineCompletionProviderImpl extends Disposable implements InlineCo
 			const [targetDocument, range] = documents.length ? documents[0] : [undefined, undefined];
 
 			addNotebookTelemetry(document, position, result.edit.newText, documents, telemetryBuilder);
+			telemetryBuilder.setIsNESForOtherEditor(targetDocument !== undefined && targetDocument !== document);
 			telemetryBuilder.setIsActiveDocument(window.activeTextEditor?.document === targetDocument);
 
 			if (!targetDocument) {
@@ -769,6 +773,5 @@ function addNotebookTelemetry(document: TextDocument, position: Position, newTex
 		.setIsNextEditorVisible(!!nextEditor)
 		.setIsNextEditorRangeVisible(!!isNextEditorRangeVisible)
 		.setNotebookCellLines(lineCounts)
-		.setNotebookId(notebookId)
-		.setIsNESForOtherEditor(documents[0][0] !== document);
+		.setNotebookId(notebookId);
 }


### PR DESCRIPTION
Previously isNESForAnotherDoc was only set inside addNotebookTelemetry, so non-notebook cross-file NES always reported false.

- Set the flag on the main edit path for all cases (notebook and non-notebook)
- Set the flag on the jump-to-position path when targetDocumentId differs
- Set the flag and status 'noEdit:crossFileTargetNotFound' when cross-file target document is not found in the workspace
- Remove redundant setIsNESForOtherEditor call from addNotebookTelemetry

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
