### PR TITLE
chat: tighten generated title prompt

### DIFF
--- a/extensions/copilot/src/extension/prompts/node/panel/title.tsx
+++ b/extensions/copilot/src/extension/prompts/node/panel/title.tsx
@@ -16,16 +16,21 @@ export class TitlePrompt extends PromptElement<TitlePromptProps> {
 		return (
 			<>
 				<SystemMessage priority={1000}>
-					You are an expert in crafting pithy titles for chatbot conversations. You are presented with a chat request, and you reply with a brief title that captures the main topic of that request.<br />
+					You are an expert in crafting ultra-compact titles for chatbot conversations. You are presented with a chat request, and you reply with only a brief title that captures the main topic of that request.<br />
 					<SafetyRules />
 					<ResponseTranslationRules />
-					The title should not be wrapped in quotes. It should be about 8 words or fewer.<br />
+					Write the title in sentence case, not title case. Preserve product names, abbreviations, code symbols, and proper nouns.<br />
+					Aim for 3-6 words. Prefer the shortest accurate title.<br />
+					Drop articles like "a", "an", and "the" unless needed for clarity.<br />
+					Drop filler and generic framing like "help with", "question about", "request for", or "issue with".<br />
+					Prefer short, concrete synonyms and omit unnecessary words.<br />
+					Do not wrap the title in quotes or add trailing punctuation.<br />
 					Here are some examples of good titles:<br />
 					- Git rebase question<br />
-					- Installing Python packages<br />
-					- Location of LinkedList implementation in codebase<br />
-					- Adding a tree view to a VS Code extension<br />
-					- React useState hook usage
+					- Install Python packages<br />
+					- LinkedList implementation location<br />
+					- Add VS Code tree view<br />
+					- React useState usage
 				</SystemMessage>
 				<UserMessage priority={900}>
 					Please write a brief title for the following request:<br />


### PR DESCRIPTION
## Summary

Part of https://github.com/microsoft/vscode/issues/310018 workstream

- tighten the title-generation prompt used for chat/session titles
- ask for sentence-case titles and more compact 3-6 word summaries
- add guidance to drop articles, filler, and unnecessary words

## Why
The sessions app title prompt should bias toward shorter, cleaner titles that read consistently in the UI.

## Notes
- prompt-only change
- no post-processing or normalization logic added