### PR TITLE
Fix notebook style resets

### DIFF
--- a/src/vs/base/browser/overlayLayoutElement.ts
+++ b/src/vs/base/browser/overlayLayoutElement.ts
@@ -53,6 +53,13 @@ export class OverlayLayoutElement implements IDisposable {
 		this.content.style.position = 'absolute';
 		this.content.style.overflow = 'hidden';
 
+		this._root = document.createElement('div');
+		this._root.appendChild(this.content);
+
+		this.reapplyLayoutStyles();
+	}
+
+	public reapplyLayoutStyles(): void {
 		if (supportsAnchorPositioning.value) {
 			this.content.style.position = 'fixed';
 			this.content.style.top = 'anchor(top)';
@@ -62,10 +69,8 @@ export class OverlayLayoutElement implements IDisposable {
 			this.content.style.pointerEvents = 'auto';
 		}
 
-		this._root = document.createElement('div');
 		this._root.style.position = 'absolute';
 		this._root.style.pointerEvents = 'none';
-		this._root.appendChild(this.content);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -331,7 +331,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this.isReplHistory = creationOptions.isReplHistory ?? false;
 		this._readOnly = creationOptions.isReadOnly ?? false;
 
-		this._overlayLayout = new OverlayLayoutElement();
+		this._overlayLayout = this._register(new OverlayLayoutElement());
 		this._overlayContainer = this._overlayLayout.content;
 		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this._overlayContainer));
 		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
@@ -1953,8 +1953,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		this._overlayContainer.style.visibility = 'visible';
-		this._overlayContainer.style.left = ''; // Clear hide offset
 		this._overlayLayout.layoutOverAnchorElement(shadowElement, { clippingContainer, fallbackDimension: dimension, fallbackPosition: position });
+		this._overlayLayout.reapplyLayoutStyles();
 	}
 
 	//#endregion


### PR DESCRIPTION
Fixes #311100

`left` is used for the moving off screen so we need to reapply it when showing the notebook again

