### PR TITLE
Fix: hide browser on overlays within shadow roots

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/overlayManager.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/overlayManager.ts
@@ -262,7 +262,11 @@ export class BrowserOverlayManager extends Disposable implements IBrowserOverlay
 				// (the overlay either doesn't cover the element, or is also covered by another overlay).
 				const clientX = overlapCenter.x - this.targetWindow.scrollX;
 				const clientY = overlapCenter.y - this.targetWindow.scrollY;
-				const elementAtPoint = this.targetWindow.document.elementFromPoint(clientX, clientY);
+				let elementAtPoint = this.targetWindow.document.elementFromPoint(clientX, clientY);
+				// Account for shadow roots
+				if (elementAtPoint?.shadowRoot && !overlay.element.contains(elementAtPoint)) {
+					elementAtPoint = elementAtPoint.shadowRoot.elementFromPoint(clientX, clientY);
+				}
 				if (elementAtPoint && overlay.element.contains(elementAtPoint)) {
 					overlappingOverlays.push({
 						type: overlay.type,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/311149