### PR TITLE
Allow cherry-pick bot PRs in engineering system changes check

### DIFF
--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -90,10 +90,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Allow cherry-pick bot PRs
         id: cherry_pick_exception
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'vs-code-engineering[bot]' && startsWith(github.event.pull_request.title, '[cherry-pick]') && contains(github.event.pull_request.labels.*.name, 'cherry-pick-artifact') }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'vs-code-engineering[bot]' && startsWith(github.event.pull_request.title, '[cherry-pick]') }}
         run: |
-          echo "Cherry-pick PR by vs-code-engineering bot with cherry-pick-artifact label — allowing"
-          echo "allowed=true" >> $GITHUB_OUTPUT
+          # The label is applied ~2s after PR creation, so the webhook payload
+          # may not include it yet. Fetch current labels from the API instead.
+          if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'cherry-pick-artifact'; then
+            echo "Cherry-pick PR by vs-code-engineering bot with cherry-pick-artifact label — allowing"
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Cherry-pick PR by bot but missing cherry-pick-artifact label — not allowed"
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prevent Copilot from modifying engineering systems
         if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
         run: |

--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -93,32 +93,49 @@ jobs:
         if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'vs-code-engineering[bot]' && startsWith(github.event.pull_request.title, '[cherry-pick]') }}
         run: |
           # The label is applied ~2s after PR creation, so the webhook payload
-          # may not include it yet. Fetch current labels from the API instead.
-          if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'cherry-pick-artifact'; then
-            echo "Cherry-pick PR by vs-code-engineering bot with cherry-pick-artifact label — allowing"
-            echo "allowed=true" >> $GITHUB_OUTPUT
-          else
-            echo "Cherry-pick PR by bot but missing cherry-pick-artifact label — not allowed"
-            echo "allowed=false" >> $GITHUB_OUTPUT
-          fi
+          # may not include it yet. Fetch current labels from the API with retries.
+          for attempt in 1 2 3; do
+            if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'cherry-pick-artifact'; then
+              echo "Cherry-pick PR by vs-code-engineering bot with cherry-pick-artifact label — allowing"
+              echo "allowed=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "cherry-pick-artifact label not present yet (attempt $attempt/3); retrying in 2s"
+              sleep 2
+            fi
+          done
+          echo "Cherry-pick PR by bot but missing cherry-pick-artifact label after retries — not allowed"
+          echo "allowed=false" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine if engineering system changes are allowed
+        id: allowed
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' }}
+        run: |
+          if [[ "${{ steps.bot_field_exception.outputs.allowed }}" == "true" || "${{ steps.cherry_pick_exception.outputs.allowed }}" == "true" ]]; then
+            echo "Engineering system changes are allowed by an exception"
+            echo "blocked=false" >> $GITHUB_OUTPUT
+          else
+            echo "No exception applies — enforcing restrictions"
+            echo "blocked=true" >> $GITHUB_OUTPUT
+          fi
       - name: Prevent Copilot from modifying engineering systems
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
+        if: ${{ steps.allowed.outputs.blocked == 'true' && github.event.pull_request.user.login == 'Copilot' }}
         run: |
           echo "Copilot is not allowed to modify .github/workflows, build folder files, or package.json files."
           echo "If you need to update engineering systems, please do so manually or through authorized means."
           exit 1
       - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: get_permissions
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.allowed.outputs.blocked == 'true' && github.event.pull_request.user.login != 'Copilot' }}
         with:
           route: GET /repos/microsoft/vscode/collaborators/${{ github.event.pull_request.user.login }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set control output variable
         id: control
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.allowed.outputs.blocked == 'true' && github.event.pull_request.user.login != 'Copilot' }}
         run: |
           echo "user: ${{ github.event.pull_request.user.login }}"
           echo "role: ${{ fromJson(steps.get_permissions.outputs.data).permission }}"
@@ -126,7 +143,7 @@ jobs:
           echo "should_run: ${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) }}"
           echo "should_run=${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) && github.event.pull_request.user.login != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
       - name: Check for engineering system changes
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && steps.control.outputs.should_run == 'true' }}
+        if: ${{ steps.allowed.outputs.blocked == 'true' && steps.control.outputs.should_run == 'true' }}
         run: |
           echo "Changes to .github/workflows/, build/ folder files, or package.json files aren't allowed in PRs."
           exit 1

--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -88,22 +88,28 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Allow cherry-pick bot PRs
+        id: cherry_pick_exception
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'vs-code-engineering[bot]' && startsWith(github.event.pull_request.title, '[cherry-pick]') && contains(github.event.pull_request.labels.*.name, 'cherry-pick-artifact') }}
+        run: |
+          echo "Cherry-pick PR by vs-code-engineering bot with cherry-pick-artifact label — allowing"
+          echo "allowed=true" >> $GITHUB_OUTPUT
       - name: Prevent Copilot from modifying engineering systems
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login == 'Copilot' }}
         run: |
           echo "Copilot is not allowed to modify .github/workflows, build folder files, or package.json files."
           echo "If you need to update engineering systems, please do so manually or through authorized means."
           exit 1
       - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: get_permissions
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
         with:
           route: GET /repos/microsoft/vscode/collaborators/${{ github.event.pull_request.user.login }}/permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set control output variable
         id: control
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && github.event.pull_request.user.login != 'Copilot' }}
         run: |
           echo "user: ${{ github.event.pull_request.user.login }}"
           echo "role: ${{ fromJson(steps.get_permissions.outputs.data).permission }}"
@@ -111,7 +117,7 @@ jobs:
           echo "should_run: ${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) }}"
           echo "should_run=${{ !contains(fromJson('["admin", "maintain", "write"]'), fromJson(steps.get_permissions.outputs.data).permission) && github.event.pull_request.user.login != 'dependabot[bot]' }}" >> $GITHUB_OUTPUT
       - name: Check for engineering system changes
-        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.control.outputs.should_run == 'true' }}
+        if: ${{ steps.engineering_systems_check.outputs.engineering_systems_modified == 'true' && steps.bot_field_exception.outputs.allowed != 'true' && steps.cherry_pick_exception.outputs.allowed != 'true' && steps.control.outputs.should_run == 'true' }}
         run: |
           echo "Changes to .github/workflows/, build/ folder files, or package.json files aren't allowed in PRs."
           exit 1


### PR DESCRIPTION
Add an exception to the "Prevent engineering system changes in PRs" workflow for cherry-pick PRs created by `vs-code-engineering[bot]`.

A PR is allowed through when **all three** conditions are met:
- Author is `vs-code-engineering[bot]`
- Title starts with `[cherry-pick]`
- PR has the `cherry-pick-artifact` label

All downstream guard steps are updated to also check this new exception.