### PR TITLE
feat: upload commit-to-version mapping for copilot source maps

### DIFF
--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -149,3 +149,23 @@ jobs:
             done
 
             echo "Successfully uploaded $UPLOADED source maps"
+
+            # Upload commit-to-version mapping so the deminify service
+            # can resolve the patched extension version from a VS Code commit hash.
+            COMMIT_HASH="$(Build.SourceVersion)"
+            MAPPING_BLOB="sourcemaps/${EXTENSION_ID}/commits/${COMMIT_HASH}.json"
+            echo "{\"version\":\"${VERSION}\",\"extensionId\":\"${EXTENSION_ID}\"}" > /tmp/commit-version.json
+
+            echo "Uploading commit mapping: $COMMIT_HASH -> $VERSION"
+            az storage blob upload \
+              --account-name "$STORAGE_ACCOUNT" \
+              --container-name '$web' \
+              --name "$MAPPING_BLOB" \
+              --file "/tmp/commit-version.json" \
+              --content-type "application/json" \
+              --content-cache-control "max-age=31536000, public" \
+              --auth-mode login \
+              --overwrite \
+              --only-show-errors
+
+            echo "Commit mapping uploaded: $MAPPING_BLOB"

--- a/build/azure-pipelines/product-copilot.yml
+++ b/build/azure-pipelines/product-copilot.yml
@@ -163,7 +163,7 @@ jobs:
               --name "$MAPPING_BLOB" \
               --file "/tmp/commit-version.json" \
               --content-type "application/json" \
-              --content-cache-control "max-age=31536000, public" \
+              --content-cache-control "no-cache, no-store, must-revalidate" \
               --auth-mode login \
               --overwrite \
               --only-show-errors


### PR DESCRIPTION
## Summary

During the Copilot CI build (product-copilot.yml), after uploading source maps to the CDN, also upload a small JSON mapping file at:

\\\
sourcemaps/{extensionId}/commits/{commitHash}.json
\\\

containing:

\\\json
{"version": "0.44.2026041004", "extensionId": "github.copilot-chat"}
\\\

## Motivation

The [vscode-errors](https://github.com/microsoft/vscode-errors) deminify service needs to resolve the correct copilot extension version to fetch source maps from the CDN. For **stable** builds the repo version works, but for **Insider** builds the version is date-patched (e.g. \