### PR TITLE
Fix: Disable dropdown shows both 'Disable' and 'Disable (Workspace)' when extension is workspace-enabled

### DIFF
--- a/src/vs/base/browser/formattedTextRenderer.ts
+++ b/src/vs/base/browser/formattedTextRenderer.ts
@@ -91,6 +91,7 @@ function _renderFormattedText(element: Node, treeNode: IFormatParseTree, actionH
 		child = document.createElement('code');
 	} else if (treeNode.type === FormatType.Action && actionHandler) {
 		const a = document.createElement('a');
+		a.tabIndex = 0;
 		actionHandler.disposables.add(DOM.addStandardDisposableListener(a, 'click', (event) => {
 			actionHandler.callback(String(treeNode.index), event);
 		}));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
## Summary

When an extension is disabled globally but enabled for workspace (`EnabledWorkspace` state), the disable button incorrectly shows a dropdown containing both **'Disable'** and **'Disable (Workspace)'** options.

## Root Cause

In `src/vs/workbench/contrib/extensions/browser/extensionsActions.ts`, `DisableGloballyAction` was enabled for both `EnabledGlobally` and `EnabledWorkspace` states. When in `EnabledWorkspace`, the extension is already disabled globally — offering to disable it globally again is incorrect.

## Fix

Changed the condition to only enable `DisableGloballyAction` when `enablementState === EnabledGlobally`:

```typescript
this.enabled = this.extension.state === ExtensionState.Installed
    && this.extension.enablementState === EnablementState.EnabledGlobally
    && this.extensionEnablementService.canChangeEnablement(this.extension.local);
```

Fixes #244138

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.
Warmly, RoomWithOutRoof