### PR TITLE
Add improved transition handling for workbench startup

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -432,10 +432,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.agent-sessions-workbench .part.auxiliarybar,
-	.agent-sessions-workbench .part.panel,
-	.agent-sessions-workbench .part.chatbar,
-	.agent-sessions-workbench .part.sidebar > .content {
+	.agent-sessions-workbench.animations-ready .part.auxiliarybar,
+	.agent-sessions-workbench.animations-ready .part.panel,
+	.agent-sessions-workbench.animations-ready .part.chatbar,
+	.agent-sessions-workbench.animations-ready .part.sidebar > .content {
 		transition: none;
 	}
 }

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -371,9 +371,9 @@
  * within the grid-allocated space.
  */
 
-.agent-sessions-workbench .part.auxiliarybar,
-.agent-sessions-workbench .part.panel,
-.agent-sessions-workbench .part.chatbar {
+.agent-sessions-workbench.animations-ready .part.auxiliarybar,
+.agent-sessions-workbench.animations-ready .part.panel,
+.agent-sessions-workbench.animations-ready .part.chatbar {
 	transition:
 		opacity 250ms ease-out,
 		margin-top 250ms ease-out,
@@ -382,13 +382,13 @@
 }
 
 /* Auxiliary bar also transitions horizontal margin */
-.agent-sessions-workbench .part.auxiliarybar {
+.agent-sessions-workbench.animations-ready .part.auxiliarybar {
 	transition:
 		opacity 250ms ease-out,
 		margin 250ms ease-out;
 }
 
-.agent-sessions-workbench .part.sidebar > .content {
+.agent-sessions-workbench.animations-ready .part.sidebar > .content {
 	transition:
 		opacity 250ms ease-out,
 		transform 250ms ease-out;
@@ -396,37 +396,37 @@
 
 @starting-style {
 	/* Shared starting values */
-	.agent-sessions-workbench .part.auxiliarybar,
-	.agent-sessions-workbench .part.panel,
-	.agent-sessions-workbench .part.chatbar {
+	.agent-sessions-workbench.animations-ready .part.auxiliarybar,
+	.agent-sessions-workbench.animations-ready .part.panel,
+	.agent-sessions-workbench.animations-ready .part.chatbar {
 		opacity: 0;
 		border-color: transparent;
 	}
 
 	/* Card parts: blend from surrounding background */
-	.agent-sessions-workbench .part.auxiliarybar,
-	.agent-sessions-workbench .part.panel,
-	.agent-sessions-workbench .part.chatbar {
+	.agent-sessions-workbench.animations-ready .part.auxiliarybar,
+	.agent-sessions-workbench.animations-ready .part.panel,
+	.agent-sessions-workbench.animations-ready .part.chatbar {
 		background: color-mix(in srgb, var(--part-background) 60%, var(--vscode-sideBar-background));
 	}
 
-	.agent-sessions-workbench .part.sidebar > .content {
+	.agent-sessions-workbench.animations-ready .part.sidebar > .content {
 		opacity: 0;
 		transform: translateX(-6px);
 	}
 
 	/* Panel (bottom): slides down from 6px above → margin: 0 10px 10px 10px */
-	.agent-sessions-workbench .part.panel {
+	.agent-sessions-workbench.animations-ready .part.panel {
 		margin: 6px 16px 16px 16px;
 	}
 
 	/* Auxiliary bar (right): slides in from 6px right → margin: 0 10px 0px 0 */
-	.agent-sessions-workbench .part.auxiliarybar {
+	.agent-sessions-workbench.animations-ready .part.auxiliarybar {
 		margin: 0 16px 0px 6px;
 	}
 
 	/* Chat bar (center-bottom): slides up from 6px below → margin: 0 10px 0px 10px */
-	.agent-sessions-workbench .part.chatbar {
+	.agent-sessions-workbench.animations-ready .part.chatbar {
 		margin: 6px 16px 0px 16px;
 	}
 }
@@ -434,25 +434,10 @@
 @media (prefers-reduced-motion: reduce) {
 	.agent-sessions-workbench .part.auxiliarybar,
 	.agent-sessions-workbench .part.panel,
-	.agent-sessions-workbench .part.chatbar {
-		transition: none;
-	}
-
+	.agent-sessions-workbench .part.chatbar,
 	.agent-sessions-workbench .part.sidebar > .content {
 		transition: none;
 	}
-}
-
-/* Suppress all part-reveal transitions on initial startup so that
- * visible parts appear instantly without animation or layout shift. */
-.agent-sessions-workbench.starting-up .part.auxiliarybar,
-.agent-sessions-workbench.starting-up .part.panel,
-.agent-sessions-workbench.starting-up .part.chatbar {
-	transition: none;
-}
-
-.agent-sessions-workbench.starting-up .part.sidebar > .content {
-	transition: none;
 }
 
 /* ---- Widget Customizations ---- */

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -443,6 +443,18 @@
 	}
 }
 
+/* Suppress all part-reveal transitions on initial startup so that
+ * visible parts appear instantly without animation or layout shift. */
+.agent-sessions-workbench.starting-up .part.auxiliarybar,
+.agent-sessions-workbench.starting-up .part.panel,
+.agent-sessions-workbench.starting-up .part.chatbar {
+	transition: none;
+}
+
+.agent-sessions-workbench.starting-up .part.sidebar > .content {
+	transition: none;
+}
+
 /* ---- Widget Customizations ---- */
 
 /* Action Widget */

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -642,7 +642,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 				return;
 			}
 			this.mainContainer.classList.add(LayoutClasses.ANIMATIONS_READY);
-		});
+		}, onUnexpectedError);
 
 		// Set lifecycle phase to `Eventually` after a short delay and when idle (min 2.5sec, max 5sec)
 		const eventuallyPhaseScheduler = this._register(new RunOnceScheduler(() => {

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -85,7 +85,8 @@ enum LayoutClasses {
 	STATUSBAR_HIDDEN = 'nostatusbar',
 	EXPERIMENTAL_SHELL_GRADIENT_BACKGROUND = 'experimental-shell-gradient-background',
 	FULLSCREEN = 'fullscreen',
-	MAXIMIZED = 'maximized'
+	MAXIMIZED = 'maximized',
+	STARTING_UP = 'starting-up'
 }
 
 //#endregion
@@ -623,6 +624,13 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		// Restore parts (open default view containers)
 		this.restoreParts();
 
+		// Remove starting-up class after the initial paint so that
+		// part-reveal transitions are suppressed on first render but
+		// enabled for subsequent user-driven visibility changes.
+		// Double rAF guarantees at least one painted frame before
+		// re-enabling transitions (rAF fires before paint in Chromium).
+		mainWindow.requestAnimationFrame(() => mainWindow.requestAnimationFrame(() => this.mainContainer.classList.remove(LayoutClasses.STARTING_UP)));
+
 		// Set lifecycle phase to `Restored`
 		lifecycleService.phase = LifecyclePhase.Restored;
 
@@ -970,6 +978,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 
 	getLayoutClasses(): string[] {
 		return coalesce([
+			LayoutClasses.STARTING_UP, // suppress part-reveal animations until first paint
 			!this.partVisibility.sidebar ? LayoutClasses.SIDEBAR_HIDDEN : undefined,
 			!this.partVisibility.editor ? LayoutClasses.MAIN_EDITOR_AREA_HIDDEN : undefined,
 			!this.partVisibility.panel ? LayoutClasses.PANEL_HIDDEN : undefined,

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -237,7 +237,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 
 	private readonly partVisibility: IPartVisibilityState = {
 		sidebar: true,
-		auxiliaryBar: false,
+		auxiliaryBar: true,
 		editor: false,
 		panel: false,
 		chatBar: true

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -8,7 +8,7 @@ import './media/style.css';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 import { Emitter, Event, setGlobalLeakWarningThreshold } from '../../base/common/event.js';
 import { getActiveDocument, getActiveElement, getClientArea, getWindowId, getWindows, IDimension, isAncestorUsingFlowTo, size, Dimension, runWhenWindowIdle } from '../../base/browser/dom.js';
-import { DeferredPromise, disposableTimeout, RunOnceScheduler } from '../../base/common/async.js';
+import { DeferredPromise, RunOnceScheduler } from '../../base/common/async.js';
 import { isFullscreen, onDidChangeFullscreen, isChrome, isFirefox, isSafari } from '../../base/browser/browser.js';
 import { mark } from '../../base/common/performance.js';
 import { onUnexpectedError, setUnexpectedErrorHandler } from '../../base/common/errors.js';
@@ -624,19 +624,25 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		// Restore parts (open default view containers)
 		this.restoreParts();
 
-		// Enable part-reveal transitions only after the initial startup
-		// phase has settled. Both the `transition` declarations and the
-		// `@starting-style` rules are scoped behind `.animations-ready`,
-		// so any parts revealed during startup (including async pane-
-		// composite opens triggered by session loading) appear instantly.
-		// Subsequent user-driven toggles animate normally.
-		disposableTimeout(() => this.mainContainer.classList.add(LayoutClasses.ANIMATIONS_READY), 1500, this._store);
-
 		// Set lifecycle phase to `Restored`
 		lifecycleService.phase = LifecyclePhase.Restored;
 
 		// Mark as restored
 		this.setRestored();
+
+		// Enable part-reveal transitions once the workbench reaches the
+		// `Eventually` lifecycle phase. Both the `transition` declarations
+		// and the `@starting-style` rules are scoped behind `.animations-ready`,
+		// so any parts revealed during startup — including async pane-
+		// composite opens triggered by session-loading autoruns — appear
+		// instantly. `Eventually` is a well-defined signal that startup
+		// work has fully settled, avoiding any magic-number timing.
+		lifecycleService.when(LifecyclePhase.Eventually).then(() => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			this.mainContainer.classList.add(LayoutClasses.ANIMATIONS_READY);
+		});
 
 		// Set lifecycle phase to `Eventually` after a short delay and when idle (min 2.5sec, max 5sec)
 		const eventuallyPhaseScheduler = this._register(new RunOnceScheduler(() => {

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -8,7 +8,7 @@ import './media/style.css';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 import { Emitter, Event, setGlobalLeakWarningThreshold } from '../../base/common/event.js';
 import { getActiveDocument, getActiveElement, getClientArea, getWindowId, getWindows, IDimension, isAncestorUsingFlowTo, size, Dimension, runWhenWindowIdle } from '../../base/browser/dom.js';
-import { DeferredPromise, RunOnceScheduler } from '../../base/common/async.js';
+import { DeferredPromise, disposableTimeout, RunOnceScheduler } from '../../base/common/async.js';
 import { isFullscreen, onDidChangeFullscreen, isChrome, isFirefox, isSafari } from '../../base/browser/browser.js';
 import { mark } from '../../base/common/performance.js';
 import { onUnexpectedError, setUnexpectedErrorHandler } from '../../base/common/errors.js';
@@ -86,7 +86,7 @@ enum LayoutClasses {
 	EXPERIMENTAL_SHELL_GRADIENT_BACKGROUND = 'experimental-shell-gradient-background',
 	FULLSCREEN = 'fullscreen',
 	MAXIMIZED = 'maximized',
-	STARTING_UP = 'starting-up'
+	ANIMATIONS_READY = 'animations-ready'
 }
 
 //#endregion
@@ -624,12 +624,13 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		// Restore parts (open default view containers)
 		this.restoreParts();
 
-		// Remove starting-up class after the initial paint so that
-		// part-reveal transitions are suppressed on first render but
-		// enabled for subsequent user-driven visibility changes.
-		// Double rAF guarantees at least one painted frame before
-		// re-enabling transitions (rAF fires before paint in Chromium).
-		mainWindow.requestAnimationFrame(() => mainWindow.requestAnimationFrame(() => this.mainContainer.classList.remove(LayoutClasses.STARTING_UP)));
+		// Enable part-reveal transitions only after the initial startup
+		// phase has settled. Both the `transition` declarations and the
+		// `@starting-style` rules are scoped behind `.animations-ready`,
+		// so any parts revealed during startup (including async pane-
+		// composite opens triggered by session loading) appear instantly.
+		// Subsequent user-driven toggles animate normally.
+		disposableTimeout(() => this.mainContainer.classList.add(LayoutClasses.ANIMATIONS_READY), 1500, this._store);
 
 		// Set lifecycle phase to `Restored`
 		lifecycleService.phase = LifecyclePhase.Restored;
@@ -978,7 +979,6 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 
 	getLayoutClasses(): string[] {
 		return coalesce([
-			LayoutClasses.STARTING_UP, // suppress part-reveal animations until first paint
 			!this.partVisibility.sidebar ? LayoutClasses.SIDEBAR_HIDDEN : undefined,
 			!this.partVisibility.editor ? LayoutClasses.MAIN_EDITOR_AREA_HIDDEN : undefined,
 			!this.partVisibility.panel ? LayoutClasses.PANEL_HIDDEN : undefined,

--- a/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
@@ -25,10 +25,10 @@ const changesViewContainer = viewContainersRegistry.registerViewContainer({
 	title: localize2('changes', 'Changes'),
 	ctorDescriptor: new SyncDescriptor(ChangesViewPaneContainer),
 	icon: changesViewIcon,
-	order: 10,
+	order: 11,
 	hideIfEmpty: true,
 	windowVisibility: WindowVisibility.Sessions
-}, ViewContainerLocation.AuxiliaryBar, { doNotRegisterOpenCommand: true, isDefault: true });
+}, ViewContainerLocation.AuxiliaryBar, { doNotRegisterOpenCommand: true });
 
 const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry);
 

--- a/src/vs/sessions/contrib/files/browser/files.contribution.ts
+++ b/src/vs/sessions/contrib/files/browser/files.contribution.ts
@@ -11,7 +11,6 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
-import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { IViewContainersRegistry, IViewsRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, WindowVisibility } from '../../../../workbench/common/views.js';
 import { ExplorerView } from '../../../../workbench/contrib/files/browser/views/explorerView.js';
 import { ViewPaneContainer } from '../../../../workbench/browser/parts/views/viewPaneContainer.js';
@@ -23,53 +22,46 @@ export const SESSIONS_FILES_CONTAINER_ID = 'workbench.sessions.auxiliaryBar.file
 
 const filesViewIcon = registerIcon('sessions-files-view-icon', Codicon.files, localize2('sessionsFilesViewIcon', 'View icon of the files view in the sessions window.').value);
 
-class RegisterFilesViewContribution implements IWorkbenchContribution {
+const viewContainerRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
+const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry);
 
-	static readonly ID = 'sessions.registerFilesView';
+// Register a new Files view container in the auxiliary bar for the sessions window.
+// Registered eagerly (module load) so the container exists when the workbench
+// restores parts and can be opened as the default auxiliary bar view.
+const filesViewContainer = viewContainerRegistry.registerViewContainer({
+	id: SESSIONS_FILES_CONTAINER_ID,
+	title: localize2('files', "Files"),
+	icon: filesViewIcon,
+	order: 10,
+	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [SESSIONS_FILES_CONTAINER_ID, { mergeViewWithContainerWhenSingleView: true }]),
+	storageId: SESSIONS_FILES_CONTAINER_ID,
+	hideIfEmpty: true,
+	windowVisibility: WindowVisibility.Sessions,
+}, ViewContainerLocation.AuxiliaryBar, { doNotRegisterOpenCommand: true, isDefault: true });
 
-	constructor() {
-		const viewContainerRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
-		const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry);
+// Re-register the explorer view inside the new Files container
+viewsRegistry.registerViews([{
+	id: SESSIONS_FILES_VIEW_ID,
+	name: localize2('files', "Files"),
+	containerIcon: filesViewIcon,
+	ctorDescriptor: new SyncDescriptor(SessionsExplorerView),
+	canToggleVisibility: true,
+	canMoveView: false,
+	when: WorkspaceFolderCountContext.notEqualsTo('0'),
+	windowVisibility: WindowVisibility.Sessions,
+}], filesViewContainer);
 
-		// Register a new Files view container in the auxiliary bar for the sessions window
-		const filesViewContainer = viewContainerRegistry.registerViewContainer({
-			id: SESSIONS_FILES_CONTAINER_ID,
-			title: localize2('files', "Files"),
-			icon: filesViewIcon,
-			order: 11,
-			ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [SESSIONS_FILES_CONTAINER_ID, { mergeViewWithContainerWhenSingleView: true }]),
-			storageId: SESSIONS_FILES_CONTAINER_ID,
-			hideIfEmpty: true,
-			windowVisibility: WindowVisibility.Sessions,
-		}, ViewContainerLocation.AuxiliaryBar, { doNotRegisterOpenCommand: true });
-
-		// Re-register the explorer view inside the new Files container
-		viewsRegistry.registerViews([{
-			id: SESSIONS_FILES_VIEW_ID,
-			name: localize2('files', "Files"),
-			containerIcon: filesViewIcon,
-			ctorDescriptor: new SyncDescriptor(SessionsExplorerView),
-			canToggleVisibility: true,
-			canMoveView: false,
-			when: WorkspaceFolderCountContext.notEqualsTo('0'),
-			windowVisibility: WindowVisibility.Sessions,
-		}], filesViewContainer);
-
-		// Register an empty view to show when there are no workspace folders
-		viewsRegistry.registerViews([{
-			id: SESSIONS_FILES_EMPTY_VIEW_ID,
-			name: localize2('files', "Files"),
-			containerIcon: filesViewIcon,
-			ctorDescriptor: new SyncDescriptor(SessionsExplorerEmptyView),
-			canToggleVisibility: true,
-			canMoveView: false,
-			when: WorkspaceFolderCountContext.isEqualTo('0'),
-			windowVisibility: WindowVisibility.Sessions,
-		}], filesViewContainer);
-	}
-}
-
-registerWorkbenchContribution2(RegisterFilesViewContribution.ID, RegisterFilesViewContribution, WorkbenchPhase.AfterRestored);
+// Register an empty view to show when there are no workspace folders
+viewsRegistry.registerViews([{
+	id: SESSIONS_FILES_EMPTY_VIEW_ID,
+	name: localize2('files', "Files"),
+	containerIcon: filesViewIcon,
+	ctorDescriptor: new SyncDescriptor(SessionsExplorerEmptyView),
+	canToggleVisibility: true,
+	canMoveView: false,
+	when: WorkspaceFolderCountContext.isEqualTo('0'),
+	windowVisibility: WindowVisibility.Sessions,
+}], filesViewContainer);
 
 registerAction2(class extends Action2 {
 	constructor() {


### PR DESCRIPTION
Introduce a new layout class to manage part-reveal transitions during startup. Refactor the transition handling to activate after reaching the Eventually lifecycle phase, ensuring smoother animations. Address unexpected errors when applying the new class in the Workbench.

