### PR TITLE
fix(workbench): guard BannerPart.show against calls before createContentArea (#310358)

### DIFF
--- a/src/vs/workbench/browser/parts/banner/bannerPart.ts
+++ b/src/vs/workbench/browser/parts/banner/bannerPart.ts
@@ -179,6 +179,15 @@ export class BannerPart extends Part implements IBannerService {
 	}
 
 	show(item: IBannerItem): void {
+		// Guard against `show` being called before the banner part's content
+		// area has been created (e.g. when `onDidChangeTrust` fires before the
+		// workbench layout has initialized this part). `this.element` is only
+		// assigned inside `createContentArea` so accessing it earlier would
+		// throw from `clearNode(undefined)`.
+		if (!this.element) {
+			return;
+		}
+
 		if (item.id === this.item?.id) {
 			this.setVisibility(true);
 			return;

--- a/src/vs/workbench/test/browser/parts/banner/bannerPart.test.ts
+++ b/src/vs/workbench/test/browser/parts/banner/bannerPart.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { TestStorageService } from '../../../common/workbenchTestServices.js';
+import { TestLayoutService } from '../../workbenchTestServices.js';
+import { BannerPart } from '../../../../browser/parts/banner/bannerPart.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IBannerItem } from '../../../../services/banner/browser/bannerService.js';
+
+suite('BannerPart', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	function createBannerPart(): BannerPart {
+		const themeService = new TestThemeService();
+		const storageService = disposables.add(new TestStorageService());
+		const layoutService = new TestLayoutService();
+		const contextKeyService = new MockContextKeyService();
+
+		// Minimal stubs — these services must not be invoked when `show()`
+		// returns early because the content area hasn't been created yet.
+		const instantiationService = { createInstance: () => { throw new Error('not expected'); } } as unknown as IInstantiationService;
+		const markdownRendererService = { render: () => { throw new Error('not expected'); } } as unknown as IMarkdownRendererService;
+
+		return disposables.add(new BannerPart(
+			themeService,
+			layoutService,
+			storageService,
+			contextKeyService,
+			instantiationService,
+			markdownRendererService,
+		));
+	}
+
+	// Regression test for https://github.com/microsoft/vscode/issues/310358.
+	// `BannerPart.show()` can be invoked by `WorkspaceTrustManagementService.onDidChangeTrust`
+	// during startup before the workbench layout has created the part's DOM element.
+	// Prior to the fix, this threw `TypeError: Cannot read properties of undefined
+	// (reading 'firstChild')` from `clearNode(this.element)`.
+	test('show() does not throw when called before createContentArea()', () => {
+		const part = createBannerPart();
+
+		const item: IBannerItem = {
+			id: 'test.banner',
+			icon: undefined,
+			message: 'hello',
+		};
+
+		assert.doesNotThrow(() => part.show(item));
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
**What** — `BannerPart.show()` now no-ops when the banner hasn't been rendered yet, instead of throwing on `clearNode(undefined)`.

**Why** — `WorkspaceTrustManagementService.onDidChangeTrust` can fire its subscriber (which calls `BannerPart.show()`) during startup before `createContentArea()` runs. The first line of `show()` dereferences `this.element`, producing `TypeError: Cannot read properties of undefined (reading 'firstChild')` (#310358).

**How** — Added `if (!this.element) return;` at the top of `show()`. Once the banner is rendered, behavior is unchanged.

**Test plan** — New `bannerPart.test.ts` instantiates `BannerPart`, calls `show(...)` before `create(...)`, and asserts no throw. Pre-fix this failed with `clearNode(undefined)`.

Fixes #310358