### PR TITLE
Add `Developer: Sync Account Policy` command

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -922,6 +922,33 @@ class PolicyDiagnosticsAction extends Action2 {
 	}
 }
 
+class SyncAccountPolicyAction extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.syncAccountPolicy',
+			title: localize2('syncAccountPolicy', 'Sync Account Policy'),
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const defaultAccountService = accessor.get(IDefaultAccountService);
+		const dialogService = accessor.get(IDialogService);
+		const logService = accessor.get(ILogService);
+
+		try {
+			logService.info('[DefaultAccount] Manually syncing account policy');
+			await defaultAccountService.refresh({ forceRefresh: true });
+			dialogService.info(localize('syncAccountPolicy.success', "Account policy has been synced."));
+		} catch (error) {
+			logService.error('[DefaultAccount] Failed to sync account policy', error);
+			dialogService.error(localize('syncAccountPolicy.error', "Failed to sync account policy: {0}", error instanceof Error ? error.message : String(error)));
+		}
+	}
+}
+
 // --- Actions Registration
 registerAction2(InspectContextKeysAction);
 registerAction2(ToggleScreencastModeAction);
@@ -929,6 +956,7 @@ registerAction2(LogStorageAction);
 registerAction2(LogWorkingCopiesAction);
 registerAction2(RemoveLargeStorageEntriesAction);
 registerAction2(PolicyDiagnosticsAction);
+registerAction2(SyncAccountPolicyAction);
 if (!product.commit) {
 	registerAction2(StartTrackDisposables);
 	registerAction2(SnapshotTrackedDisposables);

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -941,10 +941,13 @@ class SyncAccountPolicyAction extends Action2 {
 		try {
 			logService.info('[DefaultAccount] Manually syncing account policy');
 			await defaultAccountService.refresh({ forceRefresh: true });
-			dialogService.info(localize('syncAccountPolicy.success', "Account policy has been synced."));
+			await dialogService.info(localize('syncAccountPolicy.success', "Account policy has been synced."));
 		} catch (error) {
 			logService.error('[DefaultAccount] Failed to sync account policy', error);
-			dialogService.error(localize('syncAccountPolicy.error', "Failed to sync account policy: {0}", error instanceof Error ? error.message : String(error)));
+			await dialogService.error(
+				localize('syncAccountPolicy.error', "Failed to sync account policy."),
+				error instanceof Error ? error.message : String(error)
+			);
 		}
 	}
 }

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -536,7 +536,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 			const entitlementsResult = await this.getEntitlements(sessions, accountPolicyData, options);
 			const entitlementsData = entitlementsResult?.data;
 			const entitlementsFetchedAt = entitlementsResult?.fetchedAt;
-			const tokenEntitlementsResult = entitlementsData?.chat_enabled ? await this.getTokenEntitlements(sessions, accountPolicyData) : undefined;
+			const tokenEntitlementsResult = entitlementsData?.chat_enabled ? await this.getTokenEntitlements(sessions, accountPolicyData, options) : undefined;
 
 			const tokenEntitlementsFetchedAt: number | undefined = tokenEntitlementsResult?.fetchedAt;
 			let mcpRegistryDataFetchedAt: number | undefined;
@@ -548,7 +548,7 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 				policyData.chat_preview_features_enabled = tokenEntitlementsData.policyData.chat_preview_features_enabled;
 				policyData.mcp = tokenEntitlementsData.policyData.mcp;
 				if (policyData.mcp) {
-					const mcpRegistryResult = await this.getMcpRegistryProvider(sessions, accountPolicyData);
+					const mcpRegistryResult = await this.getMcpRegistryProvider(sessions, accountPolicyData, options);
 					mcpRegistryDataFetchedAt = mcpRegistryResult?.fetchedAt;
 					policyData.mcpRegistryUrl = mcpRegistryResult?.data?.url;
 					policyData.mcpAccess = mcpRegistryResult?.data?.registry_access;
@@ -629,8 +629,8 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		return expectedScopes.every(scope => scopes.includes(scope));
 	}
 
-	private async getTokenEntitlements(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined): Promise<{ data: { policyData: Partial<IPolicyData>; copilotTokenInfo: ICopilotTokenInfo } | undefined; fetchedAt: number }> {
-		if (accountPolicyData?.tokenEntitlementsFetchedAt && !this.isDataStale(accountPolicyData.tokenEntitlementsFetchedAt)) {
+	private async getTokenEntitlements(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined, options?: { forceRefresh?: boolean }): Promise<{ data: { policyData: Partial<IPolicyData>; copilotTokenInfo: ICopilotTokenInfo } | undefined; fetchedAt: number }> {
+		if (!options?.forceRefresh && accountPolicyData?.tokenEntitlementsFetchedAt && !this.isDataStale(accountPolicyData.tokenEntitlementsFetchedAt)) {
 			this.logService.debug('[DefaultAccount] Using last fetched token entitlements data');
 			return { data: { policyData: accountPolicyData.policyData, copilotTokenInfo: this._copilotTokenInfo ?? {} }, fetchedAt: accountPolicyData.tokenEntitlementsFetchedAt };
 		}
@@ -723,8 +723,8 @@ class DefaultAccountProvider extends Disposable implements IDefaultAccountProvid
 		return { data: undefined, fetchedAt: Date.now() };
 	}
 
-	private async getMcpRegistryProvider(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined): Promise<{ data: IMcpRegistryProvider | null; fetchedAt: number } | undefined> {
-		if (accountPolicyData?.mcpRegistryDataFetchedAt && !this.isDataStale(accountPolicyData.mcpRegistryDataFetchedAt)) {
+	private async getMcpRegistryProvider(sessions: AuthenticationSession[], accountPolicyData: IAccountPolicyData | undefined, options?: { forceRefresh?: boolean }): Promise<{ data: IMcpRegistryProvider | null; fetchedAt: number } | undefined> {
+		if (!options?.forceRefresh && accountPolicyData?.mcpRegistryDataFetchedAt && !this.isDataStale(accountPolicyData.mcpRegistryDataFetchedAt)) {
 			this.logService.debug('[DefaultAccount] Using last fetched MCP registry data');
 			const data = accountPolicyData.policyData.mcpRegistryUrl && accountPolicyData.policyData.mcpAccess ? { url: accountPolicyData.policyData.mcpRegistryUrl, registry_access: accountPolicyData.policyData.mcpAccess } : null;
 			return { data, fetchedAt: accountPolicyData.mcpRegistryDataFetchedAt };


### PR DESCRIPTION
Adds a `Developer: Sync Account Policy` command that manually triggers the account-policy sync job that otherwise runs on a 1-hour timer in the background.

### Why

`DefaultAccountService` polls account/policy data via a `RunOnceScheduler` with `ACCOUNT_DATA_POLL_INTERVAL_MS = 1 hour`. The fetched entitlements, token entitlements, and MCP registry data are cached in `StorageScope.APPLICATION` along with a `fetchedAt` timestamp, and each sub-fetch short-circuits via `isDataStale()` (also 1 hour) when the cache is fresh.

Because that cache is persisted, a window reload — or even a full app restart — does **not** invalidate it. So if an account admin flips a policy, a user could wait up to ~1 hour before VS Code picks it up, no matter how many times they reload.

### What

- New developer command `workbench.action.syncAccountPolicy` calls `IDefaultAccountService.refresh({ forceRefresh: true })` and surfaces success/error via `IDialogService`.
- Plumbs `options?: { forceRefresh?: boolean }` through `getTokenEntitlements` and `getMcpRegistryProvider` so a forced sync bypasses the 1-hour cache for **all three** sub-fetches (previously only `getEntitlements` honored `forceRefresh`).
