### PR TITLE
fix: fix multiple window memory leaky

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -154,6 +154,7 @@ export abstract class BaseWindow extends Disposable {
 					didClear = true;
 					(window as { vscodeOriginalClearTimeout?: typeof window.clearTimeout }).vscodeOriginalClearTimeout?.apply(this, [handle]);
 					timeoutDisposables.delete(timeoutDisposable);
+					disposables.delete(timeoutDisposable);
 				});
 
 				disposables.add(timeoutDisposable);


### PR DESCRIPTION
The follow steps will trigger the memory leaky.
1. open a window.
2. open a file.
3. right-click on the title of the file, click `move file to new window`.

