### PR TITLE
Agents - add editor layout toolbar to the editor title

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -672,10 +672,10 @@
 			"name": "vs/sessions/contrib/files",
 			"project": "vscode-sessions"
 		},
-                {
-                        "name": "vs/sessions/contrib/policyBlocked",
-                        "project": "vscode-sessions"
-                },
+		{
+			"name": "vs/sessions/contrib/policyBlocked",
+			"project": "vscode-sessions"
+		},
 		{
 			"name": "vs/sessions/contrib/git",
 			"project": "vscode-sessions"
@@ -710,6 +710,10 @@
 		},
 		{
 			"name": "vs/sessions/contrib/tunnelHost",
+			"project": "vscode-sessions"
+		},
+		{
+			"name": "vs/sessions/contrib/editor",
 			"project": "vscode-sessions"
 		}
 	]

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -939,6 +939,7 @@
 		"--inline-chat-frame-progress",
 		"--insert-border-color",
 		"--last-tab-margin-right",
+		"--last-tab-layout-actions-width",
 		"--list-scroll-right-offset",
 		"--monaco-monospace-font",
 		"--monaco-monospace-font",

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -88,6 +88,7 @@ export class MenuId {
 	static readonly EditorContextPeek = new MenuId('EditorContextPeek');
 	static readonly EditorContextShare = new MenuId('EditorContextShare');
 	static readonly EditorTitle = new MenuId('EditorTitle');
+	static readonly EditorTitleLayout = new MenuId('EditorTitleLayout');
 	static readonly ModalEditorTitle = new MenuId('ModalEditorTitle');
 	static readonly ModalEditorEditorTitle = new MenuId('ModalEditorEditorTitle');
 	static readonly CompactWindowEditorTitle = new MenuId('CompactWindowEditorTitle');

--- a/src/vs/sessions/browser/parts/media/editorPart.css
+++ b/src/vs/sessions/browser/parts/media/editorPart.css
@@ -19,3 +19,47 @@
 .agent-sessions-workbench.nosidebar.nochatbar .part.editor:not(.modal-editor-part) {
 	margin-left: 10px;
 }
+
+/* Editor Layout Actions Toolbar */
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
+	padding-right: 0;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-actions-separator {
+	display: block;
+	align-self: center;
+	width: 1px;
+	height: 16px;
+	margin: 0 4px;
+	background-color: var(--vscode-titleBar-activeForeground);
+	opacity: 0.3;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-layout-actions {
+	display: block;
+	cursor: default;
+	flex: initial;
+	padding: 0 8px 0 4px;
+	height: var(--editor-group-tab-height);
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-layout-actions.hidden {
+	display: none;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title .editor-layout-actions .action-item {
+	margin-right: 4px;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-layout-actions {
+	/* When tabs are wrapped, position the trailing editor actions at the end of the very last row */
+	position: absolute;
+	bottom: 0;
+	right: 0;
+}
+
+.agent-sessions-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-layout-actions {
+	/* When multiple tab bars are visible, only show editor actions for the last tab bar */
+	display: none;
+}

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -26,9 +26,6 @@ import { ViewContainerLocation } from '../../../../workbench/common/views.js';
 import { ChangesViewPane } from './changesView.js';
 import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribution.js';
 import { SESSIONS_FILES_VIEW_ID } from '../../files/browser/filesView.js';
-import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
-import { EditorMaximizedContext } from '../../../common/contextkeys.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 const openChangesViewActionOptions: IAction2Options = {
 	id: 'workbench.action.agentSessions.openChangesView',
@@ -204,85 +201,3 @@ class OpenPullRequestAction extends Action2 {
 }
 
 registerAction2(OpenPullRequestAction);
-
-class MaximizeMainEditorPartAction extends Action2 {
-	static readonly ID = 'workbench.action.agentSessions.maximizeMainEditorPart';
-
-	constructor() {
-		super({
-			id: MaximizeMainEditorPartAction.ID,
-			title: localize2('maximizeMainEditorPart', "Maximize Editor"),
-			icon: Codicon.screenFull,
-			f1: false,
-			menu: {
-				id: MenuId.EditorTitleLayout,
-				group: 'navigation',
-				order: 1,
-				when: ContextKeyExpr.and(
-					IsSessionsWindowContext,
-					EditorMaximizedContext.negate())
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
-		layoutService.setEditorMaximized(true);
-	}
-}
-
-registerAction2(MaximizeMainEditorPartAction);
-
-class RestoreMainEditorPartAction extends Action2 {
-	static readonly ID = 'workbench.action.agentSessions.restoreMainEditorPart';
-
-	constructor() {
-		super({
-			id: RestoreMainEditorPartAction.ID,
-			title: localize2('restoreMainEditorPart', "Restore Editor"),
-			icon: Codicon.screenNormal,
-			f1: false,
-			menu: {
-				id: MenuId.EditorTitleLayout,
-				group: 'navigation',
-				order: 1,
-				when: ContextKeyExpr.and(
-					IsSessionsWindowContext,
-					EditorMaximizedContext)
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
-		layoutService.setEditorMaximized(false);
-	}
-}
-
-registerAction2(RestoreMainEditorPartAction);
-
-class CloseMainEditorPartAction extends Action2 {
-	static readonly ID = 'workbench.action.agentSessions.closeMainEditorPart';
-
-	constructor() {
-		super({
-			id: CloseMainEditorPartAction.ID,
-			title: localize2('closeMainEditorPart', "Close Editor"),
-			icon: Codicon.close,
-			f1: false,
-			menu: {
-				id: MenuId.EditorTitleLayout,
-				group: 'navigation',
-				order: 100,
-				when: IsSessionsWindowContext
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const commandService = accessor.get(ICommandService);
-		await commandService.executeCommand('workbench.action.closeAllGroups');
-	}
-}
-
-registerAction2(CloseMainEditorPartAction);

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -28,6 +28,7 @@ import { SESSIONS_FILES_CONTAINER_ID } from '../../files/browser/files.contribut
 import { SESSIONS_FILES_VIEW_ID } from '../../files/browser/filesView.js';
 import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
 import { EditorMaximizedContext } from '../../../common/contextkeys.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 const openChangesViewActionOptions: IAction2Options = {
 	id: 'workbench.action.agentSessions.openChangesView',
@@ -279,8 +280,8 @@ class CloseMainEditorPartAction extends Action2 {
 	}
 
 	async run(accessor: ServicesAccessor): Promise<void> {
-		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
-		layoutService.setEditorMaximized(false);
+		const commandService = accessor.get(ICommandService);
+		await commandService.executeCommand('workbench.action.closeAllGroups');
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesViewActions.ts
@@ -214,9 +214,9 @@ class MaximizeMainEditorPartAction extends Action2 {
 			icon: Codicon.screenFull,
 			f1: false,
 			menu: {
-				id: MenuId.EditorTitle,
+				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
-				order: 100001,
+				order: 1,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
 					EditorMaximizedContext.negate())
@@ -242,9 +242,9 @@ class RestoreMainEditorPartAction extends Action2 {
 			icon: Codicon.screenNormal,
 			f1: false,
 			menu: {
-				id: MenuId.EditorTitle,
+				id: MenuId.EditorTitleLayout,
 				group: 'navigation',
-				order: 100001,
+				order: 1,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
 					EditorMaximizedContext)
@@ -259,3 +259,29 @@ class RestoreMainEditorPartAction extends Action2 {
 }
 
 registerAction2(RestoreMainEditorPartAction);
+
+class CloseMainEditorPartAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.closeMainEditorPart';
+
+	constructor() {
+		super({
+			id: CloseMainEditorPartAction.ID,
+			title: localize2('closeMainEditorPart', "Close Editor"),
+			icon: Codicon.close,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 100,
+				when: IsSessionsWindowContext
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		layoutService.setEditorMaximized(false);
+	}
+}
+
+registerAction2(CloseMainEditorPartAction);

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../../nls.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
+import { IAgentWorkbenchLayoutService } from '../../../browser/workbench.js';
+import { EditorMaximizedContext } from '../../../common/contextkeys.js';
+
+class MaximizeMainEditorPartAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.maximizeMainEditorPart';
+
+	constructor() {
+		super({
+			id: MaximizeMainEditorPartAction.ID,
+			title: localize2('maximizeMainEditorPart', "Maximize Editor"),
+			icon: Codicon.screenFull,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext,
+					EditorMaximizedContext.negate())
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		layoutService.setEditorMaximized(true);
+	}
+}
+
+registerAction2(MaximizeMainEditorPartAction);
+
+class RestoreMainEditorPartAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.restoreMainEditorPart';
+
+	constructor() {
+		super({
+			id: RestoreMainEditorPartAction.ID,
+			title: localize2('restoreMainEditorPart', "Restore Editor"),
+			icon: Codicon.screenNormal,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.and(
+					IsSessionsWindowContext,
+					EditorMaximizedContext)
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		layoutService.setEditorMaximized(false);
+	}
+}
+
+registerAction2(RestoreMainEditorPartAction);
+
+class CloseMainEditorPartAction extends Action2 {
+	static readonly ID = 'workbench.action.agentSessions.closeMainEditorPart';
+
+	constructor() {
+		super({
+			id: CloseMainEditorPartAction.ID,
+			title: localize2('closeMainEditorPart', "Close Editor"),
+			icon: Codicon.close,
+			f1: false,
+			menu: {
+				id: MenuId.EditorTitleLayout,
+				group: 'navigation',
+				order: 100,
+				when: IsSessionsWindowContext
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		await commandService.executeCommand('workbench.action.closeAllGroups');
+	}
+}
+
+registerAction2(CloseMainEditorPartAction);

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -475,6 +475,7 @@ import './contrib/applyCommitsToParentRepo/browser/applyChangesToParentRepo.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js'; // view registration disabled; filesystem provider still needed
 import './contrib/configuration/browser/configuration.contribution.js';
 import './contrib/workingSet/browser/workingSet.contribution.js';
+import './contrib/editor/browser/editor.contribution.js';
 
 import './contrib/terminal/browser/sessionsTerminalContribution.js';
 import './contrib/logs/browser/logs.contribution.js';

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -6,7 +6,7 @@
 import './media/editortabscontrol.css';
 import { localize } from '../../../../nls.js';
 import { DataTransfers } from '../../../../base/browser/dnd.js';
-import { $, Dimension, getActiveWindow, getWindow, isMouseEvent } from '../../../../base/browser/dom.js';
+import { $, Dimension, getActiveWindow, getWindow, isMouseEvent, setVisibility } from '../../../../base/browser/dom.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { ActionsOrientation, IActionViewItem, prepareActions } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IAction, ActionRunner } from '../../../../base/common/actions.js';
@@ -32,7 +32,7 @@ import { assertReturnsDefined } from '../../../../base/common/types.js';
 import { isFirefox } from '../../../../base/browser/browser.js';
 import { isCancellationError } from '../../../../base/common/errors.js';
 import { SideBySideEditorInput } from '../../../common/editor/sideBySideEditorInput.js';
-import { WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
+import { WorkbenchToolBar, HiddenItemStrategy } from '../../../../platform/actions/browser/toolbar.js';
 import { LocalSelectionTransfer } from '../../../../platform/dnd/browser/dnd.js';
 import { DraggedTreeItemsIdentifier } from '../../../../editor/common/services/treeViewsDnd.js';
 import { IEditorResolverService } from '../../../services/editor/common/editorResolverService.js';
@@ -109,6 +109,12 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	private readonly editorActionsToolbarDisposables = this._register(new DisposableStore());
 	private readonly editorActionsDisposables = this._register(new DisposableStore());
 
+	private editorLayoutActionsSeparator: HTMLElement | undefined;
+	protected editorLayoutActionsToolbarContainer: HTMLElement | undefined;
+	private editorLayoutActionsToolbar: WorkbenchToolBar | undefined;
+	private readonly editorLayoutActionsToolbarDisposables = this._register(new DisposableStore());
+	private readonly editorLayoutActionsDisposables = this._register(new DisposableStore());
+
 	private readonly contextMenuContextKeyService: IContextKeyService;
 	private resourceContext: ResourceContextKey;
 
@@ -182,6 +188,16 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		parent.appendChild(this.editorActionsToolbarContainer);
 
 		this.handleEditorActionToolBarVisibility(this.editorActionsToolbarContainer);
+
+		this.editorLayoutActionsSeparator = $('div.editor-action-separator');
+		parent.appendChild(this.editorLayoutActionsSeparator);
+		setVisibility(false, this.editorLayoutActionsSeparator);
+
+		this.editorLayoutActionsToolbarContainer = $('div.editor-layout-actions');
+		this.editorLayoutActionsToolbarContainer.classList.add(...classes);
+		parent.appendChild(this.editorLayoutActionsToolbarContainer);
+
+		this.handleEditorLayoutActionsToolBarVisibility(this.editorLayoutActionsToolbarContainer);
 	}
 
 	private handleEditorActionToolBarVisibility(container: HTMLElement): void {
@@ -198,6 +214,25 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 			this.editorActionsToolbar = undefined;
 			this.editorActionsToolbarDisposables.clear();
 			this.editorActionsDisposables.clear();
+		}
+
+		container.classList.toggle('hidden', !editorActionsEnabled);
+	}
+
+	private handleEditorLayoutActionsToolBarVisibility(container: HTMLElement): void {
+		const editorActionsEnabled = this.editorActionsEnabled;
+		const editorActionsVisible = !!this.editorLayoutActionsToolbar;
+
+		// Create toolbar if it is enabled (and not yet created)
+		if (editorActionsEnabled && !editorActionsVisible) {
+			this.doCreateEditorLayoutActionsToolBar(container);
+		}
+		// Remove toolbar if it is not enabled (and is visible)
+		else if (!editorActionsEnabled && editorActionsVisible) {
+			this.editorLayoutActionsToolbar?.getElement().remove();
+			this.editorLayoutActionsToolbar = undefined;
+			this.editorLayoutActionsToolbarDisposables.clear();
+			this.editorLayoutActionsDisposables.clear();
 		}
 
 		container.classList.toggle('hidden', !editorActionsEnabled);
@@ -226,6 +261,38 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 		// Action Run Handling
 		this.editorActionsToolbarDisposables.add(this.editorActionsToolbar.actionRunner.onDidRun(e => {
+
+			// Notify for Error
+			if (e.error && !isCancellationError(e.error)) {
+				this.notificationService.error(e.error);
+			}
+		}));
+	}
+
+	private doCreateEditorLayoutActionsToolBar(container: HTMLElement): void {
+		const context: IEditorCommandsContext = { groupId: this.groupView.id };
+
+		// Toolbar Widget (no overflow, no hidden-item "..." button so layout actions
+		// are always rendered inline after the primary toolbar's own overflow).
+		this.editorLayoutActionsToolbar = this.editorLayoutActionsToolbarDisposables.add(this.instantiationService.createInstance(WorkbenchToolBar, container, {
+			actionViewItemProvider: (action, options) => this.actionViewItemProvider(action, options),
+			orientation: ActionsOrientation.HORIZONTAL,
+			ariaLabel: localize('ariaLabelEditorActionsLayout', "Editor layout actions"),
+			getKeyBinding: action => this.getKeybinding(action),
+			actionRunner: this.editorLayoutActionsToolbarDisposables.add(new EditorCommandsContextActionRunner(context)),
+			anchorAlignmentProvider: () => AnchorAlignment.RIGHT,
+			renderDropdownAsChildElement: this.renderDropdownAsChildElement,
+			telemetrySource: 'editorPartTrailing',
+			resetMenu: MenuId.EditorTitleLayout,
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			highlightToggledItems: true
+		}));
+
+		// Context
+		this.editorLayoutActionsToolbar.context = context;
+
+		// Action Run Handling
+		this.editorLayoutActionsToolbarDisposables.add(this.editorLayoutActionsToolbar.actionRunner.onDidRun(e => {
 
 			// Notify for Error
 			if (e.error && !isCancellationError(e.error)) {
@@ -263,9 +330,33 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		const editorActionsToolbar = assertReturnsDefined(this.editorActionsToolbar);
 		const { primary, secondary } = this.prepareEditorActions(editorActions.actions);
 		editorActionsToolbar.setActions(prepareActions(primary), prepareActions(secondary));
+
+		this.updateEditorLayoutActionsToolbar();
+	}
+
+	private updateEditorLayoutActionsToolbar(): void {
+		if (!this.editorActionsEnabled || !this.editorLayoutActionsToolbar) {
+			return;
+		}
+
+		this.editorLayoutActionsDisposables.clear();
+
+		const editorActions = this.groupView.createEditorActions(this.editorLayoutActionsDisposables, MenuId.EditorTitleLayout);
+		this.editorLayoutActionsDisposables.add(editorActions.onDidChange(() => this.updateEditorLayoutActionsToolbar()));
+
+		const { primary, secondary } = this.prepareEditorLayoutActions(editorActions.actions);
+		this.editorLayoutActionsToolbar.setActions(prepareActions(primary), prepareActions(secondary));
+
+		// Only show the separator when the layout toolbar actually has actions.
+		if (this.editorLayoutActionsSeparator) {
+			setVisibility(primary.length > 0 || secondary.length > 0, this.editorLayoutActionsSeparator);
+		}
 	}
 
 	protected abstract prepareEditorActions(editorActions: IToolbarActions): IToolbarActions;
+
+	protected abstract prepareEditorLayoutActions(editorActions: IToolbarActions): IToolbarActions;
+
 	private getEditorPaneAwareContextKeyService(): IContextKeyService {
 		return this.groupView.activeEditorPane?.scopedContextKeyService ?? this.contextKeyService;
 	}
@@ -277,6 +368,8 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 		const editorActionsToolbar = assertReturnsDefined(this.editorActionsToolbar);
 		editorActionsToolbar.setActions([], []);
+
+		this.editorLayoutActionsToolbar?.setActions([], []);
 	}
 
 	protected onGroupDragStart(e: DragEvent, element: HTMLElement): boolean {
@@ -482,6 +575,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 			if (this.editorActionsToolbarContainer) {
 				this.handleEditorActionToolBarVisibility(this.editorActionsToolbarContainer);
 				this.updateEditorActionsToolbar();
+			}
+			if (this.editorLayoutActionsToolbarContainer) {
+				this.handleEditorLayoutActionsToolBarVisibility(this.editorLayoutActionsToolbarContainer);
+				this.updateEditorLayoutActionsToolbar();
 			}
 		}
 	}

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -189,12 +189,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 		this.handleEditorActionToolBarVisibility(this.editorActionsToolbarContainer);
 
-		this.editorLayoutActionsSeparator = $('div.editor-action-separator');
+		this.editorLayoutActionsSeparator = $('div.editor-actions-separator');
 		parent.appendChild(this.editorLayoutActionsSeparator);
-		setVisibility(false, this.editorLayoutActionsSeparator);
 
 		this.editorLayoutActionsToolbarContainer = $('div.editor-layout-actions');
-		this.editorLayoutActionsToolbarContainer.classList.add(...classes);
 		parent.appendChild(this.editorLayoutActionsToolbarContainer);
 
 		this.handleEditorLayoutActionsToolBarVisibility(this.editorLayoutActionsToolbarContainer);
@@ -236,6 +234,13 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		}
 
 		container.classList.toggle('hidden', !editorActionsEnabled);
+
+		// Keep the sibling separator in sync with the toolbar. The separator lives outside
+		// the hidden containers so it must be explicitly hidden whenever the layout toolbar
+		// is disabled/removed; otherwise it would remain visible as an orphan line.
+		if (this.editorLayoutActionsSeparator && !editorActionsEnabled) {
+			setVisibility(false, this.editorLayoutActionsSeparator);
+		}
 	}
 
 	private doCreateEditorActionsToolBar(container: HTMLElement): void {
@@ -370,6 +375,9 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		editorActionsToolbar.setActions([], []);
 
 		this.editorLayoutActionsToolbar?.setActions([], []);
+		if (this.editorLayoutActionsSeparator) {
+			setVisibility(false, this.editorLayoutActionsSeparator);
+		}
 	}
 
 	protected onGroupDragStart(e: DragEvent, element: HTMLElement): boolean {

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -431,12 +431,12 @@
 	display: none; /* hide the tab actions when we are configured to hide it (unless dirty, but always when sticky-compact) */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label, /* always show tab actions for active tab */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus, /* always show tab actions on focus */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label, /* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label, /* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label, /* always show tab actions for sticky tabs */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label { /* always show tab actions for dirty tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label,		/* always show tab actions for active tab */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus,		/* always show tab actions on focus */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label,		/* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label,	/* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,		/* always show tab actions for sticky tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label {		/* always show tab actions for dirty tabs */
 	opacity: 1;
 }
 

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -43,8 +43,7 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
 	display: flex;
-	position: relative;
-	/* position tabs border bottom or editor actions (when tabs wrap) relative to this container */
+	position: relative; /* position tabs border bottom or editor actions (when tabs wrap) relative to this container */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.empty {
@@ -77,8 +76,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
 	display: flex;
 	height: var(--editor-group-tab-height);
-	scrollbar-width: none;
-	/* Firefox: hide scrollbar */
+	scrollbar-width: none; /* Firefox: hide scrollbar */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.scroll {
@@ -93,8 +91,7 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container::-webkit-scrollbar {
-	display: none;
-	/* Chrome + Safari: hide scrollbar */
+	display: none; /* Chrome + Safari: hide scrollbar */
 }
 
 /* Tab */
@@ -114,15 +111,12 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
 	background-color: var(--vscode-tab-unfocusedInactiveBackground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab {
 	background-color: var(--vscode-tab-inactiveBackground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-unfocusedActiveBackground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-activeBackground);
 }
@@ -131,15 +125,12 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
 	color: var(--vscode-tab-unfocusedInactiveForeground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab {
 	color: var(--vscode-tab-inactiveForeground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	color: var(--vscode-tab-unfocusedActiveForeground);
 }
-
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	color: var(--vscode-tab-activeForeground);
 }
@@ -162,21 +153,18 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child {
-	margin-right: var(--last-tab-margin-right);
-	/* when tabs wrap, we need a margin away from the absolute positioned editor actions */
+	margin-right: var(--last-tab-margin-right); /* when tabs wrap, we need a margin away from the absolute positioned editor actions */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.last-in-row:not(:last-child) {
-	border-right: 0 !important;
-	/* ensure no border for every last tab in a row except last row (#115046) */
+	border-right: 0 !important; /* ensure no border for every last tab in a row except last row (#115046) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon.tab-actions-right,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon.close-action-off:not(.sticky-compact),
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.has-icon.tab-actions-right,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.has-icon.close-action-off:not(.sticky-compact) {
-	padding-left: 5px;
-	/* reduce padding when we show icons and are in shrinking mode and tab actions is not left (unless sticky-compact) */
+	padding-left: 5px; /* reduce padding when we show icons and are in shrinking mode and tab actions is not left (unless sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit {
@@ -188,8 +176,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed {
 	min-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-min-width, 50px));
 	max-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-max-width, 160px));
-	flex: 1 0 0;
-	/* all tabs are evenly sized and grow */
+	flex: 1 0 0; /* all tabs are evenly sized and grow */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.last-in-row {
@@ -200,16 +187,13 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child) {
-	flex-grow: 1;
-	/* grow the last tab in a row for a more homogeneous look except for last row (#113801) */
+	flex-grow: 1; /* grow the last tab in a row for a more homogeneous look except for last row (#113801) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink {
 	min-width: 80px;
-	flex-basis: 0;
-	/* all tabs are even */
-	flex-grow: 1;
-	/* all tabs grow even */
+	flex-basis: 0; /* all tabs are even */
+	flex-grow: 1; /* all tabs grow even */
 	max-width: fit-content;
 }
 
@@ -276,16 +260,13 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.close-action-off .tab-fade-hider {
 	display: flex;
 	flex: 0;
-	width: 5px;
-	/* reserve space to hide tab fade when close button is left or off (fixes https://github.com/microsoft/vscode/issues/45728) */
+	width: 5px; /* reserve space to hide tab fade when close button is left or off (fixes https://github.com/microsoft/vscode/issues/45728) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-left,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.tab-actions-left {
-	min-width: 80px;
-	/* make more room for close button when it shows to the left */
-	padding-right: 5px;
-	/* we need less room when sizing is shrink/fixed */
+	min-width: 80px; /* make more room for close button when it shows to the left */
+	padding-right: 5px; /* we need less room when sizing is shrink/fixed */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-left:not(.sticky-compact) {
@@ -298,8 +279,7 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-border-top-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-border-bottom-container {
-	display: none;
-	/* hidden by default until a color is provided (see below) */
+	display: none; /* hidden by default until a color is provided (see below) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-top > .tab-border-top-container,
@@ -341,8 +321,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label {
 	margin-top: auto;
 	margin-bottom: auto;
-	line-height: var(--editor-group-tab-height);
-	/* aligns icon and label vertically centered in the tab */
+	line-height: var(--editor-group-tab-height); /* aligns icon and label vertically centered in the tab */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink .tab-label,
@@ -352,8 +331,7 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .tab-label > .monaco-icon-label-container::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .tab-label > .monaco-icon-label-container::after {
-	content: '';
-	/* enables a linear gradient to overlay the end of the label when tabs overflow */
+	content: ''; /* enables a linear gradient to overlay the end of the label when tabs overflow */
 	position: absolute;
 	right: 0;
 	width: 5px;
@@ -367,39 +345,30 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink:focus > .tab-label > .monaco-icon-label-container::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed:focus > .tab-label > .monaco-icon-label-container::after {
-	opacity: 0;
-	/* when tab has the focus this shade breaks the tab border (fixes https://github.com/microsoft/vscode/issues/57819) */
+	opacity: 0; /* when tab has the focus this shade breaks the tab border (fixes https://github.com/microsoft/vscode/issues/57819) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .tab-label.tab-label-has-badge::after,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .tab-label.tab-label-has-badge::after {
-	margin-right: 5px;
-	/* with tab sizing shrink/fixed and badges, we want a right-margin because the close button is hidden. Use margin instead of padding to support animating the badge (https://github.com/microsoft/vscode/issues/242661) */
+	margin-right: 5px; /* with tab sizing shrink/fixed and badges, we want a right-margin because the close button is hidden. Use margin instead of padding to support animating the badge (https://github.com/microsoft/vscode/issues/242661) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink:not(.tab-actions-left):not(.close-action-off) .tab-label {
-	padding-right: 5px;
-	/* ensure that the gradient does not show when tab actions show https://github.com/microsoft/vscode/issues/189625*/
+	padding-right: 5px; /* ensure that the gradient does not show when tab actions show https://github.com/microsoft/vscode/issues/189625*/
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky-compact:not(.has-icon) .monaco-icon-label {
-	text-align: center;
-	/* ensure that sticky-compact tabs without icon have label centered */
+	text-align: center; /* ensure that sticky-compact tabs without icon have label centered */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label > .monaco-icon-label-container {
-	overflow-x: visible;
-	/* fixes https://github.com/microsoft/vscode/issues/20182 by ensuring the horizontal overflow is visible */
+	overflow-x: visible; /* fixes https://github.com/microsoft/vscode/issues/20182 by ensuring the horizontal overflow is visible */
 
-	scrollbar-width: none;
-	/* Firefox */
-	-ms-overflow-style: none;
-
-	/* Internet Explorer 10+ */
+	scrollbar-width: none; /* Firefox */
+	-ms-overflow-style: none; /* Internet Explorer 10+ */
 	&::-webkit-scrollbar {
-		display: none;
-		/* Chrome, Safari, and Opera */
+		display: none; /* Chrome, Safari, and Opera */
 	}
 }
 
@@ -443,8 +412,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-shrink > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed > .tab-actions {
 	flex: 0;
-	overflow: hidden;
-	/* let the tab actions be pushed out of view when sizing is set to shrink/fixed to make more room */
+	overflow: hidden; /* let the tab actions be pushed out of view when sizing is set to shrink/fixed to make more room */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty.tab-actions-right.sizing-shrink > .tab-actions,
@@ -455,28 +423,20 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky.tab-actions-right.sizing-fixed > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed:hover > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed > .tab-actions:focus-within {
-	overflow: visible;
-	/* ...but still show the tab actions on hover, focus and when dirty or sticky */
+	overflow: visible; /* ...but still show the tab actions on hover, focus and when dirty or sticky */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off:not(.dirty) > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky-compact > .tab-actions {
-	display: none;
-	/* hide the tab actions when we are configured to hide it (unless dirty, but always when sticky-compact) */
+	display: none; /* hide the tab actions when we are configured to hide it (unless dirty, but always when sticky-compact) */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label,
-/* always show tab actions for active tab */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus,
-/* always show tab actions on focus */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label,
-/* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label,
-/* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,
-/* always show tab actions for sticky tabs */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label {
-	/* always show tab actions for dirty tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label, /* always show tab actions for active tab */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus, /* always show tab actions on focus */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label, /* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label, /* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label, /* always show tab actions for sticky tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label { /* always show tab actions for dirty tabs */
 	opacity: 1;
 }
 
@@ -511,8 +471,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty > .tab-actions .action-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:hover > .tab-actions .action-label {
-	opacity: 0.5;
-	/* show tab actions dimmed for inactive group */
+	opacity: 0.5; /* show tab actions dimmed for inactive group */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-actions .action-label {
@@ -522,29 +481,24 @@
 /* Tab Actions: Off */
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off {
-	padding-right: 10px;
-	/* give a little bit more room if tab actions is off */
+	padding-right: 10px; /* give a little bit more room if tab actions is off */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.close-action-off:not(.sticky-compact),
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.close-action-off:not(.sticky-compact) {
-	padding-right: 5px;
-	/* we need less room when sizing is shrink/fixed (unless tab is sticky-compact) */
+	padding-right: 5px; /* we need less room when sizing is shrink/fixed (unless tab is sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off.dirty-border-top > .tab-actions {
-	display: none;
-	/* hide dirty state when highlightModifiedTabs is enabled and when running without tab actions */
+	display: none; /* hide dirty state when highlightModifiedTabs is enabled and when running without tab actions */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off.dirty:not(.dirty-border-top):not(.sticky-compact) {
-	padding-right: 0;
-	/* remove extra padding when we are running without tab actions (unless tab is sticky-compact) */
+	padding-right: 0; /* remove extra padding when we are running without tab actions (unless tab is sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off > .tab-actions {
-	pointer-events: none;
-	/* don't allow tab actions to be clicked when running without tab actions */
+	pointer-events: none; /* don't allow tab actions to be clicked when running without tab actions */
 }
 
 /* Editor Actions Toolbar */
@@ -597,8 +551,7 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.drop-target-left::after {
-	right: -1px;
-	/* -1 to connect with drop-target-right */
+	right: -1px; /* -1 to connect with drop-target-right */
 }
 
 /* Make drop target edge cases more visible (wrapped tabs & first/last) */

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -43,7 +43,8 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
 	display: flex;
-	position: relative; /* position tabs border bottom or editor actions (when tabs wrap) relative to this container */
+	position: relative;
+	/* position tabs border bottom or editor actions (when tabs wrap) relative to this container */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.empty {
@@ -76,7 +77,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
 	display: flex;
 	height: var(--editor-group-tab-height);
-	scrollbar-width: none; /* Firefox: hide scrollbar */
+	scrollbar-width: none;
+	/* Firefox: hide scrollbar */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.scroll {
@@ -91,7 +93,8 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container::-webkit-scrollbar {
-	display: none; /* Chrome + Safari: hide scrollbar */
+	display: none;
+	/* Chrome + Safari: hide scrollbar */
 }
 
 /* Tab */
@@ -111,12 +114,15 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
 	background-color: var(--vscode-tab-unfocusedInactiveBackground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab {
 	background-color: var(--vscode-tab-inactiveBackground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-unfocusedActiveBackground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-activeBackground);
 }
@@ -125,12 +131,15 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
 	color: var(--vscode-tab-unfocusedInactiveForeground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab {
 	color: var(--vscode-tab-inactiveForeground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	color: var(--vscode-tab-unfocusedActiveForeground);
 }
+
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	color: var(--vscode-tab-activeForeground);
 }
@@ -153,18 +162,21 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child {
-	margin-right: var(--last-tab-margin-right); /* when tabs wrap, we need a margin away from the absolute positioned editor actions */
+	margin-right: var(--last-tab-margin-right);
+	/* when tabs wrap, we need a margin away from the absolute positioned editor actions */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.last-in-row:not(:last-child) {
-	border-right: 0 !important; /* ensure no border for every last tab in a row except last row (#115046) */
+	border-right: 0 !important;
+	/* ensure no border for every last tab in a row except last row (#115046) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon.tab-actions-right,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon.close-action-off:not(.sticky-compact),
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.has-icon.tab-actions-right,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.has-icon.close-action-off:not(.sticky-compact) {
-	padding-left: 5px; /* reduce padding when we show icons and are in shrinking mode and tab actions is not left (unless sticky-compact) */
+	padding-left: 5px;
+	/* reduce padding when we show icons and are in shrinking mode and tab actions is not left (unless sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit {
@@ -176,7 +188,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed {
 	min-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-min-width, 50px));
 	max-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-max-width, 160px));
-	flex: 1 0 0; /* all tabs are evenly sized and grow */
+	flex: 1 0 0;
+	/* all tabs are evenly sized and grow */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.last-in-row {
@@ -187,13 +200,16 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child) {
-	flex-grow: 1; /* grow the last tab in a row for a more homogeneous look except for last row (#113801) */
+	flex-grow: 1;
+	/* grow the last tab in a row for a more homogeneous look except for last row (#113801) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink {
 	min-width: 80px;
-	flex-basis: 0; /* all tabs are even */
-	flex-grow: 1; /* all tabs grow even */
+	flex-basis: 0;
+	/* all tabs are even */
+	flex-grow: 1;
+	/* all tabs grow even */
 	max-width: fit-content;
 }
 
@@ -260,13 +276,16 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.close-action-off .tab-fade-hider {
 	display: flex;
 	flex: 0;
-	width: 5px; /* reserve space to hide tab fade when close button is left or off (fixes https://github.com/microsoft/vscode/issues/45728) */
+	width: 5px;
+	/* reserve space to hide tab fade when close button is left or off (fixes https://github.com/microsoft/vscode/issues/45728) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-left,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.tab-actions-left {
-	min-width: 80px; /* make more room for close button when it shows to the left */
-	padding-right: 5px; /* we need less room when sizing is shrink/fixed */
+	min-width: 80px;
+	/* make more room for close button when it shows to the left */
+	padding-right: 5px;
+	/* we need less room when sizing is shrink/fixed */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-left:not(.sticky-compact) {
@@ -279,13 +298,14 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-border-top-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-border-bottom-container {
-	display: none; /* hidden by default until a color is provided (see below) */
+	display: none;
+	/* hidden by default until a color is provided (see below) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-top > .tab-border-top-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.selected.tab-border-top > .tab-border-top-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title:not(.two-tab-bars) .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container,
-.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars .tabs-and-actions-container:not(:first-child)  .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container,
+.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars .tabs-and-actions-container:not(:first-child) .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border-top > .tab-border-top-container {
 	display: block;
 	position: absolute;
@@ -321,7 +341,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label {
 	margin-top: auto;
 	margin-bottom: auto;
-	line-height: var(--editor-group-tab-height); /* aligns icon and label vertically centered in the tab */
+	line-height: var(--editor-group-tab-height);
+	/* aligns icon and label vertically centered in the tab */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink .tab-label,
@@ -329,9 +350,10 @@
 	position: relative;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-shrink > .tab-label > .monaco-icon-label-container::after,
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-fixed > .tab-label > .monaco-icon-label-container::after {
-	content: ''; /* enables a linear gradient to overlay the end of the label when tabs overflow */
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .tab-label > .monaco-icon-label-container::after,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .tab-label > .monaco-icon-label-container::after {
+	content: '';
+	/* enables a linear gradient to overlay the end of the label when tabs overflow */
 	position: absolute;
 	right: 0;
 	width: 5px;
@@ -343,32 +365,41 @@
 	height: calc(100% - 2px);
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-shrink:focus > .tab-label > .monaco-icon-label-container::after,
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-fixed:focus > .tab-label > .monaco-icon-label-container::after {
-	opacity: 0; /* when tab has the focus this shade breaks the tab border (fixes https://github.com/microsoft/vscode/issues/57819) */
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink:focus > .tab-label > .monaco-icon-label-container::after,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed:focus > .tab-label > .monaco-icon-label-container::after {
+	opacity: 0;
+	/* when tab has the focus this shade breaks the tab border (fixes https://github.com/microsoft/vscode/issues/57819) */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-shrink > .tab-label.tab-label-has-badge::after,
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container >  .tab.sizing-fixed > .tab-label.tab-label-has-badge::after {
-	margin-right: 5px; /* with tab sizing shrink/fixed and badges, we want a right-margin because the close button is hidden. Use margin instead of padding to support animating the badge (https://github.com/microsoft/vscode/issues/242661) */
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink > .tab-label.tab-label-has-badge::after,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed > .tab-label.tab-label-has-badge::after {
+	margin-right: 5px;
+	/* with tab sizing shrink/fixed and badges, we want a right-margin because the close button is hidden. Use margin instead of padding to support animating the badge (https://github.com/microsoft/vscode/issues/242661) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink:not(.tab-actions-left):not(.close-action-off) .tab-label {
-	padding-right: 5px; /* ensure that the gradient does not show when tab actions show https://github.com/microsoft/vscode/issues/189625*/
+	padding-right: 5px;
+	/* ensure that the gradient does not show when tab actions show https://github.com/microsoft/vscode/issues/189625*/
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky-compact:not(.has-icon) .monaco-icon-label {
-	text-align: center; /* ensure that sticky-compact tabs without icon have label centered */
+	text-align: center;
+	/* ensure that sticky-compact tabs without icon have label centered */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label > .monaco-icon-label-container {
-	overflow-x: visible; /* fixes https://github.com/microsoft/vscode/issues/20182 by ensuring the horizontal overflow is visible */
+	overflow-x: visible;
+	/* fixes https://github.com/microsoft/vscode/issues/20182 by ensuring the horizontal overflow is visible */
 
-	scrollbar-width: none; /* Firefox */
-	-ms-overflow-style: none; /* Internet Explorer 10+ */
+	scrollbar-width: none;
+	/* Firefox */
+	-ms-overflow-style: none;
+
+	/* Internet Explorer 10+ */
 	&::-webkit-scrollbar {
-		display: none; /* Chrome, Safari, and Opera */
+		display: none;
+		/* Chrome, Safari, and Opera */
 	}
 }
 
@@ -412,7 +443,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-shrink > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed > .tab-actions {
 	flex: 0;
-	overflow: hidden; /* let the tab actions be pushed out of view when sizing is set to shrink/fixed to make more room */
+	overflow: hidden;
+	/* let the tab actions be pushed out of view when sizing is set to shrink/fixed to make more room */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty.tab-actions-right.sizing-shrink > .tab-actions,
@@ -423,20 +455,28 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky.tab-actions-right.sizing-fixed > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed:hover > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-right.sizing-fixed > .tab-actions:focus-within {
-	overflow: visible; /* ...but still show the tab actions on hover, focus and when dirty or sticky */
+	overflow: visible;
+	/* ...but still show the tab actions on hover, focus and when dirty or sticky */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off:not(.dirty) > .tab-actions,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky-compact > .tab-actions {
-	display: none; /* hide the tab actions when we are configured to hide it (unless dirty, but always when sticky-compact) */
+	display: none;
+	/* hide the tab actions when we are configured to hide it (unless dirty, but always when sticky-compact) */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label,		/* always show tab actions for active tab */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus,		/* always show tab actions on focus */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label,		/* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label,	/* always show tab actions on hover */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,		/* always show tab actions for sticky tabs */
-.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label {		/* always show tab actions for dirty tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active > .tab-actions .action-label,
+/* always show tab actions for active tab */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab > .tab-actions .action-label:focus,
+/* always show tab actions on focus */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab:hover > .tab-actions .action-label,
+/* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:hover > .tab-actions .action-label,
+/* always show tab actions on hover */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,
+/* always show tab actions for sticky tabs */
+.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty > .tab-actions .action-label {
+	/* always show tab actions for dirty tabs */
 	opacity: 1;
 }
 
@@ -471,7 +511,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty > .tab-actions .action-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sticky:not(.pinned-action-off) > .tab-actions .action-label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:hover > .tab-actions .action-label {
-	opacity: 0.5; /* show tab actions dimmed for inactive group */
+	opacity: 0.5;
+	/* show tab actions dimmed for inactive group */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-actions .action-label {
@@ -481,24 +522,29 @@
 /* Tab Actions: Off */
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off {
-	padding-right: 10px; /* give a little bit more room if tab actions is off */
+	padding-right: 10px;
+	/* give a little bit more room if tab actions is off */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.close-action-off:not(.sticky-compact),
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed.close-action-off:not(.sticky-compact) {
-	padding-right: 5px; /* we need less room when sizing is shrink/fixed (unless tab is sticky-compact) */
+	padding-right: 5px;
+	/* we need less room when sizing is shrink/fixed (unless tab is sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off.dirty-border-top > .tab-actions {
-	display: none; /* hide dirty state when highlightModifiedTabs is enabled and when running without tab actions */
+	display: none;
+	/* hide dirty state when highlightModifiedTabs is enabled and when running without tab actions */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off.dirty:not(.dirty-border-top):not(.sticky-compact) {
-	padding-right: 0; /* remove extra padding when we are running without tab actions (unless tab is sticky-compact) */
+	padding-right: 0;
+	/* remove extra padding when we are running without tab actions (unless tab is sticky-compact) */
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-action-off > .tab-actions {
-	pointer-events: none; /* don't allow tab actions to be clicked when running without tab actions */
+	pointer-events: none;
+	/* don't allow tab actions to be clicked when running without tab actions */
 }
 
 /* Editor Actions Toolbar */
@@ -518,15 +564,47 @@
 	margin-right: 4px;
 }
 
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-action-separator {
+	align-self: center;
+	width: 1px;
+	height: 16px;
+	margin: 0 4px;
+	background-color: var(--vscode-titleBar-activeForeground);
+	opacity: 0.3;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing {
+	cursor: default;
+	flex: initial;
+	padding: 0 8px 0 0;
+	height: var(--editor-group-tab-height);
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing.hidden {
+	display: none;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing .action-item {
+	margin-right: 4px;
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-actions {
 
 	/* When tabs are wrapped, position the editor actions at the end of the very last row */
 	position: absolute;
 	bottom: 0;
+	right: var(--last-tab-layout-actions-width, 0);
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-actions-trailing {
+	/* When tabs are wrapped, position the trailing editor actions at the end of the very last row */
+	position: absolute;
+	bottom: 0;
 	right: 0;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions {
+.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions,
+.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions-trailing {
 
 	/* When multiple tab bars are visible, only show editor actions for the last tab bar */
 	display: none;
@@ -551,7 +629,8 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.drop-target-left::after {
-	right: -1px; /* -1 to connect with drop-target-right */
+	right: -1px;
+	/* -1 to connect with drop-target-right */
 }
 
 /* Make drop target edge cases more visible (wrapped tabs & first/last) */

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -518,6 +518,14 @@
 	margin-right: 4px;
 }
 
+.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-actions {
+
+	/* When tabs are wrapped, position the editor actions at the end of the very last row */
+	position: absolute;
+	bottom: 0;
+	right: 0;
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-separator {
 	display: none;
 }

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -564,47 +564,15 @@
 	margin-right: 4px;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-action-separator {
-	align-self: center;
-	width: 1px;
-	height: 16px;
-	margin: 0 4px;
-	background-color: var(--vscode-titleBar-activeForeground);
-	opacity: 0.3;
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing {
-	cursor: default;
-	flex: initial;
-	padding: 0 8px 0 0;
-	height: var(--editor-group-tab-height);
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing.hidden {
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-separator {
 	display: none;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions-trailing .action-item {
-	margin-right: 4px;
+.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-layout-actions {
+	display: none;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-actions {
-
-	/* When tabs are wrapped, position the editor actions at the end of the very last row */
-	position: absolute;
-	bottom: 0;
-	right: var(--last-tab-layout-actions-width, 0);
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .editor-actions-trailing {
-	/* When tabs are wrapped, position the trailing editor actions at the end of the very last row */
-	position: absolute;
-	bottom: 0;
-	right: 0;
-}
-
-.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions,
-.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions-trailing {
+.monaco-workbench .part.editor > .content .editor-group-container > .title.two-tab-bars > .tabs-and-actions-container:first-child .editor-actions {
 
 	/* When multiple tab bars are visible, only show editor actions for the last tab bar */
 	display: none;

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1775,6 +1775,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		}
 	}
 
+	protected override prepareEditorLayoutActions(editorActions: IToolbarActions): IToolbarActions {
+		return editorActions;
+	}
+
 	getHeight(): number {
 
 		// Return quickly if our used dimensions are known
@@ -1880,6 +1884,9 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	private doLayoutTabsWrapping(dimensions: IEditorTitleControlDimensions): boolean {
 		const [tabsAndActionsContainer, tabsContainer, editorToolbarContainer, tabsScrollbar] = assertReturnsAllDefined(this.tabsAndActionsContainer, this.tabsContainer, this.editorActionsToolbarContainer, this.tabsScrollbar);
 
+		const layoutActionsContainer = this.editorLayoutActionsToolbarContainer;
+		const editorToolbarWidth = () => editorToolbarContainer.offsetWidth + (layoutActionsContainer?.offsetWidth ?? 0);
+
 		// Handle wrapping tabs according to setting:
 		// - enabled: only add class if tabs wrap and don't exceed available dimensions
 		// - disabled: remove class and margin-right variable
@@ -1896,7 +1903,8 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			// Update `last-tab-margin-right` CSS variable to account for the absolute
 			// positioned editor actions container when tabs wrap. The margin needs to
 			// be the width of the editor actions container to avoid screen cheese.
-			tabsContainer.style.setProperty('--last-tab-margin-right', tabsWrapMultiLine ? `${editorToolbarContainer.offsetWidth}px` : '0');
+			tabsContainer.style.setProperty('--last-tab-margin-right', tabsWrapMultiLine ? `${editorToolbarWidth()}px` : '0');
+			tabsAndActionsContainer.style.setProperty('--last-tab-layout-actions-width', `${layoutActionsContainer?.offsetWidth ?? 0}px`);
 
 			// Remove old css classes that are not needed anymore
 			for (const tab of tabsContainer.children) {
@@ -1914,7 +1922,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 					return true; // no tab always fits
 				}
 
-				const lastTabOverlapWithToolbarWidth = lastTab.offsetWidth + editorToolbarContainer.offsetWidth - dimensions.available.width;
+				const lastTabOverlapWithToolbarWidth = lastTab.offsetWidth + editorToolbarWidth() - dimensions.available.width;
 				if (lastTabOverlapWithToolbarWidth > 1) {
 					// Allow for slight rounding errors related to zooming here
 					// https://github.com/microsoft/vscode/issues/116385

--- a/src/vs/workbench/browser/parts/editor/noEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noEditorTabsControl.ts
@@ -20,6 +20,13 @@ export class NoEditorTabsControl extends EditorTabsControl {
 		};
 	}
 
+	protected override prepareEditorLayoutActions(): IToolbarActions {
+		return {
+			primary: [],
+			secondary: []
+		};
+	}
+
 	openEditor(editor: EditorInput): boolean {
 		return this.handleOpenedEditors();
 	}

--- a/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
@@ -359,6 +359,13 @@ export class SingleEditorTabsControl extends EditorTabsControl {
 		}
 	}
 
+	protected override prepareEditorLayoutActions(): IToolbarActions {
+		return {
+			primary: [],
+			secondary: []
+		};
+	}
+
 	getHeight(): number {
 		return this.tabHeight;
 	}


### PR DESCRIPTION
Adds a new editor layout toolbar for the editor part in the Agents app.
<img width="662" height="77" alt="image" src="https://github.com/user-attachments/assets/4cc695a4-c176-42f4-b30f-ae92cec9c161" />
