### PR TITLE
Fix bad modal clipping

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1946,7 +1946,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		const modalEditorContainer = this.editorGroupsService.activeModalEditorPart?.modalElement;
 		let clippingContainer: HTMLElement | undefined;
-		if (DOM.isHTMLElement(modalEditorContainer)) {
+		if (DOM.isHTMLElement(modalEditorContainer) && modalEditorContainer.contains(shadowElement)) {
 			clippingContainer = modalEditorContainer;
 		} else {
 			clippingContainer = this.layoutService.getContainer(DOM.getWindow(this.getDomNode()), Parts.EDITOR_PART);


### PR DESCRIPTION
Fixes #311426

We only want to apply the modal clipping  when the editor itself is in the modal. Already fixed this for webview editors
