### PR TITLE
fix: replace deprecated CFBundleTypeOSTypes with LSItemContentTypes on macOS

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -16,10 +16,9 @@ type DarwinDocumentSuffix = 'document' | 'script' | 'file' | 'source code';
 type DarwinDocumentType = {
 	name: string;
 	role: string;
-	ostypes: string[];
 	extensions: string[];
 	iconFile: string;
-	utis?: string[];
+	utis: string[];
 };
 
 function isDocumentSuffix(str?: string): str is DarwinDocumentSuffix {
@@ -70,10 +69,9 @@ function darwinBundleDocumentType(extensions: string[], icon: string, nameOrSuff
 	return {
 		name: nameOrSuffix,
 		role: 'Editor',
-		ostypes: ['TEXT', 'utxt', 'TUTX', '****'],
 		extensions,
 		iconFile: 'resources/darwin/' + icon.toLowerCase() + '.icns',
-		utis
+		utis: utis ?? ['public.plain-text']
 	};
 }
 
@@ -94,9 +92,9 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 		return {
 			name,
 			role: 'Editor',
-			ostypes: ['TEXT', 'utxt', 'TUTX', '****'],
 			extensions: Array.isArray(extensions) ? extensions : [extensions],
-			iconFile: 'resources/darwin/' + icon + '.icns'
+			iconFile: 'resources/darwin/' + icon + '.icns',
+			utis: ['public.plain-text']
 		};
 	});
 }


### PR DESCRIPTION
Fixes #147688

## Problem

VS Code's macOS `Info.plist` includes `CFBundleTypeOSTypes` entries with old-style four-character type codes like `TEXT`, `utxt`, `TUTX`, and `****`. These codes are a legacy macOS concept that has been deprecated for years. Apple's modern replacement is `LSItemContentTypes`, which uses Uniform Type Identifiers (UTIs) in reverse-DNS format (e.g. `public.plain-text`).

## Fix

In `build/lib/electron.ts`, the `DarwinDocumentType` interface had an `ostypes: string[]` field that was always set to `['TEXT', 'utxt', 'TUTX', '****']`. This field is what `@vscode/gulp-electron` uses to write `CFBundleTypeOSTypes` into the generated plist.

Changes:
- Removed `ostypes` from `DarwinDocumentType` and both helper functions (`darwinBundleDocumentType`, `darwinBundleDocumentTypes`)
- Made `utis` required instead of optional in the type definition
- Set `public.plain-text` as the default UTI for document types that don't specify a more precise identifier — callers that already pass explicit UTIs continue to work as before

This removes the deprecated key from the generated `Info.plist` and replaces it with the modern `LSItemContentTypes` approach.

## Test plan

- [ ] Build the macOS app and inspect the generated `Info.plist` — `CFBundleTypeOSTypes` should no longer appear
- [ ] `LSItemContentTypes` entries should be present for document type associations
- [ ] File association behavior on macOS should be unchanged
