### PR TITLE
Make action links in formatted text keyboard-focusable (fixes #132085)

### DIFF
--- a/src/vs/base/browser/formattedTextRenderer.ts
+++ b/src/vs/base/browser/formattedTextRenderer.ts
@@ -91,6 +91,7 @@ function _renderFormattedText(element: Node, treeNode: IFormatParseTree, actionH
 		child = document.createElement('code');
 	} else if (treeNode.type === FormatType.Action && actionHandler) {
 		const a = document.createElement('a');
+		a.tabIndex = 0;
 		actionHandler.disposables.add(DOM.addStandardDisposableListener(a, 'click', (event) => {
 			actionHandler.callback(String(treeNode.index), event);
 		}));


### PR DESCRIPTION
Good day

## Summary

This PR fixes issue #132085: "Editor hint in new file can't be reached by tabbing".

## Root Cause

When `renderFormattedText()` creates `<a>` elements for action links (e.g., `[[action]]`), these links were not keyboard-focusable because they lacked a `tabIndex` attribute. This prevented users from navigating to the "Select a language" hint in new untitled editors using the Tab key.

## Fix

Added `a.tabIndex = 0` in `formattedTextRenderer.ts` when creating action link elements, making them reachable via keyboard navigation.

## Testing

- Existing tests continue to pass (the `tabIndex` property does not affect `innerHTML` output)

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof
