### PR TITLE
Refactor chat UI for improved layout and consistency

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -62,7 +62,7 @@
 
 /* Height constraints are driven by MIN_EDITOR_HEIGHT / MAX_EDITOR_HEIGHT in newChatViewPane.ts */
 .sessions-chat-editor {
-	padding: 0 8px 6px 10px;
+	padding: 6px 6px 0 6px;
 	flex-shrink: 1;
 }
 
@@ -77,8 +77,8 @@
 .sessions-chat-toolbar {
 	display: flex;
 	align-items: center;
-	padding: 0 6px 6px 6px;
-	gap: 4px;
+	padding: 4px 6px 6px 6px;
+	gap: 6px;
 	color: var(--vscode-icon-foreground);
 }
 
@@ -108,11 +108,10 @@
 	display: flex;
 	align-items: center;
 	height: 16px;
-	padding: 3px 3px 3px 6px;
+	padding: 3px 1px 3px 7px;
 	background-color: transparent;
 	border: none;
 	border-radius: 4px;
-	font-size: 13px;
 	cursor: pointer;
 	touch-action: manipulation;
 	color: var(--vscode-icon-foreground);
@@ -126,14 +125,20 @@
 	color: var(--vscode-foreground);
 }
 
+.sessions-chat-config-toolbar .action-label,
+.sessions-chat-config-toolbar .action-label .chat-input-picker-label {
+	font-size: 12px;
+}
+
 .sessions-chat-config-toolbar .action-label .codicon {
-	font-size: 14px;
+	font-size: 12px !important;
 	flex-shrink: 0;
 }
 
 .sessions-chat-config-toolbar .action-label .codicon-chevron-down {
-	font-size: 12px;
-	margin-left: 6px;
+	font-size: 10px !important;
+	margin-left: 4px;
+	opacity: 0.75;
 }
 
 /* Send button - wraps a Button widget */
@@ -166,7 +171,7 @@
 }
 
 .sessions-chat-send-button .monaco-button .codicon {
-	font-size: 16px;
+	font-size: 14px;
 }
 
 /* Loading spinner in toolbar */
@@ -231,7 +236,7 @@
 }
 
 .sessions-chat-attach-button .codicon {
-	font-size: 16px;
+	font-size: 14px;
 }
 
 /* Attached context container */

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -110,8 +110,14 @@
 .sessions-chat-config-toolbar .monaco-action-bar .action-item {
 	display: flex;
 	align-items: center;
-	min-width: 48px;
+	min-width: 30px;
 	overflow: hidden;
+}
+
+/* Prevent the mode picker from shrinking so the model picker label
+ * ellipsizes first rather than the mode picker collapsing to icon-only. */
+.sessions-chat-config-toolbar .monaco-action-bar .action-item:has(.sessions-chat-dropdown-label) {
+	flex-shrink: 0;
 }
 
 .sessions-chat-config-toolbar .action-label {
@@ -126,7 +132,7 @@
 	touch-action: manipulation;
 	color: var(--vscode-icon-foreground);
 	white-space: nowrap;
-	min-width: 38px;
+	min-width: 30px;
 	overflow: hidden;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -97,11 +97,21 @@
 
 .sessions-chat-config-toolbar .monaco-toolbar {
 	height: auto;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.sessions-chat-config-toolbar .monaco-action-bar,
+.sessions-chat-config-toolbar .monaco-action-bar .actions-container {
+	min-width: 0;
+	overflow: hidden;
 }
 
 .sessions-chat-config-toolbar .monaco-action-bar .action-item {
 	display: flex;
 	align-items: center;
+	min-width: 48px;
+	overflow: hidden;
 }
 
 .sessions-chat-config-toolbar .action-label {
@@ -116,7 +126,7 @@
 	touch-action: manipulation;
 	color: var(--vscode-icon-foreground);
 	white-space: nowrap;
-	min-width: 0;
+	min-width: 38px;
 	overflow: hidden;
 }
 
@@ -128,6 +138,14 @@
 .sessions-chat-config-toolbar .action-label,
 .sessions-chat-config-toolbar .action-label .chat-input-picker-label {
 	font-size: 12px;
+}
+
+/* Allow long labels (e.g. the model picker name) to ellipsize when space is tight */
+.sessions-chat-config-toolbar .action-label .chat-input-picker-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .sessions-chat-config-toolbar .action-label .codicon {

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -148,21 +148,38 @@
 	min-width: 0;
 }
 
-.sessions-chat-config-toolbar .action-label .codicon {
-	font-size: 12px !important;
+.sessions-chat-config-toolbar .monaco-action-bar .action-item .action-label > .codicon {
+	font-size: 12px;
 	flex-shrink: 0;
+	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
+	 * so the leading icon sizes naturally to its font-size, matching the bottom-row pickers. */
+	width: auto;
+	height: auto;
 }
 
-.sessions-chat-config-toolbar .action-label .codicon-chevron-down {
-	font-size: 10px !important;
+.sessions-chat-config-toolbar .monaco-action-bar .action-item .action-label > .codicon-chevron-down {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 10px;
 	margin-left: 4px;
-	opacity: 0.75;
+	line-height: 1;
+	/* Restore the 16x16 codicon box for the chevron so it has equal padding on both sides,
+	 * matching the bottom-row picker chevrons. */
+	width: 16px;
+	height: 16px;
+}
+
+/* Spacing between action items inside the chat input config toolbar (mode + model picker) */
+.sessions-chat-config-toolbar .monaco-action-bar .actions-container {
+	gap: 4px;
 }
 
 /* Send button - wraps a Button widget */
 .sessions-chat-send-button {
 	display: flex;
 	align-items: center;
+	flex-shrink: 0;
 }
 
 .sessions-chat-send-button .monaco-button {
@@ -236,6 +253,7 @@
 	justify-content: center;
 	width: 22px;
 	height: 22px;
+	flex-shrink: 0;
 	border-radius: 4px;
 	cursor: pointer;
 	color: var(--vscode-icon-foreground);

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -78,7 +78,7 @@
 	display: flex;
 	align-items: center;
 	padding: 4px 6px 6px 6px;
-	gap: 6px;
+	gap: 4px;
 	color: var(--vscode-icon-foreground);
 }
 
@@ -137,15 +137,21 @@
 
 .sessions-chat-config-toolbar .action-label,
 .sessions-chat-config-toolbar .action-label .chat-input-picker-label {
-	font-size: 12px;
+	font-size: 11px;
 }
 
 /* Allow long labels (e.g. the model picker name) to ellipsize when space is tight */
 .sessions-chat-config-toolbar .action-label .chat-input-picker-label {
+	margin-left: 6px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	min-width: 0;
+}
+
+/* When the picker has no leading icon (e.g. model picker), drop the icon-to-label gap. */
+.sessions-chat-config-toolbar .action-label .chat-input-picker-label:first-child {
+	margin-left: 0;
 }
 
 .sessions-chat-config-toolbar .monaco-action-bar .action-item .action-label > .codicon {
@@ -162,12 +168,10 @@
 	align-items: center;
 	justify-content: center;
 	font-size: 10px;
-	margin-left: 4px;
+	margin-left: 2px;
 	line-height: 1;
-	/* Restore the 16x16 codicon box for the chevron so it has equal padding on both sides,
-	 * matching the bottom-row picker chevrons. */
-	width: 16px;
-	height: 16px;
+	width: 12px;
+	height: 12px;
 }
 
 /* Spacing between action items inside the chat input config toolbar (mode + model picker) */
@@ -205,7 +209,7 @@
 	background-color: var(--vscode-toolbar-hoverBackground) !important;
 }
 
-.sessions-chat-send-button .monaco-button .codicon {
+.monaco-workbench .sessions-chat-send-button .monaco-button .codicon[class*='codicon-'] {
 	font-size: 14px;
 }
 
@@ -271,7 +275,7 @@
 	outline-offset: -1px;
 }
 
-.sessions-chat-attach-button .codicon {
+.monaco-workbench .sessions-chat-attach-button .codicon[class*='codicon-'] {
 	font-size: 14px;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -94,6 +94,8 @@
 .new-chat-widget-container .new-chat-bottom-container .new-chat-controls-container {
 	display: flex;
 	gap: 4px;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .new-chat-widget-container .new-chat-bottom-container .new-chat-repo-config-container {
@@ -101,6 +103,42 @@
 	align-items: center;
 	gap: 2px;
 	min-width: 0;
+	overflow: hidden;
+}
+
+/* Allow nested toolbar items to shrink so labels can ellipsize when space is tight.
+ * Mirrors the regular chat-input-toolbar pattern: each flex layer between the
+ * bounded container and the ellipsizing label gets `min-width: 0; overflow: hidden`. */
+.new-chat-widget-container .new-chat-bottom-container .new-chat-controls-container > *,
+.new-chat-widget-container .new-chat-bottom-container .new-chat-repo-config-container > *,
+.new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item,
+.new-chat-widget-container .new-chat-bottom-container .sessions-chat-picker-slot .action-label {
+	min-width: 0;
+	overflow: hidden;
+}
+
+/* Floor each picker so the icon + chevron (+ padding) stay visible even when
+ * the label is fully ellipsized. Approx: 7px padding-left + 12px icon + 2px
+ * label margin + 16px chevron box + 1px padding-right ~= 38px. */
+.new-chat-widget-container .new-chat-bottom-container .sessions-chat-picker-slot .action-label,
+.new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item .action-label {
+	min-width: 38px;
+}
+
+/* Below this width the bottom-row pickers can't fit their labels comfortably,
+ * so collapse to icon + chevron only. The .new-chat-widget-container declares
+ * `container-type: size` which makes this a size container query. */
+@container (max-width: 320px) {
+	/* Bottom-row pickers (Copilot CLI, Default Approvals, Worktree, branch): icon-only */
+	.new-chat-widget-container .new-chat-bottom-container .sessions-chat-dropdown-label {
+		display: none;
+	}
+
+	/* Chat input config toolbar: hide mode picker label (uses sessions-chat-dropdown-label),
+	 * but keep the model picker label (uses chat-input-picker-label) visible. */
+	.new-chat-widget-container .sessions-chat-config-toolbar .sessions-chat-dropdown-label {
+		display: none;
+	}
 }
 
 /* Spacing between action items inside the repo-config toolbar (e.g. Worktree, branch) */
@@ -195,6 +233,10 @@
 
 .sessions-chat-dropdown-label {
 	margin-left: 2px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
 }
 
 .sessions-chat-picker-slot {

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -75,6 +75,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
+	align-self: center;
 }
 
 .new-chat-widget-container .new-chat-bottom-container {

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -93,6 +93,7 @@
 
 .new-chat-widget-container .new-chat-bottom-container .new-chat-controls-container {
 	display: flex;
+	gap: 4px;
 }
 
 .new-chat-widget-container .new-chat-bottom-container .new-chat-repo-config-container {
@@ -100,6 +101,11 @@
 	align-items: center;
 	gap: 2px;
 	min-width: 0;
+}
+
+/* Spacing between action items inside the repo-config toolbar (e.g. Worktree, branch) */
+.new-chat-widget-container .monaco-action-bar .actions-container {
+	gap: 4px;
 }
 
 /* Match VS Code chat-secondary-toolbar sizing for action items in the bottom row

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -161,7 +161,7 @@
 .new-chat-widget-container .new-chat-bottom-container .action-label {
 	height: 16px;
 	padding: 3px 1px 3px 7px;
-	font-size: 12px;
+	font-size: 11px;
 	color: var(--vscode-icon-foreground);
 }
 
@@ -240,7 +240,7 @@
 }
 
 .sessions-chat-dropdown-label {
-	margin-left: 2px;
+	margin-left: 6px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -334,12 +334,10 @@
 	align-items: center;
 	justify-content: center;
 	font-size: 10px;
-	margin-left: 4px;
+	margin-left: 2px;
 	line-height: 1;
-	/* Match the 16x16 codicon box that the action-bar gives the regular chat
-	 * picker's chevron, so the small chevron icon has equal padding on both sides. */
-	width: 16px;
-	height: 16px;
+	width: 12px;
+	height: 12px;
 }
 
 .sessions-chat-picker-slot .action-label .chat-session-option-label {

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -102,6 +102,26 @@
 	min-width: 0;
 }
 
+/* Match VS Code chat-secondary-toolbar sizing for action items in the bottom row
+ * (e.g. session control pickers and repo config pickers) so they align with the
+ * mode/model picker font in the input toolbar. */
+.new-chat-widget-container .new-chat-bottom-container .action-label {
+	height: 16px;
+	padding: 3px 1px 3px 7px;
+	font-size: 12px;
+	color: var(--vscode-icon-foreground);
+}
+
+.new-chat-widget-container .new-chat-bottom-container .action-label .codicon {
+	font-size: 12px !important;
+}
+
+.new-chat-widget-container .new-chat-bottom-container .action-label .codicon-chevron-down {
+	font-size: 10px !important;
+	margin-left: 4px;
+	opacity: 0.75;
+}
+
 .chat-controls-container .monaco-editor-background {
 	background-color: var(--vscode-input-background) !important;
 }
@@ -168,7 +188,7 @@
 }
 
 .sessions-chat-dropdown-label {
-	margin-left: 4px;
+	margin-left: 2px;
 }
 
 .sessions-chat-picker-slot {
@@ -182,11 +202,10 @@
 	display: flex;
 	align-items: center;
 	height: 16px;
-	padding: 3px 3px 3px 6px;
+	padding: 3px 1px 3px 7px;
 	background-color: transparent;
 	border: none;
 	color: var(--vscode-icon-foreground);
-	font-size: 13px;
 	cursor: pointer;
 	touch-action: manipulation;
 	white-space: nowrap;
@@ -245,18 +264,27 @@
 }
 
 .sessions-chat-picker-slot .action-label .codicon {
-	font-size: 14px;
+	font-size: 12px;
 	flex-shrink: 0;
+	/* Override the base .monaco-action-bar .action-item .codicon { width:16px; height:16px }
+	 * so codicons here size naturally to their font-size, matching pickers (like Copilot CLI)
+	 * that are rendered outside a monaco-action-bar. */
+	width: auto;
+	height: auto;
 }
 
 .sessions-chat-picker-slot .action-label .codicon-chevron-down {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 12px;
-	margin-left: 6px;
+	font-size: 10px;
+	margin-left: 4px;
+	opacity: 0.75;
 	line-height: 1;
-	transform: translateY(1px);
+	/* Match the 16x16 codicon box that the action-bar gives the regular chat
+	 * picker's chevron, so the small chevron icon has equal padding on both sides. */
+	width: 16px;
+	height: 16px;
 }
 
 .sessions-chat-picker-slot .action-label .chat-session-option-label {

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -39,7 +39,6 @@
 	display: none;
 	width: 100%;
 	max-width: 800px;
-	margin: 0 0 8px 0;
 	padding: 0;
 	box-sizing: border-box;
 }
@@ -77,7 +76,8 @@
 .new-chat-widget-container .new-chat-bottom-container {
 	width: 100%;
 	max-width: 800px;
-	margin-top: 8px;
+	margin-top: 4px;
+	padding: 0 4px;
 	box-sizing: border-box;
 	display: none;
 	flex-direction: row;

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -23,7 +23,7 @@
 	box-sizing: border-box;
 	overflow: hidden;
 	padding: 16px 16px 20px 16px;
-	/* Establishes a size container so the @container (max-width: 320px) query below
+	/* Establishes a size container so the @container (max-width: 330px) query below
 	 * can collapse picker labels to icon-only when the new-chat area is narrow. */
 	container-type: size;
 	position: relative;

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -14,13 +14,17 @@
 .new-chat-widget-container {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	/* Cross-axis: keep children flush left so the input's left edge — and therefore
+	 * the attach (+) button — stays anchored as the viewport narrows past max-width. */
+	align-items: flex-start;
 	justify-content: center;
 	width: 100%;
 	height: 100%;
 	box-sizing: border-box;
 	overflow: hidden;
 	padding: 16px 16px 20px 16px;
+	/* Establishes a size container so the @container (max-width: 320px) query below
+	 * can collapse picker labels to icon-only when the new-chat area is narrow. */
 	container-type: size;
 	position: relative;
 }
@@ -111,7 +115,6 @@
  * bounded container and the ellipsizing label gets `min-width: 0; overflow: hidden`. */
 .new-chat-widget-container .new-chat-bottom-container .new-chat-controls-container > *,
 .new-chat-widget-container .new-chat-bottom-container .new-chat-repo-config-container > *,
-.new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item,
 .new-chat-widget-container .new-chat-bottom-container .sessions-chat-picker-slot .action-label {
 	min-width: 0;
 	overflow: hidden;
@@ -119,16 +122,20 @@
 
 /* Floor each picker so the icon + chevron (+ padding) stay visible even when
  * the label is fully ellipsized. Approx: 7px padding-left + 12px icon + 2px
- * label margin + 16px chevron box + 1px padding-right ~= 38px. */
+ * label margin + 16px chevron box + 1px padding-right ~= 38px. The floor must
+ * be applied to the outermost flex item (.action-item), not just the label,
+ * because the parent's `min-width: 0` would otherwise let it clip the chevron. */
+.new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item,
 .new-chat-widget-container .new-chat-bottom-container .sessions-chat-picker-slot .action-label,
 .new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item .action-label {
 	min-width: 38px;
+	overflow: hidden;
 }
 
 /* Below this width the bottom-row pickers can't fit their labels comfortably,
  * so collapse to icon + chevron only. The .new-chat-widget-container declares
  * `container-type: size` which makes this a size container query. */
-@container (max-width: 320px) {
+@container (max-width: 330px) {
 	/* Bottom-row pickers (Copilot CLI, Default Approvals, Worktree, branch): icon-only */
 	.new-chat-widget-container .new-chat-bottom-container .sessions-chat-dropdown-label {
 		display: none;
@@ -141,14 +148,15 @@
 	}
 }
 
-/* Spacing between action items inside the repo-config toolbar (e.g. Worktree, branch) */
-.new-chat-widget-container .monaco-action-bar .actions-container {
+/* Spacing between action items inside the bottom-row toolbars (e.g. Worktree, branch) */
+.new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .actions-container {
 	gap: 4px;
 }
 
 /* Match VS Code chat-secondary-toolbar sizing for action items in the bottom row
  * (e.g. session control pickers and repo config pickers) so they align with the
- * mode/model picker font in the input toolbar. */
+ * mode/model picker font in the input toolbar. The 1px right padding is intentional
+ * because the chevron's 16x16 codicon box supplies the visual right padding. */
 .new-chat-widget-container .new-chat-bottom-container .action-label {
 	height: 16px;
 	padding: 3px 1px 3px 7px;
@@ -156,14 +164,13 @@
 	color: var(--vscode-icon-foreground);
 }
 
-.new-chat-widget-container .new-chat-bottom-container .action-label .codicon {
-	font-size: 12px !important;
+.new-chat-widget-container .new-chat-bottom-container .action-label > .codicon {
+	font-size: 12px;
 }
 
-.new-chat-widget-container .new-chat-bottom-container .action-label .codicon-chevron-down {
-	font-size: 10px !important;
+.new-chat-widget-container .new-chat-bottom-container .action-label > .codicon-chevron-down {
+	font-size: 10px;
 	margin-left: 4px;
-	opacity: 0.75;
 }
 
 .chat-controls-container .monaco-editor-background {
@@ -327,7 +334,6 @@
 	justify-content: center;
 	font-size: 10px;
 	margin-left: 4px;
-	opacity: 0.75;
 	line-height: 1;
 	/* Match the 16x16 codicon box that the action-bar gives the regular chat
 	 * picker's chevron, so the small chevron icon has equal padding on both sides. */

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -129,7 +129,7 @@
 .new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item,
 .new-chat-widget-container .new-chat-bottom-container .sessions-chat-picker-slot .action-label,
 .new-chat-widget-container .new-chat-bottom-container .monaco-action-bar .action-item .action-label {
-	min-width: 38px;
+	min-width: 30px;
 	overflow: hidden;
 }
 

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -95,7 +95,7 @@
 }
 
 .new-chat-in-session .sessions-chat-dropdown-label {
-	margin-left: 4px;
+	margin-left: 2px;
 }
 
 /* Disable fade-in animations — show content immediately */

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -16,7 +16,11 @@
 .new-chat-in-session .new-chat-widget-content {
 	width: 100%;
 	max-width: 950px;
-	margin: 0 auto !important;
+	/* Left-align (rather than centering with `margin: 0 auto`) so the input's
+	 * left edge — and therefore the attach (+) button — stays anchored as the
+	 * viewport narrows past max-width. */
+	margin: 0 !important;
+	align-self: flex-start !important;
 	padding: 4px 10px !important;
 	box-sizing: border-box;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -20,7 +20,6 @@
 	 * left edge — and therefore the attach (+) button — stays anchored as the
 	 * viewport narrows past max-width. */
 	margin: 0 !important;
-	align-self: flex-start !important;
 	padding: 4px 10px !important;
 	box-sizing: border-box;
 }

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -98,7 +98,7 @@
 }
 
 .new-chat-in-session .sessions-chat-dropdown-label {
-	margin-left: 2px;
+	margin-left: 6px;
 }
 
 /* Disable fade-in animations — show content immediately */

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -384,7 +384,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			title: localize('send', "Send"),
 			ariaLabel: localize('send', "Send"),
 		}));
-		sendButton.icon = Codicon.send;
+		sendButton.icon = Codicon.arrowUp;
 		this._register(sendButton.onDidClick(() => this._send()));
 	}
 


### PR DESCRIPTION
This pull request updates the chat input and widget CSS to improve layout consistency, responsiveness, and label handling, particularly in narrow viewports. It also changes the send button icon for better clarity. The changes focus on ensuring toolbar and picker elements remain usable and visually aligned as the UI resizes, with improved ellipsis and spacing for long labels.

https://github.com/user-attachments/assets/e0e8890c-e728-4671-8994-e8e2227fd381


**UI and Layout Improvements:**

* Adjusted padding, gap, and alignment for `.sessions-chat-editor`, `.sessions-chat-toolbar`, and `.new-chat-widget-container` to improve consistency and anchoring of elements, especially as the viewport narrows [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L65-R65) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L80-R81) [[3]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL17-R27) [[4]](diffhunk://#diff-37362f8da1613c5403e627bad99373321a000255480edc86e001dc30ec0be160L19-R22).
* Updated margins and padding for bottom containers and controls to enhance spacing and alignment [[1]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL42) [[2]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eR78-R85) [[3]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eR101-R174).

**Responsiveness and Label Handling:**

* Introduced `min-width: 0` and `overflow: hidden` to multiple flex containers and toolbar elements, allowing labels to ellipsize gracefully when space is tight [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33R100-R129) [[2]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eR101-R174) [[3]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL171-R247).
* Added container queries to collapse picker labels to icon-only below 330px width, improving usability on small screens.

**Toolbar and Picker Styling:**

* Standardized font sizes, padding, and icon sizing for action labels and chevrons in toolbars and pickers, ensuring visual consistency and alignment [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L129-R182) [[2]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL185-L189) [[3]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL248-R342).
* Adjusted spacing and sizing for `.sessions-chat-dropdown-label` and related classes for better overflow handling and alignment [[1]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL171-R247) [[2]](diffhunk://#diff-37362f8da1613c5403e627bad99373321a000255480edc86e001dc30ec0be160L98-R101).

**Icon and Visual Tweaks:**

* Changed the send button icon from `Codicon.send` to `Codicon.arrowUp` for improved clarity.
* Reduced icon font sizes in send and attach buttons for better visual balance [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L169-R209) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L234-R275).
* Ensured consistent sizing and alignment for chevron icons and action items across toolbars [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L129-R182) [[2]](diffhunk://#diff-83275f73d2a4d754bb3de569831b872db071d6afd74929b978f7b8cbad8efa0eL248-R342).

**Minor Enhancements:**

* Added `flex-shrink: 0` to certain elements to prevent unwanted shrinking [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33R256) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L169-R209).

These changes collectively make the chat input UI more robust, visually consistent, and user-friendly across different screen sizes.

