### PR TITLE
fix: dispose event listeners in BaseIssueReporterService

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/browser/baseIssueReporterService.ts
@@ -1626,7 +1626,10 @@ export class BaseIssueReporterService extends Disposable {
 	public addEventListener(elementId: string, eventType: string, handler: (event: Event) => void): void {
 		// eslint-disable-next-line no-restricted-syntax
 		const element = this.getElementById(elementId);
-		element?.addEventListener(eventType, handler);
+    if (element) {
+        element.addEventListener(eventType, handler);
+        this._register({ dispose: () => element.removeEventListener(eventType, handler) });
+        
 	}
 }
 


### PR DESCRIPTION
The `addEventListener()` helper in `BaseIssueReporterService` (line 1626) never 
removes the listeners it registers. Every other listener in the class goes through 
`this._register()` so it gets disposed properly, but this method just calls the 
native `addEventListener` and leaves the handler hanging.

There are about 15 calls to this method throughout the class. Each time the Issue 
Reporter opens, 15 handlers accumulate and are never removed — meaning if the 
window is reopened in the same session, those handlers fire multiple times.

The fix wraps each registration in `this._register({ dispose: () => 
element.removeEventListener(...) })` so handlers are cleaned up when the service 
is disposed, consistent with the pattern used everywhere else in the class