### PR TITLE
Fix crash renaming file into a new folder with the same name

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -743,6 +743,27 @@ export function validateFileName(pathService: IPathService, item: ExplorerItem, 
 		}
 	}
 
+	// When the new name is a path (contains separators), the first segment
+	// becomes an intermediate directory. Reject if that directory would
+	// collide with the item being renamed (item is not a directory) or with
+	// an existing non-directory sibling that cannot be used as a folder.
+	if (names.length > 1) {
+		const firstSegment = names[0];
+		if (!item.isDirectory && item.name === firstSegment) {
+			return {
+				content: nls.localize('fileNameCollidesWithSelfError', "The name **{0}** cannot contain a path segment that matches the file being renamed.", firstSegment),
+				severity: Severity.Error
+			};
+		}
+		const sibling = parent?.getChild(firstSegment);
+		if (sibling && sibling !== item && !sibling.isDirectory) {
+			return {
+				content: nls.localize('fileNameCollidesWithSiblingError', "A file **{0}** already exists at this location and cannot be used as a folder. Please choose a different name.", firstSegment),
+				severity: Severity.Error
+			};
+		}
+	}
+
 	// Check for invalid file name.
 	if (names.some(folderName => !pathService.hasValidBasename(item.resource, os, folderName))) {
 		// Escape * characters


### PR DESCRIPTION
## Summary

Renaming a file to a path where the first segment matches the file being renamed (e.g. \`hello.ts\` → \`hello.ts/world.ts\`) silently failed without an error message.

## Root cause

\`validateFileName\`'s "already exists" check used \`parent.getChild(fullName)\`, but \`getChild\` does a literal name lookup — not a path traversal. For a multi-segment name like \`hello.ts/world.ts\` there is never a child with that literal name, so validation passed. The rename then asked the file service to move \`hello.ts\` into a subdirectory of itself, which fails.

## Fix

Add an early validation when the new name contains path separators:
- If the first segment matches the file being renamed (and the item is not a directory), reject with a clear "cannot contain a path segment that matches the file being renamed" message.
- If the first segment matches an existing non-directory sibling, reject with a "cannot be used as a folder" message.

This validates at the point the user commits the rename (error badge in the inline input), instead of silently failing after the edit is submitted.

## Test plan

- [ ] Right-click a file \`hello.ts\` → Rename → \`hello.ts/world.ts\` → see error badge, rename is blocked
- [ ] Given two sibling files \`foo.ts\` and \`bar.ts\` → rename \`bar.ts\` to \`foo.ts/bar.ts\` → see error badge
- [ ] Given folder \`utils\` and file \`logger.ts\` → rename \`logger.ts\` to \`utils/logger.ts\` → still works (utils is a directory)

Fixes #245942