### PR TITLE
feat(copilotcli): Support CLI todo via worker support

### DIFF
--- a/extensions/copilot/.esbuild.ts
+++ b/extensions/copilot/.esbuild.ts
@@ -184,6 +184,7 @@ const nodeExtHostBuildOptions = {
 		{ in: './src/platform/tokenizer/node/tikTokenizerWorker.ts', out: 'tikTokenizerWorker' },
 		{ in: './src/platform/diff/node/diffWorkerMain.ts', out: 'diffWorker' },
 		{ in: './src/platform/tfidf/node/tfidfWorker.ts', out: 'tfidfWorker' },
+		{ in: './src/extension/chatSessions/copilotcli/node/copilotCLITodoWorker.ts', out: 'copilotCLITodoWorker' },
 		{ in: './src/extension/onboardDebug/node/copilotDebugWorker/index.ts', out: 'copilotDebugCommand' },
 		{ in: './src/extension/chatSessions/vscode-node/copilotCLIShim.ts', out: 'copilotCLIShim' },
 		{ in: './src/test-extension.ts', out: 'test-extension' },

--- a/extensions/copilot/.vscodeignore
+++ b/extensions/copilot/.vscodeignore
@@ -13,6 +13,7 @@ assets/walkthroughs/**
 !dist/worker2.js
 !dist/tikTokenizerWorker.js
 !dist/diffWorker.js
+!dist/copilotCLITodoWorker.js
 !dist/webview.js
 !dist/copilotDebugCommand.js
 !dist/copilotCLIShim.js

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
@@ -1546,11 +1546,16 @@ function formatUpdateTodoInvocationCompleted(invocation: ChatToolInvocationPart,
 
 
 /**
- * Check whether a SQL query targets the `todos` or `todo_deps` table.
+ * Check whether a SQL query writes to the `todos` or `todo_deps` table.
+ * Pure reads (SELECT) are ignored to avoid unnecessary widget refreshes.
  */
 export function isTodoRelatedSqlQuery(query: string): boolean {
 	const normalized = query.replace(/\s+/g, ' ').toLowerCase();
-	return /\btodos\b/.test(normalized) || /\btodo_deps\b/.test(normalized);
+	const targetsTodoTable = /\btodos\b/.test(normalized) || /\btodo_deps\b/.test(normalized);
+	if (!targetsTodoTable) {
+		return false;
+	}
+	return /\b(insert|update|delete|create|drop|alter)\b/.test(normalized);
 }
 
 interface SqlTodoItem {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/copilotCLITools.ts
@@ -1545,30 +1545,51 @@ function formatUpdateTodoInvocationCompleted(invocation: ChatToolInvocationPart,
 }
 
 
-export async function updateTodoList(
-	event: ToolExecutionStartEvent,
+/**
+ * Check whether a SQL query targets the `todos` or `todo_deps` table.
+ */
+export function isTodoRelatedSqlQuery(query: string): boolean {
+	const normalized = query.replace(/\s+/g, ' ').toLowerCase();
+	return /\btodos\b/.test(normalized) || /\btodo_deps\b/.test(normalized);
+}
+
+interface SqlTodoItem {
+	readonly id: string;
+	readonly title: string;
+	readonly description: string;
+	readonly status: 'pending' | 'in_progress' | 'done' | 'blocked';
+}
+
+function mapSqlStatusToTodoStatus(status: string): 'not-started' | 'in-progress' | 'completed' {
+	switch (status) {
+		case 'done':
+			return 'completed';
+		case 'in_progress':
+			return 'in-progress';
+		case 'pending':
+		case 'blocked':
+		default:
+			return 'not-started';
+	}
+}
+
+/**
+ * Update the todo list widget from SQL todo items queried from the session database.
+ */
+export async function updateTodoListFromSqlItems(
+	items: readonly SqlTodoItem[],
 	toolsService: IToolsService,
 	toolInvocationToken: ChatParticipantToolToken,
 	token: CancellationToken
-) {
-	const toolData = event.data as ToolCall;
-
-	if (toolData.toolName !== 'update_todo' || !toolData.arguments.todos) {
-		return;
-	}
-	const { todoList } = parseTodoMarkdown(toolData.arguments.todos);
-	if (!todoList.length) {
-		return;
-	}
-
+): Promise<void> {
 	await toolsService.invokeTool(ToolName.CoreManageTodoList, {
 		input: {
 			operation: 'write',
-			todoList: todoList.map((item, i) => ({
+			todoList: items.map((item, i) => ({
 				id: i,
 				title: item.title,
-				description: '',
-				status: item.status
+				description: item.description || '',
+				status: mapSqlStatusToTodoStatus(item.status)
 			} satisfies IManageTodoListToolInputParams['todoList'][number])),
 		} satisfies IManageTodoListToolInputParams,
 		toolInvocationToken,

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/common/test/copilotCLITools.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/common/test/copilotCLITools.spec.ts
@@ -11,8 +11,9 @@ import { URI } from '../../../../../util/vs/base/common/uri';
 import {
 	ChatRequestTurn2, ChatResponseMarkdownPart, ChatResponsePullRequestPart, ChatResponseThinkingProgressPart, ChatResponseTurn2, ChatToolInvocationPart, MarkdownString
 } from '../../../../../vscodeTypes';
+import { CancellationToken } from '../../../../../util/vs/base/common/cancellation';
 import {
-	buildChatHistoryFromEvents, createCopilotCLIToolInvocation, enrichToolInvocationWithSubagentMetadata, extractCdPrefix, getAffectedUrisForEditTool, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, processToolExecutionComplete, processToolExecutionStart, RequestIdDetails, stripReminders, ToolCall
+	buildChatHistoryFromEvents, createCopilotCLIToolInvocation, enrichToolInvocationWithSubagentMetadata, extractCdPrefix, FakeToolsService, getAffectedUrisForEditTool, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, isTodoRelatedSqlQuery, processToolExecutionComplete, processToolExecutionStart, RequestIdDetails, stripReminders, ToolCall, updateTodoListFromSqlItems
 } from '../copilotCLITools';
 import { IChatDelegationSummaryService } from '../delegationSummaryService';
 
@@ -1172,6 +1173,118 @@ describe('CopilotCLITools', () => {
 			// grep tool at level 3 also resolves to root L0
 			const grep = toolParts.find(p => p.toolCallId === 'grep-1')!;
 			expect(grep.subAgentInvocationId).toBe('L0');
+		});
+	});
+
+	describe('isTodoRelatedSqlQuery', () => {
+		it('returns true for INSERT into todos', () => {
+			expect(isTodoRelatedSqlQuery('INSERT INTO todos (title, status) VALUES (\'task\', \'pending\')')).toBe(true);
+		});
+
+		it('returns true for UPDATE todos', () => {
+			expect(isTodoRelatedSqlQuery('UPDATE todos SET status = \'done\' WHERE id = 1')).toBe(true);
+		});
+
+		it('returns true for DELETE from todos', () => {
+			expect(isTodoRelatedSqlQuery('DELETE FROM todos WHERE id = 1')).toBe(true);
+		});
+
+		it('returns true for CREATE TABLE todos', () => {
+			expect(isTodoRelatedSqlQuery('CREATE TABLE todos (id INTEGER PRIMARY KEY, title TEXT)')).toBe(true);
+		});
+
+		it('returns true for queries targeting todo_deps table', () => {
+			expect(isTodoRelatedSqlQuery('INSERT INTO todo_deps (todo_id, dep_id) VALUES (1, 2)')).toBe(true);
+		});
+
+		it('returns false for SELECT-only queries on todos', () => {
+			expect(isTodoRelatedSqlQuery('SELECT * FROM todos')).toBe(false);
+		});
+
+		it('returns false for queries not targeting todos or todo_deps', () => {
+			expect(isTodoRelatedSqlQuery('INSERT INTO tasks (title) VALUES (\'task\')')).toBe(false);
+		});
+
+		it('returns false for empty query', () => {
+			expect(isTodoRelatedSqlQuery('')).toBe(false);
+		});
+
+		it('is case insensitive', () => {
+			expect(isTodoRelatedSqlQuery('INSERT INTO TODOS (title) VALUES (\'task\')')).toBe(true);
+		});
+
+		it('handles multiline queries', () => {
+			expect(isTodoRelatedSqlQuery('INSERT INTO\n  todos\n  (title) VALUES (\'task\')')).toBe(true);
+		});
+
+		it('returns true for DROP TABLE todos', () => {
+			expect(isTodoRelatedSqlQuery('DROP TABLE todos')).toBe(true);
+		});
+
+		it('returns true for ALTER TABLE todo_deps', () => {
+			expect(isTodoRelatedSqlQuery('ALTER TABLE todo_deps ADD COLUMN priority INTEGER')).toBe(true);
+		});
+	});
+
+	describe('updateTodoListFromSqlItems', () => {
+		it('invokes the manage_todo_list tool with mapped items', async () => {
+			const toolsService = new FakeToolsService();
+
+			await updateTodoListFromSqlItems(
+				[
+					{ id: '1', title: 'First task', description: 'desc1', status: 'pending' },
+					{ id: '2', title: 'Second task', description: 'desc2', status: 'in_progress' },
+					{ id: '3', title: 'Third task', description: '', status: 'done' },
+					{ id: '4', title: 'Fourth task', description: 'blocked desc', status: 'blocked' },
+				],
+				toolsService,
+				undefined as never,
+				CancellationToken.None,
+			);
+
+			expect(toolsService.invokeToolCalls).toHaveLength(1);
+			expect(toolsService.invokeToolCalls[0].name).toBe('manage_todo_list');
+			expect(toolsService.invokeToolCalls[0].input).toEqual({
+				operation: 'write',
+				todoList: [
+					{ id: 0, title: 'First task', description: 'desc1', status: 'not-started' },
+					{ id: 1, title: 'Second task', description: 'desc2', status: 'in-progress' },
+					{ id: 2, title: 'Third task', description: '', status: 'completed' },
+					{ id: 3, title: 'Fourth task', description: 'blocked desc', status: 'not-started' },
+				],
+			});
+		});
+
+		it('maps unknown status to not-started', async () => {
+			const toolsService = new FakeToolsService();
+
+			await updateTodoListFromSqlItems(
+				[{ id: '1', title: 'task', description: '', status: 'unknown_status' as never }],
+				toolsService,
+				undefined as never,
+				CancellationToken.None,
+			);
+
+			const input = toolsService.invokeToolCalls[0].input as { todoList: { status: string }[] };
+			expect(input.todoList[0].status).toBe('not-started');
+		});
+
+		it('uses sequential ids starting from 0', async () => {
+			const toolsService = new FakeToolsService();
+
+			await updateTodoListFromSqlItems(
+				[
+					{ id: '100', title: 'a', description: '', status: 'pending' },
+					{ id: '200', title: 'b', description: '', status: 'done' },
+				],
+				toolsService,
+				undefined as never,
+				CancellationToken.None,
+			);
+
+			const input = toolsService.invokeToolCalls[0].input as { todoList: { id: number }[] };
+			expect(input.todoList[0].id).toBe(0);
+			expect(input.todoList[1].id).toBe(1);
 		});
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCLITodoWorker.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCLITodoWorker.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { existsSync } from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 import { parentPort } from 'worker_threads';
 import { RcpResponseHandler, RpcRequest, RpcResponse } from '../../../../util/node/worker';
@@ -43,9 +44,13 @@ function handleRequest(fn: string, args: unknown[]): unknown {
 }
 
 function queryTodos(dbPath: string): TodoItem[] {
+	if (!existsSync(dbPath)) {
+		return [];
+	}
 	let db: DatabaseSync | undefined;
 	try {
 		db = new DatabaseSync(dbPath, { open: true });
+		db.exec('PRAGMA busy_timeout = 2000');
 		// Check if the todos table exists
 		const tableCheck = db.prepare(
 			'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'todos\''

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCLITodoWorker.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCLITodoWorker.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DatabaseSync } from 'node:sqlite';
+import { parentPort } from 'worker_threads';
+import { RcpResponseHandler, RpcRequest, RpcResponse } from '../../../../util/node/worker';
+
+export interface TodoItem {
+	id: string;
+	title: string;
+	description: string;
+	status: 'pending' | 'in_progress' | 'done' | 'blocked';
+}
+
+export interface TodoSqlWorkerApi {
+	queryTodos(dbPath: string): TodoItem[];
+}
+
+const responseHandler = new RcpResponseHandler();
+
+parentPort!.on('message', (msg: RpcRequest | RpcResponse) => {
+	if ('fn' in msg) {
+		try {
+			const result = handleRequest(msg.fn, msg.args);
+			parentPort!.postMessage({ id: msg.id, res: result } satisfies RpcResponse);
+		} catch (err) {
+			parentPort!.postMessage({ id: msg.id, err } satisfies RpcResponse);
+		}
+	} else {
+		responseHandler.handleResponse(msg);
+	}
+});
+
+function handleRequest(fn: string, args: unknown[]): unknown {
+	switch (fn) {
+		case 'queryTodos':
+			return queryTodos(args[0] as string);
+		default:
+			throw new Error(`Unknown function: ${fn}`);
+	}
+}
+
+function queryTodos(dbPath: string): TodoItem[] {
+	let db: DatabaseSync | undefined;
+	try {
+		db = new DatabaseSync(dbPath, { open: true });
+		// Check if the todos table exists
+		const tableCheck = db.prepare(
+			'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'todos\''
+		);
+		const tables = tableCheck.all() as Record<string, unknown>[];
+		if (tables.length === 0) {
+			return [];
+		}
+
+		const stmt = db.prepare('SELECT id, title, description, status FROM todos ORDER BY created_at ASC');
+		const rows = stmt.all() as Record<string, unknown>[];
+		return rows.map(row => ({
+			id: String(row.id ?? ''),
+			title: String(row.title ?? ''),
+			description: String(row.description ?? ''),
+			status: String(row.status ?? 'pending') as TodoItem['status'],
+		}));
+	} finally {
+		db?.close();
+	}
+}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -704,11 +704,9 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 								if (token.isCancellationRequested) {
 									return;
 								}
-								if (items.length > 0) {
-									return updateTodoListFromSqlItems(items, this._toolsService, request.toolInvocationToken, token);
-								}
+								return updateTodoListFromSqlItems(items, this._toolsService, request.toolInvocationToken, token);
 							}).catch(err => {
-								this.logService.error(`[CopilotCLISession] Failed to query todos from session database`, err);
+								this.logService.error(err, '[CopilotCLISession] Failed to query todos from session database');
 							});
 						}
 					} catch (ex) {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -692,21 +692,27 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				const result = event.data.result ? `result: ${event.data.result?.content}` : '';
 				const parts = [success, error, result].filter(part => part.length > 0).join(', ');
 
-
 				// When a sql tool execution completes that modifies the todos table,
 				// query the session database and update the todo list widget.
 				if (toolName === 'sql' && event.data.success) {
 					const toolCallData = toolCalls.get(event.data.toolCallId);
-					const query = (toolCallData?.arguments as { query?: string } | undefined)?.query ?? '';
-					if (isTodoRelatedSqlQuery(query)) {
-						const sessionDir = getCopilotCLISessionDir(this.sessionId);
-						this._todoSqlQuery.queryTodos(sessionDir).then(items => {
-							if (items.length > 0) {
-								return updateTodoListFromSqlItems(items, this._toolsService, request.toolInvocationToken, token);
-							}
-						}).catch(err => {
-							this.logService.error(`[CopilotCLISession] Failed to query todos from session database`, err);
-						});
+					try {
+						const query = (toolCallData?.arguments as { query?: string } | undefined)?.query ?? '';
+						if (isTodoRelatedSqlQuery(query)) {
+							const sessionDir = getCopilotCLISessionDir(this.sessionId);
+							this._todoSqlQuery.queryTodos(sessionDir).then(items => {
+								if (token.isCancellationRequested) {
+									return;
+								}
+								if (items.length > 0) {
+									return updateTodoListFromSqlItems(items, this._toolsService, request.toolInvocationToken, token);
+								}
+							}).catch(err => {
+								this.logService.error(`[CopilotCLISession] Failed to query todos from session database`, err);
+							});
+						}
+					} catch (ex) {
+						this.logService.error(ex, `[CopilotCLISession] Failed to process completed sql tool call for todos`);
 					}
 				}
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -29,12 +29,14 @@ import { IToolsService } from '../../../tools/common/toolsService';
 import { IChatSessionMetadataStore } from '../../common/chatSessionMetadataStore';
 import { ExternalEditTracker } from '../../common/externalEditTracker';
 import { getWorkingDirectory, isIsolationEnabled, IWorkspaceInfo } from '../../common/workspaceInfo';
-import { enrichToolInvocationWithSubagentMetadata, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, processToolExecutionComplete, processToolExecutionStart, ToolCall, updateTodoList } from '../common/copilotCLITools';
+import { enrichToolInvocationWithSubagentMetadata, isCopilotCliEditToolCall, isCopilotCLIToolThatCouldRequirePermissions, isTodoRelatedSqlQuery, processToolExecutionComplete, processToolExecutionStart, ToolCall, updateTodoListFromSqlItems } from '../common/copilotCLITools';
 import { SessionIdForCLI } from '../common/utils';
+import { getCopilotCLISessionDir } from './cliHelpers';
 import type { CopilotCliBridgeSpanProcessor } from './copilotCliBridgeSpanProcessor';
 import { ICopilotCLIImageSupport } from './copilotCLIImageSupport';
 import { handleExitPlanMode } from './exitPlanModeHandler';
 import { handleMcpPermission, handleReadPermission, handleShellPermission, handleWritePermission, type PermissionRequest, type PermissionRequestResult, showInteractivePermissionPrompt } from './permissionHelpers';
+import { TodoSqlQuery } from './todoSqlQuery';
 import { IQuestion, IUserQuestionHandler } from './userInputHelpers';
 
 /**
@@ -142,6 +144,8 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	private _permissionLevel: string | undefined;
 	private _pendingPrompt: string | undefined;
 	private _bridgeProcessor: CopilotCliBridgeSpanProcessor | undefined;
+	private readonly _todoSqlQuery = new TodoSqlQuery();
+
 	/** Callback to propagate trace context to the SDK's OtelLifecycle. */
 	private _updateSdkTraceContext: ((traceparent?: string, tracestate?: string) => void) | undefined;
 	public get pendingPrompt(): string | undefined {
@@ -176,6 +180,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 	) {
 		super();
 		this.sessionId = _sdkSession.sessionId;
+		this.add(toDisposable(() => this._todoSqlQuery.dispose()));
 		this._sessionResource = SessionIdForCLI.getResource(this.sessionId);
 	}
 
@@ -646,12 +651,6 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 							flushPendingInvocationMessages();
 							this._stream?.push(responsePart);
 						}
-
-						if ((event.data as ToolCall).toolName === 'update_todo') {
-							updateTodoList(event, this._toolsService, request.toolInvocationToken, token).catch(error => {
-								this.logService.error(`[CopilotCLISession] Failed to invoke todo tool for toolCallId ${event.data.toolCallId}`, error);
-							});
-						}
 					}
 				}
 				this.logService.trace(`[CopilotCLISession] Start Tool ${event.data.toolName || '<unknown>'}`);
@@ -692,6 +691,24 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				const error = event.data.error ? `error: ${event.data.error.code},${event.data.error.message}` : '';
 				const result = event.data.result ? `result: ${event.data.result?.content}` : '';
 				const parts = [success, error, result].filter(part => part.length > 0).join(', ');
+
+
+				// When a sql tool execution completes that modifies the todos table,
+				// query the session database and update the todo list widget.
+				if (toolName === 'sql' && event.data.success) {
+					const toolCallData = toolCalls.get(event.data.toolCallId);
+					const query = (toolCallData?.arguments as { query?: string } | undefined)?.query ?? '';
+					if (isTodoRelatedSqlQuery(query)) {
+						const sessionDir = getCopilotCLISessionDir(this.sessionId);
+						this._todoSqlQuery.queryTodos(sessionDir).then(items => {
+							if (items.length > 0) {
+								return updateTodoListFromSqlItems(items, this._toolsService, request.toolInvocationToken, token);
+							}
+						}).catch(err => {
+							this.logService.error(`[CopilotCLISession] Failed to query todos from session database`, err);
+						});
+					}
+				}
 
 				this.logService.trace(`[CopilotCLISession]Complete Tool ${toolName}, ${parts}`);
 			})));

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/todoSqlQuery.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/todoSqlQuery.spec.ts
@@ -40,7 +40,7 @@ describe('TodoSqlQuery', () => {
 	it('queryTodos passes the correct database path to the worker', async () => {
 		mockQueryTodos.mockResolvedValue([]);
 		await query.queryTodos('/some/session/dir');
-		expect(mockQueryTodos).toHaveBeenCalledWith(expect.stringContaining('/some/session/dir/session.db'));
+		expect(mockQueryTodos).toHaveBeenCalledWith(expect.stringMatching(/[\\/]some[\\/]session[\\/]dir[\\/]session\.db$/));
 	});
 
 	it('queryTodos returns items from the worker', async () => {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/todoSqlQuery.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/todoSqlQuery.spec.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface TodoItem {
+	id: string;
+	title: string;
+	description: string;
+	status: 'pending' | 'in_progress' | 'done' | 'blocked';
+}
+
+const mockQueryTodos = vi.fn<(dbPath: string) => Promise<TodoItem[]>>();
+const mockTerminate = vi.fn();
+
+vi.mock('../../../../../util/node/worker', () => ({
+	WorkerWithRpcProxy: class {
+		proxy = { queryTodos: mockQueryTodos };
+		terminate = mockTerminate;
+	},
+}));
+
+// Import after mock so the mock is in place
+const { TodoSqlQuery } = await import('../todoSqlQuery');
+
+describe('TodoSqlQuery', () => {
+	let query: InstanceType<typeof TodoSqlQuery>;
+
+	beforeEach(() => {
+		query = new TodoSqlQuery();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		query.dispose();
+	});
+
+	it('queryTodos passes the correct database path to the worker', async () => {
+		mockQueryTodos.mockResolvedValue([]);
+		await query.queryTodos('/some/session/dir');
+		expect(mockQueryTodos).toHaveBeenCalledWith(expect.stringContaining('/some/session/dir/session.db'));
+	});
+
+	it('queryTodos returns items from the worker', async () => {
+		const items: TodoItem[] = [
+			{ id: '1', title: 'Task 1', description: '', status: 'pending' },
+			{ id: '2', title: 'Task 2', description: 'desc', status: 'done' },
+		];
+		mockQueryTodos.mockResolvedValue(items);
+		const result = await query.queryTodos('/session/dir');
+		expect(result).toEqual(items);
+	});
+
+	it('reuses the same worker across multiple queries', async () => {
+		mockQueryTodos.mockResolvedValue([]);
+		await query.queryTodos('/dir1');
+		await query.queryTodos('/dir2');
+		// The worker constructor is called once (lazy init), proxy is reused
+		expect(mockQueryTodos).toHaveBeenCalledTimes(2);
+	});
+
+	it('dispose terminates the worker', () => {
+		// Force worker creation by calling queryTodos
+		mockQueryTodos.mockResolvedValue([]);
+		void query.queryTodos('/dir');
+		query.dispose();
+		expect(mockTerminate).toHaveBeenCalledOnce();
+	});
+
+	it('dispose is safe to call when worker was never created', () => {
+		// Should not throw
+		query.dispose();
+		expect(mockTerminate).not.toHaveBeenCalled();
+	});
+
+	it('dispose is safe to call multiple times', () => {
+		mockQueryTodos.mockResolvedValue([]);
+		void query.queryTodos('/dir');
+		query.dispose();
+		query.dispose();
+		// Only one terminate call since the second dispose finds no worker
+		expect(mockTerminate).toHaveBeenCalledOnce();
+	});
+});

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/todoSqlQuery.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/todoSqlQuery.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { RpcProxy, WorkerWithRpcProxy } from '../../../../util/node/worker';
+import type { TodoItem, TodoSqlWorkerApi } from './copilotCLITodoWorker';
+
+const DATABASE_FILENAME = 'session.db';
+
+/**
+ * Queries the session SQLite database for todo items using a worker thread
+ * to avoid blocking the extension host with synchronous I/O.
+ *
+ * The worker is created lazily on first use and reused for subsequent queries.
+ * Call {@link dispose} to terminate the worker when no longer needed.
+ */
+export class TodoSqlQuery {
+	private _worker: WorkerWithRpcProxy<TodoSqlWorkerApi> | undefined;
+	private _proxy: RpcProxy<TodoSqlWorkerApi> | undefined;
+
+	private ensureWorker(): RpcProxy<TodoSqlWorkerApi> {
+		if (!this._proxy) {
+			this._worker = new WorkerWithRpcProxy<TodoSqlWorkerApi>(
+				join(__dirname, 'copilotCLITodoWorker.js')
+			);
+			this._proxy = this._worker.proxy;
+		}
+		return this._proxy;
+	}
+
+	/**
+	 * Query todos from the session database.
+	 * @param sessionDir - The session state directory (e.g. ~/.copilot/session-state/{session-id})
+	 * @returns Array of todo items, or empty array if database or table doesn't exist
+	 */
+	async queryTodos(sessionDir: string): Promise<TodoItem[]> {
+		const dbPath = join(sessionDir, DATABASE_FILENAME);
+		const proxy = this.ensureWorker();
+		return proxy.queryTodos(dbPath);
+	}
+
+	dispose(): void {
+		this._worker?.terminate();
+		this._worker = undefined;
+		this._proxy = undefined;
+	}
+}
+
+export type { TodoItem };

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/todoSqlQuery.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/todoSqlQuery.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { RpcProxy, WorkerWithRpcProxy } from '../../../../util/node/worker';
+import { WorkerWithRpcProxy, type RpcProxy } from '../../../../util/node/worker';
 import type { TodoItem, TodoSqlWorkerApi } from './copilotCLITodoWorker';
 
 const DATABASE_FILENAME = 'session.db';


### PR DESCRIPTION
## Summary

Adds CLI todo support via a dedicated worker for the Copilot CLI session.

### Changes
- Add todo SQL query utilities (`todoSqlQuery.ts`)
- Add dedicated CLI todo worker (`copilotCLITodoWorker.ts`)
- Extend CLI tools with todo support (`copilotCLITools.ts`)
- Update CLI session to integrate worker (`copilotcliSession.ts`)
- Add esbuild config and vscodeignore entries for the worker
- Add tests for todo SQL queries and CLI tools