### PR TITLE
chat customizations: splash when MCP/plugins disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -5,7 +5,7 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { Disposable, DisposableStore, isDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, isDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -16,6 +16,8 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, McpConnectionState, McpServerInstallState, IMcpService, IMcpServer } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../mcp/common/mcpRegistryTypes.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
@@ -371,6 +373,10 @@ export class McpListWidget extends Disposable {
 	private emptyContainer!: HTMLElement;
 	private emptyText!: HTMLElement;
 	private emptySubtext!: HTMLElement;
+	private disabledContainer!: HTMLElement;
+	private disabledIcon!: HTMLElement;
+	private disabledMessage!: HTMLElement;
+	private readonly disabledLinkListener = this._register(new MutableDisposable());
 	private browseButton!: Button;
 	private addButton!: Button;
 	private backLink!: HTMLElement;
@@ -400,10 +406,17 @@ export class McpListWidget extends Disposable {
 		@IHoverService private readonly hoverService: IHoverService,
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IDialogService private readonly dialogService: IDialogService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget');
 		this.create();
+		this.updateAccessState();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(mcpAccessConfig)) {
+				this.updateAccessState();
+			}
+		}));
 		this._register({
 			dispose: () => {
 				this.galleryCts?.dispose();
@@ -484,6 +497,15 @@ export class McpListWidget extends Disposable {
 		emptyIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.server));
 		this.emptyText = DOM.append(emptyHeader, $('.empty-text'));
 		this.emptySubtext = DOM.append(this.emptyContainer, $('.empty-subtext'));
+
+		// Disabled (access blocked) state — shown when chat.mcp.access is set to none,
+		// either by user setting or by enterprise policy.
+		this.disabledContainer = DOM.append(this.element, $('.mcp-disabled-state'));
+		const disabledHeader = DOM.append(this.disabledContainer, $('.empty-state-header'));
+		this.disabledIcon = DOM.append(disabledHeader, $('.empty-icon'));
+		const disabledText = DOM.append(disabledHeader, $('.empty-text'));
+		disabledText.textContent = localize('mcpAccessDisabledTitle', "MCP servers are disabled");
+		this.disabledMessage = DOM.append(this.disabledContainer, $('.empty-subtext'));
 
 		// List container
 		this.listContainer = DOM.append(this.element, $('.mcp-list-container'));
@@ -584,6 +606,36 @@ export class McpListWidget extends Disposable {
 			await this.queryGallery();
 		} else {
 			this.filterServers();
+		}
+	}
+
+	private updateAccessState(): void {
+		const inspect = this.configurationService.inspect<string>(mcpAccessConfig);
+		const value = inspect.value ?? inspect.defaultValue;
+		const disabled = value === McpAccessValue.None;
+		const policyLocked = inspect.policyValue === McpAccessValue.None;
+
+		this.element.classList.toggle('access-disabled', disabled);
+
+		if (disabled) {
+			this.disabledIcon.className = 'empty-icon';
+			this.disabledIcon.classList.add(...ThemeIcon.asClassNameArray(policyLocked ? Codicon.shield : mcpServerIcon));
+
+			DOM.clearNode(this.disabledMessage);
+			this.disabledLinkListener.clear();
+			if (policyLocked) {
+				this.disabledMessage.textContent = localize('mcpAccessDisabledByPolicy', "Access to MCP servers is disabled by your organization. Contact your organization administrator for more information.");
+			} else {
+				this.disabledMessage.appendChild(document.createTextNode(localize('mcpAccessDisabledBySettingPrefix', "MCP servers are disabled in settings. ")));
+				const link = DOM.append(this.disabledMessage, $('a.mcp-disabled-settings-link')) as HTMLAnchorElement;
+				link.textContent = localize('mcpAccessDisabledSettingLink', "Configure in settings.");
+				link.href = '#';
+				link.setAttribute('role', 'button');
+				this.disabledLinkListener.value = DOM.addDisposableListener(link, 'click', (e) => {
+					e.preventDefault();
+					this.commandService.executeCommand('workbench.action.openSettings', `@id:${mcpAccessConfig}`);
+				});
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -795,6 +795,73 @@
 	margin-top: 16px;
 }
 
+/* MCP Disabled (access blocked) state */
+.mcp-list-widget .mcp-disabled-state {
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 48px 24px;
+	gap: 8px;
+	text-align: center;
+	flex: 1;
+}
+
+.mcp-list-widget .mcp-disabled-state .empty-state-header {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+}
+
+.mcp-list-widget .mcp-disabled-state .empty-icon.codicon::before {
+	font-size: 48px;
+}
+
+.mcp-list-widget .mcp-disabled-state .empty-icon {
+	opacity: 0.5;
+	margin-bottom: 8px;
+	height: 48px;
+	width: 48px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.mcp-list-widget .mcp-disabled-state .empty-text {
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--vscode-foreground);
+}
+
+.mcp-list-widget .mcp-disabled-state .empty-subtext {
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	max-width: 420px;
+	line-height: 1.5;
+}
+
+.mcp-list-widget .mcp-disabled-state .mcp-disabled-settings-link {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.mcp-list-widget .mcp-disabled-state .mcp-disabled-settings-link:hover,
+.mcp-list-widget .mcp-disabled-state .mcp-disabled-settings-link:focus {
+	color: var(--vscode-textLink-activeForeground);
+	text-decoration: underline;
+	outline: none;
+}
+
+.mcp-list-widget.access-disabled > *:not(.mcp-disabled-state) {
+	display: none !important;
+}
+
+.mcp-list-widget.access-disabled .mcp-disabled-state {
+	display: flex;
+}
+
 /* MCP Server Item */
 .mcp-server-item {
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -39,6 +39,8 @@ import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { CustomizationGroupHeaderRenderer, ICustomizationGroupHeaderEntry, CUSTOMIZATION_GROUP_HEADER_HEIGHT, CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR } from './customizationGroupHeaderRenderer.js';
 import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ChatConfiguration } from '../../common/constants.js';
 
 const $ = DOM.$;
 
@@ -338,6 +340,10 @@ export class PluginListWidget extends Disposable {
 	private emptyContainer!: HTMLElement;
 	private emptyText!: HTMLElement;
 	private emptySubtext!: HTMLElement;
+	private disabledContainer!: HTMLElement;
+	private disabledIcon!: HTMLElement;
+	private disabledMessage!: HTMLElement;
+	private readonly disabledLinkListener = this._register(new MutableDisposable());
 	private browseButton!: Button;
 	private backLink!: HTMLElement;
 
@@ -365,10 +371,17 @@ export class PluginListWidget extends Disposable {
 		@ILabelService private readonly labelService: ILabelService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget'); // reuse MCP list widget CSS
 		this.create();
+		this.updateAccessState();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.PluginsEnabled)) {
+				this.updateAccessState();
+			}
+		}));
 		this._register({
 			dispose: () => {
 				this.marketplaceCts?.dispose();
@@ -452,6 +465,15 @@ export class PluginListWidget extends Disposable {
 		emptyIcon.classList.add(...ThemeIcon.asClassNameArray(pluginIcon));
 		this.emptyText = DOM.append(emptyHeader, $('.empty-text'));
 		this.emptySubtext = DOM.append(this.emptyContainer, $('.empty-subtext'));
+
+		// Disabled (access blocked) state — shown when chat.plugins.enabled is false,
+		// either by user setting or by enterprise policy.
+		this.disabledContainer = DOM.append(this.element, $('.mcp-disabled-state'));
+		const disabledHeader = DOM.append(this.disabledContainer, $('.empty-state-header'));
+		this.disabledIcon = DOM.append(disabledHeader, $('.empty-icon'));
+		const disabledText = DOM.append(disabledHeader, $('.empty-text'));
+		disabledText.textContent = localize('pluginsDisabledTitle', "Plugins are disabled");
+		this.disabledMessage = DOM.append(this.disabledContainer, $('.empty-subtext'));
 
 		// List container
 		this.listContainer = DOM.append(this.element, $('.mcp-list-container'));
@@ -580,6 +602,36 @@ export class PluginListWidget extends Disposable {
 			await this.queryMarketplace();
 		} else {
 			this.filterPlugins();
+		}
+	}
+
+	private updateAccessState(): void {
+		const inspect = this.configurationService.inspect<boolean>(ChatConfiguration.PluginsEnabled);
+		const value = inspect.value ?? inspect.defaultValue;
+		const disabled = value === false;
+		const policyLocked = inspect.policyValue === false;
+
+		this.element.classList.toggle('access-disabled', disabled);
+
+		if (disabled) {
+			this.disabledIcon.className = 'empty-icon';
+			this.disabledIcon.classList.add(...ThemeIcon.asClassNameArray(policyLocked ? Codicon.shield : pluginIcon));
+
+			DOM.clearNode(this.disabledMessage);
+			this.disabledLinkListener.clear();
+			if (policyLocked) {
+				this.disabledMessage.textContent = localize('pluginsDisabledByPolicy', "Plugin integration in chat is disabled by your organization. Contact your organization administrator for more information.");
+			} else {
+				this.disabledMessage.appendChild(document.createTextNode(localize('pluginsDisabledBySettingPrefix', "Plugins are disabled in settings. ")));
+				const link = DOM.append(this.disabledMessage, $('a.mcp-disabled-settings-link')) as HTMLAnchorElement;
+				link.textContent = localize('pluginsDisabledSettingLink', "Configure in settings.");
+				link.href = '#';
+				link.setAttribute('role', 'button');
+				this.disabledLinkListener.value = DOM.addDisposableListener(link, 'click', (e) => {
+					e.preventDefault();
+					this.commandService.executeCommand('workbench.action.openSettings', `@id:${ChatConfiguration.PluginsEnabled}`);
+				});
+			}
 		}
 	}
 

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -43,6 +43,9 @@ import { IPluginInstallService } from '../../../../contrib/chat/common/plugins/p
 import { AICustomizationManagementEditor } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { ContributionEnablementState } from '../../../../contrib/chat/common/enablement.js';
 import { AICustomizationManagementEditorInput } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
+import { IConfigurationService, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
+import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, IMcpService, McpServerInstallState } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../../contrib/mcp/common/mcpRegistryTypes.js';
 import { IWorkbenchLocalMcpServer, LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
@@ -808,6 +811,117 @@ async function renderPluginBrowseMode(ctx: ComponentFixtureContext): Promise<voi
 }
 
 // ============================================================================
+// MCP / Plugin Disabled (access blocked) splash
+// ============================================================================
+
+function createDisabledConfigService(key: string, disabledValue: unknown, byPolicy: boolean): IConfigurationService {
+	return new class extends mock<IConfigurationService>() {
+		override readonly onDidChangeConfiguration = Event.None;
+		override getValue<T>(arg1?: string | object, _arg2?: object): T {
+			const k = typeof arg1 === 'string' ? arg1 : undefined;
+			return (k === key ? disabledValue : undefined) as T;
+		}
+		override inspect<T>(k: string): IConfigurationValue<T> {
+			if (k !== key) {
+				return { value: undefined, defaultValue: undefined };
+			}
+			return {
+				value: disabledValue as T,
+				defaultValue: disabledValue as T,
+				policyValue: byPolicy ? (disabledValue as T) : undefined,
+			};
+		}
+	}();
+}
+
+function renderMcpDisabled(ctx: ComponentFixtureContext, byPolicy: boolean): void {
+	const width = 650;
+	const height = 500;
+	ctx.container.style.width = `${width}px`;
+	ctx.container.style.height = `${height}px`;
+
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.define(IListService, ListService);
+			reg.defineInstance(IConfigurationService, createDisabledConfigService(mcpAccessConfig, McpAccessValue.None, byPolicy));
+			reg.defineInstance(IMcpWorkbenchService, new class extends mock<IMcpWorkbenchService>() {
+				override readonly onChange = Event.None;
+				override readonly onReset = Event.None;
+				override readonly local: IWorkbenchMcpServer[] = [];
+			}());
+			reg.defineInstance(IMcpService, new class extends mock<IMcpService>() {
+				override readonly servers = constObservable([] as never[]);
+			}());
+			reg.defineInstance(IMcpRegistry, new class extends mock<IMcpRegistry>() {
+				override readonly collections = constObservable([]);
+				override readonly delegates = constObservable([]);
+				override readonly onDidChangeInputs = Event.None;
+			}());
+			reg.defineInstance(IAgentPluginService, new class extends mock<IAgentPluginService>() {
+				override readonly plugins = constObservable([]);
+			}());
+			reg.defineInstance(IDialogService, new class extends mock<IDialogService>() { }());
+			reg.defineInstance(IAICustomizationWorkspaceService, new class extends mock<IAICustomizationWorkspaceService>() {
+				override readonly isSessionsWindow = false;
+				override readonly welcomePageFeatures = { showGettingStartedBanner: true };
+				override readonly activeProjectRoot = observableValue('root', URI.file('/workspace'));
+				override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
+				override getActiveProjectRoot() { return URI.file('/workspace'); }
+				override getStorageSourceFilter() {
+					return { sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin] };
+				}
+			}());
+			reg.defineInstance(ICustomizationHarnessService, new class extends mock<ICustomizationHarnessService>() {
+				override readonly activeHarness = observableValue<string>('activeHarness', CustomizationHarness.VSCode);
+				override getActiveDescriptor() { return createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]); }
+				override registerExternalHarness() { return { dispose() { } }; }
+			}());
+		},
+	});
+
+	const widget = ctx.disposableStore.add(instantiationService.createInstance(McpListWidget));
+	ctx.container.appendChild(widget.element);
+	widget.layout(height, width);
+}
+
+function renderPluginDisabled(ctx: ComponentFixtureContext, byPolicy: boolean): void {
+	const width = 650;
+	const height = 500;
+	ctx.container.style.width = `${width}px`;
+	ctx.container.style.height = `${height}px`;
+
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.define(IListService, ListService);
+			reg.defineInstance(IConfigurationService, createDisabledConfigService(ChatConfiguration.PluginsEnabled, false, byPolicy));
+			reg.defineInstance(ICustomizationHarnessService, new class extends mock<ICustomizationHarnessService>() {
+				override readonly activeHarness = observableValue<string>('activeHarness', CustomizationHarness.VSCode);
+				override getActiveDescriptor() { return createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]); }
+				override registerExternalHarness() { return { dispose() { } }; }
+			}());
+			reg.defineInstance(IAgentPluginService, new class extends mock<IAgentPluginService>() {
+				override readonly plugins = constObservable([]);
+				override readonly enablementModel = undefined!;
+			}());
+			reg.defineInstance(IPluginMarketplaceService, new class extends mock<IPluginMarketplaceService>() {
+				override readonly installedPlugins = constObservable([]);
+				override readonly onDidChangeMarketplaces = Event.None;
+				override async fetchMarketplacePlugins() { return []; }
+			}());
+			reg.defineInstance(IPluginInstallService, new class extends mock<IPluginInstallService>() { }());
+		},
+	});
+
+	const widget = ctx.disposableStore.add(instantiationService.createInstance(PluginListWidget));
+	ctx.container.appendChild(widget.element);
+	widget.layout(height, width);
+}
+
+// ============================================================================
 // Fixtures
 // ============================================================================
 
@@ -956,6 +1070,30 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 	PluginBrowseMode: defineComponentFixture({
 		labels: { kind: 'screenshot' },
 		render: renderPluginBrowseMode,
+	}),
+
+	// MCP disabled splash — chat.mcp.access set to 'none' by user
+	McpDisabledByUser: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderMcpDisabled(ctx, false),
+	}),
+
+	// MCP disabled splash — chat.mcp.access locked to 'none' by enterprise policy
+	McpDisabledByPolicy: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderMcpDisabled(ctx, true),
+	}),
+
+	// Plugins disabled splash — chat.plugins.enabled=false by user
+	PluginsDisabledByUser: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderPluginDisabled(ctx, false),
+	}),
+
+	// Plugins disabled splash — chat.plugins.enabled locked to false by enterprise policy
+	PluginsDisabledByPolicy: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderPluginDisabled(ctx, true),
 	}),
 
 	// Scrolled-to-bottom variants — verify last items are fully visible above footer


### PR DESCRIPTION
Block the MCP servers and Plugins tabs in the chat customizations editor when their respective access settings are disabled, including via enterprise policy.

## Behavior

- **MCP tab** — `McpListWidget` watches `chat.mcp.access`. When the value is `none`, the tab is replaced by a splash with a shield icon, explanation, and an "Open Setting" button. If `policyValue === 'none'` (locked by `ChatMCP` policy), the message switches to "disabled by your organization's policy" and the settings button is hidden.
- **Plugins tab** — `PluginListWidget` watches `chat.plugins.enabled` (boolean, policy `ChatPluginsEnabled`) with the same user-vs-policy distinction.
- Both widgets react live via `onDidChangeConfiguration` — no reload required when the setting toggles.

## Implementation notes

- Reuses the `.mcp-list-widget` root class on both widgets so a single `.access-disabled` CSS modifier (in `aiCustomizationManagement.css`) blocks the rest of the page and reveals `.mcp-disabled-state`.
- Disabled-vs-policy decision uses `IConfigurationService.inspect(...).policyValue`, matching the existing pattern in `modePickerActionItem.ts`, `chatModes.ts`, `chatInputPart.ts`, etc.

## Fixtures

Adds 4 new component fixtures (× Dark/Light = 8 screenshots) in `aiCustomizationManagementEditor.fixture.ts`:

- `McpDisabledByUser`
- `McpDisabledByPolicy`
- `PluginsDisabledByUser`
- `PluginsDisabledByPolicy`