### PR TITLE
Fix steer/queue keybinding labels in picker dropdown

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionWidgetService } from './actionWidget.js';
-import { IAction } from '../../../base/common/actions.js';
-import { BaseDropdown, IActionProvider, IBaseDropdownOptions } from '../../../base/browser/ui/dropdown/dropdown.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListItemHover, IActionListOptions } from './actionList.js';
-import { ThemeIcon } from '../../../base/common/themables.js';
-import { Codicon } from '../../../base/common/codicons.js';
 import { getActiveElement, isHTMLElement } from '../../../base/browser/dom.js';
-import { IKeybindingService } from '../../keybinding/common/keybinding.js';
-import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
+import { BaseDropdown, IActionProvider, IBaseDropdownOptions } from '../../../base/browser/ui/dropdown/dropdown.js';
 import { IListAccessibilityProvider } from '../../../base/browser/ui/list/listWidget.js';
+import { IAction } from '../../../base/common/actions.js';
+import { Codicon } from '../../../base/common/codicons.js';
+import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
+import { ThemeIcon } from '../../../base/common/themables.js';
+import { IKeybindingService } from '../../keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListItemHover, IActionListOptions } from './actionList.js';
+import { IActionWidgetService } from './actionWidget.js';
 
 export interface IActionWidgetDropdownAction extends IAction {
 	category?: { label: string; order: number; showHeader?: boolean };

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -11,6 +11,7 @@ import { ThemeIcon } from '../../../base/common/themables.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { getActiveElement, isHTMLElement } from '../../../base/browser/dom.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
+import { ResolvedKeybinding } from '../../../base/common/keybindings.js';
 import { IListAccessibilityProvider } from '../../../base/browser/ui/list/listWidget.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 
@@ -26,6 +27,13 @@ export interface IActionWidgetDropdownAction extends IAction {
 	 * Optional toolbar actions shown when the item is focused or hovered.
 	 */
 	toolbarActions?: IAction[];
+	/**
+	 * Optional keybinding to display next to the action. When provided, this overrides the
+	 * keybinding that would otherwise be looked up via {@link IKeybindingService.lookupKeybinding}.
+	 * Useful when the active keybinding depends on a scoped context (e.g. focus state) that the
+	 * dropdown cannot evaluate at display time.
+	 */
+	keybinding?: ResolvedKeybinding;
 }
 
 // TODO @lramos15 - Should we just make IActionProvider templated?
@@ -139,7 +147,7 @@ export class ActionWidgetDropdown extends BaseDropdown {
 					hideIcon: false,
 					label: action.label,
 					keybinding: this._options.showItemKeybindings ?
-						this.keybindingService.lookupKeybinding(action.id) :
+						(action.keybinding ?? this.keybindingService.lookupKeybinding(action.id)) :
 						undefined,
 				});
 			}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -8,10 +8,8 @@ import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEv
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Action, IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { decodeKeybinding } from '../../../../../../base/common/keybindings.js';
-import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
+import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
-import { OS } from '../../../../../../base/common/platform.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../../platform/actions/browser/actionViewItemService.js';
@@ -53,7 +51,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super(undefined, action);
@@ -65,13 +63,13 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			'chat.queuePickerPrimary',
 			isSteerDefault ? localize('chat.steerWithMessage', "Steer with Message") : localize('chat.queueMessage', "Add to Queue"),
 			ThemeIcon.asClassName(isSteerDefault ? Codicon.arrowUp : Codicon.add),
-			!!contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key),
+			!!this.contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key),
 			() => this._runDefaultAction()
 		));
 		this._primaryAction = this._register(new ActionViewItem(undefined, this._primaryActionAction, { icon: true, label: false }));
 
-		this._register(contextKeyService.onDidChangeContext(e => {
-			this._primaryActionAction.enabled = !!contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key);
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			this._primaryActionAction.enabled = !!this.contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key);
 		}));
 
 		// Dropdown - action widget with hover descriptions and chevron-down icon
@@ -84,7 +82,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			},
 			actionWidgetService,
 			this.keybindingService,
-			contextKeyService,
+			this.contextKeyService,
 			telemetryService,
 		));
 
@@ -106,14 +104,6 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 
 	private _isSteerDefault(): boolean {
 		return this.configurationService.getValue<string>(ChatConfiguration.RequestQueueingDefaultAction) === 'steer';
-	}
-
-	private _resolveKeybinding(keybinding: number) {
-		const decoded = decodeKeybinding(keybinding, OS);
-		if (!decoded) {
-			return undefined;
-		}
-		return this.keybindingService.resolveKeybinding(decoded)[0];
 	}
 
 	private _isEffectiveSteer(): boolean {
@@ -186,16 +176,15 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 	private _getDropdownActions(): IActionWidgetDropdownAction[] {
 		const isSteerDefault = this._isSteerDefault();
 
-		// Resolve display keybindings explicitly: the dropdown's default keybinding lookup uses
-		// the global context, where the chat input's scoped context keys (`inChatInput`,
-		// `requestInProgress`) are not visible — so none of the queue/steer keybinding `when`
-		// clauses match and the resolver falls back to the last-registered binding, which can
-		// produce labels that contradict actual behavior. We know which key is bound to each
-		// action based on the user's configured default, so resolve them directly here.
-		const enterKeybinding = this._resolveKeybinding(KeyCode.Enter);
-		const altEnterKeybinding = this._resolveKeybinding(KeyMod.Alt | KeyCode.Enter);
-		const queueKeybinding = isSteerDefault ? altEnterKeybinding : enterKeybinding;
-		const steerKeybinding = isSteerDefault ? enterKeybinding : altEnterKeybinding;
+		// Resolve display keybindings against the scoped chat input context so the labels
+		// reflect the bindings actually active for the current state, including any user
+		// customizations and scoped overrides (e.g. when editing a queued/steer request).
+		// Without an explicit context the dropdown falls back to the global context, where
+		// `inChatInput`/`requestInProgress` are not set — none of the `when` clauses match
+		// and the resolver falls back to the last-registered binding, producing labels that
+		// contradict actual behavior.
+		const queueKeybinding = this.keybindingService.lookupKeybinding(ChatQueueMessageAction.ID, this.contextKeyService, true);
+		const steerKeybinding = this.keybindingService.lookupKeybinding(ChatSteerWithMessageAction.ID, this.contextKeyService, true);
 
 		const queueAction: IActionWidgetDropdownAction = {
 			id: ChatQueueMessageAction.ID,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -176,15 +176,23 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 	private _getDropdownActions(): IActionWidgetDropdownAction[] {
 		const isSteerDefault = this._isSteerDefault();
 
-		// Resolve display keybindings against the scoped chat input context so the labels
-		// reflect the bindings actually active for the current state, including any user
-		// customizations and scoped overrides (e.g. when editing a queued/steer request).
-		// Without an explicit context the dropdown falls back to the global context, where
-		// `inChatInput`/`requestInProgress` are not set — none of the `when` clauses match
-		// and the resolver falls back to the last-registered binding, producing labels that
-		// contradict actual behavior.
-		const queueKeybinding = this.keybindingService.lookupKeybinding(ChatQueueMessageAction.ID, this.contextKeyService, true);
-		const steerKeybinding = this.keybindingService.lookupKeybinding(ChatSteerWithMessageAction.ID, this.contextKeyService, true);
+		// Resolve display keybindings against an overlay context that simulates the chat input
+		// being focused with a request in progress. The injected `contextKeyService` may be the
+		// chat widget's outer scope (which has `requestInProgress` but lacks `inChatInput`) or
+		// even the global scope; either way, the queue/steer keybindings' `when` clauses would
+		// not match and the resolver would fall back to the last-registered binding for each
+		// command, producing labels that contradict actual behavior. Overlaying the scope keys
+		// the bindings expect ensures we look up the binding that would actually fire.
+		// Other context keys (e.g. `editingRequestType`, `config.chat.requestQueuing.defaultAction`)
+		// are read from the parent context, so user customizations and scoped overrides like
+		// editing a queued/steer request are still respected.
+		const lookupContext = this.contextKeyService.createOverlay([
+			[ChatContextKeys.inputHasText.key, true],
+			[ChatContextKeys.inChatInput.key, true],
+			[ChatContextKeys.requestInProgress.key, true],
+		]);
+		const queueKeybinding = this.keybindingService.lookupKeybinding(ChatQueueMessageAction.ID, lookupContext, true);
+		const steerKeybinding = this.keybindingService.lookupKeybinding(ChatSteerWithMessageAction.ID, lookupContext, true);
 
 		const queueAction: IActionWidgetDropdownAction = {
 			id: ChatQueueMessageAction.ID,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -8,8 +8,10 @@ import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEv
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Action, IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { decodeKeybinding } from '../../../../../../base/common/keybindings.js';
+import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { OS } from '../../../../../../base/common/platform.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../../platform/actions/browser/actionViewItemService.js';
@@ -50,7 +52,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		@ICommandService private readonly commandService: ICommandService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
-		@IKeybindingService keybindingService: IKeybindingService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ITelemetryService telemetryService: ITelemetryService,
 	) {
@@ -81,7 +83,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 				showItemKeybindings: true,
 			},
 			actionWidgetService,
-			keybindingService,
+			this.keybindingService,
 			contextKeyService,
 			telemetryService,
 		));
@@ -104,6 +106,14 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 
 	private _isSteerDefault(): boolean {
 		return this.configurationService.getValue<string>(ChatConfiguration.RequestQueueingDefaultAction) === 'steer';
+	}
+
+	private _resolveKeybinding(keybinding: number) {
+		const decoded = decodeKeybinding(keybinding, OS);
+		if (!decoded) {
+			return undefined;
+		}
+		return this.keybindingService.resolveKeybinding(decoded)[0];
 	}
 
 	private _isEffectiveSteer(): boolean {
@@ -176,6 +186,17 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 	private _getDropdownActions(): IActionWidgetDropdownAction[] {
 		const isSteerDefault = this._isSteerDefault();
 
+		// Resolve display keybindings explicitly: the dropdown's default keybinding lookup uses
+		// the global context, where the chat input's scoped context keys (`inChatInput`,
+		// `requestInProgress`) are not visible — so none of the queue/steer keybinding `when`
+		// clauses match and the resolver falls back to the last-registered binding, which can
+		// produce labels that contradict actual behavior. We know which key is bound to each
+		// action based on the user's configured default, so resolve them directly here.
+		const enterKeybinding = this._resolveKeybinding(KeyCode.Enter);
+		const altEnterKeybinding = this._resolveKeybinding(KeyMod.Alt | KeyCode.Enter);
+		const queueKeybinding = isSteerDefault ? altEnterKeybinding : enterKeybinding;
+		const steerKeybinding = isSteerDefault ? enterKeybinding : altEnterKeybinding;
+
 		const queueAction: IActionWidgetDropdownAction = {
 			id: ChatQueueMessageAction.ID,
 			label: localize('chat.queueMessage', "Add to Queue"),
@@ -184,6 +205,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			checked: !isSteerDefault,
 			icon: Codicon.add,
 			class: undefined,
+			keybinding: queueKeybinding,
 			hover: {
 				content: localize('chat.queueMessage.hover', "Queue this message to send after the current request completes. The current response will finish uninterrupted before the queued message is sent."),
 			},
@@ -200,6 +222,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			checked: isSteerDefault,
 			icon: Codicon.arrowUp,
 			class: undefined,
+			keybinding: steerKeybinding,
 			hover: {
 				content: localize('chat.steerWithMessage.hover', "Send this message at the next opportunity, signaling the current request to yield. The current response will stop and the new message will be sent immediately."),
 			},

--- a/src/vs/workbench/contrib/chat/test/browser/actions/chatQueueActions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/chatQueueActions.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { OS } from '../../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { KeybindingsRegistry } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeybindingResolver } from '../../../../../../platform/keybinding/common/keybindingResolver.js';
+import { ResolvedKeybindingItem } from '../../../../../../platform/keybinding/common/resolvedKeybindingItem.js';
+import { USLayoutResolvedKeybinding } from '../../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { ChatQueueMessageAction, ChatSteerWithMessageAction, registerChatQueueActions } from '../../../browser/actions/chatQueueActions.js';
+import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+
+// Register actions once so the keybindings appear in KeybindingsRegistry.
+registerChatQueueActions();
+
+suite('Queue/Steer keybinding resolution', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function buildResolverForCommands(commandIds: string[]): KeybindingResolver {
+		const items: ResolvedKeybindingItem[] = [];
+		for (const item of KeybindingsRegistry.getDefaultKeybindingsForOS(OS)) {
+			if (!item.command || !commandIds.includes(item.command) || !item.keybinding) {
+				continue;
+			}
+			const resolved = USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding, OS)[0];
+			items.push(new ResolvedKeybindingItem(resolved, item.command, item.commandArgs, item.when ?? undefined, true, null, false));
+		}
+		return new KeybindingResolver(items, [], () => { });
+	}
+
+	function lookupForConfig(defaultAction: 'steer' | 'queue') {
+		const config = new TestConfigurationService({ [ChatConfiguration.RequestQueueingDefaultAction]: defaultAction });
+		const ctxService = new ContextKeyService(config);
+		// Simulate the chat input being focused with a request in progress, like the picker does.
+		const overlay = ctxService.createOverlay([
+			[ChatContextKeys.inputHasText.key, true],
+			[ChatContextKeys.inChatInput.key, true],
+			[ChatContextKeys.requestInProgress.key, true],
+		]);
+		const resolver = buildResolverForCommands([ChatQueueMessageAction.ID, ChatSteerWithMessageAction.ID]);
+		return {
+			result: {
+				queue: resolver.lookupPrimaryKeybinding(ChatQueueMessageAction.ID, overlay, true)?.resolvedKeybinding?.getDispatchChords()[0] ?? null,
+				steer: resolver.lookupPrimaryKeybinding(ChatSteerWithMessageAction.ID, overlay, true)?.resolvedKeybinding?.getDispatchChords()[0] ?? null,
+			},
+			dispose: () => ctxService.dispose(),
+		};
+	}
+
+	test('with default=steer, Enter steers and Alt+Enter queues', () => {
+		const { result, dispose } = lookupForConfig('steer');
+		try {
+			assert.deepStrictEqual(result, { queue: 'alt+Enter', steer: 'Enter' });
+		} finally {
+			dispose();
+		}
+	});
+
+	test('with default=queue, Enter queues and Alt+Enter steers', () => {
+		const { result, dispose } = lookupForConfig('queue');
+		try {
+			assert.deepStrictEqual(result, { queue: 'Enter', steer: 'alt+Enter' });
+		} finally {
+			dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

The queue/steer picker dropdown showed incorrect keybinding labels when a chat request was in progress. For example, with the default config (`steer`), **Steer** was labelled **Alt+Enter** in the dropdown, but **Enter** actually steered.

## Root Cause

`ActionWidgetDropdown` resolved keybindings via the global `IKeybindingService` context. The queue/steer keybindings have `when` clauses that require `inChatInput` and `requestInProgress`, which are scoped context keys not visible to the global context. With no matching `when` clause, `lookupPrimaryKeybinding` fell back to `items[items.length - 1]` — the *last* registered binding for each command (the Alt+Enter variant), which is the opposite of the one actually active.

## Fix

- **`actionWidgetDropdown.ts`** — Added an optional `keybinding?: ResolvedKeybinding` field to `IActionWidgetDropdownAction`. When provided, the dropdown uses it directly instead of the global lookup.
- **`chatQueuePickerActionItem.ts`** — `ChatQueuePickerActionItem._getDropdownActions()` now resolves Enter / Alt+Enter via `keybindingService.resolveKeybinding(...)` and assigns them to the queue/steer items based on the user's configured default (`chat.requestQueuing.defaultAction`), so the displayed labels always reflect the actually-bound keys.

**Best reviewed by looking all file changes (rather than by commit)**

fixes https://github.com/microsoft/vscode/issues/310962