### PR TITLE
fix: add web-safe keybinding for Go to Symbol in Workspace

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -9,6 +9,7 @@ import * as Constants from '../common/constants.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { isWeb } from '../../../../base/common/platform.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 
 //#region Actions
@@ -29,7 +30,8 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT
+				primary: isWeb ? KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyT : KeyMod.CtrlCmd | KeyCode.KeyT,
+				secondary: isWeb ? [KeyMod.CtrlCmd | KeyCode.KeyT] : undefined
 			},
 			menu: {
 				id: MenuId.MenubarGoMenu,


### PR DESCRIPTION
Fixes #232381

## Problem

When using VS Code in the browser (e.g. GitHub Codespaces), the default `Ctrl+T` keybinding for "Go to Symbol in Workspace" is intercepted by the browser to open a new tab. This makes the command effectively inaccessible via keyboard in web contexts.

## Fix

On web, set `Ctrl+Alt+T` as the primary keybinding for `workbench.action.showAllSymbols`, while keeping `Ctrl+T` as a secondary fallback (in case the user has remapped the browser shortcut or is using a keyboard layout where it doesn't conflict). On desktop, nothing changes — `Ctrl+T` remains the primary binding.

This follows the same pattern already used for other commands that have browser conflicts, such as "New Window" and "New Untitled File".

## Test plan

- [ ] In browser (Codespaces): `Ctrl+Alt+T` opens "Go to Symbol in Workspace"
- [ ] In browser: `Ctrl+T` still works as a fallback (doesn't conflict by default, just opens a new browser tab)
- [ ] On desktop: `Ctrl+T` still opens "Go to Symbol in Workspace" as before
