### PR TITLE
sessions: center Add Chat tooltip

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -85,6 +85,7 @@ The widget:
 - Extends `BaseActionViewItem` and renders a clickable label showing the active session title
 - Shows kind icon (provider type icon), session title, repository folder name, and the active git branch/worktree name in parentheses when available, plus the changes summary (+insertions -deletions)
 - Truncates the repository/worktree metadata with ellipsis before truncating the primary AI-generated session title when command center space is constrained
+- Keeps the divider before adjacent command-center icon actions outside the action item's hover anchor so tooltips stay centered under icon-only buttons such as "Add Chat"
 - On click, opens the `AgentSessionsPicker` quick pick to switch between sessions
 - Gets the active session label from `IActiveSessionService.getActiveSession()` and the live model title from `IChatService`, falling back to "New Session" if no active session is found
 - Re-renders automatically when the active session changes via `autorun` on `IActiveSessionService.activeSession`, and when session data changes via `IAgentSessionsService.model.onDidChangeSessions`
@@ -658,6 +659,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-17 | Moved the command-center divider for sessions titlebar icon actions outside the action item's box so icon-button hovers such as "Add Chat" stay centered under the visible button. |
 | 2026-04-17 | Added a subtle 1px titlebar-token border around the sessions account widget's GitHub profile image, including the inactive-window variant, and documented the avatar chrome in the layout spec. |
 | 2026-04-16 | Softened the experimental sessions shell gradient by reducing the accent tint mix strength across the shared default, light-theme, and dark-theme variants so the primary color reads more subtly behind the workbench chrome. |
 | 2026-04-16 | Updated the layout visual representation to show the editor part in the top-right row and mark it as hidden by default. |

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -11,14 +11,13 @@
 
 .agent-sessions-workbench .command-center .monaco-action-bar .actions-container > .action-item.agent-sessions-titlebar-container + .action-item {
 	position: relative;
-	margin-left: 8px;
-	padding-left: 12px;
+	margin-left: 20px;
 }
 
 .agent-sessions-workbench .command-center .monaco-action-bar .actions-container > .action-item.agent-sessions-titlebar-container + .action-item::before {
 	content: '';
 	position: absolute;
-	left: 0;
+	left: -12px;
 	top: 50%;
 	width: 1px;
 	height: 16px;


### PR DESCRIPTION
## Summary
Fix the sessions titlebar command-center spacing so the **Add Chat** tooltip is centered under the visible icon button instead of being pulled left by the divider spacing.

## What changed
- move the spacing before the adjacent command-center icon action from internal padding to outer margin
- position the divider pseudo-element outside the icon action's box so the hover anchor matches the visible button
- document the titlebar hover-alignment detail in `src/vs/sessions/LAYOUT.md`

## Notes
- repo checks completed locally before opening this PR