### PR TITLE
agentHost: set non-interactive env vars for tool-triggered terminals

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -200,15 +200,14 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			env['VSCODE_PREVENT_SHELL_HISTORY'] = '1';
 		}
 		if (options?.nonInteractive) {
-			// Suppress paging, and interactive prompts so that tool-spawned
-			// terminals produce clean, machine-friendly output.
-			env['TERM'] = 'dumb';
-			env['LANG'] = 'C.UTF-8';
-			env['LC_CTYPE'] = 'C.UTF-8';
+			// Suppress paging and interactive prompts so that tool-spawned
+			// terminals produce clean, machine-friendly output. An empty
+			// string disables paging in git, less, and most CLI tools and
+			// is safe on all platforms (unlike 'cat' which isn't on Windows PATH).
 			env['LC_ALL'] = 'C.UTF-8';
-			env['PAGER'] = 'cat';
-			env['GIT_PAGER'] = 'cat';
-			env['GH_PAGER'] = 'cat';
+			env['PAGER'] = '';
+			env['GIT_PAGER'] = '';
+			env['GH_PAGER'] = '';
 			env['GIT_TERMINAL_PROMPT'] = '0';
 			env['DEBIAN_FRONTEND'] = 'noninteractive';
 		}

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -38,7 +38,7 @@ export interface ICommandFinishedEvent {
  */
 export interface IAgentHostTerminalManager {
 	readonly _serviceBrand: undefined;
-	createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void>;
+	createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void>;
 	writeInput(uri: string, data: string): void;
 	onData(uri: string, cb: (data: string) => void): IDisposable;
 	onExit(uri: string, cb: (exitCode: number) => void): IDisposable;
@@ -172,7 +172,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 	 * Create a new terminal backed by node-pty.
 	 * Spawns the user's default shell.
 	 */
-	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void> {
+	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
 		const uri = params.terminal;
 		if (this._terminals.has(uri)) {
 			throw new Error(`Terminal already exists: ${uri}`);
@@ -198,6 +198,19 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			// Combined with the leading-space prefix applied at command-write time, this
 			// prevents agent-executed commands from polluting the user's shell history.
 			env['VSCODE_PREVENT_SHELL_HISTORY'] = '1';
+		}
+		if (options?.nonInteractive) {
+			// Suppress paging, and interactive prompts so that tool-spawned
+			// terminals produce clean, machine-friendly output.
+			env['TERM'] = 'dumb';
+			env['LANG'] = 'C.UTF-8';
+			env['LC_CTYPE'] = 'C.UTF-8';
+			env['LC_ALL'] = 'C.UTF-8';
+			env['PAGER'] = 'cat';
+			env['GIT_PAGER'] = 'cat';
+			env['GH_PAGER'] = 'cat';
+			env['GIT_TERMINAL_PROMPT'] = '0';
+			env['DEBIAN_FRONTEND'] = 'noninteractive';
 		}
 		let shellArgs: string[] = [];
 

--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -109,7 +109,7 @@ export class ShellManager {
 			claim,
 			name: shellDisplayName,
 			cwd: cwd ?? this._workingDirectory?.fsPath,
-		}, { shell: getShellExecutable(shellType), preventShellHistory: true });
+		}, { shell: getShellExecutable(shellType), preventShellHistory: true, nonInteractive: true });
 
 		const shell: IManagedShell = { id, terminalUri, shellType };
 		this._shells.set(id, shell);

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -19,9 +19,9 @@ import { ShellManager, prefixForHistorySuppression } from '../../node/copilot/co
 class TestAgentHostTerminalManager implements IAgentHostTerminalManager {
 	declare readonly _serviceBrand: undefined;
 
-	readonly created: { params: ICreateTerminalParams; options?: { shell?: string; preventShellHistory?: boolean } }[] = [];
+	readonly created: { params: ICreateTerminalParams; options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean } }[] = [];
 
-	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean }): Promise<void> {
+	async createTerminal(params: ICreateTerminalParams, options?: { shell?: string; preventShellHistory?: boolean; nonInteractive?: boolean }): Promise<void> {
 		this.created.push({ params, options });
 	}
 	writeInput(): void { }
@@ -66,7 +66,7 @@ suite('CopilotShellTools', () => {
 		]);
 	});
 
-	test('opts every managed shell into shell-history suppression', async () => {
+	test('opts every managed shell into shell-history suppression and non-interactive mode', async () => {
 		const terminalManager = new TestAgentHostTerminalManager();
 		const services = new ServiceCollection();
 		services.set(ILogService, new NullLogService());
@@ -79,6 +79,7 @@ suite('CopilotShellTools', () => {
 
 		assert.strictEqual(terminalManager.created.length, 1);
 		assert.strictEqual(terminalManager.created[0].options?.preventShellHistory, true);
+		assert.strictEqual(terminalManager.created[0].options?.nonInteractive, true);
 	});
 
 	test('prefixForHistorySuppression prepends a space for POSIX shells, no-op for PowerShell', () => {


### PR DESCRIPTION
Inspired by what Codex does, but allows for colors since we can display those. I think `TERM=dumb` is not strictly needed, but it should make it less likely for tools to try to do things that would need complex interaction which is probably a good thing.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
