### PR TITLE
fix(mcp): skip workspace folders without a path

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -48,7 +48,7 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 	}
 
 	private watchFolder(folder: IWorkspaceFolder) {
-		if(!folder.uri.path){
+		if (!folder.uri.path) {
 			return;
 		}
 		const configFile = joinPath(folder.uri, '.cursor', 'mcp.json');

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -48,6 +48,9 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 	}
 
 	private watchFolder(folder: IWorkspaceFolder) {
+		if(!folder.uri.path){
+			return;
+		}
 		const configFile = joinPath(folder.uri, '.cursor', 'mcp.json');
 		const collection: WritableMcpCollectionDefinition = {
 			id: `cursor-workspace.${folder.index}`,


### PR DESCRIPTION
Fixes #310371

## Problem
`watchFolder()` calls `joinPath(folder.uri, '.cursor', 'mcp.json')` without checking if the URI has a path.

In virtual/remote workspace scenarios, `folder.uri.path` can be empty, causing:
[UriError]: cannot call joinPath on URI without path

## Solution
Add a guard to skip workspace folders that do not have a path component.

## Changes
- Added early return in `watchFolder()` when `folder.uri.path` is falsy

## Testing
- Verified VS Code runs normally after the change
- Ensured no crash occurs when workspace folders without paths are processed