### PR TITLE
agentHost: fix bugs around message handling

### DIFF
--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -1127,16 +1127,16 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		}
 
 		const handler = controllerData.controller.getChatSessionInputState;
-		if (!handler || !sessionResourceComponents) {
+		if (!handler) {
 			return undefined;
 		}
-		const sessionResource = URI.revive(sessionResourceComponents);
-		const inputState = await handler(isUntitledChatSession(sessionResource) ? undefined : sessionResource, { previousInputState: undefined }, token);
+		const sessionResource = sessionResourceComponents ? URI.revive(sessionResourceComponents) : undefined;
+		const inputState = await handler(!sessionResource || isUntitledChatSession(sessionResource) ? undefined : sessionResource, { previousInputState: undefined }, token);
 		if (!inputState) {
 			return undefined;
 		}
 
-		if (inputState instanceof ChatSessionInputStateImpl) {
+		if (inputState instanceof ChatSessionInputStateImpl && sessionResource) {
 			if (isUntitledChatSession(sessionResource)) {
 				inputState.untitledSessionResource = sessionResource;
 			} else {

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -1119,7 +1119,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		controllerData.onDidChangeChatSessionItemStateEmitter.fire(item);
 	}
 
-	async $provideChatSessionInputState(controllerHandle: number, sessionResourceComponents: UriComponents, token: CancellationToken): Promise<vscode.ChatSessionProviderOptionGroup[] | undefined> {
+	async $provideChatSessionInputState(controllerHandle: number, sessionResourceComponents: UriComponents | undefined, token: CancellationToken): Promise<vscode.ChatSessionProviderOptionGroup[] | undefined> {
 		const controllerData = this._chatSessionItemControllers.get(controllerHandle);
 		if (!controllerData) {
 			this._logService.warn(`No controller found for handle ${controllerHandle}`);
@@ -1127,10 +1127,9 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 		}
 
 		const handler = controllerData.controller.getChatSessionInputState;
-		if (!handler) {
+		if (!handler || !sessionResourceComponents) {
 			return undefined;
 		}
-
 		const sessionResource = URI.revive(sessionResourceComponents);
 		const inputState = await handler(isUntitledChatSession(sessionResource) ? undefined : sessionResource, { previousInputState: undefined }, token);
 		if (!inputState) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -11,7 +11,7 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableResourceMap, DisposableStore, IReference, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
-import { autorun, derived, IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { autorun, derived, IObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
@@ -180,7 +180,7 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 	private readonly _onDidStartServerRequest = this._register(new Emitter<{ prompt: string }>());
 	readonly onDidStartServerRequest = this._onDidStartServerRequest.event;
 
-	interruptActiveResponseCallback: IChatSession['interruptActiveResponseCallback'];
+	readonly interruptActiveResponseCallback: IChatSession['interruptActiveResponseCallback'];
 	readonly forkSession: IChatSession['forkSession'];
 
 	constructor(
@@ -189,6 +189,7 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 		private readonly _forkSession: ((request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => Promise<IChatSessionItem>),
 		initialProgress: IChatProgress[] | undefined,
 		onDispose: () => void,
+		interruptActiveResponse: () => boolean,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
@@ -202,11 +203,10 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 		this._register(toDisposable(() => this._onWillDispose.fire()));
 		this._register(toDisposable(onDispose));
 
-		// Provide interrupt callback when reconnecting to an active turn or
-		// when this is a brand-new session (no history yet).
-		this.interruptActiveResponseCallback = (hasActiveTurn || history.length === 0) ? async () => {
-			return true;
-		} : undefined;
+		// Always provide an interrupt callback so the chat UI's stop button
+		// can cancel a remote turn at any time. The callback resolves the
+		// current active turn at call time and dispatches SessionTurnCancelled.
+		this.interruptActiveResponseCallback = async () => interruptActiveResponse();
 
 		this.forkSession = this._forkSession;
 	}
@@ -241,8 +241,10 @@ class AgentHostChatSession extends Disposable implements IChatSession {
 	 */
 	startServerRequest(prompt: string): void {
 		this._logService.info('[AgentHost] Server-initiated request started');
-		this.progressObs.set([], undefined);
-		this.isCompleteObs.set(false, undefined);
+		transaction(tx => {
+			this.progressObs.set([], tx);
+			this.isCompleteObs.set(false, tx);
+		});
 		this._onDidStartServerRequest.fire({ prompt });
 	}
 }
@@ -523,6 +525,24 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				if (resolvedSession) {
 					this._releaseSessionSubscription(resolvedSession.toString());
 				}
+			},
+			() => {
+				const backend = resolvedSession ?? this._sessionToBackend.get(sessionResource);
+				if (!backend) {
+					return false;
+				}
+				const sessionKey = backend.toString();
+				const turnId = this._getSessionState(sessionKey)?.activeTurn?.id;
+				if (!turnId) {
+					return false;
+				}
+				this._logService.info(`[AgentHost] Cancellation requested for ${sessionKey}, dispatching turnCancelled`);
+				this._config.connection.dispatch({
+					type: ActionType.SessionTurnCancelled,
+					session: sessionKey,
+					turnId,
+				});
+				return true;
 			},
 		);
 		this._activeSessions.set(sessionResource, session);
@@ -2000,18 +2020,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		const observedSubagentToolIds = new Set<string>();
 		const throttler = new Throttler();
 		reconnectDisposables.add(throttler);
-
-		// Set up the interrupt callback so the user can actually cancel the
-		// remote turn. This dispatches session/turnCancelled to the server.
-		chatSession.interruptActiveResponseCallback = async () => {
-			this._logService.info(`[AgentHost] Reconnect cancellation requested for ${sessionKey}, dispatching turnCancelled`);
-			this._config.connection.dispatch({
-				type: ActionType.SessionTurnCancelled,
-				session: sessionKey,
-				turnId,
-			});
-			return true;
-		};
 
 		// Wire up awaitConfirmation for tool calls that were already pending
 		// confirmation at snapshot time so the user can approve/deny them.

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -529,12 +529,15 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			() => {
 				const backend = resolvedSession ?? this._sessionToBackend.get(sessionResource);
 				if (!backend) {
-					return false;
+					// Nothing to cancel. Treat as a successful noop so ChatService
+					// does not install a phantom pending request.
+					return true;
 				}
 				const sessionKey = backend.toString();
 				const turnId = this._getSessionState(sessionKey)?.activeTurn?.id;
 				if (!turnId) {
-					return false;
+					// No active turn (likely a race with completion). Noop-success.
+					return true;
 				}
 				this._logService.info(`[AgentHost] Cancellation requested for ${sessionKey}, dispatching turnCancelled`);
 				this._config.connection.dispatch({

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -685,10 +685,6 @@ export class ChatService extends Disposable implements IChatService {
 			}
 		}
 
-		if (providedSession.isCompleteObs?.get()) {
-			lastRequest?.response?.complete();
-		}
-
 		// Set up progress streaming and cancellation for contributed sessions.
 		// This handles both the initial in-flight response (from session load)
 		// and any subsequent server-initiated turns (e.g. consumed queued messages).
@@ -701,30 +697,27 @@ export class ChatService extends Disposable implements IChatService {
 				return token.onCancellationRequested(() => {
 					providedSession.interruptActiveResponseCallback?.().then(userConfirmedInterruption => {
 						if (!userConfirmedInterruption) {
-							// User cancelled the interruption
-							const newCancellationRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined, undefined, undefined);
-							this._pendingRequests.set(model.sessionResource, newCancellationRequest);
-							this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
-							cancellationListener.value = createCancellationListener(newCancellationRequest.cancellationTokenSource.token);
+							trackNewCancellableRequest();
 						}
 					});
 				});
 			};
 
+			const trackNewCancellableRequest = () => {
+				const cancellableRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined, undefined, undefined);
+				this._pendingRequests.set(model.sessionResource, cancellableRequest);
+				this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
+				cancellationListener.value = createCancellationListener(cancellableRequest.cancellationTokenSource.token);
+			};
+
 			const ensureCancellationTracking = () => {
 				if (!this._pendingRequests.has(model.sessionResource)) {
-					const cts = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined, undefined, undefined);
-					this._pendingRequests.set(model.sessionResource, cts);
-					this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
-					cancellationListener.value = createCancellationListener(cts.cancellationTokenSource.token);
+					trackNewCancellableRequest();
 				}
 			};
 
-			if (lastRequest) {
-				const initialCancellationRequest = this.instantiationService.createInstance(CancellableRequest, new CancellationTokenSource(), undefined, undefined, undefined);
-				this._pendingRequests.set(model.sessionResource, initialCancellationRequest);
-				this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'add', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
-				cancellationListener.value = createCancellationListener(initialCancellationRequest.cancellationTokenSource.token);
+			if (lastRequest && !providedSession.isCompleteObs?.get()) {
+				trackNewCancellableRequest();
 			}
 
 			// Handle server-initiated requests (e.g. consumed queued messages).
@@ -772,11 +765,16 @@ export class ChatService extends Disposable implements IChatService {
 
 				// Handle completion
 				if (isComplete && lastRequest) {
-					lastRequest.response?.complete();
+					this._pendingRequests.deleteAndDispose(model.sessionResource);
 					cancellationListener.clear();
+					lastRequest.response?.complete();
 				}
 			}));
 		} else {
+			if (providedSession.isCompleteObs?.get()) {
+				lastRequest?.response?.complete();
+			}
+
 			this.telemetryService.publicLog2<ChatPendingRequestChangeEvent, ChatPendingRequestChangeClassification>(ChatPendingRequestChangeEventName, { action: 'notCancelable', source: 'remoteSession', chatSessionId: chatSessionResourceToId(model.sessionResource) });
 			if (lastRequest && model.editingSession) {
 				// wait for timeline to load so that a 'changes' part is added when the response completes

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -42,7 +42,7 @@ import { TestMcpService } from '../../../../mcp/test/common/testMcpService.js';
 import { IChatVariablesService } from '../../../common/attachments/chatVariables.js';
 import { IChatDebugService } from '../../../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../../../common/chatDebugServiceImpl.js';
-import { ChatRequestQueueKind, ChatSendResult, IChatFollowup, IChatModelReference, IChatService, ResponseModelState } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ChatSendResult, IChatFollowup, IChatModelReference, IChatProgress, IChatService, ResponseModelState } from '../../../common/chatService/chatService.js';
 import { ChatService } from '../../../common/chatService/chatServiceImpl.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
 import { ChatEditingSessionState, IChatEditingService, IChatEditingSession, IModifiedFileEntry, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
@@ -55,7 +55,7 @@ import { MockChatVariablesService } from '../mockChatVariables.js';
 import { MockPromptsService } from '../promptSyntax/service/mockPromptsService.js';
 import { MockLanguageModelToolsService } from '../tools/mockLanguageModelToolsService.js';
 import { MockChatService } from './mockChatService.js';
-import { ChatSessionOptionsMap, IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { ChatSessionOptionsMap, IChatSession, IChatSessionHistoryItem, IChatSessionsService } from '../../../common/chatSessionsService.js';
 import { MockChatSessionsService } from '../mockChatSessionsService.js';
 import { AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING, COPILOT_SKILL_URI_SCHEME, TROUBLESHOOT_SKILL_PATH } from '../../../common/promptSyntax/promptTypes.js';
 
@@ -1327,6 +1327,166 @@ suite('ChatService', () => {
 
 		currentRef!.dispose();
 		await testService.waitForModelDisposals();
+	});
+
+	suite('loadRemoteSession progress streaming', () => {
+		const remoteScheme = 'remote-streaming-test';
+
+		interface IProvidedSessionOptions {
+			readonly progressObs?: ISettableObservable<IChatProgress[]>;
+			readonly isCompleteObs?: ISettableObservable<boolean>;
+			readonly interruptActiveResponseCallback?: () => Promise<boolean>;
+			readonly onDidStartServerRequest?: Event<{ prompt: string }>;
+			readonly history?: readonly IChatSessionHistoryItem[];
+		}
+
+		function setupRemoteProvider(opts: IProvidedSessionOptions): { resource: URI; provided: IChatSession } {
+			const resource = URI.from({ scheme: remoteScheme, path: '/session-' + generateId() });
+			const mockSessionsService = new MockChatSessionsService();
+			instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+			testDisposables.add(chatAgentService.registerAgent(remoteScheme, { ...getAgentData(remoteScheme), isDefault: true }));
+			testDisposables.add(chatAgentService.registerAgentImplementation(remoteScheme, { async invoke() { return {}; } }));
+
+			const provided: IChatSession = {
+				sessionResource: resource,
+				history: opts.history ?? [{ type: 'request', prompt: 'hello', participant: remoteScheme }],
+				onWillDispose: Event.None,
+				progressObs: opts.progressObs,
+				isCompleteObs: opts.isCompleteObs,
+				interruptActiveResponseCallback: opts.interruptActiveResponseCallback,
+				onDidStartServerRequest: opts.onDidStartServerRequest,
+				dispose: () => { },
+			};
+			testDisposables.add(mockSessionsService.registerChatSessionContentProvider(remoteScheme, {
+				provideChatSessionContent: () => Promise.resolve(provided),
+			}));
+
+			return { resource, provided };
+		}
+
+		let idCounter = 0;
+		function generateId(): string {
+			return `${Date.now()}-${idCounter++}`;
+		}
+
+		test('already-complete session at load time: no initial pending request, response is completed via autorun', async () => {
+			const progressObs = observableValue<IChatProgress[]>('progress', []);
+			const isCompleteObs = observableValue<boolean>('isComplete', true);
+			let interruptCalls = 0;
+			const { resource } = setupRemoteProvider({
+				progressObs,
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => { interruptCalls++; return true; },
+			});
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			const model = ref.object as ChatModel;
+			const lastRequest = model.lastRequest!;
+			assert.strictEqual(lastRequest.response?.isComplete, true, 'Response should be completed through the isComplete autorun');
+
+			// No pending request should exist — cancelling is a noop and must not call the interrupt callback.
+			await testService.cancelCurrentRequestForSession(resource, 'test');
+			assert.strictEqual(interruptCalls, 0, 'Interrupt callback should not be invoked when there is no pending request');
+		});
+
+		test('active session at load time: cancelCurrentRequestForSession invokes the interrupt callback', async () => {
+			const progressObs = observableValue<IChatProgress[]>('progress', []);
+			const isCompleteObs = observableValue<boolean>('isComplete', false);
+			let interruptCalls = 0;
+			const { resource } = setupRemoteProvider({
+				progressObs,
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => { interruptCalls++; return true; },
+			});
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			const model = ref.object as ChatModel;
+			assert.strictEqual(model.lastRequest?.response?.isComplete, false, 'Response must stay open while session is active');
+
+			await testService.cancelCurrentRequestForSession(resource, 'test');
+			assert.strictEqual(interruptCalls, 1, 'Interrupt callback should be invoked once');
+		});
+
+		test('transition of isCompleteObs to true clears pending request and completes response', async () => {
+			const progressObs = observableValue<IChatProgress[]>('progress', []);
+			const isCompleteObs = observableValue<boolean>('isComplete', false);
+			let interruptCalls = 0;
+			const { resource } = setupRemoteProvider({
+				progressObs,
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => { interruptCalls++; return true; },
+			});
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			const model = ref.object as ChatModel;
+			const lastRequest = model.lastRequest!;
+			assert.strictEqual(lastRequest.response?.isComplete, false);
+
+			// Simulate server finishing the turn.
+			isCompleteObs.set(true, undefined);
+
+			assert.strictEqual(lastRequest.response?.isComplete, true, 'Response should complete when isCompleteObs transitions to true');
+
+			// Pending request entry should now be gone — cancel must be a noop.
+			await testService.cancelCurrentRequestForSession(resource, 'test');
+			assert.strictEqual(interruptCalls, 0, 'Interrupt should not fire after the turn has completed');
+		});
+
+		test('interrupt callback returning false installs a fresh pending request so cancel can be retried', async () => {
+			const progressObs = observableValue<IChatProgress[]>('progress', []);
+			const isCompleteObs = observableValue<boolean>('isComplete', false);
+			const interruptResults = [false, true];
+			const interruptInvocations: number[] = [];
+			const { resource } = setupRemoteProvider({
+				progressObs,
+				isCompleteObs,
+				interruptActiveResponseCallback: async () => {
+					const index = interruptInvocations.length;
+					interruptInvocations.push(index);
+					return interruptResults[index] ?? true;
+				},
+			});
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			// First cancel: user rejects the interruption, so a new pending request is wired up.
+			await testService.cancelCurrentRequestForSession(resource, 'test-first');
+
+			// Second cancel: should find the freshly-installed pending request and fire the callback again.
+			await testService.cancelCurrentRequestForSession(resource, 'test-second');
+
+			assert.strictEqual(interruptInvocations.length, 2, 'Interrupt callback should be invoked on both cancel attempts');
+		});
+
+		test('non-streaming session with isCompleteObs=true at load: response completes synchronously', async () => {
+			const isCompleteObs = observableValue<boolean>('isComplete', true);
+			// Deliberately no progressObs / interruptActiveResponseCallback — falls through to the non-streaming branch.
+			const { resource } = setupRemoteProvider({ isCompleteObs });
+
+			const testService = createChatService();
+			const ref = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref);
+			testDisposables.add(ref);
+
+			const model = ref.object as ChatModel;
+			assert.strictEqual(model.lastRequest?.response?.isComplete, true, 'Non-streaming session should complete response at load time');
+		});
 	});
 });
 


### PR DESCRIPTION
- Fix a bug where a sessions were not restored correctly because they had in-progress data (that is the move of the `providedSession.isCompleteObs?.get()`)
- Fix a bug where sessions that supported progress streaming would not have sendable messages if they were already complete (that is the addition of `this._pendingRequests.deleteAndDispose(model.sessionResource);`)
- Fix a bug in the agent host where we didn't provide `onDidStartServerRequest` consistently which often prevented multi-client messaging from working
- DRY up some logic and add tests

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
