### PR TITLE
Change close button

### DIFF
--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/media/variationA.css
@@ -42,6 +42,7 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	position: relative;
 	transform: scale(0.96) translateY(8px);
 	transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
@@ -59,6 +60,36 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: 20px 28px 0;
+}
+
+.onboarding-a-close-btn {
+	position: absolute;
+	top: 16px;
+	right: 16px;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 0;
+	flex-shrink: 0;
+	transition: background 0.15s ease, color 0.15s ease;
+}
+
+.onboarding-a-close-btn:hover {
+	background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.1));
+	color: var(--vscode-editor-foreground);
+}
+
+.onboarding-a-close-btn:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 .onboarding-a-progress {

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -105,7 +105,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	private contentEl: HTMLElement | undefined;
 	private backButton: HTMLButtonElement | undefined;
 	private nextButton: HTMLButtonElement | undefined;
-	private skipButton: HTMLButtonElement | undefined;
+	private closeButton: HTMLButtonElement | undefined;
 	private footerLeft: HTMLElement | undefined;
 	private _footerSignInBtn: HTMLButtonElement | undefined;
 
@@ -176,6 +176,13 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		// Card
 		this.card = append(this.overlay, $('.onboarding-a-card'));
 
+		// Close button (upper-right corner of card)
+		this.closeButton = append(this.card, $<HTMLButtonElement>('button.onboarding-a-close-btn'));
+		this.closeButton.type = 'button';
+		this.closeButton.setAttribute('aria-label', localize('onboarding.close', "Close"));
+		this.closeButton.appendChild(renderIcon(Codicon.close));
+		this.footerFocusableElements.push(this.closeButton);
+
 		// Header with progress
 		const header = append(this.card, $('.onboarding-a-header'));
 		this.progressContainer = append(header, $('.onboarding-a-progress'));
@@ -194,10 +201,6 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		const footer = append(this.card, $('.onboarding-a-footer'));
 
 		this.footerLeft = append(footer, $('.onboarding-a-footer-left'));
-		this.skipButton = append(this.footerLeft, $<HTMLButtonElement>('button.onboarding-a-btn.onboarding-a-btn-ghost'));
-		this.skipButton.textContent = localize('onboarding.skip', "Skip");
-		this.skipButton.type = 'button';
-		this.footerFocusableElements.push(this.skipButton);
 
 		const footerRight = append(footer, $('.onboarding-a-footer-right'));
 
@@ -212,7 +215,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		this._updateButtonStates();
 
 		// Event handlers
-		this.disposables.add(addDisposableListener(this.skipButton, EventType.CLICK, () => {
+		this.disposables.add(addDisposableListener(this.closeButton, EventType.CLICK, () => {
 			this._logAction('skip');
 			this._dismiss('skip');
 		}));
@@ -412,15 +415,8 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 				this.nextButton.textContent = localize('onboarding.next', "Continue");
 			}
 		}
-		if (this.skipButton && this.footerLeft) {
-			if (this.currentStepIndex === 0) {
-				// Sign-in step: ghost Skip button
-				this.skipButton.className = 'onboarding-a-btn onboarding-a-btn-ghost';
-			} else {
-				this.skipButton.className = 'onboarding-a-btn onboarding-a-btn-ghost';
-			}
+		if (this.footerLeft) {
 			if (this._isLastStep()) {
-				this.skipButton.style.display = 'none';
 				// Show sign-in nudge in footer
 				if (!this._footerSignInBtn && !this._userSignedIn) {
 					this._footerSignInBtn = append(this.footerLeft, $<HTMLButtonElement>('button.onboarding-a-signin-nudge-btn'));
@@ -435,7 +431,6 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 					}));
 				}
 			} else {
-				this.skipButton.style.display = '';
 				if (this._footerSignInBtn) {
 					this._footerSignInBtn.remove();
 					this._footerSignInBtn = undefined;
@@ -1154,7 +1149,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 
 	private _focusCurrentStepElement(): void {
 		const stepFocusable = this.stepFocusableElements.find(element => this._isTabbable(element));
-		(stepFocusable ?? this.nextButton ?? this.skipButton)?.focus();
+		(stepFocusable ?? this.nextButton ?? this.closeButton)?.focus();
 	}
 
 	private _registerStepFocusable<T extends HTMLElement>(element: T): T {
@@ -1210,7 +1205,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		this.contentEl = undefined;
 		this.backButton = undefined;
 		this.nextButton = undefined;
-		this.skipButton = undefined;
+		this.closeButton = undefined;
 		this.footerLeft = undefined;
 		this._footerSignInBtn = undefined;
 		this.footerFocusableElements.length = 0;

--- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
+++ b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
@@ -181,7 +181,6 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 		this.closeButton.type = 'button';
 		this.closeButton.setAttribute('aria-label', localize('onboarding.close', "Close"));
 		this.closeButton.appendChild(renderIcon(Codicon.close));
-		this.footerFocusableElements.push(this.closeButton);
 
 		// Header with progress
 		const header = append(this.card, $('.onboarding-a-header'));
@@ -1144,7 +1143,7 @@ export class OnboardingVariationA extends Disposable implements IOnboardingServi
 	}
 
 	private _getFocusableElements(): HTMLElement[] {
-		return [...this.stepFocusableElements, ...this.footerFocusableElements].filter(element => this._isTabbable(element));
+		return [...(this.closeButton ? [this.closeButton] : []), ...this.stepFocusableElements, ...this.footerFocusableElements].filter(element => this._isTabbable(element));
 	}
 
 	private _focusCurrentStepElement(): void {


### PR DESCRIPTION
Changes "Skip" button to close the walkthrough to a `X`. Reduce confusion on behavior of Skip vs Next actions 

**UI Changes:**
* Added a new `.onboarding-a-close-btn` close button to the upper-right corner of the onboarding card, with appropriate styling and accessibility features. [[1]](diffhunk://#diff-b2a7a107a672f5094ffaff5068eef9e464577d764bc75b108efd5deb54c4ce84R65-R94) [[2]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aR179-R185)
* Removed the "Skip" button from the footer and all related logic and references. [[1]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL197-L200) [[2]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL108-R108) [[3]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL415-L423) [[4]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL438) [[5]](diffhunk://#diff-2677df85a7c2473e3867b11b3ec8466f217464832f4da47b48e4bdcd2d7f735aL1213-R1208)

**Behavior and Accessibility:**
* The close button now triggers the skip/dismiss action for onboarding, and event listeners have been updated to reflect this change.
* Focus management now prioritizes the close button instead of the removed skip button.

**Layout Adjustments:**
* Updated the card container to use `position: relative` to properly position the new close button.

<img width="1259" height="808" alt="image" src="https://github.com/user-attachments/assets/fa0ad197-d09e-431b-bd2e-660a82bc5f34" />
