### PR TITLE
Add menu toggle for cloud sync in chat panel

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3243,15 +3243,6 @@
 			{
 				"id": "experimental",
 				"properties": {
-					"github.copilot.chat.sessionSearch.cloudSync.enabled": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "%github.copilot.config.sessionSearch.cloudSync.enabled%",
-						"tags": [
-							"experimental",
-							"onExp"
-						]
-					},
 					"github.copilot.chat.getSearchViewResultsSkill.enabled": {
 						"type": "boolean",
 						"default": false,
@@ -3977,6 +3968,15 @@
 			{
 				"id": "advanced",
 				"properties": {
+					"github.copilot.chat.sessionSearch.cloudSync.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "%github.copilot.config.sessionSearch.cloudSync.enabled%",
+						"tags": [
+							"advanced",
+							"onExp"
+						]
+					},
 					"github.copilot.chat.reasoningEffortOverride": {
 						"type": [
 							"string",

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3243,6 +3243,15 @@
 			{
 				"id": "experimental",
 				"properties": {
+					"github.copilot.chat.sessionSearch.cloudSync.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "Enable cloud sync of chat session data.",
+						"tags": [
+							"experimental",
+							"onExp"
+						]
+					},
 					"github.copilot.chat.getSearchViewResultsSkill.enabled": {
 						"type": "boolean",
 						"default": false,

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3246,7 +3246,7 @@
 					"github.copilot.chat.sessionSearch.cloudSync.enabled": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "Enable cloud sync of chat session data.",
+						"markdownDescription": "%github.copilot.config.sessionSearch.cloudSync.enabled%",
 						"tags": [
 							"experimental",
 							"onExp"

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -173,7 +173,7 @@
 	"copilot.chronicle.tips.description": "Get personalized tips based on your Copilot usage patterns",
 	"github.copilot.config.sessionSearch.enabled": "Enable session search and /chronicle commands. This is a team-internal setting.",
 	"github.copilot.config.sessionSearch.localIndex.enabled": "Enable local session tracking. When enabled, Copilot tracks session data locally for /chronicle commands.",
-	"github.copilot.config.sessionSearch.cloudSync.enabled": "Enable cloud sync for session data. When enabled, session data is synced to your Copilot account for cross-device access.",
+	"github.copilot.config.sessionSearch.cloudSync.enabled": "Enable cloud sync for session data. When enabled, chat session data is synced to the cloud for cross-device querying.",
 	"github.copilot.config.sessionSearch.cloudSync.excludeRepositories": "Repository patterns to exclude from cloud sync. Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repos will only be stored locally.",
 	"copilot.workspace.explain.description": "Explain how the code in your active editor works",
 	"copilot.workspace.edit.description": "Edit files in your workspace",

--- a/extensions/copilot/src/extension/chronicle/common/sessionIndexingPreference.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionIndexingPreference.ts
@@ -46,9 +46,19 @@ export class SessionIndexingPreference {
 	/**
 	 * Check if cloud sync is enabled for a given repo.
 	 * Returns true if cloudSync.enabled is true AND the repo is not excluded.
+	 * Check both new and old setting for backward compatibility.
 	 */
 	hasCloudConsent(repoNwo?: string): boolean {
-		if (!this._configService.getConfig(ConfigKey.TeamInternal.SessionSearchCloudSyncEnabled)) {
+		let cloudEnabled: boolean;
+		if (this._configService.isConfigured(ConfigKey.Advanced.SessionSearchCloudSync)) {
+			// New key explicitly set by user — authoritative
+			cloudEnabled = this._configService.getConfig(ConfigKey.Advanced.SessionSearchCloudSync);
+		} else {
+			// Fall back to old internal key for existing users who haven't migrated yet
+			cloudEnabled = this._configService.getConfig(ConfigKey.TeamInternal.SessionSearchCloudSyncEnabled);
+		}
+
+		if (!cloudEnabled) {
 			return false;
 		}
 

--- a/extensions/copilot/src/extension/chronicle/common/standupPrompt.ts
+++ b/extensions/copilot/src/extension/chronicle/common/standupPrompt.ts
@@ -132,7 +132,6 @@ Standup for <date>:
   - Key files: list 2-3 most important files changed
   - Tools used: mention key tools if visible (e.g., apply_patch, run_in_terminal, search)
   - PR: [#123](link) — merged/closed (if applicable)
-  - Sessions: \`session-id-1\`, \`session-id-2\`
 
 **🚧 In Progress**
 
@@ -140,7 +139,6 @@ Standup for <date>:
   - Summary of current work (1-2 sentences based on turn content)
   - Key files: list 2-3 most important files being worked on
   - PR: [#789](link) — draft/open (if applicable)
-  - Sessions: \`session-id\`
 
 Formatting rules:
 - Use the turn data (user messages AND assistant responses) to understand WHAT was done, not just that something happened

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionIndexingPreference.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionIndexingPreference.spec.ts
@@ -9,16 +9,25 @@ import { SessionIndexingPreference } from '../sessionIndexingPreference';
 function createMockConfigService(opts: {
 	localIndexEnabled?: boolean;
 	cloudSyncEnabled?: boolean;
+	cloudSyncPublicEnabled?: boolean;
 	excludeRepositories?: string[];
 } = {}) {
 	const configs: Record<string, unknown> = {};
 	// Map by fullyQualifiedId
 	configs['github.copilot.chat.advanced.sessionSearch.localIndex.enabled'] = opts.localIndexEnabled ?? false;
 	configs['github.copilot.chat.advanced.sessionSearch.cloudSync.enabled'] = opts.cloudSyncEnabled ?? false;
+	configs['github.copilot.chat.sessionSearch.cloudSync.enabled'] = opts.cloudSyncPublicEnabled ?? false;
 	configs['github.copilot.chat.advanced.sessionSearch.cloudSync.excludeRepositories'] = opts.excludeRepositories ?? [];
+
+	// Track which keys are explicitly configured (set by the user)
+	const configuredKeys = new Set<string>();
+	if (opts.cloudSyncPublicEnabled !== undefined) {
+		configuredKeys.add('github.copilot.chat.sessionSearch.cloudSync.enabled');
+	}
 
 	return {
 		getConfig: (key: { fullyQualifiedId: string }) => configs[key.fullyQualifiedId],
+		isConfigured: (key: { fullyQualifiedId: string }) => configuredKeys.has(key.fullyQualifiedId),
 	} as unknown as import('../../../../platform/configuration/common/configurationService').IConfigurationService;
 }
 
@@ -80,5 +89,20 @@ describe('SessionIndexingPreference', () => {
 		expect(pref.hasCloudConsent('private-org/repo-a')).toBe(false);
 		expect(pref.hasCloudConsent('private-org/repo-b')).toBe(false);
 		expect(pref.hasCloudConsent('public-org/repo-a')).toBe(true);
+	});
+
+	it('hasCloudConsent uses new public key when explicitly configured', () => {
+		const pref = new SessionIndexingPreference(createMockConfigService({
+			cloudSyncPublicEnabled: true,
+		}));
+		expect(pref.hasCloudConsent()).toBe(true);
+	});
+
+	it('hasCloudConsent new public key overrides old internal key', () => {
+		const pref = new SessionIndexingPreference(createMockConfigService({
+			cloudSyncEnabled: true,
+			cloudSyncPublicEnabled: false,
+		}));
+		expect(pref.hasCloudConsent()).toBe(false);
 	});
 });

--- a/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/remoteSessionExporter.ts
@@ -120,12 +120,16 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 
 		// Only set up span listener when both local index and cloud sync are enabled.
 		// Uses autorun to react if settings change at runtime.
+		// Both new and old settings taken into account for backward compatibility
 		const localEnabled = this._configService.getExperimentBasedConfigObservable(ConfigKey.TeamInternal.SessionSearchLocalIndexEnabled, this._expService);
-		const cloudEnabled = this._configService.getConfigObservable(ConfigKey.TeamInternal.SessionSearchCloudSyncEnabled);
+		const cloudEnabledInternal = this._configService.getConfigObservable(ConfigKey.TeamInternal.SessionSearchCloudSyncEnabled);
+		const cloudEnabledPublic = this._configService.getConfigObservable(ConfigKey.Advanced.SessionSearchCloudSync);
 		const spanListenerStore = this._register(new DisposableStore());
 		this._register(autorun(reader => {
 			spanListenerStore.clear();
-			if (!localEnabled.read(reader) || !cloudEnabled.read(reader)) {
+			const publicValue = cloudEnabledPublic.read(reader);
+			const cloudEnabled = this._configService.isConfigured(ConfigKey.Advanced.SessionSearchCloudSync) ? publicValue : cloudEnabledInternal.read(reader);
+			if (!localEnabled.read(reader) || !cloudEnabled) {
 				return;
 			}
 
@@ -264,9 +268,10 @@ export class RemoteSessionExporter extends Disposable implements IExtensionContr
 			}
 
 			// Only export remotely if the user has cloud consent for this repo
+			// Also require localIndex to be enabled (team-internal gate) as defense-in-depth
 			const repoNwo = `${repo.owner}/${repo.repo}`;
 
-			if (!this._indexingPreference.hasCloudConsent(repoNwo)) {
+			if (!this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.SessionSearchLocalIndexEnabled, this._expService) || !this._indexingPreference.hasCloudConsent(repoNwo)) {
 				this._disabledSessions.add(sessionId);
 				return;
 			}

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -713,6 +713,8 @@ export namespace ConfigKey {
 
 		/** Internal: override reasoning/thinking effort sent to model APIs (e.g. Responses API, Messages API). Used by evals. */
 		export const ReasoningEffortOverride = defineSetting<string | null>('chat.reasoningEffortOverride', ConfigType.Simple, null);
+
+		export const SessionSearchCloudSync = defineAndMigrateSetting<boolean>('chat.advanced.sessionSearch.cloudSync.enabled', 'chat.sessionSearch.cloudSync.enabled', false);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1085,6 +1085,36 @@ export function registerChatActions() {
 		}
 	});
 
+	registerAction2(class ToggleSessionCloudSyncAction extends Action2 {
+		private static readonly _settingKey = 'github.copilot.chat.sessionSearch.cloudSync.enabled';
+		constructor() {
+			super({
+				id: 'workbench.action.chat.toggleSessionCloudSync',
+				title: localize2('chat.toggleSessionCloudSync', "Sync Chat Session to Cloud"),
+				category: CHAT_CATEGORY,
+				f1: false,
+				toggled: ContextKeyExpr.equals(`config.${ToggleSessionCloudSyncAction._settingKey}`, true),
+				menu: [{
+					id: CHAT_CONFIG_MENU_ID,
+					when: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.equals('view', ChatViewId), ContextKeyExpr.equals('github.copilot.sessionSearch.enabled', true)),
+					order: 2,
+					group: '4_logs'
+				}, {
+					id: MenuId.ViewTitle,
+					when: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.equals('view', ChatViewId), ContextKeyExpr.equals('github.copilot.sessionSearch.enabled', true)),
+					order: 2,
+					group: '4_logs'
+				}]
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const configurationService = accessor.get(IConfigurationService);
+			const currentValue = configurationService.getValue<boolean>(ToggleSessionCloudSyncAction._settingKey);
+			await configurationService.updateValue(ToggleSessionCloudSyncAction._settingKey, !currentValue);
+		}
+	});
+
 	const nonEnterpriseCopilotUsers = ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.notEquals(`config.${defaultChat.completionsAdvancedSetting}.authProvider`, defaultChat.provider.enterprise.id));
 	registerAction2(class extends Action2 {
 		constructor() {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -1090,7 +1090,7 @@ export function registerChatActions() {
 		constructor() {
 			super({
 				id: 'workbench.action.chat.toggleSessionCloudSync',
-				title: localize2('chat.toggleSessionCloudSync', "Sync Chat Session to Cloud"),
+				title: localize2('chat.toggleSessionCloudSync', "Sync Chat Sessions to Cloud"),
 				category: CHAT_CATEGORY,
 				f1: false,
 				toggled: ContextKeyExpr.equals(`config.${ToggleSessionCloudSyncAction._settingKey}`, true),


### PR DESCRIPTION
Adds a "Sync Chat Session to Cloud" toggle to the chat panel's overflow menu, allowing users to enable/disable cloud sync. Its a short cut/convenience UI to settings update.