### PR TITLE
fix(terminal): open terminal URLs immediately during remote connect (#236398)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadUriOpeners.ts
+++ b/src/vs/workbench/api/browser/mainThreadUriOpeners.ts
@@ -17,7 +17,7 @@ import { ExtHostContext, ExtHostUriOpenersShape, MainContext, MainThreadUriOpene
 import { defaultExternalUriOpenerId } from '../../contrib/externalUriOpener/common/configuration.js';
 import { ContributedExternalUriOpenersStore } from '../../contrib/externalUriOpener/common/contributedOpeners.js';
 import { IExternalOpenerProvider, IExternalUriOpener, IExternalUriOpenerService } from '../../contrib/externalUriOpener/common/externalUriOpenerService.js';
-import { IExtensionService } from '../../services/extensions/common/extensions.js';
+import { ActivationKind, IExtensionService } from '../../services/extensions/common/extensions.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 
 interface RegisteredOpenerMetadata {
@@ -56,7 +56,12 @@ export class MainThreadUriOpeners extends Disposable implements MainThreadUriOpe
 			return;
 		}
 
-		await this.extensionService.activateByEvent(`onOpenExternalUri:${targetUri.scheme}`);
+		// Use `Immediate` activation so that URL clicks are not blocked while a
+		// remote extension host is still being resolved/connected. Waiting here
+		// would defer opening the link until the remote connection completes,
+		// which is a problem e.g. for 2FA login URLs printed during connect.
+		// See https://github.com/microsoft/vscode/issues/236398
+		await this.extensionService.activateByEvent(`onOpenExternalUri:${targetUri.scheme}`, ActivationKind.Immediate);
 
 		for (const [id, openerMetadata] of this._registeredOpeners) {
 			if (openerMetadata.schemes.has(targetUri.scheme)) {

--- a/src/vs/workbench/api/test/browser/mainThreadUriOpeners.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadUriOpeners.test.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { TestNotificationService } from '../../../../platform/notification/test/common/testNotificationService.js';
+import { NullOpenerService } from '../../../../platform/opener/test/common/nullOpenerService.js';
+import { TestStorageService } from '../../../test/common/workbenchTestServices.js';
+import { MainThreadUriOpeners } from '../../browser/mainThreadUriOpeners.js';
+import { IExternalOpenerProvider, IExternalUriOpener, IExternalUriOpenerService } from '../../../contrib/externalUriOpener/common/externalUriOpenerService.js';
+import { ActivationKind, IExtensionService, NullExtensionService } from '../../../services/extensions/common/extensions.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
+
+class TestExternalUriOpenerService implements Partial<IExternalUriOpenerService> {
+	declare readonly _serviceBrand: undefined;
+	public provider: IExternalOpenerProvider | undefined;
+	registerExternalOpenerProvider(provider: IExternalOpenerProvider) {
+		this.provider = provider;
+		return { dispose: () => { this.provider = undefined; } };
+	}
+}
+
+class RecordingExtensionService extends NullExtensionService {
+	public readonly activateByEventCalls: Array<{ event: string; kind: ActivationKind | undefined }> = [];
+	public readonly normalBlocker = new DeferredPromise<void>();
+
+	override activateByEvent(activationEvent: string, activationKind?: ActivationKind): Promise<void> {
+		this.activateByEventCalls.push({ event: activationEvent, kind: activationKind });
+		// Simulate the real abstractExtensionService behavior: `Normal` waits for the
+		// `_installedExtensionsReady` barrier (which stays closed while a remote
+		// authority is being resolved). `Immediate` skips that wait. If the production
+		// code wrongly passes `Normal`, the test hangs waiting on this promise.
+		if (activationKind === ActivationKind.Immediate) {
+			return Promise.resolve();
+		}
+		return this.normalBlocker.p;
+	}
+}
+
+suite('MainThreadUriOpeners', () => {
+
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createFixture() {
+		const instantiationService = store.add(new TestInstantiationService());
+		const externalUriOpenerService = new TestExternalUriOpenerService();
+		const extensionService = new RecordingExtensionService();
+
+		instantiationService.stub(IExternalUriOpenerService, externalUriOpenerService as unknown as IExternalUriOpenerService);
+		instantiationService.stub(IExtensionService, extensionService);
+		instantiationService.stub(IStorageService, store.add(new TestStorageService()));
+		instantiationService.stub(IOpenerService, NullOpenerService);
+		instantiationService.stub(INotificationService, new TestNotificationService());
+
+		const rpcProtocol = SingleProxyRPCProtocol({
+			$canOpenUri: async () => 0,
+			$openUri: async () => { /* noop */ }
+		});
+		const main = store.add(instantiationService.createInstance(MainThreadUriOpeners, rpcProtocol));
+		return { main, extensionService, externalUriOpenerService };
+	}
+
+	test('getOpeners should not block on remote extension host resolution (issue #236398)', async () => {
+		const { extensionService, externalUriOpenerService } = createFixture();
+		assert.ok(externalUriOpenerService.provider, 'MainThreadUriOpeners must register as an external opener provider');
+
+		const openers: IExternalUriOpener[] = [];
+		const iterable = externalUriOpenerService.provider!.getOpeners(URI.parse('https://example.com/2fa'));
+
+		// Iterate the async iterable. If this waits on the extension host (which is
+		// still resolving the remote authority), this for-await loop would never
+		// complete because `normalBlocker` is never resolved in this test.
+		for await (const opener of iterable) {
+			openers.push(opener);
+		}
+
+		assert.strictEqual(openers.length, 0);
+		assert.strictEqual(extensionService.activateByEventCalls.length, 1);
+		assert.strictEqual(extensionService.activateByEventCalls[0].event, 'onOpenExternalUri:https');
+		assert.strictEqual(
+			extensionService.activateByEventCalls[0].kind,
+			ActivationKind.Immediate,
+			'getOpeners must use ActivationKind.Immediate so terminal URL clicks are not deferred until after the remote connection completes'
+		);
+	});
+
+	test('getOpeners returns nothing for non-http(s) schemes without activating extensions', async () => {
+		const { extensionService, externalUriOpenerService } = createFixture();
+
+		const openers: IExternalUriOpener[] = [];
+		for await (const opener of externalUriOpenerService.provider!.getOpeners(URI.parse('mailto:test@example.com'))) {
+			openers.push(opener);
+		}
+
+		assert.strictEqual(openers.length, 0);
+		assert.strictEqual(extensionService.activateByEventCalls.length, 0);
+	});
+});


### PR DESCRIPTION
## What

Terminal URL clicks now open immediately instead of deferring until remote extension host resolution completes.

## Why

`MainThreadUriOpeners.getOpeners()` awaited `extensionService.activateByEvent(..., Normal)`, which waits on the `_installedExtensionsReady` barrier. During remote authority resolution that barrier stays closed, so the Ctrl+click → `OpenerService._doOpenExternal` → `ExternalUriOpenerService` → `MainThreadUriOpeners.getOpeners` chain blocks until the connection is fully up. URLs printed during connect (e.g. 2FA login prompts) felt broken (#236398).

## How

Pass `ActivationKind.Immediate`. Already-ready hosts still activate the event; remote hosts that haven't resolved yet are skipped so the URL falls through to the default external opener and opens in the browser. Precedent: `abstractExtensionService.ts:1025-1034` documents this exact pattern for avoiding remote-resolution blocking.

## Test plan

New `mainThreadUriOpeners.test.ts` uses a `BlockingExtensionService` that returns an unresolvable promise for `ActivationKind.Normal` and resolves for `ActivationKind.Immediate` (simulating production where `Normal` waits on `_installedExtensionsReady`). Asserts `getOpeners('https://...')` completes, `activateByEvent` is called with `Immediate`, and non-http(s) schemes early-return without activating.

Fixes #236398