### PR TITLE
[STACKED] agentHost: correctly rewrite links in markdown for remote files

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import type { IAgentToolReadyEvent } from '../../common/agentService.js';
 import { StringOrMarkdown } from '../../common/state/protocol/state.js';
+import { basename } from '../../../../base/common/resources.js';
 
 // =============================================================================
 // Copilot CLI built-in tool interfaces
@@ -160,7 +161,8 @@ function truncate(text: string, maxLength: number): string {
  * as a clickable file widget in the chat UI.
  */
 function formatPathAsMarkdownLink(path: string): string {
-	return `[](${URI.file(path).toString()})`;
+	const uri = URI.file(path);
+	return `[${basename(uri)}](${uri})`;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -43,7 +43,7 @@ import { ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult, To
 import { getAgentHostIcon } from '../agentSessions.js';
 import { AgentHostEditingSession } from './agentHostEditingSession.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from './agentHostSessionWorkingDirectoryResolver.js';
-import { activeTurnToProgress, completedToolCallToEditParts, completedToolCallToSerialized, finalizeToolInvocation, getTerminalContentUri, makeAhpTerminalToolSessionId, parseAhpTerminalToolSessionId, toolCallStateToInvocation, turnsToHistory, updateRunningToolSpecificData, type IToolCallFileEdit } from './stateToProgressAdapter.js';
+import { activeTurnToProgress, completedToolCallToEditParts, completedToolCallToSerialized, finalizeToolInvocation, getTerminalContentUri, makeAhpTerminalToolSessionId, parseAhpTerminalToolSessionId, rawMarkdownToString, stringOrMarkdownToString, toolCallStateToInvocation, turnsToHistory, updateRunningToolSpecificData, type IToolCallFileEdit } from './stateToProgressAdapter.js';
 
 // =============================================================================
 // AgentHostSessionHandler - renderer-side handler for a single agent host
@@ -1128,9 +1128,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				existing = confirmInvocation;
 			}
 		} else if (tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.PendingResultConfirmation) {
-			existing.invocationMessage = typeof tc.invocationMessage === 'string'
-				? tc.invocationMessage
-				: new MarkdownString(tc.invocationMessage.markdown);
+			existing.invocationMessage = stringOrMarkdownToString(tc.invocationMessage, this._config.connectionAuthority);
 			this._reviveTerminalIfNeeded(existing, tc, ctx.backendSession);
 			updateRunningToolSpecificData(existing, tc, this._config.connectionAuthority);
 		}
@@ -1533,7 +1531,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 							// string gets merged into the edit part in chatModel.ts
 							// which breaks rendering because the thinking content
 							// part does not deal with this.
-							ctx.progress([{ kind: 'markdownContent', content: new MarkdownString(delta, { supportHtml: true }) }]);
+							ctx.progress([{ kind: 'markdownContent', content: rawMarkdownToString(delta, this._config.connectionAuthority, { supportHtml: true }) }]);
 						}
 						break;
 					}
@@ -1708,7 +1706,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			/* resolveId */ undefined,
 			/* data */ undefined,
 			/* isUsed */ undefined,
-			/* message */ new MarkdownString(inputReq.message),
+			/* message */ rawMarkdownToString(inputReq.message, this._config.connectionAuthority),
 		);
 
 		progress([carousel]);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -402,7 +402,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				const sessionState = this._getSessionState(resolvedSession.toString());
 				if (sessionState) {
 					const modelId = this._toLanguageModelId(sessionResource, sessionState.summary.model?.id);
-					history.push(...turnsToHistory(resolvedSession, sessionState.turns, this._config.agentId, modelId));
+					history.push(...turnsToHistory(resolvedSession, sessionState.turns, this._config.agentId, this._config.connectionAuthority, modelId));
 
 					// Enrich history with inner tool calls from subagent
 					// child sessions. Subscribes to each child session so
@@ -1079,7 +1079,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				? tc.invocationMessage
 				: new MarkdownString(tc.invocationMessage.markdown);
 			this._reviveTerminalIfNeeded(existing, tc, ctx.backendSession);
-			updateRunningToolSpecificData(existing, tc);
+			updateRunningToolSpecificData(existing, tc, this._config.connectionAuthority);
 
 			// If this is a client-provided tool call owned by us, execute it.
 			if (tc.status === ToolCallStatus.Running
@@ -1095,7 +1095,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			// Running was skipped due to throttling and terminal content
 			// only appears at Completed time.
 			this._reviveTerminalIfNeeded(existing, tc, ctx.backendSession);
-			fileEdits = finalizeToolInvocation(existing, tc, ctx.backendSession);
+			fileEdits = finalizeToolInvocation(existing, tc, ctx.backendSession, this._config.connectionAuthority);
 		}
 
 		return { invocation: existing, fileEdits };
@@ -1562,7 +1562,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 									if (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) {
 										const completedTc = tc as ICompletedToolCall;
 										const fileEditParts = completedToolCallToEditParts(completedTc);
-										const serialized = completedToolCallToSerialized(completedTc, toolCallId, URI.parse(childSessionUri));
+										const serialized = completedToolCallToSerialized(completedTc, toolCallId, URI.parse(childSessionUri), this._config.connectionAuthority);
 										if (fileEditParts.length > 0) {
 											serialized.presentation = ToolInvocationPresentation.Hidden;
 										}
@@ -1630,11 +1630,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 							this._awaitToolConfirmation(confirmInvocation, tc.toolCallId, URI.parse(childSessionUri), turnId, childCts.token);
 						}
 					} else if (tc.status === ToolCallStatus.Running) {
-						updateRunningToolSpecificData(existing, tc);
+						updateRunningToolSpecificData(existing, tc, this._config.connectionAuthority);
 					}
 
 					if (existing && (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) && !IChatToolInvocation.isComplete(existing)) {
-						finalizeToolInvocation(existing, tc, URI.parse(childSessionUri));
+						finalizeToolInvocation(existing, tc, URI.parse(childSessionUri), this._config.connectionAuthority);
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -429,7 +429,7 @@ function rewriteLinkTokenRaw(token: Tokens.Link | Tokens.Image, connectionAuthor
  * link URIs through {@link rewriteMarkdownLinks} when a connection authority
  * is provided.
  */
-function rawMarkdownToString(content: string, connectionAuthority: string | undefined, options?: { supportHtml?: boolean }): MarkdownString {
+export function rawMarkdownToString(content: string, connectionAuthority: string | undefined, options?: { supportHtml?: boolean }): MarkdownString {
 	const rewritten = connectionAuthority ? rewriteMarkdownLinks(content, connectionAuthority) : content;
 	return new MarkdownString(rewritten, options);
 }
@@ -441,9 +441,9 @@ function rawMarkdownToString(content: string, connectionAuthority: string | unde
  * through {@link rewriteMarkdownLinks} so that remote resources resolve
  * through the agent host filesystem provider.
  */
-function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined;
-function stringOrMarkdownToString(value: StringOrMarkdown, connectionAuthority: string | undefined): string | IMarkdownString;
-function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined {
+export function stringOrMarkdownToString(value: StringOrMarkdown, connectionAuthority: string | undefined): string | IMarkdownString;
+export function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined;
+export function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined {
 	if (value === undefined) {
 		return undefined;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { marked, type Token, type Tokens, type TokensList } from '../../../../../../base/common/marked/marked.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ToolCallStatus, TurnState, ResponsePartKind, getToolFileEdits, getToolOutputText, getToolSubagentContent, type IActiveTurn, type ICompletedToolCall, type IToolCallState, type ITurn, FileEditKind, ToolResultContentType, type IToolResultContent } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { getToolKind } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
-import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_SCHEME, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { StringOrMarkdown, type IFileEdit } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type IChatModifiedFilesConfirmationData, type IChatProgress, type IChatTerminalToolInvocationData, type IChatToolInputInvocationData, type IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { type IChatSessionHistoryItem } from '../../../common/chatSessionsService.js';
@@ -87,7 +88,7 @@ export function getTerminalContentUri(content: IToolResultContent[] | undefined)
 /**
  * Converts completed turns from the protocol state into session history items.
  */
-export function turnsToHistory(backendSession: URI, turns: readonly ITurn[], participantId: string, modelId?: string): IChatSessionHistoryItem[] {
+export function turnsToHistory(backendSession: URI, turns: readonly ITurn[], participantId: string, connectionAuthority: string | undefined, modelId?: string): IChatSessionHistoryItem[] {
 	const history: IChatSessionHistoryItem[] = [];
 	for (const turn of turns) {
 		// Request
@@ -100,13 +101,13 @@ export function turnsToHistory(backendSession: URI, turns: readonly ITurn[], par
 			switch (rp.kind) {
 				case ResponsePartKind.Markdown:
 					if (rp.content) {
-						parts.push({ kind: 'markdownContent', content: new MarkdownString(rp.content, { supportHtml: true }) });
+						parts.push({ kind: 'markdownContent', content: rawMarkdownToString(rp.content, connectionAuthority, { supportHtml: true }) });
 					}
 					break;
 				case ResponsePartKind.ToolCall: {
 					const tc = rp.toolCall as ICompletedToolCall;
 					const fileEditParts = completedToolCallToEditParts(tc);
-					const serialized = completedToolCallToSerialized(tc, undefined, backendSession);
+					const serialized = completedToolCallToSerialized(tc, undefined, backendSession, connectionAuthority);
 					if (fileEditParts.length > 0) {
 						serialized.presentation = ToolInvocationPresentation.Hidden;
 					}
@@ -152,7 +153,7 @@ export function activeTurnToProgress(sessionResource: URI, activeTurn: IActiveTu
 		switch (rp.kind) {
 			case ResponsePartKind.Markdown:
 				if (rp.content) {
-					parts.push({ kind: 'markdownContent', content: new MarkdownString(rp.content) });
+					parts.push({ kind: 'markdownContent', content: rawMarkdownToString(rp.content, connectionAuthority) });
 				}
 				break;
 			case ResponsePartKind.Reasoning:
@@ -163,7 +164,7 @@ export function activeTurnToProgress(sessionResource: URI, activeTurn: IActiveTu
 			case ResponsePartKind.ToolCall: {
 				const tc = rp.toolCall;
 				if (tc.status === ToolCallStatus.Completed || tc.status === ToolCallStatus.Cancelled) {
-					parts.push(completedToolCallToSerialized(tc as ICompletedToolCall, undefined, sessionResource));
+					parts.push(completedToolCallToSerialized(tc as ICompletedToolCall, undefined, sessionResource, connectionAuthority));
 				} else if (tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.Streaming || tc.status === ToolCallStatus.PendingConfirmation) {
 					parts.push(toolCallStateToInvocation(tc, undefined, sessionResource, connectionAuthority));
 				}
@@ -201,11 +202,11 @@ function getTerminalLanguage(tc: IToolCallState) {
  * Converts a completed tool call from the protocol state into a serialized
  * tool invocation suitable for history replay.
  */
-export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentInvocationId: string | undefined, sessionResource: URI): IChatToolInvocationSerialized {
+export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentInvocationId: string | undefined, sessionResource: URI, connectionAuthority: string | undefined): IChatToolInvocationSerialized {
 	const terminalContentUri = tc.status === ToolCallStatus.Completed ? getTerminalContentUri(tc.content) : undefined;
 	const isTerminal = !!terminalContentUri;
 	const isSuccess = tc.status === ToolCallStatus.Completed && tc.success;
-	const invocationMsg = stringOrMarkdownToString(tc.invocationMessage) ?? localize('ahp.running', "Running {0}...", tc.displayName);
+	const invocationMsg = stringOrMarkdownToString(tc.invocationMessage, connectionAuthority) ?? localize('ahp.running', "Running {0}...", tc.displayName);
 
 	// Check for subagent content
 	const subagentContent = tc.status === ToolCallStatus.Completed ? getToolSubagentContent(tc) : undefined;
@@ -213,7 +214,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 	if (isSubagent && tc.status === ToolCallStatus.Completed) {
 		const resultText = getToolOutputText(tc);
 		const pastTenseMsg = isSuccess
-			? stringOrMarkdownToString(tc.pastTenseMessage) ?? invocationMsg
+			? stringOrMarkdownToString(tc.pastTenseMessage, connectionAuthority) ?? invocationMsg
 			: invocationMsg;
 		return {
 			kind: 'toolInvocationSerialized',
@@ -252,7 +253,7 @@ export function completedToolCallToSerialized(tc: ICompletedToolCall, subAgentIn
 	}
 
 	const pastTenseMsg = isSuccess
-		? stringOrMarkdownToString(tc.pastTenseMessage) ?? invocationMsg
+		? stringOrMarkdownToString(tc.pastTenseMessage, connectionAuthority) ?? invocationMsg
 		: invocationMsg;
 
 	return {
@@ -322,15 +323,134 @@ export function completedToolCallToEditParts(tc: ICompletedToolCall): IChatProgr
  * state. Used during active turns to represent running tool calls in the UI.
  */
 /**
- * Converts a protocol `StringOrMarkdown` value to a chat-layer `IMarkdownString`.
+ * URI schemes that should NOT be rewritten when they appear inside markdown
+ * links received from a remote agent host. These are links that are
+ * meaningful outside the agent host's workspace (e.g. web links, VS Code
+ * commands) or are already wrapped in the agent-host scheme.
  */
-function stringOrMarkdownToString(value: StringOrMarkdown | undefined): string | IMarkdownString | undefined;
-function stringOrMarkdownToString(value: StringOrMarkdown): string | IMarkdownString;
-function stringOrMarkdownToString(value: StringOrMarkdown | undefined): string | IMarkdownString | undefined {
+const EXTERNAL_LINK_SCHEMES: ReadonlySet<string> = new Set([
+	'http',
+	'https',
+	'mailto',
+	'ws',
+	'wss',
+	'ftp',
+	'ftps',
+	'data',
+	'blob',
+	'javascript',
+	'command',
+	'vscode',
+	'vscode-insiders',
+	AGENT_HOST_SCHEME,
+]);
+
+/**
+ * Rewrites inline markdown link URIs so that non-external schemes are wrapped
+ * in the `vscode-agent-host://` scheme, mirroring {@link toAgentHostUri}.
+ * This allows links in markdown content streamed from a remote agent host
+ * (e.g. `file:///...` or `agenthost-content:///...`) to resolve correctly on
+ * the client through the agent host filesystem provider.
+ *
+ * Links with external schemes (http, https, mailto, command, etc.) and
+ * relative/anchor-only links without a scheme are preserved as-is. The
+ * markdown is parsed with marked and each `link` / `image` token is
+ * rewritten individually, so link-looking text inside code spans or fenced
+ * code blocks is untouched (marked emits those as `code`/`codespan` tokens
+ * with no nested link tokens).
+ */
+export function rewriteMarkdownLinks(markdown: string, connectionAuthority: string): string {
+	let tokens: TokensList;
+	try {
+		tokens = marked.lexer(markdown);
+	} catch {
+		return markdown;
+	}
+
+	const edits: { raw: string; replacement: string }[] = [];
+	marked.walkTokens(tokens, token => {
+		if (token.type !== 'link' && token.type !== 'image') {
+			return;
+		}
+		const replacement = rewriteLinkTokenRaw(token as Tokens.Link | Tokens.Image, connectionAuthority);
+		if (replacement !== undefined) {
+			edits.push({ raw: (token as Token & { raw: string }).raw, replacement });
+		}
+	});
+
+	if (edits.length === 0) {
+		return markdown;
+	}
+
+	// Apply edits sequentially against the original markdown. walkTokens
+	// visits tokens in document order so a forward scan is sufficient.
+	let out = '';
+	let pos = 0;
+	for (const { raw, replacement } of edits) {
+		const idx = markdown.indexOf(raw, pos);
+		if (idx < 0) {
+			continue;
+		}
+		out += markdown.substring(pos, idx) + replacement;
+		pos = idx + raw.length;
+	}
+	return out + markdown.substring(pos);
+}
+
+/**
+ * Computes the rewritten `raw` string for a single link or image token,
+ * or returns `undefined` if the token should be left alone (external
+ * scheme or unparseable URI).
+ *
+ * The output collapses to the canonical inline form `[](newHref)` (or
+ * `![](newHref)` for images) — the chat renderer has richer handling for
+ * empty-text agent-host links, so preserving the original label isn't
+ * useful. This also means autolinks (`<url>`) and reference-style links
+ * (`[text][ref]`) are normalized into the inline form.
+ */
+function rewriteLinkTokenRaw(token: Tokens.Link | Tokens.Image, connectionAuthority: string): string | undefined {
+	let parsed: URI;
+	try {
+		parsed = URI.parse(token.href, true);
+	} catch {
+		return undefined;
+	}
+	const scheme = parsed.scheme.toLowerCase();
+	if (!scheme || EXTERNAL_LINK_SCHEMES.has(scheme)) {
+		return undefined;
+	}
+	const newHref = toAgentHostUri(parsed, connectionAuthority).toString();
+	const prefix = token.type === 'image' ? '![' : '[';
+	return `${prefix}](${newHref})`;
+}
+
+/**
+ * Wraps a raw markdown string into an {@link IMarkdownString}, rewriting
+ * link URIs through {@link rewriteMarkdownLinks} when a connection authority
+ * is provided.
+ */
+function rawMarkdownToString(content: string, connectionAuthority: string | undefined, options?: { supportHtml?: boolean }): MarkdownString {
+	const rewritten = connectionAuthority ? rewriteMarkdownLinks(content, connectionAuthority) : content;
+	return new MarkdownString(rewritten, options);
+}
+
+/**
+ * Converts a protocol `StringOrMarkdown` value to a chat-layer `IMarkdownString`.
+ *
+ * When `connectionAuthority` is provided, markdown link URIs are rewritten
+ * through {@link rewriteMarkdownLinks} so that remote resources resolve
+ * through the agent host filesystem provider.
+ */
+function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined;
+function stringOrMarkdownToString(value: StringOrMarkdown, connectionAuthority: string | undefined): string | IMarkdownString;
+function stringOrMarkdownToString(value: StringOrMarkdown | undefined, connectionAuthority: string | undefined): string | IMarkdownString | undefined {
 	if (value === undefined) {
 		return undefined;
 	}
-	return typeof value === 'string' ? value : new MarkdownString(value.markdown);
+	if (typeof value === 'string') {
+		return value;
+	}
+	return rawMarkdownToString(value.markdown, connectionAuthority);
 }
 
 /**
@@ -352,8 +472,8 @@ export function toolCallStateToInvocation(tc: IToolCallState, subAgentInvocation
 	if (tc.status === ToolCallStatus.PendingConfirmation) {
 		// Tool needs confirmation — create with confirmation messages
 		const confirmationMessages: IToolConfirmationMessages = {
-			title: stringOrMarkdownToString(tc.confirmationTitle) ?? tc.displayName,
-			message: stringOrMarkdownToString(tc.invocationMessage),
+			title: stringOrMarkdownToString(tc.confirmationTitle, connectionAuthority) ?? tc.displayName,
+			message: stringOrMarkdownToString(tc.invocationMessage, connectionAuthority),
 		};
 
 		let toolSpecificData: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatModifiedFilesConfirmationData | undefined;
@@ -395,7 +515,7 @@ export function toolCallStateToInvocation(tc: IToolCallState, subAgentInvocation
 
 		return new ChatToolInvocation(
 			{
-				invocationMessage: stringOrMarkdownToString(tc.invocationMessage),
+				invocationMessage: stringOrMarkdownToString(tc.invocationMessage, connectionAuthority),
 				confirmationMessages,
 				presentation: ToolInvocationPresentation.HiddenAfterComplete,
 				toolSpecificData,
@@ -408,7 +528,7 @@ export function toolCallStateToInvocation(tc: IToolCallState, subAgentInvocation
 	}
 
 	const invocation = new ChatToolInvocation(undefined, toolData, tc.toolCallId, subAgentInvocationId, undefined);
-	invocation.invocationMessage = stringOrMarkdownToString(tc.invocationMessage) ?? localize('ahp.running', "Running {0}...", tc.displayName);
+	invocation.invocationMessage = stringOrMarkdownToString(tc.invocationMessage, connectionAuthority) ?? localize('ahp.running', "Running {0}...", tc.displayName);
 
 	const terminalContentUri = (tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.Completed)
 		? getTerminalContentUri(tc.content)
@@ -455,13 +575,11 @@ export function toolCallStateToInvocation(tc: IToolCallState, subAgentInvocation
  * Called from the session handler when a tool transitions to Running state
  * to set the initial `toolSpecificData`, or when content changes arrive.
  */
-export function updateRunningToolSpecificData(existing: ChatToolInvocation, tc: IToolCallState): void {
+export function updateRunningToolSpecificData(existing: ChatToolInvocation, tc: IToolCallState, connectionAuthority: string | undefined): void {
 	if (tc.status !== ToolCallStatus.Running) {
 		return;
 	}
-	existing.invocationMessage = typeof tc.invocationMessage === 'string'
-		? tc.invocationMessage
-		: new MarkdownString(tc.invocationMessage.markdown);
+	existing.invocationMessage = stringOrMarkdownToString(tc.invocationMessage, connectionAuthority) ?? existing.invocationMessage;
 
 
 	const subagentContent = getToolSubagentContent(tc);
@@ -505,7 +623,7 @@ export interface IToolCallFileEdit {
  * Returns file edits that the caller should route through the editing
  * session's external edits pipeline.
  */
-export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: IToolCallState, backendSession: URI): IToolCallFileEdit[] {
+export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: IToolCallState, backendSession: URI, connectionAuthority: string | undefined): IToolCallFileEdit[] {
 	const isCompleted = tc.status === ToolCallStatus.Completed;
 	const isCancelled = tc.status === ToolCallStatus.Cancelled;
 	const terminalContentUri = tc.status === ToolCallStatus.Running || tc.status === ToolCallStatus.Completed
@@ -514,7 +632,7 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ITool
 	const isTerminal = invocation.toolSpecificData?.kind === 'terminal' || !!terminalContentUri;
 
 	if ((isCompleted || isCancelled) && hasKey(tc, { invocationMessage: true })) {
-		invocation.invocationMessage = stringOrMarkdownToString(tc.invocationMessage) ?? invocation.invocationMessage;
+		invocation.invocationMessage = stringOrMarkdownToString(tc.invocationMessage, connectionAuthority) ?? invocation.invocationMessage;
 	}
 
 	// Check for subagent content — set toolSpecificData so the UI renders a subagent widget
@@ -544,7 +662,7 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ITool
 			terminalCommandUri: terminalContentUri ? URI.parse(terminalContentUri) : existing?.terminalCommandUri,
 		};
 	} else if (isCompleted && tc.pastTenseMessage) {
-		invocation.pastTenseMessage = stringOrMarkdownToString(tc.pastTenseMessage);
+		invocation.pastTenseMessage = stringOrMarkdownToString(tc.pastTenseMessage, connectionAuthority);
 	}
 
 	const isFailure = (isCompleted && !tc.success) || isCancelled;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type IActiveTurn, type ICompletedToolCall, type IToolCallRunningState, type ITurn, type IToolCallResponsePart, ToolCallCancellationReason } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatToolInvocationSerialized, type IChatMarkdownContent } from '../../../common/chatService/chatService.js';
 import { ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
-import { turnsToHistory, activeTurnToProgress, toolCallStateToInvocation as rawToolCallStateToInvocation, finalizeToolInvocation as rawFinalizeToolInvocation, updateRunningToolSpecificData } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
+import { turnsToHistory as rawTurnsToHistory, activeTurnToProgress as rawActiveTurnToProgress, toolCallStateToInvocation as rawToolCallStateToInvocation, finalizeToolInvocation as rawFinalizeToolInvocation, updateRunningToolSpecificData as rawUpdateRunningToolSpecificData } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
 
 // ---- Helper factories -------------------------------------------------------
 
@@ -56,7 +56,19 @@ function toolCallStateToInvocation(tc: Parameters<typeof rawToolCallStateToInvoc
 }
 
 function finalizeToolInvocation(invocation: Parameters<typeof rawFinalizeToolInvocation>[0], tc: Parameters<typeof rawFinalizeToolInvocation>[1]) {
-	return rawFinalizeToolInvocation(invocation, tc, URI.file('/'));
+	return rawFinalizeToolInvocation(invocation, tc, URI.file('/'), undefined);
+}
+
+function turnsToHistory(backendSession: Parameters<typeof rawTurnsToHistory>[0], turns: Parameters<typeof rawTurnsToHistory>[1], participantId: Parameters<typeof rawTurnsToHistory>[2], modelId?: Parameters<typeof rawTurnsToHistory>[4]) {
+	return rawTurnsToHistory(backendSession, turns, participantId, undefined, modelId);
+}
+
+function activeTurnToProgress(sessionResource: Parameters<typeof rawActiveTurnToProgress>[0], activeTurn: Parameters<typeof rawActiveTurnToProgress>[1], connectionAuthority?: Parameters<typeof rawActiveTurnToProgress>[2]) {
+	return rawActiveTurnToProgress(sessionResource, activeTurn, connectionAuthority);
+}
+
+function updateRunningToolSpecificData(existing: Parameters<typeof rawUpdateRunningToolSpecificData>[0], tc: Parameters<typeof rawUpdateRunningToolSpecificData>[1]) {
+	return rawUpdateRunningToolSpecificData(existing, tc, undefined);
 }
 
 // ---- Tests ------------------------------------------------------------------
@@ -215,6 +227,70 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(response.parts.length, 1);
 			assert.strictEqual(response.parts[0].kind, 'markdownContent');
 			assert.strictEqual((response.parts[0] as IChatMarkdownContent).content.value, 'Hello world');
+		});
+
+		test('markdown links in response content are rewritten through the agent host scheme', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.Markdown,
+					id: 'md-links',
+					content: 'See [local](file:///a/b.ts), [content](agenthost-content:///s/x), [external](https://example.com) and [rel](./foo.md).',
+				}],
+			});
+
+			const history = rawTurnsToHistory(URI.file('/'), [turn], 'p', 'my-host');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const part = response.parts[0] as IChatMarkdownContent;
+			assert.deepStrictEqual(part.content.value,
+				'See [](vscode-agent-host://my-host/file/-/a/b.ts), ' +
+				'[](vscode-agent-host://my-host/agenthost-content/-/s/x), ' +
+				'[external](https://example.com) and ' +
+				'[rel](./foo.md).'
+			);
+		});
+
+		test('markdown link syntax inside fenced code blocks is preserved verbatim', () => {
+			const input = [
+				'Use [real](file:///a.ts) directly.',
+				'',
+				'```md',
+				'[fake](file:///b.ts)',
+				'```',
+				'',
+				'And then [another](file:///c.ts).',
+			].join('\n');
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.Markdown, id: 'md-code', content: input }],
+			});
+
+			const history = rawTurnsToHistory(URI.file('/'), [turn], 'p', 'my-host');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const value = (response.parts[0] as IChatMarkdownContent).content.value;
+			assert.ok(value.includes('[](vscode-agent-host://my-host/file/-/a.ts)'));
+			assert.ok(value.includes('[](vscode-agent-host://my-host/file/-/c.ts)'));
+			// The link inside the fenced code block must NOT be rewritten.
+			assert.ok(value.includes('[fake](file:///b.ts)'));
+			assert.ok(!value.includes('[fake](vscode-agent-host'));
+		});
+
+		test('markdown link syntax inside inline code spans is preserved verbatim', () => {
+			const input = 'Real [one](file:///a.ts) and literal `[two](file:///b.ts)` here.';
+			const turn = createTurn({
+				responseParts: [{ kind: ResponsePartKind.Markdown, id: 'md-codespan', content: input }],
+			});
+
+			const history = rawTurnsToHistory(URI.file('/'), [turn], 'p', 'my-host');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const value = (response.parts[0] as IChatMarkdownContent).content.value;
+			assert.strictEqual(value,
+				'Real [](vscode-agent-host://my-host/file/-/a.ts) and literal `[two](file:///b.ts)` here.'
+			);
 		});
 
 		test('error turn produces error message in history', () => {


### PR DESCRIPTION
Stacked on #311025, but we don't have stacked PRs enabled for vscode yet 😓 . Just review the commit matching the PR title.