### PR TITLE
Fix some basic eslint errors in copilot

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/permissionHelpers.ts
@@ -28,7 +28,7 @@ type CoreTerminalConfirmationToolParams = {
 		command: string | undefined;
 		isBackground: boolean;
 	};
-}
+};
 
 type CoreConfirmationToolParams = {
 	tool: ToolName.CoreConfirmationTool;
@@ -37,7 +37,7 @@ type CoreConfirmationToolParams = {
 		message: string;
 		confirmationType: 'basic';
 	};
-}
+};
 
 /**
  * The result of requesting permissions — the full union accepted by `Session.respondToPermission`.

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/test/claudeChatSessionContentProvider.spec.ts
@@ -1202,6 +1202,7 @@ class FakeGitService extends mock<IGitService>() {
 	}
 
 	override dispose(): void {
+		super.dispose();
 		this._onDidOpenRepository.dispose();
 		this._onDidCloseRepository.dispose();
 	}

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/codeReferencing/index.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/codeReferencing/index.ts
@@ -21,7 +21,7 @@ export class CodeReference implements IDisposable {
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ICompletionsRuntimeModeService readonly _runtimeMode: ICompletionsRuntimeModeService,
+		@ICompletionsRuntimeModeService private readonly _runtimeMode: ICompletionsRuntimeModeService,
 		@ICompletionsLogTargetService private readonly _logTarget: ICompletionsLogTargetService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 	) { }

--- a/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/statusBar.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/extension/src/statusBar.ts
@@ -21,8 +21,8 @@ export class CopilotStatusBar extends StatusReporter implements IDisposable {
 
 	constructor(
 		id: string,
-		@ICompletionsExtensionStatus readonly extensionStatusService: ICompletionsExtensionStatus,
-		@IInstantiationService readonly instantiationService: IInstantiationService,
+		@ICompletionsExtensionStatus private readonly extensionStatusService: ICompletionsExtensionStatus,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 
 	) {
 		super();

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/featuresService.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/experiments/featuresService.ts
@@ -17,7 +17,7 @@ export type ContextProviderExpSettings = {
 	excludeRelatedFiles: boolean;
 	timeBudget: number;
 	params?: Record<string, string | boolean | number>;
-}
+};
 
 export const ICompletionsFeaturesService = createServiceIdentifier<ICompletionsFeaturesService>('ICompletionsFeaturesService');
 export interface ICompletionsFeaturesService {

--- a/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/similarFiles/openTabFiles.ts
+++ b/extensions/copilot/src/extension/completions-core/vscode-node/lib/src/prompt/similarFiles/openTabFiles.ts
@@ -15,7 +15,9 @@ import {
 } from './neighborFiles';
 
 export class OpenTabFiles implements INeighborSource {
-	constructor(@ICompletionsTextDocumentManagerService readonly docManager: ICompletionsTextDocumentManagerService) { }
+	constructor(
+		@ICompletionsTextDocumentManagerService private readonly docManager: ICompletionsTextDocumentManagerService
+	) { }
 
 	private truncateDocs(
 		docs: readonly TextDocumentContents[],

--- a/extensions/copilot/src/extension/conversation/vscode-node/conversationFeature.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/conversationFeature.ts
@@ -49,9 +49,9 @@ import { generateTerminalFixes, setLastCommandMatchResult } from './terminalFixG
  */
 export class ConversationFeature implements IExtensionContribution {
 	/** Disposables that exist for the lifetime of this object */
-	private _disposables = new DisposableStore();
+	private readonly _disposables = new DisposableStore();
 	/** Disposables that are cleared whenever feature enablement is toggled */
-	private _activatedDisposables = new DisposableStore();
+	private readonly _activatedDisposables = new DisposableStore();
 	/** For the conversation features to be enabled, the proxy needs to return a token with k/v pair: chat=1 */
 	public _enabled;
 	/** The feature is marked as active the first time it is enabled. */

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -486,7 +486,6 @@ class LanguageModelAccessPromptBaseCountCache {
 export class CopilotLanguageModelWrapper extends Disposable {
 
 	constructor(
-		@IExperimentationService readonly _expService: IExperimentationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IBlockedExtensionService private readonly _blockedExtensionService: IBlockedExtensionService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,

--- a/extensions/copilot/src/extension/conversation/vscode-node/remoteAgents.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/remoteAgents.ts
@@ -88,7 +88,7 @@ interface IGitHubRepositoryReference {
 }
 
 export class RemoteAgentContribution implements IDisposable {
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private refreshRemoteAgentsP: Promise<void> | undefined;
 	private enabledSkillsPromise: Promise<Set<string>> | undefined;
 

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -29,7 +29,7 @@ suite('CopilotLanguageModelWrapper', () => {
 		instaService = accessor.get(IInstantiationService);
 	}
 
-	suite('validateRequest - invalid', async () => {
+	suite('validateRequest - invalid', () => {
 		let wrapper: CopilotLanguageModelWrapper;
 		let endpoint: IChatEndpoint;
 		setup(async () => {
@@ -59,7 +59,7 @@ suite('CopilotLanguageModelWrapper', () => {
 		});
 	});
 
-	suite('validateRequest - valid', async () => {
+	suite('validateRequest - valid', () => {
 		let wrapper: CopilotLanguageModelWrapper;
 		let endpoint: IChatEndpoint;
 		setup(async () => {

--- a/extensions/copilot/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/importDiagnosticsCompletionProvider.ts
+++ b/extensions/copilot/src/extension/inlineEdits/vscode-node/features/diagnosticsBasedCompletions/importDiagnosticsCompletionProvider.ts
@@ -361,7 +361,7 @@ export type ImportDetails = {
 	labelShort: string;
 	labelDeduped: string;
 	importSource: ImportSource;
-}
+};
 
 export interface ILanguageImportHandler {
 	isImportDiagnostic(diagnostic: Diagnostic): boolean;

--- a/extensions/copilot/src/extension/log/node/chatLogExport.ts
+++ b/extensions/copilot/src/extension/log/node/chatLogExport.ts
@@ -139,7 +139,7 @@ export async function createExportedPrompt(
 				kind: 'error',
 				error: error?.toString() || 'Unknown error',
 				timestamp: new Date().toISOString()
-			} as unknown as ExportedLogEntry);
+			});
 		}
 	}
 

--- a/extensions/copilot/src/extension/mcp/vscode-node/commands.ts
+++ b/extensions/copilot/src/extension/mcp/vscode-node/commands.ts
@@ -115,10 +115,10 @@ export class McpSetupCommands extends Disposable {
 	};
 
 	constructor(
-		@ITelemetryService readonly telemetryService: ITelemetryService,
-		@ILogService readonly logService: ILogService,
-		@IFetcherService readonly fetcherService: IFetcherService,
-		@IInstantiationService readonly instantiationService: IInstantiationService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@ILogService private readonly logService: ILogService,
+		@IFetcherService private readonly fetcherService: IFetcherService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 		this._register(toDisposable(() => this.pendingSetup?.cts.dispose(true)));

--- a/extensions/copilot/src/extension/search/vscode-node/commands.ts
+++ b/extensions/copilot/src/extension/search/vscode-node/commands.ts
@@ -12,7 +12,7 @@ import { SearchFeedbackKind, SemanticSearchTextSearchProvider } from '../../work
 
 export class SearchPanelCommands extends Disposable {
 	constructor(
-		@ITelemetryService readonly telemetryService: ITelemetryService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IFeedbackReporter private readonly feedbackReporter: IFeedbackReporter,
 	) {
 		super();

--- a/extensions/copilot/src/extension/tools/common/virtualTools/preComputedToolEmbeddingsCache.ts
+++ b/extensions/copilot/src/extension/tools/common/virtualTools/preComputedToolEmbeddingsCache.ts
@@ -18,7 +18,7 @@ export class PreComputedToolEmbeddingsCache implements IToolEmbeddingsCache {
 	private embeddingsMap: Map<string, Embedding> | undefined;
 
 	constructor(
-		@ILogService readonly _logService: ILogService,
+		@ILogService private readonly _logService: ILogService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IEnvService envService: IEnvService
 	) {

--- a/extensions/copilot/src/extension/typescriptContext/common/serverProtocol.ts
+++ b/extensions/copilot/src/extension/typescriptContext/common/serverProtocol.ts
@@ -30,30 +30,30 @@ export enum CacheScopeKind {
 
 export type FileCacheScope = {
 	kind: CacheScopeKind.File;
-}
+};
 export type NeighborFilesCacheScope = {
 	kind: CacheScopeKind.NeighborFiles;
-}
+};
 
 export type Position = {
 	line: number;
 	character: number;
-}
+};
 
 export type Range = {
 	start: Position;
 	end: Position;
-}
+};
 
 export type WithinRangeCacheScope = {
 	kind: CacheScopeKind.WithinRange;
 	range: Range;
-}
+};
 
 export type OutsideRangeCacheScope = {
 	kind: CacheScopeKind.OutsideRange;
 	ranges: Range[];
-}
+};
 
 export type CacheScope = FileCacheScope | NeighborFilesCacheScope | WithinRangeCacheScope | OutsideRangeCacheScope;
 
@@ -66,7 +66,7 @@ export enum EmitMode {
 export type CacheInfo = {
 	emitMode: EmitMode;
 	scope: CacheScope;
-}
+};
 export namespace CacheInfo {
 	export type has = { cache: CacheInfo };
 	export function has(item: unknown): item is has {
@@ -76,7 +76,7 @@ export namespace CacheInfo {
 export type CachedContextItem = {
 	key: ContextItemKey;
 	sizeInChars?: number;
-}
+};
 export namespace CachedContextItem {
 	export function create(key: ContextItemKey, sizeInChars?: number): CachedContextItem {
 		return { key, sizeInChars };
@@ -236,7 +236,7 @@ export namespace ContextItem {
 
 export type PriorityTag = {
 	priority: number;
-}
+};
 
 export enum ContextRunnableState {
 	Created = 'created',
@@ -291,7 +291,7 @@ export type ContextRunnableResult = {
 	 * A human readable path to the signature to ease debugging.
 	 */
 	debugPath?: ContextRunnableResultId | undefined;
-}
+};
 
 export type CachedContextRunnableResult = {
 
@@ -317,7 +317,7 @@ export type CachedContextRunnableResult = {
 	 * The cache information of the runnable.
 	 */
 	cache?: CacheInfo;
-}
+};
 
 export type ContextRunnableResultReference = {
 
@@ -328,7 +328,7 @@ export type ContextRunnableResultReference = {
 	 * this state.
 	 */
 	id: ContextRunnableResultId;
-}
+};
 
 export type ContextRunnableResultTypes = ContextRunnableResult | ContextRunnableResultReference;
 
@@ -345,7 +345,7 @@ export namespace ErrorData {
 export type Timings = {
 	totalTime: number;
 	computeTime: number;
-}
+};
 export namespace Timings {
 	export function create(totalTime: number, computeTime: number): Timings {
 		return { totalTime, computeTime };
@@ -397,7 +397,7 @@ export type ContextRequestResult = {
 	 * New server side context items that were computed.
 	 */
 	contextItems?: ContextItem[];
-}
+};
 
 export interface ComputeContextRequestArgs extends tt.server.protocol.FileLocationRequestArgs {
 	startTime: number;
@@ -504,17 +504,17 @@ export namespace PrepareNesRenameResult {
 		canRename: RenameKind.yes;
 		oldName: string;
 		onOldState: boolean;
-	}
+	};
 	export type Maybe = {
 		canRename: RenameKind.maybe;
 		oldName: string;
 		onOldState: boolean;
-	}
+	};
 	export type No = {
 		canRename: RenameKind.no;
 		timedOut: boolean;
 		reason?: string;
-	}
+	};
 }
 
 export type PrepareNesRenameResult = PrepareNesRenameResult.Yes | PrepareNesRenameResult.Maybe | PrepareNesRenameResult.No;
@@ -566,17 +566,17 @@ export interface NesRenameRequestArgs extends tt.server.protocol.FileLocationReq
 export type TextChange = {
 	range: Range;
 	newText?: string;
-}
+};
 
 export type RenameGroup = {
 	file: FilePath;
 	changes: TextChange[];
-}
+};
 
 export namespace NesRenameResult {
 	export type OK = {
 		groups: RenameGroup[];
-	}
+	};
 	export type Failed = CustomResponse.Failed;
 }
 

--- a/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/contextProvider.ts
+++ b/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/contextProvider.ts
@@ -374,7 +374,7 @@ export class RunnableResult {
 	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined): void;
 	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined, ifRoom: false): void;
 	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined, ifRoom: true): boolean;
-	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined, ifRoom: boolean): boolean
+	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined, ifRoom: boolean): boolean;
 	public addSnippet(code: SnippetProvider, location: SnippetLocation, key: string | undefined, ifRoom: boolean = false): boolean {
 		const budget = location === SnippetLocation.Primary ? this.primaryBudget : this.secondaryBudget;
 		if (code.isEmpty()) {
@@ -684,7 +684,7 @@ class CacheBasedContextRunnable implements ContextRunnable {
 export type SymbolData = {
 	symbol: tt.Symbol;
 	name?: string;
-}
+};
 
 enum SymbolEmitDataKind {
 	symbol = 'symbol',
@@ -695,12 +695,12 @@ type SymbolEmitData = {
 	kind: SymbolEmitDataKind.symbol;
 	symbol: tt.Symbol;
 	name?: string;
-}
+};
 
 type TypeAliasEmitData = {
 	kind: SymbolEmitDataKind.typeAlias;
 	node: tt.TypeAliasDeclaration;
-}
+};
 
 type EmitData = SymbolEmitData | TypeAliasEmitData;
 

--- a/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/protocol.ts
+++ b/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/protocol.ts
@@ -30,30 +30,30 @@ export enum CacheScopeKind {
 
 export type FileCacheScope = {
 	kind: CacheScopeKind.File;
-}
+};
 export type NeighborFilesCacheScope = {
 	kind: CacheScopeKind.NeighborFiles;
-}
+};
 
 export type Position = {
 	line: number;
 	character: number;
-}
+};
 
 export type Range = {
 	start: Position;
 	end: Position;
-}
+};
 
 export type WithinRangeCacheScope = {
 	kind: CacheScopeKind.WithinRange;
 	range: Range;
-}
+};
 
 export type OutsideRangeCacheScope = {
 	kind: CacheScopeKind.OutsideRange;
 	ranges: Range[];
-}
+};
 
 export type CacheScope = FileCacheScope | NeighborFilesCacheScope | WithinRangeCacheScope | OutsideRangeCacheScope;
 
@@ -66,7 +66,7 @@ export enum EmitMode {
 export type CacheInfo = {
 	emitMode: EmitMode;
 	scope: CacheScope;
-}
+};
 export namespace CacheInfo {
 	export type has = { cache: CacheInfo };
 	export function has(item: unknown): item is has {
@@ -76,7 +76,7 @@ export namespace CacheInfo {
 export type CachedContextItem = {
 	key: ContextItemKey;
 	sizeInChars?: number;
-}
+};
 export namespace CachedContextItem {
 	export function create(key: ContextItemKey, sizeInChars?: number): CachedContextItem {
 		return { key, sizeInChars };
@@ -236,7 +236,7 @@ export namespace ContextItem {
 
 export type PriorityTag = {
 	priority: number;
-}
+};
 
 export enum ContextRunnableState {
 	Created = 'created',
@@ -291,7 +291,7 @@ export type ContextRunnableResult = {
 	 * A human readable path to the signature to ease debugging.
 	 */
 	debugPath?: ContextRunnableResultId | undefined;
-}
+};
 
 export type CachedContextRunnableResult = {
 
@@ -317,7 +317,7 @@ export type CachedContextRunnableResult = {
 	 * The cache information of the runnable.
 	 */
 	cache?: CacheInfo;
-}
+};
 
 export type ContextRunnableResultReference = {
 
@@ -328,7 +328,7 @@ export type ContextRunnableResultReference = {
 	 * this state.
 	 */
 	id: ContextRunnableResultId;
-}
+};
 
 export type ContextRunnableResultTypes = ContextRunnableResult | ContextRunnableResultReference;
 
@@ -345,7 +345,7 @@ export namespace ErrorData {
 export type Timings = {
 	totalTime: number;
 	computeTime: number;
-}
+};
 export namespace Timings {
 	export function create(totalTime: number, computeTime: number): Timings {
 		return { totalTime, computeTime };
@@ -397,7 +397,7 @@ export type ContextRequestResult = {
 	 * New server side context items that were computed.
 	 */
 	contextItems?: ContextItem[];
-}
+};
 
 export interface ComputeContextRequestArgs extends tt.server.protocol.FileLocationRequestArgs {
 	startTime: number;
@@ -504,17 +504,17 @@ export namespace PrepareNesRenameResult {
 		canRename: RenameKind.yes;
 		oldName: string;
 		onOldState: boolean;
-	}
+	};
 	export type Maybe = {
 		canRename: RenameKind.maybe;
 		oldName: string;
 		onOldState: boolean;
-	}
+	};
 	export type No = {
 		canRename: RenameKind.no;
 		timedOut: boolean;
 		reason?: string;
-	}
+	};
 }
 
 export type PrepareNesRenameResult = PrepareNesRenameResult.Yes | PrepareNesRenameResult.Maybe | PrepareNesRenameResult.No;
@@ -566,17 +566,17 @@ export interface NesRenameRequestArgs extends tt.server.protocol.FileLocationReq
 export type TextChange = {
 	range: Range;
 	newText?: string;
-}
+};
 
 export type RenameGroup = {
 	file: FilePath;
 	changes: TextChange[];
-}
+};
 
 export namespace NesRenameResult {
 	export type OK = {
 		groups: RenameGroup[];
-	}
+	};
 	export type Failed = CustomResponse.Failed;
 }
 

--- a/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/typescripts.ts
+++ b/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/common/typescripts.ts
@@ -451,7 +451,7 @@ namespace tss {
 		}
 	}
 
-	export type DirectSuperSymbolInfo = { extends?: { symbol: tt.Symbol; name: string } | undefined; implements?: { symbol: tt.Symbol; name: string }[] }
+	export type DirectSuperSymbolInfo = { extends?: { symbol: tt.Symbol; name: string } | undefined; implements?: { symbol: tt.Symbol; name: string }[] };
 
 	export class Symbols {
 

--- a/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/node/create.ts
+++ b/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/node/create.ts
@@ -114,7 +114,7 @@ type ResolvedInput = {
 	startTime: number;
 	timeBudget: number;
 	requestStartTime: number;
-}
+};
 const resolveInput = <T extends tt.server.protocol.FileRequestArgs & tt.server.protocol.Location & { timeBudget?: number; startTime?: number }>(args: T | undefined, defaultTimeBudget: number): ResolvedInput | FailedHandlerResponse => {
 	const requestStartTime = Date.now();
 	if (args === undefined) {

--- a/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/node/test/nes.spec.ts
+++ b/extensions/copilot/src/extension/typescriptContext/serverPlugin/src/node/test/nes.spec.ts
@@ -80,12 +80,12 @@ type TrackedRenameInfo = {
 	oldName: string;
 	newName: string;
 	range: Range;
-}
+};
 
 type PostRenameTestCase = {
 	trackedRename: TrackedRenameInfo;
 	testCase: NesRenameTestCase;
-}
+};
 
 function computeNesRenameTestCases(filePath: string): NesRenameTestCase[] {
 	const text = fs.readFileSync(filePath, 'utf8');

--- a/extensions/copilot/src/extension/typescriptContext/vscode-node/languageContextService.ts
+++ b/extensions/copilot/src/extension/typescriptContext/vscode-node/languageContextService.ts
@@ -477,7 +477,7 @@ type ContextRequestState = {
 type CacheInfo = {
 	version: number;
 	state: CacheState;
-}
+};
 
 enum CacheState {
 	NotPopulated = 'NotPopulated',
@@ -1244,9 +1244,9 @@ export class LanguageContextServiceImpl implements ILanguageContextService, vsco
 	public readonly onContextComputedOnTimeout: vscode.Event<OnContextComputedOnTimeoutEvent>;
 
 	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
-		@ITelemetryService readonly telemetryService: ITelemetryService,
 		@ILogService private readonly logService: ILogService
 	) {
 		this.isDebugging = process.execArgv.some((arg) => /^--(?:inspect|debug)(?:-brk)?(?:=\d+)?$/i.test(arg));
@@ -1791,7 +1791,7 @@ async function* mapAsyncIterable<T, U>(
 const showContextInspectorViewContextKey = `github.copilot.chat.showContextInspectorView`;
 export class InlineCompletionContribution implements vscode.Disposable, TokenBudgetProvider {
 
-	private disposables: DisposableStore;
+	private readonly disposables: DisposableStore;
 
 	private registrations: DisposableStore | undefined;
 	private readonly registrationQueue: Queue<void>;
@@ -1799,10 +1799,10 @@ export class InlineCompletionContribution implements vscode.Disposable, TokenBud
 	private readonly telemetrySender: TelemetrySender;
 
 	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
-		@ILogService readonly logService: ILogService,
-		@ITelemetryService readonly telemetryService: ITelemetryService,
+		@ILogService private readonly logService: ILogService,
 		@ILanguageContextService private readonly languageContextService: ILanguageContextService,
 		@ILanguageContextProviderService private readonly languageContextProviderService: ILanguageContextProviderService,
 	) {

--- a/extensions/copilot/src/extension/typescriptContext/vscode-node/nesRenameService.ts
+++ b/extensions/copilot/src/extension/typescriptContext/vscode-node/nesRenameService.ts
@@ -70,7 +70,7 @@ namespace NesRenameRequestArgs {
 type TextChange = {
 	range: protocol.Range;
 	newText?: string;
-}
+};
 type RenameGroup = {
 	file: vscode.Uri;
 	changes: TextChange[];
@@ -138,14 +138,14 @@ class TelemetrySender {
 export class NesRenameContribution implements vscode.Disposable {
 
 	private _isActivated: Promise<boolean> | undefined;
-	private disposables: DisposableStore;
+	private readonly disposables: DisposableStore;
 	private readonly telemetrySender: TelemetrySender;
 
 	private static readonly ExecConfig: ExecConfig = { executionTarget: ExecutionTarget.Semantic };
 
 	constructor(
-		@ITelemetryService readonly telemetryService: ITelemetryService,
-		@ILogService readonly logService: ILogService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		this.telemetrySender = new TelemetrySender(telemetryService, logService);
 		this.disposables = new DisposableStore();

--- a/extensions/copilot/src/extension/typescriptContext/vscode-node/types.ts
+++ b/extensions/copilot/src/extension/typescriptContext/vscode-node/types.ts
@@ -15,7 +15,7 @@ export type ResolvedRunnableResult = {
 	items: protocol.FullContextItem[];
 	cache?: protocol.CacheInfo;
 	debugPath?: protocol.ContextRunnableResultId | undefined;
-}
+};
 export namespace ResolvedRunnableResult {
 	export function from(result: protocol.ContextRunnableResult, items: protocol.FullContextItem[]): ResolvedRunnableResult {
 		return {
@@ -34,7 +34,7 @@ export type ContextComputedEvent = {
 	position: vscode.Position;
 	source?: string;
 	summary: ContextItemSummary;
-}
+};
 
 export type OnCachePopulatedEvent = ContextComputedEvent & { items: ReadonlyArray<ResolvedRunnableResult> };
 export type OnContextComputedEvent = ContextComputedEvent & { items: ReadonlyArray<ContextItem> };

--- a/extensions/copilot/src/extension/workspaceRecorder/vscode-node/workspaceListenerService.ts
+++ b/extensions/copilot/src/extension/workspaceRecorder/vscode-node/workspaceListenerService.ts
@@ -10,7 +10,7 @@ import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { IRecordableEditorLogEntry, IRecordableLogEntry, ITextModelEditReasonMetadata, IWorkspaceListenerService } from '../common/workspaceListenerService';
 
 export class WorkspacListenerService extends Disposable implements IWorkspaceListenerService {
-	readonly _serviceBrand = undefined;
+	declare _serviceBrand: undefined;
 
 	private readonly _onStructuredData = this._register(new Emitter<IRecordableLogEntry | IRecordableEditorLogEntry>());
 	readonly onStructuredData = this._onStructuredData.event;

--- a/extensions/copilot/src/lib/node/chatLibMain.ts
+++ b/extensions/copilot/src/lib/node/chatLibMain.ts
@@ -716,7 +716,7 @@ export interface IEditorSession {
 	readonly uiKind?: string;
 }
 
-export type IActionItem = ActionItem
+export type IActionItem = ActionItem;
 export interface INotificationSender {
 	showWarningMessage(message: string, ...actions: IActionItem[]): Promise<IActionItem | undefined>;
 }

--- a/extensions/copilot/src/platform/authentication/common/authentication.ts
+++ b/extensions/copilot/src/platform/authentication/common/authentication.ts
@@ -277,7 +277,7 @@ export abstract class BaseAuthenticationService extends Disposable implements IA
 	// #endregion
 
 	//#region ADO Token
-	abstract getAdoAccessTokenBase64(options?: AuthenticationGetSessionOptions): Promise<string | undefined>
+	abstract getAdoAccessTokenBase64(options?: AuthenticationGetSessionOptions): Promise<string | undefined>;
 	//#endregion
 
 	protected async _handleAuthChangeEvent(): Promise<void> {

--- a/extensions/copilot/src/platform/chat/common/commonTypes.ts
+++ b/extensions/copilot/src/platform/chat/common/commonTypes.ts
@@ -187,7 +187,7 @@ export type ChatFetchRetriableError<T> =
 	/**
 	 * We requested conversation, the response was filtered by RAI, but we want to retry.
 	 */
-	{ type: ChatFetchResponseType.FilteredRetry; reason: string; category: FilterReason; value: T; requestId: string; serverRequestId: string | undefined }
+	{ type: ChatFetchResponseType.FilteredRetry; reason: string; category: FilterReason; value: T; requestId: string; serverRequestId: string | undefined };
 
 export type FetchSuccess<T> =
 	{ type: ChatFetchResponseType.Success; value: T; requestId: string; serverRequestId: string | undefined; usage: APIUsage | undefined; resolvedModel: string };

--- a/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
+++ b/extensions/copilot/src/platform/endpoint/common/endpointProvider.ts
@@ -70,7 +70,7 @@ type ICompletionModelCapabilities = {
 	type: 'completion';
 	family: string;
 	tokenizer: TokenizerType;
-}
+};
 
 export enum ModelSupportedEndpoint {
 	ChatCompletions = '/chat/completions',

--- a/extensions/copilot/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/openaiCompatibleEndpoint.ts
@@ -73,7 +73,7 @@ export type IModelConfig = {
 		max_completion_tokens?: number | null;
 		intent?: boolean | null;
 	};
-}
+};
 
 export class OpenAICompatibleTestEndpoint extends ChatEndpoint {
 	constructor(

--- a/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
+++ b/extensions/copilot/src/platform/git/vscode-node/gitServiceImpl.ts
@@ -483,7 +483,7 @@ export class GitServiceImpl extends Disposable implements IGitService {
 	}
 
 	private static repoToRepoContext(repo: Repository): RepoContext;
-	private static repoToRepoContext(repo: Repository | undefined | null): RepoContext | undefined
+	private static repoToRepoContext(repo: Repository | undefined | null): RepoContext | undefined;
 	private static repoToRepoContext(repo: Repository | undefined | null): RepoContext | undefined {
 		if (!repo) {
 			return undefined;

--- a/extensions/copilot/src/platform/inlineCompletions/common/api.ts
+++ b/extensions/copilot/src/platform/inlineCompletions/common/api.ts
@@ -11,12 +11,12 @@ export namespace Copilot {
 	export type Position = {
 		line: number;
 		character: number;
-	}
+	};
 
 	export type Range = {
 		start: Position;
 		end: Position;
-	}
+	};
 
 	/**
 	* The ContextProvider API allows extensions to provide additional context items that

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/languageContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/languageContext.ts
@@ -11,13 +11,13 @@ export type LanguageContextEntry = {
 	context: ContextItem;
 	timeStamp: number;
 	onTimeout: boolean;
-}
+};
 
 export type LanguageContextResponse = {
 	start: number;
 	end: number;
 	items: LanguageContextEntry[];
-}
+};
 
 type SerializedSnippetContext = {
 	kind: ContextKind.Snippet;
@@ -25,21 +25,21 @@ type SerializedSnippetContext = {
 	uri: string;
 	additionalUris?: string[];
 	value: string;
-}
+};
 
 type SerializedTraitContext = {
 	kind: ContextKind.Trait;
 	priority: number;
 	name: string;
 	value: string;
-}
+};
 
 type SerializedDiagnosticBagContext = {
 	kind: ContextKind.DiagnosticBag;
 	priority: number;
 	uri: string;
 	values: Omit<SerializedDiagnostic, 'uri'>[];
-}
+};
 
 type SerializedContextItem = SerializedSnippetContext | SerializedTraitContext | SerializedDiagnosticBagContext;
 
@@ -50,7 +50,7 @@ export type SerializedContextResponse = {
 		context: SerializedContextItem;
 		timeStamp: number;
 	}[];
-}
+};
 
 export function serializeLanguageContext(response: LanguageContextResponse): SerializedContextResponse {
 	return {
@@ -113,7 +113,7 @@ export type SerializedDiagnostic = {
 	source: string;
 	code: string | number | undefined;
 	range: string;
-}
+};
 
 function serializeDiagnostic(diagnostic: Diagnostic): Omit<SerializedDiagnostic, 'uri'>;
 function serializeDiagnostic(diagnostic: Diagnostic, resource: Uri): SerializedDiagnostic;

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/xtabPromptOptions.ts
@@ -31,7 +31,7 @@ export type RecentlyViewedDocumentsOptions = {
 	readonly includeViewedFiles: boolean;
 	readonly includeLineNumbers: IncludeLineNumbersOption;
 	readonly clippingStrategy: RecentFileClippingStrategy;
-}
+};
 
 export namespace RecentlyViewedDocumentsOptions {
 	export const VALIDATOR: IValidator<Partial<RecentlyViewedDocumentsOptions>> = vObj({
@@ -49,14 +49,14 @@ export type LanguageContextOptions = {
 	readonly enabled: boolean;
 	readonly maxTokens: number;
 	readonly traitPosition: 'before' | 'after';
-}
+};
 
 export type DiffHistoryOptions = {
 	readonly nEntries: number;
 	readonly maxTokens: number;
 	readonly onlyForDocsInPrompt: boolean;
 	readonly useRelativePaths: boolean;
-}
+};
 
 export type PagedClipping = { pageSize: number };
 
@@ -66,7 +66,7 @@ export type CurrentFileOptions = {
 	readonly includeLineNumbers: IncludeLineNumbersOption;
 	readonly includeCursorTag: boolean;
 	readonly prioritizeAboveCursor: boolean;
-}
+};
 
 export namespace CurrentFileOptions {
 	export const VALIDATOR: IValidator<Partial<CurrentFileOptions>> = vObj({
@@ -96,7 +96,7 @@ export type LintOptions = {
 	maxLineDistance: number;
 	/** When set to a value > 0, also include linter diagnostics from the N most recently edited/viewed files. */
 	nRecentFiles: number;
-}
+};
 
 /**
  * The raw user-facing aggressiveness setting. Includes `Default` to distinguish
@@ -241,7 +241,7 @@ export type PromptOptions = {
 	readonly diffHistory: DiffHistoryOptions;
 	readonly includePostScript: boolean;
 	readonly lintOptions: LintOptions | undefined;
-}
+};
 
 /**
  * Prompt strategies that tweak prompt in a way that's different from current prod prompting strategy.

--- a/extensions/copilot/src/platform/inlineEdits/common/statelessNextEditProvider.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/statelessNextEditProvider.ts
@@ -26,7 +26,7 @@ import { InlineEditRequestLogContext } from './inlineEditLogContext';
 import { stringifyChatMessages } from './utils/stringifyChatMessages';
 import { IXtabHistoryEntry } from './workspaceEditTracker/nesXtabHistoryTracker';
 
-export type EditStreaming = AsyncGenerator<StreamedEdit, NoNextEditReason, void>
+export type EditStreaming = AsyncGenerator<StreamedEdit, NoNextEditReason, void>;
 
 export class WithStatelessProviderTelemetry<T> {
 	constructor(
@@ -36,7 +36,7 @@ export class WithStatelessProviderTelemetry<T> {
 	}
 }
 
-export type EditStreamingWithTelemetry = AsyncGenerator<WithStatelessProviderTelemetry<StreamedEdit>, WithStatelessProviderTelemetry<NoNextEditReason>, void>
+export type EditStreamingWithTelemetry = AsyncGenerator<WithStatelessProviderTelemetry<StreamedEdit>, WithStatelessProviderTelemetry<NoNextEditReason>, void>;
 
 export type StreamedEdit = {
 	readonly targetDocument: DocumentId;
@@ -49,7 +49,7 @@ export type StreamedEdit = {
 	 * in either the original location or the jump target location.
 	 */
 	readonly originalWindow?: OffsetRange;
-}
+};
 
 export type PushEdit = (edit: Result<StreamedEdit, NoNextEditReason>) => void;
 
@@ -432,7 +432,7 @@ export type FetchResultWithStats = {
 	readonly response: FetchResponse<string>;
 	readonly fetchTime: number;
 	readonly fetchResult: ChatFetchResponseType;
-}
+};
 
 export class StatelessNextEditTelemetryBuilder {
 

--- a/extensions/copilot/src/platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/workspaceEditTracker/nesXtabHistoryTracker.ts
@@ -38,19 +38,19 @@ export interface IXtabHistoryVisibleRangesEntry extends IXtabHistoryDocumentEntr
 
 export type IXtabHistoryEntry =
 	| IXtabHistoryEditEntry
-	| IXtabHistoryVisibleRangesEntry
+	| IXtabHistoryVisibleRangesEntry;
 
 type DocumentChangedEvent = {
 	value: StringText;
 	changes: StringEdit[];
 	previous: StringText | undefined;
-}
+};
 
 type DocumentSelectionChangedEvent = {
 	value: readonly OffsetRange[];
 	changes: unknown[];
 	previous: readonly OffsetRange[] | undefined;
-}
+};
 
 /**
  * Controls how consecutive edits to the same document are merged in history.

--- a/extensions/copilot/src/platform/inlineEdits/common/workspaceEditTracker/workspaceDocumentEditTracker.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/workspaceEditTracker/workspaceDocumentEditTracker.ts
@@ -17,7 +17,7 @@ export type DocumentHistoryDifference = {
 	before: StringText;
 	after: StringText;
 	edits: StringEdit;
-}
+};
 
 export class WorkspaceDocumentEditHistory extends Disposable {
 	private readonly _documentState = new Map<DocumentId, DocumentEditHistory>();

--- a/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
+++ b/extensions/copilot/src/platform/inlineEdits/node/inlineEditsModelService.ts
@@ -39,7 +39,7 @@ interface ModelConfigurationWithSource extends ModelConfiguration {
 type ModelInfo = {
 	models: ModelConfigurationWithSource[];
 	currentModelId: string;
-}
+};
 
 export class InlineEditsModelService extends Disposable implements IInlineEditsModelService {
 

--- a/extensions/copilot/src/platform/networking/common/fetch.ts
+++ b/extensions/copilot/src/platform/networking/common/fetch.ts
@@ -304,12 +304,12 @@ export type StreamOptions = {
 	 * All other chunks will also include a usage field, but with a null value. NOTE: If the stream is interrupted, you may not receive the final usage chunk which contains the total token usage for the request.
 	 */
 	include_usage?: boolean;
-}
+};
 
 export type Prediction = {
 	type: 'content';
 	content: string | { type: string; text: string }[];
-}
+};
 
 /** based on https://platform.openai.com/docs/api-reference/chat/create
  *

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -231,7 +231,7 @@ export type IChatRequestTelemetryProperties = {
 	parentRequestId?: string;
 	/** For a subagent: The tool_call_id from the parent agent's LLM response that triggered this subagent invocation. */
 	parentToolCallId?: string;
-}
+};
 
 export interface ICreateEndpointBodyOptions extends IMakeChatRequestOptions {
 	requestId: string;

--- a/extensions/copilot/src/platform/notebook/common/alternativeContentEditGenerator.ts
+++ b/extensions/copilot/src/platform/notebook/common/alternativeContentEditGenerator.ts
@@ -23,7 +23,7 @@ export type NotebookEditGenerationTelemtryOptions = {
 	model: Promise<string> | string | undefined;
 	requestId: string | undefined;
 	source: NotebookEditGenrationSource;
-}
+};
 
 export enum NotebookEditGenrationSource {
 	codeMapperEditNotebook = 'codeMapperEditNotebook',

--- a/extensions/copilot/src/platform/review/vscode/reviewServiceImpl.ts
+++ b/extensions/copilot/src/platform/review/vscode/reviewServiceImpl.ts
@@ -24,8 +24,8 @@ const numberOfReviewCommentsKey = 'github.copilot.chat.review.numberOfComments';
 
 export class ReviewServiceImpl implements IReviewService {
 	declare _serviceBrand: undefined;
-	private _disposables = new DisposableStore();
-	private _repositoryDisposables = new DisposableStore();
+	private readonly _disposables = new DisposableStore();
+	private readonly _repositoryDisposables = new DisposableStore();
 	private _reviewDiffReposString: string | undefined;
 	private _diagnosticCollection: vscode.DiagnosticCollection | undefined;
 	private _commentController = vscode.comments.createCommentController('github-copilot-review', 'Code Review');

--- a/extensions/copilot/src/platform/telemetry/common/msftTelemetrySender.ts
+++ b/extensions/copilot/src/platform/telemetry/common/msftTelemetrySender.ts
@@ -20,7 +20,7 @@ export class BaseMsftTelemetrySender implements IMSFTTelemetrySender {
 	protected _internalLargeEventTelemetryReporter: ITelemetryReporter | undefined;
 	private _externalTelemetryReporter: ITelemetryReporter;
 
-	protected _disposables: DisposableStore = new DisposableStore();
+	protected readonly _disposables: DisposableStore = new DisposableStore();
 	private _username: string | undefined;
 	private _vscodeTeamMember: boolean = false;
 	private _sku: string | undefined;

--- a/extensions/copilot/src/platform/thinking/common/thinking.ts
+++ b/extensions/copilot/src/platform/thinking/common/thinking.ts
@@ -46,7 +46,7 @@ export type EncryptedThinkingDelta = {
 	id: string;
 	text?: string;
 	encrypted: string;
-}
+};
 
 export function isEncryptedThinkingDelta(delta: ThinkingDelta | EncryptedThinkingDelta): delta is EncryptedThinkingDelta {
 	return (delta as EncryptedThinkingDelta).encrypted !== undefined;

--- a/extensions/copilot/src/util/node/worker.ts
+++ b/extensions/copilot/src/util/node/worker.ts
@@ -60,7 +60,7 @@ export class RcpResponseHandler {
 
 export type RpcProxy<ProxyType> = {
 	[K in keyof ProxyType]: ProxyType[K] extends ((...args: infer Args) => infer R) ? (...args: Args) => Promise<Awaited<R>> : never;
-}
+};
 
 export function createRpcProxy<ProxyType>(remoteCall: (name: string, args: any[]) => Promise<any>): RpcProxy<ProxyType> {
 	const handler = {

--- a/extensions/copilot/test/base/simulationOptions.ts
+++ b/extensions/copilot/test/base/simulationOptions.ts
@@ -14,7 +14,7 @@ export type NesDatagen = {
 	readonly output: string | undefined;
 	readonly rowOffset: number;
 	readonly workerMode: boolean;
-}
+};
 
 export class SimulationOptions {
 	public static fromProcessArgs(): SimulationOptions {

--- a/extensions/copilot/test/pipeline/alternativeAction/types.ts
+++ b/extensions/copilot/test/pipeline/alternativeAction/types.ts
@@ -18,7 +18,7 @@ export type IData = {
 		isInlineCompletion: boolean;
 	};
 	suggestionStatus: NextEditTelemetryStatus;
-}
+};
 
 export namespace NextUserEdit {
 	export type t = {
@@ -36,7 +36,7 @@ export namespace Recording {
 			relativePath: string;
 			originalOpIdx: number;
 		};
-	}
+	};
 }
 
 export namespace SuggestedEdit {
@@ -45,7 +45,7 @@ export namespace SuggestedEdit {
 		edit: ISerializedEdit;
 		scoreCategory: 'nextEdit';
 		score: number;
-	}
+	};
 }
 
 export namespace Scoring {

--- a/extensions/copilot/test/pipeline/pipeline.ts
+++ b/extensions/copilot/test/pipeline/pipeline.ts
@@ -40,7 +40,7 @@ export type RunPipelineOptions = {
 	readonly configFile: string | undefined;
 	readonly verbose: number | boolean | undefined;
 	readonly parallelism: number;
-}
+};
 
 export async function runInputPipeline(opts: RunPipelineOptions, log = console.log.bind(console)): Promise<void> {
 	const nesDatagenOpts = opts.nesDatagen!;

--- a/extensions/copilot/test/testVisualizationRunner.ts
+++ b/extensions/copilot/test/testVisualizationRunner.ts
@@ -25,7 +25,7 @@ function run(args: { fileName: string; path: string[] }) {
 	runCurrentTest();
 }
 
-const g = globalThis as any as IDebugValueEditorGlobals & IPlaygroundRunnerGlobals;
+const g = globalThis as unknown as IDebugValueEditorGlobals & IPlaygroundRunnerGlobals;
 g.$$playgroundRunner_data = { currentPath: [] };
 
 // The timeout seems to fix a deadlock-issue of tsx, when the run function is called from the debugger.

--- a/extensions/copilot/test/testVisualizationRunnerSTest.ts
+++ b/extensions/copilot/test/testVisualizationRunnerSTest.ts
@@ -18,7 +18,7 @@ function run(args: { fileName: string; path: string }) {
 	runCurrentTest();
 }
 
-const g = globalThis as any as IDebugValueEditorGlobals & IPlaygroundRunnerGlobals;
+const g = globalThis as unknown as IDebugValueEditorGlobals & IPlaygroundRunnerGlobals;
 g.$$playgroundRunner_data = { currentPath: [] };
 
 


### PR DESCRIPTION
Starts working through some basic repo wide eslint rules for the copilot extension. Stuff like missing semicolons, missing super calls, and missing readonly modifiers for disposables


