### PR TITLE
Fix devcontainer check-requirements-linux.sh to handle quoted ID values in /etc/os-release

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## Summary

The devcontainer setup script `check-requirements-linux.sh` fails to parse `OS_ID` on Rocky Linux 8.5 because it uses quoted values in `/etc/os-release` (e.g., `ID="rocky"`).

## Root Cause

The original grep+sed approach:
```bash
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
```

This only matches unquoted formats (`ID=rocky`) and returns empty for quoted formats (`ID="rocky"`), causing the script to exit with code 1.

## Fix

Use `source /etc/os-release` which properly handles both quoted and unquoted values:

```bash
OS_ID=$(source /etc/os-release && echo $ID)
```

This runs in a subshell so it doesn't pollute the current shell environment.

## Testing

Verified the fix works correctly:
- **Old approach** on quoted format: `OS_ID=''` (empty/fail)
- **New approach** on quoted format: `OS_ID='rocky'` ✓
- **New approach** on unquoted format: `OS_ID='rocky'` ✓

## Related

Fixes #232159

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof