### PR TITLE
Fix agent host worktree terminal cwd

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -346,11 +346,11 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		const sessionId = config?.session ? AgentSession.id(config.session) : generateUuid();
 		const sessionUri = AgentSession.uri(this.id, sessionId);
-		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri);
 		const activeClient = this._activeClients.get(sessionUri);
 		const snapshot = activeClient ? await activeClient.snapshot() : undefined;
-		const sessionConfig = this._buildSessionConfig(snapshot, shellManager);
 		const workingDirectory = await this._resolveSessionWorkingDirectory(config, sessionId);
+		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
+		const sessionConfig = this._buildSessionConfig(snapshot, shellManager);
 
 		const factory: SessionWrapperFactory = async callbacks => {
 			const raw = await client.createSession({
@@ -365,7 +365,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 		let agentSession: CopilotAgentSession;
 		try {
-			agentSession = this._createAgentSession(factory, workingDirectory, sessionId, shellManager, snapshot);
+			agentSession = this._createAgentSession(factory, sessionId, shellManager, snapshot);
 			await agentSession.initializeSession();
 		} catch (error) {
 			await this._removeCreatedWorktree(sessionId);
@@ -635,7 +635,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 * and returns it. The caller must call {@link CopilotAgentSession.initializeSession}
 	 * to wire up the SDK session.
 	 */
-	private _createAgentSession(wrapperFactory: SessionWrapperFactory, _workingDirectory: URI | undefined, sessionId: string, shellManager: ShellManager, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
+	private _createAgentSession(wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager, snapshot?: IActiveClientSnapshot): CopilotAgentSession {
 		const sessionUri = AgentSession.uri(this.id, sessionId);
 
 		const agentSession = this._instantiationService.createInstance(
@@ -710,7 +710,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			throw new Error(`workingDirectory is required to resume Copilot session '${sessionId}'`);
 		}
 
-		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri);
+		const shellManager = this._instantiationService.createInstance(ShellManager, sessionUri, workingDirectory);
 		const sessionConfig = this._buildSessionConfig(snapshot, shellManager);
 
 		const factory: SessionWrapperFactory = async callbacks => {
@@ -742,7 +742,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			}
 		};
 
-		const agentSession = this._createAgentSession(factory, workingDirectory, sessionId, shellManager, snapshot);
+		const agentSession = this._createAgentSession(factory, sessionId, shellManager, snapshot);
 		await agentSession.initializeSession();
 
 		return agentSession;

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -70,6 +70,7 @@ export class ShellManager {
 
 	constructor(
 		private readonly _sessionUri: URI,
+		private readonly _workingDirectory: URI | undefined,
 		@IAgentHostTerminalManager private readonly _terminalManager: IAgentHostTerminalManager,
 		@ILogService private readonly _logService: ILogService,
 	) { }
@@ -107,7 +108,7 @@ export class ShellManager {
 			terminal: terminalUri,
 			claim,
 			name: shellDisplayName,
-			cwd,
+			cwd: cwd ?? this._workingDirectory?.fsPath,
 		}, { shell: getShellExecutable(shellType) });
 
 		const shell: IManagedShell = { id, terminalUri, shellType };

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -12,7 +12,7 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { ICreateTerminalParams } from '../../common/state/protocol/commands.js';
-import type { ITerminalClaim } from '../../common/state/protocol/state.js';
+import type { ITerminalClaim, ITerminalInfo } from '../../common/state/protocol/state.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { ShellManager } from '../../node/copilot/copilotShellTools.js';
 
@@ -35,7 +35,7 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	getExitCode(): number | undefined { return undefined; }
 	supportsCommandDetection(): boolean { return false; }
 	disposeTerminal(): void { }
-	getTerminalInfos(): [] { return []; }
+	getTerminalInfos(): ITerminalInfo[] { return []; }
 	getTerminalState(): undefined { return undefined; }
 }
 
@@ -53,14 +53,16 @@ suite('CopilotShellTools', () => {
 		services.set(IAgentHostTerminalManager, terminalManager);
 		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 		services.set(IInstantiationService, instantiationService);
-		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), URI.file('/workspace/worktree')));
+		const worktreePath = URI.file('/workspace/worktree').fsPath;
+		const explicitCwd = URI.file('/explicit/cwd').fsPath;
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), URI.file(worktreePath)));
 
 		await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
-		await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', '/explicit/cwd');
+		await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', explicitCwd);
 
 		assert.deepStrictEqual(terminalManager.created.map(c => c.cwd), [
-			'/workspace/worktree',
-			'/explicit/cwd',
+			worktreePath,
+			explicitCwd,
 		]);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { Disposable, DisposableStore, type IDisposable } from '../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
+import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
+import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import type { ICreateTerminalParams } from '../../common/state/protocol/commands.js';
+import type { ITerminalClaim } from '../../common/state/protocol/state.js';
+import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
+import { ShellManager } from '../../node/copilot/copilotShellTools.js';
+
+class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
+	declare readonly _serviceBrand: undefined;
+
+	readonly created: ICreateTerminalParams[] = [];
+
+	async createTerminal(params: ICreateTerminalParams): Promise<void> {
+		this.created.push(params);
+	}
+	writeInput(): void { }
+	onData(): IDisposable { return Disposable.None; }
+	onExit(): IDisposable { return Disposable.None; }
+	onClaimChanged(): IDisposable { return Disposable.None; }
+	onCommandFinished(): IDisposable { return Disposable.None; }
+	getContent(): string | undefined { return undefined; }
+	getClaim(): ITerminalClaim | undefined { return undefined; }
+	hasTerminal(): boolean { return false; }
+	getExitCode(): number | undefined { return undefined; }
+	supportsCommandDetection(): boolean { return false; }
+	disposeTerminal(): void { }
+	getTerminalInfos(): [] { return []; }
+	getTerminalState(): undefined { return undefined; }
+}
+
+suite('CopilotShellTools', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('uses session working directory for created shells', async () => {
+		const terminalManager = new TestAgentHostTerminalManager();
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IAgentHostTerminalManager, terminalManager);
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		services.set(IInstantiationService, instantiationService);
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), URI.file('/workspace/worktree')));
+
+		await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
+		await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', '/explicit/cwd');
+
+		assert.deepStrictEqual(terminalManager.created.map(c => c.cwd), [
+			'/workspace/worktree',
+			'/explicit/cwd',
+		]);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
@@ -25,12 +25,13 @@ import assert from 'assert';
 import { execSync } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
+import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ISubscribeResult } from '../../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
 import type { ISessionAddedNotification } from '../../../common/state/sessionActions.js';
 import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
-import type { ISessionState } from '../../../common/state/sessionState.js';
+import { ToolResultContentType, type ISessionState, type ITerminalState, type IToolResultContent } from '../../../common/state/sessionState.js';
 import {
 	getActionEnvelope,
 	isActionNotification,
@@ -101,6 +102,15 @@ function dispatchTurn(c: TestProtocolClient, session: string, turnId: string, te
 			userMessage: { text },
 		},
 	});
+}
+
+function terminalResourceFromContent(content: readonly IToolResultContent[]): string | undefined {
+	const terminalContent = content.find(c => c.type === ToolResultContentType.Terminal);
+	return terminalContent?.resource;
+}
+
+function terminalText(state: ITerminalState): string {
+	return removeAnsiEscapeCodes(state.content.map(part => part.type === 'command' ? `${part.commandLine}\n${part.output}` : part.value).join(''));
 }
 
 (REAL_SDK_ENABLED ? suite : suite.skip)('Protocol WebSocket — Real Copilot SDK', function () {
@@ -321,6 +331,7 @@ function dispatchTurn(c: TestProtocolClient, session: string, turnId: string, te
 			addedSummary.workingDirectory!.includes('.worktrees'),
 			`workingDirectory should be under the .worktrees folder, got: ${addedSummary.workingDirectory}`,
 		);
+		const resolvedWorkingDirectoryPath = URI.parse(addedSummary.workingDirectory!).fsPath;
 
 		// Set the active client with tools (matching real VS Code flow where
 		// activeClientChanged is dispatched AFTER createSession). When the next
@@ -373,5 +384,52 @@ function dispatchTurn(c: TestProtocolClient, session: string, turnId: string, te
 		// Verify the turn got a response (the session resumed successfully)
 		const responseParts = client.receivedNotifications(n => isActionNotification(n, 'session/responsePart'));
 		assert.ok(responseParts.length > 0, 'should have received at least one response part after session refresh');
+
+		client.clearReceived();
+		dispatchTurn(client, addedSummary.resource, 'turn-wt-terminal', 'Run the shell command: pwd', 3);
+
+		const toolStartNotif = await client.waitForNotification(
+			n => isActionNotification(n, 'session/toolCallStart'),
+			60_000,
+		);
+		const toolStartAction = getActionEnvelope(toolStartNotif).action as { toolCallId: string };
+
+		const toolReadyNotif = await client.waitForNotification(
+			n => isActionNotification(n, 'session/toolCallReady'),
+			30_000,
+		);
+		const toolReadyAction = getActionEnvelope(toolReadyNotif).action as { confirmed?: string };
+		if (!toolReadyAction.confirmed) {
+			client.notify('dispatchAction', {
+				clientSeq: 4,
+				action: {
+					type: 'session/toolCallConfirmed',
+					session: addedSummary.resource,
+					turnId: 'turn-wt-terminal',
+					toolCallId: toolStartAction.toolCallId,
+					approved: true,
+				},
+			});
+		}
+
+		const terminalContentNotif = await client.waitForNotification(n => {
+			if (!isActionNotification(n, 'session/toolCallContentChanged')) {
+				return false;
+			}
+			const action = getActionEnvelope(n).action as { toolCallId: string; content: readonly IToolResultContent[] };
+			return action.toolCallId === toolStartAction.toolCallId && terminalResourceFromContent(action.content) !== undefined;
+		}, 30_000);
+		const terminalContentAction = getActionEnvelope(terminalContentNotif).action as { content: readonly IToolResultContent[] };
+		const terminalUri = terminalResourceFromContent(terminalContentAction.content);
+		assert.ok(terminalUri, 'shell tool should expose its terminal resource');
+
+		const terminalSubscribeResult = await client.call<ISubscribeResult>('subscribe', { resource: terminalUri });
+		const initialTerminalState = terminalSubscribeResult.snapshot.state as ITerminalState;
+		assert.strictEqual(initialTerminalState.cwd, resolvedWorkingDirectoryPath, 'terminal should be created in the resolved worktree directory');
+
+		await client.waitForNotification(n => isActionNotification(n, 'session/turnComplete'), 90_000);
+		const terminalSnapshot = await client.call<ISubscribeResult>('subscribe', { resource: terminalUri });
+		const terminalState = terminalSnapshot.snapshot.state as ITerminalState;
+		assert.ok(terminalText(terminalState).includes(resolvedWorkingDirectoryPath), `pwd output should include the resolved worktree path ${resolvedWorkingDirectoryPath}`);
 	});
 });


### PR DESCRIPTION
Fixes Agent Host Copilot shell terminals created for worktree-isolated sessions so they start in the resolved worktree directory instead of the Agent Host process cwd.

Summary:
- Pass the resolved session working directory into `ShellManager` on create and resume paths.
- Use that directory as the default cwd when shell tools create Agent Host terminals, while preserving explicit cwd overrides.
- Add unit coverage for the ShellManager cwd fallback.
- Extend the real SDK worktree integration test to run `pwd` in the shell terminal and verify the terminal cwd/output matches the resolved worktree path.

Validation:
- VS Code build task clean: Core Transpile, Core Typecheck, Ext Build, Copilot Build.
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotAgent.ts src/vs/platform/agentHost/node/copilot/copilotShellTools.ts src/vs/platform/agentHost/test/node/copilotShellTools.test.ts src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts`
- `AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh --run src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts --grep "worktree session uses the resolved worktree as working directory"`

(Written by Copilot)