### PR TITLE
fix: correct extension disable dropdown for workspace-only enabled state

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

## Summary
When an extension is disabled globally but enabled for a workspace, the Disable button dropdown incorrectly shows both "Disable" and "Disable (Workspace)" items.

## Root cause
`DisableGloballyAction.update()` checks for both `EnabledGlobally` and `EnabledWorkspace` enablement states. When an extension is disabled globally but enabled for workspace (`EnabledWorkspace`), both `DisableGloballyAction` and `DisableForWorkspaceAction` become enabled, causing both to appear in the dropdown.

## Fix
Changed `DisableGloballyAction` to only be enabled when the extension's enablement state is `EnabledGlobally`. When the extension is only enabled at the workspace level, the global disable action is no longer shown since the extension is already disabled globally.

## Test plan
1. Install an extension and disable it globally
2. Enable the extension for the current workspace
3. Verify the Disable button shows only "Disable (Workspace)" without a dropdown