### PR TITLE
Restrict autoImportSpecifierExcludeRegexes to trusted workspaces

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -32,7 +32,10 @@
         "typescript.tsserver.nodePath",
         "js/ts.tsserver.node.path",
         "js/ts.tsserver.diagnosticDir",
-        "js/ts.tsserver.heapProfile"
+        "js/ts.tsserver.heapProfile",
+        "js/ts.preferences.autoImportSpecifierExcludeRegexes",
+        "typescript.preferences.autoImportSpecifierExcludeRegexes",
+        "javascript.preferences.autoImportSpecifierExcludeRegexes"
       ]
     }
   },


### PR DESCRIPTION
`autoImportSpecifierExcludeRegexes` is a regex that tsserver will parse and use, which means that one can put a complicated regex and ReDoS themselves. Restrict this setting to trusted workspaces, which is more reasonable than attempting to determine if a given input is okay or not.

TypeScript 7+ are in Go and we chose to switch to Go's `regexp` library, which is based on RE2, so does not have this problem.