### PR TITLE
Simplify compaction fallback: use Simple mode on budget exceeded

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -539,6 +539,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					endpoint: this.endpoint,
 					promptContext: renderProps.promptContext,
 					triggerSummarize: true,
+					forceSimpleSummary: true,
 				});
 				return await renderer.render(progress, token);
 			} catch (e) {
@@ -862,7 +863,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 							"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." },
 							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
 							"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
-							"source": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether background or foreground." },
 							"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
 							"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
 							"lastUsedTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The last tool used before summarization." },
@@ -881,7 +881,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						outcome: 'success',
 						model: this.endpoint.model,
 						summarizationMode: 'inline',
-						source: 'background',
 						conversationId,
 						chatRequestId: associatedRequestId,
 						lastUsedTool,
@@ -925,7 +924,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						endpoint: this.endpoint,
 						promptContext: snapshotProps.promptContext,
 						triggerSummarize: true,
-						summarizationSource: 'background',
 					});
 					const bgProgress: vscode.Progress<vscode.ChatResponseReferencePart | vscode.ChatResponseProgressPart> = { report: () => { } };
 					const bgRenderResult = await bgRenderer.render(bgProgress, bgToken);
@@ -960,7 +958,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 							"detailedOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Detailed failure reason." },
 							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
 							"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
-							"source": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether background or foreground." },
 							"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
 							"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
 							"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Duration in ms." }
@@ -971,7 +968,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						detailedOutcome: err instanceof Error ? err.message : String(err),
 						model: this.endpoint.model,
 						summarizationMode: 'inline',
-						source: 'background',
 						conversationId,
 						chatRequestId: associatedRequestId,
 					}, {

--- a/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -71,8 +71,8 @@ export interface AgentPromptProps extends GenericBasePromptElementProps {
 	 */
 	readonly customizations?: AgentPromptCustomizations;
 
-	/** Whether this summarization was triggered as a background or foreground operation. */
-	readonly summarizationSource?: 'background' | 'foreground';
+	/** Skip Full mode and go straight to Simple mode for summarization. */
+	readonly forceSimpleSummary?: boolean;
 }
 
 /** Proportion of the prompt token budget any singular textual tool result is allowed to use. */
@@ -143,6 +143,7 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 				<SummarizedConversationHistory
 					flexGrow={1}
 					triggerSummarize={this.props.triggerSummarize}
+					forceSimpleSummary={this.props.forceSimpleSummary}
 					priority={900}
 					promptContext={this.props.promptContext}
 					location={this.props.location}
@@ -150,7 +151,6 @@ export class AgentPrompt extends PromptElement<AgentPromptProps> {
 					endpoint={this.props.endpoint}
 					tools={this.props.promptContext.tools?.availableTools}
 					enableCacheBreakpoints={this.props.enableCacheBreakpoints}
-					summarizationSource={this.props.summarizationSource}
 					userQueryTagName={userQueryTagName}
 					ReminderInstructionsClass={ReminderInstructionsClass}
 					ToolReferencesHintClass={ToolReferencesHintClass}

--- a/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/agentPrompt.tsx
@@ -71,7 +71,10 @@ export interface AgentPromptProps extends GenericBasePromptElementProps {
 	 */
 	readonly customizations?: AgentPromptCustomizations;
 
-	/** Skip Full mode and go straight to Simple mode for summarization. */
+	/**
+	 * Prefer Simple mode for summarization, typically for the budget-exceeded recovery path.
+	 * An explicit summarization mode configuration can still force Full mode.
+	 */
 	readonly forceSimpleSummary?: boolean;
 }
 

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -405,8 +405,8 @@ export interface SummarizedAgentHistoryProps extends BasePromptElementProps, Age
 	readonly maxSummaryTokens?: number;
 	/** Optional custom instructions to include in the summarization prompt */
 	readonly summarizationInstructions?: string;
-	/** Whether this summarization was triggered as a background or foreground operation. Defaults to 'foreground'. */
-	readonly summarizationSource?: 'background' | 'foreground';
+	/** Skip Full mode and go straight to Simple mode for foreground budget-exceeded recovery. */
+	readonly forceSimpleSummary?: boolean;
 }
 
 /**
@@ -604,6 +604,10 @@ class ConversationHistorySummarizer {
 
 	private async getSummaryWithFallback(propsInfo: ISummarizedConversationHistoryInfo): Promise<SummarizationResult> {
 		const forceMode = this.configurationService.getConfig<string | undefined>(ConfigKey.Advanced.AgentHistorySummarizationMode);
+		if (this.props.forceSimpleSummary && forceMode !== SummaryMode.Full) {
+			// Foreground budget-exceeded recovery — go straight to Simple.
+			return await this.getSummary(SummaryMode.Simple, propsInfo);
+		}
 		if (forceMode === SummaryMode.Simple) {
 			return await this.getSummary(SummaryMode.Simple, propsInfo);
 		} else {
@@ -874,8 +878,7 @@ class ConversationHistorySummarizer {
 				"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The duration of the summarization attempt in ms." },
 				"promptTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of prompt tokens, server side counted", "isMeasurement": true },
 				"promptCacheTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of prompt tokens hitting cache as reported by server", "isMeasurement": true },
-				"responseTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of generated tokens", "isMeasurement": true },
-				"source": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the summarization was triggered as a background or foreground operation." }
+				"responseTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "comment": "Number of generated tokens", "isMeasurement": true }
 			}
 		*/
 		this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
@@ -889,7 +892,6 @@ class ConversationHistorySummarizer {
 			conversationId,
 			mode,
 			summarizationMode: mode, // Try to unstick GDPR
-			source: this.props.summarizationSource ?? 'foreground',
 		}, {
 			numRounds,
 			numRoundsSinceLastSummarization,


### PR DESCRIPTION
When the main prompt render exceeds the token budget and falls back to foreground summarization (`renderWithSummarization`), skip Full mode and go straight to Simple mode via `forceSimpleSummary`. This saves a wasted LLM request since Full would likely also fail under the same budget pressure, and Simple is guaranteed to fit via hard tool-result truncation.
