### PR TITLE
chat: add "Don't show again" to Autopilot and Bypass Approvals warning dialogs

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -17,6 +17,8 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 import { IChatWidgetService } from '../chat.js';
+import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../widget/input/permissionPickerActionItem.js';
 
 function uriReplacer(_key: string, value: unknown): unknown {
 	if (URI.isUri(value)) {
@@ -37,6 +39,7 @@ export function registerChatDeveloperActions() {
 	registerAction2(InspectChatModelAction);
 	registerAction2(InspectChatModelReferencesAction);
 	registerAction2(ClearRecentlyUsedLanguageModelsAction);
+	registerAction2(ResetChatPermissionWarningDialogsAction);
 }
 
 function formatChatModelReferenceInspection(accessor: ServicesAccessor): string {
@@ -231,5 +234,25 @@ class ClearRecentlyUsedLanguageModelsAction extends Action2 {
 
 	override run(accessor: ServicesAccessor): void {
 		accessor.get(ILanguageModelsService).clearRecentlyUsedList();
+	}
+}
+
+class ResetChatPermissionWarningDialogsAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.resetPermissionWarningDialogs';
+
+	constructor() {
+		super({
+			id: ResetChatPermissionWarningDialogsAction.ID,
+			title: localize2('workbench.action.chat.resetPermissionWarningDialogs.label', "Reset Permission Warning Dialogs (Autopilot, Bypass Approvals)"),
+			category: Categories.Developer,
+			f1: true,
+			precondition: ChatContextKeys.enabled
+		});
+	}
+
+	override run(accessor: ServicesAccessor): void {
+		const storageService = accessor.get(IStorageService);
+		storageService.remove(AUTOPILOT_DONT_SHOW_AGAIN_KEY, StorageScope.PROFILE);
+		storageService.remove(AUTO_APPROVE_DONT_SHOW_AGAIN_KEY, StorageScope.PROFILE);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatDeveloperActions.ts
@@ -18,7 +18,7 @@ import { IChatService } from '../../common/chatService/chatService.js';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 import { IChatWidgetService } from '../chat.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
-import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../widget/input/permissionPickerActionItem.js';
+import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../../common/chatPermissionStorageKeys.js';
 
 function uriReplacer(_key: string, value: unknown): unknown {
 	if (URI.isUri(value)) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -52,13 +52,6 @@ function hasShownElevatedWarning(level: ChatPermissionLevel, storageService: ISt
 	if (key && storageService.getBoolean(key, StorageScope.PROFILE, false)) {
 		return true;
 	}
-	// Autopilot is stricter than AutoApprove, so confirming Autopilot in this
-	// session implies the user already accepted the AutoApprove risks. We do
-	// not extend this to the persisted "don't show again" setting — that
-	// choice is scoped to the level the user made it on.
-	if (level === ChatPermissionLevel.AutoApprove && shownWarnings.has(ChatPermissionLevel.Autopilot)) {
-		return true;
-	}
 	return false;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -31,8 +31,8 @@ const shownWarnings = new Set<ChatPermissionLevel>();
 
 // Storage keys for persisting the user's choice to skip the warning dialog
 // across sessions when "Don't show again" is checked.
-const AUTOPILOT_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autopilot.dontShowWarningAgain';
-const AUTO_APPROVE_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autoApprove.dontShowWarningAgain';
+export const AUTOPILOT_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autopilot.dontShowWarningAgain';
+export const AUTO_APPROVE_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autoApprove.dontShowWarningAgain';
 
 function dontShowAgainKey(level: ChatPermissionLevel): string | undefined {
 	if (level === ChatPermissionLevel.Autopilot) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -24,16 +24,38 @@ import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 
 // Track whether warnings have been shown this VS Code session
 const shownWarnings = new Set<ChatPermissionLevel>();
 
-function hasShownElevatedWarning(level: ChatPermissionLevel): boolean {
+// Storage keys for persisting the user's choice to skip the warning dialog
+// across sessions when "Don't show again" is checked.
+const AUTOPILOT_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autopilot.dontShowWarningAgain';
+const AUTO_APPROVE_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autoApprove.dontShowWarningAgain';
+
+function dontShowAgainKey(level: ChatPermissionLevel): string | undefined {
+	if (level === ChatPermissionLevel.Autopilot) {
+		return AUTOPILOT_DONT_SHOW_AGAIN_KEY;
+	}
+	if (level === ChatPermissionLevel.AutoApprove) {
+		return AUTO_APPROVE_DONT_SHOW_AGAIN_KEY;
+	}
+	return undefined;
+}
+
+function hasShownElevatedWarning(level: ChatPermissionLevel, storageService: IStorageService): boolean {
 	if (shownWarnings.has(level)) {
 		return true;
 	}
-	// Autopilot is stricter than AutoApprove, so confirming Autopilot
-	// implies the user already accepted the AutoApprove risks.
+	const key = dontShowAgainKey(level);
+	if (key && storageService.getBoolean(key, StorageScope.PROFILE, false)) {
+		return true;
+	}
+	// Autopilot is stricter than AutoApprove, so confirming Autopilot in this
+	// session implies the user already accepted the AutoApprove risks. We do
+	// not extend this to the persisted "don't show again" setting — that
+	// choice is scoped to the level the user made it on.
 	if (level === ChatPermissionLevel.AutoApprove && shownWarnings.has(ChatPermissionLevel.Autopilot)) {
 		return true;
 	}
@@ -57,6 +79,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		@IConfigurationService configurationService: IConfigurationService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IOpenerService openerService: IOpenerService,
+		@IStorageService storageService: IStorageService,
 	) {
 		const isAutoApprovePolicyRestricted = () => configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
 		const isAutopilotEnabled = () => configurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
@@ -98,7 +121,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors"),
 						},
 						run: async () => {
-							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove)) {
+							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove, storageService)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
 									message: localize('permissions.autoApprove.warning.title', "Enable Bypass Approvals?"),
@@ -112,6 +135,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 											run: () => false
 										},
 									],
+									checkbox: {
+										label: localize('permissions.warning.dontShowAgain', "Don't show again"),
+										checked: false,
+									},
 									custom: {
 										icon: Codicon.warning,
 										markdownDetails: [{
@@ -121,6 +148,9 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 								});
 								if (result.result !== true) {
 									return;
+								}
+								if (result.checkboxChecked) {
+									storageService.store(AUTO_APPROVE_DONT_SHOW_AGAIN_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 								}
 								shownWarnings.add(ChatPermissionLevel.AutoApprove);
 							}
@@ -147,7 +177,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done"),
 						},
 						run: async () => {
-							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot)) {
+							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot, storageService)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
 									message: localize('permissions.autopilot.warning.title', "Enable Autopilot?"),
@@ -161,6 +191,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 											run: () => false
 										},
 									],
+									checkbox: {
+										label: localize('permissions.warning.dontShowAgain', "Don't show again"),
+										checked: false,
+									},
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
@@ -170,6 +204,9 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 								});
 								if (result.result !== true) {
 									return;
+								}
+								if (result.checkboxChecked) {
+									storageService.store(AUTOPILOT_DONT_SHOW_AGAIN_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 								}
 								shownWarnings.add(ChatPermissionLevel.Autopilot);
 							}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -29,10 +29,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../../../
 // Track whether warnings have been shown this VS Code session
 const shownWarnings = new Set<ChatPermissionLevel>();
 
-// Storage keys for persisting the user's choice to skip the warning dialog
-// across sessions when "Don't show again" is checked.
-export const AUTOPILOT_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autopilot.dontShowWarningAgain';
-export const AUTO_APPROVE_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autoApprove.dontShowWarningAgain';
+import { AUTOPILOT_DONT_SHOW_AGAIN_KEY, AUTO_APPROVE_DONT_SHOW_AGAIN_KEY } from '../../../common/chatPermissionStorageKeys.js';
 
 function dontShowAgainKey(level: ChatPermissionLevel): string | undefined {
 	if (level === ChatPermissionLevel.Autopilot) {

--- a/src/vs/workbench/contrib/chat/common/chatPermissionStorageKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/chatPermissionStorageKeys.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Storage keys for persisting the user's choice to skip the warning dialog
+// across sessions when "Don't show again" is checked.
+export const AUTOPILOT_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autopilot.dontShowWarningAgain';
+export const AUTO_APPROVE_DONT_SHOW_AGAIN_KEY = 'chat.permissions.autoApprove.dontShowWarningAgain';


### PR DESCRIPTION
## Summary

Adds a **"Don't show again"** checkbox to the confirmation dialogs shown when the user enables **Autopilot** or **Bypass Approvals** in the chat permissions picker.

When the checkbox is checked and the user clicks **Enable**, the choice is persisted to profile storage (`StorageScope.PROFILE`) so the warning is not shown again across sessions. Each permission level (Autopilot and Bypass Approvals) is tracked independently — suppressing one does not suppress the other.

## Changes

### `permissionPickerActionItem.ts`
- Added `IStorageService` injection to `PermissionPickerActionItem`.
- Exported two storage keys (`AUTOPILOT_DONT_SHOW_AGAIN_KEY`, `AUTO_APPROVE_DONT_SHOW_AGAIN_KEY`) for use by the reset command.
- Extended `hasShownElevatedWarning()` to check persisted storage in addition to the existing in-session `shownWarnings` Set.
- Added `checkbox: { label: "Don't show again", checked: false }` to both dialog `prompt()` calls.
- On confirm + checkbox checked, stores `true` via `storageService.store(..., StorageScope.PROFILE, StorageTarget.USER)`.
- Removed the implicit "Autopilot implies AutoApprove" cross-level implication so each warning shows independently.

### `chatDeveloperActions.ts`
- Added `ResetChatPermissionWarningDialogsAction` (Developer category, command `workbench.action.chat.resetPermissionWarningDialogs`, title **"Reset Permission Warning Dialogs (Autopilot, Bypass Approvals)"**).
- The command removes both storage keys from PROFILE scope, allowing the warnings to appear again.
