### PR TITLE
Fix "Add to Chat" using current tab instead of right-clicked tab

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -90,7 +90,7 @@ abstract class AttachResourceAction extends Action2 {
 	protected _getResources(accessor: ServicesAccessor, ...args: unknown[]): URI[] {
 		const editorService = accessor.get(IEditorService);
 
-		const contexts = isEditorCommandsContext(args[1]) ? this._getEditorResources(accessor, args) : Array.isArray(args[1]) ? args[1] : [args[0]];
+		const contexts = isEditorCommandsContext(args[1]) ? this._getEditorResources(accessor, ...args) : Array.isArray(args[1]) ? args[1] : [args[0]];
 		const files = [];
 		for (const context of contexts) {
 			let uri;


### PR DESCRIPTION
## Summary

Right-clicking a non-current editor tab and selecting "Add File to Chat" / "Add Folder to Chat" attached the CURRENT editor instead of the right-clicked one.

## Root cause

`AttachResourceAction._getResources()` in `chatContextActions.ts` called:

```ts
this._getEditorResources(accessor, args)
```

`_getEditorResources` is declared with `...args: unknown[]`, so passing `args` as a single argument wraps it into a nested array (`args` inside the callee becomes `[[a, b, c]]`). `resolveCommandsContext` then filters the nested array out because it is neither a URI nor an editor commands context, falls back to the active editor group, and attaches the current editor.

## Fix

Spread the arguments (`...args`) so `_getEditorResources` receives the original argument list. `resolveCommandsContext` then sees the `{ groupId, editorIndex }` commands context (passed by the editor title menu) and resolves the right-clicked editor.

## Test plan

- [ ] Open two files, make one active
- [ ] Right-click the non-active tab, pick "Add File to Chat"
- [ ] The non-active file should be attached to the chat (not the active one)

Fixes #276020