### PR TITLE
Agents tunnels: auto-reconnect with backoff and wake-triggered retry

### DIFF
--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -111,3 +111,64 @@ type ChangesViewReviewCommentAddedClassification = {
 export function logChangesViewReviewCommentAdded(telemetryService: ITelemetryService, data: { hasExistingFeedback: boolean; hasSuggestion: boolean; isFromPRReview: boolean }): void {
 	telemetryService.publicLog2<ChangesViewReviewCommentAddedEvent, ChangesViewReviewCommentAddedClassification>('vscodeAgents.changesView/reviewCommentAdded', data);
 }
+
+// --- Tunnel agent host connect ---
+
+export type TunnelConnectErrorCategory = 'relayConnectionFailed' | 'auth' | 'network' | 'other';
+export type TunnelConnectFailureReason = 'hostOffline' | 'maxAttemptsReached';
+
+type TunnelConnectAttemptEvent = {
+	isReconnect: boolean;
+	attempt: number;
+	durationMs: number;
+	success: boolean;
+	errorCategory: string;
+};
+
+type TunnelConnectAttemptClassification = {
+	owner: 'osortega';
+	comment: 'Tracks individual agent-host tunnel connect attempts for performance and reliability.';
+	isReconnect: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether this attempt was part of a reconnect cycle (true) or an initial connect (false).' };
+	attempt: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Attempt number within the current connect session (1-based).' };
+	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration of this individual attempt in milliseconds.' };
+	success: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this individual attempt succeeded.' };
+	errorCategory: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Category of error when the attempt failed (relayConnectionFailed, auth, network, other); empty on success.' };
+};
+
+export function logTunnelConnectAttempt(telemetryService: ITelemetryService, data: { isReconnect: boolean; attempt: number; durationMs: number; success: boolean; errorCategory?: TunnelConnectErrorCategory }): void {
+	telemetryService.publicLog2<TunnelConnectAttemptEvent, TunnelConnectAttemptClassification>('vscodeAgents.tunnelConnect/attempt', {
+		isReconnect: data.isReconnect,
+		attempt: data.attempt,
+		durationMs: data.durationMs,
+		success: data.success,
+		errorCategory: data.errorCategory ?? '',
+	});
+}
+
+type TunnelConnectResolvedEvent = {
+	isReconnect: boolean;
+	totalAttempts: number;
+	totalDurationMs: number;
+	success: boolean;
+	failureReason: string;
+};
+
+type TunnelConnectResolvedClassification = {
+	owner: 'osortega';
+	comment: 'Tracks overall agent-host tunnel connect session outcomes for reliability.';
+	isReconnect: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the resolved session was a reconnect cycle (true) or an initial connect (false).' };
+	totalAttempts: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total number of attempts made before resolution.' };
+	totalDurationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total elapsed time from session start to resolution in milliseconds.' };
+	success: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the connect session ultimately succeeded.' };
+	failureReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Reason the session terminated without connecting (hostOffline, maxAttemptsReached); empty on success.' };
+};
+
+export function logTunnelConnectResolved(telemetryService: ITelemetryService, data: { isReconnect: boolean; totalAttempts: number; totalDurationMs: number; success: boolean; failureReason?: TunnelConnectFailureReason }): void {
+	telemetryService.publicLog2<TunnelConnectResolvedEvent, TunnelConnectResolvedClassification>('vscodeAgents.tunnelConnect/resolved', {
+		isReconnect: data.isReconnect,
+		totalAttempts: data.totalAttempts,
+		totalDurationMs: data.totalDurationMs,
+		success: data.success,
+		failureReason: data.failureReason ?? '',
+	});
+}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -315,11 +315,17 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 
 			// Only track previous status while the entry is present so a
-			// future re-registration starts from a clean slate.
+			// future re-registration starts from a clean slate. If the
+			// entry disappeared (e.g. user-initiated removal), also cancel
+			// any already-scheduled reconnect and clear its backoff state
+			// so the removal is honoured even if a timer was already armed.
 			if (current !== undefined) {
 				this._previousStatuses.set(address, current);
 			} else {
 				this._previousStatuses.delete(address);
+				this._cancelReconnect(address);
+				this._reconnectAttempts.delete(address);
+				this._reconnectPaused.delete(address);
 			}
 		}
 
@@ -378,6 +384,21 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 		const timer = setTimeout(() => {
 			this._reconnectTimeouts.delete(address);
+
+			// A manual (or other) connect may have started or completed while
+			// we were waiting. Re-check before counting this as a new attempt,
+			// otherwise `_connectTunnel` would just return the in-flight promise
+			// and we'd inflate the backoff counter without really trying again.
+			if (this._pendingConnects.has(address)) {
+				return;
+			}
+			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
+				this._reconnectAttempts.delete(address);
+				this._reconnectPaused.delete(address);
+				return;
+			}
+
 			this._reconnectAttempts.set(address, attempt + 1);
 			this._connectTunnel(address).catch(() => { /* _connectTunnel already re-schedules on failure */ });
 		}, delay);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -13,8 +13,10 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
+import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory } from '../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 
@@ -52,6 +54,13 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
 	private _lastResumeAt = 0;
 
+	/**
+	 * Per-address connect sessions for telemetry. A session starts at the
+	 * first attempt of a connect cycle (initial or reconnect) and ends on
+	 * terminal resolution (connected, host-offline, max-attempts).
+	 */
+	private readonly _connectSessions = new Map<string, { startedAt: number; attempts: number; isReconnect: boolean }>();
+
 	constructor(
 		@ITunnelAgentHostService private readonly _tunnelService: ITunnelAgentHostService,
 		@IRemoteAgentHostService private readonly _remoteAgentHostService: IRemoteAgentHostService,
@@ -61,6 +70,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		@INotificationService private readonly _notificationService: INotificationService,
 		@ILogService private readonly _logService: ILogService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -225,6 +235,19 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		// success/failure of this attempt will drive the next decision.
 		this._cancelReconnect(address);
 
+		// Record attempt for telemetry. A session exists already if
+		// `_handleConnectionChanges` marked this as a reconnect cycle;
+		// otherwise this is an initial (user-initiated) connect.
+		let session = this._connectSessions.get(address);
+		if (!session) {
+			session = { startedAt: Date.now(), attempts: 0, isReconnect: false };
+			this._connectSessions.set(address, session);
+		}
+		session.attempts++;
+		const attemptStart = Date.now();
+		const attemptNumber = session.attempts;
+		const isReconnect = session.isReconnect;
+
 		const promise = (async () => {
 			// Show a progress notification after a short delay so quick
 			// connects don't flash a notification.
@@ -251,9 +274,38 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				// Success: reset any reconnect backoff/pause state.
 				this._reconnectAttempts.delete(address);
 				this._reconnectPaused.delete(address);
+				logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs: Date.now() - attemptStart, success: true });
+				logTunnelConnectResolved(this._telemetryService, { isReconnect, totalAttempts: attemptNumber, totalDurationMs: Date.now() - session.startedAt, success: true });
+				this._connectSessions.delete(address);
 			} catch (err) {
-				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed, scheduling reconnect:`, err);
-				this._scheduleReconnect(address);
+				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed:`, err);
+				const errorCategory = this._categorizeError(err);
+				logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs: Date.now() - attemptStart, success: false, errorCategory });
+				// Clear the pending-connect entry BEFORE deciding what to do next;
+				// otherwise `_scheduleReconnect`'s in-flight guard
+				// (`_pendingConnects.has(address)`) would silently bail out
+				// and we'd never re-arm the timer, leaving the tunnel stuck.
+				this._pendingConnects.delete(address);
+
+				// Probe whether the host is actually online. If not, pause the
+				// reconnect loop — retrying against an offline host just wastes
+				// attempts. A wake/online/visibility event (or the periodic
+				// silent status check) will resume us when the host reappears.
+				const hostOnline = await this._probeHostOnline(cached.tunnelId);
+				if (hostOnline === false) {
+					this._logService.info(
+						`[TunnelAgentHost] Host for ${address} is offline; pausing auto-reconnect ` +
+						`until network-online, tab-visible, or next status check.`
+					);
+					this._cancelReconnect(address);
+					this._reconnectAttempts.delete(address);
+					this._reconnectPaused.add(address);
+					logTunnelConnectResolved(this._telemetryService, { isReconnect, totalAttempts: attemptNumber, totalDurationMs: Date.now() - session.startedAt, success: false, failureReason: 'hostOffline' });
+					this._connectSessions.delete(address);
+				} else {
+					this._logService.info(`[TunnelAgentHost] Scheduling reconnect for ${address}`);
+					this._scheduleReconnect(address);
+				}
 				throw err;
 			} finally {
 				clearTimeout(timer);
@@ -308,6 +360,11 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 			if (wasConnected && isExplicitlyDisconnected && !this._pendingConnects.has(address)) {
 				this._logService.info(`[TunnelAgentHost] Connection lost for ${address}, scheduling reconnect`);
+				// Start a fresh reconnect telemetry session so we can measure
+				// how long recovery takes from the moment the connection dropped.
+				if (!this._connectSessions.has(address)) {
+					this._connectSessions.set(address, { startedAt: Date.now(), attempts: 0, isReconnect: true });
+				}
 				// Immediate first attempt (no delay) — matches user expectation
 				// that a transient blip recovers quickly. If that fails,
 				// `_connectTunnel` will call `_scheduleReconnect` with backoff.
@@ -326,6 +383,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._cancelReconnect(address);
 				this._reconnectAttempts.delete(address);
 				this._reconnectPaused.delete(address);
+				this._connectSessions.delete(address);
 			}
 		}
 
@@ -371,6 +429,11 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				`[TunnelAgentHost] Pausing auto-reconnect for ${address} after ${attempt} attempts; ` +
 				`will resume on network-online or tab-visible.`
 			);
+			const session = this._connectSessions.get(address);
+			if (session) {
+				logTunnelConnectResolved(this._telemetryService, { isReconnect: session.isReconnect, totalAttempts: session.attempts, totalDurationMs: Date.now() - session.startedAt, success: false, failureReason: 'maxAttemptsReached' });
+				this._connectSessions.delete(address);
+			}
 			return;
 		}
 
@@ -405,12 +468,51 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		this._reconnectTimeouts.set(address, timer);
 	}
 
+	/**
+	 * Best-effort probe of whether the host backing `tunnelId` is online
+	 * (has any host connections). Returns `undefined` if we couldn't
+	 * determine — caller should treat as "retry normally" in that case.
+	 */
+	private async _probeHostOnline(tunnelId: string): Promise<boolean | undefined> {
+		try {
+			const tunnels = await this._tunnelService.listTunnels({ silent: true });
+			if (!tunnels) {
+				return undefined;
+			}
+			const info = tunnels.find(t => t.tunnelId === tunnelId);
+			if (!info) {
+				// Tunnel no longer exists on the account — treat as offline so we
+				// stop retrying; `_pruneReconnectState` will clean up eventually.
+				return false;
+			}
+			return info.hostConnectionCount > 0;
+		} catch {
+			return undefined;
+		}
+	}
+
 	private _cancelReconnect(address: string): void {
 		const timer = this._reconnectTimeouts.get(address);
 		if (timer !== undefined) {
 			clearTimeout(timer);
 			this._reconnectTimeouts.delete(address);
 		}
+	}
+
+	// -- Telemetry --
+
+	private _categorizeError(err: unknown): TunnelConnectErrorCategory {
+		const message = err instanceof Error ? err.message : String(err);
+		if (/WebSocket relay connection failed/i.test(message)) {
+			return 'relayConnectionFailed';
+		}
+		if (/authenticat|token|unauthor/i.test(message)) {
+			return 'auth';
+		}
+		if (/network|fetch|offline/i.test(message)) {
+			return 'network';
+		}
+		return 'other';
 	}
 
 	/**
@@ -477,6 +579,11 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		for (const address of [...this._reconnectPaused]) {
 			if (!cachedAddresses.has(address)) {
 				this._reconnectPaused.delete(address);
+			}
+		}
+		for (const address of [...this._connectSessions.keys()]) {
+			if (!cachedAddresses.has(address)) {
+				this._connectSessions.delete(address);
 			}
 		}
 	}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -5,6 +5,7 @@
 
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { isWeb } from '../../../../base/common/platform.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 import * as nls from '../../../../nls.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
@@ -20,6 +21,17 @@ import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvid
 /** Minimum interval between silent status checks (5 minutes). */
 const STATUS_CHECK_INTERVAL = 5 * 60 * 1000;
 
+/** Initial auto-reconnect delay after an unexpected tunnel disconnect. */
+const RECONNECT_INITIAL_DELAY = 1000;
+/** Maximum auto-reconnect backoff delay. */
+const RECONNECT_MAX_DELAY = 30_000;
+/**
+ * Consecutive failures before pausing auto-reconnect. We resume immediately
+ * on a network-online event or when the tab becomes visible, so this is
+ * mostly a guard against a permanently dead tunnel.
+ */
+const RECONNECT_MAX_ATTEMPTS = 10;
+
 export class TunnelAgentHostContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'sessions.contrib.tunnelAgentHostContribution';
@@ -28,6 +40,17 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _providerInstances = new Map<string, RemoteAgentHostSessionsProvider>();
 	private readonly _pendingConnects = new Map<string, Promise<void>>();
 	private _lastStatusCheck = 0;
+
+	/** Previous connection status per address — used to detect Connected→Disconnected transitions. */
+	private readonly _previousStatuses = new Map<string, RemoteAgentHostConnectionStatus>();
+	/** Pending auto-reconnect timer per address. */
+	private readonly _reconnectTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+	/** Consecutive failed auto-reconnect attempts per address. */
+	private readonly _reconnectAttempts = new Map<string, number>();
+	/** Addresses whose auto-reconnect loop has paused after too many failures. */
+	private readonly _reconnectPaused = new Set<string>();
+	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
+	private _lastResumeAt = 0;
 
 	constructor(
 		@ITunnelAgentHostService private readonly _tunnelService: ITunnelAgentHostService,
@@ -46,6 +69,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Update connection statuses when connections change
 		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
+			this._handleConnectionChanges();
 			this._updateConnectionStatuses();
 			this._wireConnections();
 		}));
@@ -53,6 +77,8 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		// Reconcile providers when the tunnel cache changes
 		this._register(this._tunnelService.onDidChangeTunnels(() => {
 			this._reconcileProviders();
+			// Stop any reconnect loops for tunnels that no longer exist
+			this._pruneReconnectState();
 		}));
 
 		// Re-run discovery when a GitHub session becomes available
@@ -62,6 +88,32 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._logService.info('[TunnelAgentHost] GitHub sessions changed, retrying discovery...');
 				this._silentStatusCheck();
 			}
+		}));
+
+		// Wake-triggered retry: when the browser regains connectivity or
+		// the tab becomes visible again, immediately attempt to reconnect
+		// any disconnected tunnels. This covers laptop-sleep / Wi-Fi-drop
+		// scenarios where we may have paused the reconnect loop.
+		if (isWeb) {
+			const onWake = () => this._resumeReconnects('wake');
+			mainWindow.addEventListener('online', onWake);
+			this._register(toDisposable(() => mainWindow.removeEventListener('online', onWake)));
+
+			const onVisibilityChange = () => {
+				if (mainWindow.document.visibilityState === 'visible') {
+					this._resumeReconnects('visible');
+				}
+			};
+			mainWindow.document.addEventListener('visibilitychange', onVisibilityChange);
+			this._register(toDisposable(() => mainWindow.document.removeEventListener('visibilitychange', onVisibilityChange)));
+		}
+
+		// Cancel any pending reconnect timers on disposal.
+		this._register(toDisposable(() => {
+			for (const timer of this._reconnectTimeouts.values()) {
+				clearTimeout(timer);
+			}
+			this._reconnectTimeouts.clear();
 		}));
 
 		// Silently check status of cached tunnels on startup
@@ -169,6 +221,10 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			return Promise.resolve();
 		}
 
+		// A new attempt is starting — cancel any scheduled reconnect timer;
+		// success/failure of this attempt will drive the next decision.
+		this._cancelReconnect(address);
+
 		const promise = (async () => {
 			// Show a progress notification after a short delay so quick
 			// connects don't flash a notification.
@@ -192,6 +248,13 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 					hostConnectionCount: 0,
 				};
 				await this._tunnelService.connect(tunnelInfo, cached.authProvider);
+				// Success: reset any reconnect backoff/pause state.
+				this._reconnectAttempts.delete(address);
+				this._reconnectPaused.delete(address);
+			} catch (err) {
+				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed, scheduling reconnect:`, err);
+				this._scheduleReconnect(address);
+				throw err;
 			} finally {
 				clearTimeout(timer);
 				handle?.close();
@@ -200,8 +263,201 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 		})();
 
+		// Swallow the promise rejection here so unhandled rejection noise
+		// doesn't bubble up for the background reconnect path; callers that
+		// await `_connectTunnel` directly will still see it via their own `await`.
+		promise.catch(() => { /* handled via _scheduleReconnect */ });
+
 		this._pendingConnects.set(address, promise);
 		return promise;
+	}
+
+	// -- Auto-reconnect --
+
+	/**
+	 * Detect tunnel connections that transitioned from Connected to
+	 * Disconnected and schedule an auto-reconnect.
+	 *
+	 * Important: we only trigger on a Connected → Disconnected transition
+	 * where the connection entry is still present. If the entry has been
+	 * removed from the service (e.g. the user clicked "Remove Remote"),
+	 * we do NOT schedule a reconnect — that would override their intent.
+	 */
+	private _handleConnectionChanges(): void {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			return;
+		}
+
+		const cachedAddresses = new Set(
+			this._tunnelService.getCachedTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`)
+		);
+		const currentStatuses = new Map<string, RemoteAgentHostConnectionStatus>();
+		for (const conn of this._remoteAgentHostService.connections) {
+			currentStatuses.set(conn.address, conn.status);
+		}
+
+		for (const address of cachedAddresses) {
+			const previous = this._previousStatuses.get(address);
+			const current = currentStatuses.get(address);
+
+			// Only schedule a reconnect on an explicit Connected→Disconnected
+			// transition. If the address is absent from the connection list,
+			// the user (or another code path) removed it — honour that.
+			const wasConnected = previous === RemoteAgentHostConnectionStatus.Connected;
+			const isExplicitlyDisconnected = current === RemoteAgentHostConnectionStatus.Disconnected;
+
+			if (wasConnected && isExplicitlyDisconnected && !this._pendingConnects.has(address)) {
+				this._logService.info(`[TunnelAgentHost] Connection lost for ${address}, scheduling reconnect`);
+				// Immediate first attempt (no delay) — matches user expectation
+				// that a transient blip recovers quickly. If that fails,
+				// `_connectTunnel` will call `_scheduleReconnect` with backoff.
+				this._scheduleReconnect(address, /*immediate*/ true);
+			}
+
+			// Only track previous status while the entry is present so a
+			// future re-registration starts from a clean slate.
+			if (current !== undefined) {
+				this._previousStatuses.set(address, current);
+			} else {
+				this._previousStatuses.delete(address);
+			}
+		}
+
+		// Drop previous-status entries for addresses no longer cached.
+		for (const address of [...this._previousStatuses.keys()]) {
+			if (!cachedAddresses.has(address)) {
+				this._previousStatuses.delete(address);
+			}
+		}
+	}
+
+	private _scheduleReconnect(address: string, immediate = false): void {
+		// Respect enablement and tunnel-still-cached.
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			return;
+		}
+		const tunnelId = address.slice(TUNNEL_ADDRESS_PREFIX.length);
+		const cached = this._tunnelService.getCachedTunnels().find(t => t.tunnelId === tunnelId);
+		if (!cached) {
+			return;
+		}
+
+		// Already connected or a connect is in flight — nothing to do.
+		if (this._pendingConnects.has(address)) {
+			return;
+		}
+		const live = this._remoteAgentHostService.connections.find(c => c.address === address);
+		if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
+			this._reconnectAttempts.delete(address);
+			this._reconnectPaused.delete(address);
+			return;
+		}
+
+		// Cancel any existing timer — we're rescheduling.
+		this._cancelReconnect(address);
+
+		const attempt = this._reconnectAttempts.get(address) ?? 0;
+
+		if (attempt >= RECONNECT_MAX_ATTEMPTS) {
+			// Pause: let wake/online/visibility events resume us.
+			this._reconnectPaused.add(address);
+			this._logService.info(
+				`[TunnelAgentHost] Pausing auto-reconnect for ${address} after ${attempt} attempts; ` +
+				`will resume on network-online or tab-visible.`
+			);
+			return;
+		}
+
+		const delay = immediate
+			? 0
+			: Math.min(RECONNECT_INITIAL_DELAY * Math.pow(2, attempt), RECONNECT_MAX_DELAY);
+
+		this._logService.info(
+			`[TunnelAgentHost] Scheduling reconnect for ${address} in ${delay}ms (attempt ${attempt + 1}/${RECONNECT_MAX_ATTEMPTS})`
+		);
+
+		const timer = setTimeout(() => {
+			this._reconnectTimeouts.delete(address);
+			this._reconnectAttempts.set(address, attempt + 1);
+			this._connectTunnel(address).catch(() => { /* _connectTunnel already re-schedules on failure */ });
+		}, delay);
+		this._reconnectTimeouts.set(address, timer);
+	}
+
+	private _cancelReconnect(address: string): void {
+		const timer = this._reconnectTimeouts.get(address);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this._reconnectTimeouts.delete(address);
+		}
+	}
+
+	/**
+	 * Invoked on `online` / `visibilitychange→visible`. Kicks off an
+	 * immediate attempt for any disconnected cached tunnel.
+	 *
+	 * Rate-limited: at most one resume per RESUME_RATE_LIMIT_MS so that
+	 * rapid tab toggling can't hammer a permanently broken endpoint with
+	 * an unbounded number of attempt bursts. Resumes the normal backoff
+	 * sequence (by clearing the pause flag) rather than zeroing the
+	 * attempt counter.
+	 */
+	private _resumeReconnects(trigger: 'wake' | 'visible'): void {
+		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+			return;
+		}
+
+		const RESUME_RATE_LIMIT_MS = 10_000;
+		const now = Date.now();
+		if (now - this._lastResumeAt < RESUME_RATE_LIMIT_MS) {
+			return;
+		}
+		this._lastResumeAt = now;
+
+		const cached = this._tunnelService.getCachedTunnels();
+		for (const tunnel of cached) {
+			const address = `${TUNNEL_ADDRESS_PREFIX}${tunnel.tunnelId}`;
+			if (this._pendingConnects.has(address)) {
+				continue;
+			}
+			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
+				continue;
+			}
+
+			this._logService.info(`[TunnelAgentHost] Resuming reconnect for ${address} (trigger: ${trigger})`);
+			// If we were paused (exhausted the backoff budget), give a fresh
+			// budget since the wake event is itself evidence the environment
+			// has changed. Otherwise keep the current attempt counter so an
+			// in-progress backoff isn't short-circuited.
+			if (this._reconnectPaused.has(address)) {
+				this._reconnectAttempts.delete(address);
+				this._reconnectPaused.delete(address);
+			}
+			this._scheduleReconnect(address, /*immediate*/ true);
+		}
+	}
+
+	/** Drop reconnect state for addresses whose tunnel is no longer cached. */
+	private _pruneReconnectState(): void {
+		const cachedAddresses = new Set(
+			this._tunnelService.getCachedTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`)
+		);
+		for (const address of [...this._reconnectTimeouts.keys()]) {
+			if (!cachedAddresses.has(address)) {
+				this._cancelReconnect(address);
+			}
+		}
+		for (const address of [...this._reconnectAttempts.keys()]) {
+			if (!cachedAddresses.has(address)) {
+				this._reconnectAttempts.delete(address);
+			}
+		}
+		for (const address of [...this._reconnectPaused]) {
+			if (!cachedAddresses.has(address)) {
+				this._reconnectPaused.delete(address);
+			}
+		}
 	}
 
 	// -- Silent status check --

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -16,7 +16,7 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
-import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory } from '../../../common/sessionsTelemetry.js';
+import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory, TunnelConnectFailureReason } from '../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 
@@ -235,18 +235,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		// success/failure of this attempt will drive the next decision.
 		this._cancelReconnect(address);
 
-		// Record attempt for telemetry. A session exists already if
-		// `_handleConnectionChanges` marked this as a reconnect cycle;
-		// otherwise this is an initial (user-initiated) connect.
-		let session = this._connectSessions.get(address);
-		if (!session) {
-			session = { startedAt: Date.now(), attempts: 0, isReconnect: false };
-			this._connectSessions.set(address, session);
-		}
-		session.attempts++;
-		const attemptStart = Date.now();
-		const attemptNumber = session.attempts;
-		const isReconnect = session.isReconnect;
+		const { attemptNumber, attemptStart, session, isReconnect } = this._beginConnectAttempt(address);
 
 		const promise = (async () => {
 			// Show a progress notification after a short delay so quick
@@ -271,37 +260,19 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 					hostConnectionCount: 0,
 				};
 				await this._tunnelService.connect(tunnelInfo, cached.authProvider);
-				// Success: reset any reconnect backoff/pause state.
-				this._reconnectAttempts.delete(address);
-				this._reconnectPaused.delete(address);
-				logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs: Date.now() - attemptStart, success: true });
-				logTunnelConnectResolved(this._telemetryService, { isReconnect, totalAttempts: attemptNumber, totalDurationMs: Date.now() - session.startedAt, success: true });
-				this._connectSessions.delete(address);
+				this._finishConnectAttempt(address, { success: true, attemptNumber, attemptStart, session, isReconnect });
 			} catch (err) {
 				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed:`, err);
-				const errorCategory = this._categorizeError(err);
-				logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs: Date.now() - attemptStart, success: false, errorCategory });
-				// Clear the pending-connect entry BEFORE deciding what to do next;
-				// otherwise `_scheduleReconnect`'s in-flight guard
-				// (`_pendingConnects.has(address)`) would silently bail out
-				// and we'd never re-arm the timer, leaving the tunnel stuck.
+				this._finishConnectAttempt(address, { success: false, attemptNumber, attemptStart, session, isReconnect, error: err });
+				// Clear the pending-connect entry BEFORE deciding what to do
+				// next; otherwise `_scheduleReconnect`'s in-flight guard
+				// (`_pendingConnects.has(address)`) would silently bail and
+				// we'd never re-arm the timer, leaving the tunnel stuck.
 				this._pendingConnects.delete(address);
 
-				// Probe whether the host is actually online. If not, pause the
-				// reconnect loop — retrying against an offline host just wastes
-				// attempts. A wake/online/visibility event (or the periodic
-				// silent status check) will resume us when the host reappears.
 				const hostOnline = await this._probeHostOnline(cached.tunnelId);
 				if (hostOnline === false) {
-					this._logService.info(
-						`[TunnelAgentHost] Host for ${address} is offline; pausing auto-reconnect ` +
-						`until network-online, tab-visible, or next status check.`
-					);
-					this._cancelReconnect(address);
-					this._reconnectAttempts.delete(address);
-					this._reconnectPaused.add(address);
-					logTunnelConnectResolved(this._telemetryService, { isReconnect, totalAttempts: attemptNumber, totalDurationMs: Date.now() - session.startedAt, success: false, failureReason: 'hostOffline' });
-					this._connectSessions.delete(address);
+					this._pauseReconnect(address, 'hostOffline');
 				} else {
 					this._logService.info(`[TunnelAgentHost] Scheduling reconnect for ${address}`);
 					this._scheduleReconnect(address);
@@ -323,8 +294,6 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		this._pendingConnects.set(address, promise);
 		return promise;
 	}
-
-	// -- Auto-reconnect --
 
 	/**
 	 * Detect tunnel connections that transitioned from Connected to
@@ -360,14 +329,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 			if (wasConnected && isExplicitlyDisconnected && !this._pendingConnects.has(address)) {
 				this._logService.info(`[TunnelAgentHost] Connection lost for ${address}, scheduling reconnect`);
-				// Start a fresh reconnect telemetry session so we can measure
-				// how long recovery takes from the moment the connection dropped.
 				if (!this._connectSessions.has(address)) {
 					this._connectSessions.set(address, { startedAt: Date.now(), attempts: 0, isReconnect: true });
 				}
-				// Immediate first attempt (no delay) — matches user expectation
-				// that a transient blip recovers quickly. If that fails,
-				// `_connectTunnel` will call `_scheduleReconnect` with backoff.
 				this._scheduleReconnect(address, /*immediate*/ true);
 			}
 
@@ -380,10 +344,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._previousStatuses.set(address, current);
 			} else {
 				this._previousStatuses.delete(address);
-				this._cancelReconnect(address);
-				this._reconnectAttempts.delete(address);
-				this._reconnectPaused.delete(address);
-				this._connectSessions.delete(address);
+				this._resetReconnectState(address);
 			}
 		}
 
@@ -412,8 +373,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		}
 		const live = this._remoteAgentHostService.connections.find(c => c.address === address);
 		if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
-			this._reconnectAttempts.delete(address);
-			this._reconnectPaused.delete(address);
+			this._clearReconnectBackoff(address);
 			return;
 		}
 
@@ -423,17 +383,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		const attempt = this._reconnectAttempts.get(address) ?? 0;
 
 		if (attempt >= RECONNECT_MAX_ATTEMPTS) {
-			// Pause: let wake/online/visibility events resume us.
-			this._reconnectPaused.add(address);
-			this._logService.info(
-				`[TunnelAgentHost] Pausing auto-reconnect for ${address} after ${attempt} attempts; ` +
-				`will resume on network-online or tab-visible.`
-			);
-			const session = this._connectSessions.get(address);
-			if (session) {
-				logTunnelConnectResolved(this._telemetryService, { isReconnect: session.isReconnect, totalAttempts: session.attempts, totalDurationMs: Date.now() - session.startedAt, success: false, failureReason: 'maxAttemptsReached' });
-				this._connectSessions.delete(address);
-			}
+			this._pauseReconnect(address, 'maxAttemptsReached');
 			return;
 		}
 
@@ -457,8 +407,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 			const live = this._remoteAgentHostService.connections.find(c => c.address === address);
 			if (live && live.status === RemoteAgentHostConnectionStatus.Connected) {
-				this._reconnectAttempts.delete(address);
-				this._reconnectPaused.delete(address);
+				this._clearReconnectBackoff(address);
 				return;
 			}
 
@@ -481,8 +430,6 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			}
 			const info = tunnels.find(t => t.tunnelId === tunnelId);
 			if (!info) {
-				// Tunnel no longer exists on the account — treat as offline so we
-				// stop retrying; `_pruneReconnectState` will clean up eventually.
 				return false;
 			}
 			return info.hostConnectionCount > 0;
@@ -499,7 +446,84 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		}
 	}
 
-	// -- Telemetry --
+	/** Clear retry-backoff and pause state for an address. */
+	private _clearReconnectBackoff(address: string): void {
+		this._reconnectAttempts.delete(address);
+		this._reconnectPaused.delete(address);
+	}
+
+	/** Drop all reconnect + telemetry state for an address (e.g. on removal). */
+	private _resetReconnectState(address: string): void {
+		this._cancelReconnect(address);
+		this._clearReconnectBackoff(address);
+		this._connectSessions.delete(address);
+	}
+
+	/**
+	 * Stop auto-reconnecting for an address until a wake/online/visibility
+	 * event resumes us, and close out any active telemetry session.
+	 */
+	private _pauseReconnect(address: string, reason: TunnelConnectFailureReason): void {
+		this._cancelReconnect(address);
+		this._reconnectAttempts.delete(address);
+		this._reconnectPaused.add(address);
+		this._logService.info(
+			`[TunnelAgentHost] Pausing auto-reconnect for ${address} (${reason}); ` +
+			`will resume on network-online, tab-visible, or next status check.`
+		);
+		const session = this._connectSessions.get(address);
+		if (session) {
+			logTunnelConnectResolved(this._telemetryService, {
+				isReconnect: session.isReconnect,
+				totalAttempts: session.attempts,
+				totalDurationMs: Date.now() - session.startedAt,
+				success: false,
+				failureReason: reason,
+			});
+			this._connectSessions.delete(address);
+		}
+	}
+
+	/**
+	 * Begin (or continue) a connect telemetry session for `address` and
+	 * return the bookkeeping needed to later finish the attempt. A session
+	 * already exists if `_handleConnectionChanges` marked this as a
+	 * reconnect cycle; otherwise this starts a fresh initial-connect session.
+	 */
+	private _beginConnectAttempt(address: string): { session: { startedAt: number; attempts: number; isReconnect: boolean }; attemptNumber: number; attemptStart: number; isReconnect: boolean } {
+		let session = this._connectSessions.get(address);
+		if (!session) {
+			session = { startedAt: Date.now(), attempts: 0, isReconnect: false };
+			this._connectSessions.set(address, session);
+		}
+		session.attempts++;
+		return { session, attemptNumber: session.attempts, attemptStart: Date.now(), isReconnect: session.isReconnect };
+	}
+
+	/**
+	 * Finalize the telemetry for a single connect attempt. On success, also
+	 * clears backoff state and closes the session; on failure, only the
+	 * per-attempt event is emitted (the caller decides whether to retry).
+	 */
+	private _finishConnectAttempt(address: string, args: {
+		success: boolean;
+		attemptNumber: number;
+		attemptStart: number;
+		session: { startedAt: number; attempts: number; isReconnect: boolean };
+		isReconnect: boolean;
+		error?: unknown;
+	}): void {
+		const { success, attemptNumber, attemptStart, session, isReconnect, error } = args;
+		const durationMs = Date.now() - attemptStart;
+		if (success) {
+			this._clearReconnectBackoff(address);
+			logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs, success: true });
+			logTunnelConnectResolved(this._telemetryService, { isReconnect, totalAttempts: attemptNumber, totalDurationMs: Date.now() - session.startedAt, success: true });
+			this._connectSessions.delete(address);
+		} else {
+			logTunnelConnectAttempt(this._telemetryService, { isReconnect, attempt: attemptNumber, durationMs, success: false, errorCategory: this._categorizeError(error) });
+		}
+	}
 
 	private _categorizeError(err: unknown): TunnelConnectErrorCategory {
 		const message = err instanceof Error ? err.message : String(err);
@@ -554,8 +578,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			// has changed. Otherwise keep the current attempt counter so an
 			// in-progress backoff isn't short-circuited.
 			if (this._reconnectPaused.has(address)) {
-				this._reconnectAttempts.delete(address);
-				this._reconnectPaused.delete(address);
+				this._clearReconnectBackoff(address);
 			}
 			this._scheduleReconnect(address, /*immediate*/ true);
 		}
@@ -566,24 +589,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		const cachedAddresses = new Set(
 			this._tunnelService.getCachedTunnels().map(t => `${TUNNEL_ADDRESS_PREFIX}${t.tunnelId}`)
 		);
-		for (const address of [...this._reconnectTimeouts.keys()]) {
+		const tracked = new Set<string>([
+			...this._reconnectTimeouts.keys(),
+			...this._reconnectAttempts.keys(),
+			...this._reconnectPaused,
+			...this._connectSessions.keys(),
+		]);
+		for (const address of tracked) {
 			if (!cachedAddresses.has(address)) {
-				this._cancelReconnect(address);
-			}
-		}
-		for (const address of [...this._reconnectAttempts.keys()]) {
-			if (!cachedAddresses.has(address)) {
-				this._reconnectAttempts.delete(address);
-			}
-		}
-		for (const address of [...this._reconnectPaused]) {
-			if (!cachedAddresses.has(address)) {
-				this._reconnectPaused.delete(address);
-			}
-		}
-		for (const address of [...this._connectSessions.keys()]) {
-			if (!cachedAddresses.has(address)) {
-				this._connectSessions.delete(address);
+				this._resetReconnectState(address);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Tunnel-backed remote agent hosts previously had no auto-reconnect behavior — on laptop sleep or network drop the tunnel would flip to `Disconnected` and stay there until the user manually retried. This adds a reconnect loop inside `TunnelAgentHostContribution`.

## Changes

In [src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts](https://github.com/microsoft/vscode/blob/osortega/agents-tunnel-reconnect/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts):

- **Detect Connected → Disconnected transitions** for still-cached tunnels and schedule an immediate reconnect. Only fires when the entry is explicitly `Disconnected` — if the entry has been removed from the connection list (e.g. user clicked "Remove Remote"), we honour the removal and do not reconnect.
- **Exponential backoff** on consecutive failures: 1s → 30s cap, up to 10 attempts, then pause.
- **Wake-triggered retry** (web only): on browser `online` or tab `visibilitychange` → visible, resume any paused reconnects. Rate-limited to one resume per 10s so rapid tab toggling can't hammer a permanently broken endpoint with unbounded attempt bursts. Only clears the attempt counter when the address is actually paused, so in-progress backoff sequences aren't short-circuited.
- **State pruning** when a tunnel is uncached or the contribution is disposed (all pending `setTimeout`s cleared).
- `_connectTunnel` now resets backoff/pause state on success and re-schedules on failure via `_scheduleReconnect`.

## Related

Pairs with the `microsoft/vscode-dev` PR that adds `offline` + long-hidden-resume force-close to the browser tunnel WebSocket.

## Risk

- Scoped to `TunnelAgentHostContribution` — does not touch the generic `IRemoteAgentHostService` reconnect machinery (which still explicitly skips tunnel entries in `reconnect()`).
- Wake listeners are `isWeb`-gated.
- Status UI update is through the existing `_updateConnectionStatuses` path — no new UI surface.

## Follow-ups (not in this PR)

- Unit tests for the reconnect state machine.
- Telemetry for reconnect attempts / pause events.
- A manual "Retry now" action on the provider.