### PR TITLE
prompts: fix vscode-remote path corruption in PromptPathRepresentationService

### DIFF
--- a/extensions/copilot/src/platform/prompts/common/promptPathRepresentationService.ts
+++ b/extensions/copilot/src/platform/prompts/common/promptPathRepresentationService.ts
@@ -36,7 +36,9 @@ export interface IPromptPathRepresentationService {
  * When readong a LLM response, use `resolveFilePath` to get the URI from from a `filepath`
  *
  * Do not use this service for other usages than prompts.
- * We currently use the fsPath for local and remote filesystems, and URI.toString() for other schemes.
+ * For `file` URIs we use `fsPath`, for `vscode-remote` URIs we use `path`
+ * (always POSIX, to avoid local-OS separator corruption), and for other
+ * schemes we use `URI.toString()`.
  */
 export class PromptPathRepresentationService implements IPromptPathRepresentationService {
 
@@ -49,7 +51,12 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 	constructor(@IWorkspaceService private readonly workspaceService: IWorkspaceService) { }
 
 	getFilePath(uri: Uri): string {
-		if (uri.scheme === Schemas.file || uri.scheme === Schemas.vscodeRemote) {
+		if (uri.scheme === Schemas.vscodeRemote) {
+			// Use uri.path (always POSIX) instead of uri.fsPath which applies
+			// local OS separators — corrupting remote Linux paths on Windows.
+			return uri.path;
+		}
+		if (uri.scheme === Schemas.file) {
 			return uri.fsPath;
 		}
 		return uri.toString();
@@ -64,6 +71,14 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 	 * @returns The resolved URI or undefined if filepath does not look like a file path or URI.
 	 */
 	resolveFilePath(filepath: string, predominantScheme = Schemas.file): Uri | undefined {
+		// Match against workspace folders first — this preserves scheme and
+		// authority for remote workspaces where a plain path string cannot
+		// encode the full URI (e.g. vscode-remote://ssh-remote+host/...).
+		const folderMatch = this._matchWorkspaceFolder(filepath);
+		if (folderMatch) {
+			return folderMatch;
+		}
+
 		// Always check for posix-like absolute paths, and also for platform-like
 		// (i.e. Windows) absolute paths in case the model generates them.
 		const isPosixPath = filepath.startsWith('/');
@@ -103,6 +118,45 @@ export class PromptPathRepresentationService implements IPromptPathRepresentatio
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * Matches a filepath string against known workspace folders and reconstructs
+	 * the full URI (preserving scheme and authority) from the folder.
+	 *
+	 * When multiple folders match as prefixes, the longest (most specific) one
+	 * wins so nested workspace folders resolve correctly.
+	 */
+	private _matchWorkspaceFolder(filepath: string): Uri | undefined {
+		let best: { folder: Uri; folderPath: string } | undefined;
+		for (const folder of this.workspaceService.getWorkspaceFolders()) {
+			const raw = this.getFilePath(folder);
+			// Normalize trailing separators so root folders (e.g. "/" or "C:\")
+			// match correctly — the separator check below needs folderPath to
+			// NOT end with a separator.
+			const folderPath = raw.length > 1 ? raw.replace(/[\/\\]+$/, '') : raw;
+			if (!filepath.startsWith(folderPath)) {
+				continue;
+			}
+			// Filesystem roots ("/" or "\") have no separator following them;
+			// any absolute path under them matches without the next-char check.
+			const isRoot = folderPath === '/' || folderPath === '\\';
+			if (filepath.length > folderPath.length && !isRoot) {
+				const sep = filepath[folderPath.length];
+				if (sep !== '/' && sep !== '\\') {
+					continue;
+				}
+			}
+			if (!best || folderPath.length > best.folderPath.length) {
+				best = { folder, folderPath };
+			}
+		}
+		if (!best) {
+			return undefined;
+		}
+		const relative = filepath.substring(best.folderPath.length);
+		const segments = relative.split(/[\/\\]/).filter(Boolean);
+		return segments.length > 0 ? URI.joinPath(best.folder, ...segments) : best.folder;
 	}
 
 	getExampleFilePath(absolutePosixFilePath: string): string {

--- a/extensions/copilot/src/platform/prompts/test/node/promptPathRepresentationService.spec.ts
+++ b/extensions/copilot/src/platform/prompts/test/node/promptPathRepresentationService.spec.ts
@@ -34,9 +34,9 @@ describe('PromptPathRepresentationService', () => {
 			expect(service.getFilePath(uri)).toBe(uri.fsPath);
 		});
 
-		it('returns fsPath for vscode-remote scheme URIs', () => {
+		it('returns posix path (uri.path) for vscode-remote scheme URIs', () => {
 			const uri = URI.from({ scheme: Schemas.vscodeRemote, path: '/home/user/project/file.ts', authority: 'ssh-remote+myhost' });
-			expect(service.getFilePath(uri)).toBe(uri.fsPath);
+			expect(service.getFilePath(uri)).toBe(uri.path);
 		});
 
 		it('returns toString for other schemes', () => {
@@ -103,6 +103,106 @@ describe('PromptPathRepresentationService', () => {
 			const resolved = service.resolveFilePath(filepath);
 			expect(resolved).toBeDefined();
 			expect(resolved!.path).toBe(original.path);
+		});
+
+		it('resolves vscode-remote paths back to vscode-remote URIs via workspace folder match', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project/src/file.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/home/user/project/src/file.ts');
+		});
+
+		it('roundtrips vscode-remote URIs through getFilePath and resolveFilePath', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const original = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project/src/file.ts' });
+			const filepath = service.getFilePath(original);
+			const resolved = service.resolveFilePath(filepath);
+			expect(resolved).toBeDefined();
+			expect(resolved!.scheme).toBe(Schemas.vscodeRemote);
+			expect(resolved!.authority).toBe('ssh-remote+myhost');
+			expect(resolved!.path).toBe(original.path);
+		});
+
+		it('resolves vscode-remote workspace folder root path', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/home/user/project');
+		});
+
+		it('matches correct folder in multi-root vscode-remote workspace', () => {
+			const folder1 = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project-a' });
+			const folder2 = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project-b' });
+			workspaceService = new TestWorkspaceService([folder1, folder2]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project-b/src/main.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.path).toBe('/home/user/project-b/src/main.ts');
+		});
+
+		it('resolves paths under a vscode-remote workspace folder at filesystem root', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/file.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/home/user/file.ts');
+		});
+
+		it('resolves root path itself when a workspace folder is at filesystem root', () => {
+			const folderUri = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/' });
+			workspaceService = new TestWorkspaceService([folderUri]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			expect(result!.authority).toBe('ssh-remote+myhost');
+			expect(result!.path).toBe('/');
+		});
+
+		it('picks the longest matching folder when workspace folders are nested', () => {
+			const outer = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			const inner = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+otherhost', path: '/home/user/project/sub' });
+			workspaceService = new TestWorkspaceService([outer, inner]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project/sub/file.ts');
+			expect(result).toBeDefined();
+			expect(result!.scheme).toBe(Schemas.vscodeRemote);
+			// longest-match must select the inner folder (distinct authority proves it)
+			expect(result!.authority).toBe('ssh-remote+otherhost');
+			expect(result!.path).toBe('/home/user/project/sub/file.ts');
+		});
+
+		it('picks the longest matching folder regardless of workspace folder order', () => {
+			const outer = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+myhost', path: '/home/user/project' });
+			const inner = URI.from({ scheme: Schemas.vscodeRemote, authority: 'ssh-remote+otherhost', path: '/home/user/project/sub' });
+			// reversed registration order
+			workspaceService = new TestWorkspaceService([inner, outer]);
+			service = new PromptPathRepresentationService(workspaceService);
+
+			const result = service.resolveFilePath('/home/user/project/sub/file.ts');
+			expect(result).toBeDefined();
+			expect(result!.authority).toBe('ssh-remote+otherhost');
 		});
 	});
 


### PR DESCRIPTION
# Fix vscode-remote path round-tripping for UI-side Copilot hosts

## Problem

This PR fixes prompt filepath round-tripping when GitHub Copilot runs in a UI-side extension host and the workspace itself is remote.

The concrete user scenario is:

```json
"remote.extensionKind": {
  "GitHub.copilot-chat": ["ui"]
}
```

This is a legitimate configuration for air-gapped or restricted-internet remote hosts where the extension cannot authenticate or reach GitHub APIs from the remote side.

In this configuration, Copilot sees real `vscode-remote://...` URIs and currently serializes them with `uri.fsPath`. On Windows UI hosts that applies local path separator conversion, so remote Linux paths such as `/opt/app/file.ts` become `\opt\app\file.ts` in prompts.

When those prompt paths come back from the model, `resolveFilePath()` reconstructs them with `URI.file()`, which loses the original `vscode-remote` scheme and remote authority.

## What Is Already Avoided By VS Code

This is **not** a general bug in all remote scenarios.

When Copilot runs in the remote workspace extension host, VS Code already installs a URI transformer that maps:

- `vscode-remote` on the UI side → `file` on the agent side
- `file` on the agent side → `vscode-remote` on the UI side

So the default remote-workspace-host path is already handled by the platform before `PromptPathRepresentationService` sees the URI.

This means the bug is specifically about **UI-side extension hosts working against remote workspaces**, not about all remote execution modes.

## What Copilot Already Avoids Internally

One major edit flow already has partial protection:

- `editCodeIntent` first tries to match model-returned paths directly against the working set
- only if that fails does it fall back to `resolveFilePath(...)`
- that fallback also carries a predominant scheme

So this PR is **not justified mainly by editCodeIntent**.

## What Still Breaks Without This Fix

Many other consumers do not have the original URI or remote authority available when they parse a filepath string back from prompt/model space.

Examples include:

- agent file tools such as create/edit/insert operations
- code block filepath parsing
- notebook-oriented tools
- conversation-history recovery that parses prior tool arguments

These flows often call `resolveFilePath()` directly, or via `resolveToolInputPath()`, with only a plain path string. In those cases, recovering only the scheme is insufficient — the remote authority is still lost.

That is why the fix belongs in `PromptPathRepresentationService`, which is the shared boundary for prompt path serialization and deserialization.

## Fix

Three focused changes in `PromptPathRepresentationService`:

1. `getFilePath()` returns `uri.path` for `vscode-remote` URIs instead of `uri.fsPath`
2. `resolveFilePath()` first tries to match the incoming filepath against known workspace folders and reconstructs the URI with `URI.joinPath(...)`
3. the workspace-folder matcher handles filesystem roots (`/`, `\\`) and picks the longest matching folder when workspace folders overlap

## Why Both Sides Of The Round Trip Matter

Technically, a folder-prefix match in `resolveFilePath()` would recover many cases even if prompts continued to emit the old backslash representation.

However, that would still leave Copilot emitting a semantically wrong representation of remote Linux paths into prompts and relying on the model to echo that representation back exactly.

Changing `getFilePath()` fixes the representation at the source.
Changing `resolveFilePath()` restores the original URI when the filepath comes back.

Together they make the prompt path contract both correct and robust.

## Scope Of Necessity

- The base round-trip fix is necessary for UI-side extension hosts on remote workspaces
- The workspace-folder reconstruction is necessary because existing callers generally do not carry remote authority separately
- The root-folder and longest-match handling are not specific to the original issue report, but they are necessary to make the new matching strategy correct once introduced

## Prior Art

This is a corrected and more complete version of [PR #3177](https://github.com/microsoft/vscode-copilot-chat/pull/3177).

Compared with that PR, this one:

- does not assume `folders[0]` is sufficient
- only reconstructs remote URIs for paths that actually match a known workspace folder
- handles nested/overlapping workspace folders correctly
- handles filesystem-root workspace folders correctly

## Related Issues

- [Agent mode cannot edit files with remote-ssh extension #11526](https://github.com/microsoft/vscode-copilot-release/issues/11526)
- [Copilot attempts writing files in windows format on linux remote host via ssh #284417](https://github.com/microsoft/vscode/issues/284417)

## Use Case — Air-Gapped / Restricted-Internet Remote Hosts

In laboratory and enterprise environments, remote hosts are often behind strict network policies:

- air-gapped networks
- firewalls that block external APIs
- hosts with no direct internet access

In those environments, running Copilot on the remote side is not always possible.
Running the extension on the local side via `remote.extensionKind` is therefore a valid and important scenario.

This PR fixes the remaining prompt path gap in that configuration.

## Test

Unit tests cover:

- `vscode-remote` path emission via `getFilePath()`
- round-tripping through `resolveFilePath()` via workspace-folder matching
- workspace-folder root handling
- longest-match behavior for nested workspace folders

Current result:

```
✓ src/platform/prompts/test/node/promptPathRepresentationService.spec.ts (35 tests | 1 skipped)
  Test Files  1 passed (1)
```

## Disclosure

This patch (code + commit message + PR description) was fully generated by AI — **Claude Opus 4.6** driven by **GitHub Copilot** in VS Code agent mode. The author reviewed, verified, and approved all changes before submission.
