### PR TITLE
Bake transcript pointer into conversation summaries at creation time

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -9,6 +9,7 @@ import { BudgetExceededError } from '@vscode/prompt-tsx/dist/base/materialized';
 import type * as vscode from 'vscode';
 import { IChatSessionService } from '../../../platform/chat/common/chatSessionService';
 import { ChatFetchResponseType, ChatLocation, ChatResponse } from '../../../platform/chat/common/commonTypes';
+import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { isAnthropicFamily, isGptFamily, modelCanUseApplyPatchExclusively, modelCanUseReplaceStringExclusively, modelSupportsApplyPatch, modelSupportsMultiReplaceString, modelSupportsReplaceString, modelSupportsSimplifiedApplyPatchInstructions } from '../../../platform/endpoint/common/chatModelCapabilities';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
@@ -47,7 +48,7 @@ import { IBuildPromptResult, IIntent, IIntentInvocation } from '../../prompt/nod
 import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPrompt';
 import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
-import { extractInlineSummary, InlineSummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../../prompts/node/agent/summarizedConversationHistory';
+import { extractInlineSummary, InlineSummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary } from '../../prompts/node/agent/summarizedConversationHistory';
 import { PromptRenderer, renderPromptElement } from '../../prompts/node/base/promptRenderer';
 import { ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { EditCodePrompt2 } from '../../prompts/node/panel/editCodePrompt2';
@@ -388,6 +389,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		@IExperimentationService private readonly expService: IExperimentationService,
 		@IAutomodeService private readonly automodeService: IAutomodeService,
 		@IOTelService override readonly otelService: IOTelService,
+		@ISessionTranscriptService private readonly sessionTranscriptService: ISessionTranscriptService,
 	) {
 		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, otelService);
 	}
@@ -860,13 +862,22 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					if (response.type !== ChatFetchResponseType.Success) {
 						throw new Error(`Background inline summarization request failed: ${response.type}`);
 					}
-					const summaryText = extractInlineSummary(response.value);
-					if (!summaryText) {
+					const rawSummaryText = extractInlineSummary(response.value);
+					if (!rawSummaryText) {
 						throw new Error('Background inline summarization: no <summary> tags found in response');
 					}
 					if (!toolCallRoundId) {
 						throw new Error('Background inline summarization: no round ID to apply summary to');
 					}
+					// Flush the transcript before snapshotting the line count so
+					// the baked "N lines" hint matches the on-disk file at this
+					// moment (mirrors the full/simple path in SummarizedConversationHistory.render).
+					if (conversationId && this.sessionTranscriptService.getTranscriptPath(conversationId)) {
+						await this.sessionTranscriptService.flush(conversationId);
+					}
+					const summaryText = conversationId
+						? appendTranscriptHintToSummary(rawSummaryText, conversationId, this.sessionTranscriptService)
+						: rawSummaryText;
 					this.logService.debug(`[ConversationHistorySummarizer] background inline compaction completed (${summaryText.length} chars, roundId=${toolCallRoundId})`);
 
 					// Send summarizedConversationHistory telemetry for parity

--- a/extensions/copilot/src/extension/intents/node/askAgentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/askAgentIntent.ts
@@ -14,6 +14,7 @@ import { IEditLogService } from '../../../platform/multiFileEdit/common/editLogS
 import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { INotebookService } from '../../../platform/notebook/common/notebookService';
 import { IOTelService } from '../../../platform/otel/common/otelService';
+import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -128,8 +129,9 @@ export class AskAgentIntentInvocation extends AgentIntentInvocation {
 		@IExperimentationService expService: IExperimentationService,
 		@IAutomodeService automodeService: IAutomodeService,
 		@IOTelService otelService: IOTelService,
+		@ISessionTranscriptService sessionTranscriptService: ISessionTranscriptService,
 	) {
-		super(intent, location, endpoint, request, { processCodeblocks: true }, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService);
+		super(intent, location, endpoint, request, { processCodeblocks: true }, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService, sessionTranscriptService);
 	}
 
 	public override async getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {

--- a/extensions/copilot/src/extension/intents/node/editCodeIntent2.ts
+++ b/extensions/copilot/src/extension/intents/node/editCodeIntent2.ts
@@ -16,6 +16,7 @@ import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { requestHasNotebookRefs } from '../../../platform/notebook/common/helpers';
 import { INotebookService } from '../../../platform/notebook/common/notebookService';
 import { IOTelService } from '../../../platform/otel/common/otelService';
+import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -89,8 +90,9 @@ export class EditCode2IntentInvocation extends AgentIntentInvocation {
 		@IExperimentationService expService: IExperimentationService,
 		@IAutomodeService automodeService: IAutomodeService,
 		@IOTelService otelService: IOTelService,
+		@ISessionTranscriptService sessionTranscriptService: ISessionTranscriptService,
 	) {
-		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService);
+		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService, sessionTranscriptService);
 	}
 
 	public override async getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {

--- a/extensions/copilot/src/extension/intents/node/notebookEditorIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/notebookEditorIntent.ts
@@ -16,6 +16,7 @@ import { IAlternativeNotebookContentService } from '../../../platform/notebook/c
 import { getCellId } from '../../../platform/notebook/common/helpers';
 import { INotebookService } from '../../../platform/notebook/common/notebookService';
 import { IOTelService } from '../../../platform/otel/common/otelService';
+import { ISessionTranscriptService } from '../../../platform/chat/common/sessionTranscriptService';
 import { IPromptPathRepresentationService } from '../../../platform/prompts/common/promptPathRepresentationService';
 import { ITabsAndEditorsService } from '../../../platform/tabs/common/tabsAndEditorsService';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
@@ -107,8 +108,9 @@ export class NotebookEditorIntentInvocation extends EditCode2IntentInvocation {
 		@IExperimentationService expService: IExperimentationService,
 		@IAutomodeService automodeService: IAutomodeService,
 		@IOTelService otelService: IOTelService,
+		@ISessionTranscriptService sessionTranscriptService: ISessionTranscriptService,
 	) {
-		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService);
+		super(intent, location, endpoint, request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, logService, expService, automodeService, otelService, sessionTranscriptService);
 	}
 
 	protected override prompt = NotebookInlinePrompt;

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -424,8 +424,6 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 	override async render(state: void, sizing: PromptSizing, progress: Progress<ChatResponsePart> | undefined, token: CancellationToken | undefined) {
 		const promptContext = { ...this.props.promptContext };
 		let historyMetadata: SummarizedConversationHistoryMetadata | undefined;
-		// Resolve transcript path and flush to disk so the model can read the up-to-date file
-		let transcriptPath: string | undefined;
 		const sessionId = this.props.promptContext.conversation?.sessionId;
 		if (sessionId) {
 			// Lazily start the transcript session now (before summarization) so it
@@ -433,10 +431,8 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 			// idempotent — if hooks already started it, this is a no-op.
 			await this.ensureTranscriptSession();
 
-			const transcriptUri = this.sessionTranscriptService.getTranscriptPath(sessionId);
-			if (transcriptUri) {
+			if (this.sessionTranscriptService.getTranscriptPath(sessionId)) {
 				await this.sessionTranscriptService.flush(sessionId);
-				transcriptPath = transcriptUri.fsPath;
 			}
 		}
 
@@ -445,20 +441,7 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 			const summarizer = this.instantiationService.createInstance(ConversationHistorySummarizer, this.props, sizing, progress, token);
 			const summResult = await summarizer.summarizeHistory();
 			if (summResult) {
-				// Bake the transcript hint into the summary text so it is
-				// frozen at compaction time and never changes on subsequent renders
-				// (preserving Anthropic prompt cache stability).
-				let summary = summResult.summary;
-				if (transcriptPath) {
-					const lineCount = this.sessionTranscriptService.getLineCount(sessionId!);
-					summary += `\nIf you need specific details from before compaction (such as exact code snippets, error messages, tool results, or content you previously generated), use the ${ToolName.ReadFile} tool to look up the full uncompacted conversation transcript at: "${transcriptPath}"`;
-					if (lineCount !== undefined) {
-						summary += `\nAt the time of this request, the transcript has ${lineCount} lines.`;
-					}
-					summary += `\nExample usage: ${ToolName.ReadFile}(filePath: "${transcriptPath}")`;
-				}
-
-				historyMetadata = new SummarizedConversationHistoryMetadata(summResult.toolCallRoundId, summary, {
+				historyMetadata = new SummarizedConversationHistoryMetadata(summResult.toolCallRoundId, summResult.summary, {
 					thinking: summResult.thinking,
 					usage: summResult.usage,
 					promptTokenDetails: summResult.promptTokenDetails,
@@ -468,7 +451,7 @@ export class SummarizedConversationHistory extends PromptElement<SummarizedAgent
 					numRoundsSinceLastSummarization: summResult.numRoundsSinceLastSummarization,
 					durationMs: summResult.durationMs,
 				});
-				this.addSummaryToHistory(summary, summResult.toolCallRoundId, summResult.thinking);
+				this.addSummaryToHistory(summResult.summary, summResult.toolCallRoundId, summResult.thinking);
 			}
 		}
 
@@ -569,6 +552,7 @@ class ConversationHistorySummarizer {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatHookService private readonly chatHookService: IChatHookService,
+		@ISessionTranscriptService private readonly sessionTranscriptService: ISessionTranscriptService,
 	) { }
 
 	async summarizeHistory(): Promise<{ summary: string; toolCallRoundId: string; thinking?: ThinkingData; usage?: APIUsage; promptTokenDetails?: readonly ChatResultPromptTokenDetail[]; model?: string; summarizationMode?: string; numRounds?: number; numRoundsSinceLastSummarization?: number; durationMs?: number }> {
@@ -589,7 +573,7 @@ class ConversationHistorySummarizer {
 		const summary = await summaryPromise;
 		const { numRounds, numRoundsSinceLastSummarization } = this.computeRoundCounts();
 		return {
-			summary: summary.result.value,
+			summary: this.appendTranscriptHint(summary.result.value),
 			toolCallRoundId: propsInfo.summarizedToolCallRoundId,
 			thinking: propsInfo.summarizedThinking,
 			usage: summary.result.usage,
@@ -600,6 +584,14 @@ class ConversationHistorySummarizer {
 			numRoundsSinceLastSummarization,
 			durationMs: summary.durationMs,
 		};
+	}
+
+	private appendTranscriptHint(summary: string): string {
+		const sessionId = this.props.promptContext.conversation?.sessionId;
+		if (!sessionId) {
+			return summary;
+		}
+		return appendTranscriptHintToSummary(summary, sessionId, this.sessionTranscriptService);
 	}
 
 	private async getSummaryWithFallback(propsInfo: ISummarizedConversationHistoryInfo): Promise<SummarizationResult> {
@@ -924,6 +916,35 @@ function replaceImageContentWithPlaceholders(messages: ChatMessage[]): void {
 			return part;
 		});
 	});
+}
+
+/**
+ * Bake a stable transcript pointer into a freshly-produced summary text.
+ *
+ * Shared by both the full/simple summarization path
+ * ({@link ConversationHistorySummarizer}) and the inline background
+ * summarization path in `agentIntent.ts`. The hint is appended exactly once,
+ * at summary creation time, so the resulting string is frozen from then on
+ * and replayed verbatim — preserving Anthropic prompt cache hits across
+ * subsequent renders.
+ *
+ * Returns the input unchanged when there is no transcript on disk for the
+ * session.
+ */
+export function appendTranscriptHintToSummary(summary: string, sessionId: string, sessionTranscriptService: ISessionTranscriptService): string {
+	const transcriptUri = sessionTranscriptService.getTranscriptPath(sessionId);
+	if (!transcriptUri) {
+		return summary;
+	}
+	const transcriptPath = transcriptUri.fsPath;
+	const lineCount = sessionTranscriptService.getLineCount(sessionId);
+	let out = summary;
+	out += `\nIf you need specific details from before compaction (such as exact code snippets, error messages, tool results, or content you previously generated), use the ${ToolName.ReadFile} tool to look up the full uncompacted conversation transcript at: "${transcriptPath}"`;
+	if (lineCount !== undefined) {
+		out += `\nAt the time this summary was created, the transcript had ${lineCount} lines.`;
+	}
+	out += `\nExample usage: ${ToolName.ReadFile}(filePath: "${transcriptPath}")`;
+	return out;
 }
 
 /**

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -30,7 +30,8 @@ import { ToolName } from '../../../../tools/common/toolNames';
 import { PromptRenderer } from '../../base/promptRenderer';
 import { AgentPrompt, AgentPromptProps } from '../agentPrompt';
 import { PromptRegistry } from '../promptRegistry';
-import { ConversationHistorySummarizationPrompt, extractInlineSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
+import { ISessionTranscriptService, NullSessionTranscriptService } from '../../../../../platform/chat/common/sessionTranscriptService';
+import { appendTranscriptHintToSummary, ConversationHistorySummarizationPrompt, extractInlineSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
 
 suite('Agent Summarization', () => {
 	let accessor: ITestingServicesAccessor;
@@ -668,5 +669,46 @@ suite('stripToolSearchMessages', () => {
 		expect(result).toHaveLength(5);
 		expect(result[0].content[0]).toEqual({ type: Raw.ChatCompletionContentPartKind.Text, text: 'first' });
 		expect(result[2].content[0]).toEqual({ type: Raw.ChatCompletionContentPartKind.Text, text: 'second' });
+	});
+});
+
+suite('appendTranscriptHintToSummary', () => {
+	class FakeTranscriptService extends NullSessionTranscriptService {
+		constructor(
+			private readonly path: URI | undefined,
+			private readonly lineCount: number | undefined,
+		) {
+			super();
+		}
+		override getTranscriptPath(): URI | undefined { return this.path; }
+		override getLineCount(): number | undefined { return this.lineCount; }
+	}
+
+	function makeService(path: URI | undefined, lineCount: number | undefined): ISessionTranscriptService {
+		return new FakeTranscriptService(path, lineCount);
+	}
+
+	test('returns summary unchanged when no transcript path is available', () => {
+		const svc = makeService(undefined, undefined);
+		const result = appendTranscriptHintToSummary('original summary', 'session-1', svc);
+		expect(result).toBe('original summary');
+	});
+
+	test('appends path-only hint when line count is missing', () => {
+		const transcript = URI.file('/tmp/transcript.jsonl');
+		const svc = makeService(transcript, undefined);
+		const result = appendTranscriptHintToSummary('S', 'session-1', svc);
+		expect(result.startsWith('S\n')).toBe(true);
+		expect(result).toContain(transcript.fsPath);
+		expect(result).toContain(`${ToolName.ReadFile}`);
+		expect(result).not.toContain('the transcript had');
+	});
+
+	test('bakes line count snapshot into hint when available', () => {
+		const transcript = URI.file('/tmp/transcript.jsonl');
+		const svc = makeService(transcript, 42);
+		const result = appendTranscriptHintToSummary('S', 'session-1', svc);
+		expect(result).toContain('At the time this summary was created, the transcript had 42 lines.');
+		expect(result).toContain(transcript.fsPath);
 	});
 });


### PR DESCRIPTION
For inline background compaction only (legacy background compaction already supports this) - Append a stable transcript-file hint (path + line-count snapshot) to every conversation summary, so after compaction the model can read the uncompacted transcript on disk via \`read_file\`.
