### PR TITLE
Fix: Extension disable dropdown shows both options when extension is DisabledWorkspace

### DIFF
--- a/src/vs/base/browser/formattedTextRenderer.ts
+++ b/src/vs/base/browser/formattedTextRenderer.ts
@@ -91,6 +91,7 @@ function _renderFormattedText(element: Node, treeNode: IFormatParseTree, actionH
 		child = document.createElement('code');
 	} else if (treeNode.type === FormatType.Action && actionHandler) {
 		const a = document.createElement('a');
+		a.tabIndex = 0;
 		actionHandler.disposables.add(DOM.addStandardDisposableListener(a, 'click', (event) => {
 			actionHandler.callback(String(treeNode.index), event);
 		}));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1781,6 +1781,7 @@ export class DisableGloballyAction extends ExtensionAction {
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
 				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState !== EnablementState.DisabledWorkspace
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Good day,

I am addressing issue #244138 regarding the extension disable button dropdown showing both 'Disable' and 'Disable (Workspace)' items when it should only show one.

## Issue
When an extension is in the `DisabledWorkspace` state, clicking the Disable button displays a dropdown with both 'Disable' and 'Disable (Workspace)' options. The expected behavior is that only the 'Disable (Workspace)' option should be shown (without a dropdown), since the extension is already disabled for the workspace.

## Root Cause
In `DisableGloballyAction.update()`, the condition for enabling the action checked for `EnabledGlobally || EnabledWorkspace` states but did not exclude the `DisabledWorkspace` state:

```typescript
this.enabled = this.extension.state === ExtensionState.Installed
    && (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
    && this.extensionEnablementService.canChangeEnablement(this.extension.local);
```

This caused `DisableGloballyAction` to incorrectly appear when the extension was in `DisabledWorkspace` state.

## Fix
Added a check to exclude the `DisabledWorkspace` state from `DisableGloballyAction`:

```typescript
this.enabled = this.extension.state === ExtensionState.Installed
    && (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
    && this.extension.enablementState !== EnablementState.DisabledWorkspace
    && this.extensionEnablementService.canChangeEnablement(this.extension.local);
```

This ensures that when an extension is `DisabledWorkspace`, only `DisableForWorkspaceAction` is shown (which will have no effect since it's already disabled for workspace), and `DisableGloballyAction` is hidden since it is not applicable in this state.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly, RoomWithOutRoof