### PR TITLE
fix: force re-render markdown cell on explicit execute even when content unchanged

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2775,6 +2775,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		const top = !!webviewTop ? (0 - webviewTop) : 0;
 
 		const cellTop = this._list.getCellViewScrollTop(cell);
+		// Force re-render when the cell was explicitly executed so that resources
+		// like images are refreshed even when the markdown content hasn't changed.
+		const executeSources = new Set(['notebook.cell.executeAndSelectBelow', 'notebook.cell.executeAndInsertBelow']);
+		const forceRender = executeSources.has(cell.editStateSource);
 		await this._webview.showMarkupPreview({
 			mime: cell.mime,
 			cellHandle: cell.handle,
@@ -2783,7 +2787,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			offset: cellTop + top,
 			visible: true,
 			metadata: cell.metadata,
-		});
+		}, forceRender);
 	}
 
 	private cellIsHidden(cell: ICellViewModel): boolean {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1344,7 +1344,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
-	async showMarkupPreview(newContent: IMarkupCellInitialization) {
+	async showMarkupPreview(newContent: IMarkupCellInitialization, forceRender = false) {
 		if (this._disposed) {
 			return;
 		}
@@ -1354,7 +1354,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			return this.createMarkupPreview(newContent);
 		}
 
-		const sameContent = newContent.content === entry.content;
+		const sameContent = !forceRender && newContent.content === entry.content;
 		const sameMetadata = (equals(newContent.metadata, entry.metadata));
 		if (!sameContent || !sameMetadata || !entry.visible) {
 			this._sendMessageToWebview({


### PR DESCRIPTION
Fixes #151151

## Problem

When a markdown cell in a Jupyter notebook is re-executed (Shift+Enter) without any content changes, images that were previously broken stay broken — even after the image file exists on disk.

The root cause is the `sameContent` check in `showMarkupPreview` (`backLayerWebView.ts`). When the markdown text hasn't changed between renders, it sends `content: undefined` to the webview, which skips re-rendering entirely. This is fine for Esc/cancel, but when the user explicitly executes the cell, they expect a fresh render that re-fetches images and other resources.

## Fix

Two small changes:

1. **`backLayerWebView.ts`**: Add a `forceRender` parameter (default `false`) to `showMarkupPreview`. When `true`, the `sameContent` check is bypassed so the full content is always sent to the webview.

2. **`notebookEditorWidget.ts`**: In `createMarkupPreview`, check `cell.editStateSource` to detect whether the preview transition came from an explicit execute action (`notebook.cell.executeAndSelectBelow` or `notebook.cell.executeAndInsertBelow`). If so, pass `forceRender: true` to `showMarkupPreview`.

This keeps the existing optimization for Esc/cancel (no re-render when content is the same) while fixing the behavior for explicit executions.

## Test plan

- [ ] Create a markdown cell with an image reference to a file that doesn't exist yet → cell renders with broken image
- [ ] Create the image file on disk
- [ ] Re-execute the cell (Shift+Enter) without changing the markdown text → image should now render correctly
- [ ] Press Esc to cancel editing (without executing) → behavior unchanged, no unnecessary re-render
