### PR TITLE
fix: improve OS_ID parsing for quoted values in /etc/os-release

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

This PR fixes #232159 - Devcontainer setup ad-hoc parsing fails on Rocky 8.5.

## Problem

The script  incorrectly parsed the  field from  when the value is quoted.

The previous regex approach:


Failed on Rocky Linux 8.5 which uses  (quoted), returning an empty string.

## Solution

Changed to:


This properly handles quoted values by loading the file as shell variables, which removes any surrounding quotes.

## Verification

Tested locally with a mock  containing :
- The new approach correctly extracts 
- Works for both quoted () and unquoted () formats

## Checklist
- [x] Code change is reasonable
- [x] Boundary cases considered (quoted/unquoted formats)
- [x] Local test passed
- [x] Fixes issue #232159

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

