### PR TITLE
Do not move fg terminal to the bg when it needs input, fix regression

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1436,14 +1436,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 				if (raceResult.type === 'inputNeeded') {
 					// Output monitor detected the terminal is waiting for input.
-					// Convert to background so the terminal stays alive for send_to_terminal.
+					// Return output to the agent so it can provide input via
+					// send_to_terminal. The terminal stays foreground so it is
+					// reused by subsequent run_in_terminal calls in this session.
 					this._logService.debug(`RunInTerminalTool: Output monitor detected input needed in foreground terminal, returning output to agent`);
 					error = 'inputNeeded';
 					didInputNeeded = true;
-					isBackgroundExecution = true;
-					toolTerminal.isBackground = true;
-					this._sessionTerminalAssociations.delete(chatSessionResource);
-					await this._associateProcessIdWithSession(toolTerminal.instance, chatSessionResource, termId, toolTerminal.shellIntegrationQuality, true);
 					// Read output directly from the execution rather than from pollingResult,
 					// because the output monitor may not have set pollingResult yet at this point
 					// (it is written in the finally block after onDidFinishCommand).
@@ -1563,8 +1561,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		} finally {
 			timeoutPromise?.cancel();
-			if (isBackgroundExecution && executionPromise) {
-				// Background terminal (started as bg or moved to bg) - attach error handler since we won't await it
+			if ((isBackgroundExecution || didInputNeeded) && executionPromise) {
+				// Background terminal (started as bg or moved to bg) or foreground
+				// terminal waiting for input - attach error handler since we won't await it.
 				executionPromise.catch((e: unknown) => {
 					if (!(e instanceof CancellationError)) {
 						this._logService.error(`RunInTerminalTool: Background execution error`, e);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1621,7 +1621,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			didSandboxWrapCommand,
 			requestUnsandboxedExecution: args.requestUnsandboxedExecution === true,
 			isPersistentSession: executionOptions.persistentSession,
-			isBackgroundExecution,
+			isBackgroundExecution: isBackgroundExecution || didInputNeeded,
 			didTimeout,
 			exitCode,
 			output: terminalResult,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1949,6 +1949,7 @@ suite('RunInTerminalTool', () => {
 
 		const commandFinishedEmitter = new Emitter<{ exitCode: number | undefined }>();
 		const terminalDisposedEmitter = new Emitter<void>();
+		const inputNeededEmitter = new Emitter<void>();
 		const inputDataEmitter = new Emitter<string>();
 
 		const terminalInstance = {
@@ -1959,22 +1960,36 @@ suite('RunInTerminalTool', () => {
 			onDidInputData: inputDataEmitter.event,
 		} as unknown as ITerminalInstance;
 
-		// Simulate the state after inputNeeded: fg terminal association is preserved
-		// and completion notification is registered (the fix ensures isBackground stays false).
+		const outputMonitor = {
+			onDidDetectInputNeeded: inputNeededEmitter.event,
+			continueMonitoringAsync: () => { },
+			dispose: () => { },
+		} as unknown as { onDidDetectInputNeeded: Event<void>; continueMonitoringAsync: () => void; dispose: () => void };
+
+		// Set up fg terminal association and active execution
 		runInTerminalTool.sessionTerminalAssociations.set(sessionResource, {
 			instance: terminalInstance,
 			shellIntegrationQuality: ShellIntegrationQuality.Rich,
 			isBackground: false,
 		});
 
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: undefined) => void })
-			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'ssh host', undefined);
+		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string }> })._activeExecutions.set(termId, {
+			getOutput: () => 'Password:',
+		});
 
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: { onDidDetectInputNeeded: Event<void>; continueMonitoringAsync: () => void; dispose: () => void }) => void })
+			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'ssh host', outputMonitor);
+
+		// Fire inputNeeded — this simulates the output monitor detecting a prompt
+		inputNeededEmitter.fire();
+		strictEqual(capturedSteeringRequests.length, 1, 'Should send steering request for input needed');
+
+		// The key assertion: fg terminal association is preserved (not deleted)
 		ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Session terminal association should be preserved for fg reuse');
 		strictEqual(runInTerminalTool.sessionTerminalAssociations.get(sessionResource)!.isBackground, false, 'Terminal should remain foreground');
 
-		// After command finishes, the notification is disposed but the fg association persists
+		// After command finishes, the fg association still persists
 		commandFinishedEmitter.fire({ exitCode: 0 });
 		ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Session terminal association should still be preserved after command finishes');
 		strictEqual(runInTerminalTool.sessionTerminalAssociations.get(sessionResource)!.isBackground, false, 'Terminal should still be foreground after command finishes');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1943,13 +1943,12 @@ suite('RunInTerminalTool', () => {
 		strictEqual(capturedSteeringRequests.length, 2, 'Expected a changed prompt to trigger a new notification');
 	});
 
-	test('should clean up stale _activeExecutions entry after inputNeeded command finishes', () => {
+	test('should preserve session terminal association after inputNeeded so fg terminal is reused', () => {
 		const termId = 'test-input-cleanup-term';
 		const sessionResource = LocalChatSessionUri.forSession('test-input-cleanup-session');
 
 		const commandFinishedEmitter = new Emitter<{ exitCode: number | undefined }>();
 		const terminalDisposedEmitter = new Emitter<void>();
-		const inputNeededEmitter = new Emitter<void>();
 		const inputDataEmitter = new Emitter<string>();
 
 		const terminalInstance = {
@@ -1960,23 +1959,25 @@ suite('RunInTerminalTool', () => {
 			onDidInputData: inputDataEmitter.event,
 		} as unknown as ITerminalInstance;
 
-		const activeExecutions = (runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string; instance: ITerminalInstance; dispose(): void }> })._activeExecutions;
-		activeExecutions.set(termId, {
-			getOutput: () => 'Password:',
+		// Simulate the state after inputNeeded: fg terminal association is preserved
+		// and completion notification is registered (the fix ensures isBackground stays false).
+		runInTerminalTool.sessionTerminalAssociations.set(sessionResource, {
 			instance: terminalInstance,
-			dispose: () => { },
+			shellIntegrationQuality: ShellIntegrationQuality.Full,
+			isBackground: false,
 		});
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: undefined) => void })
 			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'ssh host', undefined);
 
-		ok(activeExecutions.has(termId), 'Execution should exist before command finishes');
+		ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Session terminal association should be preserved for fg reuse');
+		strictEqual(runInTerminalTool.sessionTerminalAssociations.get(sessionResource)!.isBackground, false, 'Terminal should remain foreground');
 
-		// Simulate the command finishing after the user provided input
+		// After command finishes, the notification is disposed but the fg association persists
 		commandFinishedEmitter.fire({ exitCode: 0 });
-
-		ok(!activeExecutions.has(termId), 'Stale execution should be cleaned up after command finishes');
+		ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Session terminal association should still be preserved after command finishes');
+		strictEqual(runInTerminalTool.sessionTerminalAssociations.get(sessionResource)!.isBackground, false, 'Terminal should still be foreground after command finishes');
 	});
 
 	suite('auto approve warning acceptance mechanism', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1943,6 +1943,42 @@ suite('RunInTerminalTool', () => {
 		strictEqual(capturedSteeringRequests.length, 2, 'Expected a changed prompt to trigger a new notification');
 	});
 
+	test('should clean up stale _activeExecutions entry after inputNeeded command finishes', () => {
+		const termId = 'test-input-cleanup-term';
+		const sessionResource = LocalChatSessionUri.forSession('test-input-cleanup-session');
+
+		const commandFinishedEmitter = new Emitter<{ exitCode: number | undefined }>();
+		const terminalDisposedEmitter = new Emitter<void>();
+		const inputNeededEmitter = new Emitter<void>();
+		const inputDataEmitter = new Emitter<string>();
+
+		const terminalInstance = {
+			capabilities: {
+				get: (cap: TerminalCapability) => cap === TerminalCapability.CommandDetection ? { onCommandFinished: commandFinishedEmitter.event } : undefined,
+			},
+			onDisposed: terminalDisposedEmitter.event,
+			onDidInputData: inputDataEmitter.event,
+		} as unknown as ITerminalInstance;
+
+		const activeExecutions = (runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string; instance: ITerminalInstance; dispose(): void }> })._activeExecutions;
+		activeExecutions.set(termId, {
+			getOutput: () => 'Password:',
+			instance: terminalInstance,
+			dispose: () => { },
+		});
+
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: undefined) => void })
+			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'ssh host', undefined);
+
+		ok(activeExecutions.has(termId), 'Execution should exist before command finishes');
+
+		// Simulate the command finishing after the user provided input
+		commandFinishedEmitter.fire({ exitCode: 0 });
+
+		ok(!activeExecutions.has(termId), 'Stale execution should be cleaned up after command finishes');
+	});
+
 	suite('auto approve warning acceptance mechanism', () => {
 		test('should require confirmation for auto-approvable commands when warning not accepted', async () => {
 			setConfig(TerminalChatAgentToolsSettingId.EnableAutoApprove, true);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1963,7 +1963,7 @@ suite('RunInTerminalTool', () => {
 		// and completion notification is registered (the fix ensures isBackground stays false).
 		runInTerminalTool.sessionTerminalAssociations.set(sessionResource, {
 			instance: terminalInstance,
-			shellIntegrationQuality: ShellIntegrationQuality.Full,
+			shellIntegrationQuality: ShellIntegrationQuality.Rich,
 			isBackground: false,
 		});
 


### PR DESCRIPTION
## Root Cause

In #308587, the LLM-based prompt detection in the output monitor was replaced with a simpler `onDidDetectInputNeeded` event. When this event fires during a **foreground** terminal execution, the race handler in `runInTerminalTool` converts the terminal to background mode:

```typescript
isBackgroundExecution = true;
toolTerminal.isBackground = true;
this._sessionTerminalAssociations.delete(chatSessionResource);
```

This was done so "the terminal stays alive for send_to_terminal," but it's unnecessary — `send_to_terminal` already supports foreground terminals via `terminalId`, and the execution stays alive in `_activeExecutions` regardless of fg/bg status.

## Fix

Removed the three lines that promote the terminal to background. The `inputNeeded` handler now returns early with output (so the agent can provide input) but **preserves the terminal as foreground** and keeps the session association intact. Updated the `finally` block condition from `isBackgroundExecution` to `isBackgroundExecution || didInputNeeded` so the execution isn't disposed while the agent handles input.

## Issues Addressed

1. **Terminal proliferation** — Each interactive prompt (password, `[Y/n]`, "press any key") permanently promoted the fg terminal to bg. The next `run_in_terminal` couldn't find a cached fg terminal and spawned a new one. Over a session with multiple interactive commands, terminals accumulated instead of being reused.

2. **Benchmark regression (April 13)** — Extra terminal creation per command adds shell spawn + shell integration setup latency. This directly inflated terminal benchmark times.

3. **Spurious "moved to background" messages** — The result text included `Note: This terminal execution was moved to the background` for terminals that the user expected to remain foreground, since `isBackgroundExecution` was true but `executionOptions.persistentSession` was false.

4. **User-reported premature fg→bg transfer** — Users observed their foreground terminal unexpectedly becoming a background terminal when a command hit an interactive prompt, losing the fg terminal reuse behavior. 


