### PR TITLE
GitHub: fix lowercase pull_request_template.md not found in .github/ folder

### DIFF
--- a/extensions/github/src/pushErrorHandler.ts
+++ b/extensions/github/src/pushErrorHandler.ts
@@ -22,7 +22,7 @@ export function isInCodespaces(): boolean {
 const PR_TEMPLATE_FILES = [
 	{ dir: '.', files: ['pull_request_template.md', 'PULL_REQUEST_TEMPLATE.md'] },
 	{ dir: 'docs', files: ['pull_request_template.md', 'PULL_REQUEST_TEMPLATE.md'] },
-	{ dir: '.github', files: ['PULL_REQUEST_TEMPLATE.md', 'PULL_REQUEST_TEMPLATE.md'] }
+	{ dir: '.github', files: ['pull_request_template.md', 'PULL_REQUEST_TEMPLATE.md'] }
 ];
 
 const PR_TEMPLATE_DIRECTORY_NAMES = [


### PR DESCRIPTION
Fixes #310976

## What

One-character fix in `extensions/github/src/pushErrorHandler.ts`.

## Root Cause

`PR_TEMPLATE_FILES` had a copy-paste error on the `.github` row:

```ts
// Before (broken):
{ dir: '.github', files: ['PULL_REQUEST_TEMPLATE.md', 'PULL_REQUEST_TEMPLATE.md'] }
//                          ^^^ uppercase duplicated — lowercase never checked

// After (fixed):
{ dir: '.github', files: ['pull_request_template.md', 'PULL_REQUEST_TEMPLATE.md'] }
//                          ^^^ lowercase first, matching root and docs/ rows
```

The root (`.`) and `docs/` directories correctly carry both `pull_request_template.md` and `PULL_REQUEST_TEMPLATE.md`. The `.github/` row accidentally had the uppercase string in both positions, so any repo using the lowercase filename inside `.github/` would never have that template offered during PR creation.

## Testing

- Repository with `.github/pull_request_template.md` (lowercase) → template is now found and offered.
- Repository with `.github/PULL_REQUEST_TEMPLATE.md` (uppercase) → still found (no regression).
- Repository with `pull_request_template.md` in root or `docs/` → unchanged.