### PR TITLE
fix(sessions): use non-empty path for unknown-workspace fallback URI to prevent joinPath crashes (#310777)

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -975,7 +975,10 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		const [repoUri, worktreeUri, branchName, baseBranchName, baseBranchProtected] = this._extractRepositoryFromMetadata(session);
 
 		const repository: ISessionRepository = {
-			uri: repoUri ?? URI.parse('unknown:'),
+			// Fallback URI must carry a non-empty path, otherwise downstream callers
+			// such as URI.joinPath / WorkspaceFolder.toResource throw
+			// "cannot call joinPath on URI without path" (see #310777).
+			uri: repoUri ?? URI.from({ scheme: 'unknown', path: '/' }),
 			workingDirectory: worktreeUri,
 			detail: branchName,
 			baseBranchName,

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -41,10 +41,12 @@ function createMockAgentSession(resource: URI, opts?: {
 	title?: string;
 	archived?: boolean;
 	read?: boolean;
+	metadata?: Record<string, unknown> | undefined;
 }): IAgentSession {
 	const providerType = opts?.providerType ?? AgentSessionProviders.Background;
 	let archived = opts?.archived ?? false;
 	let read = opts?.read ?? true;
+	const metadata = opts && 'metadata' in opts ? opts.metadata : { repositoryPath: '/test/repo' };
 	return new class extends mock<IAgentSession>() {
 		override readonly resource = resource;
 		override readonly providerType = providerType;
@@ -53,7 +55,7 @@ function createMockAgentSession(resource: URI, opts?: {
 		override readonly status = ChatSessionStatus.Completed;
 		override readonly icon = Codicon.copilot;
 		override readonly timing = { created: Date.now(), lastRequestStarted: undefined, lastRequestEnded: undefined };
-		override readonly metadata = { repositoryPath: '/test/repo' };
+		override readonly metadata = metadata as IAgentSession['metadata'];
 		override isArchived(): boolean { return archived; }
 		override setArchived(value: boolean): void { archived = value; }
 		override isPinned(): boolean { return false; }
@@ -614,6 +616,33 @@ suite('CopilotChatSessionsProvider', () => {
 				assert.strictEqual(changedIds.length, uniqueIds.size, 'Changed events should not have duplicates');
 			}
 		});
+	});
+
+	// ---- Workspace fallback (repo-less sessions) -------
+
+	test('session without repository metadata has a workspace URI with a non-empty path (regression #310777)', () => {
+		// Background session with no metadata: _extractRepositoryFromMetadata
+		// returns [undefined, ...] and _buildWorkspace must provide a safe
+		// fallback URI. Historically this used URI.parse('unknown:'), which
+		// produced a URI with an empty path that crashed URI.joinPath /
+		// WorkspaceFolder.toResource / compareAndDeleteFolderConfiguration
+		// across ~13 telemetry buckets (see issues #310777, #310752, #310369,
+		// #310370, #310368, #310364, #310365, #310366, #310357, #310180,
+		// #308827).
+		const resource = URI.from({ scheme: AgentSessionProviders.Background, path: '/session-no-repo' });
+		model.addSession(createMockAgentSession(resource, { metadata: undefined }));
+
+		const provider = createProvider(disposables, model);
+		const session = provider.getSessions()[0];
+		const workspace = session.workspace.get();
+
+		assert.ok(workspace, 'session should have a workspace');
+		const fallbackUri = workspace!.repositories[0].uri;
+		assert.ok(fallbackUri.path.length > 0, `fallback URI must have a non-empty path, got ${fallbackUri.toString()}`);
+
+		// The core symptom of #310777: any of these calls must not throw.
+		assert.doesNotThrow(() => URI.joinPath(fallbackUri, '.vscode', 'settings.json'));
+		assert.doesNotThrow(() => URI.joinPath(fallbackUri, '.vscode/extensions.json'));
 	});
 
 	// ---- Browse actions -------


### PR DESCRIPTION
## What

Replace the repo-less session fallback URI `URI.parse('unknown:')` with `URI.from({ scheme: 'unknown', path: '/' })` so downstream workspace-folder operations don't explode on a path-less URI.

## Why

`URI.parse('unknown:')` yields a URI with an empty path. `URI.joinPath` throws `cannot call joinPath on URI without path` for such URIs, so any code iterating workspace folders and calling `folder.toResource(...)` / `URI.joinPath(folder.uri, ...)` crashed — fanning out into ~13 telemetry buckets (#310777, #310752, #310751, #310369, #310370, #310368, #310364, #310365, #310366, #310357, #310180, #308827).

Snippets service, workspace extensions config, preferences editor menu, and `compareAndDeleteFolderConfiguration` all hit this path for Copilot agent sessions without repository metadata.

## How

`URI.from({ scheme: 'unknown', path: '/' })` produces a URI whose path is non-empty, so `URI.joinPath` and friends behave correctly. Fallback is only taken when `repoUri === undefined`; sessions with real repo URIs are unaffected.

This was the approach flagged (but deferred) by @aeschli when landing PR #309777.

## Test plan

New test in `copilotChatSessionsProvider.test.ts`: construct a session with `metadata: undefined`, read `session.workspace.get()`, and assert the fallback URI has a non-empty path and that `URI.joinPath(fallbackUri, '.vscode', 'settings.json')` does not throw (both were broken pre-fix).

---

Closes the root cause for the following telemetry buckets: #310777, #310752, #310751, #310370, #310368, #310364, #310365, #310366, #310357, #310180, #308827.

(Does NOT close the separate `compareAndDeleteFolderConfiguration` race-condition bug tracked in #310369 — that's a distinct fix.)

Fixes #310777