### PR TITLE
Render search/glob tool messages as markdown in agent host

### DIFF
--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -173,6 +173,23 @@ export function appendEscapedMarkdownCodeBlockFence(code: string, langId: string
 	].join('\n');
 }
 
+/**
+ * Wraps arbitrary text in a markdown inline code span using a backtick fence
+ * long enough to safely contain any backtick sequences present in the text.
+ *
+ * Backticks inside an inline code span cannot be backslash-escaped per the
+ * CommonMark spec — the only safe way is to choose a delimiter run longer
+ * than any run of backticks in the content (and pad with spaces if the
+ * content begins or ends with a backtick).
+ */
+export function appendEscapedMarkdownInlineCode(text: string): string {
+	const longestBacktickRun = Math.max(0, ...(text.match(/`+/g) ?? []).map(m => m.length));
+	const fence = '`'.repeat(longestBacktickRun + 1);
+	const needsSpace = text.startsWith('`') || text.endsWith('`');
+	const content = needsSpace ? ` ${text} ` : text;
+	return `${fence}${content}${fence}`;
+}
+
 export function escapeDoubleQuotes(input: string) {
 	return input.replace(/"/g, '&quot;');
 }

--- a/src/vs/base/test/common/htmlContent.test.ts
+++ b/src/vs/base/test/common/htmlContent.test.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import { appendEscapedMarkdownInlineCode } from '../../common/htmlContent.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
+
+suite('htmlContent', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('appendEscapedMarkdownInlineCode', () => {
+		test('wraps plain text in single backticks', () => {
+			assert.strictEqual(appendEscapedMarkdownInlineCode('hello'), '`hello`');
+			assert.strictEqual(appendEscapedMarkdownInlineCode(''), '``');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('foo bar'), '`foo bar`');
+		});
+
+		test('chooses a fence longer than any backtick run in the content', () => {
+			assert.strictEqual(appendEscapedMarkdownInlineCode('a`b'), '``a`b``');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('a``b'), '```a``b```');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('a```b```c'), '````a```b```c````');
+		});
+
+		test('pads with spaces when the content begins or ends with a backtick', () => {
+			assert.strictEqual(appendEscapedMarkdownInlineCode('`'), '`` ` ``');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('`hello'), '`` `hello ``');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('hello`'), '`` hello` ``');
+			assert.strictEqual(appendEscapedMarkdownInlineCode('`a`b`'), '`` `a`b` ``');
+		});
+
+		test('does not pad when backticks are only in the interior', () => {
+			assert.strictEqual(appendEscapedMarkdownInlineCode('a`b'), '``a`b``');
+		});
+
+		test('handles content composed entirely of backticks', () => {
+			assert.strictEqual(appendEscapedMarkdownInlineCode('``'), '``` `` ```');
+		});
+	});
+});

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -157,6 +157,15 @@ function truncate(text: string, maxLength: number): string {
 }
 
 /**
+ * Escapes backticks in a value that will be embedded inside an inline-code
+ * span (`` `...` ``) in a markdown string, so the value can't break out of
+ * the code span.
+ */
+function escapeMdInlineCode(value: string): string {
+	return value.replace(/`/g, '\\`');
+}
+
+/**
  * Formats a file path as a markdown link `[](file-uri)` so it renders
  * as a clickable file widget in the chat UI.
  */
@@ -203,7 +212,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return md(localize('toolInvoke.shellCmd', "Running `{0}`", truncate(firstLine, 80)));
+			return md(localize('toolInvoke.shellCmd', "Running {0}", '`' + escapeMdInlineCode(truncate(firstLine, 80)) + '`'));
 		}
 		return localize('toolInvoke.shell', "Running {0} command", displayName);
 	}
@@ -233,14 +242,14 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolInvoke.grepPattern', "Searching for `{0}`", truncate(args.pattern, 80)));
+				return md(localize('toolInvoke.grepPattern', "Searching for {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
 			}
 			return localize('toolInvoke.grep', "Searching files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolInvoke.globPattern', "Finding files matching `{0}`", truncate(args.pattern, 80)));
+				return md(localize('toolInvoke.globPattern', "Finding files matching {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
 			}
 			return localize('toolInvoke.glob', "Finding files");
 		}
@@ -258,7 +267,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return md(localize('toolComplete.shellCmd', "Ran `{0}`", truncate(firstLine, 80)));
+			return md(localize('toolComplete.shellCmd', "Ran {0}", '`' + escapeMdInlineCode(truncate(firstLine, 80)) + '`'));
 		}
 		return localize('toolComplete.shell', "Ran {0} command", displayName);
 	}
@@ -288,14 +297,14 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolComplete.grepPattern', "Searched for `{0}`", truncate(args.pattern, 80)));
+				return md(localize('toolComplete.grepPattern', "Searched for {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
 			}
 			return localize('toolComplete.grep', "Searched files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolComplete.globPattern', "Found files matching `{0}`", truncate(args.pattern, 80)));
+				return md(localize('toolComplete.globPattern', "Found files matching {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
 			}
 			return localize('toolComplete.glob', "Found files");
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -6,6 +6,7 @@
 import type { PermissionRequest } from '@github/copilot-sdk';
 import { hasKey } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
+import { appendEscapedMarkdownInlineCode } from '../../../../base/common/htmlContent.js';
 import { localize } from '../../../../nls.js';
 import type { IAgentToolReadyEvent } from '../../common/agentService.js';
 import { StringOrMarkdown } from '../../common/state/protocol/state.js';
@@ -157,15 +158,6 @@ function truncate(text: string, maxLength: number): string {
 }
 
 /**
- * Escapes backticks in a value that will be embedded inside an inline-code
- * span (`` `...` ``) in a markdown string, so the value can't break out of
- * the code span.
- */
-function escapeMdInlineCode(value: string): string {
-	return value.replace(/`/g, '\\`');
-}
-
-/**
  * Formats a file path as a markdown link `[](file-uri)` so it renders
  * as a clickable file widget in the chat UI.
  */
@@ -212,7 +204,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return md(localize('toolInvoke.shellCmd', "Running {0}", '`' + escapeMdInlineCode(truncate(firstLine, 80)) + '`'));
+			return md(localize('toolInvoke.shellCmd', "Running {0}", appendEscapedMarkdownInlineCode(truncate(firstLine, 80))));
 		}
 		return localize('toolInvoke.shell', "Running {0} command", displayName);
 	}
@@ -242,14 +234,14 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolInvoke.grepPattern', "Searching for {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
+				return md(localize('toolInvoke.grepPattern', "Searching for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolInvoke.grep', "Searching files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolInvoke.globPattern', "Finding files matching {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
+				return md(localize('toolInvoke.globPattern', "Finding files matching {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolInvoke.glob', "Finding files");
 		}
@@ -267,7 +259,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return md(localize('toolComplete.shellCmd', "Ran {0}", '`' + escapeMdInlineCode(truncate(firstLine, 80)) + '`'));
+			return md(localize('toolComplete.shellCmd', "Ran {0}", appendEscapedMarkdownInlineCode(truncate(firstLine, 80))));
 		}
 		return localize('toolComplete.shell', "Ran {0} command", displayName);
 	}
@@ -297,14 +289,14 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolComplete.grepPattern', "Searched for {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
+				return md(localize('toolComplete.grepPattern', "Searched for {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolComplete.grep', "Searched files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return md(localize('toolComplete.globPattern', "Found files matching {0}", '`' + escapeMdInlineCode(truncate(args.pattern, 80)) + '`'));
+				return md(localize('toolComplete.globPattern', "Found files matching {0}", appendEscapedMarkdownInlineCode(truncate(args.pattern, 80))));
 			}
 			return localize('toolComplete.glob', "Found files");
 		}

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -233,14 +233,14 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return localize('toolInvoke.grepPattern', "Searching for `{0}`", truncate(args.pattern, 80));
+				return md(localize('toolInvoke.grepPattern', "Searching for `{0}`", truncate(args.pattern, 80)));
 			}
 			return localize('toolInvoke.grep', "Searching files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return localize('toolInvoke.globPattern', "Finding files matching `{0}`", truncate(args.pattern, 80));
+				return md(localize('toolInvoke.globPattern', "Finding files matching `{0}`", truncate(args.pattern, 80)));
 			}
 			return localize('toolInvoke.glob', "Finding files");
 		}
@@ -258,7 +258,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
 			const firstLine = args.command.split('\n')[0];
-			return localize('toolComplete.shellCmd', "Ran `{0}`", truncate(firstLine, 80));
+			return md(localize('toolComplete.shellCmd', "Ran `{0}`", truncate(firstLine, 80)));
 		}
 		return localize('toolComplete.shell', "Ran {0} command", displayName);
 	}
@@ -288,14 +288,14 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		case CopilotToolName.Grep: {
 			const args = parameters as ICopilotGrepToolArgs | undefined;
 			if (args?.pattern) {
-				return localize('toolComplete.grepPattern', "Searched for `{0}`", truncate(args.pattern, 80));
+				return md(localize('toolComplete.grepPattern', "Searched for `{0}`", truncate(args.pattern, 80)));
 			}
 			return localize('toolComplete.grep', "Searched files");
 		}
 		case CopilotToolName.Glob: {
 			const args = parameters as ICopilotGlobToolArgs | undefined;
 			if (args?.pattern) {
-				return localize('toolComplete.globPattern', "Found files matching `{0}`", truncate(args.pattern, 80));
+				return md(localize('toolComplete.globPattern', "Found files matching `{0}`", truncate(args.pattern, 80)));
 			}
 			return localize('toolComplete.glob', "Found files");
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -6,7 +6,7 @@
 import { timeout } from '../../../../../../base/common/async.js';
 import type { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { createCommandUri, isMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { appendEscapedMarkdownInlineCode, createCommandUri, isMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
 import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
@@ -81,18 +81,6 @@ CommandsRegistry.registerCommand(FocusTerminalByExecutionIdCommandId, async (acc
 	}
 });
 
-/**
- * Wraps arbitrary text in a markdown inline code span using a backtick fence
- * long enough to safely contain any backtick sequences present in the text.
- */
-function toMarkdownInlineCode(text: string): string {
-	const longestBacktickRun = Math.max(0, ...(text.match(/`+/g) ?? []).map(m => m.length));
-	const fence = '`'.repeat(longestBacktickRun + 1);
-	const needsSpace = text.startsWith('`') || text.endsWith('`');
-	const content = needsSpace ? ` ${text} ` : text;
-	return `${fence}${content}${fence}`;
-}
-
 export class SendToTerminalTool extends Disposable implements IToolImpl {
 
 	constructor(
@@ -123,7 +111,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 			pastTenseMessage.appendMarkdown(localize('send.past.enter', "Pressed `Enter` in terminal"));
 		} else {
 			const displayCommand = buildCommandDisplayText(args.command);
-			const safeInlineCode = toMarkdownInlineCode(displayCommand);
+			const safeInlineCode = appendEscapedMarkdownInlineCode(displayCommand);
 			invocationMessage.appendMarkdown(localize('send.progressive', "Sending {0} to terminal", safeInlineCode));
 			pastTenseMessage.appendMarkdown(localize('send.past', "Sent {0} to terminal", safeInlineCode));
 		}
@@ -141,10 +129,10 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		// Build the confirmation message with a "Focus Terminal" command link
 		const instanceId = this._getTerminalInstanceId(args);
 		const confirmationMessage = new MarkdownString('', { isTrusted: { enabledCommands: [FocusTerminalByIdCommandId] } });
-		const safeTerminalLabel = toMarkdownInlineCode(terminalLabel);
+		const safeTerminalLabel = appendEscapedMarkdownInlineCode(terminalLabel);
 		const baseMessage = isEmptyInput
 			? localize('send.confirm.message.enter', "Press `Enter` in terminal {0}", safeTerminalLabel)
-			: localize('send.confirm.message', "Run {0} in terminal {1}", toMarkdownInlineCode(buildCommandDisplayText(args.command)), safeTerminalLabel);
+			: localize('send.confirm.message', "Run {0} in terminal {1}", appendEscapedMarkdownInlineCode(buildCommandDisplayText(args.command)), safeTerminalLabel);
 		if (instanceId !== undefined) {
 			const focusUri = createCommandUri(FocusTerminalByIdCommandId, instanceId);
 			confirmationMessage.appendMarkdown(`${baseMessage} — [${localize('focusTerminal', "Focus Terminal")}](${focusUri})`);


### PR DESCRIPTION
The grep/glob invocation and past-tense messages, plus the shell past-tense message, contain backtick-wrapped values (e.g. `` Searching for `foo` ``) but were being returned as plain strings. `StringOrMarkdown` treats plain strings as literal text, so the backticks rendered as bare characters in the chat UI instead of formatting the wrapped value as inline code.

Three coordinated fixes:

1. **Wrap with `md(...)`** so the message ships as `{ markdown: ... }` — matching View/Edit/Create which already did this.
2. **Move backticks outside `localize()`** so translators can't accidentally drop or transform them.
3. **Use `appendEscapedMarkdownInlineCode()`** for the interpolated values. Backslash-escaping backticks doesn't work in CommonMark inline code — the only safe approach is a fence longer than any backtick run in the content. Promoted the existing private `toMarkdownInlineCode` from `sendToTerminalTool.ts` into `vs/base/common/htmlContent.ts` as a shared utility (next to `appendEscapedMarkdownCodeBlockFence`), and switched both call sites to use it.

Includes unit tests for the new helper.

(Written by Copilot)