### PR TITLE
fix(chat): preserve user draft in input when executing Plan handoff (#288114)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -203,6 +203,35 @@ const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
 
 const DISCLAIMER = localize('chatDisclaimer', "AI responses may be inaccurate");
 
+/**
+ * Decide what (if anything) to place in the chat input when a handoff runs.
+ * If the user has a non-empty draft, that draft is preserved — this is the
+ * fix for the "Plan -> Start Implementation loses input" bug (#288114).
+ *
+ * - For regular agent handoffs (no `agentId`): returns `shouldSetValue: false`
+ *   when the user has already typed something, so the draft is left untouched.
+ * - For chat-session delegations (`agentId` provided): always returns a value
+ *   to set, prefixing with `@<agentId>`, using the user's draft if present
+ *   and otherwise falling back to the handoff's canned prompt.
+ *
+ * Exported for unit testing.
+ */
+export function computeHandoffInputUpdate(
+	handoff: Pick<IHandOff, 'prompt'>,
+	currentDraft: string,
+	agentId?: string,
+): { shouldSetValue: boolean; value?: string } {
+	const hasUserDraft = currentDraft.trim().length > 0;
+	if (agentId) {
+		const body = hasUserDraft ? currentDraft : handoff.prompt;
+		return { shouldSetValue: true, value: `@${agentId} ${body}` };
+	}
+	if (hasUserDraft) {
+		return { shouldSetValue: false };
+	}
+	return { shouldSetValue: true, value: handoff.prompt };
+}
+
 export class ChatWidget extends Disposable implements IChatWidget {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1299,13 +1328,18 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	async executeHandoff(handoff: IHandOff, agentId?: string): Promise<void> {
 		this.chatSuggestNextWidget.hide();
 
-		const promptToUse = handoff.prompt;
+		// Preserve any text the user has already typed so switching modes via a
+		// handoff (e.g. plan mode's "Start Implementation") does not discard
+		// their draft answers. When the user has typed something, prefer their
+		// text over the handoff's canned prompt.
+		const userDraft = this.input.inputEditor.getValue();
 
 		// If agentId is provided (from chevron dropdown), delegate to that chat session
 		// Otherwise, switch to the handoff agent
 		if (agentId) {
 			// Delegate to chat session (e.g., @background or @cloud)
-			this.input.setValue(`@${agentId} ${promptToUse}`, false);
+			const { value } = computeHandoffInputUpdate(handoff, userDraft, agentId);
+			this.input.setValue(value!, false);
 			this.input.focus();
 			// Auto-submit for delegated chat sessions
 			this.acceptInput().catch(e => this.logService.error(`[Handoff] Failed to submit delegated handoff to '@${agentId}'`, e));
@@ -1316,8 +1350,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			if (handoff.model) {
 				this.input.switchModelByQualifiedName([handoff.model]);
 			}
-			// Insert the handoff prompt into the input
-			this.input.setValue(promptToUse, false);
+			// Insert the handoff prompt into the input, unless the user has
+			// already typed something — in that case keep their draft.
+			const { shouldSetValue, value } = computeHandoffInputUpdate(handoff, userDraft);
+			if (shouldSetValue) {
+				this.input.setValue(value!, false);
+			}
 			this.input.focus();
 
 			// Auto-submit if send flag is true

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatHandoffInput.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatHandoffInput.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { computeHandoffInputUpdate } from '../../../browser/widget/chatWidget.js';
+
+// Regression coverage for #288114: switching from Plan mode via the
+// "Start Implementation" handoff used to discard whatever the user had typed
+// because executeHandoff unconditionally overwrote the input with the
+// handoff's canned prompt. computeHandoffInputUpdate now decides whether to
+// overwrite, preferring the user's draft when present.
+suite('computeHandoffInputUpdate', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const startImplementation = { prompt: 'Implement the plan' };
+
+	test('regular handoff preserves a non-empty user draft (bug #288114)', () => {
+		const result = computeHandoffInputUpdate(startImplementation, 'Here are my answers to the plan questions');
+		assert.strictEqual(result.shouldSetValue, false, 'user draft must not be overwritten');
+		assert.strictEqual(result.value, undefined);
+	});
+
+	test('regular handoff populates the handoff prompt when input is empty', () => {
+		const result = computeHandoffInputUpdate(startImplementation, '');
+		assert.deepStrictEqual(result, { shouldSetValue: true, value: 'Implement the plan' });
+	});
+
+	test('regular handoff treats whitespace-only input as empty', () => {
+		const result = computeHandoffInputUpdate(startImplementation, '   \n\t ');
+		assert.deepStrictEqual(result, { shouldSetValue: true, value: 'Implement the plan' });
+	});
+
+	test('delegation handoff prefixes the user draft with @agentId', () => {
+		const result = computeHandoffInputUpdate(startImplementation, 'my draft answer', 'background');
+		assert.deepStrictEqual(result, { shouldSetValue: true, value: '@background my draft answer' });
+	});
+
+	test('delegation handoff falls back to the handoff prompt when input is empty', () => {
+		const result = computeHandoffInputUpdate(startImplementation, '', 'background');
+		assert.deepStrictEqual(result, { shouldSetValue: true, value: '@background Implement the plan' });
+	});
+});


### PR DESCRIPTION
## What

When the user has typed answers/notes and clicks "Start Implementation" (or any other handoff) in Plan mode, their draft is no longer overwritten with the handoff's canned prompt. Empty-input behavior is unchanged — the canned prompt still populates.

## Why

`ChatWidget.executeHandoff` unconditionally called `input.setValue(handoff.prompt, ...)`, discarding any text the user had typed. Users asking the plan agent questions in the input and then clicking "Start Implementation" silently lost their work (#288114).

## How

Extracted a pure `computeHandoffInputUpdate(handoff, currentDraft, agentId?)` helper on `chatWidget.ts`: returns `{ shouldSetValue: false }` when the user has a non-empty trimmed draft (regular handoff), and for the delegation path (`@agentId`), prefixes the user's draft rather than the canned prompt (falling back to the canned prompt only when the draft is empty). `executeHandoff` now delegates to it and only calls `setValue` when told to.

## Test plan

5 unit tests in `chatHandoffInput.test.ts` covering:
- regular handoff preserves a non-empty draft
- empty input falls back to canned prompt
- whitespace-only input treated as empty
- delegation prefixes draft with `@agentId`
- delegation with empty input falls back

Manual repro per the issue: type answers in Plan mode, click Start Implementation — draft persists.

Fixes #288114