### PR TITLE
Fix Settings search dropping settings that contain the query substring

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -114,10 +114,17 @@ export class LocalSearchProvider implements ISearchProvider {
 
 		// Check the top key match type.
 		const topKeyMatchType = Math.max(...filterMatches.map(m => (m.matchType & SettingKeyMatchTypes)));
+		// If the query is a contiguous substring of any setting's ID, the query is
+		// specific enough that we keep all key-level matches rather than dropping
+		// lower-tier ones. This ensures siblings whose IDs differ by small details
+		// (e.g. plural vs. singular) still surface when the user types a precise
+		// substring. See https://github.com/microsoft/vscode/issues/247715.
+		const hasSubstringIdMatch = filterMatches.some(m => m.matchType & SettingMatchType.ContiguousQueryInSettingId);
+		const allowedKeyMatchTypes = hasSubstringIdMatch ? SettingKeyMatchTypes : topKeyMatchType;
 		// Always allow description matches as part of https://github.com/microsoft/vscode/issues/239936.
 		const alwaysAllowedMatchTypes = SettingMatchType.DescriptionOrValueMatch | SettingMatchType.LanguageTagSettingMatch;
 		const filteredMatches = filterMatches
-			.filter(m => (m.matchType & topKeyMatchType) || (m.matchType & alwaysAllowedMatchTypes) || m.matchType === SettingMatchType.ExactMatch)
+			.filter(m => (m.matchType & allowedKeyMatchTypes) || (m.matchType & alwaysAllowedMatchTypes) || m.matchType === SettingMatchType.ExactMatch)
 			.map(m => ({ ...m, providerName: STRING_MATCH_SEARCH_PROVIDER_NAME }));
 		return Promise.resolve({
 			filterMatches: filteredMatches,


### PR DESCRIPTION
## Summary

When a search query is a literal substring of one setting's ID, related settings whose IDs also contain the substring but only fuzzy-match (e.g. differing by a plural \"s\") were dropped from results.

Example from #247715: typing \`instructionfiles\` showed \`github.copilot.chat.codeGeneration.useInstructionFiles\` but not \`chat.instructionsFilesLocations\` — both settings clearly contain the query substring, but the second only matched as a non-contiguous query because of the plural.

## Root cause

\`preferencesSearch.ts\` computes \`topKeyMatchType\` from the best key-match score across all results, then filters out any match that doesn't include that exact bit. When one result scores \`ContiguousQueryInSettingId\` (1<<6) and another only scores \`NonContiguousQueryInSettingId\` (1<<2), the latter is dropped.

## Fix

When any result has a contiguous substring match on a setting ID, the query is specific enough that we keep all key-level matches rather than dropping lower-tier ones. The original "top match type" filter is preserved for purely fuzzy queries where it still protects against noisy results.

Quoting @joaomoreno from the issue:
> Both results include the \`instructionfiles\` substring … If I type \`instructionfiles\`, both settings need to appear no matter what.

## Test plan

- [ ] Search \`instructionfiles\` → both \`useInstructionFiles\` and \`instructionsFilesLocations\` appear
- [ ] Fuzzy queries (e.g. \`edt tb siz\`) still return only top-tier matches, not a deluge

Fixes #247715