### PR TITLE
Merge Conflict: detect and offer auto-resolution for identical-content conflicts

### DIFF
--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -1,184 +1,191 @@
 {
-  "name": "merge-conflict",
-  "publisher": "vscode",
-  "displayName": "%displayName%",
-  "description": "%description%",
-  "icon": "media/icon.png",
-  "version": "10.0.0",
-  "license": "MIT",
-  "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
-  "engines": {
-    "vscode": "^1.5.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "capabilities": {
-    "virtualWorkspaces": true,
-    "untrustedWorkspaces": {
-      "supported": true
-    }
-  },
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "main": "./out/mergeConflictMain",
-  "browser": "./dist/browser/mergeConflictMain",
-  "scripts": {
-    "compile": "gulp compile-extension:merge-conflict",
-    "watch": "gulp watch-extension:merge-conflict",
-    "compile-web": "npm-run-all2 -lp bundle-web typecheck-web",
-    "bundle-web": "node ./esbuild.browser.mts",
-    "typecheck-web": "tsgo --project ./tsconfig.json --noEmit",
-    "watch-web": "npm-run-all2 -lp watch-bundle-web watch-typecheck-web",
-    "watch-bundle-web": "node ./esbuild.browser.mts --watch",
-    "watch-typecheck-web": "tsgo --project ./tsconfig.json --noEmit --watch"
-  },
-  "contributes": {
-    "commands": [
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.all-current%",
-        "original": "Accept All Current",
-        "command": "merge-conflict.accept.all-current",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.all-incoming%",
-        "original": "Accept All Incoming",
-        "command": "merge-conflict.accept.all-incoming",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.all-both%",
-        "original": "Accept All Both",
-        "command": "merge-conflict.accept.all-both",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.current%",
-        "original": "Accept Current",
-        "command": "merge-conflict.accept.current",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.incoming%",
-        "original": "Accept Incoming",
-        "command": "merge-conflict.accept.incoming",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.selection%",
-        "original": "Accept Selection",
-        "command": "merge-conflict.accept.selection",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.accept.both%",
-        "original": "Accept Both",
-        "command": "merge-conflict.accept.both",
-        "enablement": "!isMergeEditor"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.next%",
-        "original": "Next Conflict",
-        "command": "merge-conflict.next",
-        "enablement": "!isMergeEditor",
-        "icon": "$(arrow-down)"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.previous%",
-        "original": "Previous Conflict",
-        "command": "merge-conflict.previous",
-        "enablement": "!isMergeEditor",
-        "icon": "$(arrow-up)"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.compare%",
-        "original": "Compare Current Conflict",
-        "command": "merge-conflict.compare",
-        "enablement": "!isMergeEditor"
-      }
-    ],
-    "menus": {
-      "scm/resourceState/context": [
-        {
-          "command": "merge-conflict.accept.all-current",
-          "when": "scmProvider == git && scmResourceGroup == merge",
-          "group": "1_modification"
-        },
-        {
-          "command": "merge-conflict.accept.all-incoming",
-          "when": "scmProvider == git && scmResourceGroup == merge",
-          "group": "1_modification"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "merge-conflict.previous",
-          "group": "navigation@1",
-          "when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
-        },
-        {
-          "command": "merge-conflict.next",
-          "group": "navigation@2",
-          "when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
-        }
-      ]
-    },
-    "configuration": {
-      "title": "%config.title%",
-      "properties": {
-        "merge-conflict.codeLens.enabled": {
-          "type": "boolean",
-          "description": "%config.codeLensEnabled%",
-          "default": true
-        },
-        "merge-conflict.decorators.enabled": {
-          "type": "boolean",
-          "description": "%config.decoratorsEnabled%",
-          "default": true
-        },
-        "merge-conflict.autoNavigateNextConflict.enabled": {
-          "type": "boolean",
-          "description": "%config.autoNavigateNextConflictEnabled%",
-          "default": false
-        },
-        "merge-conflict.diffViewPosition": {
-          "type": "string",
-          "enum": [
-            "Current",
-            "Beside",
-            "Below"
-          ],
-          "description": "%config.diffViewPosition%",
-          "enumDescriptions": [
-            "%config.diffViewPosition.current%",
-            "%config.diffViewPosition.beside%",
-            "%config.diffViewPosition.below%"
-          ],
-          "default": "Current"
-        }
-      }
-    }
-  },
-  "dependencies": {
-    "@vscode/extension-telemetry": "^0.9.8"
-  },
-  "devDependencies": {
-    "@types/node": "22.x"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/vscode.git"
-  }
+	"name": "merge-conflict",
+	"publisher": "vscode",
+	"displayName": "%displayName%",
+	"description": "%description%",
+	"icon": "media/icon.png",
+	"version": "10.0.0",
+	"license": "MIT",
+	"aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
+	"engines": {
+		"vscode": "^1.5.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"capabilities": {
+		"virtualWorkspaces": true,
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"main": "./out/mergeConflictMain",
+	"browser": "./dist/browser/mergeConflictMain",
+	"scripts": {
+		"compile": "gulp compile-extension:merge-conflict",
+		"watch": "gulp watch-extension:merge-conflict",
+		"compile-web": "npm-run-all2 -lp bundle-web typecheck-web",
+		"bundle-web": "node ./esbuild.browser.mts",
+		"typecheck-web": "tsgo --project ./tsconfig.json --noEmit",
+		"watch-web": "npm-run-all2 -lp watch-bundle-web watch-typecheck-web",
+		"watch-bundle-web": "node ./esbuild.browser.mts --watch",
+		"watch-typecheck-web": "tsgo --project ./tsconfig.json --noEmit --watch"
+	},
+	"contributes": {
+		"commands": [
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.all-current%",
+				"original": "Accept All Current",
+				"command": "merge-conflict.accept.all-current",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.all-incoming%",
+				"original": "Accept All Incoming",
+				"command": "merge-conflict.accept.all-incoming",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.all-both%",
+				"original": "Accept All Both",
+				"command": "merge-conflict.accept.all-both",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.current%",
+				"original": "Accept Current",
+				"command": "merge-conflict.accept.current",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.incoming%",
+				"original": "Accept Incoming",
+				"command": "merge-conflict.accept.incoming",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.selection%",
+				"original": "Accept Selection",
+				"command": "merge-conflict.accept.selection",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.both%",
+				"original": "Accept Both",
+				"command": "merge-conflict.accept.both",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.next%",
+				"original": "Next Conflict",
+				"command": "merge-conflict.next",
+				"enablement": "!isMergeEditor",
+				"icon": "$(arrow-down)"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.previous%",
+				"original": "Previous Conflict",
+				"command": "merge-conflict.previous",
+				"enablement": "!isMergeEditor",
+				"icon": "$(arrow-up)"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.compare%",
+				"original": "Compare Current Conflict",
+				"command": "merge-conflict.compare",
+				"enablement": "!isMergeEditor"
+			},
+			{
+				"category": "%command.category%",
+				"title": "%command.accept.all-identical%",
+				"original": "Accept All Identical",
+				"command": "merge-conflict.accept.all-identical",
+				"enablement": "!isMergeEditor"
+			}
+		],
+		"menus": {
+			"scm/resourceState/context": [
+				{
+					"command": "merge-conflict.accept.all-current",
+					"when": "scmProvider == git && scmResourceGroup == merge",
+					"group": "1_modification"
+				},
+				{
+					"command": "merge-conflict.accept.all-incoming",
+					"when": "scmProvider == git && scmResourceGroup == merge",
+					"group": "1_modification"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "merge-conflict.previous",
+					"group": "navigation@1",
+					"when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
+				},
+				{
+					"command": "merge-conflict.next",
+					"group": "navigation@2",
+					"when": "!isMergeEditor && mergeConflictsCount && mergeConflictsCount != 0"
+				}
+			]
+		},
+		"configuration": {
+			"title": "%config.title%",
+			"properties": {
+				"merge-conflict.codeLens.enabled": {
+					"type": "boolean",
+					"description": "%config.codeLensEnabled%",
+					"default": true
+				},
+				"merge-conflict.decorators.enabled": {
+					"type": "boolean",
+					"description": "%config.decoratorsEnabled%",
+					"default": true
+				},
+				"merge-conflict.autoNavigateNextConflict.enabled": {
+					"type": "boolean",
+					"description": "%config.autoNavigateNextConflictEnabled%",
+					"default": false
+				},
+				"merge-conflict.diffViewPosition": {
+					"type": "string",
+					"enum": [
+						"Current",
+						"Beside",
+						"Below"
+					],
+					"description": "%config.diffViewPosition%",
+					"enumDescriptions": [
+						"%config.diffViewPosition.current%",
+						"%config.diffViewPosition.beside%",
+						"%config.diffViewPosition.below%"
+					],
+					"default": "Current"
+				}
+			}
+		}
+	},
+	"dependencies": {
+		"@vscode/extension-telemetry": "^0.9.8"
+	},
+	"devDependencies": {
+		"@types/node": "22.x"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/vscode.git"
+	}
 }

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -5,6 +5,7 @@
 	"command.accept.all-current": "Accept All Current",
 	"command.accept.all-incoming": "Accept All Incoming",
 	"command.accept.all-both": "Accept All Both",
+	"command.accept.all-identical": "Accept All Identical",
 	"command.accept.current": "Accept Current",
 	"command.accept.incoming": "Accept Incoming",
 	"command.accept.selection": "Accept Selection",

--- a/extensions/merge-conflict/src/codelensProvider.ts
+++ b/extensions/merge-conflict/src/codelensProvider.ts
@@ -61,6 +61,18 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 		const items: vscode.CodeLens[] = [];
 
 		conflicts.forEach(conflict => {
+			const range = document.lineAt(conflict.range.start.line).range;
+
+			if (conflict.isIdentical(document)) {
+				const acceptIdenticalCommand: vscode.Command = {
+					command: 'merge-conflict.accept.current',
+					title: vscode.l10n.t("$(check) Accept (both changes are identical)"),
+					arguments: ['known-conflict', conflict]
+				};
+				items.push(new vscode.CodeLens(range, acceptIdenticalCommand));
+				return;
+			}
+
 			const acceptCurrentCommand: vscode.Command = {
 				command: 'merge-conflict.accept.current',
 				title: vscode.l10n.t("Accept Current Change"),
@@ -85,7 +97,6 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 				arguments: [conflict]
 			};
 
-			const range = document.lineAt(conflict.range.start.line).range;
 			items.push(
 				new vscode.CodeLens(range, acceptCurrentCommand),
 				new vscode.CodeLens(range, acceptIncomingCommand),

--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -34,6 +34,7 @@ export default class CommandHandler implements vscode.Disposable {
 			this.registerTextEditorCommand('merge-conflict.accept.all-current', this.acceptAllCurrent, this.acceptAllCurrentResources),
 			this.registerTextEditorCommand('merge-conflict.accept.all-incoming', this.acceptAllIncoming, this.acceptAllIncomingResources),
 			this.registerTextEditorCommand('merge-conflict.accept.all-both', this.acceptAllBoth),
+			this.registerTextEditorCommand('merge-conflict.accept.all-identical', this.acceptAllIdentical),
 			this.registerTextEditorCommand('merge-conflict.next', this.navigateNext),
 			this.registerTextEditorCommand('merge-conflict.previous', this.navigatePrevious),
 			this.registerTextEditorCommand('merge-conflict.compare', this.compare)
@@ -80,6 +81,28 @@ export default class CommandHandler implements vscode.Disposable {
 
 	acceptAllBoth(editor: vscode.TextEditor): Promise<void> {
 		return this.acceptAll(interfaces.CommitType.Both, editor);
+	}
+
+	async acceptAllIdentical(editor: vscode.TextEditor): Promise<void> {
+		const conflicts = await this.tracker.getConflicts(editor.document);
+
+		if (!conflicts || conflicts.length === 0) {
+			vscode.window.showWarningMessage(vscode.l10n.t("No merge conflicts found in this file"));
+			return;
+		}
+
+		const identical = conflicts.filter(c => c.isIdentical(editor.document));
+
+		if (identical.length === 0) {
+			vscode.window.showInformationMessage(vscode.l10n.t("No conflicts with identical content found in this file"));
+			return;
+		}
+
+		this.tracker.forget(editor.document);
+
+		await editor.edit((edit) => identical.forEach(conflict => {
+			conflict.applyEdit(interfaces.CommitType.Current, editor.document, edit);
+		}));
 	}
 
 	async compare(editor: vscode.TextEditor, conflict: interfaces.IDocumentMergeConflict | null) {

--- a/extensions/merge-conflict/src/documentMergeConflict.ts
+++ b/extensions/merge-conflict/src/documentMergeConflict.ts
@@ -87,6 +87,12 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 		}
 	}
 
+	public isIdentical(document: vscode.TextDocument): boolean {
+		const currentText = document.getText(this.current.content);
+		const incomingText = document.getText(this.incoming.content);
+		return currentText === incomingText;
+	}
+
 	private replaceRangeWithContent(content: string, edit: { replace(range: vscode.Range, newText: string): void }) {
 		if (this.isNewlineOnly(content)) {
 			edit.replace(this.range, '');

--- a/extensions/merge-conflict/src/interfaces.ts
+++ b/extensions/merge-conflict/src/interfaces.ts
@@ -26,6 +26,7 @@ export interface IExtensionConfiguration {
 export interface IDocumentMergeConflict extends IDocumentMergeConflictDescriptor {
 	commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean>;
 	applyEdit(type: CommitType, document: vscode.TextDocument, edit: { replace(range: vscode.Range, newText: string): void }): void;
+	isIdentical(document: vscode.TextDocument): boolean;
 }
 
 export interface IDocumentMergeConflictDescriptor {


### PR DESCRIPTION
Fixes #310971

## Problem

When two branches independently make the same change to the same region of a file, git generates a merge conflict even though the resolution is completely unambiguous — both sides contain exactly the same text. Currently VS Code shows the full four-action CodeLens (Accept Current / Accept Incoming / Accept Both / Compare) requiring the developer to read both sides, confirm they're the same, and then manually pick one.

This is common in fast-moving repositories: both branches fixed the same typo, added the same import, bumped the same version number, or had a formatter run on the same line.

## Solution

**Algorithm: `isIdentical(document)`** — compare the text of the `current` and `incoming` content regions directly. If they are byte-for-byte equal, the conflict is trivially resolvable.

### Changes

| File | Change |
|---|---|
| `interfaces.ts` | Add `isIdentical(document)` to `IDocumentMergeConflict` |
| `documentMergeConflict.ts` | Implement: `document.getText(current.content) === document.getText(incoming.content)` |
| `codelensProvider.ts` | For identical conflicts, replace the four-action row with a single **"$(check) Accept (both changes are identical)"** lens |
| `commandHandler.ts` | Add `merge-conflict.accept.all-identical` command to batch-resolve all identical conflicts in the document |
| `package.json` | Register `merge-conflict.accept.all-identical` command |
| `package.nls.json` | Add NLS string for the new command |

### UX before / after

**Before:** Identical conflict shows 4 actions — developer must read both sides to confirm they match, then click Accept Current or Accept Incoming.

**After:** Identical conflict shows 1 action — **"$(check) Accept (both changes are identical)"** — one click, zero ambiguity. Non-identical conflicts are completely unchanged.

The `merge-conflict.accept.all-identical` command lets developers clear all identical conflicts in one step before focusing on the ones that actually require a decision.

## Testing

- Manually tested with a file containing `<<<<<<< HEAD\nx = 1\n=======\nx = 1\n>>>>>>> branch` — single-action CodeLens appears.
- Mixed file (some identical, some not) — identical conflicts get the single-action lens; non-identical conflicts keep all four actions.
- `acceptAllIdentical` with no identical conflicts → informational message shown.
- `acceptAllIdentical` with identical conflicts → all resolved atomically, undo works as a single step.
- Existing tests for `merge-conflict` extension pass unmodified.