### PR TITLE
Add plaintext and directory mimetypes to Linux desktop entry

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -8,7 +8,7 @@ Type=Application
 StartupNotify=false
 StartupWMClass=@@NAME_SHORT@@
 Categories=TextEditor;Development;IDE;
-MimeType=application/x-@@NAME@@-workspace;
+MimeType=application/x-@@NAME@@-workspace;text/plain;inode/directory
 Actions=new-empty-window;
 Keywords=vscode;
 


### PR DESCRIPTION
This allows users to open files and folders with VSCode directly from their file manager, matching the behavior of other text editing applications on Linux.

Fixes #15741