### PR TITLE
sessions: add subtle border to GH profile image

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -140,6 +140,7 @@ The account widget is rendered in the **right side of the titlebar** as a custom
 - Registered in `contrib/accountMenu/browser/account.contribution.ts`
 - Uses the `Menus.TitleBarRightLayout` menu
 - Shows the signed-in GitHub profile image when available, and falls back to the existing account codicon when it is not
+- Gives the GitHub profile image a subtle 1px circular border using the titlebar command center border tokens so the avatar stays legible against nearby chrome in both active and inactive window states
 - Opens a combined account and Copilot status hover panel with sign-in/sign-out, settings, and update actions
 
 ---
@@ -657,6 +658,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-17 | Added a subtle 1px titlebar-token border around the sessions account widget's GitHub profile image, including the inactive-window variant, and documented the avatar chrome in the layout spec. |
 | 2026-04-16 | Softened the experimental sessions shell gradient by reducing the accent tint mix strength across the shared default, light-theme, and dark-theme variants so the primary color reads more subtly behind the workbench chrome. |
 | 2026-04-16 | Updated the layout visual representation to show the editor part in the top-right row and mark it as hidden by default. |
 | 2026-04-16 | Fixed the sessions workbench so modal editor opens no longer hide an already visible main editor part, and documented that the main editor stays hidden by default but can be revealed by explicit non-modal editor flows. |

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -51,12 +51,18 @@
 	flex: 0 0 auto;
 	width: 16px;
 	height: 16px;
+	border: 1px solid var(--vscode-commandCenter-border, transparent);
 	border-radius: 50%;
+	box-sizing: border-box;
 	object-fit: cover;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-widget-avatar.visible {
 	display: block;
+}
+
+.monaco-workbench .part.titlebar.inactive .sessions-account-titlebar-widget-avatar {
+	border-color: var(--vscode-commandCenter-inactiveBorder, var(--vscode-commandCenter-border, transparent));
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-widget-label {


### PR DESCRIPTION
## Summary

Part of https://github.com/microsoft/vscode/issues/310014 workstream

- add a subtle 1px circular border around the sessions titlebar GitHub profile image
- use the existing command center titlebar border tokens so the avatar stays consistent with surrounding chrome
- handle both active and inactive window states
- document the account widget avatar styling update in `src/vs/sessions/LAYOUT.md`

## Why
The GitHub profile image looked a little too edge-less against nearby titlebar surfaces. This gives it a tiny amount of definition without introducing a new color choice or making the control feel heavier.