### PR TITLE
Polish CLI error reporting to use built-in error widget

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
@@ -686,7 +686,7 @@ export function buildChatHistoryFromEvents(sessionId: string, modelId: string | 
 				break;
 			}
 			case 'session.error': {
-				currentResponseParts.push(new ChatResponseMarkdownPart(`\n\n❌ Error: (${event.data.errorType}) ${event.data.message}`));
+				currentResponseParts.push(new ChatResponseMarkdownPart(`\n\nError: (${event.data.errorType}) ${event.data.message}`));
 				break;
 			}
 			case 'assistant.message': {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -256,7 +256,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			}
 		});
 
-		this.previousRequest = this.previousRequest.then(() => handled);
+		this.previousRequest = this.previousRequest.then(() => handled).catch(() => { /* error handled by caller */ });
 		return handled;
 	}
 
@@ -385,6 +385,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 		const toolCalls = new Map<string, ToolCall>();
 		const editTracker = new ExternalEditTracker();
 		let sdkRequestId: string | undefined;
+		let sessionError: string | undefined;
 		const toolIdEditMap = new Map<string, Promise<string | undefined>>();
 		/**
 		 * The sequence of events from the SDK is as follows:
@@ -698,7 +699,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			disposables.add(toDisposable(this._sdkSession.on('session.error', (event) => {
 				flushPendingInvocationMessages();
 				this.logService.error(`[CopilotCLISession]CopilotCLI error: (${event.data.errorType}), ${event.data.message}`);
-				this._stream?.markdown(`\n\n❌ Error: (${event.data.errorType}) ${event.data.message}`);
+				sessionError = `(${event.data.errorType}) ${event.data.message}`;
 
 				const errorMarkdown = [`# Error Details`, `Type: ${event.data.errorType}`, `Message: ${event.data.message}`, `## Stack`, event.data.stack || ''].join('\n');
 				this._requestLogger.addEntry({
@@ -756,6 +757,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			if (!token.isCancellationRequested) {
 				await this.sendRequestInternal(input, attachments, false, logStartTime);
 			}
+			if (sessionError) {
+				throw new Error(sessionError);
+			}
 			this.logService.trace(`[CopilotCLISession] Invoking session (completed) ${this.sessionId}`);
 			const resolvedToolIdEditMap: Record<string, string> = {};
 			await Promise.all(Array.from(toolIdEditMap.entries()).map(async ([toolId, editFilePromise]) => {
@@ -786,7 +790,6 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			this._status = ChatSessionStatus.Failed;
 			this._statusChange.fire(this._status);
 			this.logService.error(`[CopilotCLISession] Invoking session (error) ${this.sessionId}`, error);
-			this._stream?.markdown(`\n\n❌ Error: ${error instanceof Error ? error.message : String(error)}`);
 
 			invokeAgentSpan.setStatus(SpanStatusCode.ERROR, error instanceof Error ? error.message : String(error));
 			if (error instanceof Error) {
@@ -795,6 +798,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 
 			// Log the failed conversation
 			this._logConversation(prompt, assistantMessageChunks.join(''), modelId || '', attachments, logStartTime, 'Failed', error instanceof Error ? error.message : String(error));
+			throw error;
 		} finally {
 			// End the invoke_agent wrapper span
 			const durationSec = (Date.now() - logStartTime) / 1000;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotcliSession.spec.ts
@@ -279,10 +279,10 @@ describe('CopilotCLISession', () => {
 		const session = await createSession();
 		const stream = new MockChatResponseStream();
 		session.attachStream(stream);
-		await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Boom' }, [], undefined, authInfo, CancellationToken.None);
+		await expect(session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Boom' }, [], undefined, authInfo, CancellationToken.None))
+			.rejects.toThrow('network');
 
 		expect(session.status).toBe(ChatSessionStatus.Failed);
-		expect(stream.output.join('\n')).toContain('Error: network');
 	});
 
 	it('emits status events on successful request', async () => {
@@ -306,9 +306,9 @@ describe('CopilotCLISession', () => {
 		const listener = disposables.add(session.onDidChangeStatus(s => statuses.push(s)));
 		const stream = new MockChatResponseStream();
 		session.attachStream(stream);
-		await session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Will Fail' }, [], undefined, authInfo, CancellationToken.None);
+		await expect(session.handleRequest({ id: '', toolInvocationToken: undefined as never }, { prompt: 'Will Fail' }, [], undefined, authInfo, CancellationToken.None))
+			.rejects.toThrow('boom');
 		listener.dispose?.();
-		expect(stream.output.join('\n')).toContain('Error: boom');
 	});
 
 	it('auto-approves read permission inside workspace without external handler', async () => {
@@ -735,10 +735,10 @@ describe('CopilotCLISession', () => {
 			const stream = new MockChatResponseStream();
 			session.attachStream(stream);
 
-			await session.handleRequest(
+			await expect(session.handleRequest(
 				{ id: 'req-1', toolInvocationToken: undefined as never },
 				{ prompt: 'Initial failure' }, [], undefined, authInfo, CancellationToken.None
-			);
+			)).rejects.toThrow('boom');
 			expect(session.status).toBe(ChatSessionStatus.Failed);
 
 			let resolveSecondSend!: () => void;

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessions.ts
@@ -786,7 +786,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 			if (isCancellationError(ex)) {
 				return {};
 			}
-			throw ex;
+			return { errorDetails: { message: ex instanceof Error ? ex.message : String(ex) } };
 		} finally {
 			if (sdkSessionId && session) {
 				await this.sessionRequestLifecycle.endRequest(

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/copilotCLIChatSessionsContribution.ts
@@ -1449,7 +1449,7 @@ export class CopilotCLIChatSessionParticipant extends Disposable {
 			if (isCancellationError(ex)) {
 				return {};
 			}
-			throw ex;
+			return { errorDetails: { message: ex instanceof Error ? ex.message : String(ex) } };
 		}
 		finally {
 			if (sdkSessionId) {


### PR DESCRIPTION
Instead of streaming errors as emoji markdown (`❌ Error: ...`), propagate errors from the session to callers which return them via `errorDetails`. This lets the chat renderer display errors using the built-in `ChatErrorContentPart` widget with proper styling and icons.

- Remove emoji markdown error streaming from `copilotcliSession`
- Capture `session.error` events and re-throw after request completes
- Return `{ errorDetails }` from both chat participant handlers
- Clean up emoji from history reconstruction in `copilotCLITools`
- Update tests to expect thrown errors