### PR TITLE
Fix disposed SCM source control retention

### DIFF
--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -1026,6 +1026,22 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		sourceControls.push(sourceControl);
 		this._sourceControlsByExtension.set(extension.identifier, sourceControls);
 
+		Event.once(sourceControl.onDidDispose)(() => {
+			this._sourceControls.delete(sourceControl.handle);
+
+			const sourceControls = this._sourceControlsByExtension.get(extension.identifier);
+			if (sourceControls) {
+				const index = sourceControls.indexOf(sourceControl);
+				if (index !== -1) {
+					sourceControls.splice(index, 1);
+				}
+
+				if (sourceControls.length === 0) {
+					this._sourceControlsByExtension.delete(extension.identifier);
+				}
+			}
+		});
+
 		return sourceControl;
 	}
 

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -1027,6 +1027,8 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		this._sourceControlsByExtension.set(extension.identifier, sourceControls);
 
 		Event.once(sourceControl.onDidDispose)(() => {
+			this.logService.trace('ExtHostSCM#disposeSourceControl', extension.identifier.value, id, label, rootUri);
+
 			this._sourceControls.delete(sourceControl.handle);
 
 			const sourceControls = this._sourceControlsByExtension.get(extension.identifier);

--- a/src/vs/workbench/api/test/common/extHostSCM.test.ts
+++ b/src/vs/workbench/api/test/common/extHostSCM.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../platform/log/common/log.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { nullExtensionDescription } from '../../../services/extensions/common/extensions.js';
+import { MainContext, MainThreadSCMShape, MainThreadTelemetryShape } from '../../common/extHost.protocol.js';
+import { ArgumentProcessor, ExtHostCommands } from '../../common/extHostCommands.js';
+import { ExtHostDocuments } from '../../common/extHostDocuments.js';
+import { ExtHostSCM } from '../../common/extHostSCM.js';
+import { TestRPCProtocol } from './testRPCProtocol.js';
+
+suite('ExtHostSCM', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('disposed source controls are removed from extension bookkeeping', () => {
+		const rpcProtocol = new TestRPCProtocol();
+		rpcProtocol.set(MainContext.MainThreadSCM, new class extends mock<MainThreadSCMShape>() {
+			override async $registerSourceControl(): Promise<void> { }
+			override async $unregisterSourceControl(): Promise<void> { }
+		});
+		rpcProtocol.set(MainContext.MainThreadTelemetry, new class extends mock<MainThreadTelemetryShape>() {
+			override $publicLog2(): void { }
+		});
+
+		const commands = new class extends mock<ExtHostCommands>() {
+			override registerArgumentProcessor(_processor: ArgumentProcessor): void { }
+		};
+		const extension = {
+			...nullExtensionDescription,
+			identifier: new ExtensionIdentifier('vscode.git'),
+			name: 'git',
+			displayName: 'Git',
+			extensionLocation: URI.file('/extension'),
+			isBuiltin: true
+		};
+
+		const extHostSCM = new ExtHostSCM(
+			rpcProtocol,
+			commands,
+			{} as ExtHostDocuments,
+			new NullLogService()
+		);
+
+		const sourceControl = extHostSCM.createSourceControl(extension, 'git', 'Git', URI.file('/repo'), undefined, undefined, undefined);
+		assert.ok(extHostSCM.getLastInputBox(extension));
+
+		sourceControl.dispose();
+
+		assert.strictEqual(extHostSCM.getLastInputBox(extension), undefined);
+	});
+});


### PR DESCRIPTION
This fixes an extension-host SCM bookkeeping leak where disposed source controls remained reachable from `ExtHostSCM` after they had been unregistered from the main thread.

Disposed source controls are now removed from both handle-based and extension-based bookkeeping when `onDidDispose` fires. This allows disposed Git repositories and their refs/history/artifact state to be collected instead of staying alive through stale SCM provider references.

Fixes #311282

Validation:
- `VS Code - Build` task output was clean for Core Transpile, Core Typecheck, Ext Build, and Copilot Build.
- Focused unit test passed: `disposed source controls are removed from extension bookkeeping`.
- Hygiene passed for the changed TypeScript files with only the existing TypeScript-version warning from `@typescript-eslint/typescript-estree`.

(Written by Copilot)