### PR TITLE
Fix terminal auto-approve splitting commands at `--flag=value` in powershell

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -17,6 +17,28 @@ export const enum TreeSitterCommandParserLanguage {
 	PowerShell = 'powershell',
 }
 
+/**
+ * Matches a PowerShell command token of the form `-flag=` or `--flag=` at the
+ * start of input or following whitespace. Used to work around a tree-sitter
+ * PowerShell grammar limitation where POSIX-style `--flag=value` arguments
+ * (e.g. `git log --format="a|b"`) are parsed as assignment expressions and
+ * truncate the surrounding command.
+ *
+ * See https://github.com/microsoft/vscode/issues/294010
+ */
+const pwshFlagEqualsRegex = /(^|\s)(-{1,2}[\w-]+)=/g;
+
+/**
+ * Replaces the `=` in PowerShell `--flag=value` argument patterns with a space
+ * so the tree-sitter PowerShell grammar treats the argument as a normal
+ * command parameter. Character positions and overall length are preserved so
+ * node ranges from the parsed (masked) tree can be used to slice the original
+ * command line.
+ */
+function maskPwshFlagEquals(commandLine: string): string {
+	return commandLine.replace(pwshFlagEqualsRegex, (_, pre, flag) => `${pre}${flag} `);
+}
+
 export class TreeSitterCommandParser extends Disposable {
 	private readonly _parser: Lazy<Promise<Parser>>;
 	private readonly _treeCache = this._register(new TreeCache());
@@ -32,6 +54,15 @@ export class TreeSitterCommandParser extends Disposable {
 	}
 
 	async extractSubCommands(languageId: TreeSitterCommandParserLanguage, commandLine: string): Promise<string[]> {
+		if (languageId === TreeSitterCommandParserLanguage.PowerShell) {
+			const masked = maskPwshFlagEquals(commandLine);
+			if (masked !== commandLine) {
+				const captures = await this._queryTree(languageId, masked, '(command) @command');
+				// Masked command line has identical character positions, so slice the original
+				// to preserve the user-visible text (including the `=` characters).
+				return captures.map(e => commandLine.substring(e.node.startIndex, e.node.endIndex));
+			}
+		}
 		const captures = await this._queryTree(languageId, commandLine, '(command) @command');
 		return captures.map(e => e.node.text);
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -25,16 +25,11 @@ export const enum TreeSitterCommandParserLanguage {
  * truncate the surrounding command.
  *
  * See https://github.com/microsoft/vscode/issues/294010
+ * TODO: Remove once upstream tree-sitter PowerShell grammer is updated.
  */
 const pwshFlagEqualsRegex = /(^|\s)(-{1,2}[\w-]+)=/g;
 
-/**
- * Replaces the `=` in PowerShell `--flag=value` argument patterns with a space
- * so the tree-sitter PowerShell grammar treats the argument as a normal
- * command parameter. Character positions and overall length are preserved so
- * node ranges from the parsed (masked) tree can be used to slice the original
- * command line.
- */
+// TODO: Remove once upstream tree-sitter PowerShell grammer is updated.
 function maskPwshFlagEquals(commandLine: string): string {
 	return commandLine.replace(pwshFlagEqualsRegex, (_, pre, flag) => `${pre}${flag} `);
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/treeSitterCommandParser.test.ts
@@ -179,6 +179,25 @@ suite('TreeSitterCommandParser', () => {
 				test('nested try-catch-finally', () => t('try { try { Get-Content "file" } catch { throw } } catch { Write-Error "outer" } finally { Write-Host "cleanup" }', ['Get-Content "file"', 'Write-Error "outer"', 'Write-Host "cleanup"']));
 				test('parallel processing', () => t('1..10 | ForEach-Object -Parallel { Start-Sleep 1; Write-Host $_ } ; Get-Date', ['1..10 ', 'ForEach-Object -Parallel { Start-Sleep 1; Write-Host $_ }', 'Start-Sleep 1', 'Write-Host $_', 'Get-Date']));
 			});
+
+			// https://github.com/microsoft/vscode/issues/294010
+			// The upstream tree-sitter-powershell grammar parses POSIX-style
+			// `--flag=value` arguments as assignment expressions and truncates
+			// the surrounding command. The parser masks the `=` before parsing
+			// so these arguments are preserved as part of the sub-command.
+			suite('POSIX-style `--flag=value` arguments', () => {
+				test('double-dash flag with quoted value', () => t('git log --format="abc"', ['git log --format="abc"']));
+				test('double-dash flag with value containing pipe', () => t('git log --format="a|b"', ['git log --format="a|b"']));
+				test('double-dash flag with single-quoted value', () => t(`git log --format='%h|%s'`, [`git log --format='%h|%s'`]));
+				test('multiple flag=value arguments', () => t('git log --format="%h" --date=short HEAD -1', ['git log --format="%h" --date=short HEAD -1']));
+				test('chained git log with format containing pipes', () => t(
+					'git log --format="%h|%s|%an|%ad" --date=short dff523fc450 -1; git log --format="%h|%s|%an|%ad" --date=short 0a541d056d3 -1',
+					[
+						'git log --format="%h|%s|%an|%ad" --date=short dff523fc450 -1',
+						'git log --format="%h|%s|%an|%ad" --date=short 0a541d056d3 -1',
+					]
+				));
+			});
 		});
 
 		suite('all shells', () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/294010
/cc @meganrogge 

Easy repro on windows powershell , set `git log` as entry to `"chat.tools.terminal.autoApprove": {` in settings.json

Before: 
<img width="1649" height="995" alt="image" src="https://github.com/user-attachments/assets/a5160bfd-cb14-4a1f-87a3-f3c3f22720cc" />

After: 
<img width="1894" height="1157" alt="image" src="https://github.com/user-attachments/assets/dd2076b8-7114-46f5-bd58-621158a9be3f" />

What the problem was: 
* When Copilot proposes a PowerShell command that contains a POSIX-style
`--flag=value` argument (very common: `git log --format="…"` etc.), the terminal auto-approve flow splits the command line incorrectly and refuses to auto-approve commands that should match the user's allow rules.

* Likely upstream `tree-sitter-powershell` grammar: `word=` at command-argument position is parsed as an assignment
expression, which terminates the containing command. So `git log --format="a|b" HEAD -1` becomes roughly
`["git log --format", "b\" HEAD -1"]` instead of one `git log` command.

What this PR does: 
Replaces the `=` in PowerShell `--flag=value` argument patterns with a space so the tree-sitter PowerShell grammar treats the argument as a normal command parameter. Character positions and overall length are preserved so node ranges from the parsed (masked) tree can be used to slice the original command line.

* In `extractSubCommands`, for PowerShell only, mask `--flag=` / `-flag=` to `--flag ` / `-flag ` before parsing. The replacement is length-preserving, so node start/end indices from the parsed (masked) tree still index correctly into the original command line — we slice the original so the returned sub-commands keep the user-visible `=`.

* I believe we do similar with `CommandLinePwshChainOperatorRewriter`, which works around a separate
gap in the same grammar (chain operators / `&&`).


Long term:
I've added TODO to remove "workaround" once issue is addressed in https://github.com/airbus-cert/tree-sitter-powershell

@alexr00 Is the protocol for tree-sitter that we file issue under airbus first, then we update https://github.com/microsoft/vscode-tree-sitter-wasm and eventually update https://github.com/microsoft/vscode-tree-sitter-wasm in core?
