### PR TITLE
Show loading indicator while agent host sessions authenticate

### DIFF
--- a/src/vs/platform/agentHost/browser/nullAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullAgentHostService.ts
@@ -5,6 +5,7 @@
 
 import { Event } from '../../../base/common/event.js';
 import { IReference } from '../../../base/common/lifecycle.js';
+import { constObservable, IObservable } from '../../../base/common/observable.js';
 import { URI } from '../../../base/common/uri.js';
 import type { IAgentCreateSessionConfig, IAgentHostService, IAgentHostSocketInfo, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAuthenticateParams, IAuthenticateResult } from '../common/agentService.js';
 import type { IAgentSubscription } from '../common/state/agentSubscription.js';
@@ -27,6 +28,9 @@ export class NullAgentHostService implements IAgentHostService {
 	readonly onAgentHostStart = Event.None;
 	readonly onDidNotification: Event<INotification> = Event.None;
 	readonly onDidAction: Event<IActionEnvelope> = Event.None;
+
+	readonly authenticationPending: IObservable<boolean> = constObservable(false);
+	setAuthenticationPending(_pending: boolean): void { /* no-op */ }
 
 	get rootState(): IAgentSubscription<IRootState> { return notSupported(); }
 

--- a/src/vs/platform/agentHost/common/agentService.ts
+++ b/src/vs/platform/agentHost/common/agentService.ts
@@ -672,6 +672,21 @@ export interface IAgentHostService extends IAgentConnection {
 	readonly onAgentHostExit: Event<number>;
 	readonly onAgentHostStart: Event<void>;
 
+	/**
+	 * `true` while we are in the middle of authenticating against the local
+	 * agent host (resolving tokens for any advertised `protectedResources` and
+	 * pushing them via {@link authenticate}). Defaults to `true` at startup so
+	 * that the period before the first auth pass is also covered.
+	 *
+	 * Producers (the workbench `AgentHostContribution`) flip this around their
+	 * auth pass; consumers (e.g. the local sessions provider) read it to mark
+	 * sessions as still loading.
+	 */
+	readonly authenticationPending: IObservable<boolean>;
+
+	/** Update {@link authenticationPending}. Internal — only the auth driver should call this. */
+	setAuthenticationPending(pending: boolean): void;
+
 	restartAgentHost(): Promise<void>;
 
 	startWebSocketServer(): Promise<IAgentHostSocketInfo>;

--- a/src/vs/platform/agentHost/electron-browser/agentHostService.ts
+++ b/src/vs/platform/agentHost/electron-browser/agentHostService.ts
@@ -6,6 +6,7 @@
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IReference } from '../../../base/common/lifecycle.js';
+import { IObservable, ISettableObservable, observableValue } from '../../../base/common/observable.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { getDelayedChannel, ProxyChannel } from '../../../base/parts/ipc/common/ipc.js';
 import { Client as MessagePortClient } from '../../../base/parts/ipc/common/ipc.mp.js';
@@ -49,6 +50,23 @@ class AgentHostServiceClient extends Disposable implements IAgentHostService {
 
 	private readonly _onDidNotification = this._register(new Emitter<INotification>());
 	readonly onDidNotification = this._onDidNotification.event;
+
+	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', true);
+	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	private _authenticationSettled = false;
+
+	setAuthenticationPending(pending: boolean): void {
+		// Sticky: once the first authentication pass settles, never surface
+		// pending again. Subsequent re-auths (account/session changes, reconnect)
+		// happen silently in the background and should not flicker the UI.
+		if (this._authenticationSettled) {
+			return;
+		}
+		if (!pending) {
+			this._authenticationSettled = true;
+		}
+		this._authenticationPending.set(pending, undefined);
+	}
 
 	constructor(
 		@ILogService private readonly _logService: ILogService,

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -9,7 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { constObservable, derived, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -89,7 +89,7 @@ class LocalSessionAdapter implements ISession {
 	readonly modelId: ISettableObservable<string | undefined>;
 	modelSelection: IModelSelection | undefined;
 	readonly mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>('mode', undefined);
-	readonly loading = observableValue(this, false);
+	readonly loading: IObservable<boolean>;
 	readonly isArchived = observableValue('isArchived', false);
 	readonly isRead = observableValue('isRead', true);
 	readonly description: ISettableObservable<IMarkdownString | undefined>;
@@ -107,6 +107,7 @@ class LocalSessionAdapter implements ISession {
 		providerId: string,
 		resourceScheme: string,
 		logicalSessionType: string,
+		authenticationPending: IObservable<boolean>,
 	) {
 		const rawId = AgentSession.id(metadata.session);
 		this.agentProvider = AgentSession.provider(metadata.session) ?? DEFAULT_AGENT_PROVIDER;
@@ -123,6 +124,9 @@ class LocalSessionAdapter implements ISession {
 		this.lastTurnEnd = observableValue('lastTurnEnd', metadata.modifiedTime ? new Date(metadata.modifiedTime) : undefined);
 		this.description = observableValue('description', new MarkdownString().appendText(localize('localAgentHostDescription', "Local")));
 		this.workspace = observableValue('workspace', LocalAgentHostSessionsProvider.buildWorkspace(metadata.project, metadata.workingDirectory));
+		// Cached sessions surface as loading while the local agent host is still
+		// authenticating. They have no per-session loading state of their own.
+		this.loading = authenticationPending;
 
 		if (metadata.isRead === false) {
 			this.isRead.set(false, undefined);
@@ -480,7 +484,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 			changes,
 			modelId,
 			mode,
-			loading,
+			loading: derived(reader => loading.read(reader) || this._agentHostService.authenticationPending.read(reader)),
 			isArchived,
 			isRead,
 			description,
@@ -830,7 +834,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 					}
 				} else {
 					const sessionType = this._sessionTypeForMetadata(meta);
-					const cached = new LocalSessionAdapter(meta, this.id, sessionType, sessionType);
+					const cached = new LocalSessionAdapter(meta, this.id, sessionType, sessionType, this._agentHostService.authenticationPending);
 					this._sessionCache.set(rawId, cached);
 					added.push(cached);
 				}
@@ -902,7 +906,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 			isDone: summary.isDone,
 		};
 		const sessionType = this._sessionTypeForMetadata(meta);
-		const cached = new LocalSessionAdapter(meta, this.id, sessionType, sessionType);
+		const cached = new LocalSessionAdapter(meta, this.id, sessionType, sessionType, this._agentHostService.authenticationPending);
 		this._sessionCache.set(rawId, cached);
 		this._onDidChangeSessions.fire({ added: [cached], removed: [], changed: [] });
 	}

--- a/src/vs/sessions/contrib/localAgentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/localAgentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { ISettableObservable, observableValue, type IObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
@@ -48,6 +49,12 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	public dispatchedActions: { action: ISessionAction | ITerminalAction; clientId: string; clientSeq: number }[] = [];
 	public failResolveSessionConfig = false;
 	public resolveSessionConfigResult: IResolveSessionConfigResult = { schema: { type: 'object', properties: {} }, values: { isolation: 'worktree' } };
+
+	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', false);
+	override readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	override setAuthenticationPending(pending: boolean): void {
+		this._authenticationPending.set(pending, undefined);
+	}
 
 	private _nextSeq = 0;
 
@@ -707,6 +714,38 @@ suite('LocalAgentHostSessionsProvider', () => {
 		await waitForSessionConfig(provider, session.sessionId, config => config?.schema.required?.includes('branch') === true);
 
 		assert.strictEqual(session.loading.get(), true);
+	});
+
+	test('cached session loading reflects authenticationPending', async () => {
+		agentHost.setAuthenticationPending(true);
+		agentHost.addSession(createSession('cached-auth-loading', { summary: 'Cached' }));
+
+		const provider = createProvider(disposables, agentHost);
+		provider.getSessions();
+		await timeout(0);
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Cached');
+		assert.ok(session);
+		assert.strictEqual(session!.loading.get(), true);
+
+		agentHost.setAuthenticationPending(false);
+		assert.strictEqual(session!.loading.get(), false);
+	});
+
+	test('new session loading reflects authenticationPending until config resolves', async () => {
+		agentHost.setAuthenticationPending(true);
+		const provider = createProvider(disposables, agentHost);
+		const session = provider.createNewSession(URI.parse('file:///home/user/project'), provider.sessionTypes[0].id);
+		// Wait for the resolved config (the mock returns `values.isolation: 'worktree'`)
+		// so that the per-session loading flag has been turned off.
+		await waitForSessionConfig(provider, session.sessionId, config => config?.values.isolation === 'worktree');
+
+		// Even though config has resolved (per-session loading is false), the
+		// auth-pending flag keeps the session in the loading state.
+		assert.strictEqual(session.loading.get(), true);
+
+		agentHost.setAuthenticationPending(false);
+		assert.strictEqual(session.loading.get(), false);
 	});
 
 	// ---- sendAndCreateChat -------

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -316,7 +316,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		}
 
 		// Authenticate using protectedResources from agent info
-		this._authenticateWithConnection(loggedConnection, rootState.agents)
+		this._authenticateWithConnection(address, loggedConnection, rootState.agents)
 			.catch(() => { /* best-effort */ });
 
 		// Register new agents, push model updates to existing ones
@@ -485,10 +485,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	private _authenticateAllConnections(): void {
-		for (const [, connState] of this._connections) {
+		for (const [address, connState] of this._connections) {
 			const rootState = connState.loggedConnection.rootState.value;
 			if (rootState && !(rootState instanceof Error)) {
-				this._authenticateWithConnection(connState.loggedConnection, rootState.agents).catch(() => { /* best-effort */ });
+				this._authenticateWithConnection(address, connState.loggedConnection, rootState.agents).catch(() => { /* best-effort */ });
 			}
 		}
 	}
@@ -496,8 +496,14 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	/**
 	 * Authenticate using protectedResources from agent info in root state.
 	 * Resolves tokens via the standard VS Code authentication service.
+	 *
+	 * Marks the matching provider's `authenticationPending` observable while
+	 * the auth pass is in flight so that sessions surface as still loading.
 	 */
-	private async _authenticateWithConnection(loggedConnection: LoggingAgentConnection, agents: readonly IAgentInfo[]): Promise<void> {
+	private async _authenticateWithConnection(address: string, loggedConnection: LoggingAgentConnection, agents: readonly IAgentInfo[]): Promise<void> {
+		const providerId = `agenthost-${agentHostAuthority(address)}`;
+		const provider = this._sessionsProvidersService.getProvider<RemoteAgentHostSessionsProvider>(providerId);
+		provider?.setAuthenticationPending(true);
 		try {
 			for (const agent of agents) {
 				for (const resource of agent.protectedResources ?? []) {
@@ -514,6 +520,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		} catch (err) {
 			this._logService.error('[RemoteAgentHost] Failed to authenticate with connection', err);
 			loggedConnection.logError('authenticateWithConnection', err);
+		} finally {
+			provider?.setAuthenticationPending(false);
 		}
 	}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -11,7 +11,7 @@ import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlCon
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/resources.js';
-import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { constObservable, derived, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -298,6 +298,29 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.Disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;
+
+	/**
+	 * `true` while we are still resolving and pushing tokens for the host's
+	 * `protectedResources`. Defaults to `true` so that sessions surface as
+	 * loading until the first authentication pass settles. Toggled by
+	 * {@link RemoteAgentHostContribution} around each per-connection auth pass.
+	 */
+	private readonly _authenticationPending = observableValue('authenticationPending', true);
+	readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	private _authenticationSettled = false;
+
+	setAuthenticationPending(pending: boolean): void {
+		// Sticky: once the first authentication pass settles, never surface
+		// pending again. Subsequent re-auths (account/session changes, reconnect)
+		// happen silently in the background and should not flicker the UI.
+		if (this._authenticationSettled) {
+			return;
+		}
+		if (!pending) {
+			this._authenticationSettled = true;
+		}
+		this._authenticationPending.set(pending, undefined);
+	}
 
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
@@ -1323,7 +1346,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 			changes: chat.changes,
 			modelId: chat.modelId,
 			mode: chat.mode,
-			loading: chat.loading,
+			loading: derived(reader => chat.loading.read(reader) || this._authenticationPending.read(reader)),
 			isArchived: chat.isArchived,
 			isRead: chat.isRead,
 			description: chat.description,

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -702,6 +702,24 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.strictEqual(session.loading.get(), true);
 	});
 
+	test('cached session loading reflects authenticationPending', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('cached-auth', { summary: 'Cached' }));
+		const provider = createProvider(disposables, connection);
+		await timeout(0);
+
+		const session = provider.getSessions().find(s => s.title.get() === 'Cached');
+		assert.ok(session);
+		// Default at construction is `true`; clear it and verify.
+		assert.strictEqual(session!.loading.get(), true);
+
+		provider.setAuthenticationPending(false);
+		assert.strictEqual(session!.loading.get(), false);
+
+		// Sticky: a subsequent re-auth pass must not flicker the UI back to loading.
+		provider.setAuthenticationPending(true);
+		assert.strictEqual(session!.loading.get(), false);
+	}));
+
 	test('sendAndCreateChat throws for unknown session', async () => {
 		const provider = createProvider(disposables, connection);
 		await assert.rejects(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -256,6 +256,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	 * Resolves tokens via the standard VS Code authentication service.
 	 */
 	private async _authenticateWithServer(agents: readonly IAgentInfo[]): Promise<void> {
+		this._agentHostService.setAuthenticationPending(true);
 		try {
 			for (const agent of agents) {
 				for (const resource of agent.protectedResources ?? []) {
@@ -272,6 +273,8 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		} catch (err) {
 			this._logService.error('[AgentHost] Failed to authenticate with server', err);
 			this._loggedConnection!.logError('authenticateWithServer', err);
+		} finally {
+			this._agentHostService.setAuthenticationPending(false);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -827,10 +827,16 @@ export class LanguageModelsService implements ILanguageModelsService {
 			return;
 		}
 
-		// Activate extensions before requesting to resolve the models
-		await this._extensionService.activateByEvent(`onLanguageModelChatProvider:${vendorId}`);
-
-		const provider = this._providers.get(vendorId);
+		// If a provider is already registered (e.g. a renderer-side provider
+		// such as the agent host), skip the activation wait — there's nothing
+		// more for an extension to contribute, and waiting would block on
+		// extension host startup unnecessarily.
+		let provider = this._providers.get(vendorId);
+		if (!provider) {
+			// Activate extensions before requesting to resolve the models
+			await this._extensionService.activateByEvent(`onLanguageModelChatProvider:${vendorId}`);
+			provider = this._providers.get(vendorId);
+		}
 		if (!provider) {
 			this._logService.warn(`[LM] No provider registered for vendor ${vendorId}`);
 			return;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -8,7 +8,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { observableValue } from '../../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue, type IObservable } from '../../../../../../base/common/observable.js';
 import { mock, upcastPartial } from '../../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
@@ -61,6 +61,12 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	override readonly onDidNotification = this._onDidNotification.event;
 	override readonly onAgentHostExit = Event.None;
 	override readonly onAgentHostStart = Event.None;
+
+	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', false);
+	override readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
+	override setAuthenticationPending(pending: boolean): void {
+		this._authenticationPending.set(pending, undefined);
+	}
 
 	// Track live subscriptions so fireAction can route to them
 	private readonly _liveSubscriptions = new Map<string, { state: ISessionState; emitter: Emitter<ISessionState> }>();


### PR DESCRIPTION
Adds an `authenticationPending` observable to both the local (`IAgentHostService`) and remote (`RemoteAgentHostSessionsProvider`) agent host providers. The flag defaults to `true` so cached sessions surface as **loading** from window-open until the first authentication pass settles, then is sticky — subsequent background re-auths (account change, session refresh, server reconnect) do not flicker the UI back to loading.

While investigating why the indicator wasn't visible, also fixed a separate latency bug in `LanguageModelsService._resolveAllLanguageModels`: it always awaited `extensionService.activateByEvent('onLanguageModelChatProvider:<vendor>')`, blocking renderer-registered providers (like the agent host) on extension host startup for 10+ seconds. Now skips the activation wait when a provider is already registered for the vendor.

### Behavior changes
- New `authenticationPending: IObservable<boolean>` on `IAgentHostService` and `RemoteAgentHostSessionsProvider`.
- Local + remote agent host session adapters' `loading` now ORs in `authenticationPending`.
- `setAuthenticationPending(false)` is one-way: subsequent `true` calls become no-ops.
- `LanguageModelsService` no longer awaits extension activation when the vendor's provider is already registered.

### Tests
- Updated `remoteAgentHostSessionsProvider.test.ts` to assert sticky semantics.
- Added equivalent coverage for the local provider via the test stub.
- 153 sessions tests pass; 42 LanguageModels tests pass.

(Written by Copilot)