### PR TITLE
Fix locked hover dismissing when a new hover is attempted

### DIFF
--- a/src/vs/platform/hover/browser/hoverService.ts
+++ b/src/vs/platform/hover/browser/hoverService.ts
@@ -248,9 +248,6 @@ export class HoverService extends Disposable implements IHoverService {
 	}
 
 	private _createHover(options: IHoverOptions, skipLastFocusedUpdate?: boolean): ICreateHoverResult | undefined {
-		this._currentDelayedHover?.dispose();
-		this._currentDelayedHover = undefined;
-
 		if (options.content === '') {
 			return undefined;
 		}
@@ -281,6 +278,13 @@ export class HoverService extends Disposable implements IHoverService {
 				return undefined;
 			}
 		}
+
+		// We are committed to creating a new hover. Cancel any pending delayed
+		// hover only now — disposing it earlier would destroy a locked hover
+		// that shares this reference (showDelayedHover keeps the handle even
+		// after the widget is shown, see #249143).
+		this._currentDelayedHover?.dispose();
+		this._currentDelayedHover = undefined;
 
 		this._lastHoverOptions = options;
 		const trapFocus = options.trapFocus || this._accessibilityService.isScreenReaderOptimized();


### PR DESCRIPTION
## Summary

Terminal decoration hovers (e.g. the command warning icon) dismiss even when locked with Alt/Option, because another hover attempt later in the gesture destroys the locked widget.

Per @Tyriar's diagnosis on #249143, the root cause is in \`hoverService.ts\` — the managed-hover path ultimately lands in \`_createHover\` which doesn't fully respect the locked state.

## Root cause

\`HoverService._createHover\` started with:

\`\`\`ts
this._currentDelayedHover?.dispose();
this._currentDelayedHover = undefined;
\`\`\`

...before running the nesting/lock/identity checks. \`showDelayedHover\` assigns \`this._currentDelayedHover = hover.hover\` when scheduling the widget and never clears this handle after the widget is shown. So when a hover was shown via \`showDelayedHover\` and then locked (e.g. pinned with Alt), \`_currentDelayedHover\` still pointed at the locked widget.

A subsequent hover attempt (e.g. from a sibling action icon's managed hover) disposed the locked widget at the top of \`_createHover\`, **then** hit the \`isLocked\` check and returned \`undefined\` — but by that point the locked hover had already been destroyed.

## Fix

Move the \`_currentDelayedHover\` disposal to after all the bail-out checks. It now runs only when we are committed to creating a new hover, leaving locked/duplicate hovers intact.

The original intent of the disposal (cancel any pending delayed hover when a new hover appears) is preserved — \`_hideAllHovers\` and the actual hover replacement flow in \`_showHover\` still handle widget cleanup during normal transitions.

## Test plan

- [ ] In the terminal, trigger a command with a warning decoration
- [ ] Hover the warning icon to show the tooltip
- [ ] Hold Alt/Option to lock the hover
- [ ] Move to a sibling action icon (trash/copy) — the warning hover stays visible (regression from before this fix: it disappeared)

Fixes #249143