### PR TITLE
Agents: Refactor SessionsView UI and improve action order

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -139,13 +139,7 @@
 		top: 1.5px;
 	}
 
-	/* Align the find widget close button with the toolbar's open/search button (22x22) */
-	.agent-sessions-find-widget-container > .monaco-tree-type-filter > .monaco-tree-type-filter-actionbar {
-		display: flex;
-		align-items: center;
-		margin-left: 4px;
-	}
-
+	/* Match the find widget's close button size to the header toolbar action buttons (22x22) */
 	.agent-sessions-find-widget-container > .monaco-tree-type-filter > .monaco-tree-type-filter-actionbar .monaco-action-bar .action-label {
 		width: 22px;
 		height: 22px;

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -139,6 +139,22 @@
 		top: 1.5px;
 	}
 
+	/* Align the find widget close button with the toolbar's open/search button (22x22) */
+	.agent-sessions-find-widget-container > .monaco-tree-type-filter > .monaco-tree-type-filter-actionbar {
+		display: flex;
+		align-items: center;
+		margin-left: 4px;
+	}
+
+	.agent-sessions-find-widget-container > .monaco-tree-type-filter > .monaco-tree-type-filter-actionbar .monaco-action-bar .action-label {
+		width: 22px;
+		height: 22px;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
 	/* Compact "New" button in header */
 	.agent-sessions-compact-new-button.monaco-button {
 		display: inline-flex;

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -258,8 +258,8 @@ export class SessionsView extends ViewPane {
 			this.sessionsManagementService.openNewSessionView();
 		}));
 
-		newSessionButton.label = localize('newCompact', "New");
-		const buttonLabel = $('span.new-session-button-label', undefined, localize('newCompact', "New"));
+		const newSessionLabel = localize('newCompact', "New");
+		const buttonLabel = $('span.new-session-button-label', undefined, newSessionLabel);
 		const keybindingHint = $('span.new-session-keybinding-hint');
 		const keybindingHintLabel = this._register(new KeybindingLabel(keybindingHint, OS, {
 			disableTitle: true,

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -147,18 +147,7 @@ export class SessionsView extends ViewPane {
 
 		const headerActions = this.headerActions = DOM.append(headerRow, $('.agent-sessions-header-actions'));
 
-		const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
-		this._register(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, headerActions, Menus.SidebarSessionsHeader, {
-			hiddenItemStrategy: HiddenItemStrategy.NoHide,
-			telemetrySource: 'sessionsView.header',
-			toolbarOptions: { primaryGroup: () => true },
-		}));
-
-		// Container for the tree's find widget (rendered in-place in the header)
-		const findWidgetContainer = this.findWidgetContainer = DOM.append(headerRow, $('.agent-sessions-find-widget-container'));
-		findWidgetContainer.style.display = 'none';
-
-		// Compact New Session Button
+		// Compact New Session Button (appended before the toolbar so visual order is: New, Filter, Search)
 		const newSessionButton = this._register(new Button(headerActions, {
 			...defaultButtonStyles,
 			buttonSecondaryBackground: asCssVariable(agentsNewSessionButtonBackground),
@@ -223,6 +212,17 @@ export class SessionsView extends ViewPane {
 				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));
 		};
 		this._register(Event.runAndSubscribe(this.keybindingService.onDidUpdateKeybindings, updateNewSessionButton));
+
+		const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
+		this._register(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, headerActions, Menus.SidebarSessionsHeader, {
+			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			telemetrySource: 'sessionsView.header',
+			toolbarOptions: { primaryGroup: () => true },
+		}));
+
+		// Container for the tree's find widget (toggled by the toolbar's Find action)
+		const findWidgetContainer = this.findWidgetContainer = DOM.append(headerRow, $('.agent-sessions-find-widget-container'));
+		findWidgetContainer.style.display = 'none';
 
 		// Sessions List Control
 		this.sessionsControlContainer = DOM.append(sessionsContent, $('.agent-sessions-control-container'));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -147,71 +147,8 @@ export class SessionsView extends ViewPane {
 
 		const headerActions = this.headerActions = DOM.append(headerRow, $('.agent-sessions-header-actions'));
 
-		// Compact New Session Button (appended before the toolbar so visual order is: New, Filter, Search)
-		const newSessionButton = this._register(new Button(headerActions, {
-			...defaultButtonStyles,
-			buttonSecondaryBackground: asCssVariable(agentsNewSessionButtonBackground),
-			buttonSecondaryForeground: asCssVariable(agentsNewSessionButtonForeground),
-			buttonSecondaryHoverBackground: asCssVariable(agentsNewSessionButtonHoverBackground),
-			buttonSecondaryBorder: asCssVariable(agentsNewSessionButtonBorder),
-			secondary: true,
-			supportIcons: true,
-		}));
-		newSessionButton.element.classList.add('agent-sessions-compact-new-button');
-		this._register(newSessionButton.onDidClick(() => {
-			logSessionsInteraction(this.telemetryService, 'newSession');
-			this.sessionsManagementService.openNewSessionView();
-		}));
-
-		newSessionButton.label = localize('newCompact', "New");
-		const buttonLabel = $('span.new-session-button-label', undefined, localize('newCompact', "New"));
-		const keybindingHint = $('span.new-session-keybinding-hint');
-		const keybindingHintLabel = this._register(new KeybindingLabel(keybindingHint, OS, {
-			disableTitle: true,
-			keybindingLabelBackground: 'transparent',
-			keybindingLabelForeground: 'inherit',
-			keybindingLabelBorder: 'transparent',
-			keybindingLabelBottomBorder: undefined,
-			keybindingLabelShadow: undefined,
-		}));
-		DOM.reset(newSessionButton.element, buttonLabel);
-
-		const getNewSessionKeybinding = () => {
-			const primaryKeybinding = this.keybindingService.lookupKeybinding(ACTION_ID_NEW_SESSION, this.scopedContextKeyService, true);
-			const resolvedKeybindings = this.keybindingService.lookupKeybindings(ACTION_ID_NEW_SESSION);
-			return primaryKeybinding ?? resolvedKeybindings[0];
-		};
-
-		let lastRenderedKeybindingLabel: string | undefined | null = null;
-		let lastRenderedKeybindingAriaLabel: string | undefined | null = null;
-		const updateNewSessionButton = () => {
-			const keybinding = getNewSessionKeybinding();
-			const keybindingLabel = keybinding?.getLabel() ?? undefined;
-			const keybindingAriaLabel = keybinding?.getAriaLabel() ?? undefined;
-			if (lastRenderedKeybindingLabel === keybindingLabel && lastRenderedKeybindingAriaLabel === keybindingAriaLabel) {
-				return;
-			}
-
-			lastRenderedKeybindingLabel = keybindingLabel;
-			lastRenderedKeybindingAriaLabel = keybindingAriaLabel;
-
-			keybindingHintLabel.set(keybinding);
-			if (keybinding) {
-				if (keybindingHint.parentElement !== newSessionButton.element) {
-					DOM.append(newSessionButton.element, keybindingHint);
-				}
-			} else {
-				keybindingHint.remove();
-			}
-
-			newSessionButton.element.title = keybindingLabel
-				? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
-				: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
-			newSessionButton.element.setAttribute('aria-label', keybindingAriaLabel
-				? localize('newSessionButtonAriaLabel', "New Session ({0})", keybindingAriaLabel)
-				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));
-		};
-		this._register(Event.runAndSubscribe(this.keybindingService.onDidUpdateKeybindings, updateNewSessionButton));
+		// Header actions (visual order: New, Filter, Search)
+		this.createNewSessionButton(headerActions);
 
 		const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 		this._register(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, headerActions, Menus.SidebarSessionsHeader, {
@@ -303,6 +240,73 @@ export class SessionsView extends ViewPane {
 				}
 			},
 		}));
+	}
+
+	private createNewSessionButton(container: HTMLElement): void {
+		const newSessionButton = this._register(new Button(container, {
+			...defaultButtonStyles,
+			buttonSecondaryBackground: asCssVariable(agentsNewSessionButtonBackground),
+			buttonSecondaryForeground: asCssVariable(agentsNewSessionButtonForeground),
+			buttonSecondaryHoverBackground: asCssVariable(agentsNewSessionButtonHoverBackground),
+			buttonSecondaryBorder: asCssVariable(agentsNewSessionButtonBorder),
+			secondary: true,
+			supportIcons: true,
+		}));
+		newSessionButton.element.classList.add('agent-sessions-compact-new-button');
+		this._register(newSessionButton.onDidClick(() => {
+			logSessionsInteraction(this.telemetryService, 'newSession');
+			this.sessionsManagementService.openNewSessionView();
+		}));
+
+		newSessionButton.label = localize('newCompact', "New");
+		const buttonLabel = $('span.new-session-button-label', undefined, localize('newCompact', "New"));
+		const keybindingHint = $('span.new-session-keybinding-hint');
+		const keybindingHintLabel = this._register(new KeybindingLabel(keybindingHint, OS, {
+			disableTitle: true,
+			keybindingLabelBackground: 'transparent',
+			keybindingLabelForeground: 'inherit',
+			keybindingLabelBorder: 'transparent',
+			keybindingLabelBottomBorder: undefined,
+			keybindingLabelShadow: undefined,
+		}));
+		DOM.reset(newSessionButton.element, buttonLabel);
+
+		const getNewSessionKeybinding = () => {
+			const primaryKeybinding = this.keybindingService.lookupKeybinding(ACTION_ID_NEW_SESSION, this.scopedContextKeyService, true);
+			const resolvedKeybindings = this.keybindingService.lookupKeybindings(ACTION_ID_NEW_SESSION);
+			return primaryKeybinding ?? resolvedKeybindings[0];
+		};
+
+		let lastRenderedKeybindingLabel: string | undefined | null = null;
+		let lastRenderedKeybindingAriaLabel: string | undefined | null = null;
+		const updateNewSessionButton = () => {
+			const keybinding = getNewSessionKeybinding();
+			const keybindingLabel = keybinding?.getLabel() ?? undefined;
+			const keybindingAriaLabel = keybinding?.getAriaLabel() ?? undefined;
+			if (lastRenderedKeybindingLabel === keybindingLabel && lastRenderedKeybindingAriaLabel === keybindingAriaLabel) {
+				return;
+			}
+
+			lastRenderedKeybindingLabel = keybindingLabel;
+			lastRenderedKeybindingAriaLabel = keybindingAriaLabel;
+
+			keybindingHintLabel.set(keybinding);
+			if (keybinding) {
+				if (keybindingHint.parentElement !== newSessionButton.element) {
+					DOM.append(newSessionButton.element, keybindingHint);
+				}
+			} else {
+				keybindingHint.remove();
+			}
+
+			newSessionButton.element.title = keybindingLabel
+				? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
+				: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
+			newSessionButton.element.setAttribute('aria-label', keybindingAriaLabel
+				? localize('newSessionButtonAriaLabel', "New Session ({0})", keybindingAriaLabel)
+				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));
+		};
+		this._register(Event.runAndSubscribe(this.keybindingService.onDidUpdateKeybindings, updateNewSessionButton));
 	}
 
 	focusCustomizations(): void {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -720,6 +720,7 @@ registerAction2(class MarkSessionAsDoneAction extends Action2 {
 						ContextKeyExpr.and(
 							ContextKeyExpr.equals('sessions.hasGitRepository', true),
 							ContextKeyExpr.equals('sessions.hasPullRequest', false),
+							ContextKeyExpr.equals('sessions.hasIncomingChanges', false),
 							ContextKeyExpr.equals('sessions.hasOutgoingChanges', false),
 							ContextKeyExpr.equals('sessions.hasUncommittedChanges', false),
 						),

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -67,21 +67,21 @@ KeybindingsRegistry.registerKeybindingRule({
 //  View Title Menu
 
 MenuRegistry.appendMenuItem(Menus.SidebarSessionsHeader, {
+	submenu: SessionsViewFilterSubMenu,
+	title: localize2('filterSessions', "Filter Sessions"),
+	icon: Codicon.settings,
+	group: 'navigation',
+	order: 10,
+});
+
+MenuRegistry.appendMenuItem(Menus.SidebarSessionsHeader, {
 	command: {
 		id: 'sessionsViewPane.find',
 		title: localize2('find', "Find Session"),
 		icon: Codicon.search,
 	},
 	group: 'navigation',
-	order: 0,
-});
-
-MenuRegistry.appendMenuItem(Menus.SidebarSessionsHeader, {
-	submenu: SessionsViewFilterSubMenu,
-	title: localize2('filterSessions', "Filter Sessions"),
-	icon: Codicon.settings,
-	group: 'navigation',
-	order: 1,
+	order: 20,
 });
 
 MenuRegistry.appendMenuItem(SessionsViewFilterSubMenu, {
@@ -720,7 +720,6 @@ registerAction2(class MarkSessionAsDoneAction extends Action2 {
 						ContextKeyExpr.and(
 							ContextKeyExpr.equals('sessions.hasGitRepository', true),
 							ContextKeyExpr.equals('sessions.hasPullRequest', false),
-							ContextKeyExpr.equals('sessions.hasIncomingChanges', false),
 							ContextKeyExpr.equals('sessions.hasOutgoingChanges', false),
 							ContextKeyExpr.equals('sessions.hasUncommittedChanges', false),
 						),


### PR DESCRIPTION
This pull request refactors and improves the Sessions View header in both functionality and visual consistency. The main changes include extracting the "New Session" button logic into a dedicated method for better code organization, updating the header action order, and refining the appearance of the find widget's close button to match other toolbar buttons.

**UI/UX Improvements:**

* The find widget's close button in the sessions view now matches the size and style of the header toolbar action buttons for a more consistent look (`sessionsViewPane.css`).

**Code Refactoring & Organization:**

* The logic for creating the "New Session" button has been moved into a new private method `createNewSessionButton`, simplifying the main constructor and improving maintainability (`sessionsView.ts`).
* The header action order is now: New, Filter, Search, for better usability and visual clarity (`sessionsView.ts`).

**Menu and Action Ordering:**

* The "Filter Sessions" submenu and "Find Session" action have been reordered in the header menu for improved navigation, with "Filter" now before "Find" (`sessionsViewActions.ts`).

