### PR TITLE
Fix Copilot Welcome Page title line height

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
@@ -40,6 +40,7 @@
 .agentSessionsWelcome-header h1.product-name {
 	font-size: 32px;
 	font-weight: 400;
+	line-height: 1;
 	margin: 0 0 12px 0;
 	color: var(--vscode-foreground);
 }


### PR DESCRIPTION
Fixes line-height for the Copilot Welcome Page title to prevent text overlap when the title wraps to multiple lines.

Before: Without explicit line-height, the title text would overlap when wrapped in narrow layouts.
After: Adding `line-height: 1` ensures proper spacing between wrapped title lines.

**Before:**
<img width="512" alt="image" src="https://private-user-images.githubusercontent.com/1588988/555060100-d771e65f-4cb5-4edf-88a2-60827b153dab.png">

**After:**  
<img width="512" alt="image" src="https://private-user-images.githubusercontent.com/1588988/569202586-de4f0a37-19e9-41d4-83d1-18176bf0a465.png">

Closes #297827