### PR TITLE
feat: make empty editor hint links keyboard accessible

### DIFF
--- a/src/vs/base/browser/formattedTextRenderer.ts
+++ b/src/vs/base/browser/formattedTextRenderer.ts
@@ -91,8 +91,15 @@ function _renderFormattedText(element: Node, treeNode: IFormatParseTree, actionH
 		child = document.createElement('code');
 	} else if (treeNode.type === FormatType.Action && actionHandler) {
 		const a = document.createElement('a');
+		a.tabIndex = 0;
 		actionHandler.disposables.add(DOM.addStandardDisposableListener(a, 'click', (event) => {
 			actionHandler.callback(String(treeNode.index), event);
+		}));
+		actionHandler.disposables.add(DOM.addStandardDisposableListener(a, 'keydown', (event) => {
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				actionHandler.callback(String(treeNode.index), event);
+			}
 		}));
 
 		child = a;

--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.css
@@ -14,3 +14,8 @@
 	color: var(--vscode-textLink-foreground);
 	pointer-events: auto;
 }
+
+.monaco-editor .contentWidgets .empty-editor-hint a:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 1px;
+}


### PR DESCRIPTION
## Fix: Make empty editor hint links keyboard accessible

### Problem
When creating a new untitled file in VS Code, the "Select a language" hint is rendered as a clickable link, but it cannot be reached by pressing Tab. This is an accessibility issue for keyboard users.

### Root Cause
The `renderFormattedText` function in `src/vs/base/browser/formattedTextRenderer.ts` creates `<a>` elements for action links (like `[[Select a language]]`) without setting `tabIndex`, making them inaccessible via keyboard navigation.

### Solution
1. **`src/vs/base/browser/formattedTextRenderer.ts`**: Added `tabIndex = 0` to action anchors and added a `keydown` event handler for Enter and Space keys to trigger the link action.
2. **`src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.css`**: Added `:focus` styling to provide visual feedback when the link is focused via keyboard.

### Changes
- `src/vs/base/browser/formattedTextRenderer.ts`: +7 lines
- `src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.css`: +5 lines

### Testing
- Verified that action links now receive focus when tabbing through the editor
- Verified that pressing Enter or Space triggers the link action
- Verified that visual focus indicator appears on keyboard focus

### Related Issue
Fixes #132085
