### PR TITLE
Don't add agent-host worktree as workspace folder

### DIFF
--- a/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
+++ b/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
@@ -72,6 +72,12 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		const worktree = repo?.workingDirectory;
 		const branchName = repo?.detail;
 
+		// Remote agent host sessions use a read-only FS provider that
+		// should not be added as a workspace folder.
+		if (worktree?.scheme === AGENT_HOST_SCHEME || repository?.scheme === AGENT_HOST_SCHEME) {
+			return undefined;
+		}
+
 		if (worktree) {
 			return {
 				uri: worktree,
@@ -80,11 +86,6 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		}
 
 		if (repository) {
-			// Remote agent host sessions use a read-only FS provider that
-			// should not be added as a workspace folder.
-			if (repository.scheme === AGENT_HOST_SCHEME) {
-				return undefined;
-			}
 			return {
 				uri: repository,
 				name: workspace?.label,


### PR DESCRIPTION
The `AGENT_HOST_SCHEME` guard in `getActiveSessionFolderData` only covered the `repository` fallback branch. When a remote agent host session provides a `workingDirectory` (worktree), it was added as a workspace folder unconditionally. This caused `PromptFilesLocator` to probe all customization sub-paths (`.claude/agents`, `.claude/rules`, `.agents`, etc.) over RPC, producing noisy warnings for directories that don't exist.

Hoist the guard above both branches so any agent-host URI is excluded.

(Written by Copilot)