### PR TITLE
fix(agents): vscode app launch due to missing app identifiers

### DIFF
--- a/src/bootstrap-meta.ts
+++ b/src/bootstrap-meta.ts
@@ -31,7 +31,11 @@ if ((process as INodeProcess).isEmbeddedApp) {
 
 	try {
 		const productSubObj = require('../product.sub.json');
-		productObj = Object.assign(productObj, productSubObj);
+		if (productObj.embedded && productSubObj.embedded) {
+			Object.assign(productObj.embedded, productSubObj.embedded);
+			delete productSubObj.embedded;
+		}
+		Object.assign(productObj, productSubObj);
 	} catch (error) { /* ignore */ }
 	try {
 		const pkgSubObj = require('../package.sub.json');


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/310773

```
The product.sub.json overlay in bootstrap-meta.ts uses shallow merge.
This caused the entire `embedded` object from product.json to be replaced by product.sub.json's version,
losing unique properties injected by the build such as `darwinSiblingBundleIdentifier` and `win32SiblingExeBasename`.
```