### PR TITLE
chat: have register*Actions return DisposableStore

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -53,15 +53,17 @@ import { registerPromptActions } from '../promptSyntax/promptFileActions.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 import { registerCreatePluginAction } from './createPluginAction.js';
 
-export function registerChatContextActions() {
-	registerAction2(AttachContextAction);
-	registerAction2(AttachFileToChatAction);
-	registerAction2(AttachFolderToChatAction);
-	registerAction2(AttachSelectionToChatAction);
-	registerAction2(AttachSearchResultAction);
-	registerAction2(AttachPinnedEditorsToChatAction);
-	registerPromptActions();
-	registerCreatePluginAction();
+export function registerChatContextActions(): DisposableStore {
+	const store = new DisposableStore();
+	store.add(registerAction2(AttachContextAction));
+	store.add(registerAction2(AttachFileToChatAction));
+	store.add(registerAction2(AttachFolderToChatAction));
+	store.add(registerAction2(AttachSelectionToChatAction));
+	store.add(registerAction2(AttachSearchResultAction));
+	store.add(registerAction2(AttachPinnedEditorsToChatAction));
+	store.add(registerCreatePluginAction());
+	registerPromptActions(); // TODO@jrieken: should also return a DisposableStore
+	return store;
 }
 
 async function withChatView(accessor: ServicesAccessor): Promise<IChatWidget | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -5,6 +5,7 @@
 
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { basename } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { assertType } from '../../../../../base/common/types.js';
@@ -1161,24 +1162,26 @@ class ExecuteHandoffAction extends Action2 {
 }
 
 
-export function registerChatExecuteActions() {
-	registerAction2(ChatSubmitAction);
-	registerAction2(ChatEditingSessionSubmitAction);
-	registerAction2(SubmitWithoutDispatchingAction);
-	registerAction2(CancelAction);
-	registerAction2(SendToNewChatAction);
-	registerAction2(ChatSubmitWithCodebaseAction);
-	registerAction2(ToggleChatModeAction);
-	registerAction2(SwitchToNextModelAction);
-	registerAction2(OpenModelPickerAction);
-	registerAction2(OpenPermissionPickerAction);
-	registerAction2(OpenModePickerAction);
-	registerAction2(OpenSessionTargetPickerAction);
-	registerAction2(OpenDelegationPickerAction);
-	registerAction2(OpenWorkspacePickerAction);
-	registerAction2(ChatSessionPrimaryPickerAction);
-	registerAction2(ChangeChatModelAction);
-	registerAction2(CancelEdit);
-	registerAction2(GetHandoffsAction);
-	registerAction2(ExecuteHandoffAction);
+export function registerChatExecuteActions(): DisposableStore {
+	const store = new DisposableStore();
+	store.add(registerAction2(ChatSubmitAction));
+	store.add(registerAction2(ChatEditingSessionSubmitAction));
+	store.add(registerAction2(SubmitWithoutDispatchingAction));
+	store.add(registerAction2(CancelAction));
+	store.add(registerAction2(SendToNewChatAction));
+	store.add(registerAction2(ChatSubmitWithCodebaseAction));
+	store.add(registerAction2(ToggleChatModeAction));
+	store.add(registerAction2(SwitchToNextModelAction));
+	store.add(registerAction2(OpenModelPickerAction));
+	store.add(registerAction2(OpenPermissionPickerAction));
+	store.add(registerAction2(OpenModePickerAction));
+	store.add(registerAction2(OpenSessionTargetPickerAction));
+	store.add(registerAction2(OpenDelegationPickerAction));
+	store.add(registerAction2(OpenWorkspacePickerAction));
+	store.add(registerAction2(ChatSessionPrimaryPickerAction));
+	store.add(registerAction2(ChangeChatModelAction));
+	store.add(registerAction2(CancelEdit));
+	store.add(registerAction2(GetHandoffsAction));
+	store.add(registerAction2(ExecuteHandoffAction));
+	return store;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -7,6 +7,7 @@ import { CancellationTokenSource } from '../../../../../base/common/cancellation
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
@@ -234,8 +235,10 @@ export class ConfigureToolsAction extends Action2 {
 	}
 }
 
-export function registerChatToolActions() {
-	registerAction2(AcceptToolConfirmation);
-	registerAction2(SkipToolConfirmation);
-	registerAction2(ConfigureToolsAction);
+export function registerChatToolActions(): DisposableStore {
+	const store = new DisposableStore();
+	store.add(registerAction2(AcceptToolConfirmation));
+	store.add(registerAction2(SkipToolConfirmation));
+	store.add(registerAction2(ConfigureToolsAction));
+	return store;
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/createPluginAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/createPluginAction.ts
@@ -583,6 +583,8 @@ export async function updateMarketplaceIfNeeded(fileService: IFileService, targe
 	}
 }
 
-export function registerCreatePluginAction(): void {
-	registerAction2(CreatePluginAction);
+export function registerCreatePluginAction(): DisposableStore {
+	const store = new DisposableStore();
+	store.add(registerAction2(CreatePluginAction));
+	return store;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatExecuteActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatExecuteActions.test.ts
@@ -47,12 +47,18 @@ function createMockMode(overrides: Partial<IChatMode> & { id: string; kind: Chat
 	} as IChatMode;
 }
 
-// Register once at module level so disposables are created before suite tracking begins
-registerChatExecuteActions();
-
 suite('GetHandoffsAction', () => {
 	const store = new DisposableStore();
 	let instantiationService: TestInstantiationService;
+
+	let chatExecuteActions: DisposableStore;
+	suiteSetup(() => {
+		chatExecuteActions = registerChatExecuteActions();
+	});
+
+	suiteTeardown(() => {
+		chatExecuteActions.dispose();
+	});
 
 	setup(() => {
 		instantiationService = store.add(new TestInstantiationService());
@@ -124,6 +130,15 @@ suite('GetHandoffsAction', () => {
 suite('ExecuteHandoffAction', () => {
 	const store = new DisposableStore();
 	let instantiationService: TestInstantiationService;
+
+	let chatExecuteActions: DisposableStore;
+	suiteSetup(() => {
+		chatExecuteActions = registerChatExecuteActions();
+	});
+
+	suiteTeardown(() => {
+		chatExecuteActions.dispose();
+	});
 
 	setup(() => {
 		instantiationService = store.add(new TestInstantiationService());

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatZoneMenus.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatZoneMenus.test.ts
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { isIMenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import {
+	KeepSessionAction2,
+	UndoSessionAction2,
+	UndoAndCloseSessionAction2,
+	CancelSessionAction,
+	ContinueInlineChatInChatViewAction,
+	RephraseInlineChatSessionAction,
+} from '../../browser/inlineChatActions.js';
+import { registerChatExecuteActions } from '../../../chat/browser/actions/chatExecuteActions.js';
+import { registerChatContextActions } from '../../../chat/browser/actions/chatContextActions.js';
+import { registerChatToolActions } from '../../../chat/browser/actions/chatToolActions.js';
+
+/**
+ * The inline chat zone widget hosts four menus: `ChatEditorInlineExecute`,
+ * `ChatEditorInlineInputSide`, `ChatInput`, and `ChatExecute`. The latter
+ * two are shared with the regular chat widget, which evolves frequently.
+ *
+ * These snapshot tests guard against accidental additions, removals, or `when`
+ * changes that would silently affect the inline chat zone widget toolbars.
+ * When a snapshot fails, double-check that the change is intentional for the
+ * inline chat zone widget specifically and update the snapshot.
+ */
+suite('Inline chat zone widget — menu contributions', function () {
+
+	const disposables = new DisposableStore();
+
+	suiteSetup(() => {
+		// Register every action whose menu items can appear in the inline chat
+		// zone widget. We only call the public registration helpers so that
+		// adding a new action to one of those helpers will surface here.
+		disposables.add(registerChatExecuteActions());
+		disposables.add(registerChatContextActions());
+		disposables.add(registerChatToolActions());
+
+		disposables.add(registerAction2(KeepSessionAction2));
+		disposables.add(registerAction2(UndoSessionAction2));
+		disposables.add(registerAction2(UndoAndCloseSessionAction2));
+		disposables.add(registerAction2(CancelSessionAction));
+		disposables.add(registerAction2(ContinueInlineChatInChatViewAction));
+		disposables.add(registerAction2(RephraseInlineChatSessionAction));
+	});
+
+	suiteTeardown(() => {
+		disposables.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function snapshot(menuId: MenuId): Array<{ id: string; group: string; order: number; when: string }> {
+		return MenuRegistry.getMenuItems(menuId)
+			.filter(isIMenuItem)
+			.map(item => ({
+				id: item.command.id,
+				group: item.group ?? '',
+				order: item.order ?? 0,
+				when: item.when?.serialize() ?? '',
+			}))
+			.sort((a, b) => a.id.localeCompare(b.id) || a.group.localeCompare(b.group) || a.order - b.order);
+	}
+
+	test('ChatEditorInlineExecute', () => {
+		assert.deepStrictEqual(snapshot(MenuId.ChatEditorInlineExecute), [
+			{
+				id: 'inlineChat2.cancel',
+				group: 'navigation',
+				order: 100,
+				when: 'chatEdits.isRequestInProgress && inlineChatHasEditsAgent && config.inlineChat.renderMode == \'hover\' || chatEdits.isRequestInProgress && inlineChatHasNotebookAgent && activeEditor == \'workbench.editor.notebook\' && config.inlineChat.renderMode == \'hover\'',
+			},
+			{
+				id: 'inlineChat2.close',
+				group: 'navigation',
+				order: 100,
+				when: 'inlineChatHasEditsAgent && config.inlineChat.renderMode != \'hover\' || inlineChatHasEditsAgent && inlineChatPendingConfirmation && config.inlineChat.renderMode == \'hover\' || inlineChatHasNotebookAgent && activeEditor == \'workbench.editor.notebook\' && config.inlineChat.renderMode != \'hover\' || inlineChatHasEditsAgent && !chatEdits.hasEditorModifications && !chatEdits.isRequestInProgress && config.inlineChat.renderMode == \'hover\' || inlineChatHasNotebookAgent && inlineChatPendingConfirmation && activeEditor == \'workbench.editor.notebook\' && config.inlineChat.renderMode == \'hover\' || inlineChatHasNotebookAgent && !chatEdits.hasEditorModifications && !chatEdits.isRequestInProgress && activeEditor == \'workbench.editor.notebook\' && config.inlineChat.renderMode == \'hover\'',
+			},
+			{
+				id: 'inlineChat2.continueInChat',
+				group: 'navigation',
+				order: 2,
+				when: 'inlineChatHasEditsAgent && inlineChatTerminated || inlineChatHasNotebookAgent && inlineChatTerminated && activeEditor == \'workbench.editor.notebook\'',
+			},
+			{
+				id: 'inlineChat2.keep',
+				group: 'navigation',
+				order: 4,
+				when: 'chatEdits.hasEditorModifications && inlineChatHasEditsAgent && !chatEdits.isRequestInProgress && !chatInputHasText || chatEdits.hasEditorModifications && inlineChatHasNotebookAgent && !chatEdits.isRequestInProgress && !chatInputHasText && activeEditor == \'workbench.editor.notebook\'',
+			},
+			{
+				id: 'inlineChat2.rephrase',
+				group: 'navigation',
+				order: 1,
+				when: 'inlineChatHasEditsAgent && inlineChatTerminated || inlineChatHasNotebookAgent && inlineChatTerminated && activeEditor == \'workbench.editor.notebook\'',
+			},
+			{
+				id: 'inlineChat2.undo',
+				group: 'navigation',
+				order: 100,
+				when: 'chatEdits.hasEditorModifications && inlineChatHasEditsAgent && !chatEdits.isRequestInProgress && config.inlineChat.renderMode == \'hover\' || chatEdits.hasEditorModifications && inlineChatHasNotebookAgent && !chatEdits.isRequestInProgress && activeEditor == \'workbench.editor.notebook\' && config.inlineChat.renderMode == \'hover\'',
+			},
+			{
+				id: 'workbench.action.chat.cancel',
+				group: 'navigation',
+				order: 4,
+				when: 'chatEdits.isRequestInProgress && !chatEdits.isGlobalEditingSession && config.inlineChat.renderMode != \'hover\'',
+			},
+			{
+				id: 'workbench.action.chat.submit',
+				group: 'navigation',
+				order: 4,
+				when: 'chatInputHasText && !chatSessionHasActiveRequest && chatAgentKind == \'ask\' || !chatEdits.hasEditorModifications && !chatSessionHasActiveRequest && chatAgentKind == \'ask\'',
+			},
+		]);
+	});
+
+	test('ChatEditorInlineInputSide', () => {
+		// This menu is inline-chat-zone-widget specific. Any item appearing
+		// here must be deliberately scoped to the inline chat zone widget.
+		assert.deepStrictEqual(snapshot(MenuId.ChatEditorInlineInputSide), []);
+	});
+
+	test('ChatInput', () => {
+		// This menu is shared with the regular chat widget. The inline chat
+		// zone widget renders these as the attachment/picker row below the
+		// input. Any new item here will appear in inline chat too.
+		assert.deepStrictEqual(snapshot(MenuId.ChatInput), [
+			{
+				id: 'workbench.action.chat.attachContext',
+				group: 'navigation',
+				order: -1,
+				when: 'agentSupportsAttachments && !quickChatHasFocus && chatLocation == \'panel\' || !lockedToCodingAgent && !quickChatHasFocus && chatLocation == \'panel\'',
+			},
+			{
+				id: 'workbench.action.chat.attachContext',
+				group: 'navigation',
+				order: 2,
+				when: 'agentSupportsAttachments && inlineChatHasEditsAgent && !quickChatHasFocus && chatLocation == \'editor\' || inlineChatHasEditsAgent && !lockedToCodingAgent && !quickChatHasFocus && chatLocation == \'editor\' || agentSupportsAttachments && inlineChatHasNotebookAgent && !quickChatHasFocus && activeEditor == \'workbench.editor.notebook\' && chatLocation == \'editor\' || inlineChatHasNotebookAgent && !lockedToCodingAgent && !quickChatHasFocus && activeEditor == \'workbench.editor.notebook\' && chatLocation == \'editor\'',
+			},
+			{
+				id: 'workbench.action.chat.chatSessionPrimaryPicker',
+				group: 'navigation',
+				order: 4,
+				when: 'chatSessionHasModels && lockedToCodingAgent || chatSessionHasModels && inAgentSessionsWelcome && chatSessionType != \'local\'',
+			},
+			{
+				id: 'workbench.action.chat.configureTools',
+				group: 'navigation',
+				order: 100,
+				when: '!lockedToCodingAgent && chatAgentKind == \'agent\'',
+			},
+			{
+				id: 'workbench.action.chat.openModelPicker',
+				group: 'navigation',
+				order: 3,
+				when: 'chatSessionHasTargetedModels && chatLocation == \'editor\' || chatSessionHasTargetedModels && chatLocation == \'notebook\' || chatSessionHasTargetedModels && chatLocation == \'panel\' || chatSessionHasTargetedModels && chatLocation == \'terminal\' || chatSessionHasTargetedModels && !inAgentSessionsWelcome && chatLocation == \'editor\' || chatSessionHasTargetedModels && !inAgentSessionsWelcome && chatLocation == \'notebook\' || chatSessionHasTargetedModels && !inAgentSessionsWelcome && chatLocation == \'panel\' || chatSessionHasTargetedModels && !inAgentSessionsWelcome && chatLocation == \'terminal\' || chatSessionHasTargetedModels && !lockedToCodingAgent && chatLocation == \'editor\' || chatSessionHasTargetedModels && !lockedToCodingAgent && chatLocation == \'notebook\' || chatSessionHasTargetedModels && !lockedToCodingAgent && chatLocation == \'panel\' || chatSessionHasTargetedModels && !lockedToCodingAgent && chatLocation == \'terminal\' || chatSessionHasTargetedModels && chatLocation == \'editor\' && chatSessionType == \'local\' || chatSessionHasTargetedModels && chatLocation == \'notebook\' && chatSessionType == \'local\' || chatSessionHasTargetedModels && chatLocation == \'panel\' && chatSessionType == \'local\' || chatSessionHasTargetedModels && chatLocation == \'terminal\' && chatSessionType == \'local\' || !inAgentSessionsWelcome && !lockedToCodingAgent && chatLocation == \'editor\' || !inAgentSessionsWelcome && !lockedToCodingAgent && chatLocation == \'notebook\' || !inAgentSessionsWelcome && !lockedToCodingAgent && chatLocation == \'panel\' || !inAgentSessionsWelcome && !lockedToCodingAgent && chatLocation == \'terminal\' || !lockedToCodingAgent && chatLocation == \'editor\' && chatSessionType == \'local\' || !lockedToCodingAgent && chatLocation == \'notebook\' && chatSessionType == \'local\' || !lockedToCodingAgent && chatLocation == \'panel\' && chatSessionType == \'local\' || !lockedToCodingAgent && chatLocation == \'terminal\' && chatSessionType == \'local\'',
+			},
+			{
+				id: 'workbench.action.chat.openModePicker',
+				group: 'navigation',
+				order: 1,
+				when: 'chatIsEnabled && chatSessionHasCustomAgentTarget && !quickChatHasFocus && chatLocation == \'panel\' || chatIsEnabled && chatSessionHasCustomAgentTarget && !inAgentSessionsWelcome && !quickChatHasFocus && chatLocation == \'panel\' || chatIsEnabled && chatSessionHasCustomAgentTarget && !lockedToCodingAgent && !quickChatHasFocus && chatLocation == \'panel\' || chatIsEnabled && chatSessionHasCustomAgentTarget && !quickChatHasFocus && chatLocation == \'panel\' && chatSessionType == \'local\' || chatIsEnabled && !inAgentSessionsWelcome && !lockedToCodingAgent && !quickChatHasFocus && chatLocation == \'panel\' || chatIsEnabled && !lockedToCodingAgent && !quickChatHasFocus && chatLocation == \'panel\' && chatSessionType == \'local\'',
+			},
+			{
+				id: 'workbench.action.chat.openSessionTargetPicker',
+				group: 'navigation',
+				order: 0,
+				when: 'chatIsEnabled && chatSessionIsEmpty && isSessionsWindow && !quickChatHasFocus && chatLocation == \'panel\'',
+			},
+			{
+				id: 'workbench.action.chat.openWorkspacePicker',
+				group: 'navigation',
+				order: 0.6,
+				when: 'inAgentSessionsWelcome && isSessionsWindow && chatSessionType == \'local\'',
+			},
+		]);
+	});
+
+	test('ChatExecute', () => {
+		// This menu is shared with the regular chat widget. The inline chat
+		// zone widget exposes it as the execute toolbar.
+		assert.deepStrictEqual(snapshot(MenuId.ChatExecute), [
+			{
+				id: 'workbench.action.chat.attachContext',
+				group: 'navigation',
+				order: -1,
+				when: 'agentSupportsAttachments && quickChatHasFocus || quickChatHasFocus && !lockedToCodingAgent',
+			},
+			{
+				id: 'workbench.action.chat.cancel',
+				group: 'navigation',
+				order: 4,
+				when: 'chatSessionHasActiveRequest && !chatRemoteJobCreating && !chatSessionCurrentlyEditing',
+			},
+			{
+				id: 'workbench.action.chat.submit',
+				group: 'navigation',
+				order: 4,
+				when: '!chatSessionHasActiveRequest && !withinEditSessionDiff && chatAgentKind == \'ask\'',
+			},
+			{
+				id: 'workbench.action.edits.submit',
+				group: 'navigation',
+				order: 4,
+				when: '!chatSessionHasActiveRequest && chatAgentKind != \'ask\' && chatEditingSentRequest != \'q\' && chatEditingSentRequest != \'st\' || chatEditingSentRequest == \'s\' && chatAgentKind != \'ask\' && chatEditingSentRequest != \'q\' && chatEditingSentRequest != \'st\'',
+			},
+		]);
+	});
+});

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -1,0 +1,387 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { CodeEditorWidget, ICodeEditorWidgetOptions } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { Position } from '../../../../../editor/common/core/position.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IAccessibleViewService } from '../../../../../platform/accessibility/browser/accessibleView.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyService } from '../../../../../platform/contextkey/browser/contextKeyService.js';
+import { IMenuService, MenuId, MenuRegistry } from '../../../../../platform/actions/common/actions.js';
+import { MenuService } from '../../../../../platform/actions/common/menuService.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { ILifecycleService } from '../../../../services/lifecycle/common/lifecycle.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { IDecorationsService } from '../../../../services/decorations/common/decorations.js';
+import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
+import { IWorkbenchAssignmentService } from '../../../../services/assignment/common/assignmentService.js';
+import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IChatWidgetService, IChatAccessibilityService } from '../../../../contrib/chat/browser/chat.js';
+import { IChatContextPickService } from '../../../../contrib/chat/browser/attachments/chatContextPickService.js';
+import { IChatAttachmentResolveService } from '../../../../contrib/chat/browser/attachments/chatAttachmentResolveService.js';
+import { IChatAttachmentWidgetRegistry } from '../../../../contrib/chat/browser/attachments/chatAttachmentWidgetRegistry.js';
+import { IChatContextService } from '../../../../contrib/chat/browser/contextContrib/chatContextService.js';
+import { IChatImageCarouselService } from '../../../../contrib/chat/browser/chatImageCarouselService.js';
+import { IChatTipService } from '../../../../contrib/chat/browser/chatTipService.js';
+import { ChatAgentLocation } from '../../../../contrib/chat/common/constants.js';
+import { IChatService } from '../../../../contrib/chat/common/chatService/chatService.js';
+import { IChatSessionsService } from '../../../../contrib/chat/common/chatSessionsService.js';
+import { IChatModeService, ChatMode } from '../../../../contrib/chat/common/chatModes.js';
+import { ILanguageModelsService } from '../../../../contrib/chat/common/languageModels.js';
+import { IChatAgentService } from '../../../../contrib/chat/common/participants/chatAgents.js';
+import { IChatSlashCommandService } from '../../../../contrib/chat/common/participants/chatSlashCommands.js';
+import { ILanguageModelToolsService } from '../../../../contrib/chat/common/tools/languageModelToolsService.js';
+import { IChatArtifacts, IChatArtifactsService, IArtifactSourceGroup } from '../../../../contrib/chat/common/tools/chatArtifactsService.js';
+import { IChatTodoListService } from '../../../../contrib/chat/common/tools/chatTodoListService.js';
+import { IChatDebugService } from '../../../../contrib/chat/common/chatDebugService.js';
+import { IPromptsService } from '../../../../contrib/chat/common/promptSyntax/service/promptsService.js';
+import { IChatWidgetHistoryService } from '../../../../contrib/chat/common/widget/chatWidgetHistoryService.js';
+import { IChatLayoutService } from '../../../../contrib/chat/common/widget/chatLayoutService.js';
+import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IWorkspaceContextService, IWorkspace } from '../../../../../platform/workspace/common/workspace.js';
+import { IViewDescriptorService } from '../../../../common/views.js';
+import { IListService, ListService } from '../../../../../platform/list/browser/listService.js';
+import { INotebookDocumentService } from '../../../../services/notebook/common/notebookDocumentService.js';
+import { ISCMService } from '../../../../contrib/scm/common/scm.js';
+import { IActionWidgetService } from '../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { ISharedWebContentExtractorService } from '../../../../../platform/webContentExtractor/common/webContentExtractor.js';
+import { IUpdateService, StateType } from '../../../../../platform/update/common/update.js';
+import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IMarkdownRendererService, MarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ComponentFixtureContext, createEditorServices, createTextModel, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from '../fixtureUtils.js';
+import { InlineChatZoneWidget } from '../../../../contrib/inlineChat/browser/inlineChatZoneWidget.js';
+
+// CSS imports
+import '../../../../contrib/inlineChat/browser/media/inlineChat.css';
+import '../../../../contrib/chat/browser/widget/media/chat.css';
+import '../../../../../editor/contrib/zoneWidget/browser/zoneWidget.css';
+import '../../../../../base/browser/ui/codicons/codiconStyles.js';
+
+const SAMPLE_CODE = `import { useState, useEffect } from 'react';
+
+interface User {
+	id: number;
+	name: string;
+	email: string;
+}
+
+function useUsers() {
+	const [users, setUsers] = useState<User[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		fetch('/api/users')
+			.then(res => res.json())
+			.then(data => {
+				setUsers(data);
+				setLoading(false);
+			});
+	}, []);
+
+	return { users, loading };
+}
+
+export function UserList() {
+	const { users, loading } = useUsers();
+
+	if (loading) {
+		return <div>Loading...</div>;
+	}
+
+	return (
+		<ul>
+			{users.map(user => (
+				<li key={user.id}>{user.name}</li>
+			))}
+		</ul>
+	);
+}
+`;
+
+// Register fake menu items once at module scope (not per-render) to avoid
+// duplicates when Dark and Light fixtures are rendered simultaneously,
+// since MenuRegistry is a global singleton.
+MenuRegistry.appendMenuItem(MenuId.ChatEditorInlineExecute, {
+	group: 'navigation', order: 1,
+	command: { id: 'inlineChat.accept', title: 'Accept' },
+});
+MenuRegistry.appendMenuItem(MenuId.ChatEditorInlineExecute, {
+	group: 'navigation', order: 2,
+	command: { id: 'inlineChat.discard', title: 'Discard' },
+});
+MenuRegistry.appendMenuItem(MenuId.ChatInput, {
+	group: 'navigation', order: -1,
+	command: { id: 'workbench.action.chat.attachContext', title: '+', icon: Codicon.add },
+});
+MenuRegistry.appendMenuItem(MenuId.ChatInput, {
+	group: 'navigation', order: 3,
+	command: { id: 'workbench.action.chat.openModelPicker', title: 'GPT-4.1' },
+});
+MenuRegistry.appendMenuItem(MenuId.ChatExecute, {
+	group: 'navigation', order: 4,
+	command: { id: 'workbench.action.chat.submit', title: 'Send', icon: Codicon.arrowUp },
+});
+
+function renderInlineChatZoneWidget({ container, disposableStore, theme }: ComponentFixtureContext, showTerminationCard: boolean): void {
+	container.style.width = '600px';
+	container.style.height = '700px';
+	container.style.border = '1px solid var(--vscode-editorWidget-border)';
+
+	// The component-explorer harness injects a global `* { box-sizing: border-box }`
+	// reset into the document head. The chat input toolbar (and other Monaco UI bits)
+	// rely on the browser default `content-box` so that explicit `height` plus `padding`
+	// add up correctly (e.g. the attachments row is 16px height + 3px padding = 22px).
+	// Revert the reset for our subtree so the fixture renders like the real product.
+	const styleReset = document.createElement('style');
+	styleReset.textContent = '.component-fixture-box-sizing-reset, .component-fixture-box-sizing-reset * { box-sizing: revert; }';
+	container.appendChild(styleReset);
+	container.classList.add('component-fixture-box-sizing-reset');
+
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.define(IContextKeyService, ContextKeyService);
+			reg.define(IMenuService, MenuService);
+			reg.define(IMarkdownRendererService, MarkdownRendererService);
+
+			reg.defineInstance(IAccessibleViewService, new class extends mock<IAccessibleViewService>() {
+				declare readonly _serviceBrand: undefined;
+				override getOpenAriaHint() { return ''; }
+			}());
+			reg.defineInstance(IProductService, new class extends mock<IProductService>() {
+				override readonly urlProtocol = 'vscode';
+			}());
+			reg.defineInstance(ILifecycleService, new class extends mock<ILifecycleService>() {
+				declare readonly _serviceBrand: undefined;
+				override readonly onBeforeShutdown = Event.None;
+				override readonly onWillShutdown = Event.None;
+				override readonly onDidShutdown = Event.None;
+				override readonly onShutdownVeto = Event.None;
+			}());
+
+			// Chat services
+			reg.defineInstance(IChatService, new class extends mock<IChatService>() {
+				override readonly onDidPerformUserAction = Event.None;
+				override readonly onDidSubmitRequest = Event.None;
+				override readonly requestInProgressObs = observableValue('requestInProgress', false);
+			}());
+			reg.defineInstance(IChatAgentService, new class extends mock<IChatAgentService>() {
+				override readonly onDidChangeAgents = Event.None;
+				override getAgents() { return []; }
+				override getActivatedAgents() { return []; }
+			}());
+			reg.defineInstance(IChatWidgetService, new class extends mock<IChatWidgetService>() {
+				getWidgetBySessionId() { return undefined; }
+				override register() { return { dispose() { } }; }
+			}());
+			reg.defineInstance(IChatAccessibilityService, new class extends mock<IChatAccessibilityService>() {
+				override acceptRequest() { }
+				override acceptResponse() { }
+			}());
+			reg.defineInstance(IChatSlashCommandService, new class extends mock<IChatSlashCommandService>() {
+				override readonly onDidChangeCommands = Event.None;
+				override getCommands() { return []; }
+			}());
+			reg.defineInstance(IPromptsService, new class extends mock<IPromptsService>() { }());
+			reg.defineInstance(IChatLayoutService, new class extends mock<IChatLayoutService>() {
+				override readonly fontFamily = observableValue<string | null>('fontFamily', null);
+				override readonly fontSize = observableValue('fontSize', 13);
+			}());
+			reg.defineInstance(IChatTipService, new class extends mock<IChatTipService>() {
+				readonly onDidReceiveTip = Event.None;
+			}());
+			reg.defineInstance(IChatDebugService, new class extends mock<IChatDebugService>() {
+				override readonly onDidAddEvent = Event.None;
+			}());
+			reg.defineInstance(IChatEntitlementService, new class extends mock<IChatEntitlementService>() {
+				override readonly sentimentObs = observableValue('sentiment', { completed: true });
+				override readonly anonymousObs = observableValue('anonymous', false);
+				override readonly onDidChangeAnonymous = Event.None;
+			}());
+			reg.defineInstance(IChatModeService, new class extends mock<IChatModeService>() {
+				override readonly onDidChangeChatModes = Event.None;
+				override getModes() { return { builtin: [], custom: [] }; }
+				override findModeById() { return undefined; }
+			}());
+			reg.defineInstance(IChatSessionsService, new class extends mock<IChatSessionsService>() {
+				override getAllChatSessionContributions() { return []; }
+				override readonly onDidChangeSessionOptions = Event.None;
+				override readonly onDidChangeOptionGroups = Event.None;
+				override readonly onDidChangeAvailability = Event.None;
+			}());
+			reg.defineInstance(ILanguageModelsService, new class extends mock<ILanguageModelsService>() {
+				override readonly onDidChangeLanguageModels = Event.None;
+				override getLanguageModelIds() { return []; }
+			}());
+			reg.defineInstance(ILanguageModelToolsService, new class extends mock<ILanguageModelToolsService>() {
+				override readonly onDidChangeTools = Event.None;
+				override getTools() { return []; }
+				override observeTools() { return observableValue('tools', []); }
+				override getToolSetsForModel() { return []; }
+			}());
+			reg.defineInstance(IAgentSessionsService, new class extends mock<IAgentSessionsService>() {
+				override readonly model = new class extends mock<IAgentSessionsService['model']>() {
+					override readonly onDidChangeSessions = Event.None;
+				}();
+			}());
+			reg.defineInstance(IChatContextService, new class extends mock<IChatContextService>() { }());
+			reg.defineInstance(IChatAttachmentWidgetRegistry, new class extends mock<IChatAttachmentWidgetRegistry>() { }());
+			reg.defineInstance(IChatAttachmentResolveService, new class extends mock<IChatAttachmentResolveService>() { }());
+			reg.defineInstance(IChatImageCarouselService, new class extends mock<IChatImageCarouselService>() { }());
+			reg.defineInstance(IChatArtifactsService, new class extends mock<IChatArtifactsService>() {
+				override getArtifacts(): IChatArtifacts {
+					return new class extends mock<IChatArtifacts>() {
+						override readonly artifactGroups = observableValue<readonly IArtifactSourceGroup[]>('artifactGroups', []);
+						override setAgentArtifacts() { }
+						override clearAgentArtifacts() { }
+						override clearSubagentArtifacts() { }
+						override migrate() { }
+					}();
+				}
+			}());
+			reg.defineInstance(IChatTodoListService, new class extends mock<IChatTodoListService>() {
+				override readonly onDidUpdateTodos = Event.None;
+				override getTodos() { return []; }
+				override setTodos() { }
+				override migrateTodos() { }
+			}());
+			reg.defineInstance(IChatWidgetHistoryService, new class extends mock<IChatWidgetHistoryService>() {
+				override getHistory() { return []; }
+				override readonly onDidChangeHistory = Event.None;
+			}());
+			reg.defineInstance(IChatContextPickService, new class extends mock<IChatContextPickService>() { }());
+			reg.defineInstance(IDecorationsService, new class extends mock<IDecorationsService>() { override readonly onDidChangeDecorations = Event.None; }());
+			reg.defineInstance(ITextFileService, new class extends mock<ITextFileService>() { override readonly untitled = new class extends mock<ITextFileService['untitled']>() { override readonly onDidChangeLabel = Event.None; }(); }());
+			reg.defineInstance(IFileService, new class extends mock<IFileService>() { override readonly onDidFilesChange = Event.None; override readonly onDidRunOperation = Event.None; }());
+			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() { override readonly onDidActiveEditorChange = Event.None; }());
+			reg.defineInstance(ISharedWebContentExtractorService, new class extends mock<ISharedWebContentExtractorService>() { }());
+			reg.defineInstance(IWorkbenchAssignmentService, new class extends mock<IWorkbenchAssignmentService>() { override async getCurrentExperiments() { return []; } override async getTreatment() { return undefined; } override readonly onDidRefetchAssignments = Event.None; }());
+			reg.defineInstance(IWorkbenchLayoutService, new class extends mock<IWorkbenchLayoutService>() {
+				declare readonly _serviceBrand: undefined;
+				override get mainContainer() { return container; }
+				override get activeContainer() { return container; }
+				override get mainContainerDimension() { return { width: 600, height: 400 }; }
+				override get activeContainerDimension() { return { width: 600, height: 400 }; }
+				override readonly mainContainerOffset = { top: 0, quickPickTop: 0 };
+				override readonly onDidLayoutMainContainer = Event.None;
+				override readonly onDidLayoutActiveContainer = Event.None;
+				override readonly onDidLayoutContainer = Event.None;
+				override readonly onDidChangeActiveContainer = Event.None;
+				override readonly onDidAddContainer = Event.None;
+				override get containers() { return [container]; }
+				override getContainer() { return container; }
+				override whenContainerStylesLoaded() { return undefined; }
+				override readonly onDidChangePartVisibility = Event.None;
+				override readonly onDidChangeWindowMaximized = Event.None;
+				override isVisible() { return true; }
+			}());
+			reg.defineInstance(IViewDescriptorService, new class extends mock<IViewDescriptorService>() { override readonly onDidChangeLocation = Event.None; }());
+			reg.defineInstance(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() { override readonly onDidChangeWorkspaceFolders = Event.None; override getWorkspace(): IWorkspace { return { id: '', folders: [], configuration: undefined }; } }());
+			reg.defineInstance(IExtensionService, new class extends mock<IExtensionService>() { override readonly onDidChangeExtensions = Event.None; }());
+			reg.defineInstance(IPathService, new class extends mock<IPathService>() { }());
+			reg.defineInstance(IListService, new ListService());
+			reg.defineInstance(INotebookDocumentService, new class extends mock<INotebookDocumentService>() { }());
+			reg.defineInstance(ISCMService, new class extends mock<ISCMService>() {
+				override readonly onDidAddRepository = Event.None;
+				override readonly onDidRemoveRepository = Event.None;
+				override readonly repositories = [];
+				override readonly repositoryCount = 0;
+			}());
+			reg.defineInstance(IActionWidgetService, new class extends mock<IActionWidgetService>() { override show() { } override hide() { } override get isVisible() { return false; } }());
+			reg.defineInstance(IFileDialogService, new class extends mock<IFileDialogService>() { }());
+			reg.defineInstance(IUpdateService, new class extends mock<IUpdateService>() { override readonly onStateChange = Event.None; override get state() { return { type: StateType.Uninitialized as const }; } }());
+			reg.defineInstance(IUriIdentityService, new class extends mock<IUriIdentityService>() { }());
+		},
+	});
+
+	// Configure chat editor settings required by ChatEditorOptions
+	const configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+	configService.setUserConfiguration('chat', { editor: { fontSize: 14, fontFamily: 'default', fontWeight: 'normal', lineHeight: 0, wordWrap: 'on' } });
+	configService.setUserConfiguration('editor', { fontFamily: 'monospace', fontLigatures: false, accessibilitySupport: 'off' });
+
+	const textModel = disposableStore.add(createTextModel(
+		instantiationService,
+		SAMPLE_CODE,
+		URI.parse('inmemory://inline-chat-zone.tsx'),
+		'typescriptreact'
+	));
+
+	const editor = disposableStore.add(instantiationService.createInstance(
+		CodeEditorWidget,
+		container,
+		{
+			automaticLayout: true,
+			minimap: { enabled: false },
+			lineNumbers: 'on',
+			scrollBeyondLastLine: false,
+			fontSize: 14,
+			cursorBlinking: 'solid',
+		},
+		{ contributions: [] } satisfies ICodeEditorWidgetOptions
+	));
+
+	editor.setModel(textModel);
+	editor.focus();
+
+	const zoneWidget = disposableStore.add(instantiationService.createInstance(
+		InlineChatZoneWidget,
+		{ location: ChatAgentLocation.EditorInline },
+		{
+			enableWorkingSet: 'implicit',
+			enableImplicitContext: false,
+			renderInputOnTop: false,
+			renderInputToolbarBelowInput: true,
+			menus: {
+				telemetrySource: 'inlineChatWidget',
+				executeToolbar: MenuId.ChatEditorInlineExecute,
+				inputSideToolbar: MenuId.ChatEditorInlineInputSide,
+			},
+			defaultMode: ChatMode.Ask,
+		},
+		{ editor },
+		() => Promise.resolve(),
+	));
+
+	// Match what InlineChatController does in the real product so that the
+	// inline-chat-2 specific styles (toolbar layout, attachment row sizing) apply.
+	zoneWidget.domNode.classList.add('inline-chat-2');
+
+	zoneWidget.show(new Position(10, 1));
+
+	// Force a relayout after the initial show so that the chat widget's
+	// contentHeight (which includes the toolbar row rendered below the input)
+	// is fully measured and the zone widget adjusts its height accordingly.
+	zoneWidget.updatePositionAndHeight(new Position(10, 1));
+
+	if (showTerminationCard) {
+		zoneWidget.showTerminationCard(
+			'The agent ran into an issue and stopped. You can review the changes made so far.',
+			instantiationService,
+		);
+	}
+}
+
+export default defineThemedFixtureGroup({ path: 'editor/' }, {
+	InlineChatZoneWidget: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderInlineChatZoneWidget(context, false),
+	}),
+	InlineChatZoneWidgetTerminated: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (context) => renderInlineChatZoneWidget(context, true),
+	}),
+});


### PR DESCRIPTION
## Summary

The chat action registration helpers `registerChatExecuteActions`, `registerChatContextActions`, `registerChatToolActions`, and `registerCreatePluginAction` now return a `DisposableStore`. This lets test suites register and dispose those actions per-suite instead of leaking globally and tripping `Cannot register two commands with the same id` when more than one test file contributes the same actions.

A new snapshot test, `inlineChatZoneMenus.test.ts`, locks down the four `MenuId`s the inline chat zone widget renders (`ChatEditorInlineExecute`, `ChatEditorInlineInputSide`, `ChatInput`, `ChatExecute`) so future drift in the shared chat widget surfaces as a snapshot diff.

<details>
<summary>Session Context</summary>

Key decisions from the development session:
- **Snapshot over targeted assertions**: We use a single `assert.deepStrictEqual` snapshot per `MenuId`. Per project guidelines this is preferred over many precise assertions and matches how drift is best surfaced.
- **Don't import real inline-chat contributions in the fixture**: For the (separate) component-explorer fixture work, we deliberately keep `MenuRegistry.appendMenuItem` fakes rather than importing the real contributions to avoid pulling the workbench into the fixture.
- **Why preconditions appear in serialized `when`**: `AbstractInlineChatAction` explicitly merges `CTX_INLINE_CHAT_V2_ENABLED` into each `menu.when` (not only into `precondition`). That's why the snapshot strings include `inlineChatHasEditsAgent` / `inlineChatHasNotebookAgent`. The snapshot serializes only `item.when`, which is sufficient for drift detection.
- **`registerPromptActions` left as `void`**: It cascades into many sub-helpers (`registerRunPromptActions`, `registerAttachPromptActions`, `registerSkillActions`, `registerHookActions`, `registerAgentActions`, `registerNewPromptFileActions`). Converting all of them is out of scope for this PR; a TODO is left in `registerChatContextActions`. This is harmless because no test currently registers those actions.
- **Per-suite `suiteSetup`/`suiteTeardown` in `chatExecuteActions.test.ts`**: Replaced the previous module-level `registerChatExecuteActions()` call so registration is scoped to each suite and does not collide with other suites.

</details>

## Changes

- `chat/browser/actions/chatExecuteActions.ts`, `chatToolActions.ts`, `chatContextActions.ts`, `createPluginAction.ts`: helpers return `DisposableStore`.
- `chat/test/browser/actions/chatExecuteActions.test.ts`: register/dispose per suite via `suiteSetup`/`suiteTeardown`.
- `inlineChat/test/browser/inlineChatZoneMenus.test.ts`: new snapshot test.
