### PR TITLE
fix(sessions): only delete folder configs that are actually cached to avoid Unknown folder crash (#310369)

### DIFF
--- a/src/vs/sessions/services/configuration/browser/configurationService.ts
+++ b/src/vs/sessions/services/configuration/browser/configurationService.ts
@@ -254,15 +254,24 @@ export class ConfigurationService extends Disposable implements IWorkbenchConfig
 	}
 
 	private onWorkspaceFoldersChanged(e: IWorkspaceFoldersChangeEvent): void {
-		// Remove configurations for removed folders
+		// Remove configurations for folders no longer part of the workspace.
+		// Iterate the cached folder configs (rather than `e.removed`) so that we only
+		// delete folder configurations that were actually loaded. A removal event for a
+		// folder whose configuration was never loaded (e.g., due to an init/load race)
+		// would otherwise cause `compareAndDeleteFolderConfiguration` to throw
+		// `Unknown folder`. This mirrors the safe pattern used by the workbench
+		// `ConfigurationService.onFoldersChanged`.
 		const previousData = this._configuration.toData();
 		const keys: string[] = [];
 		const overrides: [string, string[]][] = [];
-		for (const folder of e.removed) {
-			const change = this._configuration.compareAndDeleteFolderConfiguration(folder.uri);
-			keys.push(...change.keys);
-			overrides.push(...change.overrides);
-			this.cachedFolderConfigs.deleteAndDispose(folder.uri);
+		const workspaceFolders = this.workspaceService.getWorkspace().folders;
+		for (const key of [...this.cachedFolderConfigs.keys()]) {
+			if (!workspaceFolders.some(folder => folder.uri.toString() === key.toString())) {
+				const change = this._configuration.compareAndDeleteFolderConfiguration(key);
+				keys.push(...change.keys);
+				overrides.push(...change.overrides);
+				this.cachedFolderConfigs.deleteAndDispose(key);
+			}
 		}
 		if (keys.length || overrides.length) {
 			this.triggerConfigurationChange({ keys, overrides }, previousData, ConfigurationTarget.WORKSPACE_FOLDER);

--- a/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
+++ b/src/vs/sessions/services/configuration/test/browser/configurationService.test.ts
@@ -125,6 +125,24 @@ suite('Sessions ConfigurationService', () => {
 		assert.strictEqual(testObject.getValue('sessionsConfigurationService.testSetting', { resource: folder }), 'defaultValue');
 	}));
 
+	test('removing a folder whose configuration was never loaded does not throw (issue #310369)', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		// Simulates the lifecycle race where `onDidChangeWorkspaceFolders` fires a removal
+		// for a folder that has no entry in the internal `_configuration.folderConfigurations`
+		// map (e.g., because `initialize()` replaced `_configuration` between an add and a
+		// remove, or because the folder was never loaded due to timing). Prior to the fix
+		// this caused `compareAndDeleteFolderConfiguration` to throw `Unknown folder`.
+		const neverLoadedFolder = joinPath(ROOT, 'neverLoadedFolder');
+		await fileService.createFolder(neverLoadedFolder);
+		const event = {
+			added: [],
+			removed: [{ uri: neverLoadedFolder, name: 'neverLoadedFolder', index: 0, toResource: (r: string) => joinPath(neverLoadedFolder, r) }],
+			changed: []
+		};
+		assert.doesNotThrow(() => {
+			(testObject as unknown as { onWorkspaceFoldersChanged: (e: unknown) => void }).onWorkspaceFoldersChanged(event);
+		});
+	}));
+
 	test('configuration change event is fired when folders with settings are removed', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
 		const folder = joinPath(ROOT, 'removedFolder2');
 		await fileService.createFolder(folder);


### PR DESCRIPTION
## What

When a workspace folder is removed, only delete configuration entries that are actually in the cache (and no longer part of the workspace), rather than blindly processing everything in `e.removed`.

## Why

`onWorkspaceFoldersChanged` previously iterated `e.removed` and called `compareAndDeleteFolderConfiguration(folder.uri)` for each entry. If the folder's configuration was never loaded (race between `initialize()` replacing `_configuration` and the removal event, or a folder that never successfully loaded), `compareAndDeleteFolderConfiguration` throws `Error('Unknown folder')`. This showed up as a recurring error-telemetry bucket (#310369).

## How

Iterate `cachedFolderConfigs.keys()` and only delete entries whose URI is no longer present in `workspaceService.getWorkspace().folders`. This mirrors the workbench `ConfigurationService.onFoldersChanged` safe pattern (see `src/vs/workbench/services/configuration/browser/configurationService.ts:944-953`).

## Test plan

New regression test in `configurationService.test.ts` invokes the private `onWorkspaceFoldersChanged` handler with a removal event for a folder that was never added to `cachedFolderConfigs`. Pre-fix this threw `Unknown folder`; post-fix it is a no-op.

Fixes #310369