### PR TITLE
Enable remote agent hosts by default in Insiders

### DIFF
--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -19,6 +19,7 @@ import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurati
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import product from '../../../../platform/product/common/product.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
@@ -577,7 +578,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[RemoteAgentHostsEnabledSettingId]: {
 			type: 'boolean',
 			description: nls.localize('chat.remoteAgentHosts.enabled', "Enable connecting to remote agent hosts."),
-			default: false,
+			default: product.quality === 'insider',
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},


### PR DESCRIPTION
Enable remote agent host connections by default for Insiders builds while keeping Stable and other product qualities disabled by default.

Validation:
- Core Typecheck: 0 errors
- Core Transpile: 0 errors
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts` passed with the existing TypeScript version warning

(Written by Copilot)