### PR TITLE
Fix Agents window accessibility: picker aria labels and keybindings

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/repoPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/repoPicker.ts
@@ -249,6 +249,8 @@ export class RepoPicker extends Disposable {
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+
+		this._triggerElement.ariaLabel = localize('repoPicker.triggerAriaLabel', "Pick Repository, {0}", label);
 	}
 
 }

--- a/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTypePicker.ts
@@ -166,5 +166,7 @@ export class SessionTypePicker extends Disposable {
 		labelSpan.textContent = modeLabel;
 
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+
+		this._triggerElement.ariaLabel = localize('sessionTypePicker.triggerAriaLabel', "Pick Session Type, {0}", modeLabel);
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -145,6 +145,8 @@ export class BranchPicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
+		this._triggerElement.ariaLabel = localize('branchPicker.triggerAriaLabel', "Pick Branch, {0}", label);
+
 		this._slotElement?.classList.toggle('disabled', isLoading || isDisabled);
 		this._triggerElement.setAttribute('aria-disabled', String(isLoading || isDisabled));
 		this._triggerElement.tabIndex = (isLoading || isDisabled) ? -1 : 0;

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -197,6 +197,8 @@ export class IsolationPicker extends Disposable {
 		labelSpan.textContent = modeLabel;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
+		this._triggerElement.ariaLabel = localize('isolationPicker.triggerAriaLabel', "Pick Isolation Mode, {0}", modeLabel);
+
 		const isDisabled = !this._hasGitRepo;
 		this._slotElement?.classList.toggle('disabled', isDisabled);
 		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -90,7 +90,6 @@ export class ModePicker extends Disposable {
 		const trigger = dom.append(slot, dom.$('a.action-label'));
 		trigger.tabIndex = 0;
 		trigger.role = 'button';
-		trigger.setAttribute('aria-label', localize('sessions.modePicker.ariaLabel', "Select chat mode"));
 		this._triggerElement = trigger;
 
 		this._updateTriggerLabel();
@@ -236,5 +235,7 @@ export class ModePicker extends Disposable {
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = this._selectedMode.label.get();
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+
+		this._triggerElement.ariaLabel = localize('modePicker.triggerAriaLabel', "Pick Mode, {0}", this._selectedMode.label.get());
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
@@ -209,6 +209,8 @@ export class CloudModelPicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 
+		this._triggerElement.ariaLabel = localize('modelPicker.triggerAriaLabel', "Pick Model, {0}", label);
+
 		this._slotElement?.classList.toggle('disabled', this._models.length === 0);
 		this._triggerElement.setAttribute('aria-disabled', String(this._models.length === 0));
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/permissionPicker.ts
@@ -287,6 +287,8 @@ export class PermissionPicker extends Disposable {
 		labelSpan.textContent = label;
 		dom.append(trigger, renderIcon(Codicon.chevronDown));
 
+		trigger.ariaLabel = localize('permissionPicker.triggerAriaLabel', "Pick Permission Level, {0}", label);
+
 		trigger.classList.toggle('warning', this._currentLevel === ChatPermissionLevel.Autopilot);
 		trigger.classList.toggle('info', this._currentLevel === ChatPermissionLevel.AutoApprove);
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -891,8 +891,13 @@ export class RefreshAgentSessionsViewerAction extends Action2 {
 		});
 	}
 
-	override run(accessor: ServicesAccessor, agentSessionsControl: IAgentSessionsControl) {
-		agentSessionsControl.refresh();
+	override run(accessor: ServicesAccessor, agentSessionsControl?: IAgentSessionsControl) {
+		const control = agentSessionsControl ?? accessor.get(IViewsService).getActiveViewWithId<ChatViewPane>(ChatViewId)?.agentSessionsControl;
+		if (control) {
+			control.refresh();
+		} else {
+			accessor.get(ICommandService).executeCommand('sessionsViewPane.refresh');
+		}
 	}
 }
 
@@ -911,8 +916,13 @@ export class FindAgentSessionInViewerAction extends Action2 {
 		});
 	}
 
-	override run(accessor: ServicesAccessor, agentSessionsControl: IAgentSessionsControl) {
-		return agentSessionsControl.openFind();
+	override run(accessor: ServicesAccessor, agentSessionsControl?: IAgentSessionsControl) {
+		const control = agentSessionsControl ?? accessor.get(IViewsService).getActiveViewWithId<ChatViewPane>(ChatViewId)?.agentSessionsControl;
+		if (control) {
+			return control.openFind();
+		} else {
+			return accessor.get(ICommandService).executeCommand('sessionsViewPane.find');
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -351,6 +351,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 	private sessionsNewButtonContainer: HTMLElement | undefined;
 	private sessionsControlContainer: HTMLElement | undefined;
 	private sessionsControl: AgentSessionsControl | undefined;
+
+	get agentSessionsControl(): AgentSessionsControl | undefined { return this.sessionsControl; }
+
 	private sessionsViewerVisible: boolean;
 	private sessionsViewerOrientation = AgentSessionsViewerOrientation.Stacked;
 	private sessionsViewerOrientationConfiguration: 'stacked' | 'sideBySide' = 'sideBySide';


### PR DESCRIPTION
Fixes #309585
Fixes #307649

### Picker aria labels (#309585)
The Agents window's standalone picker classes in sessions were missing `ariaLabel` on their trigger elements. Added dynamic aria labels (e.g. "Pick Mode, Ask") to all 7 pickers' `_updateTriggerLabel()` methods, matching the pattern used by `ModelPickerWidget` in the main window.

### Keybindings (#307649)
`RefreshAgentSessionsViewerAction` and `FindAgentSessionInViewerAction` required an `IAgentSessionsControl` argument only provided by toolbar buttons. Made it optional with fallback to `ChatViewPane` or `ICommandService.executeCommand` delegation for the Agents window. 

