### PR TITLE
fix: denormalize CLI time_to_first_chunk into ttft_ms column

### DIFF
--- a/extensions/copilot/src/platform/otel/node/sqlite/otelSqliteStore.ts
+++ b/extensions/copilot/src/platform/otel/node/sqlite/otelSqliteStore.ts
@@ -162,7 +162,7 @@ export class OTelSqliteStore {
 				this._attr(span, DENORMALIZED_ATTRS.tool_type),
 				this._attr(span, DENORMALIZED_ATTRS.chat_session_id),
 				this._attr(span, DENORMALIZED_ATTRS.turn_index),
-				this._attr(span, DENORMALIZED_ATTRS.ttft_ms),
+				this._ttftMs(span),
 			);
 
 			for (const [key, value] of Object.entries(span.attributes)) {
@@ -284,6 +284,19 @@ export class OTelSqliteStore {
 		if (Array.isArray(val)) { return JSON.stringify(val); }
 		if (typeof val === 'boolean') { return val ? 1 : 0; }
 		return val as string | number;
+	}
+
+	/**
+	 * Coalesce TTFT from foreground extension (`copilot_chat.time_to_first_token`, ms)
+	 * and CLI runtime (`github.copilot.time_to_first_chunk`, seconds → ms).
+	 */
+	private _ttftMs(span: ICompletedSpanData): number | null {
+		const foreground = this._attr(span, CopilotChatAttr.TIME_TO_FIRST_TOKEN);
+		if (foreground !== null) { return foreground as number; }
+		const cli = span.attributes['github.copilot.time_to_first_chunk'];
+		if (cli === undefined) { return null; }
+		const sec = typeof cli === 'number' ? cli : parseFloat(String(cli));
+		return isNaN(sec) ? null : Math.round(sec * 1000);
 	}
 
 	private _ensureDb(): DatabaseSync {

--- a/extensions/copilot/src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts
+++ b/extensions/copilot/src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts
@@ -195,4 +195,47 @@ describe('OTelSqliteStore', () => {
 		expect(spans).toHaveLength(1);
 		expect(spans[0].agent_name).toBe('updated');
 	});
+
+	it('denormalizes copilot_chat.time_to_first_token into ttft_ms', () => {
+		store.insertSpan(makeSpan({
+			spanId: 'fg-chat',
+			traceId: 'trace-fg',
+			attributes: {
+				'gen_ai.operation.name': 'chat',
+				'copilot_chat.time_to_first_token': 450,
+			},
+		}));
+
+		const spans = store.getSpansByTraceId('trace-fg');
+		expect(spans[0].ttft_ms).toBe(450);
+	});
+
+	it('denormalizes github.copilot.time_to_first_chunk (seconds) into ttft_ms (ms)', () => {
+		store.insertSpan(makeSpan({
+			spanId: 'cli-chat',
+			traceId: 'trace-cli',
+			attributes: {
+				'gen_ai.operation.name': 'chat',
+				'github.copilot.time_to_first_chunk': 0.4386763570001349,
+			},
+		}));
+
+		const spans = store.getSpansByTraceId('trace-cli');
+		expect(spans[0].ttft_ms).toBe(439);
+	});
+
+	it('prefers copilot_chat.time_to_first_token over github.copilot.time_to_first_chunk', () => {
+		store.insertSpan(makeSpan({
+			spanId: 'both-chat',
+			traceId: 'trace-both',
+			attributes: {
+				'gen_ai.operation.name': 'chat',
+				'copilot_chat.time_to_first_token': 500,
+				'github.copilot.time_to_first_chunk': 0.6,
+			},
+		}));
+
+		const spans = store.getSpansByTraceId('trace-both');
+		expect(spans[0].ttft_ms).toBe(500);
+	});
 });


### PR DESCRIPTION
## Problem

The CLI runtime emits `github.copilot.time_to_first_chunk` (in **seconds**) on chat spans, while the foreground extension uses `copilot_chat.time_to_first_token` (in **ms**). The SQLite store's `DENORMALIZED_ATTRS` map only checks the foreground attribute name, so the `ttft_ms` column stays NULL for all CLI background agent spans.

This affects the ATIF trajectory builder in vscode-copilot-evaluation, which reads `ttft_ms` from the spans table to populate `time_to_first_token_ms` in trajectory steps.

## Fix

Add a `_ttftMs()` helper in `OTelSqliteStore.insertSpan()` that coalesces both attribute names:

1. `copilot_chat.time_to_first_token` (foreground, already in ms) — checked first
2. `github.copilot.time_to_first_chunk` (CLI runtime, seconds × 1000 → ms) — fallback

## Tests

3 new tests in `otelSqliteStore.spec.ts`:
- Foreground attribute → `ttft_ms` (identity, ms)
- CLI attribute → `ttft_ms` (seconds→ms with `Math.round`)
- Both present → foreground wins