### PR TITLE
GitHub: clean up push protection error output entry after showing document

### DIFF
--- a/extensions/github/src/pushErrorHandler.ts
+++ b/extensions/github/src/pushErrorHandler.ts
@@ -309,7 +309,7 @@ export class GithubPushErrorHandler implements PushErrorHandler {
 			await window.showTextDocument(doc);
 		}
 		finally {
-			this.commandErrors.set(uri, stderr);
+			this.commandErrors.delete(uri);
 		}
 
 		// Show dialog


### PR DESCRIPTION
Fixes #310986

## What

Changed the `finally` block in `handlePushProtectionError` from `this.commandErrors.set(uri, stderr)` to `this.commandErrors.delete(uri)`.

## Why

The `CommandErrorOutputTextDocumentContentProvider` stores virtual document content in an in-memory `Map`. The method registers an entry before opening the document, and the `finally` block is meant to clean up afterward. Instead it was calling `set` again with the same content, so the entry was never removed. Each push protection rejection permanently leaked a copy of the full git stderr output into the map.

## Testing

- Trigger a GitHub push protection rejection (push a commit containing a secret to a repo with push protection enabled)
- Verify the error output is displayed correctly
- Verify the entry is cleaned up from the internal map after the document is shown