### PR TITLE
fix(chat): guard agent-sessions reveal against transient tree-map desync (#309891)

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -1042,7 +1042,20 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 	}
 
 	getRelativeTop(element: T): number | null {
-		return this.tree.getRelativeTop(this.getDataNode(element));
+		// During async refresh there is a microtask gap where this.nodes (used
+		// by hasNode) and the underlying tree's node map can be out of sync,
+		// so getDataNode or tree.getRelativeTop may throw TreeError even
+		// though hasNode returned true. Treat that as "not currently visible"
+		// — the existing semantic of returning null already covers callers
+		// that fall back to reveal().
+		try {
+			return this.tree.getRelativeTop(this.getDataNode(element));
+		} catch (err) {
+			if (err instanceof TreeError) {
+				return null;
+			}
+			throw err;
+		}
 	}
 
 	// Tree navigation

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -153,38 +153,12 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 		const matchingSession = this.agentSessionsService.model.getSession(resource);
 		if (matchingSession && this.sessionsList?.hasNode(matchingSession)) {
-			if (this.tryGetRelativeTop(matchingSession) === null) {
+			if (this.sessionsList.getRelativeTop(matchingSession) === null) {
 				this.sessionsList.reveal(matchingSession, 0.5); // only reveal when not already visible
 			}
 
 			this.sessionsList.setFocus([matchingSession]);
 			this.sessionsList.setSelection([matchingSession]);
-		}
-	}
-
-	/**
-	 * Safely queries the sessions list for the relative top of an element.
-	 *
-	 * `hasNode()` and `getRelativeTop()` consult different internal maps in the
-	 * compressible async data tree. During an async refresh there is a microtask
-	 * gap where the async tree's node map has been updated but the underlying
-	 * compressed object tree model has not (or vice versa). In that window
-	 * `hasNode()` can return `true` while `getRelativeTop()` throws
-	 * `TreeError [AgentSessionsView] Tree element not found` (issue #309891).
-	 *
-	 * Treat such a failure as "not currently visible" so that callers fall back
-	 * to `reveal()`, which is safe to call when the element is in the data
-	 * source even if the view has not caught up yet.
-	 */
-	private tryGetRelativeTop(session: IAgentSession): number | null {
-		if (!this.sessionsList) {
-			return null;
-		}
-
-		try {
-			return this.sessionsList.getRelativeTop(session);
-		} catch {
-			return null;
 		}
 	}
 
@@ -863,7 +837,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			return false;
 		}
 
-		if (this.tryGetRelativeTop(session) === null) {
+		if (this.sessionsList.getRelativeTop(session) === null) {
 			this.sessionsList.reveal(session, 0.5); // only reveal when not already visible
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -153,12 +153,38 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 		const matchingSession = this.agentSessionsService.model.getSession(resource);
 		if (matchingSession && this.sessionsList?.hasNode(matchingSession)) {
-			if (this.sessionsList.getRelativeTop(matchingSession) === null) {
+			if (this.tryGetRelativeTop(matchingSession) === null) {
 				this.sessionsList.reveal(matchingSession, 0.5); // only reveal when not already visible
 			}
 
 			this.sessionsList.setFocus([matchingSession]);
 			this.sessionsList.setSelection([matchingSession]);
+		}
+	}
+
+	/**
+	 * Safely queries the sessions list for the relative top of an element.
+	 *
+	 * `hasNode()` and `getRelativeTop()` consult different internal maps in the
+	 * compressible async data tree. During an async refresh there is a microtask
+	 * gap where the async tree's node map has been updated but the underlying
+	 * compressed object tree model has not (or vice versa). In that window
+	 * `hasNode()` can return `true` while `getRelativeTop()` throws
+	 * `TreeError [AgentSessionsView] Tree element not found` (issue #309891).
+	 *
+	 * Treat such a failure as "not currently visible" so that callers fall back
+	 * to `reveal()`, which is safe to call when the element is in the data
+	 * source even if the view has not caught up yet.
+	 */
+	private tryGetRelativeTop(session: IAgentSession): number | null {
+		if (!this.sessionsList) {
+			return null;
+		}
+
+		try {
+			return this.sessionsList.getRelativeTop(session);
+		} catch {
+			return null;
 		}
 	}
 
@@ -837,7 +863,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			return false;
 		}
 
-		if (this.sessionsList.getRelativeTop(session) === null) {
+		if (this.tryGetRelativeTop(session) === null) {
 			this.sessionsList.reveal(session, 0.5); // only reveal when not already visible
 		}
 


### PR DESCRIPTION
**What** — `AsyncDataTree.getRelativeTop()` no longer throws `TreeError [...] Tree element not found` during transient async-refresh races; it now returns `null` (the existing "not currently visible" semantic), so all consumers automatically get safe behavior.

**Why** — Originally guarded only at the `AgentSessionsControl` call site. Per @bpasero's review feedback, the fix belongs in the underlying base widget — every consumer of `AsyncDataTree.getRelativeTop()` would otherwise have to repeat the same try/catch when paired with `hasNode()`.

`AsyncDataTree.hasNode()` consults `this.nodes` (the JS-side map). `AsyncDataTree.getRelativeTop()` calls `this.getDataNode()` and then the underlying tree model's `getRelativeTop()`, which consults a different map (`compressedObjectTreeModel`'s `nodes`). During `refreshAndRenderNode()` there is a microtask gap where one map is updated and the other isn't, so `hasNode()` can return `true` while the deeper call throws `TreeError [...] Tree element not found` (#309891, 51 hits / 28 users).

**How** — `AsyncDataTree.getRelativeTop()` now wraps the underlying call in try/catch. On `TreeError` it returns `null` (matching the existing semantic for "not visible"); other errors continue to propagate. Reverted the call-site `tryGetRelativeTop` workaround in `agentSessionsControl.ts` — the call site is back to its upstream baseline.

**Test plan** — Manual: trigger the race by switching active editors while the agent-sessions list is mid-refresh. Pre-fix this reliably throws the `TreeError` when hit; post-fix the error is absorbed and the existing `reveal(…, 0.5)` fallback runs. No unit test added — reproducing the race deterministically requires driving `AsyncDataTree.refreshAndRenderNode()` across its await boundary, which would need a substantial harness.

Fixes #309891