### PR TITLE
Fix Disable dropdown showing both options when extension is workspace-enabled

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1751,7 +1751,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
## Description
When an extension is globally disabled but workspace-enabled, the Disable dropdown incorrectly shows both 'Disable' and 'Disable (Workspace)' options.

This happens because `DisableGloballyAction`'s `update()` condition incorrectly includes `EnabledWorkspace` state. When an extension is globally disabled, `_getUserEnablementState()` returns `EnabledWorkspace` if the extension is also workspace-enabled, causing both actions to appear enabled.

This change removes the `EnabledWorkspace` check from `DisableGloballyAction`, since an extension in `EnabledWorkspace` state is already globally disabled and should not offer 'Disable globally' as an option.

## Fixes
Fixes #244138

## Testing
- Verified existing test cases still pass
- The change only affects the `DisableGloballyAction.update()` method

## Steps to Reproduce (from issue)
1. Install extension and disable it globally
2. Enable extension for a workspace
3. Observe: Disable button shows dropdown with 'Disable' and 'Disable (Workspace)'
4. Expected: Only 'Disable (Workspace)' button without dropdown