### PR TITLE
fix: improve touch support for sessions app pickers and overlays

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -114,6 +114,7 @@
 	border-radius: 4px;
 	font-size: 13px;
 	cursor: pointer;
+	touch-action: manipulation;
 	color: var(--vscode-icon-foreground);
 	white-space: nowrap;
 	min-width: 0;

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -140,6 +140,7 @@
 	background-color: transparent;
 	color: var(--vscode-foreground);
 	border-radius: 4px;
+	touch-action: manipulation;
 }
 
 .sessions-chat-picker-slot.sessions-chat-workspace-picker .action-label:hover {
@@ -187,6 +188,7 @@
 	color: var(--vscode-icon-foreground);
 	font-size: 13px;
 	cursor: pointer;
+	touch-action: manipulation;
 	white-space: nowrap;
 	border-radius: 4px;
 	min-width: 0;

--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { $, addDisposableListener, append, EventType } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableListener, append, EventType } from '../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { Action, IAction } from '../../../../base/common/actions.js';
@@ -432,7 +432,7 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 			quickWidget.widget = widget.domNode;
 			this._layoutService.mainContainer.classList.add(RUN_SCRIPT_ACTION_MODAL_VISIBLE_CLASS);
 			const backdrop = append(this._layoutService.mainContainer, $('.run-script-action-modal-backdrop'));
-			disposables.add(addDisposableListener(backdrop, EventType.MOUSE_DOWN, e => {
+			disposables.add(addDisposableGenericMouseDownListener(backdrop, e => {
 				e.preventDefault();
 				e.stopPropagation();
 				complete(undefined);

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -5,7 +5,7 @@
 
 import './media/sessionsPolicyBlocked.css';
 import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { $, append, EventType, addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, append, EventType, addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
 import { localize } from '../../../../nls.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
@@ -50,7 +50,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 
 		// Block mouse interaction on the overlay background, but allow
 		// clicks through to card children (e.g. the "Open VS Code" button).
-		this._register(addDisposableListener(this.overlay, EventType.MOUSE_DOWN, e => {
+		this._register(addDisposableGenericMouseDownListener(this.overlay, e => {
 			if (e.target === this.overlay) {
 				e.preventDefault();
 				e.stopPropagation();

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -56,6 +56,8 @@
 	border-radius: 4px;
 	min-width: 0;
 	max-width: 600px;
+	cursor: pointer;
+	touch-action: manipulation;
 }
 
 .command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-pill:hover {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/sessionsTitleBarWidget.css';
-import { $, addDisposableListener, EventType, getActiveWindow, reset } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, addDisposableListener, EventType, getActiveWindow, reset } from '../../../../base/browser/dom.js';
 import { Separator } from '../../../../base/common/actions.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
@@ -186,7 +186,7 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			sessionPill.appendChild(centerGroup);
 
 			// Click handler on pill
-			this._dynamicDisposables.add(addDisposableListener(sessionPill, EventType.MOUSE_DOWN, (e) => {
+			this._dynamicDisposables.add(addDisposableGenericMouseDownListener(sessionPill, (e) => {
 				e.preventDefault();
 				e.stopPropagation();
 			}));

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -6,7 +6,7 @@
 import './media/sessionsWalkthrough.css';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { $, append, EventType, addDisposableListener, getActiveElement, isHTMLElement } from '../../../../base/browser/dom.js';
+import { $, addDisposableGenericMouseDownListener, append, EventType, addDisposableListener, getActiveElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -84,7 +84,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				this._trapFocus(e);
 			}
 		}));
-		this._register(addDisposableListener(this.overlay, EventType.MOUSE_DOWN, e => {
+		this._register(addDisposableGenericMouseDownListener(this.overlay, e => {
 			if (e.target === this.overlay) {
 				e.preventDefault();
 				e.stopPropagation();


### PR DESCRIPTION
Replace EventType.MOUSE_DOWN with addDisposableGenericMouseDownListener for overlay dismissal in runScriptAction, sessionsWalkthrough, sessionsPolicyBlocked, and sessionsTitleBarWidget. This uses POINTER_DOWN on iOS where pointer events are available.

Add `touch-action: manipulation` to picker trigger elements and the session title bar pill to eliminate the 300ms tap delay on touch devices.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
