### PR TITLE
agents: restore built-in skills and merge them into the provider-based customizations UI

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -28,6 +28,8 @@ import './nullChatTipService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ISessionsConfigurationService, SessionsConfigurationService } from './sessionsConfigurationService.js';
+import { AgenticPromptsService } from './promptsService.js';
+import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { SessionsAICustomizationWorkspaceService } from './aiCustomizationWorkspaceService.js';
@@ -308,6 +310,7 @@ registerWorkbenchContribution2(RegisterChatViewContainerContribution.ID, Registe
 registerWorkbenchContribution2(RunScriptContribution.ID, RunScriptContribution, WorkbenchPhase.AfterRestored);
 
 // register services
+registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);
 registerSingleton(ISessionsConfigurationService, SessionsConfigurationService, InstantiationType.Delayed);
 registerSingleton(IAICustomizationWorkspaceService, SessionsAICustomizationWorkspaceService, InstantiationType.Delayed);
 registerSingleton(ICustomizationHarnessService, SessionsCustomizationHarnessService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { FileAccess } from '../../../../base/common/network.js';
+import { basename, dirname, joinPath } from '../../../../base/common/resources.js';
+import { SKILL_FILENAME } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
+import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { IAgentSkill, IPromptPath, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { PromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.js';
+import { BUILTIN_STORAGE, IBuiltinPromptPath } from '../common/builtinPromptsStorage.js';
+
+/** URI root for built-in skills bundled with the Agents app. */
+export const BUILTIN_SKILLS_URI = FileAccess.asFileUri('vs/sessions/skills');
+
+/**
+ * Sessions-specific PromptsService that additionally discovers built-in skills
+ * bundled at `vs/sessions/skills/{folder}/SKILL.md`.
+ *
+ * Built-in skills are merged into `findAgentSkills()` and exposed via
+ * `listPromptFilesForStorage(skill, BUILTIN_STORAGE)` so that the existing
+ * AI customization UI (groups, badges, overrides) picks them up naturally.
+ *
+ * User/workspace skills with the same folder name take precedence (built-ins
+ * are appended last and filtered when overridden).
+ */
+export class AgenticPromptsService extends PromptsService {
+
+	private _builtinSkillsCache: Promise<readonly IAgentSkill[]> | undefined;
+
+	private async getBuiltinSkills(): Promise<readonly IAgentSkill[]> {
+		if (!this._builtinSkillsCache) {
+			this._builtinSkillsCache = this.discoverBuiltinSkills();
+		}
+		return this._builtinSkillsCache;
+	}
+
+	private async discoverBuiltinSkills(): Promise<readonly IAgentSkill[]> {
+		try {
+			const stat = await this.fileService.resolve(BUILTIN_SKILLS_URI);
+			if (!stat.children) {
+				return [];
+			}
+
+			const skills: IAgentSkill[] = [];
+			for (const child of stat.children) {
+				if (!child.isDirectory) {
+					continue;
+				}
+				const skillFileUri = joinPath(child.resource, SKILL_FILENAME);
+				try {
+					const parsed = await this.parseNew(skillFileUri, CancellationToken.None);
+					const rawName = parsed.header?.name;
+					const rawDescription = parsed.header?.description;
+					if (!rawName || !rawDescription) {
+						continue;
+					}
+					const name = sanitizeSkillText(rawName, 64);
+					const description = sanitizeSkillText(rawDescription, 1024);
+					const folderName = basename(child.resource);
+					if (name !== folderName) {
+						continue;
+					}
+					skills.push({
+						uri: skillFileUri,
+						storage: BUILTIN_STORAGE as PromptsStorage,
+						name,
+						description,
+						disableModelInvocation: parsed.header?.disableModelInvocation === true,
+						userInvocable: parsed.header?.userInvocable !== false,
+					});
+				} catch (e) {
+					this.logger.warn(`[AgenticPromptsService] Failed to parse built-in skill: ${skillFileUri}`, e instanceof Error ? e.message : String(e));
+				}
+			}
+			return skills;
+		} catch {
+			return [];
+		}
+	}
+
+	private async getBuiltinSkillPaths(): Promise<readonly IBuiltinPromptPath[]> {
+		const skills = await this.getBuiltinSkills();
+		return skills.map(s => ({
+			uri: s.uri,
+			storage: BUILTIN_STORAGE,
+			type: PromptsType.skill,
+			name: s.name,
+			description: s.description,
+		}));
+	}
+
+	public override async findAgentSkills(token: CancellationToken): Promise<IAgentSkill[] | undefined> {
+		const baseResult = await super.findAgentSkills(token);
+		if (baseResult === undefined) {
+			return undefined;
+		}
+
+		const builtinSkills = await this.getBuiltinSkills();
+		if (builtinSkills.length === 0) {
+			return baseResult;
+		}
+
+		const existingNames = new Set(baseResult.map(s => s.name));
+		const disabledSkills = this.getDisabledPromptFiles(PromptsType.skill);
+		const nonOverridden = builtinSkills.filter(s => !existingNames.has(s.name) && !disabledSkills.has(s.uri));
+		if (nonOverridden.length === 0) {
+			return baseResult;
+		}
+
+		return [...baseResult, ...nonOverridden];
+	}
+
+	public override async listPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]> {
+		const baseResults = await super.listPromptFiles(type, token);
+
+		if (type !== PromptsType.skill) {
+			return baseResults;
+		}
+
+		const builtinItems = await this.getBuiltinSkillPaths();
+		if (builtinItems.length === 0) {
+			return baseResults;
+		}
+
+		// Filter out built-ins overridden by user/workspace skills of the same folder name.
+		const overriddenNames = new Set<string>();
+		for (const p of baseResults) {
+			if (p.storage === PromptsStorage.local || p.storage === PromptsStorage.user) {
+				overriddenNames.add(basename(dirname(p.uri)));
+			}
+		}
+		const nonOverridden = builtinItems.filter(p => !overriddenNames.has(basename(dirname(p.uri))));
+
+		// Built-in items use BUILTIN_STORAGE ('builtin') which is not in the core
+		// IPromptPath union but is handled by the sessions UI layer.
+		return [...baseResults, ...nonOverridden] as readonly IPromptPath[];
+	}
+
+	public override async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly IPromptPath[]> {
+		if ((storage as PromptsStorage | typeof BUILTIN_STORAGE) === BUILTIN_STORAGE) {
+			if (type === PromptsType.skill) {
+				return this.getBuiltinSkillPaths() as Promise<readonly IPromptPath[]>;
+			}
+			return [];
+		}
+		return super.listPromptFilesForStorage(type, storage, token);
+	}
+}
+
+/**
+ * Strips XML tags and truncates to the given max length.
+ * Matches the sanitization applied by PromptsService for other skill sources.
+ */
+function sanitizeSkillText(text: string, maxLength: number): string {
+	const sanitized = text.replace(/<[^>]+>/g, '');
+	return sanitized.length > maxLength ? sanitized.substring(0, maxLength) : sanitized;
+}

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -103,7 +103,11 @@ export class AgenticPromptsService extends PromptsService {
 			return baseResult;
 		}
 
-		const existingNames = new Set(baseResult.map(s => s.name));
+		const existingNames = new Set(
+			baseResult
+				.filter(s => s.storage === PromptsStorage.local || s.storage === PromptsStorage.user)
+				.map(s => s.name)
+		);
 		const disabledSkills = this.getDisabledPromptFiles(PromptsType.skill);
 		const nonOverridden = builtinSkills.filter(s => !existingNames.has(s.name) && !disabledSkills.has(s.uri));
 		if (nonOverridden.length === 0) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -10,7 +10,7 @@ import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { ResourceMap } from '../../../../../base/common/map.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
-import { basename, isEqualOrParent } from '../../../../../base/common/resources.js';
+import { basename, dirname, isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
@@ -362,9 +362,63 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 
 		if (promptType === PromptsType.skill) {
 			providerItems = await this.addSkillDescriptionFallbacks(providerItems);
+			providerItems = await this.mergeBuiltinSkills(providerItems);
 		}
 
 		return this.itemNormalizer.normalizeItems(providerItems, promptType);
+	}
+
+	/**
+	 * Merges built-in skills (bundled with the app under `vs/sessions/skills/`)
+	 * into the provider's items. The provider may re-discover the bundled
+	 * copies when scanning disk — those duplicates are dropped (deduped by
+	 * URI) and replaced with the authoritative built-in entry tagged
+	 * `groupKey: BUILTIN_STORAGE` so the UI renders them in the "Built-in"
+	 * group. User-authored overrides (different URI, same name) are preserved.
+	 *
+	 * A workbench that uses the base `PromptsService` will throw on
+	 * `BUILTIN_STORAGE` — we catch and return the items unchanged in that case.
+	 */
+	private async mergeBuiltinSkills(items: readonly ICustomizationItem[]): Promise<readonly ICustomizationItem[]> {
+		let builtinPaths: readonly { uri: URI; name?: string; description?: string }[] = [];
+		try {
+			builtinPaths = await this.promptsService.listPromptFilesForStorage(PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage, CancellationToken.None);
+		} catch {
+			return items;
+		}
+		if (builtinPaths.length === 0) {
+			return items;
+		}
+
+		const builtinUris = new ResourceMap<typeof builtinPaths[number]>();
+		for (const p of builtinPaths) {
+			builtinUris.set(p.uri, p);
+		}
+
+		// Drop provider items that are the same URI as a built-in (the provider
+		// re-discovered the bundled copy by scanning disk).
+		const deduped = items.filter(item => !builtinUris.has(item.uri));
+
+		const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
+		const uiIntegrationBadge = localize('uiIntegrationBadge', "UI Integration");
+
+		// Append authoritative built-in entries.
+		const builtinItems: ICustomizationItem[] = builtinPaths.map(p => {
+			const folderName = basename(dirname(p.uri));
+			const uiTooltip = uiIntegrations.get(folderName);
+			return {
+				uri: p.uri,
+				type: PromptsType.skill,
+				name: p.name ?? basename(p.uri),
+				description: p.description,
+				groupKey: BUILTIN_STORAGE,
+				enabled: true,
+				badge: uiTooltip ? uiIntegrationBadge : undefined,
+				badgeTooltip: uiTooltip,
+			};
+		});
+
+		return [...deduped, ...builtinItems];
 	}
 
 	private async addSkillDescriptionFallbacks(items: readonly ICustomizationItem[]): Promise<readonly ICustomizationItem[]> {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -239,8 +239,16 @@ export class AICustomizationItemNormalizer {
 		}
 
 		switch (item.groupKey) {
-			case BUILTIN_STORAGE:
-				return { storage: PromptsStorage.extension, groupKey: BUILTIN_STORAGE, isBuiltin: true, extensionLabel };
+			case BUILTIN_STORAGE: {
+				// Preserve a provider-supplied BUILTIN_STORAGE so the management
+				// editor's "edit built-in and save as user/workspace copy" flow
+				// activates. Otherwise fall back to extension storage (the
+				// historical source of built-in items).
+				const builtinStorage = (item.storage as PromptsStorage | typeof BUILTIN_STORAGE | undefined) === BUILTIN_STORAGE
+					? (BUILTIN_STORAGE as unknown as PromptsStorage)
+					: PromptsStorage.extension;
+				return { storage: builtinStorage, groupKey: BUILTIN_STORAGE, isBuiltin: true, extensionLabel };
+			}
 			default:
 				return { storage, groupKey: item.groupKey, extensionLabel };
 		}
@@ -411,6 +419,7 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 				type: PromptsType.skill,
 				name: p.name ?? basename(p.uri),
 				description: p.description,
+				storage: BUILTIN_STORAGE as unknown as PromptsStorage,
 				groupKey: BUILTIN_STORAGE,
 				enabled: true,
 				badge: uiTooltip ? uiIntegrationBadge : undefined,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -370,10 +370,13 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 
 		if (promptType === PromptsType.skill) {
 			providerItems = await this.addSkillDescriptionFallbacks(providerItems);
-			providerItems = await this.mergeBuiltinSkills(providerItems);
 		}
 
-		return this.itemNormalizer.normalizeItems(providerItems, promptType);
+		const normalized = this.itemNormalizer.normalizeItems(providerItems, promptType);
+		if (promptType === PromptsType.skill) {
+			return this.mergeBuiltinSkills(normalized, promptType);
+		}
+		return normalized;
 	}
 
 	/**
@@ -387,15 +390,15 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 	 * A workbench that uses the base `PromptsService` will throw on
 	 * `BUILTIN_STORAGE` — we catch and return the items unchanged in that case.
 	 */
-	private async mergeBuiltinSkills(items: readonly ICustomizationItem[]): Promise<readonly ICustomizationItem[]> {
+	private async mergeBuiltinSkills(items: readonly IAICustomizationListItem[], promptType: PromptsType): Promise<IAICustomizationListItem[]> {
 		let builtinPaths: readonly { uri: URI; name?: string; description?: string }[] = [];
 		try {
 			builtinPaths = await this.promptsService.listPromptFilesForStorage(PromptsType.skill, BUILTIN_STORAGE as unknown as PromptsStorage, CancellationToken.None);
 		} catch {
-			return items;
+			return [...items];
 		}
 		if (builtinPaths.length === 0) {
-			return items;
+			return [...items];
 		}
 
 		const builtinUris = new ResourceMap<typeof builtinPaths[number]>();
@@ -410,14 +413,35 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 		const uiIntegrations = this.workspaceService.getSkillUIIntegrations();
 		const uiIntegrationBadge = localize('uiIntegrationBadge', "UI Integration");
 
-		// Append authoritative built-in entries.
-		const builtinItems: ICustomizationItem[] = builtinPaths.map(p => {
+		// Collect names of user/workspace skills so we can hide the built-in
+		// copy once the user has added an override at either level.
+		const overriddenNames = new Set<string>();
+		for (const item of deduped) {
+			if (item.storage === PromptsStorage.local || item.storage === PromptsStorage.user) {
+				if (item.name) {
+					overriddenNames.add(item.name);
+				}
+			}
+		}
+
+		// Append authoritative built-in entries (excluding any that have been
+		// overridden by a workspace or user copy with the same name).
+		const uriUseCounts = new ResourceMap<number>();
+		for (const item of deduped) {
+			uriUseCounts.set(item.uri, (uriUseCounts.get(item.uri) ?? 0) + 1);
+		}
+		const appended: IAICustomizationListItem[] = [];
+		for (const p of builtinPaths) {
+			const name = p.name ?? basename(p.uri);
+			if (overriddenNames.has(name)) {
+				continue;
+			}
 			const folderName = basename(dirname(p.uri));
 			const uiTooltip = uiIntegrations.get(folderName);
-			return {
+			const builtinItem: ICustomizationItem = {
 				uri: p.uri,
 				type: PromptsType.skill,
-				name: p.name ?? basename(p.uri),
+				name,
 				description: p.description,
 				storage: BUILTIN_STORAGE as unknown as PromptsStorage,
 				groupKey: BUILTIN_STORAGE,
@@ -425,9 +449,10 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 				badge: uiTooltip ? uiIntegrationBadge : undefined,
 				badgeTooltip: uiTooltip,
 			};
-		});
+			appended.push(this.itemNormalizer.normalizeItem(builtinItem, promptType, uriUseCounts));
+		}
 
-		return [...deduped, ...builtinItems];
+		return [...deduped, ...appended];
 	}
 
 	private async addSkillDescriptionFallbacks(items: readonly ICustomizationItem[]): Promise<readonly ICustomizationItem[]> {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -431,6 +431,7 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 			uriUseCounts.set(item.uri, (uriUseCounts.get(item.uri) ?? 0) + 1);
 		}
 		const appended: IAICustomizationListItem[] = [];
+		const disabledPromptFiles = this.promptsService.getDisabledPromptFiles(PromptsType.skill);
 		for (const p of builtinPaths) {
 			const name = p.name ?? basename(p.uri);
 			if (overriddenNames.has(name)) {
@@ -445,7 +446,7 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 				description: p.description,
 				storage: BUILTIN_STORAGE as unknown as PromptsStorage,
 				groupKey: BUILTIN_STORAGE,
-				enabled: true,
+				enabled: !disabledPromptFiles.has(p.uri),
 				badge: uiTooltip ? uiIntegrationBadge : undefined,
 				badgeTooltip: uiTooltip,
 			};


### PR DESCRIPTION
## Problem

PR #310000 deleted `AgenticPromptsService`, which was responsible for discovering built-in skills bundled under `src/vs/sessions/skills/`. This caused:

1. **Built-in skills disappeared** from the Agent Customizations UI in the Agents window
2. **UI Integration badges** (hardcoded tooltips for skills with workbench integrations) were lost
3. **Edit built-in → save as workspace/user copy** flow was broken — built-ins opened read-only instead of editable

## Solution

### 1. Restore `AgenticPromptsService` (`promptsService.ts`)
- Minimal subclass of `PromptsService` registered as `IPromptsService` in the sessions layer
- Overrides `findAgentSkills`, `listPromptFiles`, and `listPromptFilesForStorage` to discover bundled `SKILL.md` files under `vs/sessions/skills/`

### 2. Merge built-ins into the provider pipeline (`aiCustomizationItemSource.ts`)
- `mergeBuiltinSkills()` on `ProviderCustomizationItemSource` fetches built-in skills and appends them to the normalized list
- Deduplicates by URI (drops provider items that re-discovered bundled copies from disk)
- Restores **UI Integration** badge + tooltip via `workspaceService.getSkillUIIntegrations()`
- **Hides built-in entry** when a workspace or user override with the same name exists

### 3. Preserve `BUILTIN_STORAGE` through normalization (`aiCustomizationItemSource.ts`)
- The normalizer's `resolveSource()` was unconditionally rewriting `BUILTIN_STORAGE` → `PromptsStorage.extension`
- Now preserves provider-supplied `BUILTIN_STORAGE` so the management editor's editable-builtin code path activates
- The "Edit built-in → save as…" flow works again: built-in opens editable, save prompts for workspace/user target

## Files Changed

| File | Change |
|------|--------|
| `src/vs/sessions/contrib/chat/browser/promptsService.ts` | **New** — `AgenticPromptsService` with built-in skill discovery |
| `src/vs/sessions/contrib/chat/browser/chat.contribution.ts` | Registers `AgenticPromptsService` as `IPromptsService` |
| `src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts` | `mergeBuiltinSkills()`, `resolveSource()` BUILTIN_STORAGE preservation, UI Integration badges |