### PR TITLE
AgentHost: prevent agent shell commands from polluting user shell history

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -38,7 +38,7 @@ export interface ICommandFinishedEvent {
  */
 export interface IAgentHostTerminalManager {
 	readonly _serviceBrand: undefined;
-	createTerminal(params: ICreateTerminalParams, options?: { shell?: string }): Promise<void>;
+	createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void>;
 	writeInput(uri: string, data: string): void;
 	onData(uri: string, cb: (data: string) => void): IDisposable;
 	onExit(uri: string, cb: (exitCode: number) => void): IDisposable;
@@ -172,7 +172,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 	 * Create a new terminal backed by node-pty.
 	 * Spawns the user's default shell.
 	 */
-	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string }): Promise<void> {
+	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void> {
 		const uri = params.terminal;
 		if (this._terminals.has(uri)) {
 			throw new Error(`Terminal already exists: ${uri}`);
@@ -192,6 +192,13 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		// Shell integration — inject scripts so the shell emits OSC 633 sequences
 		const nonce = generateUuid();
 		const env: Record<string, string> = { ...process.env as Record<string, string> };
+		if (options?.preventShellHistory) {
+			// Picked up by the shell integration scripts to set HISTCONTROL=ignorespace
+			// (bash) / HIST_IGNORE_SPACE (zsh), or suppress PSReadLine history (pwsh).
+			// Combined with the leading-space prefix applied at command-write time, this
+			// prevents agent-executed commands from polluting the user's shell history.
+			env['VSCODE_PREVENT_SHELL_HISTORY'] = '1';
+		}
 		let shellArgs: string[] = [];
 
 		const injection = await getShellIntegrationInjection(

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -39,7 +39,7 @@ interface IManagedShell {
 	readonly shellType: ShellType;
 }
 
-type ShellType = 'bash' | 'powershell';
+export type ShellType = 'bash' | 'powershell';
 
 function getShellExecutable(shellType: ShellType): string {
 	if (shellType === 'powershell') {
@@ -109,7 +109,7 @@ export class ShellManager {
 			claim,
 			name: shellDisplayName,
 			cwd: cwd ?? this._workingDirectory?.fsPath,
-		}, { shell: getShellExecutable(shellType) });
+		}, { shell: getShellExecutable(shellType), preventShellHistory: true });
 
 		const shell: IManagedShell = { id, terminalUri, shellType };
 		this._shells.set(id, shell);
@@ -186,6 +186,20 @@ function buildSentinelCommand(sentinelId: string, shellType: ShellType): string 
 	return `echo "${SENTINEL_PREFIX}${sentinelId}_EXIT_$?>>>"`;
 }
 
+/**
+ * For POSIX shells (bash/zsh) that honor `HISTCONTROL=ignorespace` /
+ * `HIST_IGNORE_SPACE`, prepending a single space prevents the command from
+ * being recorded in shell history. The shell integration scripts opt these
+ * settings in via the `VSCODE_PREVENT_SHELL_HISTORY` env var (set when the
+ * terminal is created with `preventShellHistory: true`). PowerShell
+ * suppresses history through PSReadLine instead, so no prefix is needed.
+ *
+ * Exported for tests.
+ */
+export function prefixForHistorySuppression(shellType: ShellType): string {
+	return shellType === 'powershell' ? '' : ' ';
+}
+
 function parseSentinel(content: string, sentinelId: string): { found: boolean; exitCode: number; outputBeforeSentinel: string } {
 	const marker = `${SENTINEL_PREFIX}${sentinelId}_EXIT_`;
 	const idx = content.indexOf(marker);
@@ -252,7 +266,7 @@ async function executeCommandWithShellIntegration(
 ): Promise<ToolResultObject> {
 	const disposables = new DisposableStore();
 
-	terminalManager.writeInput(shell.terminalUri, `${command}\r`);
+	terminalManager.writeInput(shell.terminalUri, `${prefixForHistorySuppression(shell.shellType)}${command}\r`);
 
 	return new Promise<ToolResultObject>(resolve => {
 		let resolved = false;
@@ -322,7 +336,7 @@ async function executeCommandWithSentinel(
 	const offsetBefore = contentBefore.length;
 
 	// PTY input uses \r for line endings — the PTY translates to \r\n
-	const input = `${command}\r${sentinelCmd}\r`;
+	const input = `${prefixForHistorySuppression(shell.shellType)}${command}\r${sentinelCmd}\r`;
 	terminalManager.writeInput(shell.terminalUri, input);
 
 	return new Promise<ToolResultObject>(resolve => {

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -14,15 +14,15 @@ import { ILogService, NullLogService } from '../../../log/common/log.js';
 import type { ICreateTerminalParams } from '../../common/state/protocol/commands.js';
 import type { ITerminalClaim, ITerminalInfo } from '../../common/state/protocol/state.js';
 import { IAgentHostTerminalManager } from '../../node/agentHostTerminalManager.js';
-import { ShellManager } from '../../node/copilot/copilotShellTools.js';
+import { ShellManager, prefixForHistorySuppression } from '../../node/copilot/copilotShellTools.js';
 
 class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	declare readonly _serviceBrand: undefined;
 
-	readonly created: ICreateTerminalParams[] = [];
+	readonly created: { params: ICreateTerminalParams; options?: { shell?: string; preventShellHistory?: boolean } }[] = [];
 
-	async createTerminal(params: ICreateTerminalParams): Promise<void> {
-		this.created.push(params);
+	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void> {
+		this.created.push({ params, options });
 	}
 	writeInput(): void { }
 	onData(): IDisposable { return Disposable.None; }
@@ -60,9 +60,29 @@ suite('CopilotShellTools', () => {
 		await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
 		await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', explicitCwd);
 
-		assert.deepStrictEqual(terminalManager.created.map(c => c.cwd), [
+		assert.deepStrictEqual(terminalManager.created.map(c => c.params.cwd), [
 			worktreePath,
 			explicitCwd,
 		]);
+	});
+
+	test('opts every managed shell into shell-history suppression', async () => {
+		const terminalManager = new TestAgentHostTerminalManager();
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IAgentHostTerminalManager, terminalManager);
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		services.set(IInstantiationService, instantiationService);
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+
+		await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
+
+		assert.strictEqual(terminalManager.created.length, 1);
+		assert.strictEqual(terminalManager.created[0].options?.preventShellHistory, true);
+	});
+
+	test('prefixForHistorySuppression prepends a space for POSIX shells, no-op for PowerShell', () => {
+		assert.strictEqual(prefixForHistorySuppression('bash'), ' ');
+		assert.strictEqual(prefixForHistorySuppression('powershell'), '');
 	});
 });


### PR DESCRIPTION
Fixes #311245.

Mirrors VS Code's run-in-terminal tool behavior for agent-spawned shells:

1. **Env var**: when `ShellManager` creates a managed shell via `IAgentHostTerminalManager.createTerminal`, it now passes a new `preventShellHistory: true` option, which sets `VSCODE_PREVENT_SHELL_HISTORY=1` on the spawned PTY's env. The existing shell integration scripts already pick this up to set `HISTCONTROL=ignorespace` (bash), `HIST_IGNORE_SPACE` (zsh), or suppress PSReadLine history (pwsh).
2. **Leading-space prefix**: commands written to bash/zsh shells from `executeCommandWithShellIntegration` and `executeCommandWithSentinel` are now prefixed with a single space, which (combined with the env var above) keeps them out of `~/.bash_history` / zsh history. PowerShell relies on the PSReadLine handler instead, so no prefix is added.

Unlike the workbench's `chat.tools.terminal.preventShellHistory` setting, this is always-on for managed agent shells — the agent host has no equivalent user-facing setting today, and the leading space + env var are harmless when shell integration is missing.

### Tests
- `opts every managed shell into shell-history suppression` — asserts `ShellManager` passes `preventShellHistory: true` to `createTerminal`.
- `prefixForHistorySuppression prepends a space for POSIX shells, no-op for PowerShell` — direct unit test for the prefix helper.

(Written by Copilot)