### PR TITLE
Remove old `MSGestureEvent` based conditional

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -67,14 +67,8 @@ export class StandardMouseEvent implements IMouseEvent {
 		this.altKey = e.altKey;
 		this.metaKey = e.metaKey;
 
-		if (typeof e.pageX === 'number') {
-			this.posx = e.pageX;
-			this.posy = e.pageY;
-		} else {
-			// Probably hit by MSGestureEvent
-			this.posx = e.clientX + this.target.ownerDocument.body.scrollLeft + this.target.ownerDocument.documentElement.scrollLeft;
-			this.posy = e.clientY + this.target.ownerDocument.body.scrollTop + this.target.ownerDocument.documentElement.scrollTop;
-		}
+		this.posx = e.pageX;
+		this.posy = e.pageY;
 
 		// Find the position of the iframe this code is executing in relative to the iframe where the event was captured.
 		const iframeOffsets = IframeUtils.getPositionOfChildWindowRelativeToAncestorWindow(targetWindow, e.view);


### PR DESCRIPTION
I think this only existed in ie/edge which we haven't supported for a while