### PR TITLE
Restore session config for sessions opened from list

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -283,7 +283,9 @@ export class AgentService extends Disposable implements IAgentService {
 			state.config = sessionConfig;
 		}
 		// Persist initial config values so a subsequent `restoreSession` can
-		// re-hydrate them. Mid-session changes are persisted by `AgentSideEffects`
+		// re-hydrate them. We persist the full resolved values (not just the
+		// user's input) so clients can render them on restore without having
+		// to re-resolve. Mid-session changes are persisted by `AgentSideEffects`
 		// when handling `SessionConfigChanged`.
 		if (sessionConfig?.values && Object.keys(sessionConfig.values).length > 0) {
 			this._persistConfigValues(session, sessionConfig.values);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeBase64, VSBuffer } from '../../../base/common/buffer.js';
+import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { observableValue } from '../../../base/common/observable.js';
@@ -281,9 +282,30 @@ export class AgentService extends Disposable implements IAgentService {
 			const state = this._stateManager.createSession(summary);
 			state.config = sessionConfig;
 		}
+		// Persist initial config values so a subsequent `restoreSession` can
+		// re-hydrate them. Mid-session changes are persisted by `AgentSideEffects`
+		// when handling `SessionConfigChanged`.
+		if (sessionConfig?.values && Object.keys(sessionConfig.values).length > 0) {
+			this._persistConfigValues(session, sessionConfig.values);
+		}
 		this._stateManager.dispatchServerAction({ type: ActionType.SessionReady, session: session.toString() });
 
 		return session;
+	}
+
+	private _persistConfigValues(session: URI, values: Record<string, string>): void {
+		let ref;
+		try {
+			ref = this._sessionDataService.openDatabase(session);
+		} catch (err) {
+			this._logService.warn(`[AgentService] Failed to open session database to persist configValues for ${session.toString()}: ${toErrorMessage(err)}`);
+			return;
+		}
+		ref.object.setMetadata('configValues', JSON.stringify(values)).catch(err => {
+			this._logService.warn(`[AgentService] Failed to persist configValues for ${session.toString()}: ${toErrorMessage(err)}`);
+		}).finally(() => {
+			ref.dispose();
+		});
 	}
 
 	private async _resolveCreatedSessionConfig(provider: IAgent, config: IAgentCreateSessionConfig | undefined): Promise<ISessionConfigState | undefined> {
@@ -455,13 +477,14 @@ export class AgentService extends Disposable implements IAgentService {
 		let isRead: boolean | undefined;
 		let isDone: boolean | undefined;
 		let diffs: ISessionFileDiff[] | undefined;
+		let persistedConfigValues: Record<string, string> | undefined;
 		const ref = this._sessionDataService.tryOpenDatabase?.(session);
 		if (ref) {
 			try {
 				const db = await ref;
 				if (db) {
 					try {
-						const m = await db.object.getMetadataObject({ customTitle: true, isRead: true, isDone: true, diffs: true });
+						const m = await db.object.getMetadataObject({ customTitle: true, isRead: true, isDone: true, diffs: true, configValues: true });
 						if (m.customTitle) {
 							title = m.customTitle;
 						}
@@ -473,6 +496,13 @@ export class AgentService extends Disposable implements IAgentService {
 						}
 						if (m.diffs) {
 							try { diffs = JSON.parse(m.diffs); } catch { /* ignore malformed */ }
+						}
+						if (m.configValues) {
+							try {
+								persistedConfigValues = JSON.parse(m.configValues);
+							} catch (err) {
+								this._logService.warn(`[AgentService] Failed to parse persisted configValues for ${sessionStr}: ${toErrorMessage(err)}`);
+							}
 						}
 					} finally {
 						db.dispose();
@@ -499,6 +529,23 @@ export class AgentService extends Disposable implements IAgentService {
 		};
 
 		this._stateManager.restoreSession(summary, turns);
+
+		// Resolve the session config so clients (e.g. the running-session
+		// auto-approve picker) can render session-mutable properties for
+		// sessions that were not created in the current process lifetime.
+		// Overlay any values the user previously selected (persisted via
+		// `SessionConfigChanged`) on top of the provider's resolved defaults.
+		const restoredConfig = await this._resolveCreatedSessionConfig(agent, {
+			workingDirectory: meta.workingDirectory,
+			config: persistedConfigValues,
+		});
+		if (restoredConfig) {
+			const restoredState = this._stateManager.getSessionState(sessionStr);
+			if (restoredState) {
+				restoredState.config = restoredConfig;
+			}
+		}
+
 		this._logService.info(`[AgentService] Restored session ${sessionStr} with ${turns.length} turns`);
 	}
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -746,6 +746,16 @@ export class AgentSideEffects extends Disposable {
 				this._persistSessionFlag(action.session, 'isDone', action.isDone ? 'true' : '');
 				break;
 			}
+			case ActionType.SessionConfigChanged: {
+				// Persist merged values so a future `restoreSession` can re-hydrate
+				// the user's previous selections (e.g. autoApprove).
+				const sessionState = this._stateManager.getSessionState(action.session);
+				const values = sessionState?.config?.values;
+				if (values) {
+					this._persistSessionFlag(action.session, 'configValues', JSON.stringify(values));
+				}
+				break;
+			}
 			case ActionType.SessionToolCallComplete: {
 				const agent = this._options.getAgent(action.session);
 				agent?.onClientToolCallComplete(URI.parse(action.session), action.toolCallId, action.result);

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -570,7 +570,7 @@ suite('AgentService (node dispatcher)', () => {
 			await new Promise(r => setTimeout(r, 50));
 
 			// Simulate a server restart: drop the in-memory state
-			localService.stateManager.removeSession(session);
+			localService.stateManager.removeSession(session.toString());
 
 			localAgent.sessionMessages = [
 				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -24,6 +24,7 @@ import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
 import { MockAgent } from './mockAgent.js';
 import { mapSessionEvents, type ISessionEvent } from '../../node/copilot/mapSessionEvents.js';
+import { createSessionDataService } from '../common/sessionTestHelpers.js';
 
 /**
  * Loads a JSONL fixture of raw Copilot SDK events, runs them through
@@ -481,6 +482,135 @@ suite('AgentService (node dispatcher)', () => {
 			// Should have the final markdown
 			const mdParts = state!.turns[0].responseParts.filter((p): p is IMarkdownResponsePart => p.kind === ResponsePartKind.Markdown);
 			assert.ok(mdParts.length > 0, 'Should have markdown content');
+		});
+	});
+
+	// ---- session config persistence -------------------------------------
+
+	suite('session config persistence', () => {
+
+		test('createSession persists initial config values to the session DB', async () => {
+			const sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService));
+			localService.registerProvider(localAgent);
+
+			await localService.createSession({ provider: 'copilot', config: { autoApprove: 'autoApprove' } });
+
+			// Persistence is fire-and-forget; wait for it to flush
+			await new Promise(r => setTimeout(r, 50));
+
+			const persisted = await sessionDb.getMetadata('configValues');
+			assert.ok(persisted, 'configValues should be persisted');
+			assert.deepStrictEqual(JSON.parse(persisted!), { autoApprove: 'autoApprove' });
+		});
+
+		test('createSession does not write configValues when there are no values', async () => {
+			const sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService));
+			localService.registerProvider(localAgent);
+
+			await localService.createSession({ provider: 'copilot' });
+
+			await new Promise(r => setTimeout(r, 50));
+
+			const persisted = await sessionDb.getMetadata('configValues');
+			assert.strictEqual(persisted, undefined);
+		});
+
+		test('restoreSession overlays persisted config values onto the resolved config', async () => {
+			const sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService));
+			localService.registerProvider(localAgent);
+
+			// Create a session on the agent backend (no config) so listSessions can find it
+			const { session } = await localAgent.createSession();
+			const sessions = await localAgent.listSessions();
+			const sessionResource = sessions[0].session;
+
+			// Pre-seed persisted config values
+			await sessionDb.setMetadata('configValues', JSON.stringify({ autoApprove: 'autoApprove' }));
+
+			localAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+			];
+
+			await localService.restoreSession(sessionResource);
+
+			const state = localService.stateManager.getSessionState(sessionResource.toString());
+			assert.ok(state);
+			// MockAgent.resolveSessionConfig echoes params.config back as values, so the
+			// persisted values are forwarded through and end up on state.config.values.
+			assert.deepStrictEqual(state!.config?.values, { autoApprove: 'autoApprove' });
+		});
+
+		test('createSession + restoreSession round-trip restores initial config without any mid-session changes', async () => {
+			// Regression test: when a session is created with initial config but no
+			// mid-session SessionConfigChanged actions are dispatched, restoring it
+			// must still rehydrate the initial values.
+			const sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService));
+			localService.registerProvider(localAgent);
+
+			const session = await localService.createSession({ provider: 'copilot', config: { autoApprove: 'autoApprove' } });
+
+			// Wait for the fire-and-forget persistence to flush
+			await new Promise(r => setTimeout(r, 50));
+
+			// Simulate a server restart: drop the in-memory state
+			localService.stateManager.removeSession(session);
+
+			localAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+			];
+			await localService.restoreSession(session);
+
+			const state = localService.stateManager.getSessionState(session.toString());
+			assert.ok(state);
+			assert.deepStrictEqual(state!.config?.values, { autoApprove: 'autoApprove' });
+		});
+
+		test('restoreSession ignores malformed persisted configValues', async () => {
+			const sessionDb = disposables.add(await SessionDatabase.open(':memory:'));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localAgent = new MockAgent('copilot');
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localService = disposables.add(new AgentService(new NullLogService(), fileService, sessionDataService, { _serviceBrand: undefined } as IProductService));
+			localService.registerProvider(localAgent);
+
+			const { session } = await localAgent.createSession();
+			const sessions = await localAgent.listSessions();
+			const sessionResource = sessions[0].session;
+
+			await sessionDb.setMetadata('configValues', '{not json');
+
+			localAgent.sessionMessages = [
+				{ type: 'message', session, role: 'user', messageId: 'msg-1', content: 'Hello', toolRequests: [] },
+				{ type: 'message', session, role: 'assistant', messageId: 'msg-2', content: 'Hi', toolRequests: [] },
+			];
+
+			// Should not throw despite the malformed JSON
+			await localService.restoreSession(sessionResource);
+
+			const state = localService.stateManager.getSessionState(sessionResource.toString());
+			assert.ok(state);
+			// MockAgent has a workingDirectory? No — but the metadata supplies it as undefined.
+			// _resolveCreatedSessionConfig bails when both .config and .workingDirectory are
+			// missing, so state.config is undefined here. The key point is: no throw.
+			assert.strictEqual(state!.config, undefined);
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1241,6 +1241,47 @@ suite('AgentSideEffects', () => {
 			assert.ok(state);
 			assert.strictEqual(state!.summary.title, 'Restored Title');
 		});
+
+		test('SessionConfigChanged persists merged config values to the database', async () => {
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+			const localAgent = new MockAgent();
+			disposables.add(toDisposable(() => localAgent.dispose()));
+			const localSideEffects = disposables.add(new AgentSideEffects(localStateManager, {
+				getAgent: () => localAgent,
+				agents: observableValue<readonly IAgent[]>('agents', [localAgent]),
+				sessionDataService,
+			}, new NullLogService()));
+
+			const session = localStateManager.createSession({
+				resource: sessionUri.toString(),
+				provider: 'mock',
+				title: 'Initial',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+				project: { uri: 'file:///test-project', displayName: 'Test Project' },
+			});
+			session.config = { schema: { type: 'object', properties: {} }, values: { autoApprove: 'default' } };
+
+			// Mid-session change merges new values into existing.
+			localStateManager.dispatchClientAction({
+				type: ActionType.SessionConfigChanged,
+				session: sessionUri.toString(),
+				config: { autoApprove: 'autoApprove' },
+			}, { clientId: 'test-client', clientSeq: 1 });
+			localSideEffects.handleAction({
+				type: ActionType.SessionConfigChanged,
+				session: sessionUri.toString(),
+				config: { autoApprove: 'autoApprove' },
+			});
+
+			await new Promise(r => setTimeout(r, 50));
+
+			const persisted = await sessionDb.getMetadata('configValues');
+			assert.ok(persisted);
+			assert.deepStrictEqual(JSON.parse(persisted!), { autoApprove: 'autoApprove' });
+		});
 	});
 
 	// ---- Subagent sessions ----------------------------------------------

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -205,6 +205,21 @@ export class ScriptedMockAgent implements IAgent {
 	constructor() {
 		// Seed the pre-existing session so it appears in listSessions()
 		this._sessions.set(AgentSession.id(PRE_EXISTING_SESSION_URI), PRE_EXISTING_SESSION_URI);
+
+		// Allow integration tests to seed additional pre-existing sessions across
+		// server restarts via env var. The value is a comma-separated list of
+		// session URIs (e.g. `mock://pre-1,mock://pre-2`).
+		const seeded = process.env['VSCODE_AGENT_HOST_MOCK_SEED_SESSIONS'];
+		if (seeded) {
+			for (const raw of seeded.split(',')) {
+				const trimmed = raw.trim();
+				if (!trimmed) {
+					continue;
+				}
+				const uri = URI.parse(trimmed);
+				this._sessions.set(AgentSession.id(uri), uri);
+			}
+		}
 	}
 
 	getDescriptor(): IAgentDescriptor {

--- a/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { timeout } from '../../../../../base/common/async.js';
 import { URI } from '../../../../../base/common/uri.js';
 import type { IResolveSessionConfigResult, ISessionConfigCompletionsResult, ISubscribeResult } from '../../../common/state/protocol/commands.js';
 import { ActionType, type ISessionAddedNotification } from '../../../common/state/sessionActions.js';
@@ -140,5 +143,104 @@ suite('Protocol WebSocket - Session Config', function () {
 		const snapshot = await client.call<ISubscribeResult>('subscribe', { resource: session });
 		const state = snapshot.snapshot.state as ISessionState;
 		assert.deepStrictEqual(state.config?.values, { isolation: 'folder', branch: 'release' });
+	});
+});
+
+suite('Protocol WebSocket - Session Config persistence across restarts', function () {
+
+	let userDataDir: string;
+
+	setup(function () {
+		userDataDir = mkdtempSync(`${tmpdir()}/vscode-agent-host-config-`);
+	});
+
+	teardown(function () {
+		try {
+			rmSync(userDataDir, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup; the OS will reap the temp dir eventually.
+		}
+	});
+
+	test('persisted config values are restored on subscribe after server restart', async function () {
+		this.timeout(30_000);
+
+		const initialConfig = { isolation: 'worktree', branch: 'main' };
+		const updatedBranch = 'release';
+		let sessionUri: string;
+
+		// ---- Phase 1: create session, change config, wait for persistence ----
+		const server1 = await startServer({ userDataDir });
+		try {
+			const client1 = new TestProtocolClient(server1.port);
+			await client1.connect();
+			await client1.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'test-config-restore-1' });
+
+			await client1.call('createSession', {
+				session: nextSessionUri(),
+				provider: 'mock',
+				workingDirectory: URI.file('/mock/workspace').toString(),
+				config: initialConfig,
+			});
+			const addedNotif = await client1.waitForNotification(n =>
+				n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded'
+			);
+			// The mock agent assigns its own URI rather than honoring the
+			// requested one, so capture the real URI from the notification.
+			sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as ISessionAddedNotification).summary.resource;
+
+			await client1.call<ISubscribeResult>('subscribe', { resource: sessionUri });
+
+			client1.notify('dispatchAction', {
+				clientSeq: 1,
+				action: {
+					type: ActionType.SessionConfigChanged,
+					session: sessionUri,
+					config: { branch: updatedBranch },
+				},
+			});
+			const configChanged = await client1.waitForNotification(n => isActionNotification(n, ActionType.SessionConfigChanged));
+			assert.strictEqual(getActionEnvelope(configChanged).action.type, ActionType.SessionConfigChanged);
+
+			// `_persistConfigValues` is fire-and-forget; give the SQLite write
+			// a moment to flush before tearing down the server.
+			await timeout(500);
+
+			client1.close();
+		} finally {
+			server1.process.kill();
+			await new Promise<void>(resolve => server1.process.once('exit', () => resolve()));
+		}
+
+		// ---- Phase 2: restart server, subscribe, verify restored config ----
+		// The mock agent does not persist its in-memory session list across
+		// restarts, so seed it via env var so `agent.listSessions()` includes
+		// our session and `restoreSession` proceeds.
+		const server2 = await startServer({
+			userDataDir,
+			env: { VSCODE_AGENT_HOST_MOCK_SEED_SESSIONS: sessionUri },
+		});
+		try {
+			const client2 = new TestProtocolClient(server2.port);
+			await client2.connect();
+			await client2.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'test-config-restore-2' });
+
+			// Subscribing triggers the restore-on-subscribe path on the server,
+			// which reads `configValues` from the per-session DB and overlays
+			// them on the freshly-resolved schema.
+			const snapshot = await client2.call<ISubscribeResult>('subscribe', { resource: sessionUri });
+			const state = snapshot.snapshot.state as ISessionState;
+
+			assert.ok(state.config, 'restored session should have state.config populated');
+			// Schema is re-resolved by the provider (worktree-mode mock returns
+			// dynamic branch enum), so just check that our persisted user
+			// selections survived the round trip.
+			assert.deepStrictEqual(state.config.values, { isolation: 'worktree', branch: updatedBranch });
+
+			client2.close();
+		} finally {
+			server2.process.kill();
+			await new Promise<void>(resolve => server2.process.once('exit', () => resolve()));
+		}
 	});
 });

--- a/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/testHelpers.ts
@@ -176,15 +176,19 @@ export interface IServerHandle {
 	port: number;
 }
 
-export async function startServer(options?: { readonly quiet?: boolean }): Promise<IServerHandle> {
+export async function startServer(options?: { readonly quiet?: boolean; readonly userDataDir?: string; readonly env?: NodeJS.ProcessEnv }): Promise<IServerHandle> {
 	return new Promise((resolve, reject) => {
 		const serverPath = fileURLToPath(new URL('../../../node/agentHostServerMain.js', import.meta.url));
 		const args = ['--enable-mock-agent', '--port', '0', '--without-connection-token'];
 		if (options?.quiet ?? true) {
 			args.push('--quiet');
 		}
+		if (options?.userDataDir) {
+			args.push('--user-data-dir', options.userDataDir);
+		}
 		const child = fork(serverPath, args, {
 			stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+			env: options?.env ? { ...process.env, ...options.env } : process.env,
 		});
 
 		const timer = setTimeout(() => {

--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -48,3 +48,35 @@ const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
 export function isAgentHostProvider(provider: ISessionsProvider): provider is IAgentHostSessionsProvider {
 	return provider.id === LOCAL_AGENT_HOST_PROVIDER_ID || provider.id.startsWith(REMOTE_AGENT_HOST_PROVIDER_PREFIX);
 }
+
+/**
+ * Shallow structural equality for resolved session configs. Returns true when
+ * both inputs have the same value-key set with identical string values and
+ * the same set of schema property keys with identical (by-identity) property
+ * objects. Schema property objects are compared by identity since they
+ * originate from the same protocol snapshot in the providers that use this
+ * helper.
+ */
+export function resolvedConfigsEqual(a: IResolveSessionConfigResult, b: IResolveSessionConfigResult): boolean {
+	const aValueKeys = Object.keys(a.values);
+	const bValueKeys = Object.keys(b.values);
+	if (aValueKeys.length !== bValueKeys.length) {
+		return false;
+	}
+	for (const key of aValueKeys) {
+		if (a.values[key] !== b.values[key]) {
+			return false;
+		}
+	}
+	const aPropKeys = Object.keys(a.schema.properties);
+	const bPropKeys = Object.keys(b.schema.properties);
+	if (aPropKeys.length !== bPropKeys.length) {
+		return false;
+	}
+	for (const key of aPropKeys) {
+		if (a.schema.properties[key] !== b.schema.properties[key]) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHostSessionConfigPicker.ts
@@ -520,6 +520,10 @@ class AgentHostNewSessionApprovePicker extends Disposable {
 		const rawProvider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
 		const provider = rawProvider && isAgentHostProvider(rawProvider) ? rawProvider : undefined;
 		const config = session && provider?.getSessionConfig(session.sessionId);
+		// `getSessionConfig` may return undefined for sessions whose config
+		// hasn't been seeded yet (e.g. opened from list, no in-window create).
+		// The provider lazily acquires a session-state subscription and will fire
+		// `onDidChangeSessionConfig` once the snapshot arrives, re-rendering us.
 		if (!session || !provider || !config) {
 			return;
 		}
@@ -693,6 +697,9 @@ class AgentHostRunningSessionConfigPicker extends Disposable {
 		const rawProvider = session ? this._sessionsProvidersService.getProvider(session.providerId) : undefined;
 		const provider = rawProvider && isAgentHostProvider(rawProvider) ? rawProvider : undefined;
 		const config = session && provider?.getSessionConfig(session.sessionId);
+		// See note in `AgentHostNewSessionApprovePicker._render`: `config` may be
+		// undefined until the lazy session-state subscription hydrates and the
+		// provider fires `onDidChangeSessionConfig`.
 		if (!session || !provider || !config) {
 			return;
 		}

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -31,7 +31,7 @@ import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
 import { diffsToChanges, diffsEqual, mapProtocolStatus } from '../../../common/agentHostDiffs.js';
 import { NotificationType } from '../../../../platform/agentHost/common/state/protocol/notifications.js';
 import { ISendRequestOptions, ISessionChangeEvent } from '../../../services/sessions/common/sessionsProvider.js';
-import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
+import { IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../common/agentHostSessionsProvider.js';
 import { IChat, ISession, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, type IGitHubInfo, ISessionType } from '../../../services/sessions/common/session.js';
 
 const LOCAL_PROVIDER_ID = 'local-agent-host';
@@ -58,37 +58,6 @@ function buildMutableConfigSchema(config: Record<string, string>): Record<string
 		};
 	}
 	return properties;
-}
-
-/**
- * Shallow structural equality for resolved session configs. Returns true when
- * both values record the same keys with the same string values and the same
- * set of property keys in the schema. The schema property objects themselves
- * are compared by identity since they originate from the same protocol
- * snapshot.
- */
-function resolvedConfigsEqual(a: IResolveSessionConfigResult, b: IResolveSessionConfigResult): boolean {
-	const aValueKeys = Object.keys(a.values);
-	const bValueKeys = Object.keys(b.values);
-	if (aValueKeys.length !== bValueKeys.length) {
-		return false;
-	}
-	for (const key of aValueKeys) {
-		if (a.values[key] !== b.values[key]) {
-			return false;
-		}
-	}
-	const aPropKeys = Object.keys(a.schema.properties);
-	const bPropKeys = Object.keys(b.schema.properties);
-	if (aPropKeys.length !== bPropKeys.length) {
-		return false;
-	}
-	for (const key of aPropKeys) {
-		if (a.schema.properties[key] !== b.schema.properties[key]) {
-			return false;
-		}
-	}
-	return true;
 }
 
 /**

--- a/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider.ts
@@ -8,7 +8,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { basename } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -16,9 +16,10 @@ import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { AgentSession, IAgentHostService, type IAgentSessionMetadata } from '../../../../platform/agentHost/common/agentService.js';
-import type { IFileEdit, IModelSelection, IRootState, ISessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
+import type { IFileEdit, IModelSelection, IRootState, ISessionConfigPropertySchema, ISessionState, ISessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
+import { StateComponents } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSendRequestOptions, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
@@ -57,6 +58,37 @@ function buildMutableConfigSchema(config: Record<string, string>): Record<string
 		};
 	}
 	return properties;
+}
+
+/**
+ * Shallow structural equality for resolved session configs. Returns true when
+ * both values record the same keys with the same string values and the same
+ * set of property keys in the schema. The schema property objects themselves
+ * are compared by identity since they originate from the same protocol
+ * snapshot.
+ */
+function resolvedConfigsEqual(a: IResolveSessionConfigResult, b: IResolveSessionConfigResult): boolean {
+	const aValueKeys = Object.keys(a.values);
+	const bValueKeys = Object.keys(b.values);
+	if (aValueKeys.length !== bValueKeys.length) {
+		return false;
+	}
+	for (const key of aValueKeys) {
+		if (a.values[key] !== b.values[key]) {
+			return false;
+		}
+	}
+	const aPropKeys = Object.keys(a.schema.properties);
+	const bPropKeys = Object.keys(b.schema.properties);
+	if (aPropKeys.length !== bPropKeys.length) {
+		return false;
+	}
+	for (const key of aPropKeys) {
+		if (a.schema.properties[key] !== b.schema.properties[key]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 /**
@@ -273,6 +305,17 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 
 	/** Config for running sessions (session-mutable properties only), keyed by session ID. */
 	private readonly _runningSessionConfigs = new Map<string, IResolveSessionConfigResult>();
+
+	/**
+	 * Lazy session-state subscriptions used to seed {@link _runningSessionConfigs}
+	 * for sessions that already exist on the agent host (e.g. created in a prior
+	 * window). The underlying wire subscription is reference-counted by
+	 * {@link IAgentConnection.getSubscription}, so when the session handler is
+	 * also subscribed (i.e. chat content is loaded) no extra wire subscribe is
+	 * issued. Keyed by session ID. Each entry owns the subscription `IReference`
+	 * plus the `onDidChange` listener.
+	 */
+	private readonly _sessionStateSubscriptions = this._register(new DisposableMap<string, DisposableStore>());
 
 	private _cacheInitialized = false;
 
@@ -504,7 +547,16 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 	}
 
 	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined {
-		return this._newSessionConfigs.get(sessionId) ?? this._runningSessionConfigs.get(sessionId);
+		// New-session config wins (during pre-creation flow). Otherwise lazily
+		// subscribe to the session's state so the running picker can seed its
+		// schema/values from the AHP `ISessionState.config` snapshot for sessions
+		// that weren't created in this window.
+		const newSessionConfig = this._newSessionConfigs.get(sessionId);
+		if (newSessionConfig) {
+			return newSessionConfig;
+		}
+		this._ensureSessionStateSubscription(sessionId);
+		return this._runningSessionConfigs.get(sessionId);
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void> {
@@ -918,6 +970,7 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 		if (cached) {
 			this._sessionCache.delete(rawId);
 			this._runningSessionConfigs.delete(cached.sessionId);
+			this._sessionStateSubscriptions.deleteAndDispose(cached.sessionId);
 			this._onDidChangeSessions.fire({ added: [], removed: [cached], changed: [] });
 		}
 	}
@@ -1026,6 +1079,78 @@ export class LocalAgentHostSessionsProvider extends Disposable implements IAgent
 				values: config,
 			});
 		}
+		this._onDidChangeSessionConfig.fire(sessionId);
+	}
+
+	/**
+	 * Lazily acquire a session-state subscription for `sessionId` so that
+	 * `_runningSessionConfigs` is seeded from the AHP `ISessionState.config`
+	 * snapshot. Safe to call repeatedly — no-op once a subscription exists.
+	 *
+	 * The subscription is reference-counted by {@link IAgentConnection.getSubscription},
+	 * so when the session handler is also subscribed (chat content open) this
+	 * shares the existing wire subscription rather than opening a new one.
+	 */
+	private _ensureSessionStateSubscription(sessionId: string): void {
+		if (this._sessionStateSubscriptions.has(sessionId)) {
+			return;
+		}
+		const rawId = this._rawIdFromChatId(sessionId);
+		if (!rawId) {
+			return;
+		}
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const ref = this._agentHostService.getSubscription(StateComponents.Session, sessionUri);
+		const store = new DisposableStore();
+		store.add(ref);
+		store.add(ref.object.onDidChange(state => this._seedRunningConfigFromState(sessionId, state)));
+		this._sessionStateSubscriptions.set(sessionId, store);
+
+		// Seed from the current snapshot if it has already arrived.
+		const value = ref.object.value;
+		if (value && !(value instanceof Error)) {
+			this._seedRunningConfigFromState(sessionId, value);
+		}
+	}
+
+	/**
+	 * Filter `state.config` to session-mutable properties and update
+	 * {@link _runningSessionConfigs} if changed. No-op if the seeded value is
+	 * structurally equal to the existing entry to avoid spurious
+	 * `onDidChangeSessionConfig` fires.
+	 */
+	private _seedRunningConfigFromState(sessionId: string, state: ISessionState): void {
+		const stateConfig = state.config;
+		if (!stateConfig) {
+			return;
+		}
+		const properties: Record<string, ISessionConfigPropertySchema> = {};
+		const values: Record<string, string> = {};
+		for (const [key, propSchema] of Object.entries(stateConfig.schema.properties)) {
+			if (!propSchema.sessionMutable) {
+				continue;
+			}
+			properties[key] = propSchema;
+			if (Object.hasOwn(stateConfig.values, key)) {
+				values[key] = stateConfig.values[key];
+			}
+		}
+		if (Object.keys(properties).length === 0) {
+			return;
+		}
+		const seeded: IResolveSessionConfigResult = {
+			schema: { type: 'object', properties },
+			values,
+		};
+		const existing = this._runningSessionConfigs.get(sessionId);
+		if (existing && resolvedConfigsEqual(existing, seeded)) {
+			return;
+		}
+		this._runningSessionConfigs.set(sessionId, seeded);
 		this._onDidChangeSessionConfig.fire(sessionId);
 	}
 

--- a/src/vs/sessions/contrib/localAgentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/localAgentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable, type IReference } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
@@ -16,8 +16,8 @@ import type { IAgentSubscription } from '../../../../../platform/agentHost/commo
 import type { ISessionAction, ITerminalAction } from '../../../../../platform/agentHost/common/state/protocol/action-origin.generated.js';
 import type { IResolveSessionConfigResult } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { NotificationType } from '../../../../../platform/agentHost/common/state/protocol/notifications.js';
-import type { IAgentInfo, IModelSelection, IRootState } from '../../../../../platform/agentHost/common/state/protocol/state.js';
-import { SessionStatus as ProtocolSessionStatus } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { SessionLifecycle, type IAgentInfo, type IModelSelection, type IRootState, type ISessionConfigState, type ISessionState } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { SessionStatus as ProtocolSessionStatus, StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import { ActionType, type IActionEnvelope, type INotification } from '../../../../../platform/agentHost/common/state/sessionActions.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -98,6 +98,43 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		this._sessions.set(AgentSession.id(meta.session), meta);
 	}
 
+	// ---- Session-state subscriptions ---------------------------------------
+
+	private readonly _sessionStateEmitters = new Map<string, Emitter<ISessionState>>();
+	private readonly _sessionStateValues = new Map<string, ISessionState>();
+	public sessionSubscribeCounts = new Map<string, number>();
+	public sessionUnsubscribeCounts = new Map<string, number>();
+
+	override getSubscription<T>(_kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
+		const key = resource.toString();
+		this.sessionSubscribeCounts.set(key, (this.sessionSubscribeCounts.get(key) ?? 0) + 1);
+		let emitter = this._sessionStateEmitters.get(key);
+		if (!emitter) {
+			emitter = new Emitter<ISessionState>();
+			this._sessionStateEmitters.set(key, emitter);
+		}
+		const self = this;
+		const sub: IAgentSubscription<T> = {
+			get value() { return self._sessionStateValues.get(key) as unknown as T | undefined; },
+			get verifiedValue() { return self._sessionStateValues.get(key) as unknown as T | undefined; },
+			onDidChange: emitter.event as unknown as Event<T>,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+		return {
+			object: sub,
+			dispose: () => {
+				this.sessionUnsubscribeCounts.set(key, (this.sessionUnsubscribeCounts.get(key) ?? 0) + 1);
+			},
+		};
+	}
+
+	setSessionState(rawId: string, provider: string, state: ISessionState): void {
+		const key = AgentSession.uri(provider, rawId).toString();
+		this._sessionStateValues.set(key, state);
+		this._sessionStateEmitters.get(key)?.fire(state);
+	}
+
 	setAgents(agents: IAgentInfo[]): void {
 		this._rootStateValue = { agents };
 		this._onDidRootStateChange.fire(this._rootStateValue);
@@ -123,6 +160,10 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		this._onDidAction.dispose();
 		this._onDidNotification.dispose();
 		this._onDidRootStateChange.dispose();
+		for (const emitter of this._sessionStateEmitters.values()) {
+			emitter.dispose();
+		}
+		this._sessionStateEmitters.clear();
 	}
 }
 
@@ -738,4 +779,69 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 		assert.deepStrictEqual(sendOptions.map(options => options.agentHostSessionConfig), [{ isolation: 'worktree' }]);
 	});
+
+	// ---- Running session config seeding (from ISessionState.config) -------
+
+	test('getSessionConfig seeds running config from session state subscription, filtered to sessionMutable properties', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		agentHost.addSession(createSession('seed-1', { summary: 'Seeded Session' }));
+		const provider = createProvider(disposables, agentHost);
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'Seeded Session');
+		assert.ok(session);
+
+		// Initially the cache has nothing for this session — the picker reads
+		// `undefined` while the subscription kicks off (and starts subscribing).
+		assert.strictEqual(provider.getSessionConfig(session!.sessionId), undefined);
+
+		// Now have the fake host hydrate the session-state snapshot with a
+		// config containing one mutable and one read-only property.
+		const config: ISessionConfigState = {
+			schema: {
+				type: 'object',
+				properties: {
+					autoApprove: { type: 'string', title: 'Auto Approve', enum: ['default', 'autoApprove'], sessionMutable: true },
+					isolation: { type: 'string', title: 'Isolation', enum: ['folder', 'worktree'], readOnly: true },
+				},
+			},
+			values: { autoApprove: 'default', isolation: 'worktree' },
+		};
+		const fakeState: ISessionState = {
+			summary: { resource: AgentSession.uri('copilot', 'seed-1').toString(), provider: 'copilot', title: 'Seeded Session', status: ProtocolSessionStatus.Idle, createdAt: 0, modifiedAt: 0 },
+			lifecycle: SessionLifecycle.Ready,
+			turns: [],
+			config,
+		};
+		agentHost.setSessionState('seed-1', 'copilot', fakeState);
+
+		await waitForSessionConfig(provider, session!.sessionId, c => c?.values.autoApprove === 'default');
+
+		const seeded = provider.getSessionConfig(session!.sessionId);
+		assert.deepStrictEqual({
+			properties: Object.keys(seeded?.schema.properties ?? {}),
+			values: seeded?.values,
+		}, {
+			properties: ['autoApprove'],
+			values: { autoApprove: 'default' },
+		});
+	}));
+
+	test('removing a session disposes its session-state subscription', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		agentHost.addSession(createSession('seed-2', { summary: 'Sub Session' }));
+		const provider = createProvider(disposables, agentHost);
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'Sub Session');
+		assert.ok(session);
+
+		// Trigger lazy subscription
+		provider.getSessionConfig(session!.sessionId);
+		const sessionUriStr = AgentSession.uri('copilot', 'seed-2').toString();
+		assert.strictEqual(agentHost.sessionSubscribeCounts.get(sessionUriStr), 1);
+		assert.strictEqual(agentHost.sessionUnsubscribeCounts.get(sessionUriStr) ?? 0, 0);
+
+		fireSessionRemoved(agentHost, 'seed-2');
+
+		assert.strictEqual(agentHost.sessionUnsubscribeCounts.get(sessionUriStr), 1);
+	}));
 });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -8,7 +8,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../base/com
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/resources.js';
 import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
@@ -23,7 +23,8 @@ import { RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/
 import { ActionType, isSessionAction } from '../../../../platform/agentHost/common/state/sessionActions.js';
 import { NotificationType } from '../../../../platform/agentHost/common/state/protocol/notifications.js';
 import type { IResolveSessionConfigResult, ISessionConfigValueItem } from '../../../../platform/agentHost/common/state/protocol/commands.js';
-import type { IFileEdit, IModelSelection, IRootState, ISessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
+import type { IFileEdit, IModelSelection, IRootState, ISessionConfigPropertySchema, ISessionState, ISessionSummary } from '../../../../platform/agentHost/common/state/protocol/state.js';
+import { StateComponents } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
@@ -92,6 +93,37 @@ function buildMutableConfigSchema(config: Record<string, string>): Record<string
 		};
 	}
 	return properties;
+}
+
+/**
+ * Shallow structural equality for resolved session configs. Returns true when
+ * both values record the same keys with the same string values and the same
+ * set of property keys in the schema. The schema property objects themselves
+ * are compared by identity since they originate from the same protocol
+ * snapshot.
+ */
+function resolvedConfigsEqual(a: IResolveSessionConfigResult, b: IResolveSessionConfigResult): boolean {
+	const aValueKeys = Object.keys(a.values);
+	const bValueKeys = Object.keys(b.values);
+	if (aValueKeys.length !== bValueKeys.length) {
+		return false;
+	}
+	for (const key of aValueKeys) {
+		if (a.values[key] !== b.values[key]) {
+			return false;
+		}
+	}
+	const aPropKeys = Object.keys(a.schema.properties);
+	const bPropKeys = Object.keys(b.schema.properties);
+	if (aPropKeys.length !== bPropKeys.length) {
+		return false;
+	}
+	for (const key of aPropKeys) {
+		if (a.schema.properties[key] !== b.schema.properties[key]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 function toLocalProjectUri(uri: URI, connectionAuthority: string): URI {
@@ -334,6 +366,17 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	/** Config for running sessions (session-mutable properties only), keyed by session ID. */
 	private readonly _runningSessionConfigs = new Map<string, IResolveSessionConfigResult>();
 
+	/**
+	 * Lazy session-state subscriptions used to seed {@link _runningSessionConfigs}
+	 * for sessions that already exist on the agent host (e.g. created in a prior
+	 * window or after a reconnect). The underlying wire subscription is
+	 * reference-counted by {@link IAgentConnection.getSubscription}, so when
+	 * the session handler is also subscribed (chat content open) this shares
+	 * the existing wire subscription rather than opening a new one. Cleared
+	 * when the connection is replaced or removed. Keyed by session ID.
+	 */
+	private readonly _sessionStateSubscriptions = this._register(new DisposableMap<string, DisposableStore>());
+
 	private _connection: IAgentConnection | undefined;
 	private _defaultDirectory: string | undefined;
 	private readonly _connectionListeners = this._register(new DisposableStore());
@@ -395,6 +438,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 		}
 
 		this._connectionListeners.clear();
+		this._sessionStateSubscriptions.clearAndDisposeAll();
 		this._connection = connection;
 		this._defaultDirectory = defaultDirectory;
 
@@ -519,6 +563,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	 */
 	clearConnection(): void {
 		this._connectionListeners.clear();
+		this._sessionStateSubscriptions.clearAndDisposeAll();
 		this._onDidDisconnect.fire();
 		this._connection = undefined;
 		this._defaultDirectory = undefined;
@@ -688,7 +733,12 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	}
 
 	getSessionConfig(sessionId: string): IResolveSessionConfigResult | undefined {
-		return this._newSessionConfigs.get(sessionId) ?? this._runningSessionConfigs.get(sessionId);
+		const newSessionConfig = this._newSessionConfigs.get(sessionId);
+		if (newSessionConfig) {
+			return newSessionConfig;
+		}
+		this._ensureSessionStateSubscription(sessionId);
+		return this._runningSessionConfigs.get(sessionId);
 	}
 
 	async setSessionConfigValue(sessionId: string, property: string, value: string): Promise<void> {
@@ -1125,6 +1175,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 		if (cached) {
 			this._sessionCache.delete(rawId);
 			this._runningSessionConfigs.delete(cached.id);
+			this._sessionStateSubscriptions.deleteAndDispose(cached.id);
 			this._onDidChangeSessions.fire({ added: [], removed: [this._chatToSession(cached)], changed: [] });
 		}
 	}
@@ -1235,6 +1286,82 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 				values: config,
 			});
 		}
+		this._onDidChangeSessionConfig.fire(sessionId);
+	}
+
+	/**
+	 * Lazily acquire a session-state subscription for `sessionId` so that
+	 * `_runningSessionConfigs` is seeded from the AHP `ISessionState.config`
+	 * snapshot. Safe to call repeatedly — no-op once a subscription exists.
+	 *
+	 * The subscription is reference-counted by {@link IAgentConnection.getSubscription},
+	 * so when the session handler is also subscribed (chat content open) this
+	 * shares the existing wire subscription rather than opening a new one.
+	 * Subscriptions are cleared on connection replace via
+	 * {@link _sessionStateSubscriptions} so reconnects re-seed from a fresh snapshot.
+	 */
+	private _ensureSessionStateSubscription(sessionId: string): void {
+		if (this._sessionStateSubscriptions.has(sessionId)) {
+			return;
+		}
+		if (!this._connection) {
+			return;
+		}
+		const rawId = this._rawIdFromChatId(sessionId);
+		if (!rawId) {
+			return;
+		}
+		const cached = this._sessionCache.get(rawId);
+		if (!cached) {
+			return;
+		}
+		const sessionUri = AgentSession.uri(cached.agentProvider, rawId);
+		const ref = this._connection.getSubscription(StateComponents.Session, sessionUri);
+		const store = new DisposableStore();
+		store.add(ref);
+		store.add(ref.object.onDidChange(state => this._seedRunningConfigFromState(sessionId, state)));
+		this._sessionStateSubscriptions.set(sessionId, store);
+
+		const value = ref.object.value;
+		if (value && !(value instanceof Error)) {
+			this._seedRunningConfigFromState(sessionId, value);
+		}
+	}
+
+	/**
+	 * Filter `state.config` to session-mutable properties and update
+	 * {@link _runningSessionConfigs} if changed. No-op if the seeded value is
+	 * structurally equal to the existing entry to avoid spurious
+	 * `onDidChangeSessionConfig` fires.
+	 */
+	private _seedRunningConfigFromState(sessionId: string, state: ISessionState): void {
+		const stateConfig = state.config;
+		if (!stateConfig) {
+			return;
+		}
+		const properties: Record<string, ISessionConfigPropertySchema> = {};
+		const values: Record<string, string> = {};
+		for (const [key, propSchema] of Object.entries(stateConfig.schema.properties)) {
+			if (!propSchema.sessionMutable) {
+				continue;
+			}
+			properties[key] = propSchema;
+			if (Object.hasOwn(stateConfig.values, key)) {
+				values[key] = stateConfig.values[key];
+			}
+		}
+		if (Object.keys(properties).length === 0) {
+			return;
+		}
+		const seeded: IResolveSessionConfigResult = {
+			schema: { type: 'object', properties },
+			values,
+		};
+		const existing = this._runningSessionConfigs.get(sessionId);
+		if (existing && resolvedConfigsEqual(existing, seeded)) {
+			return;
+		}
+		this._runningSessionConfigs.set(sessionId, seeded);
 		this._onDidChangeSessionConfig.fire(sessionId);
 	}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -36,7 +36,7 @@ import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '..
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
 import { diffsToChanges, diffsEqual, mapProtocolStatus } from '../../../common/agentHostDiffs.js';
 import { ISessionChangeEvent, ISendRequestOptions } from '../../../services/sessions/common/sessionsProvider.js';
-import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
+import { IAgentHostSessionsProvider, resolvedConfigsEqual } from '../../../common/agentHostSessionsProvider.js';
 import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType, COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 import { remoteAgentHostSessionTypeId } from '../common/remoteAgentHostSessionType.js';
 
@@ -93,37 +93,6 @@ function buildMutableConfigSchema(config: Record<string, string>): Record<string
 		};
 	}
 	return properties;
-}
-
-/**
- * Shallow structural equality for resolved session configs. Returns true when
- * both values record the same keys with the same string values and the same
- * set of property keys in the schema. The schema property objects themselves
- * are compared by identity since they originate from the same protocol
- * snapshot.
- */
-function resolvedConfigsEqual(a: IResolveSessionConfigResult, b: IResolveSessionConfigResult): boolean {
-	const aValueKeys = Object.keys(a.values);
-	const bValueKeys = Object.keys(b.values);
-	if (aValueKeys.length !== bValueKeys.length) {
-		return false;
-	}
-	for (const key of aValueKeys) {
-		if (a.values[key] !== b.values[key]) {
-			return false;
-		}
-	}
-	const aPropKeys = Object.keys(a.schema.properties);
-	const bPropKeys = Object.keys(b.schema.properties);
-	if (aPropKeys.length !== bPropKeys.length) {
-		return false;
-	}
-	for (const key of aPropKeys) {
-		if (a.schema.properties[key] !== b.schema.properties[key]) {
-			return false;
-		}
-	}
-	return true;
 }
 
 function toLocalProjectUri(uri: URI, connectionAuthority: string): URI {

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable, type IReference } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
@@ -15,9 +15,9 @@ import { AgentSession, type IAgentConnection, type IAgentSessionMetadata } from 
 import type { ISessionAction, ITerminalAction } from '../../../../../platform/agentHost/common/state/protocol/action-origin.generated.js';
 import type { IResolveSessionConfigResult } from '../../../../../platform/agentHost/common/state/protocol/commands.js';
 import { NotificationType } from '../../../../../platform/agentHost/common/state/protocol/notifications.js';
-import type { IAgentInfo, IModelSelection, IRootState } from '../../../../../platform/agentHost/common/state/protocol/state.js';
+import { SessionLifecycle, type IAgentInfo, type IModelSelection, type IRootState, type ISessionConfigState, type ISessionState } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { ActionType, type IActionEnvelope, type INotification } from '../../../../../platform/agentHost/common/state/sessionActions.js';
-import { SessionStatus as ProtocolSessionStatus } from '../../../../../platform/agentHost/common/state/sessionState.js';
+import { SessionStatus as ProtocolSessionStatus, StateComponents } from '../../../../../platform/agentHost/common/state/sessionState.js';
 import type { IAgentSubscription } from '../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -102,6 +102,43 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 		this._sessions.set(AgentSession.id(meta.session), meta);
 	}
 
+	// ---- Session-state subscriptions ---------------------------------------
+
+	private readonly _sessionStateEmitters = new Map<string, Emitter<ISessionState>>();
+	private readonly _sessionStateValues = new Map<string, ISessionState>();
+	public sessionSubscribeCounts = new Map<string, number>();
+	public sessionUnsubscribeCounts = new Map<string, number>();
+
+	override getSubscription<T>(_kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
+		const key = resource.toString();
+		this.sessionSubscribeCounts.set(key, (this.sessionSubscribeCounts.get(key) ?? 0) + 1);
+		let emitter = this._sessionStateEmitters.get(key);
+		if (!emitter) {
+			emitter = new Emitter<ISessionState>();
+			this._sessionStateEmitters.set(key, emitter);
+		}
+		const self = this;
+		const sub: IAgentSubscription<T> = {
+			get value() { return self._sessionStateValues.get(key) as unknown as T | undefined; },
+			get verifiedValue() { return self._sessionStateValues.get(key) as unknown as T | undefined; },
+			onDidChange: emitter.event as unknown as Event<T>,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+		return {
+			object: sub,
+			dispose: () => {
+				this.sessionUnsubscribeCounts.set(key, (this.sessionUnsubscribeCounts.get(key) ?? 0) + 1);
+			},
+		};
+	}
+
+	setSessionState(rawId: string, provider: string, state: ISessionState): void {
+		const key = AgentSession.uri(provider, rawId).toString();
+		this._sessionStateValues.set(key, state);
+		this._sessionStateEmitters.get(key)?.fire(state);
+	}
+
 	setAgents(agents: IAgentInfo[]): void {
 		this._rootStateValue = { agents };
 		this._onDidRootStateChange.fire(this._rootStateValue);
@@ -119,6 +156,10 @@ class MockAgentConnection extends mock<IAgentConnection>() {
 		this._onDidAction.dispose();
 		this._onDidNotification.dispose();
 		this._onDidRootStateChange.dispose();
+		for (const emitter of this._sessionStateEmitters.values()) {
+			emitter.dispose();
+		}
+		this._sessionStateEmitters.clear();
 	}
 }
 
@@ -804,6 +845,86 @@ suite('RemoteAgentHostSessionsProvider', () => {
 		assert.ok(changes.length > 0);
 		const updatedSession = provider.getSessions().find((s) => s.title.get() === 'After');
 		assert.ok(updatedSession, 'Session should have updated title');
+	}));
+
+	// ---- Running session config seeding (from ISessionState.config) -------
+
+	test('getSessionConfig seeds running config from session state subscription, filtered to sessionMutable properties', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('seed-1', { summary: 'Seeded Session' }));
+		const provider = createProvider(disposables, connection);
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'Seeded Session');
+		assert.ok(session);
+
+		assert.strictEqual(provider.getSessionConfig(session!.sessionId), undefined);
+
+		const config: ISessionConfigState = {
+			schema: {
+				type: 'object',
+				properties: {
+					autoApprove: { type: 'string', title: 'Auto Approve', enum: ['default', 'autoApprove'], sessionMutable: true },
+					isolation: { type: 'string', title: 'Isolation', enum: ['folder', 'worktree'], readOnly: true },
+				},
+			},
+			values: { autoApprove: 'default', isolation: 'worktree' },
+		};
+		const fakeState: ISessionState = {
+			summary: { resource: AgentSession.uri('copilot', 'seed-1').toString(), provider: 'copilot', title: 'Seeded Session', status: ProtocolSessionStatus.Idle, createdAt: 0, modifiedAt: 0 },
+			lifecycle: SessionLifecycle.Ready,
+			turns: [],
+			config,
+		};
+		connection.setSessionState('seed-1', 'copilot', fakeState);
+
+		await waitForSessionConfig(provider, session!.sessionId, c => c?.values.autoApprove === 'default');
+
+		const seeded = provider.getSessionConfig(session!.sessionId);
+		assert.deepStrictEqual({
+			properties: Object.keys(seeded?.schema.properties ?? {}),
+			values: seeded?.values,
+		}, {
+			properties: ['autoApprove'],
+			values: { autoApprove: 'default' },
+		});
+	}));
+
+	test('removing a session disposes its session-state subscription', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('seed-2', { summary: 'Sub Session' }));
+		const provider = createProvider(disposables, connection);
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'Sub Session');
+		assert.ok(session);
+
+		provider.getSessionConfig(session!.sessionId);
+		const sessionUriStr = AgentSession.uri('copilot', 'seed-2').toString();
+		assert.strictEqual(connection.sessionSubscribeCounts.get(sessionUriStr), 1);
+		assert.strictEqual(connection.sessionUnsubscribeCounts.get(sessionUriStr) ?? 0, 0);
+
+		fireSessionRemoved(connection, 'seed-2');
+
+		assert.strictEqual(connection.sessionUnsubscribeCounts.get(sessionUriStr), 1);
+	}));
+
+	test('replacing the connection disposes all session-state subscriptions', () => runWithFakedTimers<void>({ useFakeTimers: true }, async () => {
+		connection.addSession(createSession('seed-3', { summary: 'Reconnect Session' }));
+		const provider = createProvider(disposables, connection);
+		provider.getSessions();
+		await timeout(0);
+		const session = provider.getSessions().find(s => s.title.get() === 'Reconnect Session');
+		assert.ok(session);
+
+		provider.getSessionConfig(session!.sessionId);
+		const sessionUriStr = AgentSession.uri('copilot', 'seed-3').toString();
+		assert.strictEqual(connection.sessionSubscribeCounts.get(sessionUriStr), 1);
+		assert.strictEqual(connection.sessionUnsubscribeCounts.get(sessionUriStr) ?? 0, 0);
+
+		const newConnection = new MockAgentConnection();
+		disposables.add(toDisposable(() => newConnection.dispose()));
+		provider.setConnection(newConnection);
+
+		assert.strictEqual(connection.sessionUnsubscribeCounts.get(sessionUriStr), 1);
 	}));
 
 });


### PR DESCRIPTION
Sessions opened from the chat list (not created in the current window lifetime) had no `state.config` populated, so the running-session auto-approve picker rendered nothing.

## Fixes

1. **Restore re-resolves config.** `AgentService.restoreSession` now re-resolves the session config from the working directory and overlays previously persisted user values, so `state.config` is set on restore.
2. **Persist user-selected values.** Selected config values are now written to the per-session DB (as a `configValues` JSON metadata entry) both when the session is created (initial values returned by the provider) and on every `SessionConfigChanged` action, so they survive across process lifetimes.
3. **Lazy seed for the picker.** The session-mutable subset of `state.config` is lazily seeded into the local/remote providers' `_runningSessionConfigs` map via a reference-counted state subscription, so the running-session picker re-renders once the snapshot arrives.

## Schema vs values

Schema is intentionally re-resolved on restore rather than persisted. That way, provider schema changes (renamed/removed properties, changed enums) are picked up automatically; persisted values that no longer satisfy the new schema are simply dropped on the next resolve.

## Tests

- 5 new unit tests in `agentService.test.ts` covering the persist-on-create, persist-on-SessionConfigChanged, restore-and-overlay, and graceful-DB-failure cases.
- 1 new unit test in `agentSideEffects.test.ts` for the `SessionConfigChanged` persistence side effect.
- New tests in the local/remote provider tests for the lazy-seed code path.

An integration test exercising the full create → change → reconnect → verify flow at the protocol level is in progress.

(Written by Copilot)