### PR TITLE
agentHost: use vacuum into for safer sqlite migration during forking

### DIFF
--- a/src/vs/platform/agentHost/common/sessionDataService.ts
+++ b/src/vs/platform/agentHost/common/sessionDataService.ts
@@ -174,6 +174,12 @@ export interface ISessionDatabase extends IDisposable {
 	remapTurnIds(mapping: ReadonlyMap<string, string>): Promise<void>;
 
 	/**
+	 * Creates a safe, consistent copy of the database at the given path
+	 * using SQLite's `VACUUM INTO` command.
+	 */
+	vacuumInto(targetPath: string): Promise<void>;
+
+	/**
 	 * Close the database connection. After calling this method, the object is
 	 * considered disposed and all other methods will reject with an error.
 	 */

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -464,15 +464,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 				});
 				const newSessionId = forkResult.sessionId;
 
-				// Copy the source session's database file so the forked session
-				// inherits turn event IDs and file-edit snapshots.
-				const sourceDbDir = this._sessionDataService.getSessionDataDir(config.fork!.session);
+				// Copy the source session's database using VACUUM INTO so the
+				// forked session inherits turn event IDs and file-edit snapshots.
+				// VACUUM INTO is safe even while the source DB is open.
 				const targetDbDir = this._sessionDataService.getSessionDataDirById(newSessionId);
-				const sourceDbPath = URI.joinPath(sourceDbDir, SESSION_DB_FILENAME);
 				const targetDbPath = URI.joinPath(targetDbDir, SESSION_DB_FILENAME);
 				try {
 					await fs.mkdir(targetDbDir.fsPath, { recursive: true });
-					await fs.copyFile(sourceDbPath.fsPath, targetDbPath.fsPath);
+					const sourceDbRef = this._sessionDataService.openDatabase(config.fork!.session);
+					try {
+						await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
+					} finally {
+						sourceDbRef.dispose();
+					}
 				} catch (err) {
 					this._logService.warn(`[Copilot] Failed to copy session database for fork: ${err instanceof Error ? err.message : String(err)}`);
 				}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -470,12 +470,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 				const targetDbDir = this._sessionDataService.getSessionDataDirById(newSessionId);
 				const targetDbPath = URI.joinPath(targetDbDir, SESSION_DB_FILENAME);
 				try {
-					await fs.mkdir(targetDbDir.fsPath, { recursive: true });
-					const sourceDbRef = this._sessionDataService.openDatabase(config.fork!.session);
-					try {
-						await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
-					} finally {
-						sourceDbRef.dispose();
+					const sourceDbRef = await this._sessionDataService.tryOpenDatabase(config.fork!.session);
+					if (sourceDbRef) {
+						try {
+							await fs.mkdir(targetDbDir.fsPath, { recursive: true });
+							await sourceDbRef.object.vacuumInto(targetDbPath.fsPath);
+						} finally {
+							sourceDbRef.dispose();
+						}
 					}
 				} catch (err) {
 					this._logService.warn(`[Copilot] Failed to copy session database for fork: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -495,6 +495,11 @@ export class SessionDatabase implements ISessionDatabase {
 		}
 	}
 
+	async vacuumInto(targetPath: string) {
+		const db = await this._ensureDb();
+		await dbRun(db, 'VACUUM INTO ?', [targetPath]);
+	}
+
 	async close() {
 		await (this._closed ??= this._dbPromise?.then(db => db.close()).catch(() => { }) || true);
 	}

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -72,6 +72,8 @@ export class TestSessionDatabase implements ISessionDatabase {
 
 	async close(): Promise<void> { }
 
+	async vacuumInto(_targetPath: string): Promise<void> { }
+
 	dispose(): void { }
 
 	async setTurnEventId(_turnId: string, _eventId: string): Promise<void> { }

--- a/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
+++ b/src/vs/platform/agentHost/test/node/sessionDatabase.test.ts
@@ -4,11 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { tmpdir } from 'os';
+import * as fs from 'fs/promises';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { SessionDatabase, runMigrations, sessionDatabaseMigrations, type ISessionDatabaseMigration } from '../../node/sessionDatabase.js';
 import { FileEditKind } from '../../common/state/sessionState.js';
 import type { Database } from '@vscode/sqlite3';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { join } from '../../../../base/common/path.js';
 
 suite('SessionDatabase', () => {
 
@@ -487,6 +491,37 @@ suite('SessionDatabase', () => {
 			db = disposables.add(await SessionDatabase.open(':memory:'));
 			const tables = await db.getAllTables();
 			assert.ok(tables.includes('session_metadata'));
+		});
+	});
+
+	// ---- vacuumInto -----------------------------------------------------
+
+	suite('vacuumInto', () => {
+
+		let tmpDir: string;
+
+		setup(async () => {
+			tmpDir = await fs.mkdtemp(join(tmpdir(), 'session-db-test-' + generateUuid()));
+		});
+
+		teardown(async () => {
+			await Promise.all([db?.close(), db2?.close()]);
+			db = db2 = undefined;
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		});
+
+		test('produces a copy with the same data', async () => {
+			db = disposables.add(await SessionDatabase.open(':memory:'));
+			await db.createTurn('turn-1');
+			await db.setTurnEventId('turn-1', 'evt-1');
+			await db.setMetadata('key', 'value');
+
+			const targetPath = join(tmpDir, 'copy.db');
+			await db.vacuumInto(targetPath);
+
+			db2 = disposables.add(await SessionDatabase.open(targetPath));
+			assert.strictEqual(await db2.getTurnEventId('turn-1'), 'evt-1');
+			assert.strictEqual(await db2.getMetadata('key'), 'value');
 		});
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
