### PR TITLE
Fix z-index for webviews with modals

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -112,7 +112,6 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			// // Mount them to a high level node to avoid this depending on the active container.
 			const root = this._layoutService.getContainer(this.window);
 			root.appendChild(this._overlayLayout.root);
-			this._overlayLayout.root.style.zIndex = '2541'; // One level above the modals
 		}
 
 		return this._overlayLayout.content;

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -43,6 +43,7 @@ export class WebviewEditor extends EditorPane {
 	private _dimension?: DOM.Dimension;
 	private _visible = false;
 	private _isDisposed = false;
+	private _clippingContainer?: HTMLElement;
 
 	private readonly _webviewVisibleDisposables = this._register(new DisposableStore());
 	private readonly _onFocusWindowHandler = this._register(new MutableDisposable());
@@ -179,6 +180,14 @@ export class WebviewEditor extends EditorPane {
 			DOM.setParentFlowTo(input.webview.container, this._element);
 		}
 
+		// Check if this editor is inside a modal editor
+		const modalEditorContainer = this._editorGroupsService.activeModalEditorPart?.modalElement;
+		const isModal = isHTMLElement(modalEditorContainer) && this._element && modalEditorContainer.contains(this._element);
+		this._clippingContainer = isModal ? undefined : this._workbenchLayoutService.getContainer(this.window, Parts.EDITOR_PART);
+
+		// When shown in a modal editor, the webview overlay must sit above the modal layer
+		input.webview.container.style.zIndex = isModal ? '2541' : ''; // One over the modal z-index
+
 		this._webviewVisibleDisposables.clear();
 
 		// Webviews are not part of the normal editor dom, so we have to register our own drag and drop handler on them.
@@ -197,14 +206,7 @@ export class WebviewEditor extends EditorPane {
 			return;
 		}
 
-		const modalEditorContainer = this._editorGroupsService.activeModalEditorPart?.modalElement;
-		let clippingContainer: HTMLElement | undefined;
-		if (isHTMLElement(modalEditorContainer)) {
-			clippingContainer = undefined;
-		} else {
-			clippingContainer = this._workbenchLayoutService.getContainer(this.window, Parts.EDITOR_PART);
-		}
-		webview.layoutWebviewOverElement(this._element.parentElement!, dimension, clippingContainer);
+		webview.layoutWebviewOverElement(this._element.parentElement!, dimension, this._clippingContainer);
 	}
 
 	private trackFocus(webview: IOverlayWebview): IDisposable {


### PR DESCRIPTION
We only want to set the zindex if we're inside a modal

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
