### PR TITLE
Warm-cache gate for inline background summarization

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -45,7 +45,7 @@ import { IDefaultIntentRequestHandlerOptions } from '../../prompt/node/defaultIn
 import { IDocumentContext } from '../../prompt/node/documentContext';
 import { IBuildPromptResult, IIntent, IIntentInvocation } from '../../prompt/node/intents';
 import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPrompt';
-import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult } from '../../prompts/node/agent/backgroundSummarizer';
+import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
 import { extractInlineSummary, InlineSummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../../prompts/node/agent/summarizedConversationHistory';
 import { PromptRenderer, renderPromptElement } from '../../prompts/node/base/promptRenderer';
@@ -360,6 +360,12 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 	/** Cached model capabilities from the most recent main agent render, reused by the background summarizer. */
 	private _lastModelCapabilities: { enableThinking: boolean; reasoningEffort: string | undefined; enableToolSearch: boolean; enableContextEditing: boolean } | undefined;
 
+	/**
+	 * RNG used to jitter the inline-summarization trigger threshold around 0.80.
+	 * Tests may overwrite this directly (e.g. `(invocation as any)._thresholdRng = () => 0.5`).
+	 */
+	private _thresholdRng: () => number = Math.random;
+
 	constructor(
 		intent: IIntent,
 		location: ChatLocation,
@@ -660,13 +666,26 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 			));
 		}
 
-		// Post-render: kick off background compaction at ≥ 80% if idle.
+		// Post-render: kick off background compaction if idle and over the
+		// threshold. For the inline-summarization path we care about prompt
+		// cache parity with the main agent fetch — so we gate kick-off on a
+		// completed tool call (cache has been warmed) and jitter the threshold
+		// around 0.80 to avoid firing at the same exact boundary every time.
+		// The non-inline path forks its own prompt and sees no cache benefit,
+		// so it keeps the simple >= 0.80 behavior.
 		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
 			const postRenderRatio = baseBudget > 0
 				? (result.tokenCount + toolTokens) / baseBudget
 				: 0;
 
-			if (postRenderRatio >= 0.80 && (backgroundSummarizer.state === BackgroundSummarizationState.Idle || backgroundSummarizer.state === BackgroundSummarizationState.Failed)) {
+			const idleOrFailed = backgroundSummarizer.state === BackgroundSummarizationState.Idle
+				|| backgroundSummarizer.state === BackgroundSummarizationState.Failed;
+
+			const cacheWarm = (promptContext.toolCallRounds?.length ?? 0) > 0;
+
+			const kickOff = shouldKickOffBackgroundSummarization(postRenderRatio, useInlineSummarization, cacheWarm, this._thresholdRng);
+
+			if (kickOff && idleOrFailed) {
 				if (useInlineSummarization) {
 					// Compute and cache model capabilities from the current render's
 					// messages. These must match the main agent fetch for cache parity.

--- a/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
@@ -40,6 +40,60 @@ export interface IBackgroundSummarizationResult {
 }
 
 /**
+ * Thresholds used by {@link shouldKickOffBackgroundSummarization}. Exported so
+ * tests can reference the same numbers without repeating them.
+ */
+export const BackgroundSummarizationThresholds = {
+	/** Trigger ratio for the non-inline path (no prompt-cache benefit). */
+	base: 0.80,
+	/** Minimum of the jittered warm-cache range for the inline path. */
+	warmJitterMin: 0.78,
+	/** Width of the jittered warm-cache range; together with `warmJitterMin` yields [0.78, 0.82). */
+	warmJitterSpan: 0.04,
+	/**
+	 * Cold-cache emergency ratio for the inline path. Above this we kick off
+	 * even without a warmed cache to avoid forcing a foreground sync compaction
+	 * on the next render. Tuned low enough that long-running sessions stay
+	 * ahead of the budget without relying on foreground compaction.
+	 */
+	emergency: 0.90,
+} as const;
+
+/**
+ * Decide whether to kick off post-render background compaction.
+ *
+ * For the inline-summarization path prompt-cache parity matters, so we:
+ *   - require a completed tool call in this turn ("warm" cache) before
+ *     firing at the normal, jittered ~0.80 threshold;
+ *   - allow an emergency kick-off at >= 0.90 even with a cold cache to
+ *     avoid forcing a foreground sync compaction on the next render.
+ *
+ * The jitter range straddles the historical 0.80 threshold (not "lower the
+ * bar") — the goal is to avoid always firing at the exact same boundary,
+ * not to kick off systematically earlier.
+ *
+ * The non-inline path forks its own prompt (no cache benefit) and keeps the
+ * simple >= 0.80 behavior. `rng` is only consumed on the warm-cache inline
+ * branch, which keeps deterministic tests straightforward.
+ */
+export function shouldKickOffBackgroundSummarization(
+	postRenderRatio: number,
+	useInlineSummarization: boolean,
+	cacheWarm: boolean,
+	rng: () => number,
+): boolean {
+	const t = BackgroundSummarizationThresholds;
+	if (!useInlineSummarization) {
+		return postRenderRatio >= t.base;
+	}
+	if (!cacheWarm) {
+		return postRenderRatio >= t.emergency;
+	}
+	const jittered = t.warmJitterMin + rng() * t.warmJitterSpan;
+	return postRenderRatio >= jittered;
+}
+
+/**
  * Tracks a single background summarization pass for one chat session.
  *
  * The singleton `AgentIntent` owns one instance per session (keyed by

--- a/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult } from '../backgroundSummarizer';
+import { BackgroundSummarizationState, BackgroundSummarizationThresholds, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../backgroundSummarizer';
 
 describe('BackgroundSummarizer', () => {
 
@@ -251,5 +251,68 @@ describe('BackgroundSummarizer', () => {
 		const result = summarizer.consumeAndReset();
 		expect(result).toBeUndefined();
 		expect(summarizer.state).toBe(BackgroundSummarizationState.Idle);
+	});
+});
+
+const { base, warmJitterMin, warmJitterSpan, emergency } = BackgroundSummarizationThresholds;
+
+// rng that always returns 0.5 -> threshold sits exactly at the center of the
+// jitter range. With [0.78, 0.82) that's 0.80.
+const midRng = () => 0.5;
+// rng that forces the maximum of the jitter range.
+const maxRng = () => 1 - Number.EPSILON;
+// rng that should never be called on cold/non-inline branches.
+const unusedRng = () => {
+	throw new Error('rng should not be consumed');
+};
+
+describe('shouldKickOffBackgroundSummarization', () => {
+	describe('inline + cold cache', () => {
+		test('defers kick-off below the emergency threshold', () => {
+			// Cold turn sitting in the old 0.80 trigger band — must not fire.
+			expect(shouldKickOffBackgroundSummarization(0.85, true, false, unusedRng)).toBe(false);
+		});
+
+		test('kicks off at the emergency threshold', () => {
+			expect(shouldKickOffBackgroundSummarization(emergency, true, false, unusedRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(0.91, true, false, unusedRng)).toBe(true);
+		});
+
+		test('does not consume the rng on the cold branch', () => {
+			// The unusedRng would throw if consumed — asserting no throw is the check.
+			expect(() => shouldKickOffBackgroundSummarization(0.85, true, false, unusedRng)).not.toThrow();
+			expect(() => shouldKickOffBackgroundSummarization(0.91, true, false, unusedRng)).not.toThrow();
+		});
+	});
+
+	describe('inline + warm cache', () => {
+		test('kicks off at the jittered midpoint (0.80) when ratio meets it', () => {
+			expect(shouldKickOffBackgroundSummarization(0.80, true, true, midRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(0.81, true, true, midRng)).toBe(true);
+		});
+
+		test('defers when ratio is under the jittered threshold', () => {
+			// midRng -> 0.80; 0.77 is below the entire jitter window.
+			expect(shouldKickOffBackgroundSummarization(0.77, true, true, midRng)).toBe(false);
+			// Also below the minimum of the window regardless of rng.
+			expect(shouldKickOffBackgroundSummarization(warmJitterMin - 0.0001, true, true, () => 0)).toBe(false);
+		});
+
+		test('respects the top of the jitter range', () => {
+			// With maxRng, threshold approaches warmJitterMin + warmJitterSpan = 0.82.
+			// 0.81 lands below it, so we defer.
+			expect(shouldKickOffBackgroundSummarization(0.81, true, true, maxRng)).toBe(false);
+			// 0.82 meets it.
+			expect(shouldKickOffBackgroundSummarization(warmJitterMin + warmJitterSpan, true, true, maxRng)).toBe(true);
+		});
+	});
+
+	describe('non-inline path', () => {
+		test('uses the fixed base threshold and ignores cache warmth', () => {
+			// Warm, cold — both behave the same on non-inline.
+			expect(shouldKickOffBackgroundSummarization(base, false, false, unusedRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(base, false, true, unusedRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(base - 0.0001, false, true, unusedRng)).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION
Gates the post-render background compaction trigger on prompt-cache warmth so the inline summarization LLM call actually benefits from cache-hit pricing, and drops the cold-cache emergency threshold so long-running sessions stay ahead of the budget without falling through to sync foreground compaction.
