### PR TITLE
Encoding: add CP 857 (Turkish DOS) to supported document encodings

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -772,6 +772,11 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
 		order: 48
+	},
+	cp857: {
+		labelLong: 'Turkish DOS (CP 857)',
+		labelShort: 'CP 857',
+		order: 49
 	}
 };
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -130,7 +130,7 @@ declare module 'vscode' {
 		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
 		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
 		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
-		 * 'cp865', 'cp850'.
+		 * 'cp865', 'cp850', 'cp857'.
 		 */
 		readonly encoding: string;
 


### PR DESCRIPTION
Fixes #300041

## What

Added `cp857` (Turkish DOS / IBM 857) to `SUPPORTED_ENCODINGS` in `encoding.ts` and updated the `vscode.d.ts` API documentation to list it.

## Why

CP857 is the DOS code page for Turkish characters and is still widely used in legacy Turkish-language projects. It was already supported by:
- The VS Code terminal (`terminalEncoding.ts` line 17: `'857': 'cp857'`)
- The underlying `@vscode/iconv-lite-umd` library (the existing `encodingExists` test validates all entries in `SUPPORTED_ENCODINGS` against iconv-lite)

Its absence from `SUPPORTED_ENCODINGS` meant users couldn't open or save Turkish legacy files using CP857 in the editor, even though the same files worked in the integrated terminal.

## Testing

- The existing `encodingExists` test in `encoding.test.ts` iterates every entry in `SUPPORTED_ENCODINGS` and asserts `iconv.encodingExists(enc) === true`. The new `cp857` entry will be covered automatically by this test.
- Manually verified that `cp857` is in `terminalEncoding.ts` (proof the iconv library already ships it).