### PR TITLE
Fix unescaped icon and undefined text in terminal tool confirmations

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -874,15 +874,17 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
 		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
 		(toolSpecificData as IRunInTerminalToolInvocationData).requiresConfirmationForRetry = (!isAutoApprovedByRules && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
+		const explanation = args.explanation || localize('runInTerminal.defaultExplanation', "No explanation provided");
+		const goal = args.goal || localize('runInTerminal.defaultGoal', "No goal provided");
 		const confirmationMessage = requiresUnsandboxConfirmation
 			? new MarkdownString(localize(
 				'runInTerminal.unsandboxed.confirmationMessage',
 				"Explanation: {0}\n\nGoal: {1}\n\nReason for leaving the sandbox: {2}",
-				args.explanation,
-				args.goal,
+				explanation,
+				goal,
 				requestUnsandboxedExecutionReason || localize('runInTerminal.unsandboxed.confirmationMessage.defaultReason', "The model indicated that this command needs unsandboxed access.")
 			))
-			: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal));
+			: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", explanation, goal));
 		const confirmationMessages = shouldShowConfirmation ? {
 			title: confirmationTitle,
 			message: confirmationMessage,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -146,7 +146,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 			: localize('send.confirm.message', "Run {0} in terminal {1}", toMarkdownInlineCode(buildCommandDisplayText(args.command)), safeTerminalLabel);
 		if (instanceId !== undefined) {
 			const focusUri = createCommandUri(FocusTerminalByIdCommandId, instanceId);
-			confirmationMessage.appendMarkdown(`${baseMessage} — [$(terminal) ${localize('focusTerminal', "Focus Terminal")}](${focusUri})`);
+			confirmationMessage.appendMarkdown(`${baseMessage} — [${localize('focusTerminal', "Focus Terminal")}](${focusUri})`);
 		} else {
 			confirmationMessage.appendMarkdown(baseMessage);
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -12,11 +12,13 @@ import { SendToTerminalTool, SendToTerminalToolData } from '../../browser/tools/
 import { RunInTerminalTool, type IActiveTerminalExecution } from '../../browser/tools/runInTerminalTool.js';
 import type { IToolInvocation, IToolInvocationPreparationContext } from '../../../../chat/common/tools/languageModelToolsService.js';
 import type { ITerminalExecuteStrategyResult } from '../../browser/executeStrategy/executeStrategy.js';
-import { ITerminalChatService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import type { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { IChatWidgetService } from '../../../../chat/browser/chat.js';
+import { ChatPermissionLevel } from '../../../../chat/common/constants.js';
 
 suite('SendToTerminalTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -349,5 +351,61 @@ suite('SendToTerminalTool', () => {
 		assert.strictEqual(third.confirmationMessages, undefined);
 		const thirdMsg = third.pastTenseMessage as IMarkdownString;
 		assert.ok(thirdMsg.value.includes('description'), 'third call should show description question');
+	});
+
+	test('prepareToolInvocation shows confirmation in default permission mode', async () => {
+		const prepared = await tool.prepareToolInvocation(
+			createPreparationContext(KNOWN_TERMINAL_ID, 'hello'),
+			CancellationToken.None,
+		);
+
+		assert.ok(prepared);
+		assert.ok(prepared.confirmationMessages, 'should show confirmation in default mode');
+		assert.strictEqual(prepared.confirmationMessages.title, 'Send to Terminal');
+	});
+
+	test('prepareToolInvocation skips confirmation in auto-approve mode', async () => {
+		const sessionResource = URI.parse('chat-session://test-session');
+		instantiationService.stub(IChatWidgetService, {
+			getWidgetBySessionResource: () => ({
+				input: {
+					currentModeInfo: {
+						permissionLevel: ChatPermissionLevel.AutoApprove,
+					},
+				},
+			}),
+			lastFocusedWidget: undefined,
+		});
+		tool = store.add(instantiationService.createInstance(SendToTerminalTool));
+
+		const prepared = await tool.prepareToolInvocation(
+			createPreparationContext(KNOWN_TERMINAL_ID, 'hello', sessionResource),
+			CancellationToken.None,
+		);
+
+		assert.ok(prepared);
+		assert.strictEqual(prepared.confirmationMessages, undefined, 'should skip confirmation in auto-approve mode');
+	});
+
+	test('prepareToolInvocation Focus Terminal link does not contain $(terminal)', async () => {
+		const mockExecution = createMockExecution('output');
+		(mockExecution.instance as { instanceId: number }).instanceId = 42;
+		(mockExecution.instance as { title: string }).title = 'node';
+		RunInTerminalTool.getExecution = () => mockExecution;
+		instantiationService.stub(ITerminalService, {
+			getInstanceFromId: () => undefined,
+		});
+		tool = store.add(instantiationService.createInstance(SendToTerminalTool));
+
+		const prepared = await tool.prepareToolInvocation(
+			createPreparationContext(KNOWN_TERMINAL_ID, 'hello'),
+			CancellationToken.None,
+		);
+
+		assert.ok(prepared);
+		assert.ok(prepared.confirmationMessages);
+		const message = prepared.confirmationMessages.message as IMarkdownString;
+		assert.ok(!message.value.includes('$(terminal)'), 'Focus Terminal link should not contain literal $(terminal)');
+		assert.ok(message.value.includes('Focus Terminal'), 'should contain Focus Terminal link text');
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -17,7 +17,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import type { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { IChatWidgetService } from '../../../../chat/browser/chat.js';
+import { IChatWidget, IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { ChatPermissionLevel } from '../../../../chat/common/constants.js';
 
 suite('SendToTerminalTool', () => {
@@ -373,7 +373,7 @@ suite('SendToTerminalTool', () => {
 						permissionLevel: ChatPermissionLevel.AutoApprove,
 					},
 				},
-			}),
+			}) as unknown as IChatWidget,
 			lastFocusedWidget: undefined,
 		});
 		tool = store.add(instantiationService.createInstance(SendToTerminalTool));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1118,6 +1118,20 @@ suite('RunInTerminalTool', () => {
 			assertConfirmationRequired(result, `Run command in \`bash\` within \`${isWindows ? '\\tmp' : '~/tmp'}\`?`);
 		});
 
+		test('should not show undefined in confirmation message when explanation and goal are missing', async () => {
+			const params: Partial<IRunInTerminalInputParams> = {
+				command: 'rm file.txt',
+			};
+			delete params.explanation;
+			delete params.goal;
+			const result = await executeToolTest(params);
+			assertConfirmationRequired(result);
+			const message = result?.confirmationMessages?.message;
+			ok(message, 'Expected confirmation message to be defined');
+			const messageText = typeof message === 'string' ? message : message.value;
+			ok(!messageText.includes('undefined'), `Confirmation message should not contain "undefined", got: ${messageText}`);
+		});
+
 		test('should use withLanguage inDirectory title when presenter returns languageDisplayName with cd prefix', async () => {
 			const workspaceFolder = URI.file(isWindows ? 'C:\\workspace\\project' : '/workspace/project');
 			const workspace = new Workspace('test', [toWorkspaceFolder(workspaceFolder)]);


### PR DESCRIPTION
Fixes #309505
Fixes #304351

- Remove `$(terminal)` ThemeIcon from the send_to_terminal Focus Terminal markdown link, which rendered as literal text
- Provide fallback strings when `explanation`/`goal` are undefined in run_in_terminal confirmation messages
- Add tests for send_to_terminal confirmation behavior