### PR TITLE
Allow vscode-agent-host scheme in chat content markdown renderer

### DIFF
--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -33,6 +33,25 @@ suite('MarkdownRenderer', () => {
 			const result: HTMLElement = store.add(renderMarkdown(markdown)).element;
 			assert.strictEqual(result.innerHTML, '<p><img alt="image"></p>');
 		});
+
+		test('Strips links with disallowed schemes (default config)', () => {
+			const markdown = { value: `Read [](vscode-agent-host://my-host/file/-/path/to/foo.ts)` };
+			const result: HTMLElement = store.add(renderMarkdown(markdown)).element;
+			// No <a> element should remain because the scheme isn't allowed.
+			assert.strictEqual(result.querySelector('a'), null);
+		});
+
+		test('Preserves link with disallowed scheme when augmented through allowedLinkSchemes', () => {
+			const markdown = { value: `Read [](vscode-agent-host://my-host/file/-/path/to/foo.ts)` };
+			const result: HTMLElement = store.add(renderMarkdown(markdown, {
+				sanitizerConfig: {
+					allowedLinkSchemes: { augment: ['vscode-agent-host'] },
+				},
+			})).element;
+			const anchor = result.querySelector('a');
+			assert.ok(anchor, 'expected <a> to be preserved when scheme is allowed');
+			assert.strictEqual(anchor!.dataset.href, 'vscode-agent-host://my-host/file/-/path/to/foo.ts');
+		});
 	});
 
 	suite('Images', () => {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -41,7 +41,7 @@ suite('MarkdownRenderer', () => {
 			assert.strictEqual(result.querySelector('a'), null);
 		});
 
-		test('Preserves link with disallowed scheme when augmented through allowedLinkSchemes', () => {
+		test('Preserves link when scheme is allowed via allowedLinkSchemes.augment', () => {
 			const markdown = { value: `Read [](vscode-agent-host://my-host/file/-/path/to/foo.ts)` };
 			const result: HTMLElement = store.add(renderMarkdown(markdown, {
 				sanitizerConfig: {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -15,6 +15,7 @@ import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import product from '../../../../../platform/product/common/product.js';
 import { Schemas } from '../../../../../base/common/network.js';
+import { AGENT_HOST_SCHEME } from '../../../../../platform/agentHost/common/agentHostUri.js';
 
 const _remoteImageDisallowed = () => false;
 
@@ -81,7 +82,7 @@ export class ChatContentMarkdownRenderer implements IMarkdownRenderer {
 					override: allowedChatMarkdownHtmlTags,
 				},
 				...options?.sanitizerConfig,
-				allowedLinkSchemes: { augment: [product.urlProtocol, 'copilot-skill', Schemas.vscodeBrowser] },
+				allowedLinkSchemes: { augment: [product.urlProtocol, 'copilot-skill', Schemas.vscodeBrowser, AGENT_HOST_SCHEME] },
 				remoteImageIsAllowed: _remoteImageDisallowed,
 			}
 		};

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -397,6 +397,27 @@ suite('stateToProgressAdapter', () => {
 
 	suite('finalizeToolInvocation', () => {
 
+		test('rewrites markdown links in pastTenseMessage through the agent host scheme', () => {
+			const tc = createToolCallState({ status: ToolCallStatus.Running });
+			const invocation = toolCallStateToInvocation(tc);
+
+			rawFinalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'view_file',
+				displayName: 'View File',
+				invocationMessage: 'Reading file...',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: true,
+				pastTenseMessage: { markdown: 'Read [foo.ts](file:///path/to/foo.ts)' },
+			} as ICompletedToolCall, URI.file('/'), 'ssh__macbook-air');
+
+			assert.ok(invocation.pastTenseMessage);
+			assert.strictEqual(typeof invocation.pastTenseMessage, 'object');
+			const value = (invocation.pastTenseMessage as { value: string }).value;
+			assert.strictEqual(value, 'Read [](vscode-agent-host://ssh__macbook-air/file/-/path/to/foo.ts)');
+		});
+
 		test('finalizes terminal tool with output and exit code', () => {
 			const tc = createToolCallState({
 				toolInput: 'echo hi',


### PR DESCRIPTION
Fixes a bug where remote agent host file references in tool past-tense messages (e.g. `Read [foo.ts](vscode-agent-host://...)`) rendered as raw markdown text instead of as clickable file widgets.

### Root cause

After the recent change to rewrite remote agent host file links into empty-text markdown links of the form `[](vscode-agent-host://...)`, the chat content markdown renderer's sanitizer didn't include `vscode-agent-host` in its allowed link schemes:

1. DOMPurify stripped the disallowed `href` during sanitization
2. `rewriteRenderedLinks` then saw an `<a>` with no `href` and no text content, and removed the element entirely
3. `renderFileWidgets` had no anchor to convert into an `InlineAnchorWidget`

The result: tool messages like "Read [...](vscode-agent-host://...)" rendered as the literal string `Read ` followed by nothing.

### Fix

Add `AGENT_HOST_SCHEME` to the augmented `allowedLinkSchemes` in `chatContentMarkdownRenderer.ts` so the link survives sanitization and reaches `renderFileWidgets`.

### Tests

- `markdownRenderer.test.ts`: new tests showing the default config strips disallowed-scheme links (reproducing the bug) and that augmenting `allowedLinkSchemes` preserves them with their `data-href`.
- `stateToProgressAdapter.test.ts`: existing test confirms `finalizeToolInvocation` rewrites `pastTenseMessage` through the agent host scheme.

(Written by Copilot)