### PR TITLE
Enhance draft input persistence for remote chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1973,6 +1973,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (!model) {
+			// Flush any unsent draft to the outgoing input model before we drop our
+			// reference to it, so the host's `willDisposeModel` persistence sees it.
+			this.inputPart.flushInputStateToModel();
 			if (this.viewModel?.editing) {
 				this.finishedEditing();
 			}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1076,6 +1076,17 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		queueMicrotask(() => this.inputActionsToolbar?.relayout());
 	}
 
+	/**
+	 * Flush the current input state to the bound input model. Use this before
+	 * the host releases its model reference (e.g. on session switch) to ensure
+	 * an unsent draft is captured by `willDisposeModel` persistence.
+	 */
+	public flushInputStateToModel(): void {
+		if (this._inputModel) {
+			this._syncInputStateToModel();
+		}
+	}
+
 	public setCurrentLanguageModel(model: ILanguageModelChatMetadataAndIdentifier) {
 		this._currentLanguageModel.set(model, undefined);
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -62,6 +62,22 @@ import { ChatMode } from '../chatModes.js';
 
 const serializedChatKey = 'interactive.sessions';
 
+/**
+ * True when the user has typed text or attached non-trivial context to the input
+ * but not yet sent it. Used to decide whether an external session needs metadata
+ * persisted on dispose so the draft survives switching sessions.
+ */
+function hasDraftInput(model: ChatModel): boolean {
+	const state = model.inputModel.state.get();
+	if (!state) {
+		return false;
+	}
+	if (state.inputText.trim().length > 0) {
+		return true;
+	}
+	return state.attachments.length > 0;
+}
+
 class CancellableRequest implements IDisposable {
 	private readonly _yieldRequested: ISettableObservable<boolean> = observableValue(this, false);
 
@@ -187,7 +203,9 @@ export class ChatService extends Disposable implements IChatService {
 					} else if (this._saveModelsEnabled) {
 						await this._chatSessionStore.storeSessions([model]);
 					}
-				} else if (!localSessionId && model.getRequests().length > 0) {
+				} else if (!localSessionId && (model.getRequests().length > 0 || hasDraftInput(model))) {
+					// External sessions: persist metadata when there are requests, OR when the
+					// user has typed/attached unsent input we need to restore on next open.
 					await this._chatSessionStore.storeSessionsMetadataOnly([model]);
 				}
 			}
@@ -575,7 +593,9 @@ export class ChatService extends Disposable implements IChatService {
 		const chatSessionType = getChatSessionType(sessionResource);
 		const modelId = findLast(providedSession.history.filter(m => m.type === 'request'), req => req.modelId)?.modelId;
 		const agentUri = findLast(providedSession.history.filter(m => m.type === 'request'), req => req.modeInstructions?.uri)?.modeInstructions?.uri;
-		const storedPermissionLevel = this._chatSessionStore.getMetadataForSessionSync(sessionResource)?.permissionLevel;
+		const storedMetadata = this._chatSessionStore.getMetadataForSessionSync(sessionResource);
+		const storedPermissionLevel = storedMetadata?.permissionLevel;
+		const storedInputState = storedMetadata?.inputState;
 		let initialData: ISerializedChatDataReference | undefined = undefined;
 		if ((modelId || agentUri)) {
 			const mode: ISerializableChatModelInputState['mode'] = agentUri ? { kind: ChatModeKind.Agent, id: agentUri.toString() } : { kind: ChatModeKind.Agent, id: ChatMode.Agent.id };
@@ -607,18 +627,21 @@ export class ChatService extends Disposable implements IChatService {
 			};
 		}
 
-		// Contributed sessions do not use UI tools
+		// Contributed sessions do not use UI tools.
+		// Prefer (in order): a transferred draft, a persisted draft from metadata,
+		// otherwise let the constructor fall back to initialData.value.inputState.
 		const modelRef = this._sessionModels.acquireOrCreate({
 			initialData,
 			location,
 			sessionResource: sessionResource,
 			canUseTools: false,
 			transferEditingSession: providedSession.transferredState?.editingSession,
-			inputState: providedSession.transferredState?.inputState,
+			inputState: providedSession.transferredState?.inputState ?? storedInputState,
 		}, debugOwner ?? 'ChatService#loadRemoteSession');
 
 		// Restore permission level from metadata even when initialData was not constructed
-		if (storedPermissionLevel && !initialData) {
+		// and no inputState carried it through.
+		if (storedPermissionLevel && !initialData && !storedInputState) {
 			modelRef.object.inputModel.setState({ permissionLevel: storedPermissionLevel });
 		}
 

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -29,7 +29,7 @@ import { awaitStatsForSession } from '../chat.js';
 import { IChatSessionStats, IChatSessionTiming, ResponseModelState } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatPermissionLevel } from '../constants.js';
 import { ModifiedFileEntryState } from '../editing/chatEditingService.js';
-import { ChatModel, ISerializableChatData, ISerializableChatDataIn, ISerializableChatsData, ISerializedChatDataReference, normalizeSerializableChatData } from './chatModel.js';
+import { ChatModel, ISerializableChatData, ISerializableChatDataIn, ISerializableChatModelInputState, ISerializableChatsData, ISerializedChatDataReference, normalizeSerializableChatData } from './chatModel.js';
 import { ChatSessionOperationLog } from './chatSessionOperationLog.js';
 import { LocalChatSessionUri } from './chatUri.js';
 
@@ -758,6 +758,13 @@ export interface IChatSessionEntryMetadata {
 	 * The permission level for tool auto-approval, if not default.
 	 */
 	permissionLevel?: ChatPermissionLevel;
+
+	/**
+	 * Serialized draft input state (text, attachments, mode, selected model, ...) for
+	 * external sessions, so that unsent input is preserved when switching away and
+	 * back. Local sessions instead persist their full state via storeSessions.
+	 */
+	inputState?: ISerializableChatModelInputState;
 }
 
 function isChatSessionEntryMetadata(obj: unknown): obj is IChatSessionEntryMetadata {
@@ -831,6 +838,12 @@ async function getSessionMetadata(session: ChatModel | ISerializableChatData): P
 		lastResponseState = ResponseModelState.Cancelled;
 	}
 
+	const isExternal = session instanceof ChatModel && !LocalChatSessionUri.parseLocalSessionId(session.sessionResource);
+	// Persist draft input state only for external sessions; local sessions already
+	// have their full state serialized via storeSessions, so duplicating here would
+	// be wasteful and risk drift between the two locations.
+	const inputState = isExternal ? (session as ChatModel).inputModel.toJSON() : undefined;
+
 	return {
 		sessionId: session.sessionId,
 		title: title || localize('newChat', "New Chat"),
@@ -840,9 +853,10 @@ async function getSessionMetadata(session: ChatModel | ISerializableChatData): P
 		hasPendingEdits: session instanceof ChatModel ? (session.editingSession?.entries.get().some(e => e.state.get() === ModifiedFileEntryState.Modified)) : false,
 		isEmpty: session instanceof ChatModel ? session.getRequests().length === 0 : session.requests.length === 0,
 		stats,
-		isExternal: session instanceof ChatModel && !LocalChatSessionUri.parseLocalSessionId(session.sessionResource),
+		isExternal,
 		lastResponseState,
 		permissionLevel: session instanceof ChatModel ? session.inputModel.state.get()?.permissionLevel : undefined,
+		inputState,
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -842,7 +842,10 @@ async function getSessionMetadata(session: ChatModel | ISerializableChatData): P
 	// Persist draft input state only for external sessions; local sessions already
 	// have their full state serialized via storeSessions, so duplicating here would
 	// be wasteful and risk drift between the two locations.
-	const inputState = isExternal ? (session as ChatModel).inputModel.toJSON() : undefined;
+	// Attachments are excluded because they can contain large binary payloads
+	// (e.g. base64-encoded images) that would bloat the session index entry.
+	const rawInputState = isExternal ? (session as ChatModel).inputModel.toJSON() : undefined;
+	const inputState = rawInputState ? { ...rawInputState, attachments: [] } : undefined;
 
 	return {
 		sessionId: session.sessionId,

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -1487,6 +1487,33 @@ suite('ChatService', () => {
 			const model = ref.object as ChatModel;
 			assert.strictEqual(model.lastRequest?.response?.isComplete, true, 'Non-streaming session should complete response at load time');
 		});
+
+		test('draft input is restored after disposing and reloading a remote session', async () => {
+			const { resource } = setupRemoteProvider({ history: [] });
+
+			const testService = createChatService();
+
+			// Load the session and seed an unsent draft on its inputModel.
+			const ref1 = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref1, 'Should load remote session');
+			const model1 = ref1.object as ChatModel;
+			model1.inputModel.setState({
+				inputText: 'unsent draft',
+				selections: [{ selectionStartLineNumber: 1, selectionStartColumn: 1, positionLineNumber: 1, positionColumn: 12 }],
+			});
+
+			// Release the only reference -> willDisposeModel runs and persists metadata.
+			ref1.dispose();
+			await testService.waitForModelDisposals();
+
+			// Reload the same session. The draft must be restored from metadata.
+			const ref2 = await testService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None);
+			assert.ok(ref2, 'Should re-load remote session');
+			testDisposables.add(ref2);
+			const model2 = ref2.object as ChatModel;
+			const restored = model2.inputModel.state.get();
+			assert.strictEqual(restored?.inputText, 'unsent draft', 'Input text should be restored');
+		});
 	});
 });
 


### PR DESCRIPTION
Improve the handling of unsent draft inputs in remote chat sessions. Ensure that draft inputs are preserved when switching sessions, allowing users to retain their input state. Add tests to verify that draft inputs are correctly restored after disposing and reloading a session.

Fixes https://github.com/microsoft/vscode/issues/311310