### PR TITLE
fix: handle quoted ID values in /etc/os-release parsing

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## Summary

This PR fixes the parsing of OS ID values in the `check-requirements-linux.sh` script, specifically addressing the issue on Rocky Linux 8.5 where `/etc/os-release` contains quoted values like `ID="rocky"`.

## Problem

The original parsing method:
```bash
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
```
fails to match lines with quoted values (e.g., `ID="rocky"`), resulting in an empty `OS_ID` variable and a non-zero exit code.

## Solution

Replace the grep/sed parsing with a subshell sourcing approach:
```bash
OS_ID=$(source /etc/os-release && echo $ID)
```
This properly handles both quoted and unquoted values since the shell's assignment parsing strips the quotes automatically.

## Testing

Verified that the new method correctly extracts `rocky` from a sample `/etc/os-release` file with quoted ID values.

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof