### PR TITLE
sessions: animate active sidebar chat spinner

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -457,7 +457,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 	private getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
 		switch (status) {
-			case SessionStatus.InProgress: return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+			case SessionStatus.InProgress: return { ...ThemeIcon.modify(Codicon.loading, 'spin'), color: themeColorFromId('textLink.foreground') };
 			case SessionStatus.NeedsInput: return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
 			case SessionStatus.Error: return { ...Codicon.error, color: themeColorFromId('errorForeground') };
 			default:


### PR DESCRIPTION
## Summary

Part of https://github.com/microsoft/vscode/issues/310018 workstream

- replace the static in-progress sidebar session icon with the existing animated loading spinner
- keep the existing sessions sidebar status color styling intact

https://github.com/user-attachments/assets/22da25c1-61a8-491c-bc5b-e70318bb4f72

## Why
Active chats in the sessions sidebar looked static even while work was running. This makes actively running chats match the rest of the sessions app, which already uses animated spinners for loading state.