### PR TITLE
inline chat: add experiment-controlled reasoning effort and thinking settings

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4231,6 +4231,33 @@
 							"onExp"
 						]
 					},
+					"github.copilot.chat.inlineChat.reasoningEffort": {
+						"type": "string",
+						"default": "low",
+						"enum": [
+							"none",
+							"minimal",
+							"low",
+							"medium",
+							"high"
+						],
+						"markdownDescription": "%github.copilot.config.inlineChat.reasoningEffort%",
+						"tags": [
+							"advanced",
+							"experimental",
+							"onExp"
+						]
+					},
+					"github.copilot.chat.inlineChat.enableThinking": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "%github.copilot.config.inlineChat.enableThinking%",
+						"tags": [
+							"advanced",
+							"experimental",
+							"onExp"
+						]
+					},
 					"github.copilot.chat.debug.requestLogger.maxEntries": {
 						"type": "number",
 						"default": 100,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -374,6 +374,8 @@
 	"github.copilot.config.localWorkspaceRecording.enabled": "Enable local workspace recording for analysis.",
 	"github.copilot.config.editRecording.enabled": "Enable edit recording for analysis.",
 	"github.copilot.config.inlineChat.selectionRatioThreshold": "Threshold at which to switch editing strategies for inline chat. When a selection portion of code matches a parse tree node, only that is presented to the language model. This speeds up response times but might have lower quality results. Requires having a parse tree for the document and the `inlineChat.enableV2` setting. Values must be between 0 and 1, where 0 means off and 1 means the selection perfectly matches a parse tree node.",
+	"github.copilot.config.inlineChat.reasoningEffort": "Controls the reasoning effort level for inline chat requests. Lower values result in faster responses with fewer reasoning tokens. Supported values depend on the model.",
+	"github.copilot.config.inlineChat.enableThinking": "Controls whether thinking/reasoning is enabled for inline chat requests. When disabled, reasoning summaries are suppressed for faster responses.",
 	"github.copilot.config.debug.requestLogger.maxEntries": "Maximum number of entries to keep in the request logger for debugging purposes.",
 	"github.copilot.config.chat.agentDebugLog.enabled": "Deprecated: use `github.copilot.chat.agentDebugLog.fileLogging.enabled` instead.",
 	"github.copilot.config.chat.agentDebugLog.enabled.deprecated": "This setting has been merged into `github.copilot.chat.agentDebugLog.fileLogging.enabled`. Please use this setting instead.",

--- a/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
@@ -459,7 +459,9 @@ class InlineChatEditToolsStrategy implements IInlineChatEditStrategy {
 			requestOptions,
 			modelCapabilities: {
 				enableThinking: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatEnableThinking, this._experimentationService),
-				reasoningEffort: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
+				reasoningEffort: typeof request.modelConfiguration?.reasoningEffort === 'string'
+					? request.modelConfiguration.reasoningEffort
+					: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
 			},
 			telemetryProperties: {
 				messageId: telemetry.telemetryMessageId,
@@ -661,7 +663,9 @@ class InlineChatEditHeuristicStrategy implements IInlineChatEditStrategy {
 			location: ChatLocation.Editor,
 			modelCapabilities: {
 				enableThinking: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatEnableThinking, this._experimentationService),
-				reasoningEffort: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
+				reasoningEffort: typeof request.modelConfiguration?.reasoningEffort === 'string'
+					? request.modelConfiguration.reasoningEffort
+					: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
 			},
 			telemetryProperties: {
 				messageId: telemetry.telemetryMessageId,

--- a/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
+++ b/extensions/copilot/src/extension/inlineChat/node/inlineChatIntent.ts
@@ -305,6 +305,8 @@ class InlineChatEditToolsStrategy implements IInlineChatEditStrategy {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 		@IToolsService private readonly _toolsService: IToolsService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 	) { }
 
 	async executeEdit(endpoint: IChatEndpoint, conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken, documentContext: IDocumentContext, chatTelemetry: ChatTelemetryBuilder): Promise<IInlineChatEditResult> {
@@ -455,6 +457,10 @@ class InlineChatEditToolsStrategy implements IInlineChatEditStrategy {
 			userInitiatedRequest: true,
 			location: ChatLocation.Editor,
 			requestOptions,
+			modelCapabilities: {
+				enableThinking: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatEnableThinking, this._experimentationService),
+				reasoningEffort: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
+			},
 			telemetryProperties: {
 				messageId: telemetry.telemetryMessageId,
 				conversationId: telemetry.sessionId,
@@ -603,6 +609,8 @@ class InlineChatEditHeuristicStrategy implements IInlineChatEditStrategy {
 	constructor(
 		private readonly _intent: InlineChatIntent,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IExperimentationService private readonly _experimentationService: IExperimentationService,
 	) { }
 
 	async executeEdit(endpoint: IChatEndpoint, conversation: Conversation, request: vscode.ChatRequest, stream: vscode.ChatResponseStream, token: CancellationToken, documentContext: IDocumentContext, chatTelemetry: ChatTelemetryBuilder): Promise<IInlineChatEditResult> {
@@ -651,6 +659,10 @@ class InlineChatEditHeuristicStrategy implements IInlineChatEditStrategy {
 			messages: renderResult.messages,
 			userInitiatedRequest: true,
 			location: ChatLocation.Editor,
+			modelCapabilities: {
+				enableThinking: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatEnableThinking, this._experimentationService),
+				reasoningEffort: this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.InlineChatReasoningEffort, this._experimentationService),
+			},
 			telemetryProperties: {
 				messageId: telemetry.telemetryMessageId,
 				conversationId: telemetry.sessionId,

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -640,6 +640,8 @@ export namespace ConfigKey {
 		export const UseAlternativeNESNotebookFormat = defineAndMigrateExpSetting<boolean>('chat.advanced.notebook.alternativeNESFormat.enabled', 'chat.notebook.alternativeNESFormat.enabled', false);
 
 		export const InlineChatSelectionRatioThreshold = defineSetting<number>('chat.inlineChat.selectionRatioThreshold', ConfigType.ExperimentBased, 0);
+		export const InlineChatReasoningEffort = defineSetting<string>('chat.inlineChat.reasoningEffort', ConfigType.ExperimentBased, 'low');
+		export const InlineChatEnableThinking = defineSetting<boolean>('chat.inlineChat.enableThinking', ConfigType.ExperimentBased, false);
 
 		export const InstantApplyShortModelName = defineAndMigrateExpSetting<string>('chat.advanced.instantApply.shortContextModelName', 'chat.instantApply.shortContextModelName', CHAT_MODEL.SHORT_INSTANT_APPLY);
 		export const InstantApplyShortContextLimit = defineAndMigrateExpSetting<number>('chat.advanced.instantApply.shortContextLimit', 'chat.instantApply.shortContextLimit', 8000);

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -86,8 +86,9 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	body.truncation = configService.getConfig(ConfigKey.Advanced.UseResponsesApiTruncation) ?
 		'auto' :
 		'disabled';
+	const thinkingExplicitlyDisabled = options.modelCapabilities?.enableThinking === false;
 	const summaryConfig = configService.getExperimentBasedConfig(ConfigKey.ResponsesApiReasoningSummary, expService);
-	const shouldDisableReasoningSummary = endpoint.family === 'gpt-5.3-codex-spark-preview';
+	const shouldDisableReasoningSummary = endpoint.family === 'gpt-5.3-codex-spark-preview' || thinkingExplicitlyDisabled;
 	const effortFromSetting = configService.getConfig(ConfigKey.Advanced.ReasoningEffortOverride);
 	const effort = endpoint.supportsReasoningEffort?.length
 		? (effortFromSetting || options.modelCapabilities?.reasoningEffort || 'medium')


### PR DESCRIPTION
## Summary

Add experiment-controlled settings for reasoning effort and thinking on inline chat requests to GPT models. Previously, inline chat did not pass any `modelCapabilities`, causing the Responses API to silently apply `reasoning: { effort: 'medium', summary: 'detailed' }` defaults - adding latency and token cost without benefit for inline edits.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Default to `low` reasoning effort, thinking disabled**: Inline chat edits are latency-sensitive and don't benefit from deep reasoning. The OpenAI Responses API was silently applying `medium` effort and `detailed` summary on all GPT models that declare `supportsReasoningEffort`, even though inline chat never intended to use reasoning.
- **Experiment-based settings over hardcoded values**: Both `reasoningEffort` and `enableThinking` are `ExperimentBased` config keys so they can be tuned via experiments without code changes. Values validated against the OpenAI API spec (`none`, `minimal`, `low`, `medium`, `high`).
- **Responses API gates summary on `enableThinking === false`**: The `responsesApi.ts` change ensures that when thinking is explicitly disabled, reasoning summaries are suppressed regardless of global experiment flags. The Messages API (Anthropic) already had this gating.
- **`low` chosen over `none`**: Per the OpenAI spec, `none` is only supported on gpt-5.1+ models. `low` works across all model versions, making it a safer default.

</details>

## Changes

- **`configurationService.ts`**: Two new experiment-based config keys: `InlineChatReasoningEffort` (default: `'low'`) and `InlineChatEnableThinking` (default: `false`)
- **`inlineChatIntent.ts`**: Both `InlineChatEditToolsStrategy` and `InlineChatEditHeuristicStrategy` now inject `IConfigurationService`/`IExperimentationService` and pass `modelCapabilities` to `makeChatRequest2`
- **`responsesApi.ts`**: When `enableThinking === false`, reasoning summary is suppressed in the Responses API request body
- **`package.json`/`package.nls.json`**: Setting declarations with `onExp` tag and NLS descriptions
