### PR TITLE
agentHost: expand AHP customization refs into per-type items for chat customizations UI

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -26,7 +26,7 @@ import { IAgentPluginService } from '../../common/plugins/agentPluginService.js'
 import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
 import { formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
 import { HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
-import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { PromptsType, isValidPromptType } from '../../common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { storageToIcon } from './aiCustomizationIcons.js';
 import { BUILTIN_STORAGE } from './aiCustomizationManagement.js';
@@ -191,7 +191,7 @@ export class AICustomizationItemNormalizer {
 	normalizeItems(items: readonly ICustomizationItem[], promptType: PromptsType): IAICustomizationListItem[] {
 		const uriUseCounts = new ResourceMap<number>();
 		return items
-			.filter(item => item.type === promptType)
+			.filter(item => item.type === promptType || !isValidPromptType(item.type))
 			.map(item => this.normalizeItem(item, promptType, uriUseCounts))
 			.sort((a, b) => a.name.localeCompare(b.name));
 	}
@@ -354,6 +354,11 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 			return [];
 		}
 
+		// Items whose type is not a recognised PromptsType (e.g. 'plugin'
+		// from AHP) are included alongside the type-matched items so they
+		// are visible in every section rather than silently dropped.
+		const untypedItems = allItems.filter(item => !isValidPromptType(item.type));
+
 		let providerItems: readonly ICustomizationItem[];
 		if (promptType === PromptsType.hook) {
 			const hookItems = allItems.filter(item => item.type === PromptsType.hook);
@@ -363,9 +368,9 @@ export class ProviderCustomizationItemSource implements IAICustomizationItemSour
 			const expanded = await expandHookFileItems(
 				toExpand, this.workspaceService, this.fileService, this.pathService,
 			);
-			providerItems = [...expanded, ...preExpanded];
+			providerItems = [...expanded, ...preExpanded, ...untypedItems];
 		} else {
-			providerItems = allItems.filter(item => item.type === promptType);
+			providerItems = [...allItems.filter(item => item.type === promptType), ...untypedItems];
 		}
 
 		if (promptType === PromptsType.skill) {


### PR DESCRIPTION
## Problem

The item source pipeline in `fetchItemsFromProvider` and `normalizeItems` filters provider items by `item.type === promptType`. AHP-contributed customizations use `type: 'plugin'` (an Open Plugins reference, not a `PromptsType` enum value), so they were silently dropped in every per-type section (Skills, Agents, Instructions, Hooks, Prompts).

This was introduced in `d7c19c5af6e` when the group-based display path (`sectionToCustomizationGroupIds`) was replaced with a type-based filter that assumed all items would have a valid `PromptsType`.

## Fix

Include items whose type is not a recognised `PromptsType` alongside the type-matched items. This is a 3-line change in `aiCustomizationItemSource.ts`:

1. In `fetchItemsFromProvider`: collect items with unrecognised types (`untypedItems`) and append them to the filtered set for every section.
2. In `normalizeItems`: relax the filter to also pass items with unrecognised types.

AHP customizations now show in every per-type section as flat remote items in the sync layout, with their server-reported status/enabled state preserved. No coupling to local plugin discovery.

## Changed files

- `src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts` — relax type filters to include untyped provider items