### PR TITLE
Include cached tokens in copilot debug log file output

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -932,6 +932,9 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 						...(span.attributes[GenAiAttr.USAGE_OUTPUT_TOKENS] !== undefined
 							? { outputTokens: asNumber(span.attributes[GenAiAttr.USAGE_OUTPUT_TOKENS]) }
 							: {}),
+						...(span.attributes[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS] !== undefined
+							? { cachedTokens: asNumber(span.attributes[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]) }
+							: {}),
 						...(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN] !== undefined
 							? { ttft: asNumber(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN]) }
 							: {}),

--- a/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
@@ -48,7 +48,7 @@ function makeToolCallSpan(sessionId: string, toolName: string): ICompletedSpanDa
 	});
 }
 
-function makeChatSpan(sessionId: string, model: string, inputTokens: number, outputTokens: number): ICompletedSpanData {
+function makeChatSpan(sessionId: string, model: string, inputTokens: number, outputTokens: number, cachedTokens?: number): ICompletedSpanData {
 	return makeSpan({
 		name: 'chat',
 		attributes: {
@@ -56,6 +56,7 @@ function makeChatSpan(sessionId: string, model: string, inputTokens: number, out
 			[GenAiAttr.REQUEST_MODEL]: model,
 			[GenAiAttr.USAGE_INPUT_TOKENS]: inputTokens,
 			[GenAiAttr.USAGE_OUTPUT_TOKENS]: outputTokens,
+			...(cachedTokens !== undefined ? { [GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]: cachedTokens } : {}),
 			[CopilotChatAttr.CHAT_SESSION_ID]: sessionId,
 		},
 	});
@@ -224,7 +225,7 @@ describe('ChatDebugFileLoggerService', () => {
 
 	it('writes LLM request with token counts', async () => {
 		await service.startSession('session-1');
-		const span = makeChatSpan('session-1', 'gpt-4o', 1000, 500);
+		const span = makeChatSpan('session-1', 'gpt-4o', 1000, 500, 250);
 		otelService.fireSpan(span);
 
 		await service.flush('session-1');
@@ -237,7 +238,7 @@ describe('ChatDebugFileLoggerService', () => {
 		expect(attrs.model).toBe('gpt-4o');
 		expect(attrs.inputTokens).toBe(1000);
 		expect(attrs.outputTokens).toBe(500);
-		expect(attrs.cachedTokens).toBeUndefined();
+		expect(attrs.cachedTokens).toBe(250);
 	});
 
 	it('records error status from failed spans', async () => {

--- a/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/test/chatDebugFileLoggerService.spec.ts
@@ -237,6 +237,7 @@ describe('ChatDebugFileLoggerService', () => {
 		expect(attrs.model).toBe('gpt-4o');
 		expect(attrs.inputTokens).toBe(1000);
 		expect(attrs.outputTokens).toBe(500);
+		expect(attrs.cachedTokens).toBeUndefined();
 	});
 
 	it('records error status from failed spans', async () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
PR implements #311186. 

Simply includes the `USAGE_CACHE_READ_INPUT_TOKENS` as pulled from OTEL. updated the `writes LLM request with token counts` test with a cachedTokens value. 

Testing:
1. Run unit tests
2. Build and run the code-oss-dev
- Open a directory
- Spawn a GitHub Copilot chat interaction that will hit the LLM 
- Load the debug log, on my macos setup ~/Library/Application Support/code-oss-dev/User/workspaceStorage/<workspace_id>/GitHub.copilot-chat/debug-logs/<session_id>/main.jsonl 
- Search for `cachedTokens` 
  - New output in my testing looks like `{"model":"claude-opus-4.6","inputTokens":22891,"outputTokens":229,"cachedTokens":22559,` 