### PR TITLE
sessions: allow session providers to lazily signal readiness

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -107,6 +107,12 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			sendRequest: (query: string, attachments?: IChatRequestVariableEntry[]) => Promise<void>;
 			canSendRequest: IObservable<boolean>;
 			loading: IObservable<boolean>;
+			/**
+			 * Optional observable reporting a provider-supplied label to display while
+			 * the selected provider is not yet ready to create sessions. When set, the
+			 * input is rendered as disabled with the label as placeholder text.
+			 */
+			preparingLabel?: IObservable<string | undefined>;
 			minEditorHeight?: number;
 			placeholder?: string;
 		},
@@ -130,7 +136,14 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		this._register(autorun(reader => {
 			this.options.canSendRequest.read(reader);
 			const isLoading = this.options.loading.read(reader);
+			const preparingLabel = this.options.preparingLabel?.read(reader);
 			this._loadingSpinner?.classList.toggle('visible', isLoading);
+			if (this._editor) {
+				this._editor.updateOptions({
+					readOnly: !!preparingLabel,
+					placeholder: preparingLabel ?? this.options.placeholder,
+				});
+			}
 			this._updateSendButtonState();
 		}));
 	}
@@ -451,7 +464,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 
 	private async _send(): Promise<void> {
 		let query = this._editor.getModel()?.getValue().trim();
-		if (!query || this._sending) {
+		if (!query || this._sending || this.options.preparingLabel?.get()) {
 			return;
 		}
 
@@ -500,7 +513,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			return;
 		}
 		const hasText = !!this._editor?.getModel()?.getValue().trim();
-		this._sendButton.enabled = !this._sending && hasText && this.options.canSendRequest.get();
+		const isPreparing = !!this.options.preparingLabel?.get();
+		this._sendButton.enabled = !this._sending && !isPreparing && hasText && this.options.canSendRequest.get();
 	}
 
 	private _restoreState(): void {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -5,8 +5,8 @@
 
 import './media/chatWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
-import { derived } from '../../../../base/common/observable.js';
+import { Disposable, IDisposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, observableFromEvent } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -20,6 +20,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { localize } from '../../../../nls.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
@@ -33,6 +34,12 @@ class NewChatWidget extends Disposable {
 
 	private readonly _workspacePicker: WorkspacePicker;
 	private readonly _newChatInput: NewChatInputWidget;
+	/** Observable reporting the currently selected workspace's provider, if any. */
+	private readonly _selectedProvider: IObservable<ISessionsProvider | undefined>;
+	/** Observable preparing label derived from the selected provider's readiness. */
+	private readonly _preparingLabel: IObservable<string | undefined>;
+	/** Disposable for the pending "retry once ready" autorun per workspace selection. */
+	private readonly _pendingReadyRun = this._register(new MutableDisposable());
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -57,11 +64,35 @@ class NewChatWidget extends Disposable {
 			return session?.loading.read(reader) ?? false;
 		});
 
+		const selectedWorkspaceObs = observableFromEvent(this, this._workspacePicker.onDidSelectWorkspace, () => this._workspacePicker.selectedProject);
+		const providersChangedObs = observableFromEvent(this, this.sessionsProvidersService.onDidChangeProviders, () => this.sessionsProvidersService.getProviders());
+
+		this._selectedProvider = derived(reader => {
+			// Recompute when the workspace picker's selection or the set of providers change.
+			selectedWorkspaceObs.read(reader);
+			providersChangedObs.read(reader);
+			const providerId = this._workspacePicker.selectedProject?.providerId;
+			if (!providerId) {
+				return undefined;
+			}
+			return this.sessionsProvidersService.getProviders().find(p => p.id === providerId);
+		});
+
+		this._preparingLabel = derived(reader => {
+			const provider = this._selectedProvider.read(reader);
+			const readiness = provider?.readiness?.read(reader);
+			if (!readiness || readiness.state === 'ready') {
+				return undefined;
+			}
+			return readiness.label;
+		});
+
 		this._newChatInput = this._register(this.instantiationService.createInstance(NewChatInputWidget, {
 			getContextFolderUri: () => this._getContextFolderUri(),
 			sendRequest: async (text: string, attachedContext?: IChatRequestVariableEntry[]) => this._send(text, attachedContext),
 			canSendRequest,
 			loading,
+			preparingLabel: this._preparingLabel,
 		}));
 
 		this._register(this._workspacePicker.onDidSelectWorkspace(async workspace => {
@@ -86,19 +117,11 @@ class NewChatWidget extends Disposable {
 
 		this._newChatInput.render(chatWidgetContent, parent);
 
-		// Create initial session — wait for providers if none registered yet
+		// Create initial session. `_tryCreateNewSession` handles the case where
+		// the restored project's provider isn't registered yet (startup race).
 		const restoredProject = this._workspacePicker.selectedProject;
 		if (restoredProject) {
-			if (this.sessionsProvidersService.getProviders().length > 0) {
-				this._createNewSession(restoredProject, this._newChatInput.sessionTypePicker.selectedType);
-			} else {
-				// Providers not yet registered (startup race) — wait for first registration
-				const sub = this.sessionsProvidersService.onDidChangeProviders(() => {
-					sub.dispose();
-					this._createNewSession(restoredProject, this._newChatInput.sessionTypePicker.selectedType);
-				});
-				this._register(sub);
-			}
+			this._tryCreateNewSession(restoredProject, this._newChatInput.sessionTypePicker.selectedType);
 		}
 
 		chatWidgetContainer.classList.add('revealed');
@@ -106,6 +129,54 @@ class NewChatWidget extends Disposable {
 
 	private _createNewSession(selection: IWorkspaceSelection, sessionTypeId: string | undefined): void {
 		this.sessionsManagementService.createNewSession(selection.providerId, selection.workspace.repositories[0].uri, sessionTypeId);
+	}
+
+	/**
+	 * Create a new session if the selected provider is ready; otherwise invoke
+	 * {@link ISessionsProvider.prepare} and arm a one-shot autorun that retries
+	 * creation as soon as readiness transitions to `ready` for the same selection.
+	 *
+	 * If the selection's provider hasn't been registered yet (startup race),
+	 * waits for the matching registration and then retries.
+	 */
+	private _tryCreateNewSession(selection: IWorkspaceSelection, sessionTypeId: string | undefined): void {
+		this._pendingReadyRun.clear();
+
+		const provider = this.sessionsProvidersService.getProviders().find(p => p.id === selection.providerId);
+		if (!provider) {
+			// Provider not yet registered — wait for it and retry.
+			this._pendingReadyRun.value = this.sessionsProvidersService.onDidChangeProviders(() => {
+				if (this.sessionsProvidersService.getProviders().some(p => p.id === selection.providerId)) {
+					this._tryCreateNewSession(selection, sessionTypeId);
+				}
+			});
+			return;
+		}
+
+		const session = this.sessionsManagementService.createNewSession(selection.providerId, selection.workspace.repositories[0].uri, sessionTypeId);
+		if (session) {
+			return;
+		}
+
+		// Provider not ready — kick off any preparation and wait for readiness.
+		const workspaceUri = selection.workspace.repositories[0].uri;
+		provider.prepare?.(workspaceUri).catch(e => this.logService.warn('[NewChatWidget] provider.prepare failed:', e));
+
+		this._pendingReadyRun.value = autorun(reader => {
+			const readiness = provider.readiness?.read(reader);
+			if (readiness && readiness.state !== 'ready') {
+				return;
+			}
+			// Ensure the selection is still the same before retrying.
+			const current = this._workspacePicker.selectedProject;
+			if (current?.providerId !== selection.providerId
+				|| current.workspace.repositories[0]?.uri.toString() !== workspaceUri.toString()) {
+				this._pendingReadyRun.clear();
+				return;
+			}
+			this._pendingReadyRun.clear();
+			this._createNewSession(selection, sessionTypeId);
+		});
 	}
 
 	/**
@@ -173,6 +244,7 @@ class NewChatWidget extends Disposable {
 	 */
 	private async _onWorkspaceSelected(selection: IWorkspaceSelection | undefined, sessionTypeId: string | undefined): Promise<void> {
 		if (!selection) {
+			this._pendingReadyRun.clear();
 			this.sessionsManagementService.unsetNewSession();
 			return;
 		}
@@ -184,7 +256,7 @@ class NewChatWidget extends Disposable {
 			}
 		}
 
-		this._createNewSession(selection, sessionTypeId);
+		this._tryCreateNewSession(selection, sessionTypeId);
 	}
 
 	prefillInput(text: string): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -11,7 +11,7 @@ import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlCon
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { basename } from '../../../../base/common/resources.js';
-import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
+import { constObservable, derived, IObservable, ISettableObservable, observableValue, waitForState } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -34,7 +34,7 @@ import { ILanguageModelsService } from '../../../../workbench/contrib/chat/commo
 import { agentHostSessionWorkspaceKey, buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { isSessionConfigComplete } from '../../../common/sessionConfig.js';
 import { diffsToChanges, diffsEqual, mapProtocolStatus } from '../../../common/agentHostDiffs.js';
-import { ISessionChangeEvent, ISendRequestOptions } from '../../../services/sessions/common/sessionsProvider.js';
+import { ISessionChangeEvent, ISendRequestOptions, ProviderReadiness } from '../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
 import { ISession, IChat, IGitHubInfo, ISessionWorkspace, ISessionWorkspaceBrowseAction, SessionStatus, ISessionType, COPILOT_CLI_SESSION_TYPE } from '../../../services/sessions/common/session.js';
 import { remoteAgentHostSessionTypeId } from '../common/remoteAgentHostSessionType.js';
@@ -287,6 +287,12 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	get sessionTypes(): readonly ISessionType[] { return this._sessionTypes; }
 
 	/**
+	 * Observable mirror of {@link _sessionTypes} length, kept in sync alongside
+	 * the existing emitter so the {@link readiness} derived can react to changes.
+	 */
+	private readonly _sessionTypesCount = observableValue<number>('sessionTypesCount', 0);
+
+	/**
 	 * Maps logical session type id → unique per-connection resource scheme.
 	 * Copilot agents map to `COPILOT_CLI_SESSION_TYPE` as the logical type
 	 * but keep the unique per-connection id as the resource scheme.
@@ -298,6 +304,20 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 
 	private readonly _connectionStatus = observableValue<RemoteAgentHostConnectionStatus>('connectionStatus', RemoteAgentHostConnectionStatus.Disconnected);
 	readonly connectionStatus: IObservable<RemoteAgentHostConnectionStatus> = this._connectionStatus;
+
+	readonly readiness: IObservable<ProviderReadiness> = derived(reader => {
+		const status = this._connectionStatus.read(reader);
+		const typesCount = this._sessionTypesCount.read(reader);
+		if (status === RemoteAgentHostConnectionStatus.Connected && typesCount > 0) {
+			return { state: 'ready' } satisfies ProviderReadiness;
+		}
+		if (status === RemoteAgentHostConnectionStatus.Connecting
+			|| status === RemoteAgentHostConnectionStatus.Connected
+			|| (status === RemoteAgentHostConnectionStatus.Disconnected && this._connectOnDemand)) {
+			return { state: 'preparing', label: localize('connectingTo', "Connecting to {0}…", this.label) } satisfies ProviderReadiness;
+		}
+		return { state: 'unavailable', label: localize('disconnectedFrom', "Disconnected from {0}", this.label) } satisfies ProviderReadiness;
+	});
 
 	private readonly _onDidChangeSessions = this._register(new Emitter<ISessionChangeEvent>());
 	readonly onDidChangeSessions: Event<ISessionChangeEvent> = this._onDidChangeSessions.event;
@@ -382,6 +402,35 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	 */
 	setOutputChannelId(id: string): void {
 		this._outputChannelId = id;
+	}
+
+	/**
+	 * Trigger any preparation required to move readiness to `ready`:
+	 * kicks off {@link _connectOnDemand} when we are disconnected, then
+	 * waits for readiness to settle before resolving.
+	 */
+	async prepare(_repositoryUri: URI): Promise<void> {
+		if (this.readiness.get().state === 'ready') {
+			return;
+		}
+
+		// For tunnels, `RemoteAgentHostConnectionStatus.Connected` signals
+		// that the tunnel host is online — not that a relay connection is
+		// established. Whenever readiness is not `ready` and a
+		// `_connectOnDemand` hook is available, invoke it; the hook itself
+		// is responsible for de-duplicating pending connect attempts.
+		if (this._connectOnDemand) {
+			await this._connectOnDemand();
+		}
+
+		const cts = new CancellationTokenSource();
+		const timer = setTimeout(() => cts.cancel(), 30_000);
+		try {
+			await waitForState(this.readiness, r => r.state !== 'preparing', undefined, cts.token);
+		} finally {
+			clearTimeout(timer);
+			cts.dispose();
+		}
 	}
 
 	// -- Connection Management --
@@ -475,6 +524,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 			return;
 		}
 		this._sessionTypes = next;
+		this._sessionTypesCount.set(next.length, undefined);
 		this._sessionTypeToResourceScheme.clear();
 		for (const [key, value] of nextMap) {
 			this._sessionTypeToResourceScheme.set(key, value);
@@ -531,6 +581,7 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 
 		if (this._sessionTypes.length > 0) {
 			this._sessionTypes = [];
+			this._sessionTypesCount.set(0, undefined);
 			this._sessionTypeToResourceScheme.clear();
 			this._onDidChangeSessionTypes.fire();
 		}
@@ -610,6 +661,8 @@ export class RemoteAgentHostSessionsProvider extends Disposable implements IAgen
 	private _currentNewSession: IChatData | undefined;
 
 	createNewSession(workspaceUri: URI, sessionTypeId: string): ISession {
+		// The sessions management service gates creation on readiness, but keep
+		// defensive guards so contract violations surface as explicit errors.
 		if (!this._connection) {
 			throw new Error(localize('notConnectedSession', "Cannot create session: not connected to remote agent host '{0}'.", this.label));
 		}

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -15,7 +15,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { ActiveSessionProviderIdContext, ActiveSessionTypeContext, IsActiveSessionArchivedContext, IsActiveSessionBackgroundProviderContext, IsNewChatInSessionContext, IsNewChatSessionContext } from '../../../common/contextkeys.js';
 import { ActiveSessionSupportsMultiChatContext, IActiveSession, ISessionsChangeEvent, ISessionsManagementService } from '../common/sessionsManagement.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sessionsProvidersService.js';
-import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
+import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider, getProviderReadiness } from '../common/sessionsProvider.js';
 import { COPILOT_CLI_SESSION_TYPE, IChat, ISession, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 
@@ -251,7 +251,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		this.setActiveSession(undefined);
 	}
 
-	createNewSession(providerId: string, repositoryUri: URI, sessionTypeId?: string): ISession {
+	createNewSession(providerId: string, repositoryUri: URI, sessionTypeId?: string): ISession | undefined {
 		if (!this.isNewChatSessionContext.get()) {
 			this.isNewChatSessionContext.set(true);
 		}
@@ -259,6 +259,15 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		const provider = this.sessionsProvidersService.getProviders().find(p => p.id === providerId);
 		if (!provider) {
 			throw new Error(`Sessions provider '${providerId}' not found`);
+		}
+
+		// If the provider isn't ready, don't throw — surface the provider as active so
+		// consumers can bind to its readiness observable, and return undefined.
+		const readiness = getProviderReadiness(provider);
+		if (readiness.state !== 'ready') {
+			this.setActiveProvider(providerId);
+			this.setActiveSession(undefined);
+			return undefined;
 		}
 
 		if (!sessionTypeId) {

--- a/src/vs/sessions/services/sessions/common/sessionsManagement.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsManagement.ts
@@ -105,8 +105,10 @@ export interface ISessionsManagementService {
 	/**
 	 * Create a new session for the given workspace.
 	 * Delegates to the provider identified by providerId.
+	 * Returns `undefined` when the provider's readiness is not `ready`; in that case
+	 * the provider is made active so consumers can observe its readiness, but no session is created.
 	 */
-	createNewSession(providerId: string, workspaceUri: URI, sessionTypeId?: string): ISession;
+	createNewSession(providerId: string, workspaceUri: URI, sessionTypeId?: string): ISession | undefined;
 
 	/**
 	 * Unset the new session

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -4,10 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../base/common/event.js';
+import { IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { IChat, ISession, ISessionType, ISessionWorkspace, ISessionWorkspaceBrowseAction } from './session.js';
+
+/**
+ * Readiness of a sessions provider, indicating whether it can currently
+ * create new sessions. Providers that are always ready (e.g. local
+ * providers) do not need to expose this observable.
+ */
+export type ProviderReadiness =
+	| { readonly state: 'ready' }
+	| { readonly state: 'preparing'; readonly label: string }
+	| { readonly state: 'unavailable'; readonly label: string };
+
+/**
+ * Returns the current readiness of a provider, defaulting to `ready` when
+ * the provider does not implement the readiness contract.
+ */
+export function getProviderReadiness(provider: ISessionsProvider): ProviderReadiness {
+	return provider.readiness?.get() ?? { state: 'ready' };
+}
 
 /**
  * Event fired when sessions change within a provider.
@@ -95,6 +114,19 @@ export interface ISessionsProvider {
 	 * @param sessionTypeId The ID of the session type to create.
 	 */
 	createNewSession(repositoryUri: URI, sessionTypeId: string): ISession;
+
+	/**
+	 * Optional observable reporting whether the provider is currently ready to
+	 * create sessions. When absent, the provider is treated as always ready.
+	 */
+	readonly readiness?: IObservable<ProviderReadiness>;
+
+	/**
+	 * Optional hook invoked by consumers to trigger any preparation steps
+	 * required to move readiness to `ready` (e.g. establishing a connection).
+	 * @param repositoryUri The URI of the repository the consumer intends to target.
+	 */
+	prepare?(repositoryUri: URI): Promise<void>;
 
 	/**
 	 * Get the session types supported for a given repository URI.


### PR DESCRIPTION
If you have remotes configured with the agent host, there was a pretty bad case you could get into if none were online because then this block

```
		if (!sessionTypeId) {
			const defaultType = provider.getSessionTypes(repositoryUri)[0];
			if (!defaultType) {
				throw new Error(`No session types available for provider '${providerId}'`);
			}
			sessionTypeId = defaultType.id;
		}
```

would throw and break the "New" window, giving you a blank screen. At least if that remote was the default for new sessions, not 100% sure on the cases where that happened.

This code fixes it and the experience is nice, but it's 100% vibed and I'm not familiar with this area. Please review/feel free to iterate on this PR.



https://github.com/user-attachments/assets/9b121172-4450-4ddf-a9f5-41b945a98b52


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
