### PR TITLE
NES: use git-merge icon for reused in-flight requests

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -670,7 +670,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		telemetryBuilder.setRequest(nextEditRequest);
 		logContext.setRequestInput(nextEditRequest);
-		logContext.setIsCachedResult(nextEditRequest.logContext);
+		logContext.setIsReusedInFlightResult(nextEditRequest.logContext);
 
 		const disp = this._hookupCancellation(nextEditRequest, cancellationToken);
 		try {

--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -37,7 +37,7 @@ export interface MarkdownLoggable {
  * - `errored`: an error occurred
  * - `previouslyRejected`: result matches a suggestion that was previously rejected
  */
-type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'skipped' | 'cancelled' | 'errored' | 'previouslyRejected';
+type LogContextOutcome = 'pending' | 'succeeded' | 'noSuggestions' | 'cached' | 'cachedFromGhostText' | 'reusedInFlight' | 'skipped' | 'cancelled' | 'errored' | 'previouslyRejected';
 
 export class InlineEditRequestLogContext {
 
@@ -95,6 +95,7 @@ export class InlineEditRequestLogContext {
 		lines.push(`- ${Icon.lightbulbFull.svg} - model had suggestions\n`);
 		lines.push(`- ${Icon.circleSlash.svg} - model had NO suggestions\n`);
 		lines.push(`- ${Icon.database.svg} - response is from cache\n`);
+		lines.push(`- ${Icon.gitMerge.svg} - joined an in-flight request (async or speculative reuse)\n`);
 		lines.push(`- ${Icon.error.svg} - error happened\n`);
 		lines.push(`- ${Icon.skipped.svg} - fetching started but got cancelled\n`);
 		lines.push('</details>\n');
@@ -312,6 +313,35 @@ export class InlineEditRequestLogContext {
 		this.fireDidChange();
 	}
 
+	/**
+	 * Marks this log context as having joined an already in-flight request
+	 * (async pending or speculative). The icon shows git-merge to distinguish
+	 * from a true cache hit.
+	 */
+	setIsReusedInFlightResult(logContextOfReusedRequest: InlineEditRequestLogContext): void {
+		this._logContextOfCachedEdit = logContextOfReusedRequest;
+
+		this.recordingBookmark = logContextOfReusedRequest.recordingBookmark;
+		this._nextEditRequest = logContextOfReusedRequest._nextEditRequest ?? this._nextEditRequest;
+		this._resultEdit = logContextOfReusedRequest._resultEdit ?? this._resultEdit;
+		this._diagnosticsResultEdit = logContextOfReusedRequest._diagnosticsResultEdit ?? this._diagnosticsResultEdit;
+		this._endpointInfo = logContextOfReusedRequest._endpointInfo ?? this._endpointInfo;
+		this._headerRequestId = logContextOfReusedRequest._headerRequestId ?? this._headerRequestId;
+		if (logContextOfReusedRequest._prompt) {
+			this._prompt = logContextOfReusedRequest._prompt;
+		}
+		this.response = logContextOfReusedRequest.response ?? this.response;
+		this._responseResults = logContextOfReusedRequest._responseResults ?? this._responseResults;
+		if (logContextOfReusedRequest.fullResponsePromise) {
+			this.setFullResponse(logContextOfReusedRequest.fullResponsePromise);
+		}
+		this._error = logContextOfReusedRequest._error ?? this._error;
+
+		this._isVisible = true;
+		this._outcome = 'reusedInFlight';
+		this.fireDidChange();
+	}
+
 	private _endpointInfo: { url: string; modelName: string } | undefined;
 
 	public setEndpointInfo(url: string, modelName: string): void {
@@ -375,6 +405,7 @@ export class InlineEditRequestLogContext {
 			case 'noSuggestions': return Icon.circleSlash;
 			case 'cached':
 			case 'cachedFromGhostText': return Icon.database;
+			case 'reusedInFlight': return Icon.gitMerge;
 			case 'skipped':
 			case 'cancelled': return Icon.skipped;
 			case 'errored': return Icon.error;

--- a/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/utils/utils.ts
@@ -54,6 +54,11 @@ export namespace Icon {
 		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M13 3.5C13 2.119 10.761 1 8 1S3 2.119 3 3.5c0 .04.02.077.024.117H3v8.872l.056.357C3.336 14.056 5.429 15 8 15s4.664-.944 4.944-2.154l.056-.357V3.617h-.024c.004-.04.024-.077.024-.117M8 2.032c2.442 0 4 .964 4 1.468s-1.558 1.468-4 1.468S4 4 4 3.5s1.558-1.468 4-1.468m4 10.458l-.03.131C11.855 13.116 10.431 14 8 14s-3.855-.884-3.97-1.379L4 12.49v-7.5A7.4 7.4 0 0 0 8 6a7.4 7.4 0 0 0 4-1.014z"/></svg>`,
 	};
 
+	export const gitMerge: t = {
+		themeIcon: ThemeIcon.fromId('git-merge'),
+		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M5 3.254V3.25v.005zm0-.004a1.25 1.25 0 1 0-2.5 0a1.25 1.25 0 0 0 2.5 0m8.001 9.5a1.25 1.25 0 1 0-2.5 0a1.25 1.25 0 0 0 2.5 0M11.5 12a.75.75 0 1 1 1.502 0a.75.75 0 0 1-1.502 0M3.75 2a1.25 1.25 0 0 0-.25 2.474V9.07A3.997 3.997 0 0 0 7.5 12.98v.046a1.25 1.25 0 1 0 1 0v-.046a3.997 3.997 0 0 0 3-3.473V7.5A2.5 2.5 0 0 0 9 5H7a2.5 2.5 0 0 0-2.5 2.5v2.026A2.997 2.997 0 0 1 2.5 7V4.474A1.25 1.25 0 0 0 3.75 2" clip-rule="evenodd"/></svg>`,
+	};
+
 	export const loading: t = {
 		themeIcon: ThemeIcon.fromId('loading~spin'),
 		svg: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M13.917 7A6.002 6.002 0 0 0 2.083 7H1.071a7.002 7.002 0 0 1 13.858 0zm0 2a6.002 6.002 0 0 1-11.834 0H1.071a7.002 7.002 0 0 0 13.858 0z" clip-rule="evenodd"/></svg>`,


### PR DESCRIPTION
Previously both cache hits and reused in-flight requests (async pending
or speculative) showed the database icon in the NES debug log. This
made it hard to tell whether a result was served from cache or joined
an existing stream.

Add a new \`reusedInFlight\` outcome with a git-merge icon ($(git-merge))
to visually distinguish 'joined an in-flight request' from 'loaded from
cache'. The database icon is preserved for true cache hits via
\`setIsCachedResult\`; reused in-flight requests now go through the new
\`setIsReusedInFlightResult\` method.
