### PR TITLE
fix: handle quoted ID values in /etc/os-release parsing

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID="$(. /etc/os-release && echo "$ID")"
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
## Fix: quoted ID values in /etc/os-release parsing

**Problem:** On Rocky Linux 8.5 (and other OS variants), `/etc/os-release` contains `ID="rocky"` (quoted), but the current grep-based parser only matches unquoted values like `ID=rocky`. This causes the devcontainer setup script to fail with exit code 1.

**Fix:** Source `/etc/os-release` directly in a subshell instead of using grep/sed. The shell correctly handles both quoted and unquoted values.

**Before:**
```bash
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
```

**After:**
```bash
OS_ID="$(. /etc/os-release && echo "$ID")"
```

**Testing:**
- ✅ Rocky Linux 8.5 with `ID="rocky"` now parses correctly
- ✅ Ubuntu/Fedora with bare `ID=ubuntu` still works
- ✅ NixOS detection unaffected

Fixes #232159