### PR TITLE
Fix wayland detection in snap electron-launch script

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -153,7 +153,7 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     fi
     wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
     wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
-    if [ -S "$wayland_sockpath" ]; then
+    if [ -S "$wayland_snappath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
         # shellcheck disable=SC2034


### PR DESCRIPTION
Good day

This PR fixes issue #223591 where the wayland detection in the snap electron-launch script fails because the path check uses an incorrect path with `..` resolution.

The script checks `wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"` but this resolves to `/run/user/$uid/$wdisplay` which may not be the correct socket path. The actual wayland socket path should be checked directly.

This fix ensures that when running under Wayland, the correct socket path is detected, preventing the "Failed to open Wayland display, fallback to X11" warning.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof