### PR TITLE
Filter Copilot sessions by local data

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CopilotClient, ResumeSessionConfig, type SessionConfig } from '@github/copilot-sdk';
+import { CopilotClient, ResumeSessionConfig, type CopilotClientOptions, type SessionConfig } from '@github/copilot-sdk';
 import { rgPath } from '@vscode/ripgrep';
 import * as fs from 'fs/promises';
 import { Limiter, SequencerByKey } from '../../../../base/common/async.js';
@@ -50,6 +50,21 @@ interface ISerializedModelSelection {
 	config?: unknown;
 }
 
+/**
+ * Narrow surface of {@link CopilotClient} used by this provider. The SDK class
+ * has private members, so tests use this structural type to inject a fake.
+ */
+export interface ICopilotClient {
+	start(): Promise<void>;
+	stop: CopilotClient['stop'];
+	listSessions: CopilotClient['listSessions'];
+	listModels: CopilotClient['listModels'];
+	createSession: CopilotClient['createSession'];
+	resumeSession: CopilotClient['resumeSession'];
+	getSessionMetadata: CopilotClient['getSessionMetadata'];
+	readonly rpc: { readonly sessions: { readonly fork: CopilotClient['rpc']['sessions']['fork'] } };
+}
+
 function isReasoningEffort(value: string | undefined): value is ReasoningEffort {
 	return ReasoningEfforts.some(reasoningEffort => reasoningEffort === value);
 }
@@ -78,8 +93,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, []);
 	readonly models = this._models;
 
-	private _client: CopilotClient | undefined;
-	private _clientStarting: Promise<CopilotClient> | undefined;
+	private _client: ICopilotClient | undefined;
+	private _clientStarting: Promise<ICopilotClient> | undefined;
 	private _githubToken: string | undefined;
 	private readonly _sessions = this._register(new DisposableMap<string, CopilotAgentSession>());
 	private readonly _createdWorktrees = new Map<string, ICreatedWorktree>();
@@ -99,6 +114,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 	) {
 		super();
 		this._plugins = this._instantiationService.createInstance(PluginController);
+	}
+
+	protected _createCopilotClient(options: CopilotClientOptions): ICopilotClient {
+		return new CopilotClient(options);
 	}
 
 	// ---- auth ---------------------------------------------------------------
@@ -166,7 +185,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	// ---- client lifecycle ---------------------------------------------------
 
-	private async _ensureClient(): Promise<CopilotClient> {
+	private async _ensureClient(): Promise<ICopilotClient> {
 		const tokenAtStartup = this._githubToken;
 		if (!tokenAtStartup) {
 			throw new ProtocolError(AHP_AUTH_REQUIRED, 'Authentication is required to use Copilot');
@@ -214,7 +233,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			env[pathKey] = currentPath ? `${currentPath}${delimiter}${rgDir}` : rgDir;
 			this._logService.info(`[Copilot] Resolved CLI path: ${cliPath}`);
 
-			const client = new CopilotClient({
+			const client = this._createCopilotClient({
 				githubToken: tokenAtStartup,
 				useLoggedInUser: false,
 				useStdio: true,
@@ -319,24 +338,30 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const sessions = await client.listSessions();
 		const projectLimiter = new Limiter<IAgentSessionProjectInfo | undefined>(4);
 		const projectByContext = new Map<string, Promise<IAgentSessionProjectInfo | undefined>>();
-		const result: IAgentSessionMetadata[] = await Promise.all(sessions.map(async s => {
+		const mapped = await Promise.all(sessions.map(async s => {
 			const session = AgentSession.uri(this.id, s.sessionId);
 			const metadata = await this._readStoredSessionMetadata(session);
+			if (!metadata) {
+				return undefined;
+			}
 			let { project, resolved } = metadata;
 			if (!resolved) {
 				project = await this._resolveSessionProject(s.context, projectLimiter, projectByContext);
 				void this._storeSessionProjectResolution(session, project);
 			}
-			return {
+			const workingDirectory = metadata.workingDirectory ?? (typeof s.context?.cwd === 'string' ? URI.file(s.context.cwd) : undefined);
+			const result: IAgentSessionMetadata = {
 				session,
 				startTime: s.startTime.getTime(),
 				modifiedTime: s.modifiedTime.getTime(),
-				...(project ? { project } : {}),
+				project,
 				summary: s.summary,
 				model: metadata.model,
-				workingDirectory: metadata.workingDirectory ?? (typeof s.context?.cwd === 'string' ? URI.file(s.context.cwd) : undefined),
+				workingDirectory,
 			};
+			return result;
 		}));
+		const result = mapped.filter((s): s is IAgentSessionMetadata => s !== undefined);
 		this._logService.info(`[Copilot] Found ${result.length} sessions`);
 		return result;
 	}
@@ -927,10 +952,10 @@ export class CopilotAgent extends Disposable implements IAgent {
 		}
 	}
 
-	private async _readStoredSessionMetadata(session: URI): Promise<{ model?: IModelSelection; workingDirectory?: URI; project?: IAgentSessionProjectInfo; resolved: boolean }> {
+	private async _readStoredSessionMetadata(session: URI): Promise<{ model?: IModelSelection; workingDirectory?: URI; project?: IAgentSessionProjectInfo; resolved: boolean } | undefined> {
 		const ref = await this._sessionDataService.tryOpenDatabase(session);
 		if (!ref) {
-			return { resolved: false };
+			return undefined;
 		}
 		try {
 			const [model, cwd, resolved, uri, displayName] = await Promise.all([
@@ -940,8 +965,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 				ref.object.getMetadata(CopilotAgent._META_PROJECT_URI),
 				ref.object.getMetadata(CopilotAgent._META_PROJECT_DISPLAY_NAME),
 			]);
+			const workingDirectory = cwd ? URI.parse(cwd) : undefined;
 			const project = uri && displayName ? { uri: URI.parse(uri), displayName } : undefined;
-			return { model: this._parseModelSelection(model), workingDirectory: cwd ? URI.parse(cwd) : undefined, project, resolved: resolved === 'true' || project !== undefined };
+			return { model: this._parseModelSelection(model), workingDirectory, project, resolved: resolved === 'true' || project !== undefined };
 		} finally {
 			ref.dispose();
 		}

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, type DisposableStore, type IDisposable, type IReference } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { FileService } from '../../../files/common/fileService.js';
@@ -14,12 +14,14 @@ import { InstantiationService } from '../../../instantiation/common/instantiatio
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
 import { ILogService, NullLogService } from '../../../log/common/log.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
+import { AgentSession, type IAgentSessionMetadata } from '../../common/agentService.js';
 import { ISessionDataService } from '../../common/sessionDataService.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { ISessionCustomization, ICustomizationRef } from '../../common/state/sessionState.js';
 import { IAgentHostGitService } from '../../node/agentHostGitService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
-import { CopilotAgent, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot } from '../../node/copilot/copilotAgent.js';
+import { CopilotAgent, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot, type ICopilotClient } from '../../node/copilot/copilotAgent.js';
+import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
 
 class TestAgentPluginManager implements IAgentPluginManager {
@@ -62,28 +64,119 @@ class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	getTerminalState(): undefined { return undefined; }
 }
 
-function createTestAgent(disposables: DisposableStore): CopilotAgent {
+class TestSessionDataService extends Disposable implements ISessionDataService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _databases = new Map<string, SessionDatabase>();
+	readonly openedSessions: string[] = [];
+
+	getSessionDataDir(session: URI): URI { return URI.from({ scheme: 'test', path: `/session-data/${AgentSession.id(session)}` }); }
+	getSessionDataDirById(sessionId: string): URI { return URI.from({ scheme: 'test', path: `/session-data/${sessionId}` }); }
+
+	openDatabase(session: URI): IReference<SessionDatabase> {
+		const sessionId = AgentSession.id(session);
+		this.openedSessions.push(sessionId);
+		let db = this._databases.get(sessionId);
+		if (!db) {
+			db = this._register(new SessionDatabase(':memory:'));
+			this._databases.set(sessionId, db);
+		}
+		return { object: db, dispose: () => { } };
+	}
+
+	async tryOpenDatabase(session: URI): Promise<IReference<SessionDatabase> | undefined> {
+		const db = this._databases.get(AgentSession.id(session));
+		return db ? { object: db, dispose: () => { } } : undefined;
+	}
+
+	deleteSessionData(): Promise<void> { return Promise.resolve(); }
+	cleanupOrphanedData(): Promise<void> { return Promise.resolve(); }
+}
+
+class TestCopilotClient implements ICopilotClient {
+	readonly rpc: ICopilotClient['rpc'] = { sessions: { fork: async () => ({ sessionId: 'forked-session' }) } };
+
+	constructor(
+		private readonly _sessions: Awaited<ReturnType<ICopilotClient['listSessions']>>,
+	) { }
+
+	async start(): Promise<void> { }
+	async stop(): ReturnType<ICopilotClient['stop']> { return []; }
+	async listSessions(): ReturnType<ICopilotClient['listSessions']> { return this._sessions; }
+	async listModels(): ReturnType<ICopilotClient['listModels']> { return []; }
+	async getSessionMetadata(): ReturnType<ICopilotClient['getSessionMetadata']> { return undefined; }
+	createSession: ICopilotClient['createSession'] = async () => { throw new Error('not implemented'); };
+	resumeSession: ICopilotClient['resumeSession'] = async () => { throw new Error('not implemented'); };
+}
+
+class TestableCopilotAgent extends CopilotAgent {
+	constructor(
+		private readonly _copilotClient: ICopilotClient,
+		@ILogService logService: ILogService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IFileService fileService: IFileService,
+		@ISessionDataService sessionDataService: ISessionDataService,
+		@IAgentHostGitService gitService: IAgentHostGitService,
+		@IAgentHostTerminalManager terminalManager: IAgentHostTerminalManager,
+	) {
+		super(logService, instantiationService, fileService, sessionDataService, gitService, terminalManager);
+	}
+
+	protected override _createCopilotClient(): ICopilotClient {
+		return this._copilotClient;
+	}
+}
+
+function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ICopilotClient }): CopilotAgent {
 	const services = new ServiceCollection();
 	const logService = new NullLogService();
 	const fileService = disposables.add(new FileService(logService));
 	services.set(ILogService, logService);
 	services.set(IFileService, fileService);
-	services.set(ISessionDataService, createNullSessionDataService());
+	services.set(ISessionDataService, options?.sessionDataService ?? createNullSessionDataService());
 	services.set(IAgentPluginManager, new TestAgentPluginManager());
 	services.set(IAgentHostGitService, new TestAgentHostGitService());
 	services.set(IAgentHostTerminalManager, new TestAgentHostTerminalManager());
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 	services.set(IInstantiationService, instantiationService);
+	if (options?.copilotClient) {
+		return instantiationService.createInstance(TestableCopilotAgent, options.copilotClient);
+	}
 	return instantiationService.createInstance(CopilotAgent);
 }
 
+function withoutUndefinedProperties(metadata: IAgentSessionMetadata): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(metadata)) {
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+function sdkSession(sessionId: string, cwd?: string): Awaited<ReturnType<ICopilotClient['listSessions']>>[number] {
+	return {
+		sessionId,
+		startTime: new Date(1000),
+		modifiedTime: new Date(2000),
+		summary: `SDK ${sessionId}`,
+		isRemote: false,
+		...(cwd ? { context: { cwd } } : {}),
+	};
+}
+
 async function disposeAgent(agent: CopilotAgent): Promise<void> {
+	await agent.shutdown();
 	agent.dispose();
+	// CopilotAgent.dispose calls super.dispose() from a promise continuation so
+	// async shutdown can stop SDK sessions before child disposables are released.
+	// Let that continuation run before the disposable leak tracker checks.
 	await Promise.resolve();
 }
 
 suite('CopilotAgent', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('uses the Copilot CLI sibling worktrees root convention', () => {
 		assert.strictEqual(
@@ -106,19 +199,16 @@ suite('CopilotAgent', () => {
 	});
 
 	test('returns empty models and sessions before authentication', async () => {
-		const disposables = new DisposableStore();
 		const agent = createTestAgent(disposables);
 		try {
 			assert.deepStrictEqual(agent.models.get(), []);
 			assert.deepStrictEqual(await agent.listSessions(), []);
 		} finally {
 			await disposeAgent(agent);
-			disposables.dispose();
 		}
 	});
 
 	test('requires authentication before creating a session', async () => {
-		const disposables = new DisposableStore();
 		const agent = createTestAgent(disposables);
 		try {
 			await assert.rejects(
@@ -127,7 +217,59 @@ suite('CopilotAgent', () => {
 			);
 		} finally {
 			await disposeAgent(agent);
-			disposables.dispose();
+		}
+	});
+
+	test('listSessions only returns sessions with a database', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const ownedSession = AgentSession.uri('copilot', 'owned');
+		const ownedDb = sessionDataService.openDatabase(ownedSession);
+		ownedDb.dispose();
+
+		const client = new TestCopilotClient([sdkSession('owned'), sdkSession('external')]);
+		const agent = createTestAgent(disposables, { sessionDataService, copilotClient: client });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+
+			assert.deepStrictEqual((await agent.listSessions()).map(s => AgentSession.id(s.session)), ['owned']);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('listSessions reads stored metadata from sessions with a database', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const legacySession = AgentSession.uri('copilot', 'legacy');
+		const legacyDb = sessionDataService.openDatabase(legacySession);
+		await legacyDb.object.setMetadata('copilot.workingDirectory', URI.file('/workspace').toString());
+		legacyDb.dispose();
+
+		const agent = createTestAgent(disposables, { sessionDataService, copilotClient: new TestCopilotClient([sdkSession('legacy')]) });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+
+			assert.deepStrictEqual((await agent.listSessions()).map(withoutUndefinedProperties), [{
+				session: legacySession,
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'SDK legacy',
+				workingDirectory: URI.file('/workspace'),
+			}]);
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('listSessions does not create databases for unowned SDK sessions', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const agent = createTestAgent(disposables, { sessionDataService, copilotClient: new TestCopilotClient([sdkSession('external', '/workspace')]) });
+		try {
+			await agent.authenticate('https://api.github.com', 'token');
+
+			assert.deepStrictEqual(await agent.listSessions(), []);
+			assert.deepStrictEqual(sessionDataService.openedSessions, []);
+		} finally {
+			await disposeAgent(agent);
 		}
 	});
 });


### PR DESCRIPTION
This change filters Copilot SDK sessions to only list sessions that already have Agent Host session data. That keeps sessions created by other Copilot CLI agents out of the Agents window without creating per-session databases during listing.

Summary:
- Gate CopilotAgent.listSessions results on an existing session database via tryOpenDatabase.
- Defer project resolution and project metadata writes until after the ownership/database-existence gate.
- Add focused unit coverage with a fake Copilot client and real in-memory SessionDatabase instances.

Validation:
- Diagnostics clean.
- CopilotAgent tests passed: 9/9.
- Hygiene passed on the changed files with only the existing TypeScript-version warning.
- Council review: no blocking issues found from two reviewers.

(Written by Copilot)