### PR TITLE
Rename remote agent host Copilot agent displayName to "Copilot CLI"

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -106,7 +106,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 	getDescriptor(): IAgentDescriptor {
 		return {
 			provider: 'copilot',
-			displayName: 'Copilot',
+			displayName: 'Copilot CLI',
 			description: 'Copilot SDK agent running in a dedicated process',
 		};
 	}


### PR DESCRIPTION
The `CopilotAgent.getDescriptor()` displayName was `"Copilot"` but should be `"Copilot CLI"` to match the well-known `CopilotCLISessionType` label used elsewhere. The remote agent host sessions provider uses this `displayName` to build the session type label shown in the UI.

(Written by Copilot)