### PR TITLE
Fix customizations sidebar restoring previous section on reopen

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -24,6 +24,7 @@ import { IPromptsService } from '../../../../workbench/contrib/chat/common/promp
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
+import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { agentIcon, instructionsIcon, mcpServerIcon, pluginIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -222,7 +223,13 @@ export class AICustomizationOverviewView extends ViewPane {
 
 	private async openOverview(): Promise<void> {
 		const input = AICustomizationManagementEditorInput.getOrCreate();
-		await this.editorService.openEditor(input, { pinned: true });
+		const editor = await this.editorService.openEditor(input, { pinned: true });
+
+		// Always reset to the welcome page when opening from the sidebar,
+		// so we don't restore the previously selected section.
+		if (editor instanceof AICustomizationManagementEditor) {
+			editor.showWelcomePage();
+		}
 	}
 
 	protected override layoutBody(height: number, width: number): void {

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -22,9 +22,8 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { ResourceSet } from '../../../../base/common/map.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection, AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
-import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { agentIcon, instructionsIcon, mcpServerIcon, pluginIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -35,6 +34,10 @@ import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/p
 const $ = DOM.$;
 
 export const AI_CUSTOMIZATION_OVERVIEW_VIEW_ID = 'workbench.view.aiCustomizationOverview';
+
+function isWelcomePageEditor(editor: unknown): editor is { showWelcomePage(): void } {
+	return typeof (editor as { showWelcomePage?: unknown })?.showWelcomePage === 'function';
+}
 
 interface ISectionSummary {
 	readonly id: AICustomizationManagementSection;
@@ -227,7 +230,7 @@ export class AICustomizationOverviewView extends ViewPane {
 
 		// Always reset to the welcome page when opening from the sidebar,
 		// so we don't restore the previously selected section.
-		if (editor instanceof AICustomizationManagementEditor) {
+		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID && isWelcomePageEditor(editor)) {
 			editor.showWelcomePage();
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -991,7 +991,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	/**
 	 * Navigates to the welcome page (no section selected).
 	 */
-	private showWelcomePage(): void {
+	public showWelcomePage(): void {
 		if (this.viewMode === 'editor') {
 			this.goBackToList();
 		}


### PR DESCRIPTION
Fixes a bug where clicking a sidebar category in the Agents app customizations view would restore the previously selected section instead of always opening the welcome page.

**Steps to reproduce:**
1. Open customizations UI
2. Select a category (e.g. Agents)
3. Close
4. Click a different category in the sidebar (e.g. Hooks)
5. ❌ Opens back to 'Agents' instead of the welcome page

**Fix:**
- Made `showWelcomePage()` public on `AICustomizationManagementEditor`
- Call `showWelcomePage()` after opening the editor from the sidebar's `openOverview()`, so the persisted section is always cleared when navigating from the sidebar