### PR TITLE
inlineEdits: remove InlineEditsCheckEditWindowOnReuse config flag

### DIFF
--- a/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nesConfigs.ts
@@ -6,5 +6,4 @@
 export interface INesConfigs {
 	isAsyncCompletions: boolean;
 	isEagerBackupRequest: boolean;
-	isCheckEditWindowOnReuse: boolean;
 }

--- a/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/node/nextEditProvider.ts
@@ -479,7 +479,6 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 		const nesConfigs: INesConfigs = {
 			isAsyncCompletions: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsAsyncCompletions, this._expService),
 			isEagerBackupRequest: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsEagerBackupRequest, this._expService),
-			isCheckEditWindowOnReuse: this._configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsCheckEditWindowOnReuse, this._expService),
 		};
 
 		telemetryBuilder.setNESConfigs({ ...nesConfigs });
@@ -537,7 +536,7 @@ export class NextEditProvider extends Disposable implements INextEditProvider<Ne
 
 		const cursorAtInvocationTime = selectionAtInvocationTime.at(0);
 		const cursorInRequestEditWindow = (request: StatelessNextEditRequest) =>
-			!nesConfigs.isCheckEditWindowOnReuse || !request.requestEditWindow || !cursorAtInvocationTime || request.requestEditWindow.containsCursor(cursorAtInvocationTime);
+			!request.requestEditWindow || !cursorAtInvocationTime || request.requestEditWindow.containsCursor(cursorAtInvocationTime);
 
 		// Check if we can reuse the regular pending request
 		const pendingRequestStillCurrent = documentAtInvocationTime.value === this._pendingStatelessNextEditRequest?.documentBeforeEdits.value;

--- a/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
+++ b/extensions/copilot/src/extension/inlineEdits/test/node/nextEditProviderSpeculative.spec.ts
@@ -18,8 +18,8 @@ import { EditStreamingWithTelemetry, IStatelessNextEditProvider, NoNextEditReaso
 import { NesHistoryContextProvider } from '../../../../platform/inlineEdits/common/workspaceEditTracker/nesHistoryContextProvider';
 import { NesXtabHistoryTracker } from '../../../../platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker';
 import { ILogger, ILogService, LogServiceImpl } from '../../../../platform/log/common/logService';
-import { NullRequestLogger } from '../../../../platform/requestLogger/node/nullRequestLogger';
 import { IRequestLogger } from '../../../../platform/requestLogger/common/requestLogger';
+import { NullRequestLogger } from '../../../../platform/requestLogger/node/nullRequestLogger';
 import { ISnippyService, NullSnippyService } from '../../../../platform/snippy/common/snippyService';
 import { IExperimentationService, NullExperimentationService } from '../../../../platform/telemetry/common/nullExperimentationService';
 import { mockNotebookService } from '../../../../platform/test/common/testNotebookService';
@@ -1131,10 +1131,6 @@ describe('NextEditProvider speculative requests', () => {
 	});
 
 	describe('edit window cursor check for request reuse', () => {
-		beforeEach(async () => {
-			await configService.setConfig(ConfigKey.TeamInternal.InlineEditsCheckEditWindowOnReuse, true);
-		});
-
 		it('does not reuse in-flight request when cursor moves outside edit window', async () => {
 			const statelessProvider = new TestStatelessNextEditProvider();
 			// Edit window covers offsets 0–20 of the document

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -764,7 +764,6 @@ export namespace ConfigKey {
 		export const DebugExpUseElectronFetcher = defineTeamInternalSetting<boolean | undefined>('chat.advanced.debug.useElectronFetcher', ConfigType.ExperimentBased, undefined);
 		export const InlineEditsAsyncCompletions = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.asyncCompletions', ConfigType.ExperimentBased, true);
 		export const InlineEditsEagerBackupRequest = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.eagerBackupRequest', ConfigType.ExperimentBased, false);
-		export const InlineEditsCheckEditWindowOnReuse = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.checkEditWindowOnReuse', ConfigType.ExperimentBased, true);
 		export const InlineEditsDebounceUseCoreRequestTime = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.debounceUseCoreRequestTime', ConfigType.ExperimentBased, false);
 		export const InlineEditsYieldToCopilot = defineTeamInternalSetting<boolean>('chat.advanced.inlineEdits.yieldToCopilot', ConfigType.ExperimentBased, false);
 		export const InlineEditsExcludedProviders = defineTeamInternalSetting<string | undefined>('chat.advanced.inlineEdits.excludedProviders', ConfigType.ExperimentBased, undefined);


### PR DESCRIPTION
The edit window cursor check on request reuse is now always enabled, so the experiment-based config flag `chat.advanced.inlineEdits.checkEditWindowOnReuse` is no longer needed.

## Changes

- **`configurationService.ts`**: Remove `InlineEditsCheckEditWindowOnReuse` config definition
- **`nesConfigs.ts`**: Remove `isCheckEditWindowOnReuse` field from `INesConfigs` interface
- **`nextEditProvider.ts`**: Remove config read from `determineNesConfigs` and drop the `isCheckEditWindowOnReuse` guard in the `cursorInRequestEditWindow` predicate — the check is now unconditional
- **`nextEditProviderSpeculative.spec.ts`**: Remove `beforeEach` that set the flag to `true` (no longer needed since behavior is always on)