### PR TITLE
Align run_in_terminal output cap to 60kb and remove dead sanitizeTerminalOutput

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
@@ -7,7 +7,7 @@ import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { truncateOutputKeepingTail } from './runInTerminalHelpers.js';
 
-const MAX_OUTPUT_LENGTH = 16000;
+const MAX_OUTPUT_LENGTH = 60000;
 
 export interface IGetOutputOptions {
 	/** When set, only return the last N non-empty lines from the bottom of the buffer. */

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalHelpers.ts
@@ -7,7 +7,7 @@ import { Separator } from '../../../../../base/common/actions.js';
 import { coalesce } from '../../../../../base/common/arrays.js';
 import { posix as pathPosix, win32 as pathWin32 } from '../../../../../base/common/path.js';
 import { OperatingSystem } from '../../../../../base/common/platform.js';
-import { escapeRegExpCharacters, removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
+import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
 import { localize } from '../../../../../nls.js';
 import type { TerminalNewAutoApproveButtonData } from '../../../chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import type { ToolConfirmationAction } from '../../../chat/common/tools/languageModelToolsService.js';
@@ -47,8 +47,6 @@ export function isFish(envShell: string, os: OperatingSystem): boolean {
 	return /^fish$/.test(pathPosix.basename(envShell));
 }
 
-// Maximum output length to prevent context overflow
-const MAX_OUTPUT_LENGTH = 60000; // ~60KB limit to keep context manageable
 export const TRUNCATION_MESSAGE = '\n\n[... PREVIOUS OUTPUT TRUNCATED ...]\n\n';
 
 export function truncateOutputKeepingTail(output: string, maxLength: number): string {
@@ -62,19 +60,6 @@ export function truncateOutputKeepingTail(output: string, maxLength: number): st
 	const availableLength = maxLength - truncationMessageLength;
 	const endPortion = output.slice(-availableLength);
 	return TRUNCATION_MESSAGE + endPortion;
-}
-
-export function sanitizeTerminalOutput(output: string): string {
-	let sanitized = removeAnsiEscapeCodes(output)
-		// Trim trailing \r\n characters
-		.trimEnd();
-
-	// Truncate if output is too long to prevent context overflow
-	if (sanitized.length > MAX_OUTPUT_LENGTH) {
-		sanitized = truncateOutputKeepingTail(sanitized, MAX_OUTPUT_LENGTH);
-	}
-
-	return sanitized;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputHelpers.test.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual } from 'assert';
+import { ok, strictEqual } from 'assert';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { getOutput } from '../../browser/outputHelpers.js';
+import { TRUNCATION_MESSAGE } from '../../browser/runInTerminalHelpers.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 
 suite('outputHelpers', () => {
@@ -59,5 +60,17 @@ suite('outputHelpers', () => {
 		const marker = { line: 1 } as IXtermMarker;
 		const output = getOutput(instance, marker);
 		strictEqual(output, `${line80}X\nafter`);
+	});
+
+	test('caps output at 60KB and prefixes the truncation marker', () => {
+		const line = 'a'.repeat(1000);
+		const instance = createMockInstance(
+			Array.from({ length: 100 }, () => ({ text: line }))
+		);
+
+		const output = getOutput(instance);
+		strictEqual(output.length, 60000);
+		ok(output.startsWith(TRUNCATION_MESSAGE));
+		ok(output.endsWith(line));
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/runInTerminalHelpers.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ok, strictEqual } from 'assert';
-import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, sanitizeTerminalOutput, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay } from '../../browser/runInTerminalHelpers.js';
+import { generateAutoApproveActions, TRUNCATION_MESSAGE, dedupeRules, isPowerShell, truncateOutputKeepingTail, extractCdPrefix, normalizeTerminalCommandForDisplay } from '../../browser/runInTerminalHelpers.js';
 import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ConfigurationTarget } from '../../../../../../platform/configuration/common/configuration.js';
@@ -280,16 +280,6 @@ suite('truncateOutputKeepingTail', () => {
 	test('gracefully handles tiny limits', () => {
 		const result = truncateOutputKeepingTail('example', 5);
 		strictEqual(result.length, 5);
-	});
-});
-
-suite('sanitizeTerminalOutput', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
-	test('adds truncation notice when exceeding max length', () => {
-		const longOutput = 'line\n'.repeat(20000);
-		const result = sanitizeTerminalOutput(longOutput);
-		ok(result.startsWith(TRUNCATION_MESSAGE));
-		ok(result.endsWith('line'));
 	});
 });
 


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/309372

/cc @meganrogge 

What was happening:
- `run_in_terminal` tool description told model output was truncated at 60kb -> https://github.com/microsoft/vscode/blob/173f07e5fc9aeeb33a6a7ea1c62a7456dc1d5108/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts#L135 
- I saw `getOutput` path was actually capping at 16kb instead.

This PR aligns it to 60kb.

Also deleting `sanitizeTerminalOutput` and the duplicate MAX_OUTPUT_LENGTH 
- `sanitizeTerminalOutput` was only referenced in test and nowhere else. Ghost code. 
