### PR TITLE
Hide system-initiated steering messages from chat UI

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -33,7 +33,7 @@ import { reviewEdits } from '../../../inlineChat/browser/inlineChatController.js
 import { ITerminalEditorService, ITerminalGroupService, ITerminalService } from '../../../terminal/browser/terminal.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatCopyKind, IChatService } from '../../common/chatService/chatService.js';
-import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
+import { IChatResponseViewModel, isResponseVM } from '../../common/model/chatViewModel.js';
 import { ChatAgentLocation } from '../../common/constants.js';
 import { IChatCodeBlockContextProviderService, IChatWidgetService } from '../chat.js';
 import { DefaultChatTextEditor, ICodeBlockActionContext, ICodeCompareBlockActionContext } from '../widget/chatContentParts/codeBlockPart.js';
@@ -157,7 +157,7 @@ export function registerChatCodeBlockActions() {
 			if (isResponseVM(context.element)) {
 				const chatService = accessor.get(IChatService);
 				const requestId = context.element.requestId;
-				const request = context.element.session.getItems().find(item => item.id === requestId && isRequestVM(item)) as IChatRequestViewModel | undefined;
+				const request = context.element.session.model.getRequests().find(r => r.id === requestId);
 				chatService.notifyUserAction({
 					agentId: context.element.agent?.id,
 					command: context.element.slashCommand?.name,
@@ -224,7 +224,7 @@ export function registerChatCodeBlockActions() {
 		const element = context.element as IChatResponseViewModel | undefined;
 		if (isResponseVM(element)) {
 			const requestId = element.requestId;
-			const request = element.session.getItems().find(item => item.id === requestId && isRequestVM(item)) as IChatRequestViewModel | undefined;
+			const request = element.session.model.getRequests().find(r => r.id === requestId);
 			chatService.notifyUserAction({
 				agentId: element.agent?.id,
 				command: element.slashCommand?.name,
@@ -383,7 +383,7 @@ export function registerChatCodeBlockActions() {
 
 			if (isResponseVM(context.element)) {
 				const requestId = context.element.requestId;
-				const request = context.element.session.getItems().find(item => item.id === requestId && isRequestVM(item)) as IChatRequestViewModel | undefined;
+				const request = context.element.session.model.getRequests().find(r => r.id === requestId);
 				chatService.notifyUserAction({
 					agentId: context.element.agent?.id,
 					command: context.element.slashCommand?.name,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
@@ -176,10 +176,10 @@ export function registerChatForkActions() {
 			// Use model-level lookup by request ID to get the correct index,
 			// since the view model may filter out hidden requests (e.g. system-initiated).
 			const requestIndex = chatModel.getRequests().findIndex(r => r.id === targetRequestId);
-			const targetIndex = isRequestItem ? Math.max(0, requestIndex - 1) : requestIndex;
-			if (targetIndex < 0) {
+			if (requestIndex < 0) {
 				return;
 			}
+			const targetIndex = isRequestItem ? Math.max(0, requestIndex - 1) : requestIndex;
 
 			const forkedData = revive(JSON.parse(JSON.stringify({
 				...serializedData,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatForkActions.ts
@@ -173,23 +173,10 @@ export function registerChatForkActions() {
 			// Export the full session data and truncate to include only requests up to and including the target
 			const serializedData = chatModel.toJSON();
 			const isRequestItem = isRequestVM(item);
-			let targetIndex = -1;
-			if (widget?.viewModel) {
-				let requestIndex = -1;
-				for (const entry of widget.viewModel.getItems()) {
-					if (isRequestVM(entry)) {
-						requestIndex += 1;
-					}
-					if (entry.id === item?.id) {
-						targetIndex = isRequestVM(entry) ? Math.max(0, requestIndex - 1) : requestIndex;
-						break;
-					}
-				}
-			}
-			if (targetIndex < 0) {
-				const requestIndex = chatModel.getRequests().findIndex(r => r.id === targetRequestId);
-				targetIndex = isRequestItem ? Math.max(0, requestIndex - 1) : requestIndex;
-			}
+			// Use model-level lookup by request ID to get the correct index,
+			// since the view model may filter out hidden requests (e.g. system-initiated).
+			const requestIndex = chatModel.getRequests().findIndex(r => r.id === targetRequestId);
+			const targetIndex = isRequestItem ? Math.max(0, requestIndex - 1) : requestIndex;
 			if (targetIndex < 0) {
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -289,7 +289,7 @@ export class ChatRemoveAllPendingRequestsAction extends Action2 {
 			return;
 		}
 
-		for (const pendingRequest of [...model.getPendingRequests()]) {
+		for (const pendingRequest of [...model.getVisiblePendingRequests()]) {
 			chatService.removePendingRequest(model.sessionResource, pendingRequest.request.id);
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/codeBlockOperations.ts
@@ -36,7 +36,7 @@ import { CellKind, ICellEditOperation, NOTEBOOK_EDITOR_ID } from '../../../noteb
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { ICodeMapperCodeBlock, ICodeMapperRequest, ICodeMapperResponse, ICodeMapperService } from '../../common/editing/chatCodeMapperService.js';
 import { ChatUserAction, IChatService } from '../../common/chatService/chatService.js';
-import { IChatRequestViewModel, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
+import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { ICodeBlockActionContext } from '../widget/chatContentParts/codeBlockPart.js';
 
 export class InsertCodeBlockOperation {
@@ -67,7 +67,7 @@ export class InsertCodeBlockOperation {
 
 		if (isResponseVM(context.element)) {
 			const requestId = context.element.requestId;
-			const request = context.element.session.getItems().find(item => item.id === requestId && isRequestVM(item)) as IChatRequestViewModel | undefined;
+			const request = context.element.session.model.getRequests().find(r => r.id === requestId);
 			notifyUserAction(this.chatService, context, {
 				kind: 'insert',
 				codeBlockIndex: context.codeBlockIndex,
@@ -197,7 +197,7 @@ export class ApplyCodeBlockOperation {
 
 		if (isResponseVM(context.element)) {
 			const requestId = context.element.requestId;
-			const request = context.element.session.getItems().find(item => item.id === requestId && isRequestVM(item)) as IChatRequestViewModel | undefined;
+			const request = context.element.session.model.getRequests().find(r => r.id === requestId);
 			notifyUserAction(this.chatService, context, {
 				kind: 'apply',
 				codeBlockIndex: context.codeBlockIndex,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2053,8 +2053,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		let lastSteeringCount = 0;
 		const updatePendingRequestKeys = (announceSteering: boolean) => {
 			const pendingRequests = model.getPendingRequests();
-			const pendingCount = pendingRequests.length;
-			this._hasPendingRequestsContextKey.set(pendingCount > 0);
+			const hasVisiblePendingRequests = pendingRequests.some(pending => !pending.request.isSystemInitiated);
+			this._hasPendingRequestsContextKey.set(hasVisiblePendingRequests);
 			// Only count user-initiated steering for announcements; system-initiated
 			// steering (e.g. terminal completion) is hidden from the conversation view.
 			const steeringCount = pendingRequests.filter(pending => pending.kind === ChatRequestQueueKind.Steering && !pending.request.isSystemInitiated).length;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2055,7 +2055,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			const pendingRequests = model.getPendingRequests();
 			const pendingCount = pendingRequests.length;
 			this._hasPendingRequestsContextKey.set(pendingCount > 0);
-			const steeringCount = pendingRequests.filter(pending => pending.kind === ChatRequestQueueKind.Steering).length;
+			// Only count user-initiated steering for announcements; system-initiated
+			// steering (e.g. terminal completion) is hidden from the conversation view.
+			const steeringCount = pendingRequests.filter(pending => pending.kind === ChatRequestQueueKind.Steering && !pending.request.isSystemInitiated).length;
 			if (announceSteering && steeringCount > 0 && lastSteeringCount === 0) {
 				status(localize('chat.pendingRequests.steeringQueued', "Steering"));
 			}
@@ -2526,7 +2528,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return true;
 		}
 
-		const hasPendingRequests = model.getPendingRequests().length > 0;
+		// Only count user-visible pending requests (exclude system-initiated ones)
+		const hasPendingRequests = model.getPendingRequests().some(p => !p.request.isSystemInitiated);
 		if (!hasPendingRequests) {
 			return true;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2052,12 +2052,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._sessionHasDebugDataContextKey.set(this.chatDebugService.getEvents(model.sessionResource).length > 0);
 		let lastSteeringCount = 0;
 		const updatePendingRequestKeys = (announceSteering: boolean) => {
-			const pendingRequests = model.getPendingRequests();
-			const hasVisiblePendingRequests = pendingRequests.some(pending => !pending.request.isSystemInitiated);
-			this._hasPendingRequestsContextKey.set(hasVisiblePendingRequests);
-			// Only count user-initiated steering for announcements; system-initiated
-			// steering (e.g. terminal completion) is hidden from the conversation view.
-			const steeringCount = pendingRequests.filter(pending => pending.kind === ChatRequestQueueKind.Steering && !pending.request.isSystemInitiated).length;
+			const visiblePendingRequests = model.getVisiblePendingRequests();
+			this._hasPendingRequestsContextKey.set(visiblePendingRequests.length > 0);
+			const steeringCount = visiblePendingRequests.filter(pending => pending.kind === ChatRequestQueueKind.Steering).length;
 			if (announceSteering && steeringCount > 0 && lastSteeringCount === 0) {
 				status(localize('chat.pendingRequests.steeringQueued', "Steering"));
 			}
@@ -2528,8 +2525,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return true;
 		}
 
-		// Only count user-visible pending requests (exclude system-initiated ones)
-		const hasPendingRequests = model.getPendingRequests().some(p => !p.request.isSystemInitiated);
+		const hasPendingRequests = model.getVisiblePendingRequests().length > 0;
 		if (!hasPendingRequests) {
 			return true;
 		}
@@ -2556,7 +2552,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (promptResult.result === 'remove') {
-			for (const pendingRequest of [...model.getPendingRequests()]) {
+			for (const pendingRequest of [...model.getVisiblePendingRequests()]) {
 				this.chatService.removePendingRequest(model.sessionResource, pendingRequest.request.id);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1517,6 +1517,8 @@ export interface IChatModel extends IDisposable {
 
 	readonly onDidChangePendingRequests: Event<void>;
 	getPendingRequests(): readonly IChatPendingRequest[];
+	/** Returns only pending requests visible to the user (excludes system-initiated ones). */
+	getVisiblePendingRequests(): readonly IChatPendingRequest[];
 }
 
 export interface ISerializableChatsData {
@@ -2037,6 +2039,10 @@ export class ChatModel extends Disposable implements IChatModel {
 
 	getPendingRequests(): readonly IChatPendingRequest[] {
 		return this._pendingRequests;
+	}
+
+	getVisiblePendingRequests(): readonly IChatPendingRequest[] {
+		return this._pendingRequests.filter(p => !p.request.isSystemInitiated);
 	}
 
 	setPendingRequests(requests: readonly { requestId: string; kind: ChatRequestQueueKind }[]): void {

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -354,8 +354,9 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 
 		const pendingRequests = this._model.getPendingRequests();
 		if (pendingRequests.length > 0) {
-			// Separate steering and queued requests, excluding system-initiated steering
-			const steeringRequests = pendingRequests.filter(p => p.kind === ChatRequestQueueKind.Steering && !p.request.isSystemInitiated);
+			// Use visible pending requests for steering (excludes system-initiated)
+			const visiblePendingRequests = this._model.getVisiblePendingRequests();
+			const steeringRequests = visiblePendingRequests.filter(p => p.kind === ChatRequestQueueKind.Steering);
 			const queuedRequests = pendingRequests.filter(p => p.kind === ChatRequestQueueKind.Queued);
 
 			// Add steering requests with their divider first

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -341,6 +341,11 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 			if (item.shouldBeRemovedOnSend && !item.shouldBeRemovedOnSend.afterUndoStop) {
 				return false;
 			}
+			// Hide system-initiated requests (e.g. terminal completion notifications)
+			// from the conversation view. Their responses remain visible.
+			if (isRequestVM(item) && item.isSystemInitiated) {
+				return false;
+			}
 			return true;
 		});
 		if (this._options?.maxVisibleItems !== undefined && items.length > this._options.maxVisibleItems) {
@@ -349,8 +354,8 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 
 		const pendingRequests = this._model.getPendingRequests();
 		if (pendingRequests.length > 0) {
-			// Separate steering and queued requests
-			const steeringRequests = pendingRequests.filter(p => p.kind === ChatRequestQueueKind.Steering);
+			// Separate steering and queued requests, excluding system-initiated steering
+			const steeringRequests = pendingRequests.filter(p => p.kind === ChatRequestQueueKind.Steering && !p.request.isSystemInitiated);
 			const queuedRequests = pendingRequests.filter(p => p.kind === ChatRequestQueueKind.Queued);
 
 			// Add steering requests with their divider first

--- a/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/mockChatModel.ts
@@ -68,6 +68,7 @@ export class MockChatModel extends Disposable implements IChatModel {
 	setRepoData(data: IExportableRepoData | undefined): void { this.repoData = data; }
 	readonly onDidChangePendingRequests: Event<void> = this._register(new Emitter<void>()).event;
 	getPendingRequests(): readonly IChatPendingRequest[] { return []; }
+	getVisiblePendingRequests(): readonly IChatPendingRequest[] { return []; }
 	toExport(): IExportableChatData {
 		return {
 			initialLocation: this.initialLocation,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/308549

Aligns VS Code's handling of background task notifications with Copilot CLI behavior.

Problem

When a background terminal command completes or needs input, VS Code shows a visible "Steering"
divider and request bubble in the chat conversation. Users see this as a separate message and
assume it's costing them a premium request, creating confusion about PRU consumption.

How Copilot CLI handles this

In the CLI, system notifications (e.g. "command finished") are injected silently into the
conversation — the user never sees the notification itself. They only see the model's brief
response acknowledging the event (e.g. "Build succeeded, all tests passed"). This keeps the
conversation clean and avoids the perception of extra cost.

This:

 - Hides system-initiated requests — Both the pending "Steering" divider and the compact request 
bubble (e.g. `npm run build` completed) are filtered from the visible conversation. The model's 
response remains visible.
 - User-initiated steering is unaffected — Messages explicitly sent as steering via queue actions 
still appear normally.
 - Fixes screen reader / pending UX — The status("Steering") announcement and "You already have 
pending requests" confirmation dialog now exclude system-initiated items, so users aren't alerted 
about things they can't see.
 - Fixes fork index calculation — Switched from counting visible requests in the view model to a 
model-level ID lookup (`getRequests().findIndex()`), preventing off-by-one errors when hidden 
requests exist between visible items.
 - Fixes telemetry lookups — `chatCodeblockActions.ts` now uses `session.model.getRequests()` instead 
of `session.getItems()` to find the originating request, so `modelId` is always resolved even for 
responses to hidden requests.