### PR TITLE
Avoid duplicating prompt text in agent host question carousel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -1723,13 +1723,21 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			});
 		}
 
+		// Suppress the carousel-level message when it would duplicate the only
+		// question's text. Agents typically populate `inputReq.message` and a
+		// single question's `message` from the same source, so rendering both
+		// produces the same prompt twice in the UI.
+		const carouselMessage = questions.length === 1 && questions[0].title === inputReq.message
+			? undefined
+			: rawMarkdownToString(inputReq.message, this._config.connectionAuthority);
+
 		const carousel = new ChatQuestionCarouselData(
 			questions,
 			/* allowSkip */ true,
 			/* resolveId */ undefined,
 			/* data */ undefined,
 			/* isUsed */ undefined,
-			/* message */ rawMarkdownToString(inputReq.message, this._config.connectionAuthority),
+			/* message */ carouselMessage,
 		);
 
 		progress([carousel]);


### PR DESCRIPTION
Fixes #311121

When an agent host input request arrives with a single question whose title is the same string as the request-level `message` (the common case for the Ask User tool), the carousel previously rendered the prompt twice — once as the carousel-level message and once as the question header.

Suppress the carousel-level message in that single-question case. Multi-question requests still show the request-level message above the questions.

(Written by Copilot)