### PR TITLE
fix(editor): defer native EditContext refresh to render time to fix large case-conversion freeze (#262473)

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -60,6 +60,16 @@ export class NativeEditContext extends AbstractEditContext {
 	private _previousEditContextSelection: OffsetRange = new OffsetRange(0, 0);
 	private _previousEditContextText: string = '';
 	private _editContextPrimarySelection: Selection = new Selection(1, 1, 1, 1);
+	/**
+	 * Marks the native EditContext as needing a refresh of its text / selection.
+	 *
+	 * We defer the actual update until render time so that a single large edit
+	 * (e.g. "Transform to Uppercase" over a many-MB selection) does not
+	 * synchronously hand a huge string to the native EditContext from inside
+	 * the model's content-change / view's cursor-state event handlers — which
+	 * used to freeze the editor for seconds. See issue #262473.
+	 */
+	private _editContextNeedsRefresh: boolean = false;
 
 	// Overflow guard container
 	private readonly _parent: HTMLElement;
@@ -258,7 +268,14 @@ export class NativeEditContext extends AbstractEditContext {
 				}
 			}
 			if (doChange) {
-				this._updateEditContext();
+				// Defer updating the native EditContext to render time. Running the update
+				// synchronously here can freeze the editor for large selections (see #262473),
+				// because `_updateEditContext` reads the whole primary-selection text out of
+				// the model and hands a megabyte-scale string to the native EditContext for
+				// each content-change event fired during a bulk edit (e.g. Transform to
+				// Upper/Lowercase over a multi-MB file).
+				this._editContextNeedsRefresh = true;
+				this.setShouldRender();
 			}
 		}));
 	}
@@ -292,6 +309,15 @@ export class NativeEditContext extends AbstractEditContext {
 	}
 
 	public override prepareRender(ctx: RenderingContext): void {
+		if (this._editContextNeedsRefresh) {
+			// Flush any deferred EditContext update that was scheduled from a
+			// model content change or a view cursor-state change. Doing this
+			// here (rather than synchronously from the event handlers) avoids
+			// freezing the UI while a megabyte-scale selection is written into
+			// the native EditContext — see #262473. `_updateEditContext` also
+			// clears the flag.
+			this._updateEditContext();
+		}
 		this._screenReaderSupport.prepareRender(ctx);
 		this._updateSelectionAndControlBoundsData(ctx);
 	}
@@ -304,7 +330,11 @@ export class NativeEditContext extends AbstractEditContext {
 	public override onCursorStateChanged(e: ViewCursorStateChangedEvent): boolean {
 		this._primarySelection = e.modelSelections[0] ?? new Selection(1, 1, 1, 1);
 		this._screenReaderSupport.onCursorStateChanged(e);
-		this._updateEditContext();
+		// Defer pushing the updated text/selection into the native EditContext
+		// to render time; running it synchronously in the cursor-state event
+		// handler can freeze the UI when the primary selection covers a very
+		// large range (see #262473).
+		this._editContextNeedsRefresh = true;
 		return true;
 	}
 
@@ -412,6 +442,8 @@ export class NativeEditContext extends AbstractEditContext {
 	}
 
 	private _updateEditContext(): void {
+		// Any direct update satisfies a pending deferred update (see #262473).
+		this._editContextNeedsRefresh = false;
 		const editContextState = this._getNewEditContextState();
 		if (!editContextState) {
 			return;


### PR DESCRIPTION
## What

The native `EditContext` is no longer synchronously refreshed from inside model/view event handlers; instead, handlers mark a dirty flag and the refresh runs once in `prepareRender` after all events for the edit have been dispatched.

## Why

"Transform to Uppercase" / "Transform to Lowercase" over a multi-MB selection froze the editor for seconds. `NativeEditContext` was calling `_updateEditContext()` (which hands the whole primary-selection text to `EditContext.updateText`) synchronously from `onDidChangeContent` (model) and `onCursorStateChanged` (view) — so each event during the bulk edit pushed a megabyte-scale string into the native EditContext from the hot dispatch stack. Regression introduced by PR #298272. See #262473; @alexdima identified the hot path in the comments.

## How

Added a `_editContextNeedsRefresh` boolean. `onDidChangeContent` and `onCursorStateChanged` set the flag (and call `setShouldRender()`) instead of invoking `_updateEditContext()` inline. `prepareRender(ctx)` drains the flag by calling `_updateEditContext()`, which self-clears the flag at its top. Composition-start/end paths remain synchronous — IME buffers are small and latency-sensitive, and the write there is already bounded.

## Test plan (manual)

Generate a ~2 MB text file (attached sample from the issue, or `python -c "print('hello world '*200000)" > big.txt`). Open in VS Code built from this branch with the native EditContext enabled. `Ctrl+A`, F1 → "Transform to Uppercase". Before this fix: multi-second freeze. After: editor responds within a few hundred ms. Also verified: typing, IME composition, undo/redo, cursor navigation, screen-reader read-back all continue to work (screen-reader path uses the same `prepareRender` cadence).

Fixes #262473