### PR TITLE
Auto-approve Copilot CLI session-state paths

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -19,6 +19,7 @@ import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { CopilotAgent } from './copilot/copilotAgent.js';
 import { ProtocolServerHandler } from './protocolServerHandler.js';
 import { WebSocketProtocolServer } from './webSocketTransport.js';
+import { INativeEnvironmentService } from '../../environment/common/environment.js';
 import { NativeEnvironmentService } from '../../environment/node/environmentService.js';
 import { parseArgs, OPTIONS } from '../../environment/node/argv.js';
 import { getLogLevel, ILogService } from '../../log/common/log.js';
@@ -90,6 +91,7 @@ function startAgentHost(): void {
 		agentService = new AgentService(logService, fileService, sessionDataService, productService);
 		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
 		const diServices = new ServiceCollection();
+		diServices.set(INativeEnvironmentService, environmentService);
 		diServices.set(ILogService, logService);
 		diServices.set(IFileService, fileService);
 		diServices.set(ISessionDataService, sessionDataService);

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { PermissionRequestResult, SessionConfig, Tool, ToolResultObject } from '@github/copilot-sdk';
-import { homedir } from 'os';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { join } from '../../../../base/common/path.js';
-import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
+import { extUriBiasedIgnorePathCase, normalizePath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import type { IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
 import { ILogService } from '../../../log/common/log.js';
@@ -31,9 +31,9 @@ import { buildPendingEditContentUri } from './pendingEditContentStore.js';
 const COPILOT_HOME_DIRECTORY = '.copilot';
 const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
 
-function getCopilotCLISessionStateDir(): string {
+function getCopilotCLISessionStateDir(userHome: string): string {
 	const xdgHome = process.env['XDG_STATE_HOME'];
-	return xdgHome ? join(xdgHome, SESSION_STATE_DIRECTORY) : join(homedir(), SESSION_STATE_DIRECTORY);
+	return xdgHome ? join(xdgHome, SESSION_STATE_DIRECTORY) : join(userHome, SESSION_STATE_DIRECTORY);
 }
 
 /**
@@ -139,6 +139,7 @@ export class CopilotAgentSession extends Disposable {
 		@ILogService private readonly _logService: ILogService,
 		@ISessionDataService sessionDataService: ISessionDataService,
 		@IFileService private readonly _fileService: IFileService,
+		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 	) {
 		super();
 		this.sessionId = options.rawSessionId;
@@ -210,14 +211,19 @@ export class CopilotAgentSession extends Disposable {
 			description: def.description ?? '',
 			parameters: def.inputSchema ?? { type: 'object' as const, properties: {} },
 			handler: async (_args: Record<string, unknown>, { toolCallId }) => {
-				let deferred = this._pendingClientToolCalls.get(toolCallId);
-				if (!deferred) {
-					deferred = new DeferredPromise<ToolResultObject>();
-					this._pendingClientToolCalls.set(toolCallId, deferred);
+				try {
+					let deferred = this._pendingClientToolCalls.get(toolCallId);
+					if (!deferred) {
+						deferred = new DeferredPromise<ToolResultObject>();
+						this._pendingClientToolCalls.set(toolCallId, deferred);
+					}
+					const result = await deferred.p;
+					this._pendingClientToolCalls.delete(toolCallId);
+					return result;
+				} catch (error) {
+					this._logService.error(error, `[Copilot:${this.sessionId}] Failed in client tool handler: tool=${def.name}, toolCallId=${toolCallId}`);
+					throw error;
 				}
-				const result = await deferred.p;
-				this._pendingClientToolCalls.delete(toolCallId);
-				return result;
 			},
 		}));
 	}
@@ -272,22 +278,8 @@ export class CopilotAgentSession extends Disposable {
 			onUserInputRequest: (request, invocation) => this.handleUserInputRequest(request, invocation),
 			clientTools: this.createClientSdkTools(),
 			hooks: {
-				onPreToolUse: async input => {
-					if (isEditTool(input.toolName)) {
-						const filePath = getEditFilePath(input.toolArgs);
-						if (filePath) {
-							await this._editTracker.trackEditStart(filePath);
-						}
-					}
-				},
-				onPostToolUse: async input => {
-					if (isEditTool(input.toolName)) {
-						const filePath = getEditFilePath(input.toolArgs);
-						if (filePath) {
-							await this._editTracker.completeEdit(filePath);
-						}
-					}
-				},
+				onPreToolUse: input => this._handlePreToolUse(input),
+				onPostToolUse: input => this._handlePostToolUse(input),
 			},
 		}));
 		this._subscribeToEvents();
@@ -377,58 +369,63 @@ export class CopilotAgentSession extends Disposable {
 	): Promise<PermissionRequestResult> {
 		this._logService.info(`[Copilot:${this.sessionId}] Permission request: kind=${request.kind}`);
 
-		const toolCallId = request.toolCallId;
-		if (!toolCallId) {
-			// TODO: handle permission requests without a toolCallId by creating a synthetic tool call
-			this._logService.warn(`[Copilot:${this.sessionId}] Permission request without toolCallId, auto-denying: kind=${request.kind}`);
-			return { kind: 'denied-interactively-by-user' };
+		try {
+			const toolCallId = request.toolCallId;
+			if (!toolCallId) {
+				// TODO: handle permission requests without a toolCallId by creating a synthetic tool call
+				this._logService.warn(`[Copilot:${this.sessionId}] Permission request without toolCallId, auto-denying: kind=${request.kind}`);
+				return { kind: 'denied-interactively-by-user' };
+			}
+
+			const sessionResourcePath = this._getInternalSessionResourcePath(request);
+			if (sessionResourcePath) {
+				this._logService.info(`[Copilot:${this.sessionId}] Auto-approving internal session resource ${sessionResourcePath}`);
+				return { kind: 'approved' };
+			}
+
+			this._logService.info(`[Copilot:${this.sessionId}] Requesting confirmation for tool call: ${toolCallId}`);
+
+			const deferred = new DeferredPromise<boolean>();
+			this._pendingPermissions.set(toolCallId, deferred);
+
+			// Derive display information from the permission request kind
+			const { confirmationTitle, invocationMessage, toolInput, permissionKind, permissionPath } = getPermissionDisplay(request);
+
+			// For write permission requests, build an IFileEdit preview so the
+			// client can show a diff before the user approves or denies. This
+			// awaits async filesystem operations; the SDK already calls
+			// `handlePermissionRequest` from an arbitrary async context, so the
+			// extra await here is fine.
+			const edits = await this._buildEditsForPermission(request, toolCallId);
+
+			// If the session was aborted/disposed while we were building the
+			// preview, the deferred has already been resolved and the
+			// `pending-edit-content:` entry has been cleaned up. Bail without
+			// firing tool_ready.
+			if (!this._pendingPermissions.has(toolCallId)) {
+				return { kind: 'denied-interactively-by-user' };
+			}
+
+			// Fire a tool_ready event to transition the tool to PendingConfirmation
+			this._onDidSessionProgress.fire({
+				session: this.sessionUri,
+				type: 'tool_ready',
+				toolCallId,
+				invocationMessage,
+				toolInput,
+				confirmationTitle,
+				permissionKind,
+				permissionPath,
+				edits,
+			});
+
+			const approved = await deferred.p;
+			this._logService.info(`[Copilot:${this.sessionId}] Permission response: toolCallId=${toolCallId}, approved=${approved}`);
+			return { kind: approved ? 'approved' : 'denied-interactively-by-user' };
+		} catch (error) {
+			this._logService.error(error, `[Copilot:${this.sessionId}] Failed to handle permission request: kind=${request.kind}, toolCallId=${request.toolCallId ?? 'missing'}`);
+			throw error;
 		}
-
-		const sessionResourcePath = this._getInternalSessionResourcePath(request);
-		if (sessionResourcePath) {
-			this._logService.info(`[Copilot:${this.sessionId}] Auto-approving internal session resource ${sessionResourcePath}`);
-			return { kind: 'approved' };
-		}
-
-		this._logService.info(`[Copilot:${this.sessionId}] Requesting confirmation for tool call: ${toolCallId}`);
-
-		const deferred = new DeferredPromise<boolean>();
-		this._pendingPermissions.set(toolCallId, deferred);
-
-		// Derive display information from the permission request kind
-		const { confirmationTitle, invocationMessage, toolInput, permissionKind, permissionPath } = getPermissionDisplay(request);
-
-		// For write permission requests, build an IFileEdit preview so the
-		// client can show a diff before the user approves or denies. This
-		// awaits async filesystem operations; the SDK already calls
-		// `handlePermissionRequest` from an arbitrary async context, so the
-		// extra await here is fine.
-		const edits = await this._buildEditsForPermission(request, toolCallId);
-
-		// If the session was aborted/disposed while we were building the
-		// preview, the deferred has already been resolved and the
-		// `pending-edit-content:` entry has been cleaned up. Bail without
-		// firing tool_ready.
-		if (!this._pendingPermissions.has(toolCallId)) {
-			return { kind: 'denied-interactively-by-user' };
-		}
-
-		// Fire a tool_ready event to transition the tool to PendingConfirmation
-		this._onDidSessionProgress.fire({
-			session: this.sessionUri,
-			type: 'tool_ready',
-			toolCallId,
-			invocationMessage,
-			toolInput,
-			confirmationTitle,
-			permissionKind,
-			permissionPath,
-			edits,
-		});
-
-		const approved = await deferred.p;
-		this._logService.info(`[Copilot:${this.sessionId}] Permission response: toolCallId=${toolCallId}, approved=${approved}`);
-		return { kind: approved ? 'approved' : 'denied-interactively-by-user' };
 	}
 
 	private _getInternalSessionResourcePath(request: ITypedPermissionRequest): string | undefined {
@@ -443,8 +440,13 @@ export class CopilotAgentSession extends Disposable {
 			return undefined;
 		}
 
-		const sessionDir = URI.joinPath(URI.file(getCopilotCLISessionStateDir()), this.sessionId);
-		const permissionUri = URI.file(permissionPath);
+		const sessionStateDir = normalizePath(URI.file(getCopilotCLISessionStateDir(this._environmentService.userHome.fsPath)));
+		const sessionDir = normalizePath(URI.joinPath(sessionStateDir, this.sessionId));
+		if (!extUriBiasedIgnorePathCase.isEqualOrParent(sessionDir, sessionStateDir)) {
+			return undefined;
+		}
+
+		const permissionUri = normalizePath(URI.file(permissionPath));
 		return extUriBiasedIgnorePathCase.isEqualOrParent(permissionUri, sessionDir) ? permissionPath : undefined;
 	}
 
@@ -532,63 +534,69 @@ export class CopilotAgentSession extends Disposable {
 		request: IUserInputRequest,
 		_invocation: { sessionId: string },
 	): Promise<IUserInputResponse> {
-		const requestId = generateUuid();
-		const questionId = generateUuid();
-		this._logService.info(`[Copilot:${this.sessionId}] User input request: requestId=${requestId}, question="${request.question.substring(0, 100)}"`);
+		const questionPreview = request.question.substring(0, 100);
+		try {
+			const requestId = generateUuid();
+			const questionId = generateUuid();
+			this._logService.info(`[Copilot:${this.sessionId}] User input request: requestId=${requestId}, question="${questionPreview}"`);
 
-		const deferred = new DeferredPromise<{ response: SessionInputResponseKind; answers?: Record<string, ISessionInputAnswer> }>();
-		this._pendingUserInputs.set(requestId, { deferred, questionId });
+			const deferred = new DeferredPromise<{ response: SessionInputResponseKind; answers?: Record<string, ISessionInputAnswer> }>();
+			this._pendingUserInputs.set(requestId, { deferred, questionId });
 
-		// Build the protocol ISessionInputRequest from the SDK's simple format
-		const inputRequest: ISessionInputRequest = {
-			id: requestId,
-			message: request.question,
-			questions: [request.choices && request.choices.length > 0
-				? {
-					kind: SessionInputQuestionKind.SingleSelect,
-					id: questionId,
-					message: request.question,
-					required: true,
-					options: request.choices.map(c => ({ id: c, label: c })),
-					allowFreeformInput: request.allowFreeform ?? true,
-				}
-				: {
-					kind: SessionInputQuestionKind.Text,
-					id: questionId,
-					message: request.question,
-					required: true,
-				},
-			],
-		};
+			// Build the protocol ISessionInputRequest from the SDK's simple format
+			const inputRequest: ISessionInputRequest = {
+				id: requestId,
+				message: request.question,
+				questions: [request.choices && request.choices.length > 0
+					? {
+						kind: SessionInputQuestionKind.SingleSelect,
+						id: questionId,
+						message: request.question,
+						required: true,
+						options: request.choices.map(c => ({ id: c, label: c })),
+						allowFreeformInput: request.allowFreeform ?? true,
+					}
+					: {
+						kind: SessionInputQuestionKind.Text,
+						id: questionId,
+						message: request.question,
+						required: true,
+					},
+				],
+			};
 
-		this._onDidSessionProgress.fire({
-			session: this.sessionUri,
-			type: 'user_input_request',
-			request: inputRequest,
-		});
+			this._onDidSessionProgress.fire({
+				session: this.sessionUri,
+				type: 'user_input_request',
+				request: inputRequest,
+			});
 
-		const result = await deferred.p;
-		this._logService.info(`[Copilot:${this.sessionId}] User input response: requestId=${requestId}, response=${result.response}`);
+			const result = await deferred.p;
+			this._logService.info(`[Copilot:${this.sessionId}] User input response: requestId=${requestId}, response=${result.response}`);
 
-		if (result.response !== SessionInputResponseKind.Accept || !result.answers) {
+			if (result.response !== SessionInputResponseKind.Accept || !result.answers) {
+				return { answer: '', wasFreeform: true };
+			}
+
+			// Extract the answer for our single question
+			const answer = result.answers[questionId];
+			if (!answer || answer.state === SessionInputAnswerState.Skipped) {
+				return { answer: '', wasFreeform: true };
+			}
+
+			const { value: val } = answer;
+			if (val.kind === SessionInputAnswerValueKind.Text) {
+				return { answer: val.value, wasFreeform: true };
+			} else if (val.kind === SessionInputAnswerValueKind.Selected) {
+				const wasFreeform = !request.choices?.includes(val.value);
+				return { answer: val.value, wasFreeform };
+			}
+
 			return { answer: '', wasFreeform: true };
+		} catch (error) {
+			this._logService.error(error, `[Copilot:${this.sessionId}] Failed to handle user input request: question="${questionPreview}"`);
+			throw error;
 		}
-
-		// Extract the answer for our single question
-		const answer = result.answers[questionId];
-		if (!answer || answer.state === SessionInputAnswerState.Skipped) {
-			return { answer: '', wasFreeform: true };
-		}
-
-		const { value: val } = answer;
-		if (val.kind === SessionInputAnswerValueKind.Text) {
-			return { answer: val.value, wasFreeform: true };
-		} else if (val.kind === SessionInputAnswerValueKind.Selected) {
-			const wasFreeform = !request.choices?.includes(val.value);
-			return { answer: val.value, wasFreeform };
-		}
-
-		return { answer: '', wasFreeform: true };
 	}
 
 	respondToUserInputRequest(requestId: string, response: SessionInputResponseKind, answers?: Record<string, ISessionInputAnswer>): boolean {
@@ -599,6 +607,34 @@ export class CopilotAgentSession extends Disposable {
 			return true;
 		}
 		return false;
+	}
+
+	private async _handlePreToolUse(input: { toolName: string; toolArgs: unknown }): Promise<void> {
+		try {
+			if (isEditTool(input.toolName)) {
+				const filePath = getEditFilePath(input.toolArgs);
+				if (filePath) {
+					await this._editTracker.trackEditStart(filePath);
+				}
+			}
+		} catch (error) {
+			this._logService.error(error, `[Copilot:${this.sessionId}] Failed in onPreToolUse: tool=${input.toolName}`);
+			throw error;
+		}
+	}
+
+	private async _handlePostToolUse(input: { toolName: string; toolArgs: unknown }): Promise<void> {
+		try {
+			if (isEditTool(input.toolName)) {
+				const filePath = getEditFilePath(input.toolArgs);
+				if (filePath) {
+					await this._editTracker.completeEdit(filePath);
+				}
+			}
+		} catch (error) {
+			this._logService.error(error, `[Copilot:${this.sessionId}] Failed in onPostToolUse: tool=${input.toolName}`);
+			throw error;
+		}
 	}
 
 	// ---- event wiring -------------------------------------------------------

--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -4,10 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { PermissionRequestResult, SessionConfig, Tool, ToolResultObject } from '@github/copilot-sdk';
+import { homedir } from 'os';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
+import { join } from '../../../../base/common/path.js';
+import { extUriBiasedIgnorePathCase } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import type { IParsedPlugin } from '../../../agentPlugins/common/pluginParsers.js';
@@ -24,6 +27,14 @@ import { getEditFilePath, getInvocationMessage, getPastTenseMessage, getPermissi
 import { FileEditTracker } from './fileEditTracker.js';
 import { mapSessionEvents } from './mapSessionEvents.js';
 import { buildPendingEditContentUri } from './pendingEditContentStore.js';
+
+const COPILOT_HOME_DIRECTORY = '.copilot';
+const SESSION_STATE_DIRECTORY = join(COPILOT_HOME_DIRECTORY, 'session-state');
+
+function getCopilotCLISessionStateDir(): string {
+	const xdgHome = process.env['XDG_STATE_HOME'];
+	return xdgHome ? join(xdgHome, SESSION_STATE_DIRECTORY) : join(homedir(), SESSION_STATE_DIRECTORY);
+}
 
 /**
  * Immutable snapshot of the active client's contributions at session creation
@@ -373,6 +384,12 @@ export class CopilotAgentSession extends Disposable {
 			return { kind: 'denied-interactively-by-user' };
 		}
 
+		const sessionResourcePath = this._getInternalSessionResourcePath(request);
+		if (sessionResourcePath) {
+			this._logService.info(`[Copilot:${this.sessionId}] Auto-approving internal session resource ${sessionResourcePath}`);
+			return { kind: 'approved' };
+		}
+
 		this._logService.info(`[Copilot:${this.sessionId}] Requesting confirmation for tool call: ${toolCallId}`);
 
 		const deferred = new DeferredPromise<boolean>();
@@ -412,6 +429,23 @@ export class CopilotAgentSession extends Disposable {
 		const approved = await deferred.p;
 		this._logService.info(`[Copilot:${this.sessionId}] Permission response: toolCallId=${toolCallId}, approved=${approved}`);
 		return { kind: approved ? 'approved' : 'denied-interactively-by-user' };
+	}
+
+	private _getInternalSessionResourcePath(request: ITypedPermissionRequest): string | undefined {
+		let permissionPath: string | undefined;
+		if (request.kind === 'read') {
+			permissionPath = typeof request.path === 'string' ? request.path : undefined;
+		} else if (request.kind === 'write') {
+			permissionPath = typeof request.fileName === 'string' ? request.fileName : undefined;
+		}
+
+		if (!permissionPath) {
+			return undefined;
+		}
+
+		const sessionDir = URI.joinPath(URI.file(getCopilotCLISessionStateDir()), this.sessionId);
+		const permissionUri = URI.file(permissionPath);
+		return extUriBiasedIgnorePathCase.isEqualOrParent(permissionUri, sessionDir) ? permissionPath : undefined;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { CopilotSession, SessionEventPayload, SessionEventType, TypedSessionEventHandler } from '@github/copilot-sdk';
 import assert from 'assert';
 import { Disposable, type DisposableStore, type IDisposable, type IReference } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { FileService } from '../../../files/common/fileService.js';
 import { IFileService } from '../../../files/common/files.js';
 import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
@@ -21,6 +23,9 @@ import { ISessionCustomization, ICustomizationRef } from '../../common/state/ses
 import { IAgentHostGitService } from '../../node/agentHostGitService.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
 import { CopilotAgent, getCopilotWorktreeBranchName, getCopilotWorktreeName, getCopilotWorktreesRoot, type ICopilotClient } from '../../node/copilot/copilotAgent.js';
+import { CopilotAgentSession, type SessionWrapperFactory } from '../../node/copilot/copilotAgentSession.js';
+import { CopilotSessionWrapper } from '../../node/copilot/copilotSessionWrapper.js';
+import { ShellManager } from '../../node/copilot/copilotShellTools.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { createNullSessionDataService } from '../common/sessionTestHelpers.js';
 
@@ -109,6 +114,20 @@ class TestCopilotClient implements ICopilotClient {
 	resumeSession: ICopilotClient['resumeSession'] = async () => { throw new Error('not implemented'); };
 }
 
+class MockCopilotSession {
+	readonly sessionId = 'test-session-1';
+
+	on<K extends SessionEventType>(_eventType: K, _handler: TypedSessionEventHandler<K>): () => void {
+		return () => { };
+	}
+
+	async send(): Promise<string> { return ''; }
+	async abort(): Promise<void> { }
+	async setModel(): Promise<void> { }
+	async getMessages(): Promise<SessionEventPayload<SessionEventType>[]> { return []; }
+	async destroy(): Promise<void> { }
+}
+
 class TestableCopilotAgent extends CopilotAgent {
 	constructor(
 		private readonly _copilotClient: ICopilotClient,
@@ -127,7 +146,7 @@ class TestableCopilotAgent extends CopilotAgent {
 	}
 }
 
-function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ICopilotClient }): CopilotAgent {
+function createTestAgentContext(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ICopilotClient; environmentServiceRegistration?: 'native' | 'none' }): { agent: CopilotAgent; instantiationService: IInstantiationService } {
 	const services = new ServiceCollection();
 	const logService = new NullLogService();
 	const fileService = disposables.add(new FileService(logService));
@@ -137,12 +156,32 @@ function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { 
 	services.set(IAgentPluginManager, new TestAgentPluginManager());
 	services.set(IAgentHostGitService, new TestAgentHostGitService());
 	services.set(IAgentHostTerminalManager, new TestAgentHostTerminalManager());
+	if (options?.environmentServiceRegistration !== 'none') {
+		const environmentService = {
+			_serviceBrand: undefined,
+			userHome: URI.file('/mock-home'),
+		} as INativeEnvironmentService;
+		services.set(INativeEnvironmentService, environmentService);
+	}
 	const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
 	services.set(IInstantiationService, instantiationService);
-	if (options?.copilotClient) {
-		return instantiationService.createInstance(TestableCopilotAgent, options.copilotClient);
-	}
-	return instantiationService.createInstance(CopilotAgent);
+	const agent = options?.copilotClient
+		? instantiationService.createInstance(TestableCopilotAgent, options.copilotClient)
+		: instantiationService.createInstance(CopilotAgent);
+	return { agent, instantiationService };
+}
+
+function createTestAgent(disposables: Pick<DisposableStore, 'add'>, options?: { sessionDataService?: ISessionDataService; copilotClient?: ICopilotClient; environmentServiceRegistration?: 'native' | 'none' }): CopilotAgent {
+	return createTestAgentContext(disposables, options).agent;
+}
+
+function createAgentSessionThroughAgent(agent: CopilotAgent, instantiationService: IInstantiationService): CopilotAgentSession {
+	const sessionUri = AgentSession.uri('copilot', 'test-session-1');
+	const shellManager = instantiationService.createInstance(ShellManager, sessionUri, undefined);
+	const wrapperFactory: SessionWrapperFactory = async () => new CopilotSessionWrapper(new MockCopilotSession() as unknown as CopilotSession);
+	return (agent as unknown as {
+		_createAgentSession: (wrapperFactory: SessionWrapperFactory, sessionId: string, shellManager: ShellManager) => CopilotAgentSession;
+	})._createAgentSession(wrapperFactory, 'test-session-1', shellManager);
 }
 
 function withoutUndefinedProperties(metadata: IAgentSessionMetadata): Record<string, unknown> {
@@ -216,6 +255,35 @@ suite('CopilotAgent', () => {
 				(error: Error) => error instanceof ProtocolError && error.code === AHP_AUTH_REQUIRED,
 			);
 		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('agent-created sessions can resolve session-state paths via INativeEnvironmentService', async () => {
+		const sessionDataService = disposables.add(new TestSessionDataService());
+		const { agent, instantiationService } = createTestAgentContext(disposables, {
+			environmentServiceRegistration: 'native',
+			sessionDataService,
+		});
+		const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+		delete process.env['XDG_STATE_HOME'];
+		try {
+			const agentSession = disposables.add(createAgentSessionThroughAgent(agent, instantiationService));
+			await agentSession.initializeSession();
+
+			const result = await agentSession.handlePermissionRequest({
+				kind: 'read',
+				path: URI.file('/mock-home/.copilot/session-state/test-session-1/plan.md').fsPath,
+				toolCallId: 'tc-read-plan-agent-composition',
+			});
+
+			assert.strictEqual(result.kind, 'approved');
+		} finally {
+			if (previousXdgStateHome === undefined) {
+				delete process.env['XDG_STATE_HOME'];
+			} else {
+				process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+			}
 			await disposeAgent(agent);
 		}
 	});

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -8,6 +8,7 @@ import assert from 'assert';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { join } from '../../../../base/common/path.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { IFileService } from '../../../files/common/files.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
@@ -167,6 +168,28 @@ suite('CopilotAgentSession', () => {
 			assert.strictEqual(result.kind, 'approved');
 		});
 
+		test('auto-approves read permission for session-state plan files', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			process.env['XDG_STATE_HOME'] = '/mock-state-home';
+			try {
+				const { session, progressEvents } = await createAgentSession(disposables);
+				const result = await session.handlePermissionRequest({
+					kind: 'read',
+					path: join('/mock-state-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
+					toolCallId: 'tc-read-plan',
+				});
+
+				assert.strictEqual(result.kind, 'approved');
+				assert.strictEqual(progressEvents.length, 0);
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
+		});
+
 		test('write permission fires tool_ready (deferred to side effects)', async () => {
 			const { session, progressEvents, waitForProgress } = await createAgentSession(disposables);
 			const resultPromise = session.handlePermissionRequest({
@@ -181,6 +204,54 @@ suite('CopilotAgentSession', () => {
 			assert.ok(session.respondToPermissionRequest('tc-1', true));
 			const result = await resultPromise;
 			assert.strictEqual(result.kind, 'approved');
+		});
+
+		test('auto-approves write permission for session-state plan files', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			process.env['XDG_STATE_HOME'] = '/mock-state-home';
+			try {
+				const { session, progressEvents } = await createAgentSession(disposables);
+				const result = await session.handlePermissionRequest({
+					kind: 'write',
+					fileName: join('/mock-state-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
+					toolCallId: 'tc-write-plan',
+				});
+
+				assert.strictEqual(result.kind, 'approved');
+				assert.strictEqual(progressEvents.length, 0);
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
+		});
+
+		test('does not auto-approve session-state files from another session', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			process.env['XDG_STATE_HOME'] = '/mock-state-home';
+			try {
+				const { session, progressEvents, waitForProgress } = await createAgentSession(disposables);
+				const resultPromise = session.handlePermissionRequest({
+					kind: 'write',
+					fileName: join('/mock-state-home', '.copilot', 'session-state', 'different-session', 'plan.md'),
+					toolCallId: 'tc-write-other-plan',
+				});
+
+				await waitForProgress(e => e.type === 'tool_ready');
+				assert.strictEqual(progressEvents.length, 1);
+
+				assert.ok(session.respondToPermissionRequest('tc-write-other-plan', true));
+				const result = await resultPromise;
+				assert.strictEqual(result.kind, 'approved');
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
 		});
 
 		test('write permission outside working directory fires tool_ready', async () => {

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -8,8 +8,10 @@ import assert from 'assert';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { join } from '../../../../base/common/path.js';
+import { join, sep } from '../../../../base/common/path.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { IFileService } from '../../../files/common/files.js';
 import { InstantiationService } from '../../../instantiation/common/instantiationService.js';
 import { ServiceCollection } from '../../../instantiation/common/serviceCollection.js';
@@ -63,6 +65,15 @@ class MockCopilotSession {
 	async destroy() { }
 }
 
+class CapturingLogService extends NullLogService {
+	readonly errors: Array<{ first: string | Error; args: unknown[] }> = [];
+
+	override error(message: string | Error, ...args: unknown[]): void {
+		this.errors.push({ first: message, args });
+		super.error(message, ...args);
+	}
+}
+
 // ---- Helpers ----------------------------------------------------------------
 
 /**
@@ -80,7 +91,25 @@ function invokeClientToolHandler(tool: { name: string; handler: (args: any, invo
 	})) as Promise<ToolResultObject>;
 }
 
-async function createAgentSession(disposables: DisposableStore, options?: { clientSnapshot?: IActiveClientSnapshot }): Promise<{
+type ISessionInternalsForTest = {
+	_onDidSessionProgress: { fire(event: IAgentProgressEvent): void };
+	_editTracker: {
+		trackEditStart(path: string): Promise<void>;
+		completeEdit(path: string): Promise<void>;
+	};
+	_pendingClientToolCalls: {
+		get(toolCallId: string): DeferredPromise<ToolResultObject> | undefined;
+		set(toolCallId: string, value: DeferredPromise<ToolResultObject>): Map<string, DeferredPromise<ToolResultObject>>;
+		delete(toolCallId: string): boolean;
+	};
+};
+
+async function createAgentSession(disposables: DisposableStore, options?: {
+	clientSnapshot?: IActiveClientSnapshot;
+	environmentServiceRegistration?: 'native' | 'none';
+	logService?: ILogService;
+	captureWrapperCallbacks?: { current?: Parameters<SessionWrapperFactory>[0] };
+}): Promise<{
 	session: CopilotAgentSession;
 	mockSession: MockCopilotSession;
 	progressEvents: IAgentProgressEvent[];
@@ -113,13 +142,25 @@ async function createAgentSession(disposables: DisposableStore, options?: { clie
 	const sessionUri = AgentSession.uri('copilot', 'test-session-1');
 	const mockSession = new MockCopilotSession();
 
-	const factory: SessionWrapperFactory = async () => new CopilotSessionWrapper(mockSession as unknown as CopilotSession);
+	const factory: SessionWrapperFactory = async callbacks => {
+		if (options?.captureWrapperCallbacks) {
+			options.captureWrapperCallbacks.current = callbacks;
+		}
+		return new CopilotSessionWrapper(mockSession as unknown as CopilotSession);
+	};
 
 	const services = new ServiceCollection();
-	services.set(ILogService, new NullLogService());
+	services.set(ILogService, options?.logService ?? new NullLogService());
 	services.set(IFileService, { _serviceBrand: undefined } as IFileService);
 	services.set(ISessionDataService, createSessionDataService());
 	services.set(IDiffComputeService, createZeroDiffComputeService());
+	const environmentService = {
+		_serviceBrand: undefined,
+		userHome: URI.file('/mock-home'),
+	} as INativeEnvironmentService;
+	if (options?.environmentServiceRegistration !== 'none') {
+		services.set(INativeEnvironmentService, environmentService);
+	}
 	const instantiationService = disposables.add(new InstantiationService(services));
 
 	const session = disposables.add(instantiationService.createInstance(
@@ -190,6 +231,59 @@ suite('CopilotAgentSession', () => {
 			}
 		});
 
+		test('resolves native environment through INativeEnvironmentService registration', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			delete process.env['XDG_STATE_HOME'];
+			try {
+				const { session, progressEvents } = await createAgentSession(disposables, { environmentServiceRegistration: 'native' });
+				const result = await session.handlePermissionRequest({
+					kind: 'read',
+					path: join('/mock-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
+					toolCallId: 'tc-read-plan-native-env',
+				});
+
+				assert.strictEqual(result.kind, 'approved');
+				assert.strictEqual(progressEvents.length, 0);
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
+		});
+
+		test('logs and rethrows permission failures', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			delete process.env['XDG_STATE_HOME'];
+			const logService = new CapturingLogService();
+			try {
+				const { session } = await createAgentSession(disposables, {
+					environmentServiceRegistration: 'none',
+					logService,
+				});
+
+				await assert.rejects(
+					session.handlePermissionRequest({
+						kind: 'read',
+						path: join('/mock-home', '.copilot', 'session-state', 'test-session-1', 'plan.md'),
+						toolCallId: 'tc-read-plan-missing-env',
+					}),
+				);
+
+				assert.strictEqual(logService.errors.length, 1);
+				const [entry] = logService.errors;
+				assert.ok(entry.first instanceof TypeError);
+				assert.strictEqual(entry.args[0], '[Copilot:test-session-1] Failed to handle permission request: kind=read, toolCallId=tc-read-plan-missing-env');
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
+		});
+
 		test('write permission fires tool_ready (deferred to side effects)', async () => {
 			const { session, progressEvents, waitForProgress } = await createAgentSession(disposables);
 			const resultPromise = session.handlePermissionRequest({
@@ -243,6 +337,33 @@ suite('CopilotAgentSession', () => {
 				assert.strictEqual(progressEvents.length, 1);
 
 				assert.ok(session.respondToPermissionRequest('tc-write-other-plan', true));
+				const result = await resultPromise;
+				assert.strictEqual(result.kind, 'approved');
+			} finally {
+				if (previousXdgStateHome === undefined) {
+					delete process.env['XDG_STATE_HOME'];
+				} else {
+					process.env['XDG_STATE_HOME'] = previousXdgStateHome;
+				}
+			}
+		});
+
+		test('does not auto-approve traversal paths that escape the session-state directory', async () => {
+			const previousXdgStateHome = process.env['XDG_STATE_HOME'];
+			process.env['XDG_STATE_HOME'] = '/mock-state-home';
+			try {
+				const { session, progressEvents, waitForProgress } = await createAgentSession(disposables);
+				const sessionDir = join('/mock-state-home', '.copilot', 'session-state', 'test-session-1');
+				const resultPromise = session.handlePermissionRequest({
+					kind: 'write',
+					fileName: `${sessionDir}${sep}..${sep}outside.md`,
+					toolCallId: 'tc-write-traversal',
+				});
+
+				await waitForProgress(e => e.type === 'tool_ready');
+				assert.strictEqual(progressEvents.length, 1);
+
+				assert.ok(session.respondToPermissionRequest('tc-write-traversal', true));
 				const result = await resultPromise;
 				assert.strictEqual(result.kind, 'approved');
 			} finally {
@@ -625,6 +746,74 @@ suite('CopilotAgentSession', () => {
 		});
 	});
 
+	suite('SDK callback logging', () => {
+
+		test('logs and rethrows user input callback failures', async () => {
+			const logService = new CapturingLogService();
+			const { session } = await createAgentSession(disposables, { logService });
+			const sessionInternals = session as unknown as ISessionInternalsForTest;
+			sessionInternals._onDidSessionProgress.fire = () => {
+				throw new Error('user input boom');
+			};
+
+			await assert.rejects(
+				session.handleUserInputRequest(
+					{ question: 'Need input' },
+					{ sessionId: 'test-session-1' },
+				),
+				/user input boom/,
+			);
+
+			assert.strictEqual(logService.errors.length, 1);
+			const [entry] = logService.errors;
+			assert.ok(entry.first instanceof Error);
+			assert.strictEqual((entry.first as Error).message, 'user input boom');
+			assert.strictEqual(entry.args[0], '[Copilot:test-session-1] Failed to handle user input request: question="Need input"');
+		});
+
+		test('logs and rethrows onPreToolUse failures', async () => {
+			const logService = new CapturingLogService();
+			const capturedCallbacks: { current?: Parameters<SessionWrapperFactory>[0] } = {};
+			const { session } = await createAgentSession(disposables, { logService, captureWrapperCallbacks: capturedCallbacks });
+			const sessionInternals = session as unknown as ISessionInternalsForTest;
+			sessionInternals._editTracker.trackEditStart = async () => {
+				throw new Error('pre tool boom');
+			};
+
+			await assert.rejects(
+				capturedCallbacks.current!.hooks.onPreToolUse({ toolName: 'edit', toolArgs: { path: '/tmp/file.ts' } }),
+				/pre tool boom/,
+			);
+
+			assert.strictEqual(logService.errors.length, 1);
+			const [entry] = logService.errors;
+			assert.ok(entry.first instanceof Error);
+			assert.strictEqual((entry.first as Error).message, 'pre tool boom');
+			assert.strictEqual(entry.args[0], '[Copilot:test-session-1] Failed in onPreToolUse: tool=edit');
+		});
+
+		test('logs and rethrows onPostToolUse failures', async () => {
+			const logService = new CapturingLogService();
+			const capturedCallbacks: { current?: Parameters<SessionWrapperFactory>[0] } = {};
+			const { session } = await createAgentSession(disposables, { logService, captureWrapperCallbacks: capturedCallbacks });
+			const sessionInternals = session as unknown as ISessionInternalsForTest;
+			sessionInternals._editTracker.completeEdit = async () => {
+				throw new Error('post tool boom');
+			};
+
+			await assert.rejects(
+				capturedCallbacks.current!.hooks.onPostToolUse({ toolName: 'edit', toolArgs: { path: '/tmp/file.ts' } }),
+				/post tool boom/,
+			);
+
+			assert.strictEqual(logService.errors.length, 1);
+			const [entry] = logService.errors;
+			assert.ok(entry.first instanceof Error);
+			assert.strictEqual((entry.first as Error).message, 'post tool boom');
+			assert.strictEqual(entry.args[0], '[Copilot:test-session-1] Failed in onPostToolUse: tool=edit');
+		});
+	});
+
 	// ---- client tool calls ----
 
 	suite('client tool calls', () => {
@@ -796,6 +985,27 @@ suite('CopilotAgentSession', () => {
 				success: true,
 				pastTenseMessage: 'done again',
 			});
+		});
+
+		test('client tool handler logs and rethrows failures', async () => {
+			const logService = new CapturingLogService();
+			const { session } = await createAgentSession(disposables, { clientSnapshot: snapshot, logService });
+			const tools = session.createClientSdkTools();
+			const sessionInternals = session as unknown as ISessionInternalsForTest;
+			sessionInternals._pendingClientToolCalls.get = () => {
+				throw new Error('client tool boom');
+			};
+
+			await assert.rejects(
+				invokeClientToolHandler(tools[0], 'tc-client-error'),
+				/client tool boom/,
+			);
+
+			assert.strictEqual(logService.errors.length, 1);
+			const [entry] = logService.errors;
+			assert.ok(entry.first instanceof Error);
+			assert.strictEqual((entry.first as Error).message, 'client tool boom');
+			assert.strictEqual(entry.args[0], '[Copilot:test-session-1] Failed in client tool handler: tool=my_tool, toolCallId=tc-client-error');
 		});
 
 		test('tool_start stores pending auto-ready data for client tools', async () => {

--- a/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
@@ -29,9 +29,9 @@ import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ISubscribeResult } from '../../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
-import type { ISessionAddedNotification } from '../../../common/state/sessionActions.js';
+import { ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolResultContentType, type ISessionInputAnswer, type ISessionInputRequest, type ISessionState, type ITerminalState, type IToolResultContent } from '../../../common/state/sessionState.js';
+import type { ISessionAddedNotification, ISessionInputRequestedAction, ISessionResponsePartAction, ISessionToolCallReadyAction } from '../../../common/state/sessionActions.js';
 import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
-import { ToolResultContentType, type ISessionState, type ITerminalState, type IToolResultContent } from '../../../common/state/sessionState.js';
 import {
 	getActionEnvelope,
 	isActionNotification,
@@ -102,6 +102,144 @@ function dispatchTurn(c: TestProtocolClient, session: string, turnId: string, te
 			userMessage: { text },
 		},
 	});
+}
+
+function getAcceptedAnswers(request: ISessionInputRequest): Record<string, ISessionInputAnswer> | undefined {
+	if (!request.questions?.length) {
+		return undefined;
+	}
+
+	return Object.fromEntries(request.questions.map(question => {
+		switch (question.kind) {
+			case SessionInputQuestionKind.Text:
+				return [question.id, {
+					state: SessionInputAnswerState.Submitted,
+					value: {
+						kind: SessionInputAnswerValueKind.Text,
+						value: question.defaultValue ?? 'interactive',
+					},
+				} satisfies ISessionInputAnswer];
+			case SessionInputQuestionKind.Number:
+			case SessionInputQuestionKind.Integer:
+				return [question.id, {
+					state: SessionInputAnswerState.Submitted,
+					value: {
+						kind: SessionInputAnswerValueKind.Number,
+						value: question.defaultValue ?? question.min ?? 1,
+					},
+				} satisfies ISessionInputAnswer];
+			case SessionInputQuestionKind.Boolean:
+				return [question.id, {
+					state: SessionInputAnswerState.Submitted,
+					value: {
+						kind: SessionInputAnswerValueKind.Boolean,
+						value: question.defaultValue ?? true,
+					},
+				} satisfies ISessionInputAnswer];
+			case SessionInputQuestionKind.SingleSelect: {
+				const preferredOption = question.options.find(option => /interactive/i.test(option.id) || /interactive/i.test(option.label))
+					?? question.options.find(option => option.recommended)
+					?? question.options[0];
+				return [question.id, {
+					state: SessionInputAnswerState.Submitted,
+					value: {
+						kind: SessionInputAnswerValueKind.Selected,
+						value: preferredOption.id,
+					},
+				} satisfies ISessionInputAnswer];
+			}
+			case SessionInputQuestionKind.MultiSelect: {
+				const preferredOptions = question.options.filter(option => option.recommended);
+				const selectedOptions = preferredOptions.length > 0 ? preferredOptions : question.options.slice(0, 1);
+				return [question.id, {
+					state: SessionInputAnswerState.Submitted,
+					value: {
+						kind: SessionInputAnswerValueKind.SelectedMany,
+						value: selectedOptions.map(option => option.id),
+					},
+				} satisfies ISessionInputAnswer];
+			}
+		}
+	}));
+}
+
+function getMarkdownResponseText(c: TestProtocolClient): string {
+	return c.receivedNotifications(n => isActionNotification(n, 'session/responsePart'))
+		.map(notification => getActionEnvelope(notification).action as ISessionResponsePartAction)
+		.flatMap(action => action.part.kind === ResponsePartKind.Markdown ? [action.part.content] : [])
+		.join('\n');
+}
+
+interface IDrivenTurnResult {
+	sawInputRequest: boolean;
+	sawPendingConfirmation: boolean;
+	responseText: string;
+}
+
+async function driveTurnToCompletion(c: TestProtocolClient, session: string, turnId: string, text: string, clientSeq: number): Promise<IDrivenTurnResult> {
+	c.clearReceived();
+	dispatchTurn(c, session, turnId, text, clientSeq);
+
+	const seenNotifications = new Set<object>();
+	let nextClientSeq = clientSeq + 1;
+	let sawInputRequest = false;
+	let sawPendingConfirmation = false;
+
+	while (true) {
+		const notification = await c.waitForNotification(n => !seenNotifications.has(n as object) && (
+			isActionNotification(n, 'session/toolCallReady')
+			|| isActionNotification(n, 'session/inputRequested')
+			|| isActionNotification(n, 'session/turnComplete')
+			|| isActionNotification(n, 'session/error')
+		), 90_000);
+		seenNotifications.add(notification as object);
+
+		if (isActionNotification(notification, 'session/error')) {
+			throw new Error(`Session error while driving ${turnId}`);
+		}
+
+		if (isActionNotification(notification, 'session/toolCallReady')) {
+			const action = getActionEnvelope(notification).action as ISessionToolCallReadyAction;
+			if (!action.confirmed) {
+				sawPendingConfirmation = true;
+				c.notify('dispatchAction', {
+					clientSeq: nextClientSeq++,
+					action: {
+						type: 'session/toolCallConfirmed',
+						session,
+						turnId,
+						toolCallId: action.toolCallId,
+						approved: true,
+					},
+				});
+			}
+			continue;
+		}
+
+		if (isActionNotification(notification, 'session/inputRequested')) {
+			sawInputRequest = true;
+			const action = getActionEnvelope(notification).action as ISessionInputRequestedAction;
+			c.notify('dispatchAction', {
+				clientSeq: nextClientSeq++,
+				action: {
+					type: 'session/inputCompleted',
+					session,
+					requestId: action.request.id,
+					response: SessionInputResponseKind.Accept,
+					answers: getAcceptedAnswers(action.request),
+				},
+			});
+			continue;
+		}
+
+		break;
+	}
+
+	return {
+		sawInputRequest,
+		sawPendingConfirmation,
+		responseText: getMarkdownResponseText(c),
+	};
 }
 
 function terminalResourceFromContent(content: readonly IToolResultContent[]): string | undefined {
@@ -212,6 +350,39 @@ function terminalText(state: ITerminalState): string {
 
 		// Wait for the turn to complete
 		await client.waitForNotification(n => isActionNotification(n, 'session/turnComplete'), 90_000);
+	});
+
+	test('planning-mode session-state writes are auto-approved in default mode', async function () {
+		this.timeout(180_000);
+
+		const tempDir = mkdtempSync(`${tmpdir()}/ahp-plan-test-`);
+		tempDirs.push(tempDir);
+		const sessionUri = await createRealSession(client, 'real-sdk-plan-mode', createdSessions, URI.file(tempDir).toString());
+
+		const planTurn = await driveTurnToCompletion(client, sessionUri, 'turn-plan',
+			'Enter plan mode for the trivial task "say hello". Write the shortest possible plan to your session plan.md, then stop at exit_plan_mode. Do not inspect or modify workspace files.', 1);
+		assert.strictEqual(planTurn.sawPendingConfirmation, false, 'should not have received pending-confirmation toolCallReady while writing session-state plan.md');
+		assert.ok(planTurn.sawInputRequest, 'should reach the exit_plan_mode question so the test can continue the same session');
+
+		const extraSessionNotificationsAfterPlan = client.receivedNotifications(n =>
+			n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
+		);
+		assert.strictEqual(extraSessionNotificationsAfterPlan.length, 0, 'should not create a second session while answering the plan-mode question');
+
+		const followupTurn = await driveTurnToCompletion(client, sessionUri, 'turn-followup',
+			'What was the trivial task from the plan? Reply with exactly "say hello".', 10,
+		);
+		assert.strictEqual(followupTurn.sawPendingConfirmation, false, 'follow-up turn should not surface new pending confirmations');
+		assert.match(followupTurn.responseText, /say hello/i, 'follow-up turn should retain the original plan context');
+
+		const extraSessionNotificationsAfterFollowup = client.receivedNotifications(n =>
+			n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
+		);
+		assert.strictEqual(extraSessionNotificationsAfterFollowup.length, 0, 'sending another message should stay on the same session instead of forking');
+
+		const resubscribeResult = await client.call<ISubscribeResult>('subscribe', { resource: sessionUri });
+		const finalSnapshot = resubscribeResult.snapshot.state as ISessionState;
+		assert.strictEqual(finalSnapshot.summary.resource, sessionUri, 'follow-up turn should keep the original session resource');
 	});
 
 	// ---- Abort / cancel -----------------------------------------------------


### PR DESCRIPTION
Auto-approve Copilot CLI session-state path reads and writes in the agent host, mirroring the existing Copilot extension behavior for `~/.copilot/session-state/<sessionId>/`.

## Changes

### Session-state auto-approval (`copilotAgentSession.ts`)
- Auto-approve file reads and writes under the session-specific directory (`~/.copilot/session-state/<sessionId>/`)
- Supports `XDG_STATE_HOME` override, falling back to `INativeEnvironmentService.userHome`
- Traversal-safe: normalizes paths before comparison to prevent `..` escape attacks

### SDK callback error logging
- Wrap **all** SDK callbacks (`handlePermissionRequest`, `handleUserInputRequest`, pre/post tool use, client tool handler) with try/catch that logs via `logService.error()` then rethrows
- Previously, exceptions in SDK callbacks were silently swallowed and surfaced as vague "Permission denied" errors with no log trace

### DI wiring fix (`agentHostMain.ts`)
- Register `INativeEnvironmentService` in the local agent-host startup path (was missing, causing `undefined` service and broken permission checks)

### Tests
- Unit tests for session-state auto-approval (read, write, negative cases, traversal regression)
- Composition test through `CopilotAgent._createAgentSession` to catch DI wiring regressions
- SDK callback logging regression tests for all callback surfaces
- Missing env-service logging regression test

(Written by Copilot)