### PR TITLE
Fix shell tool 'Running' message to render as Markdown

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -201,7 +201,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return localize('toolInvoke.shellCmd', "Running `{0}`", truncate(firstLine, 80));
+			return md(localize('toolInvoke.shellCmd', "Running `{0}`", truncate(firstLine, 80)));
 		}
 		return localize('toolInvoke.shell', "Running {0} command", displayName);
 	}


### PR DESCRIPTION
The invocation message for shell tools (e.g. "Running `command`") was returned as a plain string, so backtick formatting was not rendered in the chat UI. The past-tense "Ran `command`" message already used the `md()` wrapper and rendered correctly.

Wraps the shell invocation message with `md()` so the renderer treats it as Markdown, matching the past-tense case.

(Written by Copilot)