### PR TITLE
fix(chat): cancel in-flight streaming tool invocations when response is cancelled (#288701)

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -30,7 +30,7 @@ import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCo
 import { ChatRequestToolReferenceEntry, IChatRequestVariableEntry, isImplicitVariableEntry, isStringImplicitContextValue, isStringVariableEntry } from '../attachments/chatVariableEntries.js';
 import { migrateLegacyTerminalToolSpecificData } from '../chat.js';
 import { ChatPerfMark, markChat } from '../chatPerf.js';
-import { ChatAgentVoteDirection, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, isIUsedContext } from '../chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, ToolConfirmKind, isIUsedContext } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ChatToolInvocation } from './chatProgressTypes/chatToolInvocation.js';
 import { ToolDataSource, IToolData } from '../tools/languageModelToolsService.js';
@@ -1433,6 +1433,16 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 	cancel(): void {
+		// Transition any tool invocations that are still streaming partial
+		// input from the LM into the Cancelled state so that UI consumers
+		// (e.g. the thinking content part) stop showing their in-progress
+		// spinner/"Editing files" label. See https://github.com/microsoft/vscode/issues/288701.
+		for (const part of this._response.value) {
+			if (part.kind === 'toolInvocation' && part instanceof ChatToolInvocation) {
+				part.cancelFromStreaming(ToolConfirmKind.Skipped);
+			}
+		}
+
 		this._modelState.set({ value: ResponseModelState.Cancelled, completedAt: Date.now() }, undefined);
 		this._onDidChange.fire({ reason: 'completedRequest' });
 	}

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -26,8 +26,10 @@ import { CellUri } from '../../../../notebook/common/notebookCommon.js';
 import { IChatRequestImplicitVariableEntry, IChatRequestStringVariableEntry, IChatRequestFileEntry, StringChatContextValue } from '../../../common/attachments/chatVariableEntries.js';
 import { ChatAgentService, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatModel, ChatRequestModel, ChatResponseResource, IChatRequestModeInfo, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response } from '../../../common/model/chatModel.js';
+import { ChatToolInvocation } from '../../../common/model/chatProgressTypes/chatToolInvocation.js';
 import { ChatRequestTextPart } from '../../../common/requestParser/chatParserTypes.js';
 import { ChatRequestQueueKind, IChatService, IChatTerminalToolInvocationData, IChatToolInvocation, ResponseModelState } from '../../../common/chatService/chatService.js';
+import { ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { MockChatService } from '../chatService/mockChatService.js';
 
@@ -1120,6 +1122,43 @@ suite('ChatResponseModel', () => {
 
 		model.cancelRequest(request);
 		assert.strictEqual(response.isIncomplete.get(), false);
+		assert.strictEqual(response.state, ResponseModelState.Cancelled);
+	});
+
+	test('cancellation transitions streaming tool invocations to Cancelled (issue #288701)', async () => {
+		const model = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, { initialLocation: ChatAgentLocation.Chat, canUseTools: true }));
+
+		const text = 'edit a file';
+		const request = model.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0);
+		const response = request.response!;
+
+		// Simulate a tool invocation that is still streaming partial input from
+		// the LM (e.g. an edit tool whose args are still being produced) when
+		// the user presses Stop. This is the exact scenario reported in #288701
+		// where the "Editing files" spinner remained after cancellation.
+		const toolInvocation = ChatToolInvocation.createStreaming({
+			toolCallId: 'tool-call-1',
+			toolId: 'replace_string_in_file',
+			toolData: {
+				id: 'replace_string_in_file',
+				modelDescription: 'Replace string in file',
+				displayName: 'Replace String in File',
+				source: ToolDataSource.Internal,
+			},
+		});
+		model.acceptResponseProgress(request, toolInvocation);
+
+		// Pre-conditions: the tool is in Streaming state (UI still shows spinner).
+		assert.strictEqual(toolInvocation.state.get().type, IChatToolInvocation.StateKind.Streaming);
+		assert.strictEqual(IChatToolInvocation.isComplete(toolInvocation), false);
+
+		// User presses Stop.
+		model.cancelRequest(request);
+
+		// The tool invocation must be transitioned out of Streaming so that the
+		// thinking content part sees it as complete and drops the spinner/label.
+		assert.strictEqual(toolInvocation.state.get().type, IChatToolInvocation.StateKind.Cancelled);
+		assert.strictEqual(IChatToolInvocation.isComplete(toolInvocation), true);
 		assert.strictEqual(response.state, ResponseModelState.Cancelled);
 	});
 


### PR DESCRIPTION
**What** — Pressing Stop while a tool call is still streaming partial input now also transitions that tool invocation to `Cancelled`, so the "Editing files" label and spinner on the thinking row clear immediately instead of hanging on-screen.

**Why** — `ChatResponseModel.cancel()` only flipped its own state. Any `ChatToolInvocation` that was in `StateKind.Streaming` (LM still producing tool arguments) stayed there forever. UI consumers (the autorun in `chatThinkingContentPart.ts`) kept treating the tool as in-progress, so the spinner/shimmer never cleared (#288701).

**How** — Inside `cancel()`, walk `this._response.value` for `ChatToolInvocation` parts and call the existing `cancelFromStreaming(ToolConfirmKind.Skipped)` on each. No new API surface. The `ToolConfirmKind` symbol was already available; just added it to the existing import line.

**Test plan** — New regression test in `chatModel.test.ts` (`ChatResponseModel` suite): create a streaming `ChatToolInvocation` on a `ChatModel`, assert state `Streaming`, call `cancelRequest(request)`, assert state `Cancelled` and `IChatToolInvocation.isComplete` true. Manual: trigger a multi-file edit via an agent-mode request, press Stop while the thinking row shows "Editing files"; the label/spinner clears immediately.

Fixes #288701