### PR TITLE
revert: remove anthropic-beta header merge in Claude streaming endpoint

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -452,17 +452,7 @@ class ClaudeStreamingPassThroughEndpoint implements IChatEndpoint {
 		if (typeof this.requestHeaders['anthropic-beta'] === 'string') {
 			const filtered = filterSupportedBetas(this.requestHeaders['anthropic-beta']);
 			if (filtered) {
-				if (headers['anthropic-beta']) {
-					// Merge SDK's filtered betas with base endpoint's betas (e.g. config-driven
-					// context-management) instead of overwriting, deduplicating exact matches.
-					const allBetas = new Set([
-						...headers['anthropic-beta'].split(',').map(b => b.trim()),
-						...filtered.split(',').map(b => b.trim()),
-					]);
-					headers['anthropic-beta'] = [...allBetas].join(',');
-				} else {
-					headers['anthropic-beta'] = filtered;
-				}
+				headers['anthropic-beta'] = filtered;
 			}
 		}
 		return headers;


### PR DESCRIPTION
Reverts the `anthropic-beta` header merge logic added in microsoft/vscode-copilot-chat#4945.

## Why

Callers (e.g. the Claude agent) can now opt into Anthropic features — context editing, tool search, etc. — by setting `modelCapabilities` on the request itself.