### PR TITLE
Fix Rocky Linux os-release ID parsing

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## Summary

Fix parsing of the `ID` value from `/etc/os-release` to handle quoted values (e.g., `ID="rocky"`). The original `grep`+`sed` approach failed to match quoted values, leaving `OS_ID` empty on Rocky Linux 8.5, causing the devcontainer setup script to fail.

## Fix

Replace:
```sh
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^\"]+)' | sed -n '1s/ID=//p')"
```

With:
```sh
OS_ID=$(source /etc/os-release && echo $ID)
```

The `source /etc/os-release && echo $ID` approach properly handles both quoted and unquoted formats.

## Issue

Fixes #232159

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof
