### PR TITLE
Extensions: guard against undefined view pane container in openSearch

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1612,7 +1612,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 	}
 
 	async openSearch(searchValue: string, preserveFoucs?: boolean): Promise<void> {
-		const viewPaneContainer = (await this.viewsService.openViewContainer(VIEWLET_ID, true))?.getViewPaneContainer() as IExtensionsViewPaneContainer;
+		const viewPaneContainer = (await this.viewsService.openViewContainer(VIEWLET_ID, true))?.getViewPaneContainer() as IExtensionsViewPaneContainer | undefined;
+		if (!viewPaneContainer) {
+			return;
+		}
 		viewPaneContainer.search(searchValue);
 		if (!preserveFoucs) {
 			viewPaneContainer.focus();


### PR DESCRIPTION
Fixes #310753

## What

Added an early-return guard in `ExtensionsWorkbenchService.openSearch` when `viewPaneContainer` is `undefined`.

## Why

`openViewContainer` returns `Promise<ViewContainer | undefined>` and the optional chain `?.getViewPaneContainer()` can produce `undefined` (e.g. when the Extensions view container cannot be shown in the current context). The original code cast the result directly to `IExtensionsViewPaneContainer` without guarding, causing:

```
TypeError: Cannot read properties of undefined (reading 'search')
    at S6.openSearch (extensionsWorkbenchService.ts:1616)
```

This appeared in telemetry across Windows, Mac, and Linux. The fix reflects the actual nullable type and returns early when the container is not available, matching the intent of the optional chain that was already on `openViewContainer`.

## Testing

- Existing unit tests in `src/vs/workbench/contrib/extensions/test/` continue to pass.
- The change is a defensive null-check with no behavioural change in the happy path.