### PR TITLE
agentHost: connect status and update diffs occasionally in the sessions app

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SequencerByKey } from '../../../base/common/async.js';
+import { disposableTimeout, SequencerByKey } from '../../../base/common/async.js';
 import { match as globMatch } from '../../../base/common/glob.js';
-import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
-import { IAgent, IAgentAttachment, IAgentProgressEvent, type IAgentToolReadyEvent } from '../common/agentService.js';
+import { IAgent, IAgentAttachment, IAgentProgressEvent, type IAgentToolCompleteEvent, type IAgentToolReadyEvent } from '../common/agentService.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
 import { ActionType, ISessionAction } from '../common/state/sessionActions.js';
@@ -24,6 +24,7 @@ import {
 	ToolCallStatus,
 	ToolResultContentType,
 	buildSubagentSessionUri,
+	getToolFileEdits,
 	type ISessionCustomization,
 	type ISessionModelInfo,
 	type ISessionState,
@@ -70,6 +71,9 @@ export class AgentSideEffects extends Disposable {
 	private readonly _diffComputeService: IDiffComputeService;
 	/** Serializes per-session diff computations to avoid races with stale previousDiffs. */
 	private readonly _diffComputationSequencer = new SequencerByKey<string>();
+	/** Per-session debounce timers for mid-turn diff computation. */
+	private readonly _debouncedDiffTimers = this._register(new DisposableMap<string>());
+	private static readonly _DIFF_DEBOUNCE_MS = 5000;
 
 	/**
 	 * Maps `parentSession:toolCallId` → subagent session URI.
@@ -332,12 +336,16 @@ export class AgentSideEffects extends Disposable {
 				// When a parent tool call completes, complete any associated subagent session
 				if (e.type === 'tool_complete') {
 					this.completeSubagentSession(sessionKey, e.toolCallId);
+					if (getToolFileEdits((e as IAgentToolCompleteEvent).result).length > 0) {
+						this._scheduleDebouncedDiffComputation(sessionKey, turnId);
+					}
 				}
 			}
 
-			// After a turn completes (idle event), compute session diffs and
-			// try to consume the next queued message
+			// After a turn completes (idle event), flush any pending debounced
+			// diff computation and compute final diffs immediately.
 			if (e.type === 'idle') {
+				this._cancelDebouncedDiffComputation(sessionKey);
 				this._computeSessionDiffs(sessionKey, turnId);
 				this._tryConsumeNextQueuedMessage(sessionKey);
 			}
@@ -848,6 +856,28 @@ export class AgentSideEffects extends Disposable {
 	}
 
 	// ---- Session diff computation ----------------------------------------------
+
+	/**
+	 * Schedules a debounced diff computation for a session. If a timer is
+	 * already pending for this session, it is replaced (restarting the delay).
+	 * The computation fires after {@link _DIFF_DEBOUNCE_MS} unless cancelled
+	 * or flushed by the turn-complete handler.
+	 */
+	private _scheduleDebouncedDiffComputation(session: ProtocolURI, turnId: string): void {
+		// DisposableMap.set() auto-disposes any previous timer for this session
+		this._debouncedDiffTimers.set(session, disposableTimeout(() => {
+			this._debouncedDiffTimers.deleteAndDispose(session);
+			this._computeSessionDiffs(session, turnId);
+		}, AgentSideEffects._DIFF_DEBOUNCE_MS));
+	}
+
+	/**
+	 * Cancels any pending debounced diff computation for a session.
+	 * Called at turn end before the final (non-debounced) computation.
+	 */
+	private _cancelDebouncedDiffComputation(session: ProtocolURI): void {
+		this._debouncedDiffTimers.deleteAndDispose(session);
+	}
 
 	/**
 	 * Asynchronously (re)computes aggregated diff statistics for a session

--- a/src/vs/sessions/common/agentHostDiffs.ts
+++ b/src/vs/sessions/common/agentHostDiffs.ts
@@ -4,6 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../base/common/uri.js';
+import { SessionStatus as ProtocolSessionStatus } from '../../platform/agentHost/common/state/protocol/state.js';
+import { SessionStatus } from '../services/sessions/common/session.js';
+
+/**
+ * Maps the protocol-layer session status bitset to the UI-layer
+ * {@link SessionStatus} enum used by session adapters.
+ */
+export function mapProtocolStatus(protocol: ProtocolSessionStatus): SessionStatus {
+	if ((protocol & ProtocolSessionStatus.InputNeeded) === ProtocolSessionStatus.InputNeeded) {
+		return SessionStatus.NeedsInput;
+	}
+	if (protocol & ProtocolSessionStatus.InProgress) {
+		return SessionStatus.InProgress;
+	}
+	if (protocol & ProtocolSessionStatus.Error) {
+		return SessionStatus.Error;
+	}
+	return SessionStatus.Completed;
+}
 
 export interface IFileChange {
 	readonly modifiedUri: URI;

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { AgentSession, IAgentHostService, type IAgentSessionMetadata } from '../../../../platform/agentHost/common/agentService.js';
-import type { IRootState, ISessionFileDiff } from '../../../../platform/agentHost/common/state/protocol/state.js';
+import type { IRootState, ISessionFileDiff, ISessionSummary as IProtocolSessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
@@ -27,7 +27,8 @@ import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/c
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
-import { diffsToChanges, diffsEqual } from '../../../common/agentHostDiffs.js';
+import { diffsToChanges, diffsEqual, mapProtocolStatus } from '../../../common/agentHostDiffs.js';
+import { NotificationType } from '../../../../platform/agentHost/common/state/protocol/notifications.js';
 import { ISendRequestOptions, ISessionChangeEvent } from '../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, type IGitHubInfo, ISessionType } from '../../../services/sessions/common/session.js';
@@ -83,7 +84,7 @@ class LocalSessionAdapter implements ISession {
 	readonly workspace: ISettableObservable<ISessionWorkspace | undefined>;
 	readonly title: ISettableObservable<string>;
 	readonly updatedAt: ISettableObservable<Date>;
-	readonly status = observableValue<SessionStatus>('status', SessionStatus.Completed);
+	readonly status: ISettableObservable<SessionStatus>;
 	readonly changes = observableValue<readonly IChatSessionFileChange[]>('changes', []);
 	readonly modelId: ISettableObservable<string | undefined>;
 	readonly mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>('mode', undefined);
@@ -114,6 +115,7 @@ class LocalSessionAdapter implements ISession {
 		this.createdAt = new Date(metadata.startTime);
 		this.title = observableValue('title', metadata.summary || `Session ${rawId.substring(0, 8)}`);
 		this.updatedAt = observableValue('updatedAt', new Date(metadata.modifiedTime));
+		this.status = observableValue<SessionStatus>('status', metadata.status !== undefined ? mapProtocolStatus(metadata.status) : SessionStatus.Completed);
 		this.modelId = observableValue<string | undefined>('modelId', metadata.model ? `${logicalSessionType}:${metadata.model}` : undefined);
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
 		this.description = observableValue('description', new MarkdownString().appendText(localize('localAgentHostDescription', "Local")));
@@ -153,6 +155,14 @@ class LocalSessionAdapter implements ISession {
 		if (summary !== undefined && summary !== this.title.get()) {
 			this.title.set(summary, undefined);
 			didChange = true;
+		}
+
+		if (metadata.status !== undefined) {
+			const uiStatus = mapProtocolStatus(metadata.status);
+			if (uiStatus !== this.status.get()) {
+				this.status.set(uiStatus, undefined);
+				didChange = true;
+			}
 		}
 
 		const modifiedTime = metadata.modifiedTime;
@@ -285,10 +295,12 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 
 		// Listen for notifications from the agent host to update the session list
 		this._register(this._agentHostService.onDidNotification(n => {
-			if (n.type === 'notify/sessionAdded') {
+			if (n.type === NotificationType.SessionAdded) {
 				this._handleSessionAdded(n.summary);
-			} else if (n.type === 'notify/sessionRemoved') {
+			} else if (n.type === NotificationType.SessionRemoved) {
 				this._handleSessionRemoved(n.session);
+			} else if (n.type === NotificationType.SessionSummaryChanged) {
+				this._handleSessionSummaryChanged(n.session, n.changes);
 			}
 		}));
 
@@ -948,6 +960,38 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 		const cached = this._sessionCache.get(rawId);
 		if (cached) {
 			cached.changes.set(diffsToChanges(diffs), undefined);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
+		}
+	}
+
+	private _handleSessionSummaryChanged(session: string, changes: Partial<IProtocolSessionSummary>): void {
+		const rawId = AgentSession.id(session);
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+
+		let didChange = false;
+
+		if (changes.status !== undefined) {
+			const uiStatus = mapProtocolStatus(changes.status);
+			if (uiStatus !== cached.status.get()) {
+				cached.status.set(uiStatus, undefined);
+				didChange = true;
+			}
+		}
+
+		if (changes.title !== undefined && changes.title !== cached.title.get()) {
+			cached.title.set(changes.title, undefined);
+			didChange = true;
+		}
+
+		if (changes.diffs !== undefined && !diffsEqual(cached.changes.get(), changes.diffs)) {
+			cached.changes.set(diffsToChanges(changes.diffs), undefined);
+			didChange = true;
+		}
+
+		if (didChange) {
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [cached] });
 		}
 	}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -21,6 +21,7 @@ import { AGENT_HOST_SCHEME, agentHostAuthority, toAgentHostUri } from '../../../
 import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from '../../../../platform/agentHost/common/agentService.js';
 import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ActionType, isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
+import { NotificationType } from '../../../../platform/agentHost/common/state/protocol/notifications.js';
 import type { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
 import type { IRootState, ISessionFileDiff, ISessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
@@ -32,7 +33,7 @@ import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/c
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
-import { diffsToChanges, diffsEqual } from '../../../common/agentHostDiffs.js';
+import { diffsToChanges, diffsEqual, mapProtocolStatus } from '../../../common/agentHostDiffs.js';
 import { ISessionChangeEvent, ISendRequestOptions } from '../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType, COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
@@ -166,7 +167,7 @@ class RemoteSessionAdapter implements IChatData {
 	readonly workspace: ISettableObservable<ISessionWorkspace | undefined>;
 	readonly title: ISettableObservable<string>;
 	readonly updatedAt: ISettableObservable<Date>;
-	readonly status = observableValue<SessionStatus>('status', SessionStatus.Completed);
+	readonly status: ISettableObservable<SessionStatus>;
 	readonly changes = observableValue<readonly IChatSessionFileChange[]>('changes', []);
 	readonly modelId: ISettableObservable<string | undefined>;
 	readonly mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>('mode', undefined);
@@ -197,6 +198,7 @@ class RemoteSessionAdapter implements IChatData {
 		this.createdAt = new Date(metadata.startTime);
 		this.title = observableValue('title', metadata.summary || `Session ${rawId.substring(0, 8)}`);
 		this.updatedAt = observableValue('updatedAt', new Date(metadata.modifiedTime));
+		this.status = observableValue<SessionStatus>('status', metadata.status !== undefined ? mapProtocolStatus(metadata.status) : SessionStatus.Completed);
 		this.modelId = observableValue<string | undefined>('modelId', metadata.model ? `${resourceScheme}:${metadata.model}` : undefined);
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
 		this.description = observableValue('description', new MarkdownString().appendText(this._providerLabel));
@@ -217,6 +219,12 @@ class RemoteSessionAdapter implements IChatData {
 		this.title.set(metadata.summary || this.title.get(), undefined);
 		this.updatedAt.set(new Date(metadata.modifiedTime), undefined);
 		this.lastTurnEnd.set(metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined, undefined);
+		if (metadata.status !== undefined) {
+			const uiStatus = mapProtocolStatus(metadata.status);
+			if (uiStatus !== this.status.get()) {
+				this.status.set(uiStatus, undefined);
+			}
+		}
 		if (metadata.isRead !== undefined) {
 			this.isRead.set(metadata.isRead, undefined);
 		}
@@ -402,10 +410,12 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 		}));
 
 		this._connectionListeners.add(connection.onDidNotification(n => {
-			if (n.type === 'notify/sessionAdded') {
+			if (n.type === NotificationType.SessionAdded) {
 				this._handleSessionAdded(n.summary);
-			} else if (n.type === 'notify/sessionRemoved') {
+			} else if (n.type === NotificationType.SessionRemoved) {
 				this._handleSessionRemoved(n.session);
+			} else if (n.type === NotificationType.SessionSummaryChanged) {
+				this._handleSessionSummaryChanged(n.session, n.changes);
 			}
 		}));
 
@@ -1160,6 +1170,41 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 		if (cached) {
 			const mapUri = toLocalDiffUri(this._connectionAuthority);
 			cached.changes.set(diffsToChanges(diffs, mapUri), undefined);
+			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(cached)] });
+		}
+	}
+
+	private _handleSessionSummaryChanged(session: string, changes: Partial<ISessionSummary>): void {
+		const rawId = AgentSession.id(session);
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+
+		let didChange = false;
+
+		if (changes.status !== undefined) {
+			const uiStatus = mapProtocolStatus(changes.status);
+			if (uiStatus !== cached.status.get()) {
+				cached.status.set(uiStatus, undefined);
+				didChange = true;
+			}
+		}
+
+		if (changes.title !== undefined && changes.title !== cached.title.get()) {
+			cached.title.set(changes.title, undefined);
+			didChange = true;
+		}
+
+		if (changes.diffs !== undefined) {
+			const mapUri = toLocalDiffUri(this._connectionAuthority);
+			if (!diffsEqual(cached.changes.get(), changes.diffs, mapUri)) {
+				cached.changes.set(diffsToChanges(changes.diffs, mapUri), undefined);
+				didChange = true;
+			}
+		}
+
+		if (didChange) {
 			this._onDidChangeSessions.fire({ added: [], removed: [], changed: [this._chatToSession(cached)] });
 		}
 	}


### PR DESCRIPTION
I realized after implementing this that we avoid showing diffs for in-progress sessions

https://github.com/microsoft/vscode/blob/3267a57dc5ace468c668880fca8bb5cb73467e63/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts#L262-L264

But if that ever was to change this'd work nicely. And I think it should change :)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
