### PR TITLE
Fix leaked disposable in NewChatWidget workspace picker

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -82,7 +82,7 @@ class NewChatWidget extends Disposable {
 		const chatWidgetContent = dom.append(chatWidgetContainer, dom.$('.new-chat-widget-content'));
 
 		const workspacePickerContainer = dom.append(chatWidgetContent, dom.$('.new-session-workspace-picker-container'));
-		this._renderWorkspacePicker(workspacePickerContainer);
+		this._register(this._renderWorkspacePicker(workspacePickerContainer));
 
 		this._newChatInput.render(chatWidgetContent, parent);
 


### PR DESCRIPTION
Fix leaked disposable in `NewChatWidget._renderWorkspacePicker`.

`_renderWorkspacePicker` returns an `IDisposable` (the `onDidSelectWorkspace` event subscription), but `render()` was discarding the return value — causing a `[LEAKED DISPOSABLE]` error. Now registered on the widget's disposable store via `this._register(...)`.

Regression from #309895. (Written by Copilot)

cc @sandy081 