### PR TITLE
Try to make multiroot smoke test less flaky

### DIFF
--- a/test/automation/src/quickaccess.ts
+++ b/test/automation/src/quickaccess.ts
@@ -98,6 +98,11 @@ export class QuickAccess {
 			}
 
 			await this.quickInput.closeQuickInput();
+
+			// Back off between retries so that slow file search
+			// indexing (e.g. browser/remote on CI) has a chance to
+			// catch up before we hammer it again.
+			await this.code.wait(250 * retries);
 		}
 
 		if (!success) {

--- a/test/automation/src/quickaccess.ts
+++ b/test/automation/src/quickaccess.ts
@@ -102,7 +102,9 @@ export class QuickAccess {
 			// Back off between retries so that slow file search
 			// indexing (e.g. browser/remote on CI) has a chance to
 			// catch up before we hammer it again.
-			await this.code.wait(250 * retries);
+			if (retries < 9) {
+				await this.code.wait(250 * retries);
+			}
 		}
 
 		if (!success) {


### PR DESCRIPTION
The `Multiroot > shows results from all folders` smoke test on the macOS Browser leg was failing intermittently. Looking at the artifacts from a recent failure ([run 24590916926, job 71911301809](https://github.com/microsoft/vscode/actions/runs/24590916926/job/71911301809)):

**What happened**

In the failing run, the `*.*` quick file search returned `'No matching results'` on every one of the 9 retries — and all 9 retries fired in ~160 ms. Cross-referencing the renderer `window.log` with the runner timeline:

```
23:27:50.787  [driver] Workbench contributions created.   ← whenWorkbenchRestored returns
23:27:51.462  Test fires first quick-open
23:27:51.621  Test fails (all 9 retries done)
23:27:51.628  "Ignoring fetching additional builtin extensions..." (still loading)
23:27:51.662  Extension host pid 35111 started            ← ext host wasn't even up yet
23:27:51.872  Eager extensions activated
```

So the test fired before the extension host had started, which on a `.code-workspace` opened in browser/remote means the workspace folders weren't attached yet, so file search legitimately returned `'No matching results'`.

**Why the retry loop didn't save us**

`openFileQuickAccessAndWait` treats `'No matching results'` as a fatal-but-retryable signal: it closes quick access and reopens immediately with no delay between retries. Comparing with a passing run on the same workflow, the passing case sees `[]` (search still in progress, polled at 100ms) for ~500 ms before files appear. The failing case skips that path entirely because search has "completed" with an empty workspace.

**The fix**

Add an incremental backoff between retries (`250ms × retry#`) so the workspace/file-search has a chance to catch up. By retry 9 the cumulative wait is ~11s, which is plenty for ext host startup + workspace folder attachment on slow CI runners. Happy path is unaffected.

This is a defense-in-depth change — a more targeted fix would be to wait for the workspace title (`/smoketest \(Workspace\)/i`) or for the explorer to render its 3 folder roots before running the test, but the retry-loop fix benefits any future quickaccess-flake that hits the same 'No matching results' premature-completion case.

(Written by Copilot)