### PR TITLE
fix: prevent duplicate Simple Browser panels after window reload

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -23,12 +23,22 @@ export class SimpleBrowserManager {
 		const url = typeof inputUri === 'string' ? inputUri : inputUri.toString(true);
 		if (this._activeView) {
 			this._activeView.show(url, options);
+		} else if (this._hasExistingTab()) {
+			// A Simple Browser tab already exists but hasn't been restored yet
+			// (e.g. the window was reloaded with focus on another tab).
+			// Don't create a new panel — restore() will handle it momentarily.
 		} else {
 			const view = SimpleBrowserView.create(this.extensionUri, url, options);
 			this.registerWebviewListeners(view);
 
 			this._activeView = view;
 		}
+	}
+
+	private _hasExistingTab(): boolean {
+		return vscode.window.tabGroups.all
+			.flatMap(group => group.tabs)
+			.some(tab => tab.input instanceof vscode.TabInputWebview && tab.input.viewType === SimpleBrowserView.viewType);
 	}
 
 	public restore(panel: vscode.WebviewPanel, state: any): void {


### PR DESCRIPTION
Fixes #182795

## Problem

When VS Code reloads with the Simple Browser panel open but focus on a different tab, there's a race condition that causes two Simple Browser panels to appear.

Here's what happens:
1. Window reloads. The Simple Browser panel exists but hasn't been restored yet — `_activeView` is `undefined`.
2. `simpleBrowser.api.open` is called. Since `_activeView` is `undefined`, `show()` creates a brand new panel.
3. The original panel then gets restored via `restore()`. At this point `_activeView` is already set to the new panel (from step 2), so `restore()` skips overwriting it with `_activeView ??= view`.
4. Both panels are now open simultaneously.

## Fix

Added a `_hasExistingTab()` check in `show()` that looks at `vscode.window.tabGroups` for any tab with the Simple Browser `viewType`. If one already exists (i.e., it's pending restoration), `show()` skips creating a new panel and lets `restore()` handle it.

This avoids the duplicate without affecting normal usage — when no existing tab is found, the original code path runs unchanged.

## Test plan

- [ ] Open Simple Browser, then reload the window while focused on another tab. Call `simpleBrowser.api.open` immediately — only one Simple Browser panel should appear.
- [ ] Normal flow: open Simple Browser from a fresh state — still works as expected.
- [ ] Calling `simpleBrowser.api.open` when Simple Browser is already open — still navigates the existing panel.
