### PR TITLE
Merge conflict: use startsWith for splitter marker detection (diff3/zdiff3 support)

### DIFF
--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -59,7 +59,7 @@ export class MergeConflictParser {
 				currentConflict.commonAncestors.push(line);
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && !currentConflict.splitter && line.text === splitterMarker) {
+			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
 				currentConflict.splitter = line;
 			}
 			// Are we within a conflict block and is this a footer? >>>>>>>


### PR DESCRIPTION
Fixes #310985

## What

Changed the splitter marker (`=======`) detection in `mergeConflictParser.ts` from strict equality (`===`) to prefix matching (`startsWith`), consistent with how `<<<<<<<`, `|||||||`, and `>>>>>>>` markers are already detected.

## Why

When `merge.conflictstyle = diff3` or `merge.conflictstyle = zdiff3` is configured, git generates splitter lines with trailing text (e.g., `======= branch-name`). The strict `===` comparison caused these splitters to be silently skipped, meaning the entire conflict was dropped from the parser — leaving the file without any merge conflict decorations or CodeLens actions (Accept Current/Incoming/Both).

Using `startsWith` is the correct approach for all conflict markers, as git always starts them with the fixed prefix but may append branch names or other metadata.

## Testing

- Set `git config merge.conflictstyle zdiff3` in a test repo
- Create a merge conflict
- Open the conflicting file in VS Code
- Verify that CodeLens actions appear on the conflict markers and decorations are shown correctly