### PR TITLE
agentHost: Fix issue with auth/models

### DIFF
--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -6,6 +6,7 @@
 import { Event } from '../../../base/common/event.js';
 import { IReference } from '../../../base/common/lifecycle.js';
 import { IAuthorizationProtectedResourceMetadata } from '../../../base/common/oauth.js';
+import type { IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { ISyncedCustomization } from './agentPluginManager.js';
@@ -438,8 +439,8 @@ export interface IAgent {
 	/** Return the descriptor for this agent. */
 	getDescriptor(): IAgentDescriptor;
 
-	/** List available models from this provider. */
-	listModels(): Promise<IAgentModelInfo[]>;
+	/** Available models from this provider. */
+	readonly models: IObservable<readonly IAgentModelInfo[]>;
 
 	/** List persisted sessions from this provider. */
 	listSessions(): Promise<IAgentSessionMetadata[]>;

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -107,7 +107,8 @@ export class AgentSideEffects extends Disposable {
 					maxContextWindow: m.maxContextWindow, supportsVision: m.supportsVision,
 					policyState: m.policyState,
 				}));
-			} catch {
+			} catch (err) {
+				this._logService.error(err, `[AgentSideEffects] Failed to list models for agent '${a.id}'`);
 				models = [];
 			}
 			const protectedResources = a.getProtectedResources();
@@ -865,7 +866,8 @@ export class AgentSideEffects extends Disposable {
 		let ref: ReturnType<ISessionDataService['openDatabase']>;
 		try {
 			ref = this._options.sessionDataService.openDatabase(URI.parse(session));
-		} catch {
+		} catch (err) {
+			this._logService.warn(`[AgentSideEffects] Failed to open session database for diff computation: ${session}`, err);
 			return;
 		}
 		try {

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -6,7 +6,8 @@
 import { SequencerByKey } from '../../../base/common/async.js';
 import { match as globMatch } from '../../../base/common/glob.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
-import { autorun, IObservable } from '../../../base/common/observable.js';
+import { equals } from '../../../base/common/objects.js';
+import { autorun, IObservable, IReader } from '../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, normalizePath } from '../../../base/common/resources.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -15,6 +16,7 @@ import { ILogService } from '../../log/common/log.js';
 import { IAgent, IAgentAttachment, IAgentProgressEvent, type IAgentToolReadyEvent } from '../common/agentService.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
 import { ISessionDataService } from '../common/sessionDataService.js';
+import type { IAgentInfo } from '../common/state/protocol/state.js';
 import { ActionType, ISessionAction } from '../common/state/sessionActions.js';
 import {
 	CustomizationStatus,
@@ -25,7 +27,6 @@ import {
 	ToolResultContentType,
 	buildSubagentSessionUri,
 	type ISessionCustomization,
-	type ISessionModelInfo,
 	type ISessionState,
 	type IToolResultContent,
 	type URI as ProtocolURI,
@@ -70,6 +71,7 @@ export class AgentSideEffects extends Disposable {
 	private readonly _diffComputeService: IDiffComputeService;
 	/** Serializes per-session diff computations to avoid races with stale previousDiffs. */
 	private readonly _diffComputationSequencer = new SequencerByKey<string>();
+	private _lastAgentInfos: readonly IAgentInfo[] = [];
 
 	/**
 	 * Maps `parentSession:toolCallId` → subagent session URI.
@@ -89,34 +91,33 @@ export class AgentSideEffects extends Disposable {
 		// Whenever the agents observable changes, publish to root state.
 		this._register(autorun(reader => {
 			const agents = this._options.agents.read(reader);
-			this._publishAgentInfos(agents);
+			this._publishAgentInfos(agents, reader);
 		}));
 	}
 
 	/**
-	 * Fetches models from all agents and dispatches `root/agentsChanged`.
+	 * Publishes agent descriptors using the last known model lists.
 	 */
-	private async _publishAgentInfos(agents: readonly IAgent[]): Promise<void> {
-		const infos = await Promise.all(agents.map(async a => {
+	private _publishAgentInfos(agents: readonly IAgent[], reader: IReader): void {
+		const infos: IAgentInfo[] = agents.map(a => {
 			const d = a.getDescriptor();
-			let models: ISessionModelInfo[];
-			try {
-				const rawModels = await a.listModels();
-				models = rawModels.map(m => ({
-					id: m.id, provider: m.provider, name: m.name,
-					maxContextWindow: m.maxContextWindow, supportsVision: m.supportsVision,
-					policyState: m.policyState,
-				}));
-			} catch (err) {
-				this._logService.error(err, `[AgentSideEffects] Failed to list models for agent '${a.id}'`);
-				models = [];
-			}
 			const protectedResources = a.getProtectedResources();
 			return {
-				provider: d.provider, displayName: d.displayName, description: d.description, models,
+				provider: d.provider, displayName: d.displayName, description: d.description, models: a.models.read(reader).map(m => ({
+					id: m.id,
+					provider: m.provider,
+					name: m.name,
+					maxContextWindow: m.maxContextWindow,
+					supportsVision: m.supportsVision,
+					policyState: m.policyState,
+				})),
 				protectedResources: protectedResources.length > 0 ? protectedResources : undefined,
 			};
-		}));
+		});
+		if (equals(this._lastAgentInfos, infos)) {
+			return;
+		}
+		this._lastAgentInfos = infos;
 		this._stateManager.dispatchServerAction({ type: ActionType.RootAgentsChanged, agents: infos });
 	}
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -467,7 +467,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	async getSessionMessages(session: URI): Promise<(IAgentMessageEvent | IAgentToolStartEvent | IAgentToolCompleteEvent | IAgentSubagentStartedEvent)[]> {
 		const sessionId = AgentSession.id(session);
-		const entry = this._sessions.get(sessionId) ?? await this._resumeSession(sessionId).catch(() => undefined);
+		const entry = this._sessions.get(sessionId) ?? await this._resumeSession(sessionId).catch(err => {
+			this._logService.warn(`[Copilot:${sessionId}] Failed to resume session for message lookup`, err);
+			return undefined;
+		});
 		if (!entry) {
 			return [];
 		}
@@ -846,7 +849,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	override dispose(): void {
-		this.shutdown().catch(() => { /* best-effort */ }).finally(() => super.dispose());
+		this.shutdown().catch(err => {
+			this._logService.warn('[Copilot] Shutdown failed during dispose', err);
+		}).finally(() => super.dispose());
 	}
 }
 
@@ -874,7 +879,9 @@ class PluginController {
 
 	public sync(clientId: string, customizations: ICustomizationRef[], progress?: (results: ISyncedCustomization[]) => void) {
 		const prev = this._lastSynced;
-		const promise = this._lastSynced = prev.catch(() => []).then(async () => {
+		const promise = this._lastSynced = prev.catch(err => {
+			this._logService.warn('[Copilot:PluginController] Previous customization sync failed', err);
+		}).then(async () => {
 			const result = await this._pluginManager.syncCustomizations(clientId, customizations, status => {
 				progress?.(status.map(c => ({ customization: c })));
 			});

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -11,6 +11,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { FileAccess } from '../../../../base/common/network.js';
+import { observableValue } from '../../../../base/common/observable.js';
 import { equals } from '../../../../base/common/objects.js';
 import { basename, delimiter, dirname } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -25,6 +26,7 @@ import { AgentHostSessionConfigBranchNameHintKey, AgentSession, IAgent, IAgentAt
 import { ISessionDataService, SESSION_DB_FILENAME } from '../../common/sessionDataService.js';
 import type { IResolveSessionConfigResult, ISessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
 import { IProtectedResourceMetadata, type IToolDefinition } from '../../common/state/protocol/state.js';
+import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { CustomizationStatus, ICustomizationRef, SessionInputResponseKind, type IPendingMessage, type ISessionInputAnswer, type IToolCallResult, type PolicyState } from '../../common/state/sessionState.js';
 import { IAgentHostGitService } from '../agentHostGitService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
@@ -60,6 +62,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private readonly _onDidSessionProgress = this._register(new Emitter<IAgentProgressEvent>());
 	readonly onDidSessionProgress = this._onDidSessionProgress.event;
+	private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, []);
+	readonly models = this._models;
 
 	private _client: CopilotClient | undefined;
 	private _clientStarting: Promise<CopilotClient> | undefined;
@@ -113,25 +117,55 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] Auth token ${tokenChanged ? 'updated' : 'unchanged'}`);
 		if (tokenChanged && this._client && this._sessions.size === 0) {
 			this._logService.info('[Copilot] Restarting CopilotClient with new token');
-			const client = this._client;
-			this._client = undefined;
-			this._clientStarting = undefined;
-			await client.stop();
+			await this._stopClient();
+		}
+		if (tokenChanged) {
+			void this._refreshModels();
 		}
 		return true;
+	}
+
+	private async _refreshModels(): Promise<void> {
+		const tokenAtRefreshStart = this._githubToken;
+		if (!tokenAtRefreshStart) {
+			this._models.set([], undefined);
+			return;
+		}
+		try {
+			const models = await this._listModels();
+			if (this._githubToken === tokenAtRefreshStart) {
+				this._models.set(models, undefined);
+			}
+		} catch (err) {
+			this._logService.error(err, '[Copilot] Failed to refresh models');
+			if (this._githubToken === tokenAtRefreshStart) {
+				this._models.set([], undefined);
+			}
+		}
+	}
+
+	private async _stopClient(): Promise<void> {
+		const client = this._client;
+		this._client = undefined;
+		this._clientStarting = undefined;
+		await client?.stop();
 	}
 
 	// ---- client lifecycle ---------------------------------------------------
 
 	private async _ensureClient(): Promise<CopilotClient> {
+		const tokenAtStartup = this._githubToken;
+		if (!tokenAtStartup) {
+			throw new ProtocolError(AHP_AUTH_REQUIRED, 'Authentication is required to use Copilot');
+		}
 		if (this._client) {
 			return this._client;
 		}
 		if (this._clientStarting) {
 			return this._clientStarting;
 		}
-		this._clientStarting = (async () => {
-			this._logService.info(`[Copilot] Starting CopilotClient... ${this._githubToken ? '(with token)' : '(no token)'}`);
+		const clientStarting = (async () => {
+			this._logService.info('[Copilot] Starting CopilotClient... (with token)');
 
 			// Build a clean env for the CLI subprocess, stripping Electron/VS Code vars
 			// that can interfere with the Node.js process the SDK spawns.
@@ -168,26 +202,38 @@ export class CopilotAgent extends Disposable implements IAgent {
 			this._logService.info(`[Copilot] Resolved CLI path: ${cliPath}`);
 
 			const client = new CopilotClient({
-				githubToken: this._githubToken,
-				useLoggedInUser: !this._githubToken,
+				githubToken: tokenAtStartup,
+				useLoggedInUser: false,
 				useStdio: true,
 				autoStart: true,
 				env,
 				cliPath,
 			});
 			await client.start();
+			if (this._githubToken !== tokenAtStartup) {
+				await client.stop();
+				throw new Error('Copilot authentication changed while the client was starting');
+			}
 			this._logService.info('[Copilot] CopilotClient started successfully');
 			this._client = client;
 			this._clientStarting = undefined;
 			return client;
 		})();
-		return this._clientStarting;
+		this._clientStarting = clientStarting;
+		void clientStarting.catch(() => {
+			this._clientStarting = undefined;
+		});
+		return clientStarting;
 	}
 
 	// ---- session management -------------------------------------------------
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
 		this._logService.info('[Copilot] Listing sessions...');
+		if (!this._githubToken) {
+			this._logService.trace('[Copilot] No auth token; returning no sessions');
+			return [];
+		}
 		const client = await this._ensureClient();
 		const sessions = await client.listSessions();
 		const projectLimiter = new Limiter<IAgentSessionProjectInfo | undefined>(4);
@@ -214,8 +260,12 @@ export class CopilotAgent extends Disposable implements IAgent {
 		return result;
 	}
 
-	async listModels(): Promise<IAgentModelInfo[]> {
+	private async _listModels(): Promise<IAgentModelInfo[]> {
 		this._logService.info('[Copilot] Listing models...');
+		if (!this._githubToken) {
+			this._logService.trace('[Copilot] No auth token; returning no models');
+			return [];
+		}
 		const client = await this._ensureClient();
 		const models = await client.listModels();
 		const result = models.map(m => ({

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { VSBuffer } from '../../../../base/common/buffer.js';
+import { Event } from '../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { observableValue } from '../../../../base/common/observable.js';
@@ -334,17 +335,50 @@ suite('AgentSideEffects', () => {
 
 	suite('agents observable', () => {
 
-		test('dispatches root/agentsChanged when observable changes', async () => {
+		test('dispatches root/agentsChanged without fetching models when observable changes', async () => {
+			agentList.set([], undefined);
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents.length === 1));
+			agentList.set([agent], undefined);
+			const action = await envelope;
+
+			assert.deepStrictEqual(action.action.agents[0].models, []);
+		});
+
+		test('model observable update publishes models', async () => {
 			const envelopes: IActionEnvelope[] = [];
 			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
 
-			agentList.set([agent], undefined);
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents[0]?.models.length === 1));
+			agent.setModels([{ provider: 'mock', id: 'mock-model', name: 'mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }]);
+			await envelope;
 
-			// Model fetch is async — wait for it
-			await new Promise(r => setTimeout(r, 50));
-
-			const action = envelopes.find(e => e.action.type === ActionType.RootAgentsChanged);
+			const actions = envelopes.filter(e => e.action.type === ActionType.RootAgentsChanged);
+			const action = actions[actions.length - 1];
 			assert.ok(action, 'should dispatch root/agentsChanged');
+			assert.deepStrictEqual(action.action.agents[0].models, [{
+				id: 'mock-model',
+				provider: 'mock',
+				name: 'mock Model',
+				maxContextWindow: 128000,
+				supportsVision: false,
+				policyState: undefined,
+			}]);
+		});
+
+		test('unchanged model observable update does not dispatch unchanged agent infos', async () => {
+			const envelopes: IActionEnvelope[] = [];
+			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+			const models = [{ provider: 'mock' as const, id: 'mock-model', name: 'mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }];
+
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents[0]?.models.length === 1));
+			agent.setModels(models);
+			await envelope;
+			envelopes.length = 0;
+			agent.setModels([...models]);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			assert.strictEqual(envelopes.filter(e => e.action.type === ActionType.RootAgentsChanged).length, 0);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -337,25 +337,36 @@ suite('AgentSideEffects', () => {
 
 		test('dispatches root/agentsChanged without fetching models when observable changes', async () => {
 			agentList.set([], undefined);
-			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents.length === 1));
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => {
+				if (e.action.type !== ActionType.RootAgentsChanged) {
+					return false;
+				}
+				return e.action.agents.length === 1;
+			}));
 			agentList.set([agent], undefined);
-			const action = await envelope;
+			const { action } = await envelope;
+			assert.strictEqual(action.type, ActionType.RootAgentsChanged);
 
-			assert.deepStrictEqual(action.action.agents[0].models, []);
+			assert.deepStrictEqual(action.agents[0].models, []);
 		});
 
 		test('model observable update publishes models', async () => {
 			const envelopes: IActionEnvelope[] = [];
 			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
 
-			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents[0]?.models.length === 1));
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => {
+				if (e.action.type !== ActionType.RootAgentsChanged) {
+					return false;
+				}
+				return e.action.agents[0]?.models.length === 1;
+			}));
 			agent.setModels([{ provider: 'mock', id: 'mock-model', name: 'mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }]);
 			await envelope;
 
-			const actions = envelopes.filter(e => e.action.type === ActionType.RootAgentsChanged);
+			const actions = envelopes.map(e => e.action).filter(action => action.type === ActionType.RootAgentsChanged);
 			const action = actions[actions.length - 1];
 			assert.ok(action, 'should dispatch root/agentsChanged');
-			assert.deepStrictEqual(action.action.agents[0].models, [{
+			assert.deepStrictEqual(action.agents[0].models, [{
 				id: 'mock-model',
 				provider: 'mock',
 				name: 'mock Model',
@@ -370,7 +381,12 @@ suite('AgentSideEffects', () => {
 			disposables.add(stateManager.onDidEmitEnvelope(e => envelopes.push(e)));
 			const models = [{ provider: 'mock' as const, id: 'mock-model', name: 'mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }];
 
-			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => e.action.type === ActionType.RootAgentsChanged && e.action.agents[0]?.models.length === 1));
+			const envelope = Event.toPromise(Event.filter(stateManager.onDidEmitEnvelope, e => {
+				if (e.action.type !== ActionType.RootAgentsChanged) {
+					return false;
+				}
+				return e.action.agents[0]?.models.length === 1;
+			}));
 			agent.setModels(models);
 			await envelope;
 			envelopes.length = 0;

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -4,9 +4,83 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot } from '../../node/copilot/copilotAgent.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { IFileService } from '../../../files/common/files.js';
+import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
+import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
+import { ISessionDataService } from '../../common/sessionDataService.js';
+import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
+import { ISessionCustomization, ICustomizationRef } from '../../common/state/sessionState.js';
+import { IAgentHostGitService } from '../../node/agentHostGitService.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
+import { CopilotAgent, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot } from '../../node/copilot/copilotAgent.js';
+import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
+
+class TestAgentPluginManager implements IAgentPluginManager {
+	declare readonly _serviceBrand: undefined;
+
+	async syncCustomizations(_clientId: string, _customizations: ICustomizationRef[], _progress?: (status: ISessionCustomization[]) => void): Promise<ISyncedCustomization[]> {
+		return [];
+	}
+}
+
+class TestAgentHostGitService implements IAgentHostGitService {
+	declare readonly _serviceBrand: undefined;
+
+	async isInsideWorkTree(): Promise<boolean> { return false; }
+	async getCurrentBranch(): Promise<string | undefined> { return undefined; }
+	async getDefaultBranch(): Promise<string | undefined> { return undefined; }
+	async getBranches(): Promise<string[]> { return []; }
+	async getRepositoryRoot(): Promise<URI | undefined> { return undefined; }
+	async getWorktreeRoots(): Promise<URI[]> { return []; }
+	async addWorktree(): Promise<void> { }
+	async removeWorktree(): Promise<void> { }
+}
+
+class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
+	declare readonly _serviceBrand: undefined;
+
+	async createTerminal(): Promise<void> { }
+	writeInput(): void { }
+	onData(): IDisposable { return Disposable.None; }
+	onExit(): IDisposable { return Disposable.None; }
+	onClaimChanged(): IDisposable { return Disposable.None; }
+	onCommandFinished(): IDisposable { return Disposable.None; }
+	getContent(): string | undefined { return undefined; }
+	getClaim(): undefined { return undefined; }
+	hasTerminal(): boolean { return false; }
+	getExitCode(): number | undefined { return undefined; }
+	supportsCommandDetection(): boolean { return false; }
+	disposeTerminal(): void { }
+	getTerminalInfos(): [] { return []; }
+	getTerminalState(): undefined { return undefined; }
+}
+
+function createTestAgent(disposables: DisposableStore): CopilotAgent {
+	const services = new ServiceCollection();
+	const logService = new NullLogService();
+	const fileService = disposables.add(new FileService(logService));
+	services.set(ILogService, logService);
+	services.set(IFileService, fileService);
+	services.set(ISessionDataService, createNullSessionDataService());
+	services.set(IAgentPluginManager, new TestAgentPluginManager());
+	services.set(IAgentHostGitService, new TestAgentHostGitService());
+	services.set(IAgentHostTerminalManager, new TestAgentHostTerminalManager());
+	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+	services.set(IInstantiationService, instantiationService);
+	return instantiationService.createInstance(CopilotAgent);
+}
+
+async function disposeAgent(agent: CopilotAgent): Promise<void> {
+	agent.dispose();
+	await Promise.resolve();
+}
 
 suite('CopilotAgent', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -29,5 +103,31 @@ suite('CopilotAgent', () => {
 
 	test('keeps hinted branch names short', () => {
 		assert.strictEqual(getCopilotWorktreeBranchName('12345678-aaaa-bbbb-cccc-123456789abc', 'a'.repeat(48)).length, 'agents/'.length + 48 + '-12345678'.length);
+	});
+
+	test('returns empty models and sessions before authentication', async () => {
+		const disposables = new DisposableStore();
+		const agent = createTestAgent(disposables);
+		try {
+			assert.deepStrictEqual(agent.models.get(), []);
+			assert.deepStrictEqual(await agent.listSessions(), []);
+		} finally {
+			await disposeAgent(agent);
+			disposables.dispose();
+		}
+	});
+
+	test('requires authentication before creating a session', async () => {
+		const disposables = new DisposableStore();
+		const agent = createTestAgent(disposables);
+		try {
+			await assert.rejects(
+				() => agent.createSession({ workingDirectory: URI.file('/workspace') }),
+				(error: Error) => error instanceof ProtocolError && error.code === AHP_AUTH_REQUIRED,
+			);
+		} finally {
+			await disposeAgent(agent);
+			disposables.dispose();
+		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -5,6 +5,7 @@
 
 import { timeout } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
+import { observableValue } from '../../../../base/common/observable.js';
 import type { IAuthorizationProtectedResourceMetadata } from '../../../../base/common/oauth.js';
 import { URI } from '../../../../base/common/uri.js';
 import { type ISyncedCustomization } from '../../common/agentPluginManager.js';
@@ -27,6 +28,8 @@ function mockProject(provider: AgentProvider) {
 export class MockAgent implements IAgent {
 	private readonly _onDidSessionProgress = new Emitter<IAgentProgressEvent>();
 	readonly onDidSessionProgress = this._onDidSessionProgress.event;
+	private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, []);
+	readonly models = this._models;
 
 	private readonly _sessions = new Map<string, URI>();
 	private _nextId = 1;
@@ -41,7 +44,6 @@ export class MockAgent implements IAgent {
 	readonly authenticateCalls: { resource: string; token: string }[] = [];
 	readonly setClientCustomizationsCalls: { clientId: string; customizations: ICustomizationRef[] }[] = [];
 	readonly setCustomizationEnabledCalls: { uri: string; enabled: boolean }[] = [];
-
 	/** Configurable return value for getCustomizations. */
 	customizations: ICustomizationRef[] = [];
 
@@ -64,8 +66,8 @@ export class MockAgent implements IAgent {
 		return [];
 	}
 
-	async listModels(): Promise<IAgentModelInfo[]> {
-		return [{ provider: this.id, id: `${this.id}-model`, name: `${this.id} Model`, maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }];
+	setModels(models: readonly IAgentModelInfo[]): void {
+		this._models.set(models, undefined);
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
@@ -178,6 +180,8 @@ export class ScriptedMockAgent implements IAgent {
 
 	private readonly _onDidSessionProgress = new Emitter<IAgentProgressEvent>();
 	readonly onDidSessionProgress = this._onDidSessionProgress.event;
+	private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, [{ provider: 'mock', id: 'mock-model', name: 'Mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }]);
+	readonly models = this._models;
 
 	private readonly _sessions = new Map<string, URI>();
 	private _nextId = 1;
@@ -209,10 +213,6 @@ export class ScriptedMockAgent implements IAgent {
 
 	getProtectedResources(): IAuthorizationProtectedResourceMetadata[] {
 		return [];
-	}
-
-	async listModels(): Promise<IAgentModelInfo[]> {
-		return [{ provider: 'mock', id: 'mock-model', name: 'Mock Model', maxContextWindow: 128000, supportsVision: false, supportsReasoningEffort: false }];
 	}
 
 	async listSessions(): Promise<IAgentSessionMetadata[]> {


### PR DESCRIPTION
The original bug here was an auth/model ordering issue: root agent metadata asked providers for models before the Agent Host client had sent a GitHub auth token. For Copilot, that meant model discovery ran before the SDK client could be safely authenticated, produced an empty model set, and then nothing owned a later refresh once auth arrived.

This changes model availability to be provider-owned state instead. Agent Host providers expose their available models as an observable array, and root agent metadata updates are driven from that observable state rather than eager model listing during root publication. Copilot keeps its model list empty before explicit GitHub auth, then refreshes and publishes models after auth is received.

Summary:
- Replace the `IAgent.listModels()` contract with `models: IObservable<readonly IAgentModelInfo[]>`.
- Have `AgentSideEffects` read provider model observables when publishing `root/agentsChanged`, with a structural equality guard to avoid duplicate root updates.
- Keep Copilot model state empty until explicit GitHub auth is received, and construct the Copilot SDK client only with an explicit token and `useLoggedInUser: false`.
- Add focused coverage for pre-auth Copilot behavior and observable model publication.

Validation:
- VS Code build watch: clean
- Focused Agent Host tests: 100 passed, 0 failed
- Focused post-merge AgentSideEffects test: 48 passed, 0 failed
- Hygiene: passed with the known TypeScript parser support warning

(Written by Copilot)