### PR TITLE
Log agent host catch failures

### DIFF
--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -107,7 +107,8 @@ export class AgentSideEffects extends Disposable {
 					maxContextWindow: m.maxContextWindow, supportsVision: m.supportsVision,
 					policyState: m.policyState,
 				}));
-			} catch {
+			} catch (err) {
+				this._logService.error(err, `[AgentSideEffects] Failed to list models for agent '${a.id}'`);
 				models = [];
 			}
 			const protectedResources = a.getProtectedResources();
@@ -865,7 +866,8 @@ export class AgentSideEffects extends Disposable {
 		let ref: ReturnType<ISessionDataService['openDatabase']>;
 		try {
 			ref = this._options.sessionDataService.openDatabase(URI.parse(session));
-		} catch {
+		} catch (err) {
+			this._logService.warn(`[AgentSideEffects] Failed to open session database for diff computation: ${session}`, err);
 			return;
 		}
 		try {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -467,7 +467,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async getSessionMessages(session: URI): Promise<(IAgentMessageEvent | IAgentToolStartEvent | IAgentToolCompleteEvent | IAgentSubagentStartedEvent)[]> {
 		const sessionId = AgentSession.id(session);
-		const entry = this._sessions.get(sessionId) ?? await this._resumeSession(sessionId).catch(() => undefined);
+		const entry = this._sessions.get(sessionId) ?? await this._resumeSession(sessionId).catch(err => {
+			this._logService.warn(`[Copilot:${sessionId}] Failed to resume session for message lookup`, err);
+			return undefined;
+		});
 		if (!entry) {
 			return [];
 		}
@@ -846,7 +849,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	override dispose(): void {
-		this.shutdown().catch(() => { /* best-effort */ }).finally(() => super.dispose());
+		this.shutdown().catch(err => {
+			this._logService.warn('[Copilot] Shutdown failed during dispose', err);
+		}).finally(() => super.dispose());
 	}
 }
 
@@ -874,7 +879,9 @@ class PluginController {
 
 	public sync(clientId: string, customizations: ICustomizationRef[], progress?: (results: ISyncedCustomization[]) => void) {
 		const prev = this._lastSynced;
-		const promise = this._lastSynced = prev.catch(() => []).then(async () => {
+		const promise = this._lastSynced = prev.catch(err => {
+			this._logService.warn('[Copilot:PluginController] Previous customization sync failed', err);
+		}).then(async () => {
 			const result = await this._pluginManager.syncCustomizations(clientId, customizations, status => {
 				progress?.(status.map(c => ({ customization: c })));
 			});


### PR DESCRIPTION
Adds logging for fallback error paths in the agent host and Copilot agent so failures are visible without changing the existing recovery behavior.

Summary:
- Log `listModels` failures before falling back to an empty model list.
- Log session database, resume-for-message-lookup, dispose shutdown, and previous customization sync failures before preserving their existing fallbacks.

Validation:
- VS Code - Build reports 0 TypeScript errors.
- Precommit hygiene ran during commit; only the known TypeScript-eslint version warning was printed.

(Written by Copilot)