### PR TITLE
fix(chat): guard renderWelcomeViewContentIfNeeded against undisposed input part (#310356)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -995,6 +995,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		// The input part may not be rendered yet (or may have been disposed) when this is
+		// called from async flows such as `lockToCodingAgent` / `unlockFromCodingAgent` that
+		// run after `showModel` resolves. Bail out to avoid dereferencing an undefined input.
+		if (!this.inputPartDisposable.value) {
+			return;
+		}
+
 		this._isRenderingWelcome = true;
 		try {
 			if (this.viewOptions.renderStyle === 'compact' || this.viewOptions.renderStyle === 'minimal' || this.lifecycleService.willShutdown) {


### PR DESCRIPTION
**What** — Add an early-return in `ChatWidget.renderWelcomeViewContentIfNeeded()` when the input part has not been rendered (or was already disposed).

**Why** — The method dereferences `this.input.currentModeKind`, which hits a non-null assertion on `this.inputPartDisposable.value!`. Invocations from the async `showModel` → `updateWidgetLockState` → `lockToCodingAgent`/`unlockFromCodingAgent` chain could land while no input part was live, throwing unhandled errors (205 hits / 135 users reported in #310356).

**How** — Early-return guard `if (!this.inputPartDisposable.value) { return; }` at the top of `renderWelcomeViewContentIfNeeded()`. Mirrors the existing defensive pattern in the sibling `renderGettingStartedTipIfNeeded()` (line ~1040) and the optional-chain at line 1026.

**Test plan** — Manual repro via the agent-session flow that triggers `lockToCodingAgent`/`unlockFromCodingAgent` before the input part renders; pre-fix this throws on `inputPartDisposable.value!`, post-fix it returns early. No unit test added (no existing `chatWidget.test.ts` harness).

Fixes #310356