### PR TITLE
Policy: Restrict account-sensitive functionality with opt-in policy

### DIFF
--- a/.github/skills/add-policy/SKILL.md
+++ b/.github/skills/add-policy/SKILL.md
@@ -230,3 +230,7 @@ See `chat.tools.global.autoApprove` and `chat.useHooks` in `src/vs/workbench/con
 ## Examples
 
 Search the codebase for `policy:` to find all the examples of different policy configurations.
+
+## Learnings
+
+* Never hand-edit `build/lib/policies/policyData.jsonc` (its header explicitly forbids it). If `npm run export-policy-data` is failing, fix the script — don't patch the JSON. Common cause: running it in the wrong working directory (e.g. main repo instead of a worktree), which silently exports the wrong source tree.

--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -435,6 +435,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/services/policies",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/services/progress",
 			"project": "vscode-workbench"
 		},

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -283,21 +283,6 @@
             "included": true
         },
         {
-            "key": "chat.disableAIFeatures",
-            "name": "ChatDisableAIFeatures",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.118",
-            "localization": {
-                "description": {
-                    "key": "chat.disableAIFeatures.policy.description",
-                    "value": "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization."
-                }
-            },
-            "type": "boolean",
-            "default": false,
-            "included": true
-        },
-        {
             "key": "chat.tools.terminal.enableAutoApprove",
             "name": "ChatToolsTerminalEnableAutoApprove",
             "category": "IntegratedTerminal",

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -76,11 +76,11 @@
             "localization": {
                 "description": {
                     "key": "chat.approvedAccountOrganizations.policy.description",
-                    "value": "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced)."
+                    "value": "Setting this policy to a non-empty list activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced)."
                 }
             },
-            "type": "string",
-            "default": "",
+            "type": "array",
+            "default": [],
             "included": false
         },
         {

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -69,6 +69,21 @@
             "included": false
         },
         {
+            "key": "chat.approvedAccountOrganizations",
+            "name": "ChatApprovedAccountOrganizations",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.118",
+            "localization": {
+                "description": {
+                    "key": "chat.approvedAccountOrganizations.policy.description",
+                    "value": "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced)."
+                }
+            },
+            "type": "string",
+            "default": "",
+            "included": false
+        },
+        {
             "key": "extensions.allowed",
             "name": "AllowedExtensions",
             "category": "Extensions",
@@ -265,6 +280,21 @@
             },
             "type": "boolean",
             "default": true,
+            "included": true
+        },
+        {
+            "key": "chat.disableAIFeatures",
+            "name": "ChatDisableAIFeatures",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.118",
+            "localization": {
+                "description": {
+                    "key": "chat.disableAIFeatures.policy.description",
+                    "value": "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization."
+                }
+            },
+            "type": "boolean",
+            "default": false,
             "included": true
         },
         {
@@ -478,36 +508,6 @@
             "type": "boolean",
             "default": true,
             "included": true
-        },
-        {
-            "key": "chat.disableAIFeatures",
-            "name": "ChatDisableAIFeatures",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.118",
-            "localization": {
-                "description": {
-                    "key": "chat.disableAIFeatures.policy.description",
-                    "value": "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization."
-                }
-            },
-            "type": "boolean",
-            "default": false,
-            "included": true
-        },
-        {
-            "key": "chat.approvedAccountOrganizations",
-            "name": "ChatApprovedAccountOrganizations",
-            "category": "InteractiveSession",
-            "minimumVersion": "1.118",
-            "localization": {
-                "description": {
-                    "key": "chat.approvedAccountOrganizations.policy.description",
-                    "value": "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced)."
-                }
-            },
-            "type": "string",
-            "default": "",
-            "included": false
         }
     ]
 }

--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -478,6 +478,36 @@
             "type": "boolean",
             "default": true,
             "included": true
+        },
+        {
+            "key": "chat.disableAIFeatures",
+            "name": "ChatDisableAIFeatures",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.118",
+            "localization": {
+                "description": {
+                    "key": "chat.disableAIFeatures.policy.description",
+                    "value": "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization."
+                }
+            },
+            "type": "boolean",
+            "default": false,
+            "included": true
+        },
+        {
+            "key": "chat.approvedAccountOrganizations",
+            "name": "ChatApprovedAccountOrganizations",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.118",
+            "localization": {
+                "description": {
+                    "key": "chat.approvedAccountOrganizations.policy.description",
+                    "value": "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced)."
+                }
+            },
+            "type": "string",
+            "default": "",
+            "included": false
         }
     ]
 }

--- a/src/vs/base/common/policy.ts
+++ b/src/vs/base/common/policy.ts
@@ -97,4 +97,16 @@ export interface IPolicy {
 	 * If `undefined`, the feature's setting is not locked and can be overridden by other means.
 	 */
 	readonly value?: (policyData: IPolicyData) => string | number | boolean | undefined;
+
+	/**
+	 * The most-restrictive value that should be applied when the user is subject to the
+	 * "Require Approved Account" gate but the gate is not yet satisfied (i.e. no approved
+	 * GitHub account is signed in or the account-side policy data has not yet resolved).
+	 *
+	 * If omitted, the gate falls back to a type-driven safe default
+	 * (`false` for boolean, `0` for number, `''` for string).
+	 *
+	 * Only consulted while the gate is active and unsatisfied; ignored otherwise.
+	 */
+	readonly restrictedValue?: string | number | boolean;
 }

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/utils.ts
@@ -274,6 +274,7 @@ export async function withAsyncTestCodeEditorAndInlineCompletionsModel<T>(
 					onDidChangeDefaultAccount: Event.None,
 					onDidChangePolicyData: Event.None,
 					policyData: null,
+					currentDefaultAccount: null,
 					copilotTokenInfo: null,
 					onDidChangeCopilotTokenInfo: Event.None,
 					getDefaultAccount: async () => null,

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -1124,6 +1124,7 @@ class StandaloneDefaultAccountService implements IDefaultAccountService {
 	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null> = Event.None;
 	readonly onDidChangePolicyData: Event<IPolicyData | null> = Event.None;
 	readonly policyData: IPolicyData | null = null;
+	readonly currentDefaultAccount: IDefaultAccount | null = null;
 	readonly copilotTokenInfo = null;
 	readonly onDidChangeCopilotTokenInfo: Event<null> = Event.None;
 

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -139,11 +139,12 @@ export class PolicyConfiguration extends Disposable implements IPolicyConfigurat
 					this.logService.warn(`Policy ${config.policy.name} has unsupported type ${config.type}`);
 					continue;
 				}
-				const { value } = config.policy;
+				const { value, restrictedValue } = config.policy;
 				keys.push(key);
 				policyDefinitions[config.policy.name] = {
 					type: config.type === 'number' ? 'number' : config.type === 'boolean' ? 'boolean' : 'string',
 					value,
+					restrictedValue,
 				};
 			}
 		}

--- a/src/vs/platform/defaultAccount/common/defaultAccount.ts
+++ b/src/vs/platform/defaultAccount/common/defaultAccount.ts
@@ -27,12 +27,6 @@ export interface IDefaultAccountService {
 	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null>;
 	readonly onDidChangePolicyData: Event<IPolicyData | null>;
 	readonly policyData: IPolicyData | null;
-	/**
-	 * Synchronously returns the current default account, or `null` if no provider has been
-	 * registered yet or no account is signed in. Prefer `getDefaultAccount()` when callers
-	 * can wait for the init barrier; this synchronous getter exists for consumers that must
-	 * react immediately (e.g. policy gating) and accept that the initial value may be `null`.
-	 */
 	readonly currentDefaultAccount: IDefaultAccount | null;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null;
 	readonly onDidChangeCopilotTokenInfo: Event<ICopilotTokenInfo | null>;

--- a/src/vs/platform/defaultAccount/common/defaultAccount.ts
+++ b/src/vs/platform/defaultAccount/common/defaultAccount.ts
@@ -27,6 +27,13 @@ export interface IDefaultAccountService {
 	readonly onDidChangeDefaultAccount: Event<IDefaultAccount | null>;
 	readonly onDidChangePolicyData: Event<IPolicyData | null>;
 	readonly policyData: IPolicyData | null;
+	/**
+	 * Synchronously returns the current default account, or `null` if no provider has been
+	 * registered yet or no account is signed in. Prefer `getDefaultAccount()` when callers
+	 * can wait for the init barrier; this synchronous getter exists for consumers that must
+	 * react immediately (e.g. policy gating) and accept that the initial value may be `null`.
+	 */
+	readonly currentDefaultAccount: IDefaultAccount | null;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null;
 	readonly onDidChangeCopilotTokenInfo: Event<ICopilotTokenInfo | null>;
 	getDefaultAccount(): Promise<IDefaultAccount | null>;

--- a/src/vs/platform/policy/common/policy.ts
+++ b/src/vs/platform/policy/common/policy.ts
@@ -15,7 +15,24 @@ export type PolicyValue = string | number | boolean;
 export type PolicyDefinition = {
 	type: 'string' | 'number' | 'boolean';
 	value?: (policyData: IPolicyData) => string | number | boolean | undefined;
+	restrictedValue?: PolicyValue;
 };
+
+/**
+ * Returns the value to apply for `definition` when the account-policy gate is active
+ * but not satisfied. Uses `definition.restrictedValue` when specified, otherwise falls
+ * back to a type-driven safe default.
+ */
+export function getRestrictedPolicyValue(definition: PolicyDefinition): PolicyValue {
+	if (definition.restrictedValue !== undefined) {
+		return definition.restrictedValue;
+	}
+	switch (definition.type) {
+		case 'boolean': return false;
+		case 'number': return 0;
+		case 'string': return '';
+	}
+}
 
 export const IPolicyService = createDecorator<IPolicyService>('policy');
 

--- a/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
+++ b/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
@@ -67,6 +67,33 @@
 	text-decoration: underline;
 }
 
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs {
+	text-align: center;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs-label {
+	margin: 0 0 4px 0;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs li {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.6;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-footer {
+	font-size: 12px;
+}
+
 .sessions-policy-blocked-card .monaco-button {
 	margin-top: 4px;
 	width: auto;

--- a/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
+++ b/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
@@ -67,6 +67,58 @@
 	text-decoration: underline;
 }
 
+/* Progress bar for transient loading state */
+.sessions-policy-blocked-card .sessions-policy-blocked-progress-bar {
+	width: 100%;
+	height: 3px;
+	background: color-mix(in srgb, var(--vscode-foreground) 10%, transparent);
+	border-radius: 2px;
+	overflow: hidden;
+	margin-top: 16px;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-progress-bar-fill {
+	width: 30%;
+	height: 100%;
+	background: var(--vscode-progressBar-background, #0078d4);
+	border-radius: 2px;
+	animation: sessions-policy-blocked-progress 2s ease-in-out infinite;
+}
+
+@keyframes sessions-policy-blocked-progress {
+	0% { transform: translateX(0%); }
+	50% { transform: translateX(233%); }
+	100% { transform: translateX(0%); }
+}
+
+/* Approved organizations list */
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs {
+	text-align: center;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs-label {
+	margin: 0 0 4px 0;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs li {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.6;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-footer {
+	font-size: 12px;
+}
+
 .sessions-policy-blocked-card .monaco-button {
 	margin-top: 4px;
 	width: auto;

--- a/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
+++ b/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
@@ -67,33 +67,6 @@
 	text-decoration: underline;
 }
 
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs {
-	text-align: center;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs-label {
-	margin: 0 0 4px 0;
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--vscode-foreground);
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs ul {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs li {
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
-	line-height: 1.6;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-footer {
-	font-size: 12px;
-}
-
 .sessions-policy-blocked-card .monaco-button {
 	margin-top: 4px;
 	width: auto;

--- a/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
+++ b/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
@@ -91,34 +91,6 @@
 	100% { transform: translateX(0%); }
 }
 
-/* Approved organizations list */
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs {
-	text-align: center;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs-label {
-	margin: 0 0 4px 0;
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--vscode-foreground);
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs ul {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-orgs li {
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
-	line-height: 1.6;
-}
-
-.sessions-policy-blocked-card .sessions-policy-blocked-footer {
-	font-size: 12px;
-}
-
 .sessions-policy-blocked-card .monaco-button {
 	margin-top: 4px;
 	width: auto;

--- a/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
+++ b/src/vs/sessions/contrib/policyBlocked/browser/media/sessionsPolicyBlocked.css
@@ -91,6 +91,34 @@
 	100% { transform: translateX(0%); }
 }
 
+/* Approved organizations list */
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs {
+	text-align: center;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs-label {
+	margin: 0 0 4px 0;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-orgs li {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.6;
+}
+
+.sessions-policy-blocked-card .sessions-policy-blocked-footer {
+	font-size: 12px;
+}
+
 .sessions-policy-blocked-card .monaco-button {
 	margin-top: 4px;
 	width: auto;

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,124 +8,44 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
-import { ILogService } from '../../../../platform/log/common/log.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
-import { IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, ChatAccountPolicyGateActiveContext, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
-
-type AccountPolicyGateStateEvent = {
-	gateActive: boolean;
-	gateSatisfied: boolean;
-	reasonNotSatisfied: string | undefined;
-};
-
-type AccountPolicyGateStateClassification = {
-	owner: 'joshspicer';
-	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues.';
-	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if an admin has activated the Approved Account gate (non-empty approved-organization list).' };
-	gateSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the gate is satisfied (signed-in approved account with resolved policy).' };
-	reasonNotSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bucketed reason the gate is unsatisfied: noAccount, wrongProvider, orgNotApproved, policyNotResolved.' };
-};
+import { SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
 
 export class SessionsPolicyBlockedContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsPolicyBlocked';
 
 	private readonly overlayRef = this._register(new MutableDisposable());
-	private readonly contextKey: IContextKey<boolean>;
-	private lastGateInfo: IAccountPolicyGateInfo;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
-		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
-		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
-		@IContextKeyService contextKeyService: IContextKeyService,
-		@ILogService private readonly logService: ILogService,
-		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
-		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
-		this.lastGateInfo = this.gateService.gateInfo;
-
-		this.update(/*forceTelemetry*/ true);
+		this.update();
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatConfiguration.AgentEnabled)) {
-				this.update(/*forceTelemetry*/ false);
+				this.update();
 			}
 		}));
-
-		this._register(this.gateService.onDidChangeGateInfo(() => this.update(/*forceTelemetry*/ false)));
 	}
 
-	private update(forceTelemetry: boolean): void {
-		const gateInfo = this.gateService.gateInfo;
-		const stateChanged = forceTelemetry || gateInfo.state !== this.lastGateInfo.state || gateInfo.reason !== this.lastGateInfo.reason;
-		this.lastGateInfo = gateInfo;
+	private update(): void {
+		const enabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
 
-		// Apply context key + setForceHidden for the gate (same logic as
-		// the workbench-layer AccountPolicyGateContribution, which is NOT
-		// imported in the sessions window).
-		const isGateRestricted = gateInfo.state === AccountPolicyGateState.Restricted
-			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
-		this.contextKey.set(isGateRestricted);
-		this.chatEntitlementService.setForceHidden(isGateRestricted);
-		this.logService.info(`[SessionsPolicyBlocked] gate: state=${gateInfo.state}, reason=${gateInfo.reason}, isRestricted=${isGateRestricted}`);
-
-		if (stateChanged) {
-			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {
-				gateActive: gateInfo.state !== AccountPolicyGateState.Inactive,
-				gateSatisfied: gateInfo.state === AccountPolicyGateState.Satisfied,
-				reasonNotSatisfied: gateInfo.reason,
-			});
+		if (enabled === false) {
+			if (!this.overlayRef.value) {
+				this.overlayRef.value = this.instantiationService.createInstance(
+					SessionsPolicyBlockedOverlay,
+					this.layoutService.mainContainer,
+				);
+			}
+		} else {
+			this.overlayRef.clear();
 		}
-
-		// --- Overlay logic ---
-
-		// Priority 1: agent mode disabled by policy
-		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
-		if (agentEnabled === false) {
-			this.showOverlay({ reason: SessionsBlockedReason.AgentDisabled });
-			return;
-		}
-
-		// Priority 2: account policy gate is restricting access
-		if (isGateRestricted) {
-			const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
-			this.showOverlay({
-				reason: SessionsBlockedReason.AccountPolicyGate,
-				approvedOrganizations: gateInfo.approvedOrganizations,
-				accountName,
-			});
-			return;
-		}
-
-		// Not blocked
-		this.overlayRef.clear();
-	}
-
-	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
-		// If AgentDisabled is already showing, don't recreate.
-		if (this.overlayRef.value && options.reason === SessionsBlockedReason.AgentDisabled) {
-			return;
-		}
-		// For account policy gate, always recreate to update messaging
-		// (account name / org list may have changed).
-		this.overlayRef.clear();
-
-		this.overlayRef.value = this.instantiationService.createInstance(
-			SessionsPolicyBlockedOverlay,
-			this.layoutService.mainContainer,
-			options,
-		);
 	}
 }
 

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,16 +8,36 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
+import { IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
 import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, ChatAccountPolicyGateActiveContext, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
+
+type AccountPolicyGateStateEvent = {
+	gateActive: boolean;
+	gateSatisfied: boolean;
+	reasonNotSatisfied: string | undefined;
+};
+
+type AccountPolicyGateStateClassification = {
+	owner: 'joshspicer';
+	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues.';
+	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if an admin has activated the Approved Account gate (non-empty approved-organization list).' };
+	gateSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the gate is satisfied (signed-in approved account with resolved policy).' };
+	reasonNotSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bucketed reason the gate is unsatisfied: noAccount, wrongProvider, orgNotApproved, policyNotResolved.' };
+};
 
 export class SessionsPolicyBlockedContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsPolicyBlocked';
 
 	private readonly overlayRef = this._register(new MutableDisposable());
+	private readonly contextKey: IContextKey<boolean>;
+	private lastGateInfo: IAccountPolicyGateInfo;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -25,21 +45,51 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ILogService private readonly logService: ILogService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
 
-		this.update();
+		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
+		this.lastGateInfo = this.gateService.gateInfo;
+
+		this.update(/*forceTelemetry*/ true);
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatConfiguration.AgentEnabled)) {
-				this.update();
+				this.update(/*forceTelemetry*/ false);
 			}
 		}));
 
-		this._register(this.gateService.onDidChangeGateInfo(() => this.update()));
+		this._register(this.gateService.onDidChangeGateInfo(() => this.update(/*forceTelemetry*/ false)));
 	}
 
-	private update(): void {
+	private update(forceTelemetry: boolean): void {
+		const gateInfo = this.gateService.gateInfo;
+		const stateChanged = forceTelemetry || gateInfo.state !== this.lastGateInfo.state || gateInfo.reason !== this.lastGateInfo.reason;
+		this.lastGateInfo = gateInfo;
+
+		// Apply context key + setForceHidden for the gate (same logic as
+		// the workbench-layer AccountPolicyGateContribution, which is NOT
+		// imported in the sessions window).
+		const isGateRestricted = gateInfo.state === AccountPolicyGateState.Restricted
+			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+		this.contextKey.set(isGateRestricted);
+		this.chatEntitlementService.setForceHidden(isGateRestricted);
+		this.logService.info(`[SessionsPolicyBlocked] gate: state=${gateInfo.state}, reason=${gateInfo.reason}, isRestricted=${isGateRestricted}`);
+
+		if (stateChanged) {
+			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {
+				gateActive: gateInfo.state !== AccountPolicyGateState.Inactive,
+				gateSatisfied: gateInfo.state === AccountPolicyGateState.Satisfied,
+				reasonNotSatisfied: gateInfo.reason,
+			});
+		}
+
+		// --- Overlay logic ---
+
 		// Priority 1: agent mode disabled by policy
 		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
 		if (agentEnabled === false) {
@@ -48,10 +98,7 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		}
 
 		// Priority 2: account policy gate is restricting access
-		const gateInfo = this.gateService.gateInfo;
-		const isRestricted = gateInfo.state === AccountPolicyGateState.Restricted
-			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
-		if (isRestricted) {
+		if (isGateRestricted) {
 			const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 			this.showOverlay({
 				reason: SessionsBlockedReason.AccountPolicyGate,
@@ -66,15 +113,13 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 	}
 
 	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
-		// If the same reason is already shown, don't recreate the overlay —
-		// except for account policy gate where the account name/orgs may have changed.
-		if (this.overlayRef.value) {
-			if (options.reason === SessionsBlockedReason.AgentDisabled) {
-				return; // already showing agent disabled
-			}
-			// For account policy gate, recreate to update messaging
-			this.overlayRef.clear();
+		// If AgentDisabled is already showing, don't recreate.
+		if (this.overlayRef.value && options.reason === SessionsBlockedReason.AgentDisabled) {
+			return;
 		}
+		// For account policy gate, always recreate to update messaging
+		// (account name / org list may have changed).
+		this.overlayRef.clear();
 
 		this.overlayRef.value = this.instantiationService.createInstance(
 			SessionsPolicyBlockedOverlay,

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,8 +8,10 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
-import { SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
+import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
 
 export class SessionsPolicyBlockedContribution extends Disposable implements IWorkbenchContribution {
 
@@ -21,6 +23,8 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -31,21 +35,52 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 				this.update();
 			}
 		}));
+
+		this._register(this.gateService.onDidChangeGateInfo(() => this.update()));
 	}
 
 	private update(): void {
-		const enabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
+		// Priority 1: agent mode disabled by policy
+		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
+		if (agentEnabled === false) {
+			this.showOverlay({ reason: SessionsBlockedReason.AgentDisabled });
+			return;
+		}
 
-		if (enabled === false) {
-			if (!this.overlayRef.value) {
-				this.overlayRef.value = this.instantiationService.createInstance(
-					SessionsPolicyBlockedOverlay,
-					this.layoutService.mainContainer,
-				);
+		// Priority 2: account policy gate is restricting access
+		const gateInfo = this.gateService.gateInfo;
+		const isRestricted = gateInfo.state === AccountPolicyGateState.Restricted
+			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+		if (isRestricted) {
+			const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
+			this.showOverlay({
+				reason: SessionsBlockedReason.AccountPolicyGate,
+				approvedOrganizations: gateInfo.approvedOrganizations,
+				accountName,
+			});
+			return;
+		}
+
+		// Not blocked
+		this.overlayRef.clear();
+	}
+
+	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
+		// If the same reason is already shown, don't recreate the overlay —
+		// except for account policy gate where the account name/orgs may have changed.
+		if (this.overlayRef.value) {
+			if (options.reason === SessionsBlockedReason.AgentDisabled) {
+				return; // already showing agent disabled
 			}
-		} else {
+			// For account policy gate, recreate to update messaging
 			this.overlayRef.clear();
 		}
+
+		this.overlayRef.value = this.instantiationService.createInstance(
+			SessionsPolicyBlockedOverlay,
+			this.layoutService.mainContainer,
+			options,
+		);
 	}
 }
 

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -43,9 +43,9 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 	private update(): void {
 		const gateInfo = this.gateService.gateInfo;
 
-		// The gate forces chat.agent.enabled = false via restrictedValue when it's
-		// in a stable Restricted state (not transient PolicyNotResolved). Only
-		// suppress the AgentDisabled overlay when our gate is causing that value.
+		// The gate forces chat.agent.enabled = false via restrictedValue when stably
+		// Restricted. Suppress AgentDisabled in that case so users see the gate-specific
+		// overlay (or the welcome screen for noAccount/wrongProvider) instead.
 		const gateForcesAgentDisabled = gateInfo.state === AccountPolicyGateState.Restricted
 			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 
@@ -55,10 +55,8 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 			return;
 		}
 
-		// Account policy gate
 		if (gateInfo.state === AccountPolicyGateState.Restricted) {
-			// noAccount / wrongProvider: defer to the sessions welcome/walkthrough
-			// screen so the user can sign in via the standard flow.
+			// Defer to the sessions welcome/walkthrough so the user signs in via the standard flow.
 			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
 				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.WrongProvider) {
 				this.overlayRef.clear();
@@ -69,7 +67,6 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 				this.showOverlay({ reason: SessionsBlockedReason.Loading });
 			} else {
-				// orgNotApproved — signed in but wrong account
 				const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 				this.showOverlay({
 					reason: SessionsBlockedReason.AccountPolicyGate,
@@ -80,14 +77,12 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 			return;
 		}
 
-		// Not blocked
 		this.overlayRef.clear();
 		this.currentReason = undefined;
 	}
 
 	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
-		// Don't recreate if already showing the same reason (except AccountPolicyGate
-		// where the account name may have changed)
+		// AccountPolicyGate may need re-render when the account name changes.
 		if (this.currentReason === options.reason && options.reason !== SessionsBlockedReason.AccountPolicyGate) {
 			return;
 		}

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -42,13 +42,15 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 
 	private update(): void {
 		const gateInfo = this.gateService.gateInfo;
-		const gateActive = gateInfo.state !== AccountPolicyGateState.Inactive;
 
-		// Check agent-disabled ONLY when it's not being artificially forced
-		// by our own account policy gate (which sets restrictedValue on the
-		// ChatAgentMode policy, making chat.agent.enabled = false).
+		// The gate forces chat.agent.enabled = false via restrictedValue when it's
+		// in a stable Restricted state (not transient PolicyNotResolved). Only
+		// suppress the AgentDisabled overlay when our gate is causing that value.
+		const gateForcesAgentDisabled = gateInfo.state === AccountPolicyGateState.Restricted
+			&& gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+
 		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
-		if (agentEnabled === false && !gateActive) {
+		if (agentEnabled === false && !gateForcesAgentDisabled) {
 			this.showOverlay({ reason: SessionsBlockedReason.AgentDisabled });
 			return;
 		}

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,19 +8,24 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
-import { SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
+import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
 
 export class SessionsPolicyBlockedContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsPolicyBlocked';
 
 	private readonly overlayRef = this._register(new MutableDisposable());
+	private currentReason: SessionsBlockedReason | undefined;
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -31,21 +36,57 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 				this.update();
 			}
 		}));
+
+		this._register(this.gateService.onDidChangeGateInfo(() => this.update()));
 	}
 
 	private update(): void {
-		const enabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
-
-		if (enabled === false) {
-			if (!this.overlayRef.value) {
-				this.overlayRef.value = this.instantiationService.createInstance(
-					SessionsPolicyBlockedOverlay,
-					this.layoutService.mainContainer,
-				);
-			}
-		} else {
-			this.overlayRef.clear();
+		// Priority 1: agent mode disabled by policy
+		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
+		if (agentEnabled === false) {
+			this.showOverlay({ reason: SessionsBlockedReason.AgentDisabled });
+			return;
 		}
+
+		// Priority 2: account policy gate
+		const gateInfo = this.gateService.gateInfo;
+		if (gateInfo.state === AccountPolicyGateState.Restricted) {
+			// Transient states (noAccount before account loads, policyNotResolved)
+			// show a loading bar instead of an incorrect "Sign-In Required" message.
+			const isTransient = gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
+				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+
+			if (isTransient) {
+				this.showOverlay({ reason: SessionsBlockedReason.Loading });
+			} else {
+				const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
+				this.showOverlay({
+					reason: SessionsBlockedReason.AccountPolicyGate,
+					approvedOrganizations: gateInfo.approvedOrganizations,
+					accountName,
+				});
+			}
+			return;
+		}
+
+		// Not blocked
+		this.overlayRef.clear();
+		this.currentReason = undefined;
+	}
+
+	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
+		// Don't recreate if already showing the same reason
+		if (this.currentReason === options.reason && options.reason !== SessionsBlockedReason.AccountPolicyGate) {
+			return;
+		}
+		this.overlayRef.clear();
+		this.currentReason = options.reason;
+
+		this.overlayRef.value = this.instantiationService.createInstance(
+			SessionsPolicyBlockedOverlay,
+			this.layoutService.mainContainer,
+			options,
+		);
 	}
 }
 

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,6 +8,7 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
 import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
@@ -24,6 +25,7 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -53,16 +55,25 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 
 		// Account policy gate
 		if (gateInfo.state === AccountPolicyGateState.Restricted) {
-			// PolicyNotResolved is the only transient state — show a loading bar
-			// so we don't flash a misleading message while data is in flight.
-			// All other unsatisfied reasons (noAccount, wrongProvider, orgNotApproved)
-			// require user action: defer to the sessions welcome/walkthrough screen
-			// so the user can sign in or switch accounts via the standard flow.
+			// noAccount / wrongProvider: defer to the sessions welcome/walkthrough
+			// screen so the user can sign in via the standard flow.
+			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
+				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.WrongProvider) {
+				this.overlayRef.clear();
+				this.currentReason = undefined;
+				return;
+			}
+
 			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 				this.showOverlay({ reason: SessionsBlockedReason.Loading });
 			} else {
-				this.overlayRef.clear();
-				this.currentReason = undefined;
+				// orgNotApproved — signed in but wrong account
+				const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
+				this.showOverlay({
+					reason: SessionsBlockedReason.AccountPolicyGate,
+					approvedOrganizations: gateInfo.approvedOrganizations,
+					accountName,
+				});
 			}
 			return;
 		}
@@ -73,8 +84,9 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 	}
 
 	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
-		// Don't recreate if already showing the same reason
-		if (this.currentReason === options.reason) {
+		// Don't recreate if already showing the same reason (except AccountPolicyGate
+		// where the account name may have changed)
+		if (this.currentReason === options.reason && options.reason !== SessionsBlockedReason.AccountPolicyGate) {
 			return;
 		}
 		this.overlayRef.clear();

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -8,7 +8,6 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ChatConfiguration } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from './sessionsPolicyBlocked.js';
 import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateService } from '../../../../workbench/services/policies/common/accountPolicyService.js';
@@ -25,7 +24,6 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
-		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 	) {
 		super();
 
@@ -55,25 +53,16 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 
 		// Account policy gate
 		if (gateInfo.state === AccountPolicyGateState.Restricted) {
-			// noAccount / wrongProvider: don't show our overlay — the sessions
-			// welcome/walkthrough screen already handles sign-in.
-			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
-				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.WrongProvider) {
-				this.overlayRef.clear();
-				this.currentReason = undefined;
-				return;
-			}
-
+			// PolicyNotResolved is the only transient state — show a loading bar
+			// so we don't flash a misleading message while data is in flight.
+			// All other unsatisfied reasons (noAccount, wrongProvider, orgNotApproved)
+			// require user action: defer to the sessions welcome/walkthrough screen
+			// so the user can sign in or switch accounts via the standard flow.
 			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 				this.showOverlay({ reason: SessionsBlockedReason.Loading });
 			} else {
-				// orgNotApproved — stable restriction
-				const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
-				this.showOverlay({
-					reason: SessionsBlockedReason.AccountPolicyGate,
-					approvedOrganizations: gateInfo.approvedOrganizations,
-					accountName,
-				});
+				this.overlayRef.clear();
+				this.currentReason = undefined;
 			}
 			return;
 		}
@@ -85,7 +74,7 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 
 	private showOverlay(options: ISessionsBlockedOverlayOptions): void {
 		// Don't recreate if already showing the same reason
-		if (this.currentReason === options.reason && options.reason !== SessionsBlockedReason.AccountPolicyGate) {
+		if (this.currentReason === options.reason) {
 			return;
 		}
 		this.overlayRef.clear();

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -41,20 +41,22 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 	}
 
 	private update(): void {
-		// Priority 1: agent mode disabled by policy
+		const gateInfo = this.gateService.gateInfo;
+		const gateActive = gateInfo.state !== AccountPolicyGateState.Inactive;
+
+		// Check agent-disabled ONLY when it's not being artificially forced
+		// by our own account policy gate (which sets restrictedValue on the
+		// ChatAgentMode policy, making chat.agent.enabled = false).
 		const agentEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AgentEnabled);
-		if (agentEnabled === false) {
+		if (agentEnabled === false && !gateActive) {
 			this.showOverlay({ reason: SessionsBlockedReason.AgentDisabled });
 			return;
 		}
 
-		// Priority 2: account policy gate
-		const gateInfo = this.gateService.gateInfo;
+		// Account policy gate
 		if (gateInfo.state === AccountPolicyGateState.Restricted) {
 			// noAccount / wrongProvider: don't show our overlay — the sessions
-			// welcome/walkthrough screen already handles sign-in. We only block
-			// with the overlay when the user IS signed in but to the wrong org,
-			// or when waiting for policy data to resolve.
+			// welcome/walkthrough screen already handles sign-in.
 			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
 				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.WrongProvider) {
 				this.overlayRef.clear();

--- a/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/policyBlocked.contribution.ts
@@ -51,14 +51,21 @@ export class SessionsPolicyBlockedContribution extends Disposable implements IWo
 		// Priority 2: account policy gate
 		const gateInfo = this.gateService.gateInfo;
 		if (gateInfo.state === AccountPolicyGateState.Restricted) {
-			// Transient states (noAccount before account loads, policyNotResolved)
-			// show a loading bar instead of an incorrect "Sign-In Required" message.
-			const isTransient = gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
-				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
+			// noAccount / wrongProvider: don't show our overlay — the sessions
+			// welcome/walkthrough screen already handles sign-in. We only block
+			// with the overlay when the user IS signed in but to the wrong org,
+			// or when waiting for policy data to resolve.
+			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.NoAccount
+				|| gateInfo.reason === AccountPolicyGateUnsatisfiedReason.WrongProvider) {
+				this.overlayRef.clear();
+				this.currentReason = undefined;
+				return;
+			}
 
-			if (isTransient) {
+			if (gateInfo.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 				this.showOverlay({ reason: SessionsBlockedReason.Loading });
 			} else {
+				// orgNotApproved — stable restriction
 				const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 				this.showOverlay({
 					reason: SessionsBlockedReason.AccountPolicyGate,

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -12,10 +12,26 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+
+export const enum SessionsBlockedReason {
+	/** Agent mode disabled via group policy (`chat.agent.enabled = false`). */
+	AgentDisabled = 'agentDisabled',
+	/** Account policy gate active — user must sign in to an approved org. */
+	AccountPolicyGate = 'accountPolicyGate',
+}
+
+export interface ISessionsBlockedOverlayOptions {
+	readonly reason: SessionsBlockedReason;
+	/** Formatted approved-organization names (only for AccountPolicyGate). */
+	readonly approvedOrganizations?: readonly string[];
+	/** Current account name if signed in (only for AccountPolicyGate). */
+	readonly accountName?: string;
+}
 
 /**
- * Full-window impassable overlay shown when the Agents app has been
- * disabled via group policy. Blocks all user interaction.
+ * Full-window impassable overlay shown when the Agents app is blocked.
+ * Supports multiple blocking reasons with different messaging and actions.
  */
 export class SessionsPolicyBlockedOverlay extends Disposable {
 
@@ -23,6 +39,8 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 
 	constructor(
 		container: HTMLElement,
+		options: ISessionsBlockedOverlayOptions,
+		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 	) {
@@ -31,7 +49,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		this.overlay = append(container, $('.sessions-policy-blocked-overlay'));
 		this.overlay.setAttribute('role', 'dialog');
 		this.overlay.setAttribute('aria-modal', 'true');
-		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
 		this.overlay.tabIndex = -1;
 		this.overlay.focus();
 		this._register(toDisposable(() => this.overlay.remove()));
@@ -49,7 +66,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		}, true));
 
 		// Block mouse interaction on the overlay background, but allow
-		// clicks through to card children (e.g. the "Open VS Code" button).
+		// clicks through to card children (e.g. buttons).
 		this._register(addDisposableGenericMouseDownListener(this.overlay, e => {
 			if (e.target === this.overlay) {
 				e.preventDefault();
@@ -60,10 +77,18 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		// Sessions logo
 		append(card, $('div.sessions-policy-blocked-logo'));
 
-		// Title
+		if (options.reason === SessionsBlockedReason.AccountPolicyGate) {
+			this._renderAccountPolicyGate(card, options);
+		} else {
+			this._renderAgentDisabled(card);
+		}
+	}
+
+	private _renderAgentDisabled(card: HTMLElement): void {
+		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
+
 		append(card, $('h2', undefined, localize('policyBlocked.title', "Agents Disabled")));
 
-		// Description
 		const description = append(card, $('p'));
 		append(description, document.createTextNode(localize('policyBlocked.description', "Your organization has disabled Agents via policy.")));
 		append(description, document.createTextNode(' '));
@@ -75,10 +100,64 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			this.openerService.open(URI.parse('https://aka.ms/VSCode/Agents/docs'));
 		}));
 
-		// Open VS Code button
 		const button = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
 		button.label = localize('policyBlocked.openVSCode', "Open VS Code");
 		this._register(button.onDidClick(() => this._openVSCode()));
+	}
+
+	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
+		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
+
+		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
+
+		const description = append(card, $('p'));
+		if (options.accountName) {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization.", options.accountName)
+			));
+		} else {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionNoAccount', "Your administrator requires sign-in with a GitHub account from an approved organization to use Agents.")
+			));
+		}
+
+		// Approved organizations list
+		const approvedOrgs = options.approvedOrganizations ?? [];
+		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
+		if (hasConcreteOrgs) {
+			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
+			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
+				localize('accountGate.approvedOrgs', "Approved organizations:")
+			));
+			const orgList = append(orgSection, $('ul'));
+			for (const org of approvedOrgs) {
+				append(orgList, $('li', undefined, org));
+			}
+		}
+
+		// Contact admin + learn more
+		const footer = append(card, $('p.sessions-policy-blocked-footer'));
+		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
+		append(footer, document.createTextNode(' '));
+		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
+		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
+		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';
+		this._register(addDisposableListener(learnMore, EventType.CLICK, (e) => {
+			e.preventDefault();
+			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview'));
+		}));
+
+		// Sign In button (primary)
+		const signInButton = this._register(new Button(card, { ...defaultButtonStyles }));
+		signInButton.label = localize('accountGate.signIn', "Sign In");
+		this._register(signInButton.onDidClick(() => {
+			this.commandService.executeCommand('workbench.action.agenticSignIn');
+		}));
+
+		// Open VS Code button (secondary)
+		const openButton = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
+		openButton.label = localize('accountGate.openVSCode', "Open VS Code");
+		this._register(openButton.onDidClick(() => this._openVSCode()));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -113,7 +113,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		const description = append(card, $('p'));
 		if (options.accountName) {
 			append(description, document.createTextNode(
-				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization.", options.accountName)
+				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
 			));
 		} else {
 			append(description, document.createTextNode(

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -12,26 +12,10 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
-
-export const enum SessionsBlockedReason {
-	/** Agent mode disabled via group policy (`chat.agent.enabled = false`). */
-	AgentDisabled = 'agentDisabled',
-	/** Account policy gate active — user must sign in to an approved org. */
-	AccountPolicyGate = 'accountPolicyGate',
-}
-
-export interface ISessionsBlockedOverlayOptions {
-	readonly reason: SessionsBlockedReason;
-	/** Formatted approved-organization names (only for AccountPolicyGate). */
-	readonly approvedOrganizations?: readonly string[];
-	/** Current account name if signed in (only for AccountPolicyGate). */
-	readonly accountName?: string;
-}
 
 /**
- * Full-window impassable overlay shown when the Agents app is blocked.
- * Supports multiple blocking reasons with different messaging and actions.
+ * Full-window impassable overlay shown when the Agents app has been
+ * disabled via group policy. Blocks all user interaction.
  */
 export class SessionsPolicyBlockedOverlay extends Disposable {
 
@@ -39,8 +23,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 
 	constructor(
 		container: HTMLElement,
-		options: ISessionsBlockedOverlayOptions,
-		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 	) {
@@ -49,6 +31,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		this.overlay = append(container, $('.sessions-policy-blocked-overlay'));
 		this.overlay.setAttribute('role', 'dialog');
 		this.overlay.setAttribute('aria-modal', 'true');
+		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
 		this.overlay.tabIndex = -1;
 		this.overlay.focus();
 		this._register(toDisposable(() => this.overlay.remove()));
@@ -66,7 +49,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		}, true));
 
 		// Block mouse interaction on the overlay background, but allow
-		// clicks through to card children (e.g. buttons).
+		// clicks through to card children (e.g. the "Open VS Code" button).
 		this._register(addDisposableGenericMouseDownListener(this.overlay, e => {
 			if (e.target === this.overlay) {
 				e.preventDefault();
@@ -77,18 +60,10 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		// Sessions logo
 		append(card, $('div.sessions-policy-blocked-logo'));
 
-		if (options.reason === SessionsBlockedReason.AccountPolicyGate) {
-			this._renderAccountPolicyGate(card, options);
-		} else {
-			this._renderAgentDisabled(card);
-		}
-	}
-
-	private _renderAgentDisabled(card: HTMLElement): void {
-		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
-
+		// Title
 		append(card, $('h2', undefined, localize('policyBlocked.title', "Agents Disabled")));
 
+		// Description
 		const description = append(card, $('p'));
 		append(description, document.createTextNode(localize('policyBlocked.description', "Your organization has disabled Agents via policy.")));
 		append(description, document.createTextNode(' '));
@@ -100,64 +75,10 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			this.openerService.open(URI.parse('https://aka.ms/VSCode/Agents/docs'));
 		}));
 
+		// Open VS Code button
 		const button = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
 		button.label = localize('policyBlocked.openVSCode', "Open VS Code");
 		this._register(button.onDidClick(() => this._openVSCode()));
-	}
-
-	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
-		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
-
-		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
-
-		const description = append(card, $('p'));
-		if (options.accountName) {
-			append(description, document.createTextNode(
-				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
-			));
-		} else {
-			append(description, document.createTextNode(
-				localize('accountGate.descriptionNoAccount', "Your administrator requires sign-in with a GitHub account from an approved organization to use Agents.")
-			));
-		}
-
-		// Approved organizations list
-		const approvedOrgs = options.approvedOrganizations ?? [];
-		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
-		if (hasConcreteOrgs) {
-			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
-			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
-				localize('accountGate.approvedOrgs', "Approved organizations:")
-			));
-			const orgList = append(orgSection, $('ul'));
-			for (const org of approvedOrgs) {
-				append(orgList, $('li', undefined, org));
-			}
-		}
-
-		// Contact admin + learn more
-		const footer = append(card, $('p.sessions-policy-blocked-footer'));
-		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
-		append(footer, document.createTextNode(' '));
-		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
-		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
-		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';
-		this._register(addDisposableListener(learnMore, EventType.CLICK, (e) => {
-			e.preventDefault();
-			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview'));
-		}));
-
-		// Sign In button (primary)
-		const signInButton = this._register(new Button(card, { ...defaultButtonStyles }));
-		signInButton.label = localize('accountGate.signIn', "Sign In");
-		this._register(signInButton.onDidClick(() => {
-			this.commandService.executeCommand('workbench.action.agenticSignIn');
-		}));
-
-		// Open VS Code button (secondary)
-		const openButton = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
-		openButton.label = localize('accountGate.openVSCode', "Open VS Code");
-		this._register(openButton.onDidClick(() => this._openVSCode()));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -30,7 +30,6 @@ export interface ISessionsBlockedOverlayOptions {
 
 /**
  * Full-window impassable overlay shown when the Agents app is blocked.
- * Supports multiple blocking reasons with different messaging and actions.
  */
 export class SessionsPolicyBlockedOverlay extends Disposable {
 
@@ -69,7 +68,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			}
 		}));
 
-		// Sessions logo
 		append(card, $('div.sessions-policy-blocked-logo'));
 
 		switch (options.reason) {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -12,20 +12,15 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 export const enum SessionsBlockedReason {
 	AgentDisabled = 'agentDisabled',
 	/** Transient loading state — blocks UI but shows only a progress bar. */
 	Loading = 'loading',
-	/** Stable restriction — user must sign in to an approved org. */
-	AccountPolicyGate = 'accountPolicyGate',
 }
 
 export interface ISessionsBlockedOverlayOptions {
 	readonly reason: SessionsBlockedReason;
-	readonly approvedOrganizations?: readonly string[];
-	readonly accountName?: string;
 }
 
 /**
@@ -39,7 +34,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 	constructor(
 		container: HTMLElement,
 		options: ISessionsBlockedOverlayOptions,
-		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 	) {
@@ -79,9 +73,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			case SessionsBlockedReason.Loading:
 				this._renderLoading(card);
 				break;
-			case SessionsBlockedReason.AccountPolicyGate:
-				this._renderAccountPolicyGate(card, options);
-				break;
 		}
 	}
 
@@ -111,53 +102,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		append(card, $('div.sessions-policy-blocked-progress-bar', undefined,
 			$('div.sessions-policy-blocked-progress-bar-fill')
 		));
-	}
-
-	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
-		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
-
-		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
-
-		const description = append(card, $('p'));
-		if (options.accountName) {
-			append(description, document.createTextNode(
-				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
-			));
-		} else {
-			append(description, document.createTextNode(
-				localize('accountGate.descriptionNoAccount', "Sign in with a GitHub account from an approved organization to use Agents.")
-			));
-		}
-
-		const approvedOrgs = options.approvedOrganizations ?? [];
-		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
-		if (hasConcreteOrgs) {
-			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
-			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
-				localize('accountGate.approvedOrgs', "Approved organizations:")
-			));
-			const orgList = append(orgSection, $('ul'));
-			for (const org of approvedOrgs) {
-				append(orgList, $('li', undefined, org));
-			}
-		}
-
-		const footer = append(card, $('p.sessions-policy-blocked-footer'));
-		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
-		append(footer, document.createTextNode(' '));
-		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
-		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
-		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';
-		this._register(addDisposableListener(learnMore, EventType.CLICK, (e) => {
-			e.preventDefault();
-			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview'));
-		}));
-
-		const signInButton = this._register(new Button(card, { ...defaultButtonStyles }));
-		signInButton.label = localize('accountGate.signIn', "Sign In");
-		this._register(signInButton.onDidClick(() => {
-			this.commandService.executeCommand('workbench.action.agenticSignIn');
-		}));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -12,15 +12,20 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 export const enum SessionsBlockedReason {
 	AgentDisabled = 'agentDisabled',
 	/** Transient loading state — blocks UI but shows only a progress bar. */
 	Loading = 'loading',
+	/** Signed in but not in an approved org — must switch accounts. */
+	AccountPolicyGate = 'accountPolicyGate',
 }
 
 export interface ISessionsBlockedOverlayOptions {
 	readonly reason: SessionsBlockedReason;
+	readonly approvedOrganizations?: readonly string[];
+	readonly accountName?: string;
 }
 
 /**
@@ -34,6 +39,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 	constructor(
 		container: HTMLElement,
 		options: ISessionsBlockedOverlayOptions,
+		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 	) {
@@ -73,6 +79,9 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			case SessionsBlockedReason.Loading:
 				this._renderLoading(card);
 				break;
+			case SessionsBlockedReason.AccountPolicyGate:
+				this._renderAccountPolicyGate(card, options);
+				break;
 		}
 	}
 
@@ -102,6 +111,53 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		append(card, $('div.sessions-policy-blocked-progress-bar', undefined,
 			$('div.sessions-policy-blocked-progress-bar-fill')
 		));
+	}
+
+	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
+		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
+
+		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
+
+		const description = append(card, $('p'));
+		if (options.accountName) {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
+			));
+		} else {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionNoAccount', "Sign in with a GitHub account from an approved organization to use Agents.")
+			));
+		}
+
+		const approvedOrgs = options.approvedOrganizations ?? [];
+		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
+		if (hasConcreteOrgs) {
+			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
+			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
+				localize('accountGate.approvedOrgs', "Approved organizations:")
+			));
+			const orgList = append(orgSection, $('ul'));
+			for (const org of approvedOrgs) {
+				append(orgList, $('li', undefined, org));
+			}
+		}
+
+		const footer = append(card, $('p.sessions-policy-blocked-footer'));
+		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
+		append(footer, document.createTextNode(' '));
+		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
+		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
+		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';
+		this._register(addDisposableListener(learnMore, EventType.CLICK, (e) => {
+			e.preventDefault();
+			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview'));
+		}));
+
+		const signInButton = this._register(new Button(card, { ...defaultButtonStyles }));
+		signInButton.label = localize('accountGate.signIn', "Sign In");
+		this._register(signInButton.onDidClick(() => {
+			this.commandService.executeCommand('workbench.action.agenticSignIn');
+		}));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -12,10 +12,25 @@ import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultS
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+
+export const enum SessionsBlockedReason {
+	AgentDisabled = 'agentDisabled',
+	/** Transient loading state — blocks UI but shows only a progress bar. */
+	Loading = 'loading',
+	/** Stable restriction — user must sign in to an approved org. */
+	AccountPolicyGate = 'accountPolicyGate',
+}
+
+export interface ISessionsBlockedOverlayOptions {
+	readonly reason: SessionsBlockedReason;
+	readonly approvedOrganizations?: readonly string[];
+	readonly accountName?: string;
+}
 
 /**
- * Full-window impassable overlay shown when the Agents app has been
- * disabled via group policy. Blocks all user interaction.
+ * Full-window impassable overlay shown when the Agents app is blocked.
+ * Supports multiple blocking reasons with different messaging and actions.
  */
 export class SessionsPolicyBlockedOverlay extends Disposable {
 
@@ -23,6 +38,8 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 
 	constructor(
 		container: HTMLElement,
+		options: ISessionsBlockedOverlayOptions,
+		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
 	) {
@@ -31,15 +48,12 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		this.overlay = append(container, $('.sessions-policy-blocked-overlay'));
 		this.overlay.setAttribute('role', 'dialog');
 		this.overlay.setAttribute('aria-modal', 'true');
-		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
 		this.overlay.tabIndex = -1;
 		this.overlay.focus();
 		this._register(toDisposable(() => this.overlay.remove()));
 
 		const card = append(this.overlay, $('.sessions-policy-blocked-card'));
 
-		// Block keyboard shortcuts while the overlay is present, but allow
-		// interaction with focusable elements inside the card.
 		this._register(addDisposableListener(getWindow(this.overlay), EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			if (card.contains(e.target as Node)) {
 				return;
@@ -48,8 +62,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			e.stopPropagation();
 		}, true));
 
-		// Block mouse interaction on the overlay background, but allow
-		// clicks through to card children (e.g. the "Open VS Code" button).
 		this._register(addDisposableGenericMouseDownListener(this.overlay, e => {
 			if (e.target === this.overlay) {
 				e.preventDefault();
@@ -60,10 +72,24 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		// Sessions logo
 		append(card, $('div.sessions-policy-blocked-logo'));
 
-		// Title
+		switch (options.reason) {
+			case SessionsBlockedReason.AgentDisabled:
+				this._renderAgentDisabled(card);
+				break;
+			case SessionsBlockedReason.Loading:
+				this._renderLoading(card);
+				break;
+			case SessionsBlockedReason.AccountPolicyGate:
+				this._renderAccountPolicyGate(card, options);
+				break;
+		}
+	}
+
+	private _renderAgentDisabled(card: HTMLElement): void {
+		this.overlay.setAttribute('aria-label', localize('policyBlocked.aria', "Agents disabled by organization policy"));
+
 		append(card, $('h2', undefined, localize('policyBlocked.title', "Agents Disabled")));
 
-		// Description
 		const description = append(card, $('p'));
 		append(description, document.createTextNode(localize('policyBlocked.description', "Your organization has disabled Agents via policy.")));
 		append(description, document.createTextNode(' '));
@@ -75,10 +101,67 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 			this.openerService.open(URI.parse('https://aka.ms/VSCode/Agents/docs'));
 		}));
 
-		// Open VS Code button
 		const button = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
 		button.label = localize('policyBlocked.openVSCode', "Open VS Code");
 		this._register(button.onDidClick(() => this._openVSCode()));
+	}
+
+	private _renderLoading(card: HTMLElement): void {
+		this.overlay.setAttribute('aria-label', localize('loading.aria', "Loading"));
+		append(card, $('div.sessions-policy-blocked-progress-bar', undefined,
+			$('div.sessions-policy-blocked-progress-bar-fill')
+		));
+	}
+
+	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
+		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
+
+		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
+
+		const description = append(card, $('p'));
+		if (options.accountName) {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
+			));
+		} else {
+			append(description, document.createTextNode(
+				localize('accountGate.descriptionNoAccount', "Sign in with a GitHub account from an approved organization to use Agents.")
+			));
+		}
+
+		const approvedOrgs = options.approvedOrganizations ?? [];
+		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
+		if (hasConcreteOrgs) {
+			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
+			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
+				localize('accountGate.approvedOrgs', "Approved organizations:")
+			));
+			const orgList = append(orgSection, $('ul'));
+			for (const org of approvedOrgs) {
+				append(orgList, $('li', undefined, org));
+			}
+		}
+
+		const footer = append(card, $('p.sessions-policy-blocked-footer'));
+		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
+		append(footer, document.createTextNode(' '));
+		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
+		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
+		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';
+		this._register(addDisposableListener(learnMore, EventType.CLICK, (e) => {
+			e.preventDefault();
+			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview'));
+		}));
+
+		const signInButton = this._register(new Button(card, { ...defaultButtonStyles }));
+		signInButton.label = localize('accountGate.signIn', "Sign In");
+		this._register(signInButton.onDidClick(() => {
+			this.commandService.executeCommand('workbench.action.agenticSignIn');
+		}));
+
+		const openButton = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
+		openButton.label = localize('accountGate.openVSCode', "Open VS Code");
+		this._register(openButton.onDidClick(() => this._openVSCode()));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -158,10 +158,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		this._register(signInButton.onDidClick(() => {
 			this.commandService.executeCommand('workbench.action.agenticSignIn');
 		}));
-
-		const openButton = this._register(new Button(card, { ...defaultButtonStyles, secondary: true }));
-		openButton.label = localize('accountGate.openVSCode', "Open VS Code");
-		this._register(openButton.onDidClick(() => this._openVSCode()));
 	}
 
 	private _openVSCode(): void {

--- a/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
+++ b/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
@@ -6,15 +6,15 @@
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
-import { SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
+import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
 
-function renderPolicyBlocked({ container, disposableStore, theme }: ComponentFixtureContext): void {
-	container.style.width = '600px';
-	container.style.height = '400px';
-	container.style.position = 'relative';
+function createOverlay(ctx: ComponentFixtureContext, options: ISessionsBlockedOverlayOptions): void {
+	ctx.container.style.width = '600px';
+	ctx.container.style.height = '400px';
+	ctx.container.style.position = 'relative';
 
-	const instantiationService = createEditorServices(disposableStore, {
-		colorTheme: theme,
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
 			reg.defineInstance(IProductService, new class extends mock<IProductService>() {
 				override readonly quality = 'insider';
@@ -23,12 +23,26 @@ function renderPolicyBlocked({ container, disposableStore, theme }: ComponentFix
 		},
 	});
 
-	disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, container));
+	ctx.disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, ctx.container, options));
 }
 
 export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 	PolicyBlocked: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: renderPolicyBlocked,
+		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.AgentDisabled }),
+	}),
+	AccountPolicyGate: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+			accountName: 'octocat',
+			approvedOrganizations: ['github', 'microsoft'],
+		}),
+	}),
+	AccountPolicyGateNoAccount: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+		}),
 	}),
 });

--- a/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
+++ b/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
@@ -6,15 +6,15 @@
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
-import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
+import { SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
 
-function createOverlay(ctx: ComponentFixtureContext, options: ISessionsBlockedOverlayOptions): void {
-	ctx.container.style.width = '600px';
-	ctx.container.style.height = '400px';
-	ctx.container.style.position = 'relative';
+function renderPolicyBlocked({ container, disposableStore, theme }: ComponentFixtureContext): void {
+	container.style.width = '600px';
+	container.style.height = '400px';
+	container.style.position = 'relative';
 
-	const instantiationService = createEditorServices(ctx.disposableStore, {
-		colorTheme: ctx.theme,
+	const instantiationService = createEditorServices(disposableStore, {
+		colorTheme: theme,
 		additionalServices: (reg) => {
 			reg.defineInstance(IProductService, new class extends mock<IProductService>() {
 				override readonly quality = 'insider';
@@ -23,26 +23,12 @@ function createOverlay(ctx: ComponentFixtureContext, options: ISessionsBlockedOv
 		},
 	});
 
-	ctx.disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, ctx.container, options));
+	disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, container));
 }
 
 export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 	PolicyBlocked: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.AgentDisabled }),
-	}),
-	AccountPolicyGate: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => createOverlay(ctx, {
-			reason: SessionsBlockedReason.AccountPolicyGate,
-			accountName: 'octocat',
-			approvedOrganizations: ['github', 'microsoft'],
-		}),
-	}),
-	AccountPolicyGateNoAccount: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => createOverlay(ctx, {
-			reason: SessionsBlockedReason.AccountPolicyGate,
-		}),
+		render: renderPolicyBlocked,
 	}),
 });

--- a/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
+++ b/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
@@ -6,15 +6,15 @@
 import { mock } from '../../../../../base/test/common/mock.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup } from '../../../../../workbench/test/browser/componentFixtures/fixtureUtils.js';
-import { SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
+import { ISessionsBlockedOverlayOptions, SessionsBlockedReason, SessionsPolicyBlockedOverlay } from '../../browser/sessionsPolicyBlocked.js';
 
-function renderPolicyBlocked({ container, disposableStore, theme }: ComponentFixtureContext): void {
-	container.style.width = '600px';
-	container.style.height = '400px';
-	container.style.position = 'relative';
+function createOverlay(ctx: ComponentFixtureContext, options: ISessionsBlockedOverlayOptions): void {
+	ctx.container.style.width = '600px';
+	ctx.container.style.height = '400px';
+	ctx.container.style.position = 'relative';
 
-	const instantiationService = createEditorServices(disposableStore, {
-		colorTheme: theme,
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
 			reg.defineInstance(IProductService, new class extends mock<IProductService>() {
 				override readonly quality = 'insider';
@@ -23,12 +23,30 @@ function renderPolicyBlocked({ container, disposableStore, theme }: ComponentFix
 		},
 	});
 
-	disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, container));
+	ctx.disposableStore.add(instantiationService.createInstance(SessionsPolicyBlockedOverlay, ctx.container, options));
 }
 
 export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 	PolicyBlocked: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: renderPolicyBlocked,
+		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.AgentDisabled }),
+	}),
+	Loading: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.Loading }),
+	}),
+	AccountPolicyGate: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+			accountName: 'octocat',
+			approvedOrganizations: ['github', 'microsoft'],
+		}),
+	}),
+	AccountPolicyGateNoAccount: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+		}),
 	}),
 });

--- a/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
+++ b/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
@@ -35,4 +35,18 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		labels: { kind: 'screenshot' },
 		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.Loading }),
 	}),
+	AccountPolicyGate: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+			accountName: 'octocat',
+			approvedOrganizations: ['github', 'microsoft'],
+		}),
+	}),
+	AccountPolicyGateNoAccount: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => createOverlay(ctx, {
+			reason: SessionsBlockedReason.AccountPolicyGate,
+		}),
+	}),
 });

--- a/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
+++ b/src/vs/sessions/contrib/policyBlocked/test/browser/sessionsPolicyBlocked.fixture.ts
@@ -35,18 +35,4 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		labels: { kind: 'screenshot' },
 		render: (ctx) => createOverlay(ctx, { reason: SessionsBlockedReason.Loading }),
 	}),
-	AccountPolicyGate: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => createOverlay(ctx, {
-			reason: SessionsBlockedReason.AccountPolicyGate,
-			accountName: 'octocat',
-			approvedOrganizations: ['github', 'microsoft'],
-		}),
-	}),
-	AccountPolicyGateNoAccount: defineComponentFixture({
-		labels: { kind: 'screenshot' },
-		render: (ctx) => createOverlay(ctx, {
-			reason: SessionsBlockedReason.AccountPolicyGate,
-		}),
-	}),
 });

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -216,9 +216,9 @@ export class SessionsMain extends Disposable {
 
 		// Policies
 		let policyService: IPolicyService;
-		const accountPolicy = new AccountPolicyService(logService, defaultAccountService);
-		if (this.configuration.policiesData) {
-			const policyChannel = new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'));
+		const policyChannel = this.configuration.policiesData ? new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy')) : undefined;
+		const accountPolicy = new AccountPolicyService(logService, defaultAccountService, policyChannel);
+		if (policyChannel) {
 			policyService = new MultiplexPolicyService([policyChannel, accountPolicy], logService);
 		} else {
 			policyService = accountPolicy;

--- a/src/vs/sessions/electron-browser/sessions.main.ts
+++ b/src/vs/sessions/electron-browser/sessions.main.ts
@@ -60,7 +60,7 @@ import { applyZoom } from '../../platform/window/electron-browser/window.js';
 import { mainWindow } from '../../base/browser/window.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { DefaultAccountService } from '../../workbench/services/accounts/browser/defaultAccount.js';
-import { AccountPolicyService } from '../../workbench/services/policies/common/accountPolicyService.js';
+import { AccountPolicyService, IAccountPolicyGateService } from '../../workbench/services/policies/common/accountPolicyService.js';
 import { MultiplexPolicyService } from '../../workbench/services/policies/common/multiplexPolicyService.js';
 import { Workbench as AgenticWorkbench } from '../browser/workbench.js';
 import { NativeMenubarControl } from '../../workbench/electron-browser/parts/titlebar/menubarControl.js';
@@ -224,6 +224,7 @@ export class SessionsMain extends Disposable {
 			policyService = accountPolicy;
 		}
 		serviceCollection.set(IPolicyService, policyService);
+		serviceCollection.set(IAccountPolicyGateService, accountPolicy);
 
 		// Shared Process
 		const sharedProcessService = new SharedProcessService(this.configuration.windowId, logService);

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -196,10 +196,8 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import '../workbench/services/accounts/browser/defaultAccount.js';
 
-// Account Policy Gate — handled by sessions' own policyBlocked overlay
-// (see src/vs/sessions/contrib/policyBlocked/). The workbench-layer
-// accountPolicyGate.contribution is NOT imported here to avoid a
-// duplicate notification toast behind the full-screen overlay.
+// Account Policy Gate (notification + context key + telemetry)
+import '../workbench/services/policies/browser/accountPolicyGate.contribution.js';
 
 // Telemetry
 import '../workbench/contrib/telemetry/browser/telemetry.contribution.js';

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -196,8 +196,10 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import '../workbench/services/accounts/browser/defaultAccount.js';
 
-// Account Policy Gate (notification + context key + telemetry)
-import '../workbench/services/policies/browser/accountPolicyGate.contribution.js';
+// Account Policy Gate — handled by sessions' own policyBlocked overlay
+// (see src/vs/sessions/contrib/policyBlocked/). The workbench-layer
+// accountPolicyGate.contribution is NOT imported here to avoid a
+// duplicate notification toast behind the full-screen overlay.
 
 // Telemetry
 import '../workbench/contrib/telemetry/browser/telemetry.contribution.js';

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -196,6 +196,9 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import '../workbench/services/accounts/browser/defaultAccount.js';
 
+// Account Policy Gate (notification + context key + telemetry)
+import '../workbench/services/policies/browser/accountPolicyGate.contribution.js';
+
 // Telemetry
 import '../workbench/contrib/telemetry/browser/telemetry.contribution.js';
 

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -196,9 +196,6 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import '../workbench/services/accounts/browser/defaultAccount.js';
 
-// Account Policy Gate (notification + context key + telemetry)
-import '../workbench/services/policies/browser/accountPolicyGate.contribution.js';
-
 // Telemetry
 import '../workbench/contrib/telemetry/browser/telemetry.contribution.js';
 

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -108,6 +108,7 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs: IObservable<boolean> = observableValue('anonymous', false);
 
 	markAnonymousRateLimited(): void { }
+	setForceHidden(): void { }
 	async update(_token: CancellationToken): Promise<void> { }
 }
 

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -122,6 +122,7 @@ class MockDefaultAccountService implements IDefaultAccountService {
 	readonly onDidChangeDefaultAccount = Event.None;
 	readonly onDidChangePolicyData = Event.None;
 	readonly policyData: IPolicyData | null = null;
+	readonly currentDefaultAccount: IDefaultAccount | null = MOCK_ACCOUNT;
 	readonly copilotTokenInfo: ICopilotTokenInfo | null = null;
 	readonly onDidChangeCopilotTokenInfo = Event.None;
 

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -108,7 +108,7 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs: IObservable<boolean> = observableValue('anonymous', false);
 
 	markAnonymousRateLimited(): void { }
-	setForceHidden(): void { }
+	setForceHidden(_hidden: boolean): void { }
 	async update(_token: CancellationToken): Promise<void> { }
 }
 

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -46,6 +46,7 @@ import { IDefaultAccountService } from '../../../platform/defaultAccount/common/
 import { IAuthenticationService } from '../../services/authentication/common/authentication.js';
 import { IAuthenticationAccessService } from '../../services/authentication/browser/authenticationAccessService.js';
 import { IPolicyService } from '../../../platform/policy/common/policy.js';
+import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -683,6 +684,7 @@ class PolicyDiagnosticsAction extends Action2 {
 		const authenticationService = accessor.get(IAuthenticationService);
 		const authenticationAccessService = accessor.get(IAuthenticationAccessService);
 		const policyService = accessor.get(IPolicyService);
+		const accountPolicyGateService = accessor.get(IAccountPolicyGateService);
 
 		const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
@@ -752,6 +754,30 @@ class PolicyDiagnosticsAction extends Action2 {
 			}
 		} catch (error) {
 			content += `*Error retrieving account information: ${error}*\n\n`;
+		}
+
+		// Account Policy Gate (forces AI features off until an admin-approved
+		// GitHub account is signed in AND its account-side policy data has resolved).
+		content += '## Account Policy Gate\n\n';
+		try {
+			const gateInfo = accountPolicyGateService.gateInfo;
+			const approvedOrgsRaw = policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+			content += '| Property | Value |\n';
+			content += '|----------|-------|\n';
+			content += `| State | \`${gateInfo.state}\` |\n`;
+			content += `| Reason | ${gateInfo.reason ? `\`${gateInfo.reason}\`` : '*n/a*'} |\n`;
+			content += `| ${APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME} | ${approvedOrgsRaw !== undefined ? `\`${String(approvedOrgsRaw)}\`` : '*not set*'} |\n`;
+			content += '\n';
+			content += '**Legend**\n\n';
+			content += '- `inactive`: gate disabled (no approved orgs configured) — policies behave as account data dictates.\n';
+			content += '- `satisfied`: gate active and approved — account policy values flow normally.\n';
+			content += '- `restricted`: gate active and not satisfied — opted-in policies forced to their restricted value.\n';
+			content += '  - `noAccount`: no default account signed in.\n';
+			content += '  - `wrongProvider`: signed in with a non-GitHub provider.\n';
+			content += '  - `orgNotApproved`: signed in but account is not a member of any approved organization.\n';
+			content += '  - `policyNotResolved`: signed in to an approved org but account-side policy data has not yet been fetched.\n\n';
+		} catch (error) {
+			content += `*Error retrieving account policy gate info: ${error}*\n\n`;
 		}
 
 		content += '## Policy-Controlled Settings\n\n';

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -98,7 +98,7 @@ import { mainWindow } from '../../base/browser/window.js';
 import { INotificationService, Severity } from '../../platform/notification/common/notification.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { DefaultAccountService } from '../services/accounts/browser/defaultAccount.js';
-import { AccountPolicyService } from '../services/policies/common/accountPolicyService.js';
+import { AccountPolicyService, IAccountPolicyGateService } from '../services/policies/common/accountPolicyService.js';
 
 export interface IBrowserMainWorkbench {
 	startup(): IInstantiationService;
@@ -366,6 +366,7 @@ export class BrowserMain extends Disposable {
 		// Policies
 		const policyService = new AccountPolicyService(logService, defaultAccountService);
 		serviceCollection.set(IPolicyService, policyService);
+		serviceCollection.set(IAccountPolicyGateService, policyService);
 
 		// Long running services (workspace, config, storage)
 		const [configurationService, storageService] = await Promise.all([

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1465,21 +1465,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.disableAIFeatures', "Disable and hide built-in AI features provided by GitHub Copilot, including chat and inline suggestions."),
 			default: false,
 			scope: ConfigurationScope.WINDOW,
-			policy: {
-				name: 'ChatDisableAIFeatures',
-				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.118',
-				// `value` is intentionally omitted: this policy is not driven by IPolicyData. It is
-				// driven exclusively by the AccountPolicyService gate, which forces `restrictedValue`
-				// when an admin has set `ChatApprovedAccountOrganizations` and the gate is unsatisfied.
-				restrictedValue: true,
-				localization: {
-					description: {
-						key: 'chat.disableAIFeatures.policy.description',
-						value: nls.localize('chat.disableAIFeatures.policy.description', "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization.")
-					}
-				}
-			}
 		},
 		'chat.approvedAccountOrganizations': {
 			type: 'array',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1482,9 +1482,10 @@ configurationRegistry.registerConfiguration({
 			}
 		},
 		'chat.approvedAccountOrganizations': {
-			type: 'string',
-			description: nls.localize('chat.approvedAccountOrganizations', "Comma-separated list of GitHub organization logins whose members may use built-in AI features. When set to a non-empty value, all AI features are disabled until the user signs into a GitHub account in one of these organizations AND the account-side policy data has resolved. Use '*' to accept any signed-in GitHub or GHE account."),
-			default: '',
+			type: 'array',
+			items: { type: 'string' },
+			description: nls.localize('chat.approvedAccountOrganizations', "List of GitHub organization logins whose members may use built-in AI features. When set to a non-empty list, all AI features are disabled until the user signs into a GitHub account in one of these organizations AND the account-side policy data has resolved. Use '*' to accept any signed-in GitHub or GHE account."),
+			default: [],
 			included: false,
 			policy: {
 				name: 'ChatApprovedAccountOrganizations',
@@ -1493,7 +1494,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.approvedAccountOrganizations.policy.description',
-						value: nls.localize('chat.approvedAccountOrganizations.policy.description', "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).")
+						value: nls.localize('chat.approvedAccountOrganizations.policy.description', "Setting this policy to a non-empty list activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).")
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1471,36 +1471,19 @@ configurationRegistry.registerConfiguration({
 				minimumVersion: '1.118',
 				// `value` is intentionally omitted: this policy is not driven by IPolicyData. It is
 				// driven exclusively by the AccountPolicyService gate, which forces `restrictedValue`
-				// when an admin has enabled `ChatRequireApprovedAccount` and the gate is unsatisfied.
+				// when an admin has set `ChatApprovedAccountOrganizations` and the gate is unsatisfied.
 				restrictedValue: true,
 				localization: {
 					description: {
 						key: 'chat.disableAIFeatures.policy.description',
-						value: nls.localize('chat.disableAIFeatures.policy.description', "Force-disable built-in AI features. Set automatically when the 'Require Approved Account' policy is in effect and the user is not signed into an approved GitHub organization.")
-					}
-				}
-			}
-		},
-		'chat.requireApprovedAccount': {
-			type: 'boolean',
-			description: nls.localize('chat.requireApprovedAccount', "Require sign-in with a GitHub account from an approved organization (and a resolved account-side policy) before any AI features become available."),
-			default: false,
-			included: false,
-			policy: {
-				name: 'ChatRequireApprovedAccount',
-				category: PolicyCategory.InteractiveSession,
-				minimumVersion: '1.118',
-				localization: {
-					description: {
-						key: 'chat.requireApprovedAccount.policy.description',
-						value: nls.localize('chat.requireApprovedAccount.policy.description', "When enabled, all AI features are disabled until the user signs in with a GitHub account whose organizations intersect 'Approved Account Organizations' AND the account-side policy data has resolved.")
+						value: nls.localize('chat.disableAIFeatures.policy.description', "Force-disable built-in AI features. Set automatically when 'Approved Account Organizations' is configured and the user is not signed into an approved GitHub organization.")
 					}
 				}
 			}
 		},
 		'chat.approvedAccountOrganizations': {
 			type: 'string',
-			description: nls.localize('chat.approvedAccountOrganizations', "Comma-separated list of GitHub organization logins whose members satisfy the 'Require Approved Account' gate. Use '*' to accept any signed-in GitHub or GHE account."),
+			description: nls.localize('chat.approvedAccountOrganizations', "Comma-separated list of GitHub organization logins whose members may use built-in AI features. When set to a non-empty value, all AI features are disabled until the user signs into a GitHub account in one of these organizations AND the account-side policy data has resolved. Use '*' to accept any signed-in GitHub or GHE account."),
 			default: '',
 			included: false,
 			policy: {
@@ -1510,7 +1493,7 @@ configurationRegistry.registerConfiguration({
 				localization: {
 					description: {
 						key: 'chat.approvedAccountOrganizations.policy.description',
-						value: nls.localize('chat.approvedAccountOrganizations.policy.description', "Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).")
+						value: nls.localize('chat.approvedAccountOrganizations.policy.description', "Setting this policy to a non-empty value activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).")
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1464,7 +1464,56 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.disableAIFeatures', "Disable and hide built-in AI features provided by GitHub Copilot, including chat and inline suggestions."),
 			default: false,
-			scope: ConfigurationScope.WINDOW
+			scope: ConfigurationScope.WINDOW,
+			policy: {
+				name: 'ChatDisableAIFeatures',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.118',
+				// `value` is intentionally omitted: this policy is not driven by IPolicyData. It is
+				// driven exclusively by the AccountPolicyService gate, which forces `restrictedValue`
+				// when an admin has enabled `ChatRequireApprovedAccount` and the gate is unsatisfied.
+				restrictedValue: true,
+				localization: {
+					description: {
+						key: 'chat.disableAIFeatures.policy.description',
+						value: nls.localize('chat.disableAIFeatures.policy.description', "Force-disable built-in AI features. Set automatically when the 'Require Approved Account' policy is in effect and the user is not signed into an approved GitHub organization.")
+					}
+				}
+			}
+		},
+		'chat.requireApprovedAccount': {
+			type: 'boolean',
+			description: nls.localize('chat.requireApprovedAccount', "Require sign-in with a GitHub account from an approved organization (and a resolved account-side policy) before any AI features become available."),
+			default: false,
+			included: false,
+			policy: {
+				name: 'ChatRequireApprovedAccount',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.118',
+				localization: {
+					description: {
+						key: 'chat.requireApprovedAccount.policy.description',
+						value: nls.localize('chat.requireApprovedAccount.policy.description', "When enabled, all AI features are disabled until the user signs in with a GitHub account whose organizations intersect 'Approved Account Organizations' AND the account-side policy data has resolved.")
+					}
+				}
+			}
+		},
+		'chat.approvedAccountOrganizations': {
+			type: 'string',
+			description: nls.localize('chat.approvedAccountOrganizations', "Comma-separated list of GitHub organization logins whose members satisfy the 'Require Approved Account' gate. Use '*' to accept any signed-in GitHub or GHE account."),
+			default: '',
+			included: false,
+			policy: {
+				name: 'ChatApprovedAccountOrganizations',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.118',
+				localization: {
+					description: {
+						key: 'chat.approvedAccountOrganizations.policy.description',
+						value: nls.localize('chat.approvedAccountOrganizations.policy.description', "Comma-separated list of GitHub organization logins. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).")
+					}
+				}
+			}
 		},
 		'chat.allowAnonymousAccess': { // TODO@bpasero remove me eventually
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1469,7 +1469,7 @@ configurationRegistry.registerConfiguration({
 		'chat.approvedAccountOrganizations': {
 			type: 'array',
 			items: { type: 'string' },
-			description: nls.localize('chat.approvedAccountOrganizations', "List of GitHub organization logins whose members may use built-in AI features. When set to a non-empty list, all AI features are disabled until the user signs into a GitHub account in one of these organizations AND the account-side policy data has resolved. Use '*' to accept any signed-in GitHub or GHE account."),
+			description: nls.localize('chat.approvedAccountOrganizations', "List of GitHub organization logins whose members are permitted to use AI features. When set to a non-empty list, AI features are disabled until the user signs into a GitHub account that belongs to one of the specified organizations and account-level policy data has been resolved. Set to '*' to allow any authenticated GitHub or GitHub Enterprise account."),
 			default: [],
 			included: false,
 			policy: {

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -68,13 +68,16 @@ const chatViewDescriptor: IViewDescriptor = {
 		order: 1
 	},
 	ctorDescriptor: new SyncDescriptor(ChatViewPane),
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.and(
-			ChatContextKeys.Setup.hidden.negate(),
-			ChatContextKeys.Setup.disabledInWorkspace.negate(),
-		),
-		ChatContextKeys.panelParticipantRegistered,
-		ChatContextKeys.extensionInvalid
+	when: ContextKeyExpr.and(
+		ChatContextKeys.accountPolicyGateActive.negate(),
+		ContextKeyExpr.or(
+			ContextKeyExpr.and(
+				ChatContextKeys.Setup.hidden.negate(),
+				ChatContextKeys.Setup.disabledInWorkspace.negate(),
+			),
+			ChatContextKeys.panelParticipantRegistered,
+			ChatContextKeys.extensionInvalid
+		)
 	)
 };
 Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([chatViewDescriptor], chatViewContainer);

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -55,6 +55,7 @@ export namespace ChatContextKeys {
 
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });
+	export const accountPolicyGateActive = new RawContextKey<boolean>('chatAccountPolicyGateActive', false, { type: 'boolean', description: localize('chatAccountPolicyGateActive', "True when the 'Require Approved Account' policy is in effect and the user is not yet signed into an approved GitHub organization, so all AI features are disabled until they sign in.") });
 
 	/**
 	 * True when the chat widget is locked to the coding agent session.

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -9,6 +9,7 @@ import { IsWebContext } from '../../../../../platform/contextkey/common/contextk
 import { RemoteNameContext } from '../../../../common/contextkeys.js';
 import { ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlementContextKeys } from '../../../../services/chat/common/chatEntitlementService.js';
+import { ChatAccountPolicyGateActiveContext } from '../../../../services/policies/common/accountPolicyService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 
 export namespace ChatContextKeys {
@@ -55,7 +56,7 @@ export namespace ChatContextKeys {
 
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });
-	export const accountPolicyGateActive = new RawContextKey<boolean>('chatAccountPolicyGateActive', false, { type: 'boolean', description: localize('chatAccountPolicyGateActive', "True when the 'Require Approved Account' policy is in effect and the user is not yet signed into an approved GitHub organization, so all AI features are disabled until they sign in.") });
+	export const accountPolicyGateActive = ChatAccountPolicyGateActiveContext;
 
 	/**
 	 * True when the chat widget is locked to the coding agent session.

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -63,7 +63,7 @@ import { applyZoom } from '../../platform/window/electron-browser/window.js';
 import { mainWindow } from '../../base/browser/window.js';
 import { IDefaultAccountService } from '../../platform/defaultAccount/common/defaultAccount.js';
 import { DefaultAccountService } from '../services/accounts/browser/defaultAccount.js';
-import { AccountPolicyService } from '../services/policies/common/accountPolicyService.js';
+import { AccountPolicyService, IAccountPolicyGateService } from '../services/policies/common/accountPolicyService.js';
 import { MultiplexPolicyService } from '../services/policies/common/multiplexPolicyService.js';
 
 export class DesktopMain extends Disposable {
@@ -223,6 +223,7 @@ export class DesktopMain extends Disposable {
 			policyService = accountPolicy;
 		}
 		serviceCollection.set(IPolicyService, policyService);
+		serviceCollection.set(IAccountPolicyGateService, accountPolicy);
 
 		// Shared Process
 		const sharedProcessService = new SharedProcessService(this.configuration.windowId, logService);

--- a/src/vs/workbench/electron-browser/desktop.main.ts
+++ b/src/vs/workbench/electron-browser/desktop.main.ts
@@ -215,9 +215,9 @@ export class DesktopMain extends Disposable {
 
 		// Policies
 		let policyService: IPolicyService;
-		const accountPolicy = new AccountPolicyService(logService, defaultAccountService);
-		if (this.configuration.policiesData) {
-			const policyChannel = new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy'));
+		const policyChannel = this.configuration.policiesData ? new PolicyChannelClient(this.configuration.policiesData, mainProcessService.getChannel('policy')) : undefined;
+		const accountPolicy = new AccountPolicyService(logService, defaultAccountService, policyChannel);
+		if (policyChannel) {
 			policyService = new MultiplexPolicyService([policyChannel, accountPolicy], logService);
 		} else {
 			policyService = accountPolicy;

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -114,6 +114,7 @@ export class DefaultAccountService extends Disposable implements IDefaultAccount
 	declare _serviceBrand: undefined;
 
 	private defaultAccount: IDefaultAccount | null = null;
+	get currentDefaultAccount(): IDefaultAccount | null { return this.defaultAccount; }
 	get policyData(): IPolicyData | null { return this.defaultAccountProvider?.policyData ?? null; }
 	get copilotTokenInfo(): ICopilotTokenInfo | null { return this.defaultAccountProvider?.copilotTokenInfo ?? null; }
 

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -186,6 +186,13 @@ export interface IChatEntitlementService {
 
 	markAnonymousRateLimited(): void;
 
+	/**
+	 * Force the hidden state on or off, overriding the normal entitlement logic.
+	 * Used by the account policy gate to hide all AI features when the gate is
+	 * active and unsatisfied.
+	 */
+	setForceHidden(hidden: boolean): void;
+
 	update(token: CancellationToken): Promise<void>;
 }
 
@@ -553,6 +560,10 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 
 		this.chatQuotaExceededContextKey.set(true);
 		this._onDidChangeQuotaExceeded.fire();
+	}
+
+	setForceHidden(hidden: boolean): void {
+		this.context?.value.setForceHidden(hidden);
 	}
 
 	async update(token: CancellationToken): Promise<void> {
@@ -1131,15 +1142,24 @@ export class ChatEntitlementContext extends Disposable {
 		}));
 	}
 
+	private _forceHidden = false;
+
 	private withConfiguration(state: IChatEntitlementContextState): IChatEntitlementContextState {
-		if (this.configurationService.getValue(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY) === true) {
+		if (this._forceHidden || this.configurationService.getValue(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY) === true) {
 			return {
 				...state,
-				hidden: true // Setting always wins: if AI is disabled, set `hidden: true`
+				hidden: true
 			};
 		}
 
 		return state;
+	}
+
+	setForceHidden(hidden: boolean): void {
+		if (this._forceHidden !== hidden) {
+			this._forceHidden = hidden;
+			this.updateContext();
+		}
 	}
 
 	update(context: { installed: boolean; disabled: boolean; untrusted: boolean; disabledInWorkspace: boolean }): Promise<void>;

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -563,7 +563,13 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 	}
 
 	setForceHidden(hidden: boolean): void {
-		this.context?.value.setForceHidden(hidden);
+		if (this.context) {
+			this.context.value.setForceHidden(hidden);
+		} else {
+			// No ChatEntitlementContext (e.g. no defaultChatAgent in product.json).
+			// Set the context key directly as a fallback.
+			ChatEntitlementContextKeys.Setup.hidden.bindTo(this.contextKeyService).set(hidden);
+		}
 	}
 
 	async update(token: CancellationToken): Promise<void> {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGate.contribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGate.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { AccountPolicyGateContribution } from './accountPolicyGateContribution.js';
+
+registerWorkbenchContribution2(AccountPolicyGateContribution.ID, AccountPolicyGateContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -54,6 +54,8 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	private readonly notificationHandle = this._register(new MutableDisposable());
 	private dismissedKey: string | undefined; // tracks reason+account combo for session-scoped dismissal
 
+	private initialised = false;
+
 	constructor(
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -70,13 +72,29 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
 		this.lastInfo = this.gateService.gateInfo;
 
-		// Seed any consumer that initialised before us (e.g. context-key when-clauses).
-		this.apply(this.lastInfo, /*forceTelemetry*/ true);
+		// Seed context key + setForceHidden immediately (fail-closed) but
+		// defer the notification until the first onDidChangeGateInfo event
+		// so the default account has had time to resolve. Without this, a
+		// race on startup shows "sign in" even when the user is already
+		// signed in (just not yet loaded).
+		this.apply(this.lastInfo, /*forceTelemetry*/ true, /*showNotification*/ false);
 
-		this._register(this.gateService.onDidChangeGateInfo(info => this.apply(info, /*forceTelemetry*/ false)));
+		this._register(this.gateService.onDidChangeGateInfo(info => {
+			this.initialised = true;
+			this.apply(info, /*forceTelemetry*/ false, /*showNotification*/ true);
+		}));
+
+		// If the gate never fires a change (already stable), show the
+		// notification after a short delay to let the account service load.
+		setTimeout(() => {
+			if (!this.initialised) {
+				this.initialised = true;
+				this.apply(this.lastInfo, /*forceTelemetry*/ false, /*showNotification*/ true);
+			}
+		}, 5000);
 	}
 
-	private apply(info: IAccountPolicyGateInfo, forceTelemetry: boolean): void {
+	private apply(info: IAccountPolicyGateInfo, forceTelemetry: boolean, showNotification: boolean): void {
 		const stateChanged = forceTelemetry || info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
 		this.lastInfo = info;
 
@@ -101,6 +119,10 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			this.notificationHandle.clear();
 			this.dismissedKey = undefined;
 			this.storageService.remove(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
+			return;
+		}
+
+		if (!showNotification) {
 			return;
 		}
 

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -25,8 +25,8 @@ type AccountPolicyGateStateEvent = {
 };
 
 type AccountPolicyGateStateClassification = {
-	owner: 'copilot';
-	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues. No PII (organization names are NOT logged).';
+	owner: 'joshspicer';
+	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues.';
 	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if an admin has activated the Approved Account gate (non-empty approved-organization list).' };
 	gateSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the gate is satisfied (signed-in approved account with resolved policy).' };
 	reasonNotSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bucketed reason the gate is unsatisfied: noAccount, wrongProvider, orgNotApproved, policyNotResolved.' };
@@ -46,6 +46,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	static readonly ID = 'workbench.contrib.accountPolicyGate';
 
 	private readonly contextKey: IContextKey<boolean>;
+	private readonly chatHiddenKey: IContextKey<boolean>;
 	private lastInfo: IAccountPolicyGateInfo;
 
 	private readonly notificationHandle = this._register(new MutableDisposable());
@@ -62,6 +63,11 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	) {
 		super();
 		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
+		// Directly toggle the chat-hidden context key so the entire chat UI disappears
+		// when the gate is restricted. This is the same key that `chat.disableAIFeatures`
+		// drives via `ChatEntitlementContextKeys.Setup.hidden` — using it directly avoids
+		// a round-trip through the policy→configuration→entitlement pipeline.
+		this.chatHiddenKey = contextKeyService.createKey('chatSetupHidden', false);
 		this.lastInfo = this.gateService.gateInfo;
 
 		// Seed any consumer that initialised before us (e.g. context-key when-clauses).
@@ -81,6 +87,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const isRestricted = info.state === AccountPolicyGateState.Restricted
 			&& info.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 		this.contextKey.set(isRestricted);
+		this.chatHiddenKey.set(isRestricted);
 
 		if (stateChanged) {
 			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -8,6 +8,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -51,12 +52,13 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	private lastInfo: IAccountPolicyGateInfo;
 
 	private readonly notificationHandle = this._register(new MutableDisposable());
-	private dismissedReason: AccountPolicyGateUnsatisfiedReason | undefined;
+	private dismissedKey: string | undefined; // tracks reason+account combo for session-scoped dismissal
 
 	constructor(
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
 		@ILogService private readonly logService: ILogService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -76,7 +78,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 
 	private apply(info: IAccountPolicyGateInfo, forceTelemetry: boolean): void {
 		const stateChanged = forceTelemetry || info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
-		const reasonChanged = info.reason !== this.lastInfo.reason;
 		this.lastInfo = info;
 
 		// `policyNotResolved` is transient — the user IS in an approved org but account
@@ -97,57 +98,79 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		}
 
 		if (info.state !== AccountPolicyGateState.Restricted) {
-			// Gate is no longer restricting anything → close any open notification AND reset
-			// the "Don't Show Again" preference so a later flip back to Restricted is visible
-			// again. Also reset the in-memory dismissed-reason so reason transitions get a
-			// fresh notification.
 			this.notificationHandle.clear();
-			this.dismissedReason = undefined;
+			this.dismissedKey = undefined;
 			this.storageService.remove(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
 			return;
 		}
 
-		// `policyNotResolved` is a transient boot-time state: the user IS signed into
-		// an approved org but account-side data hasn't loaded yet. Don't show a
-		// notification for this — it will resolve on its own within seconds.
+		// `policyNotResolved` is transient — don't show a notification for it.
 		if (info.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 			return;
 		}
 
-		// Restricted. Show or refresh the notification if the reason has changed since the
-		// last shown/dismissed message. This covers cases like NoAccount → OrgNotApproved
-		// where the user needs to see updated guidance.
-		if (reasonChanged) {
+		// Build a composite key from the reason + current account name so that
+		// swapping to a different account (while still blocked) re-shows the notification.
+		const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
+		const notificationKey = `${info.reason ?? ''}:${accountName ?? ''}`;
+
+		// If the key changed (different reason or different account), close the old
+		// notification and reset the session-scoped dismissal.
+		if (this.dismissedKey !== undefined && this.dismissedKey !== notificationKey) {
 			this.notificationHandle.clear();
-			this.dismissedReason = undefined;
+			this.dismissedKey = undefined;
 		}
-		this.maybeShowNotification(info);
+		this.maybeShowNotification(info, notificationKey);
 	}
 
-	private maybeShowNotification(info: IAccountPolicyGateInfo): void {
-		const reason = info.reason;
+	private maybeShowNotification(info: IAccountPolicyGateInfo, notificationKey: string): void {
 		if (this.notificationHandle.value) {
-			return; // already showing for this reason
+			return; // already showing for this reason+account
 		}
-		if (this.dismissedReason === reason) {
-			return; // user dismissed for this reason this session
+		if (this.dismissedKey === notificationKey) {
+			return; // user dismissed for this reason+account this session
 		}
 		const persistedDismissed = this.storageService.get(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
-		if (persistedDismissed === (reason ?? '')) {
-			return; // user clicked "Don't Show Again" for this same reason on this machine
+		if (persistedDismissed === notificationKey) {
+			return; // user clicked "Don't Show Again" for this same combo on this machine
 		}
 
+		const reason = info.reason;
+		const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 		const approvedOrgs = info.approvedOrganizations ?? [];
-		const orgList = approvedOrgs.length > 0 && !approvedOrgs.includes('*')
-			? ' ' + localize('accountPolicy.notification.approvedOrgs', "Approved organizations: {0}.", approvedOrgs.join(', '))
-			: '';
-		const contactAdmin = ' ' + localize('accountPolicy.notification.contactAdmin', "Contact your administrator for more information.");
+		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
 
-		const message = reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved
-			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.") + orgList + contactAdmin
-			: reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved
-				? localize('accountPolicy.notification.unresolved', "Waiting for your GitHub account policy to load before AI features can be enabled\u2026")
-				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.") + orgList + contactAdmin;
+		// Build the message parts
+		let message: string;
+		if (reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved) {
+			if (accountName && hasConcreteOrgs) {
+				message = localize(
+					'accountPolicy.notification.orgWithAccount',
+					"The account \"{0}\" is not a member of an approved organization. Your administrator requires sign-in with a GitHub account from one of these organizations to use AI features:\n\n{1}\n\nContact your administrator for more information.",
+					accountName,
+					approvedOrgs.map(org => `\u2022 ${org}`).join('\n')
+				);
+			} else if (accountName) {
+				message = localize(
+					'accountPolicy.notification.orgWithAccountNoList',
+					"The account \"{0}\" is not a member of an approved organization. Your administrator requires sign-in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.",
+					accountName
+				);
+			} else {
+				message = localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.");
+			}
+		} else {
+			// noAccount / wrongProvider
+			if (hasConcreteOrgs) {
+				message = localize(
+					'accountPolicy.notification.signinWithOrgs',
+					"Your administrator requires sign-in with a GitHub account to use AI features. Approved organizations:\n\n{0}\n\nContact your administrator for more information.",
+					approvedOrgs.map(org => `\u2022 ${org}`).join('\n')
+				);
+			} else {
+				message = localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features. Contact your administrator for more information.");
+			}
+		}
 
 		const handleDisposables = new DisposableStore();
 		const handle = this.notificationService.prompt(
@@ -166,12 +189,8 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			{ sticky: true }
 		);
 
-		// Capture which reason the toast is showing for so a manual close treats it as a
-		// session-scoped dismissal — but only for THIS reason. A subsequent reason change
-		// will reset `dismissedReason` and re-show.
-		const reasonAtShow = reason;
 		handleDisposables.add(handle.onDidClose(() => {
-			this.dismissedReason = reasonAtShow;
+			this.dismissedKey = notificationKey;
 			this.notificationHandle.clear();
 		}));
 		handleDisposables.add({ dispose: () => handle.close() });

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -14,6 +14,7 @@ import { IStorageService, StorageScope } from '../../../../platform/storage/comm
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
+import { IChatEntitlementService } from '../../chat/common/chatEntitlementService.js';
 import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, ChatAccountPolicyGateActiveContext, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../common/accountPolicyService.js';
 
 const NOTIFICATION_DISMISSED_KEY = 'accountPolicy.gateNotificationDismissed';
@@ -46,7 +47,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	static readonly ID = 'workbench.contrib.accountPolicyGate';
 
 	private readonly contextKey: IContextKey<boolean>;
-	private readonly chatHiddenKey: IContextKey<boolean>;
 	private lastInfo: IAccountPolicyGateInfo;
 
 	private readonly notificationHandle = this._register(new MutableDisposable());
@@ -55,6 +55,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	constructor(
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
@@ -63,11 +64,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	) {
 		super();
 		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
-		// Directly toggle the chat-hidden context key so the entire chat UI disappears
-		// when the gate is restricted. This is the same key that `chat.disableAIFeatures`
-		// drives via `ChatEntitlementContextKeys.Setup.hidden` — using it directly avoids
-		// a round-trip through the policy→configuration→entitlement pipeline.
-		this.chatHiddenKey = contextKeyService.createKey('chatSetupHidden', false);
 		this.lastInfo = this.gateService.gateInfo;
 
 		// Seed any consumer that initialised before us (e.g. context-key when-clauses).
@@ -87,7 +83,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const isRestricted = info.state === AccountPolicyGateState.Restricted
 			&& info.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 		this.contextKey.set(isRestricted);
-		this.chatHiddenKey.set(isRestricted);
+		this.chatEntitlementService.setForceHidden(isRestricted);
 
 		if (stateChanged) {
 			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -72,7 +72,11 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const reasonChanged = info.reason !== this.lastInfo.reason;
 		this.lastInfo = info;
 
-		const isRestricted = info.state === AccountPolicyGateState.Restricted;
+		// `policyNotResolved` is transient — the user IS in an approved org but account
+		// data hasn't loaded yet. Don't set the context key for this state so the UI
+		// stays visible (policies aren't being restricted either — see AccountPolicyService).
+		const isRestricted = info.state === AccountPolicyGateState.Restricted
+			&& info.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 		this.contextKey.set(isRestricted);
 
 		if (stateChanged) {
@@ -91,6 +95,13 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			this.notificationHandle.clear();
 			this.dismissedReason = undefined;
 			this.storageService.remove(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
+			return;
+		}
+
+		// `policyNotResolved` is a transient boot-time state: the user IS signed into
+		// an approved org but account-side data hasn't loaded yet. Don't show a
+		// notification for this — it will resolve on its own within seconds.
+		if (info.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 			return;
 		}
 

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -135,12 +135,13 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const orgList = approvedOrgs.length > 0 && !approvedOrgs.includes('*')
 			? ' ' + localize('accountPolicy.notification.approvedOrgs', "Approved organizations: {0}.", approvedOrgs.join(', '))
 			: '';
+		const contactAdmin = ' ' + localize('accountPolicy.notification.contactAdmin', "Contact your administrator for more information.");
 
 		const message = reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved
-			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.") + orgList
+			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.") + orgList + contactAdmin
 			: reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved
 				? localize('accountPolicy.notification.unresolved', "Waiting for your GitHub account policy to load before AI features can be enabled\u2026")
-				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.") + orgList;
+				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.") + orgList + contactAdmin;
 
 		const handleDisposables = new DisposableStore();
 		const handle = this.notificationService.prompt(
@@ -150,10 +151,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 				{
 					label: localize('accountPolicy.notification.signin.action', "Sign In"),
 					run: () => this.commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND),
-				},
-				{
-					label: localize('accountPolicy.notification.contactAdmin', "Contact Your Administrator"),
-					run: () => { /* informational — no-op; the label itself is the guidance */ },
 				},
 				{
 					label: localize('accountPolicy.notification.learnMore', "Learn More"),

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -115,10 +115,11 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			this.notificationHandle.clear();
 			this.dismissedReason = undefined;
 		}
-		this.maybeShowNotification(info.reason);
+		this.maybeShowNotification(info);
 	}
 
-	private maybeShowNotification(reason: AccountPolicyGateUnsatisfiedReason | undefined): void {
+	private maybeShowNotification(info: IAccountPolicyGateInfo): void {
+		const reason = info.reason;
 		if (this.notificationHandle.value) {
 			return; // already showing for this reason
 		}
@@ -130,11 +131,16 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			return; // user clicked "Don't Show Again" for this same reason on this machine
 		}
 
+		const approvedOrgs = info.approvedOrganizations ?? [];
+		const orgList = approvedOrgs.length > 0 && !approvedOrgs.includes('*')
+			? ' ' + localize('accountPolicy.notification.approvedOrgs', "Approved organizations: {0}.", approvedOrgs.join(', '))
+			: '';
+
 		const message = reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved
-			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.")
+			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.") + orgList
 			: reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved
 				? localize('accountPolicy.notification.unresolved', "Waiting for your GitHub account policy to load before AI features can be enabled\u2026")
-				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.");
+				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.") + orgList;
 
 		const handleDisposables = new DisposableStore();
 		const handle = this.notificationService.prompt(

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -8,6 +8,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
@@ -56,6 +57,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
+		@ILogService private readonly logService: ILogService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
@@ -84,6 +86,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			&& info.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 		this.contextKey.set(isRestricted);
 		this.chatEntitlementService.setForceHidden(isRestricted);
+		this.logService.info(`[AccountPolicyGate] apply: state=${info.state}, reason=${info.reason}, isRestricted=${isRestricted}`);
 
 		if (stateChanged) {
 			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -140,35 +140,37 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const approvedOrgs = info.approvedOrganizations ?? [];
 		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
 
-		// Build the message parts
+		// Build the message — notifications render as plain inline text, so use
+		// a comma-separated org list rather than bullet points / newlines.
+		const orgList = approvedOrgs.join(', ');
 		let message: string;
 		if (reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved) {
 			if (accountName && hasConcreteOrgs) {
 				message = localize(
 					'accountPolicy.notification.orgWithAccount',
-					"The account \"{0}\" is not a member of an approved organization. Your administrator requires sign-in with a GitHub account from one of these organizations to use AI features:\n\n{1}\n\nContact your administrator for more information.",
+					"The account \"{0}\" is not a member of an approved organization ({1}). Contact your administrator for more information.",
 					accountName,
-					approvedOrgs.map(org => `\u2022 ${org}`).join('\n')
+					orgList
 				);
 			} else if (accountName) {
 				message = localize(
 					'accountPolicy.notification.orgWithAccountNoList',
-					"The account \"{0}\" is not a member of an approved organization. Your administrator requires sign-in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.",
+					"The account \"{0}\" is not a member of an approved organization. Contact your administrator for more information.",
 					accountName
 				);
 			} else {
-				message = localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.");
+				message = localize('accountPolicy.notification.org', "Sign in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.");
 			}
 		} else {
 			// noAccount / wrongProvider
 			if (hasConcreteOrgs) {
 				message = localize(
 					'accountPolicy.notification.signinWithOrgs',
-					"Your administrator requires sign-in with a GitHub account to use AI features. Approved organizations:\n\n{0}\n\nContact your administrator for more information.",
-					approvedOrgs.map(org => `\u2022 ${org}`).join('\n')
+					"Sign in with a GitHub account from an approved organization ({0}) to use AI features.",
+					orgList
 				);
 			} else {
-				message = localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features. Contact your administrator for more information.");
+				message = localize('accountPolicy.notification.signin', "Sign in with an approved GitHub account to use AI features. Contact your administrator for more information.");
 			}
 		}
 

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -170,14 +170,14 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			if (accountName && hasConcreteOrgs) {
 				message = localize(
 					'accountPolicy.notification.orgWithAccount',
-					"The account \"{0}\" is not a member of an approved organization ({1}). Contact your administrator for more information.",
+					"The account \"{0}\" is not a member of an approved organization ({1}). Sign into an approved GitHub account to use AI features. Contact your administrator for more information.",
 					accountName,
 					orgList
 				);
 			} else if (accountName) {
 				message = localize(
 					'accountPolicy.notification.orgWithAccountNoList',
-					"The account \"{0}\" is not a member of an approved organization. Contact your administrator for more information.",
+					"The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use AI features. Contact your administrator for more information.",
 					accountName
 				);
 			} else {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
@@ -54,6 +56,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IOpenerService private readonly openerService: IOpenerService,
 		@IStorageService private readonly storageService: IStorageService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
@@ -143,9 +146,13 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 					run: () => this.commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND),
 				},
 				{
-					label: localize('accountPolicy.notification.dontShowAgain', "Don't Show Again"),
-					run: () => this.storageService.store(NOTIFICATION_DISMISSED_KEY, reason ?? '', StorageScope.APPLICATION, StorageTarget.MACHINE),
-				}
+					label: localize('accountPolicy.notification.contactAdmin', "Contact Your Administrator"),
+					run: () => { /* informational — no-op; the label itself is the guidance */ },
+				},
+				{
+					label: localize('accountPolicy.notification.learnMore', "Learn More"),
+					run: () => this.openerService.open(URI.parse('https://code.visualstudio.com/docs/enterprise/overview')),
+				},
 			],
 			{ sticky: true }
 		);

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -3,19 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { IPolicyService } from '../../../../platform/policy/common/policy.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { ChatContextKeys } from '../../../contrib/chat/common/actions/chatContextKeys.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateInfo } from '../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../common/accountPolicyService.js';
 
 const NOTIFICATION_DISMISSED_KEY = 'accountPolicy.gateNotificationDismissed';
 
@@ -28,32 +26,32 @@ type AccountPolicyGateStateEvent = {
 type AccountPolicyGateStateClassification = {
 	owner: 'copilot';
 	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues. No PII (organization names are NOT logged).';
-	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the Require Approved Account policy is in effect.' };
+	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if an admin has activated the Approved Account gate (non-empty approved-organization list).' };
 	gateSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the gate is satisfied (signed-in approved account with resolved policy).' };
 	reasonNotSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bucketed reason the gate is unsatisfied: noAccount, wrongProvider, orgNotApproved, policyNotResolved.' };
 };
 
 /**
- * Observes the inputs to the Account Policy gate (managed policy values + default account state)
- * and:
+ * Observes the Account Policy gate computed by `IAccountPolicyGateService` and:
  *   - mirrors the gate state into a workbench context key so welcome views/menus can react;
- *   - shows a one-time notification with a Sign In action when the gate is active but unsatisfied;
+ *   - shows a notification with a Sign In action when the gate is active but unsatisfied;
  *   - emits telemetry whenever the gate state changes.
  *
  * The actual restriction of feature values lives in `AccountPolicyService` itself; this
- * contribution only handles UX/observability.
+ * contribution is a thin UX/observability adapter and does NOT re-evaluate the gate.
  */
 export class AccountPolicyGateContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.accountPolicyGate';
 
 	private readonly contextKey: IContextKey<boolean>;
-	private lastInfo: IAccountPolicyGateInfo = { state: AccountPolicyGateState.Inactive };
+	private lastInfo: IAccountPolicyGateInfo;
+
 	private readonly notificationHandle = this._register(new MutableDisposable());
+	private dismissedReason: AccountPolicyGateUnsatisfiedReason | undefined;
 
 	constructor(
-		@IPolicyService private readonly policyService: IPolicyService,
-		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IAccountPolicyGateService private readonly gateService: IAccountPolicyGateService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -62,20 +60,17 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	) {
 		super();
 		this.contextKey = ChatContextKeys.accountPolicyGateActive.bindTo(contextKeyService);
+		this.lastInfo = this.gateService.gateInfo;
 
-		this.update();
-		this._register(this.policyService.onDidChange(names => {
-			if (names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
-				this.update();
-			}
-		}));
-		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.update()));
-		this._register(this.defaultAccountService.onDidChangePolicyData(() => this.update()));
+		// Seed any consumer that initialised before us (e.g. context-key when-clauses).
+		this.apply(this.lastInfo, /*forceTelemetry*/ true);
+
+		this._register(this.gateService.onDidChangeGateInfo(info => this.apply(info, /*forceTelemetry*/ false)));
 	}
 
-	private update(): void {
-		const info = this.computeGateInfo();
-		const stateChanged = info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
+	private apply(info: IAccountPolicyGateInfo, forceTelemetry: boolean): void {
+		const stateChanged = forceTelemetry || info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
+		const reasonChanged = info.reason !== this.lastInfo.reason;
 		this.lastInfo = info;
 
 		const isRestricted = info.state === AccountPolicyGateState.Restricted;
@@ -89,53 +84,46 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			});
 		}
 
-		if (isRestricted) {
-			this.maybeShowNotification(info.reason);
-		} else {
+		if (info.state !== AccountPolicyGateState.Restricted) {
+			// Gate is no longer restricting anything → close any open notification AND reset
+			// the "Don't Show Again" preference so a later flip back to Restricted is visible
+			// again. Also reset the in-memory dismissed-reason so reason transitions get a
+			// fresh notification.
 			this.notificationHandle.clear();
+			this.dismissedReason = undefined;
+			this.storageService.remove(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
+			return;
 		}
-	}
 
-	private computeGateInfo(): IAccountPolicyGateInfo {
-		const approvedRaw = this.policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
-		const approved = typeof approvedRaw === 'string' ? approvedRaw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : [];
-		if (approved.length === 0) {
-			return { state: AccountPolicyGateState.Inactive };
+		// Restricted. Show or refresh the notification if the reason has changed since the
+		// last shown/dismissed message. This covers cases like NoAccount → OrgNotApproved
+		// where the user needs to see updated guidance.
+		if (reasonChanged) {
+			this.notificationHandle.clear();
+			this.dismissedReason = undefined;
 		}
-		const account = this.defaultAccountService.currentDefaultAccount;
-		if (!account) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount };
-		}
-		const configuredProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
-		if (account.authenticationProvider.id !== configuredProvider.id) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider };
-		}
-		if (this.defaultAccountService.policyData === null) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
-		}
-		if (approved.includes('*')) {
-			return { state: AccountPolicyGateState.Satisfied };
-		}
-		const orgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
-		if (!orgs.some(o => approved.includes(o))) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
-		}
-		return { state: AccountPolicyGateState.Satisfied };
+		this.maybeShowNotification(info.reason);
 	}
 
 	private maybeShowNotification(reason: AccountPolicyGateUnsatisfiedReason | undefined): void {
 		if (this.notificationHandle.value) {
-			return; // already showing
+			return; // already showing for this reason
 		}
-		if (this.storageService.getBoolean(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION, false)) {
-			return;
+		if (this.dismissedReason === reason) {
+			return; // user dismissed for this reason this session
 		}
+		const persistedDismissed = this.storageService.get(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
+		if (persistedDismissed === (reason ?? '')) {
+			return; // user clicked "Don't Show Again" for this same reason on this machine
+		}
+
 		const message = reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved
 			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.")
 			: reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved
 				? localize('accountPolicy.notification.unresolved', "Waiting for your GitHub account policy to load before AI features can be enabled\u2026")
 				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.");
 
+		const handleDisposables = new DisposableStore();
 		const handle = this.notificationService.prompt(
 			Severity.Warning,
 			message,
@@ -146,11 +134,21 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 				},
 				{
 					label: localize('accountPolicy.notification.dontShowAgain', "Don't Show Again"),
-					run: () => this.storageService.store(NOTIFICATION_DISMISSED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE),
+					run: () => this.storageService.store(NOTIFICATION_DISMISSED_KEY, reason ?? '', StorageScope.APPLICATION, StorageTarget.MACHINE),
 				}
 			],
 			{ sticky: true }
 		);
-		this.notificationHandle.value = toDisposable(() => handle.close());
+
+		// Capture which reason the toast is showing for so a manual close treats it as a
+		// session-scoped dismissal — but only for THIS reason. A subsequent reason change
+		// will reset `dismissedReason` and re-show.
+		const reasonAtShow = reason;
+		handleDisposables.add(handle.onDidClose(() => {
+			this.dismissedReason = reasonAtShow;
+			this.notificationHandle.clear();
+		}));
+		handleDisposables.add({ dispose: () => handle.close() });
+		this.notificationHandle.value = handleDisposables;
 	}
 }

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -11,9 +11,8 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
-import { ChatContextKeys } from '../../../contrib/chat/common/actions/chatContextKeys.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, ChatAccountPolicyGateActiveContext, IAccountPolicyGateInfo, IAccountPolicyGateService } from '../common/accountPolicyService.js';
 
 const NOTIFICATION_DISMISSED_KEY = 'accountPolicy.gateNotificationDismissed';
 
@@ -59,7 +58,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 	) {
 		super();
-		this.contextKey = ChatContextKeys.accountPolicyGateActive.bindTo(contextKeyService);
+		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
 		this.lastInfo = this.gateService.gateInfo;
 
 		// Seed any consumer that initialised before us (e.g. context-key when-clauses).

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -15,7 +15,7 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { ChatContextKeys } from '../../../contrib/chat/common/actions/chatContextKeys.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateInfo, REQUIRE_APPROVED_ACCOUNT_POLICY_NAME } from '../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateInfo } from '../common/accountPolicyService.js';
 
 const NOTIFICATION_DISMISSED_KEY = 'accountPolicy.gateNotificationDismissed';
 
@@ -65,7 +65,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 
 		this.update();
 		this._register(this.policyService.onDidChange(names => {
-			if (names.includes(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) || names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
+			if (names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
 				this.update();
 			}
 		}));
@@ -97,7 +97,9 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	}
 
 	private computeGateInfo(): IAccountPolicyGateInfo {
-		if (this.policyService.getPolicyValue(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) !== true) {
+		const approvedRaw = this.policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+		const approved = typeof approvedRaw === 'string' ? approvedRaw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : [];
+		if (approved.length === 0) {
 			return { state: AccountPolicyGateState.Inactive };
 		}
 		const account = this.defaultAccountService.currentDefaultAccount;
@@ -110,11 +112,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		}
 		if (this.defaultAccountService.policyData === null) {
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
-		}
-		const approvedRaw = this.policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
-		const approved = typeof approvedRaw === 'string' ? approvedRaw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : [];
-		if (approved.length === 0) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
 		}
 		if (approved.includes('*')) {
 			return { state: AccountPolicyGateState.Satisfied };

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -1,0 +1,159 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IPolicyService } from '../../../../platform/policy/common/policy.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { ChatContextKeys } from '../../../contrib/chat/common/actions/chatContextKeys.js';
+import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../accounts/browser/defaultAccount.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateInfo, REQUIRE_APPROVED_ACCOUNT_POLICY_NAME } from '../common/accountPolicyService.js';
+
+const NOTIFICATION_DISMISSED_KEY = 'accountPolicy.gateNotificationDismissed';
+
+type AccountPolicyGateStateEvent = {
+	gateActive: boolean;
+	gateSatisfied: boolean;
+	reasonNotSatisfied: string | undefined;
+};
+
+type AccountPolicyGateStateClassification = {
+	owner: 'copilot';
+	comment: 'Tracks the Account Policy gate state for diagnosing account-driven restriction issues. No PII (organization names are NOT logged).';
+	gateActive: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the Require Approved Account policy is in effect.' };
+	gateSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'True if the gate is satisfied (signed-in approved account with resolved policy).' };
+	reasonNotSatisfied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Bucketed reason the gate is unsatisfied: noAccount, wrongProvider, orgNotApproved, policyNotResolved.' };
+};
+
+/**
+ * Observes the inputs to the Account Policy gate (managed policy values + default account state)
+ * and:
+ *   - mirrors the gate state into a workbench context key so welcome views/menus can react;
+ *   - shows a one-time notification with a Sign In action when the gate is active but unsatisfied;
+ *   - emits telemetry whenever the gate state changes.
+ *
+ * The actual restriction of feature values lives in `AccountPolicyService` itself; this
+ * contribution only handles UX/observability.
+ */
+export class AccountPolicyGateContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.accountPolicyGate';
+
+	private readonly contextKey: IContextKey<boolean>;
+	private lastInfo: IAccountPolicyGateInfo = { state: AccountPolicyGateState.Inactive };
+	private readonly notificationHandle = this._register(new MutableDisposable());
+
+	constructor(
+		@IPolicyService private readonly policyService: IPolicyService,
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IStorageService private readonly storageService: IStorageService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+	) {
+		super();
+		this.contextKey = ChatContextKeys.accountPolicyGateActive.bindTo(contextKeyService);
+
+		this.update();
+		this._register(this.policyService.onDidChange(names => {
+			if (names.includes(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) || names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
+				this.update();
+			}
+		}));
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.update()));
+		this._register(this.defaultAccountService.onDidChangePolicyData(() => this.update()));
+	}
+
+	private update(): void {
+		const info = this.computeGateInfo();
+		const stateChanged = info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
+		this.lastInfo = info;
+
+		const isRestricted = info.state === AccountPolicyGateState.Restricted;
+		this.contextKey.set(isRestricted);
+
+		if (stateChanged) {
+			this.telemetryService.publicLog2<AccountPolicyGateStateEvent, AccountPolicyGateStateClassification>('accountPolicy.gateState', {
+				gateActive: info.state !== AccountPolicyGateState.Inactive,
+				gateSatisfied: info.state === AccountPolicyGateState.Satisfied,
+				reasonNotSatisfied: info.reason,
+			});
+		}
+
+		if (isRestricted) {
+			this.maybeShowNotification(info.reason);
+		} else {
+			this.notificationHandle.clear();
+		}
+	}
+
+	private computeGateInfo(): IAccountPolicyGateInfo {
+		if (this.policyService.getPolicyValue(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) !== true) {
+			return { state: AccountPolicyGateState.Inactive };
+		}
+		const account = this.defaultAccountService.currentDefaultAccount;
+		if (!account) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount };
+		}
+		const configuredProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
+		if (account.authenticationProvider.id !== configuredProvider.id) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider };
+		}
+		if (this.defaultAccountService.policyData === null) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
+		}
+		const approvedRaw = this.policyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+		const approved = typeof approvedRaw === 'string' ? approvedRaw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : [];
+		if (approved.length === 0) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
+		}
+		if (approved.includes('*')) {
+			return { state: AccountPolicyGateState.Satisfied };
+		}
+		const orgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
+		if (!orgs.some(o => approved.includes(o))) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
+		}
+		return { state: AccountPolicyGateState.Satisfied };
+	}
+
+	private maybeShowNotification(reason: AccountPolicyGateUnsatisfiedReason | undefined): void {
+		if (this.notificationHandle.value) {
+			return; // already showing
+		}
+		if (this.storageService.getBoolean(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION, false)) {
+			return;
+		}
+		const message = reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved
+			? localize('accountPolicy.notification.org', "Your administrator requires sign-in with a GitHub account from an approved organization to use AI features.")
+			: reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved
+				? localize('accountPolicy.notification.unresolved', "Waiting for your GitHub account policy to load before AI features can be enabled\u2026")
+				: localize('accountPolicy.notification.signin', "Your administrator requires sign-in with an approved GitHub account to use AI features.");
+
+		const handle = this.notificationService.prompt(
+			Severity.Warning,
+			message,
+			[
+				{
+					label: localize('accountPolicy.notification.signin.action', "Sign In"),
+					run: () => this.commandService.executeCommand(DEFAULT_ACCOUNT_SIGN_IN_COMMAND),
+				},
+				{
+					label: localize('accountPolicy.notification.dontShowAgain', "Don't Show Again"),
+					run: () => this.storageService.store(NOTIFICATION_DISMISSED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE),
+				}
+			],
+			{ sticky: true }
+		);
+		this.notificationHandle.value = toDisposable(() => handle.close());
+	}
+}

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -86,12 +87,12 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 
 		// If the gate never fires a change (already stable), show the
 		// notification after a short delay to let the account service load.
-		setTimeout(() => {
+		this._register(disposableTimeout(() => {
 			if (!this.initialised) {
 				this.initialised = true;
 				this.apply(this.lastInfo, /*forceTelemetry*/ false, /*showNotification*/ true);
 			}
-		}, 5000);
+		}, 5000));
 	}
 
 	private apply(info: IAccountPolicyGateInfo, forceTelemetry: boolean, showNotification: boolean): void {

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -37,13 +37,9 @@ type AccountPolicyGateStateClassification = {
 };
 
 /**
- * Observes the Account Policy gate computed by `IAccountPolicyGateService` and:
- *   - mirrors the gate state into a workbench context key so welcome views/menus can react;
- *   - shows a notification with a Sign In action when the gate is active but unsatisfied;
- *   - emits telemetry whenever the gate state changes.
- *
- * The actual restriction of feature values lives in `AccountPolicyService` itself; this
- * contribution is a thin UX/observability adapter and does NOT re-evaluate the gate.
+ * UX/observability adapter for the Account Policy gate. Mirrors gate state into
+ * a context key, shows a sign-in notification when restricted, and emits telemetry.
+ * Does NOT re-evaluate the gate — `AccountPolicyService` owns that.
  */
 export class AccountPolicyGateContribution extends Disposable implements IWorkbenchContribution {
 
@@ -53,7 +49,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 	private lastInfo: IAccountPolicyGateInfo;
 
 	private readonly notificationHandle = this._register(new MutableDisposable());
-	private dismissedKey: string | undefined; // tracks reason+account combo for session-scoped dismissal
+	private dismissedKey: string | undefined;
 
 	private initialised = false;
 
@@ -73,11 +69,9 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		this.contextKey = ChatAccountPolicyGateActiveContext.bindTo(contextKeyService);
 		this.lastInfo = this.gateService.gateInfo;
 
-		// Seed context key + setForceHidden immediately (fail-closed) but
-		// defer the notification until the first onDidChangeGateInfo event
-		// so the default account has had time to resolve. Without this, a
-		// race on startup shows "sign in" even when the user is already
-		// signed in (just not yet loaded).
+		// Apply context key + setForceHidden immediately (fail-closed), but defer the
+		// notification until either the first onDidChangeGateInfo or a 5s timeout —
+		// without this, a startup race shows "sign in" before the default account loads.
 		this.apply(this.lastInfo, /*forceTelemetry*/ true, /*showNotification*/ false);
 
 		this._register(this.gateService.onDidChangeGateInfo(info => {
@@ -85,8 +79,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			this.apply(info, /*forceTelemetry*/ false, /*showNotification*/ true);
 		}));
 
-		// If the gate never fires a change (already stable), show the
-		// notification after a short delay to let the account service load.
 		this._register(disposableTimeout(() => {
 			if (!this.initialised) {
 				this.initialised = true;
@@ -99,9 +91,8 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const stateChanged = forceTelemetry || info.state !== this.lastInfo.state || info.reason !== this.lastInfo.reason;
 		this.lastInfo = info;
 
-		// `policyNotResolved` is transient — the user IS in an approved org but account
-		// data hasn't loaded yet. Don't set the context key for this state so the UI
-		// stays visible (policies aren't being restricted either — see AccountPolicyService).
+		// Suppress the context key during the transient `policyNotResolved` state
+		// (user IS in approved org, just waiting for data) so the UI doesn't flash.
 		const isRestricted = info.state === AccountPolicyGateState.Restricted
 			&& info.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 		this.contextKey.set(isRestricted);
@@ -127,18 +118,14 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			return;
 		}
 
-		// `policyNotResolved` is transient — don't show a notification for it.
 		if (info.reason === AccountPolicyGateUnsatisfiedReason.PolicyNotResolved) {
 			return;
 		}
 
-		// Build a composite key from the reason + current account name so that
-		// swapping to a different account (while still blocked) re-shows the notification.
+		// Composite key so swapping accounts (while still blocked) re-shows the notification.
 		const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 		const notificationKey = `${info.reason ?? ''}:${accountName ?? ''}`;
 
-		// If the key changed (different reason or different account), close the old
-		// notification and reset the session-scoped dismissal.
 		if (this.dismissedKey !== undefined && this.dismissedKey !== notificationKey) {
 			this.notificationHandle.clear();
 			this.dismissedKey = undefined;
@@ -148,14 +135,14 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 
 	private maybeShowNotification(info: IAccountPolicyGateInfo, notificationKey: string): void {
 		if (this.notificationHandle.value) {
-			return; // already showing for this reason+account
+			return;
 		}
 		if (this.dismissedKey === notificationKey) {
-			return; // user dismissed for this reason+account this session
+			return;
 		}
 		const persistedDismissed = this.storageService.get(NOTIFICATION_DISMISSED_KEY, StorageScope.APPLICATION);
 		if (persistedDismissed === notificationKey) {
-			return; // user clicked "Don't Show Again" for this same combo on this machine
+			return;
 		}
 
 		const reason = info.reason;
@@ -163,8 +150,7 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		const approvedOrgs = info.approvedOrganizations ?? [];
 		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
 
-		// Build the message — notifications render as plain inline text, so use
-		// a comma-separated org list rather than bullet points / newlines.
+		// Notifications render as plain inline text — comma-separate orgs.
 		const orgList = approvedOrgs.join(', ');
 		let message: string;
 		if (reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved) {

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -81,12 +81,23 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	private readonly _onDidChangeGateInfo = this._register(new Emitter<IAccountPolicyGateInfo>());
 	readonly onDidChangeGateInfo = this._onDidChangeGateInfo.event;
 
+	/**
+	 * Read-only reference to the MDM/managed policy service. Used only for
+	 * reading `ChatApprovedAccountOrganizations` and listening for changes.
+	 * The `MultiplexPolicyService` is responsible for calling
+	 * `updatePolicyDefinitions` on the managed service — we must NOT do it
+	 * here to avoid duplicate IPC round-trips.
+	 */
+	private readonly managedPolicyReader?: IPolicyService;
+
 	constructor(
 		@ILogService private readonly logService: ILogService,
 		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
-		private readonly managedPolicyService?: IPolicyService,
+		managedPolicyService?: IPolicyService,
 	) {
 		super();
+
+		this.managedPolicyReader = managedPolicyService;
 
 		this._updatePolicyDefinitions(this.policyDefinitions);
 		this._register(this.defaultAccountService.onDidChangePolicyData(() => {
@@ -95,8 +106,8 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
 			this._updatePolicyDefinitions(this.policyDefinitions);
 		}));
-		if (this.managedPolicyService) {
-			this._register(this.managedPolicyService.onDidChange(names => {
+		if (this.managedPolicyReader) {
+			this._register(this.managedPolicyReader.onDidChange(names => {
 				if (names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
 					this._updatePolicyDefinitions(this.policyDefinitions);
 				}
@@ -115,22 +126,12 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {
 		this.logService.trace(`AccountPolicyService#_updatePolicyDefinitions: Got ${Object.keys(policyDefinitions).length} policy definitions`);
 
-		// Fail-closed boot ordering: the gate decision depends on the managed policy
-		// service knowing about `ChatApprovedAccountOrganizations`. If we computed the
-		// gate before the managed service had fetched its values (which is async on
-		// desktop because it crosses an IPC boundary to the main process), the gate
-		// would be evaluated as Inactive even when the admin has actually configured
-		// it — leaving AI features briefly unrestricted at startup. Pushing the
-		// definitions through the managed service first guarantees its values are
-		// loaded before we decide. (The call is a no-op when no new definitions need
-		// to be registered — see AbstractPolicyService.updatePolicyDefinitions.)
-		if (this.managedPolicyService) {
-			try {
-				await this.managedPolicyService.updatePolicyDefinitions(policyDefinitions);
-			} catch (err) {
-				this.logService.error('AccountPolicyService#_updatePolicyDefinitions: managed policy service update failed; proceeding fail-closed.', err);
-			}
-		}
+		// NOTE: We do NOT call `this.managedPolicyReader.updatePolicyDefinitions()`
+		// here. When running under MultiplexPolicyService, the multiplex already
+		// pushes definitions to all child services (including the managed policy
+		// channel). Calling it again would cause duplicate IPC round-trips.
+		// The managed policy reader is used only for getPolicyValue() and
+		// onDidChange — see constructor.
 
 		const updated: string[] = [];
 		const policyData = this.defaultAccountService.policyData;
@@ -188,12 +189,12 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	}
 
 	private computeGateInfo(): IAccountPolicyGateInfo {
-		if (!this.managedPolicyService) {
+		if (!this.managedPolicyReader) {
 			return { state: AccountPolicyGateState.Inactive };
 		}
 
 		// Gate is active iff the admin has set a non-empty approved-organizations list.
-		const approvedRaw = this.managedPolicyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+		const approvedRaw = this.managedPolicyReader.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
 		const approvedOrgs = parseApprovedOrganizations(approvedRaw);
 		if (approvedOrgs.length === 0) {
 			return { state: AccountPolicyGateState.Inactive };

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -202,19 +202,24 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider, approvedOrganizations: approvedOrgs };
 		}
 
+		// Check org membership BEFORE policy-data resolution. This ensures users
+		// who are definitively NOT in an approved org are restricted immediately,
+		// even while policy data is still loading. `policyNotResolved` is reserved
+		// for users who ARE in an approved org but whose account-side policy data
+		// hasn't been fetched yet — a transient state that resolves on its own.
+		if (!approvedOrgs.includes('*')) {
+			const accountOrgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
+			const intersects = accountOrgs.some(org => approvedOrgs.includes(org));
+			if (!intersects) {
+				return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved, approvedOrganizations: approvedOrgs };
+			}
+		}
+
 		// Account-side policy data must have resolved (rules out the pre-fetch window).
+		// At this point the user IS in an approved org (or wildcard), so skipping
+		// restrictions for this reason in _updatePolicyDefinitions is safe.
 		if (this.defaultAccountService.policyData === null) {
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved, approvedOrganizations: approvedOrgs };
-		}
-
-		if (approvedOrgs.includes('*')) {
-			return { state: AccountPolicyGateState.Satisfied, approvedOrganizations: approvedOrgs };
-		}
-
-		const accountOrgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
-		const intersects = accountOrgs.some(org => approvedOrgs.includes(org));
-		if (!intersects) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved, approvedOrganizations: approvedOrgs };
 		}
 
 		return { state: AccountPolicyGateState.Satisfied, approvedOrganizations: approvedOrgs };

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -102,6 +102,14 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 				}
 			}));
 		}
+
+		// The initial account load (DefaultAccountService.setDefaultAccountProvider →
+		// provider.refresh()) sets `currentDefaultAccount` but does NOT fire
+		// `onDidChangeDefaultAccount`. Re-evaluate once the account has resolved
+		// so the gate doesn't stay stuck on `noAccount`.
+		this.defaultAccountService.getDefaultAccount().then(() => {
+			this._updatePolicyDefinitions(this.policyDefinitions);
+		});
 	}
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -42,6 +42,8 @@ export const enum AccountPolicyGateUnsatisfiedReason {
 export interface IAccountPolicyGateInfo {
 	readonly state: AccountPolicyGateState;
 	readonly reason?: AccountPolicyGateUnsatisfiedReason;
+	/** The admin-configured approved organization logins (lower-cased). Empty when the gate is inactive. */
+	readonly approvedOrganizations?: readonly string[];
 }
 
 /**
@@ -191,31 +193,31 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 		const account = this.defaultAccountService.currentDefaultAccount;
 		if (!account) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount };
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount, approvedOrganizations: approvedOrgs };
 		}
 
 		// Sign-in: provider id must match the configured GitHub (default or enterprise) provider.
 		const configuredProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
 		if (account.authenticationProvider.id !== configuredProvider.id) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider };
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider, approvedOrganizations: approvedOrgs };
 		}
 
 		// Account-side policy data must have resolved (rules out the pre-fetch window).
 		if (this.defaultAccountService.policyData === null) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved, approvedOrganizations: approvedOrgs };
 		}
 
 		if (approvedOrgs.includes('*')) {
-			return { state: AccountPolicyGateState.Satisfied };
+			return { state: AccountPolicyGateState.Satisfied, approvedOrganizations: approvedOrgs };
 		}
 
 		const accountOrgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
 		const intersects = accountOrgs.some(org => approvedOrgs.includes(org));
 		if (!intersects) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved, approvedOrganizations: approvedOrgs };
 		}
 
-		return { state: AccountPolicyGateState.Satisfied };
+		return { state: AccountPolicyGateState.Satisfied, approvedOrganizations: approvedOrgs };
 	}
 }
 

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -128,7 +128,20 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		const previousInfo = this._gateInfo;
 		this._gateInfo = this.computeGateInfo();
 		const gateInfoChanged = previousInfo.state !== this._gateInfo.state || previousInfo.reason !== this._gateInfo.reason;
-		const gateRestricted = this._gateInfo.state === AccountPolicyGateState.Restricted;
+
+		// `policyNotResolved` means the user IS signed into an approved org but
+		// account-side policy data hasn't been fetched yet. During this transient
+		// window, we intentionally do NOT force restricted values. Policies with a
+		// `value` callback naturally return `undefined` because `policyData` is null,
+		// so no account-level overrides will slip through. Forcing `restrictedValue`
+		// here would transiently lock `chat.disableAIFeatures = true`, which surfaces
+		// confusing "Unable to write" errors and hides the UI for a split second.
+		//
+		// For the other unsatisfied reasons (`noAccount`, `wrongProvider`,
+		// `orgNotApproved`) we DO force restrictions because those are stable states
+		// that require user action to change.
+		const gateRestricted = this._gateInfo.state === AccountPolicyGateState.Restricted
+			&& this._gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 
 		for (const key in policyDefinitions) {
 			const policy = policyDefinitions[key];

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -14,10 +14,10 @@ import { IDefaultAccountService } from '../../../../platform/defaultAccount/comm
 
 /**
  * Policy name (declared by `chat.approvedAccountOrganizations` in chat.contribution.ts)
- * holding the comma-separated list of GitHub organization logins that satisfy the gate.
- * Setting this policy to a non-empty value activates the "Approved Account" gate; AI
- * features are forced off until the user signs into a GitHub account from an approved
- * organization AND the account-side policy data has resolved.
+ * holding the list of GitHub organization logins that satisfy the gate. Setting this
+ * policy to a non-empty value activates the "Approved Account" gate; AI features are
+ * forced off until the user signs into a GitHub account from an approved organization
+ * AND the account-side policy data has resolved.
  *
  * The token `*` is a wildcard that accepts any signed-in GitHub/GHE account.
  */
@@ -207,11 +207,18 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 }
 
 function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {
-	if (typeof raw !== 'string' || raw.length === 0) {
+	// `PolicyValue` is `string | number | boolean`, so even array-typed policies are
+	// delivered to AbstractPolicyService as a JSON-stringified array (this mirrors
+	// how `PolicyConfiguration.parse` normalises non-string-typed policy values).
+	let value: unknown = raw;
+	if (typeof value === 'string') {
+		try { value = JSON.parse(value); } catch { /* not JSON — leave as-is */ }
+	}
+	if (!Array.isArray(value)) {
 		return [];
 	}
-	return raw
-		.split(',')
+	return value
+		.filter((v): v is string => typeof v === 'string')
 		.map(s => s.trim().toLowerCase())
 		.filter(s => s.length > 0);
 }

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IStringDictionary } from '../../../../base/common/collections.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
@@ -40,10 +42,28 @@ export interface IAccountPolicyGateInfo {
 	readonly reason?: AccountPolicyGateUnsatisfiedReason;
 }
 
-export class AccountPolicyService extends AbstractPolicyService implements IPolicyService {
+/**
+ * Read-only accessor for the Account Policy gate state. Backed by the same
+ * `AccountPolicyService` instance that drives policy enforcement, so UX/observability
+ * consumers (notifications, context keys, telemetry) cannot drift from the
+ * authoritative gate decision.
+ */
+export const IAccountPolicyGateService = createDecorator<IAccountPolicyGateService>('accountPolicyGateService');
+export interface IAccountPolicyGateService {
+	readonly _serviceBrand: undefined;
+	readonly gateInfo: IAccountPolicyGateInfo;
+	readonly onDidChangeGateInfo: Event<IAccountPolicyGateInfo>;
+}
+
+export class AccountPolicyService extends AbstractPolicyService implements IPolicyService, IAccountPolicyGateService {
+
+	declare readonly _serviceBrand: undefined;
 
 	private _gateInfo: IAccountPolicyGateInfo = { state: AccountPolicyGateState.Inactive };
 	get gateInfo(): IAccountPolicyGateInfo { return this._gateInfo; }
+
+	private readonly _onDidChangeGateInfo = this._register(new Emitter<IAccountPolicyGateInfo>());
+	readonly onDidChangeGateInfo = this._onDidChangeGateInfo.event;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -70,10 +90,30 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {
 		this.logService.trace(`AccountPolicyService#_updatePolicyDefinitions: Got ${Object.keys(policyDefinitions).length} policy definitions`);
+
+		// Fail-closed boot ordering: the gate decision depends on the managed policy
+		// service knowing about `ChatApprovedAccountOrganizations`. If we computed the
+		// gate before the managed service had fetched its values (which is async on
+		// desktop because it crosses an IPC boundary to the main process), the gate
+		// would be evaluated as Inactive even when the admin has actually configured
+		// it — leaving AI features briefly unrestricted at startup. Pushing the
+		// definitions through the managed service first guarantees its values are
+		// loaded before we decide. (The call is a no-op when no new definitions need
+		// to be registered — see AbstractPolicyService.updatePolicyDefinitions.)
+		if (this.managedPolicyService) {
+			try {
+				await this.managedPolicyService.updatePolicyDefinitions(policyDefinitions);
+			} catch (err) {
+				this.logService.error('AccountPolicyService#_updatePolicyDefinitions: managed policy service update failed; proceeding fail-closed.', err);
+			}
+		}
+
 		const updated: string[] = [];
 		const policyData = this.defaultAccountService.policyData;
 
+		const previousInfo = this._gateInfo;
 		this._gateInfo = this.computeGateInfo();
+		const gateInfoChanged = previousInfo.state !== this._gateInfo.state || previousInfo.reason !== this._gateInfo.reason;
 		const gateRestricted = this._gateInfo.state === AccountPolicyGateState.Restricted;
 
 		for (const key in policyDefinitions) {
@@ -104,6 +144,9 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 		if (updated.length) {
 			this._onDidChange.fire(updated);
+		}
+		if (gateInfoChanged) {
+			this._onDidChangeGateInfo.fire(this._gateInfo);
 		}
 	}
 

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -5,6 +5,8 @@
 
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { localize } from '../../../../nls.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
@@ -41,6 +43,18 @@ export interface IAccountPolicyGateInfo {
 	readonly state: AccountPolicyGateState;
 	readonly reason?: AccountPolicyGateUnsatisfiedReason;
 }
+
+/**
+ * Context key that is `true` while the Account Policy gate is active and not satisfied
+ * (i.e. AI features are forced off until the user signs into an approved GitHub
+ * organization). Defined here in the services layer so both the gate contribution and
+ * `vs/workbench/contrib/chat` can use it without crossing layer boundaries.
+ */
+export const ChatAccountPolicyGateActiveContext = new RawContextKey<boolean>(
+	'chatAccountPolicyGateActive',
+	false,
+	{ type: 'boolean', description: localize('chatAccountPolicyGateActive', "True when the 'Require Approved Account' policy is in effect and the user is not yet signed into an approved GitHub organization, so all AI features are disabled until they sign in.") }
+);
 
 /**
  * Read-only accessor for the Account Policy gate state. Backed by the same

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -9,17 +9,13 @@ import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, Policy
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
 /**
- * Policy name (declared by `chat.requireApprovedAccount` in chat.contribution.ts) that
- * activates the "Require Approved Account" gate. When `true`, AI features are forced off
- * until the user signs into a GitHub account from an approved organization AND the
- * account-side policy data has resolved.
- */
-export const REQUIRE_APPROVED_ACCOUNT_POLICY_NAME = 'ChatRequireApprovedAccount';
-
-/**
  * Policy name (declared by `chat.approvedAccountOrganizations` in chat.contribution.ts)
  * holding the comma-separated list of GitHub organization logins that satisfy the gate.
- * The token `*` is treated as a wildcard that accepts any signed-in GitHub/GHE account.
+ * Setting this policy to a non-empty value activates the "Approved Account" gate; AI
+ * features are forced off until the user signs into a GitHub account from an approved
+ * organization AND the account-side policy data has resolved.
+ *
+ * The token `*` is a wildcard that accepts any signed-in GitHub/GHE account.
  */
 export const APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME = 'ChatApprovedAccountOrganizations';
 
@@ -65,7 +61,7 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		}));
 		if (this.managedPolicyService) {
 			this._register(this.managedPolicyService.onDidChange(names => {
-				if (names.includes(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) || names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
+				if (names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
 					this._updatePolicyDefinitions(this.policyDefinitions);
 				}
 			}));
@@ -115,7 +111,11 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		if (!this.managedPolicyService) {
 			return { state: AccountPolicyGateState.Inactive };
 		}
-		if (this.managedPolicyService.getPolicyValue(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) !== true) {
+
+		// Gate is active iff the admin has set a non-empty approved-organizations list.
+		const approvedRaw = this.managedPolicyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+		const approvedOrgs = parseApprovedOrganizations(approvedRaw);
+		if (approvedOrgs.length === 0) {
 			return { state: AccountPolicyGateState.Inactive };
 		}
 
@@ -135,11 +135,6 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
 		}
 
-		const approvedRaw = this.managedPolicyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
-		const approvedOrgs = parseApprovedOrganizations(approvedRaw);
-		if (approvedOrgs.length === 0) {
-			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
-		}
 		if (approvedOrgs.includes('*')) {
 			return { state: AccountPolicyGateState.Satisfied };
 		}

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -5,15 +5,54 @@
 
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { AbstractPolicyService, IPolicyService, PolicyDefinition } from '../../../../platform/policy/common/policy.js';
+import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, PolicyDefinition, PolicyValue } from '../../../../platform/policy/common/policy.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
+/**
+ * Policy name (declared by `chat.requireApprovedAccount` in chat.contribution.ts) that
+ * activates the "Require Approved Account" gate. When `true`, AI features are forced off
+ * until the user signs into a GitHub account from an approved organization AND the
+ * account-side policy data has resolved.
+ */
+export const REQUIRE_APPROVED_ACCOUNT_POLICY_NAME = 'ChatRequireApprovedAccount';
+
+/**
+ * Policy name (declared by `chat.approvedAccountOrganizations` in chat.contribution.ts)
+ * holding the comma-separated list of GitHub organization logins that satisfy the gate.
+ * The token `*` is treated as a wildcard that accepts any signed-in GitHub/GHE account.
+ */
+export const APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME = 'ChatApprovedAccountOrganizations';
+
+export const enum AccountPolicyGateState {
+	/** Gate is not active. Policies behave exactly as account policy data dictates. */
+	Inactive = 'inactive',
+	/** Gate active and satisfied. Account policy values flow through normally. */
+	Satisfied = 'satisfied',
+	/** Gate active and NOT satisfied — restricted values are applied to all gated policies. */
+	Restricted = 'restricted',
+}
+
+export const enum AccountPolicyGateUnsatisfiedReason {
+	NoAccount = 'noAccount',
+	WrongProvider = 'wrongProvider',
+	OrgNotApproved = 'orgNotApproved',
+	PolicyNotResolved = 'policyNotResolved',
+}
+
+export interface IAccountPolicyGateInfo {
+	readonly state: AccountPolicyGateState;
+	readonly reason?: AccountPolicyGateUnsatisfiedReason;
+}
 
 export class AccountPolicyService extends AbstractPolicyService implements IPolicyService {
 
+	private _gateInfo: IAccountPolicyGateInfo = { state: AccountPolicyGateState.Inactive };
+	get gateInfo(): IAccountPolicyGateInfo { return this._gateInfo; }
+
 	constructor(
 		@ILogService private readonly logService: ILogService,
-		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		private readonly managedPolicyService?: IPolicyService,
 	) {
 		super();
 
@@ -21,6 +60,16 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		this._register(this.defaultAccountService.onDidChangePolicyData(() => {
 			this._updatePolicyDefinitions(this.policyDefinitions);
 		}));
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
+			this._updatePolicyDefinitions(this.policyDefinitions);
+		}));
+		if (this.managedPolicyService) {
+			this._register(this.managedPolicyService.onDidChange(names => {
+				if (names.includes(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) || names.includes(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME)) {
+					this._updatePolicyDefinitions(this.policyDefinitions);
+				}
+			}));
+		}
 	}
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {
@@ -28,9 +77,23 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 		const updated: string[] = [];
 		const policyData = this.defaultAccountService.policyData;
 
+		this._gateInfo = this.computeGateInfo();
+		const gateRestricted = this._gateInfo.state === AccountPolicyGateState.Restricted;
+
 		for (const key in policyDefinitions) {
 			const policy = policyDefinitions[key];
-			const policyValue = policyData && policy.value ? policy.value(policyData) : undefined;
+
+			let policyValue: PolicyValue | undefined;
+			if (gateRestricted && (policy.value !== undefined || policy.restrictedValue !== undefined)) {
+				// Only policies that opt into the gate are restricted: either by declaring an
+				// account-side `value` (account-driven) or an explicit `restrictedValue`.
+				// MDM-only policies (no `value`, no `restrictedValue`) — including the two policies
+				// that DRIVE the gate itself — are left untouched so the admin remains in control.
+				policyValue = getRestrictedPolicyValue(policy);
+			} else if (policyData && policy.value) {
+				policyValue = policy.value(policyData);
+			}
+
 			if (policyValue !== undefined) {
 				if (this.policies.get(key) !== policyValue) {
 					this.policies.set(key, policyValue);
@@ -47,4 +110,56 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			this._onDidChange.fire(updated);
 		}
 	}
+
+	private computeGateInfo(): IAccountPolicyGateInfo {
+		if (!this.managedPolicyService) {
+			return { state: AccountPolicyGateState.Inactive };
+		}
+		if (this.managedPolicyService.getPolicyValue(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME) !== true) {
+			return { state: AccountPolicyGateState.Inactive };
+		}
+
+		const account = this.defaultAccountService.currentDefaultAccount;
+		if (!account) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount };
+		}
+
+		// Sign-in: provider id must match the configured GitHub (default or enterprise) provider.
+		const configuredProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
+		if (account.authenticationProvider.id !== configuredProvider.id) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider };
+		}
+
+		// Account-side policy data must have resolved (rules out the pre-fetch window).
+		if (this.defaultAccountService.policyData === null) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved };
+		}
+
+		const approvedRaw = this.managedPolicyService.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
+		const approvedOrgs = parseApprovedOrganizations(approvedRaw);
+		if (approvedOrgs.length === 0) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
+		}
+		if (approvedOrgs.includes('*')) {
+			return { state: AccountPolicyGateState.Satisfied };
+		}
+
+		const accountOrgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
+		const intersects = accountOrgs.some(org => approvedOrgs.includes(org));
+		if (!intersects) {
+			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved };
+		}
+
+		return { state: AccountPolicyGateState.Satisfied };
+	}
+}
+
+function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {
+	if (typeof raw !== 'string' || raw.length === 0) {
+		return [];
+	}
+	return raw
+		.split(',')
+		.map(s => s.trim().toLowerCase())
+		.filter(s => s.length > 0);
 }

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -13,20 +13,13 @@ import { AbstractPolicyService, getRestrictedPolicyValue, IPolicyService, Policy
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 
 /**
- * Policy name (declared by `chat.approvedAccountOrganizations` in chat.contribution.ts)
- * holding the list of GitHub organization logins that satisfy the gate. Setting this
- * policy to a non-empty value activates the "Approved Account" gate; AI features are
- * forced off until the user signs into a GitHub account from an approved organization
- * AND the account-side policy data has resolved.
- *
- * The token `*` is a wildcard that accepts any signed-in GitHub/GHE account.
+ * Policy name (declared by `chat.approvedAccountOrganizations`) holding the list of
+ * GitHub organization logins that satisfy the gate. The token `*` is a wildcard.
  */
 export const APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME = 'ChatApprovedAccountOrganizations';
 
 export const enum AccountPolicyGateState {
-	/** Gate is not active. Policies behave exactly as account policy data dictates. */
 	Inactive = 'inactive',
-	/** Gate active and satisfied. Account policy values flow through normally. */
 	Satisfied = 'satisfied',
 	/** Gate active and NOT satisfied — restricted values are applied to all gated policies. */
 	Restricted = 'restricted',
@@ -42,16 +35,9 @@ export const enum AccountPolicyGateUnsatisfiedReason {
 export interface IAccountPolicyGateInfo {
 	readonly state: AccountPolicyGateState;
 	readonly reason?: AccountPolicyGateUnsatisfiedReason;
-	/** The admin-configured approved organization logins (lower-cased). Empty when the gate is inactive. */
 	readonly approvedOrganizations?: readonly string[];
 }
 
-/**
- * Context key that is `true` while the Account Policy gate is active and not satisfied
- * (i.e. AI features are forced off until the user signs into an approved GitHub
- * organization). Defined here in the services layer so both the gate contribution and
- * `vs/workbench/contrib/chat` can use it without crossing layer boundaries.
- */
 export const ChatAccountPolicyGateActiveContext = new RawContextKey<boolean>(
 	'chatAccountPolicyGateActive',
 	false,
@@ -60,9 +46,9 @@ export const ChatAccountPolicyGateActiveContext = new RawContextKey<boolean>(
 
 /**
  * Read-only accessor for the Account Policy gate state. Backed by the same
- * `AccountPolicyService` instance that drives policy enforcement, so UX/observability
- * consumers (notifications, context keys, telemetry) cannot drift from the
- * authoritative gate decision.
+ * `AccountPolicyService` instance that drives policy enforcement, so UX consumers
+ * (notifications, context keys, telemetry) cannot drift from the authoritative
+ * gate decision.
  */
 export const IAccountPolicyGateService = createDecorator<IAccountPolicyGateService>('accountPolicyGateService');
 export interface IAccountPolicyGateService {
@@ -81,13 +67,7 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 	private readonly _onDidChangeGateInfo = this._register(new Emitter<IAccountPolicyGateInfo>());
 	readonly onDidChangeGateInfo = this._onDidChangeGateInfo.event;
 
-	/**
-	 * Read-only reference to the MDM/managed policy service. Used only for
-	 * reading `ChatApprovedAccountOrganizations` and listening for changes.
-	 * The `MultiplexPolicyService` is responsible for calling
-	 * `updatePolicyDefinitions` on the managed service — we must NOT do it
-	 * here to avoid duplicate IPC round-trips.
-	 */
+	// Read-only — the MultiplexPolicyService owns calling updatePolicyDefinitions.
 	private readonly managedPolicyReader?: IPolicyService;
 
 	constructor(
@@ -114,8 +94,7 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			}));
 		}
 
-		// The initial account load (DefaultAccountService.setDefaultAccountProvider →
-		// provider.refresh()) sets `currentDefaultAccount` but does NOT fire
+		// The initial account load sets `currentDefaultAccount` but does NOT fire
 		// `onDidChangeDefaultAccount`. Re-evaluate once the account has resolved
 		// so the gate doesn't stay stuck on `noAccount`.
 		this.defaultAccountService.getDefaultAccount().then(() => {
@@ -125,13 +104,6 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 	protected async _updatePolicyDefinitions(policyDefinitions: IStringDictionary<PolicyDefinition>): Promise<void> {
 		this.logService.trace(`AccountPolicyService#_updatePolicyDefinitions: Got ${Object.keys(policyDefinitions).length} policy definitions`);
-
-		// NOTE: We do NOT call `this.managedPolicyReader.updatePolicyDefinitions()`
-		// here. When running under MultiplexPolicyService, the multiplex already
-		// pushes definitions to all child services (including the managed policy
-		// channel). Calling it again would cause duplicate IPC round-trips.
-		// The managed policy reader is used only for getPolicyValue() and
-		// onDidChange — see constructor.
 
 		const updated: string[] = [];
 		const policyData = this.defaultAccountService.policyData;
@@ -144,17 +116,12 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			|| previousInfo.reason !== this._gateInfo.reason
 			|| previousApprovedOrgs !== currentApprovedOrgs;
 
-		// `policyNotResolved` means the user IS signed into an approved org but
-		// account-side policy data hasn't been fetched yet. During this transient
-		// window, we intentionally do NOT force restricted values. Policies with a
-		// `value` callback naturally return `undefined` because `policyData` is null,
-		// so no account-level overrides will slip through. Forcing `restrictedValue`
-		// here would transiently lock `chat.disableAIFeatures = true`, which surfaces
-		// confusing "Unable to write" errors and hides the UI for a split second.
-		//
-		// For the other unsatisfied reasons (`noAccount`, `wrongProvider`,
-		// `orgNotApproved`) we DO force restrictions because those are stable states
-		// that require user action to change.
+		// `policyNotResolved` is a transient state where the user IS in an approved
+		// org but account-side policy data hasn't loaded yet. We don't force restricted
+		// values here — `policy.value(policyData)` naturally returns undefined when
+		// `policyData` is null, so no account overrides slip through. Forcing
+		// `restrictedValue` would transiently flip `chat.disableAIFeatures = true`,
+		// surfacing confusing "Unable to write" errors and a UI flash.
 		const gateRestricted = this._gateInfo.state === AccountPolicyGateState.Restricted
 			&& this._gateInfo.reason !== AccountPolicyGateUnsatisfiedReason.PolicyNotResolved;
 
@@ -163,10 +130,8 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 			let policyValue: PolicyValue | undefined;
 			if (gateRestricted && (policy.value !== undefined || policy.restrictedValue !== undefined)) {
-				// Only policies that opt into the gate are restricted: either by declaring an
-				// account-side `value` (account-driven) or an explicit `restrictedValue`.
-				// MDM-only policies (no `value`, no `restrictedValue`) — including the two policies
-				// that DRIVE the gate itself — are left untouched so the admin remains in control.
+				// MDM-only policies (no `value`, no `restrictedValue`) — including the policy
+				// that DRIVES the gate itself — are left untouched so the admin remains in control.
 				policyValue = getRestrictedPolicyValue(policy);
 			} else if (policyData && policy.value) {
 				policyValue = policy.value(policyData);
@@ -197,7 +162,6 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			return { state: AccountPolicyGateState.Inactive };
 		}
 
-		// Gate is active iff the admin has set a non-empty approved-organizations list.
 		const approvedRaw = this.managedPolicyReader.getPolicyValue(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME);
 		const approvedOrgs = parseApprovedOrganizations(approvedRaw);
 		if (approvedOrgs.length === 0) {
@@ -209,17 +173,15 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.NoAccount, approvedOrganizations: approvedOrgs };
 		}
 
-		// Sign-in: provider id must match the configured GitHub (default or enterprise) provider.
 		const configuredProvider = this.defaultAccountService.getDefaultAccountAuthenticationProvider();
 		if (account.authenticationProvider.id !== configuredProvider.id) {
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.WrongProvider, approvedOrganizations: approvedOrgs };
 		}
 
-		// Check org membership BEFORE policy-data resolution. This ensures users
-		// who are definitively NOT in an approved org are restricted immediately,
-		// even while policy data is still loading. `policyNotResolved` is reserved
-		// for users who ARE in an approved org but whose account-side policy data
-		// hasn't been fetched yet — a transient state that resolves on its own.
+		// Org membership is checked BEFORE policy-data resolution so users definitively
+		// NOT in an approved org are restricted immediately, even while policy data is
+		// still loading. `policyNotResolved` is reserved for users who ARE in an approved
+		// org — a transient state that resolves on its own.
 		if (!approvedOrgs.includes('*')) {
 			const accountOrgs = (account.entitlementsData?.organization_login_list ?? []).map(o => o.toLowerCase());
 			const intersects = accountOrgs.some(org => approvedOrgs.includes(org));
@@ -228,9 +190,6 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 			}
 		}
 
-		// Account-side policy data must have resolved (rules out the pre-fetch window).
-		// At this point the user IS in an approved org (or wildcard), so skipping
-		// restrictions for this reason in _updatePolicyDefinitions is safe.
 		if (this.defaultAccountService.policyData === null) {
 			return { state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.PolicyNotResolved, approvedOrganizations: approvedOrgs };
 		}
@@ -240,12 +199,11 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 }
 
 function parseApprovedOrganizations(raw: PolicyValue | undefined): string[] {
-	// `PolicyValue` is `string | number | boolean`, so even array-typed policies are
-	// delivered to AbstractPolicyService as a JSON-stringified array (this mirrors
-	// how `PolicyConfiguration.parse` normalises non-string-typed policy values).
+	// Array-typed policies are delivered as JSON-stringified arrays — see
+	// `PolicyConfiguration.parse` for the same normalisation.
 	let value: unknown = raw;
 	if (typeof value === 'string') {
-		try { value = JSON.parse(value); } catch { /* not JSON — leave as-is */ }
+		try { value = JSON.parse(value); } catch { /* not JSON */ }
 	}
 	if (!Array.isArray(value)) {
 		return [];

--- a/src/vs/workbench/services/policies/common/accountPolicyService.ts
+++ b/src/vs/workbench/services/policies/common/accountPolicyService.ts
@@ -138,7 +138,11 @@ export class AccountPolicyService extends AbstractPolicyService implements IPoli
 
 		const previousInfo = this._gateInfo;
 		this._gateInfo = this.computeGateInfo();
-		const gateInfoChanged = previousInfo.state !== this._gateInfo.state || previousInfo.reason !== this._gateInfo.reason;
+		const previousApprovedOrgs = previousInfo.approvedOrganizations?.join('\n') ?? '';
+		const currentApprovedOrgs = this._gateInfo.approvedOrganizations?.join('\n') ?? '';
+		const gateInfoChanged = previousInfo.state !== this._gateInfo.state
+			|| previousInfo.reason !== this._gateInfo.reason
+			|| previousApprovedOrgs !== currentApprovedOrgs;
 
 		// `policyNotResolved` means the user IS signed into an approved org but
 		// account-side policy data hasn't been fetched yet. During this transient

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { IDefaultAccount, IDefaultAccountAuthenticationProvider, IPolicyData } from '../../../../../base/common/defaultAccount.js';
-import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Event } from '../../../../../base/common/event.js';
 import { PolicyCategory } from '../../../../../base/common/policy.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Extensions, IConfigurationNode, IConfigurationRegistry } from '../../../../../platform/configuration/common/configurationRegistry.js';
@@ -476,7 +476,4 @@ suite('AccountPolicyService', () => {
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.ok(changes.length > 0, 'expected onDidChange to fire when gate flips');
 	});
-
-	// Ensure unused import does not warn
-	void Emitter;
 });

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -257,13 +257,16 @@ suite('AccountPolicyService', () => {
 	}
 
 	async function setupGate(opts: {
-		approvedOrgs?: string;
+		approvedOrgs?: string[] | string;
 		account?: IDefaultAccount | null;
 		policyData?: IPolicyData | null;
 	}): Promise<{ policyService: AccountPolicyService; managed: FakeManagedPolicyService }> {
 		const managed = disposables.add(new FakeManagedPolicyService());
 		if (opts.approvedOrgs !== undefined) {
-			managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, opts.approvedOrgs);
+			// Mirror how the platform delivers array-typed policy values to AbstractPolicyService:
+			// as a JSON-stringified array. Tests can pass a raw string to exercise edge cases.
+			const value = typeof opts.approvedOrgs === 'string' ? opts.approvedOrgs : JSON.stringify(opts.approvedOrgs);
+			managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, value);
 		}
 
 		const accountService = disposables.add(new DefaultAccountService(TestProductService));
@@ -288,7 +291,7 @@ suite('AccountPolicyService', () => {
 	});
 
 	test('gate active, no account signed in: restricted', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: null });
+		const { policyService } = await setupGate({ approvedOrgs: ['ApprovedOrg'], account: null });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.NoAccount);
 		// Restricted values applied to policies that opt into the gate.
@@ -299,31 +302,38 @@ suite('AccountPolicyService', () => {
 	});
 
 	test('gate active, signed in but org not approved: restricted', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService } = await setupGate({ approvedOrgs: ['ApprovedOrg'], account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
 	});
 
 	test('gate active, account in approved org but policyData null (pre-resolution): restricted', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: 'approvedorg', account: APPROVED_ORG_ACCOUNT, policyData: null });
+		const { policyService } = await setupGate({ approvedOrgs: ['approvedorg'], account: APPROVED_ORG_ACCOUNT, policyData: null });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.PolicyNotResolved);
 	});
 
 	test('gate active, satisfied (case-insensitive org match): account policy values flow normally', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: ' approvedorg , Other ', account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
+		const { policyService } = await setupGate({ approvedOrgs: [' approvedorg ', ' Other '], account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false); // from account policy data, not restricted
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingA'), undefined); // not driven by account
 	});
 
 	test('gate active, wildcard "*" satisfies any signed-in account', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: '*', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService } = await setupGate({ approvedOrgs: ['*'], account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 	});
 
-	test('approved org list empty (or whitespace-only): gate inactive', async () => {
-		const { policyService } = await setupGate({ approvedOrgs: '   ', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+	test('approved org list empty: gate inactive', async () => {
+		const { policyService } = await setupGate({ approvedOrgs: [], account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
+	});
+
+	test('approved orgs raw non-array string from policy service: gate inactive (fail-safe)', async () => {
+		// Defensive: if some platform delivers the policy as a non-JSON string, treat it as no-orgs
+		// rather than half-parsing CSV. The platform's array-typed policy contract makes this rare.
+		const { policyService } = await setupGate({ approvedOrgs: 'github', account: APPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
 	});
 
@@ -340,7 +350,7 @@ suite('AccountPolicyService', () => {
 		};
 
 		const managed = disposables.add(new FakeManagedPolicyService());
-		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'ApprovedOrg');
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, JSON.stringify(['ApprovedOrg']));
 		const accountService = disposables.add(new DefaultAccountService(TestProductService));
 		accountService.setDefaultAccountProvider(new MismatchedProvider(NON_GITHUB_ACCOUNT, {}));
 		await accountService.refresh();
@@ -376,7 +386,7 @@ suite('AccountPolicyService', () => {
 		};
 		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration(node);
 		try {
-			const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: null });
+			const { policyService } = await setupGate({ approvedOrgs: ['ApprovedOrg'], account: null });
 			assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 			assert.strictEqual(policyService.getPolicyValue('PolicySettingRV'), 'locked');
 		} finally {
@@ -385,17 +395,17 @@ suite('AccountPolicyService', () => {
 	});
 
 	test('onDidChangeGateInfo fires on state/reason transitions', async () => {
-		const { policyService, managed } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService, managed } = await setupGate({ approvedOrgs: ['ApprovedOrg'], account: APPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 
 		const events: IAccountPolicyGateInfo[] = [];
 		disposables.add(policyService.onDidChangeGateInfo(info => events.push(info)));
 
 		// Satisfied → Restricted (org no longer approved)
-		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'OnlyOtherOrg');
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, JSON.stringify(['OnlyOtherOrg']));
 		await new Promise(resolve => setTimeout(resolve, 0));
 		// Restricted → Inactive (gate disabled)
-		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, '');
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, JSON.stringify([]));
 		await new Promise(resolve => setTimeout(resolve, 0));
 
 		assert.deepStrictEqual(
@@ -433,7 +443,7 @@ suite('AccountPolicyService', () => {
 			}
 		}
 
-		const managed = disposables.add(new AsyncManagedPolicyService('OnlyOtherOrg'));
+		const managed = disposables.add(new AsyncManagedPolicyService(JSON.stringify(['OnlyOtherOrg'])));
 		const accountService = disposables.add(new DefaultAccountService(TestProductService));
 		accountService.setDefaultAccountProvider(new DefaultAccountProvider(APPROVED_ORG_ACCOUNT, {}));
 		await accountService.refresh();
@@ -451,7 +461,7 @@ suite('AccountPolicyService', () => {
 	});
 
 	test('managed policy change re-evaluates the gate and fires onDidChange', async () => {
-		const { policyService, managed } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService, managed } = await setupGate({ approvedOrgs: ['ApprovedOrg'], account: APPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 
 		const changes: string[] = [];
@@ -459,7 +469,7 @@ suite('AccountPolicyService', () => {
 
 		// Change the approved-org list to one the account is NOT in → flip Satisfied → Restricted,
 		// which forces restricted values onto opted-in policies and emits onDidChange.
-		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'OnlyOtherOrg');
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, JSON.stringify(['OnlyOtherOrg']));
 		// `_updatePolicyDefinitions` is async — wait one turn for it to resolve.
 		await new Promise(resolve => setTimeout(resolve, 0));
 

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -5,17 +5,18 @@
 
 import assert from 'assert';
 import { IDefaultAccount, IDefaultAccountAuthenticationProvider, IPolicyData } from '../../../../../base/common/defaultAccount.js';
-import { Event } from '../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
 import { PolicyCategory } from '../../../../../base/common/policy.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Extensions, IConfigurationNode, IConfigurationRegistry } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { DefaultConfiguration, PolicyConfiguration } from '../../../../../platform/configuration/common/configurations.js';
 import { IDefaultAccountProvider, IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { AbstractPolicyService, IPolicyService, PolicyValue } from '../../../../../platform/policy/common/policy.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
 import { DefaultAccountService } from '../../../accounts/browser/defaultAccount.js';
-import { AccountPolicyService } from '../../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, AccountPolicyService, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, REQUIRE_APPROVED_ACCOUNT_POLICY_NAME } from '../../common/accountPolicyService.js';
 
 const BASE_DEFAULT_ACCOUNT: IDefaultAccount = {
 	authenticationProvider: {
@@ -37,7 +38,7 @@ class DefaultAccountProvider implements IDefaultAccountProvider {
 
 	constructor(
 		readonly defaultAccount: IDefaultAccount,
-		readonly policyData: IPolicyData = {},
+		readonly policyData: IPolicyData | null = {},
 	) { }
 
 	getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider {
@@ -203,4 +204,149 @@ suite('AccountPolicyService', () => {
 			assert.strictEqual(D, false);
 		}
 	});
+
+	// ---------------------------------------------------------------------
+	// "Require Approved Account" gate
+	// ---------------------------------------------------------------------
+
+	const APPROVED_ORG_ACCOUNT: IDefaultAccount = {
+		...BASE_DEFAULT_ACCOUNT,
+		entitlementsData: {
+			access_type_sku: 'sku',
+			chat_enabled: true,
+			assigned_date: '',
+			can_signup_for_limited: false,
+			copilot_plan: 'pro',
+			organization_login_list: ['ApprovedOrg'],
+			analytics_tracking_id: '',
+		},
+	};
+
+	const UNAPPROVED_ORG_ACCOUNT: IDefaultAccount = {
+		...BASE_DEFAULT_ACCOUNT,
+		entitlementsData: {
+			access_type_sku: 'sku',
+			chat_enabled: true,
+			assigned_date: '',
+			can_signup_for_limited: false,
+			copilot_plan: 'pro',
+			organization_login_list: ['SomeOtherOrg'],
+			analytics_tracking_id: '',
+		},
+	};
+
+	class FakeManagedPolicyService extends AbstractPolicyService implements IPolicyService {
+		private readonly fakePolicies = new Map<string, PolicyValue>();
+
+		setPolicy(name: string, value: PolicyValue | undefined): void {
+			if (value === undefined) {
+				if (this.fakePolicies.delete(name)) {
+					this._onDidChange.fire([name]);
+				}
+			} else {
+				this.fakePolicies.set(name, value);
+				this._onDidChange.fire([name]);
+			}
+		}
+
+		override getPolicyValue(name: string): PolicyValue | undefined {
+			return this.fakePolicies.get(name);
+		}
+
+		protected async _updatePolicyDefinitions(): Promise<void> { /* no-op */ }
+	}
+
+	async function setupGate(opts: {
+		gateOn: boolean;
+		approvedOrgs?: string;
+		account?: IDefaultAccount | null;
+		policyData?: IPolicyData | null;
+	}): Promise<{ policyService: AccountPolicyService; managed: FakeManagedPolicyService }> {
+		const managed = disposables.add(new FakeManagedPolicyService());
+		if (opts.gateOn) {
+			managed.setPolicy(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME, true);
+		}
+		if (opts.approvedOrgs !== undefined) {
+			managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, opts.approvedOrgs);
+		}
+
+		const accountService = disposables.add(new DefaultAccountService(TestProductService));
+		if (opts.account !== null && opts.account !== undefined) {
+			accountService.setDefaultAccountProvider(new DefaultAccountProvider(opts.account, 'policyData' in opts ? opts.policyData as IPolicyData | null : {}));
+			await accountService.refresh();
+		}
+
+		const service = disposables.add(new AccountPolicyService(logService, accountService, managed));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		const config = disposables.add(new PolicyConfiguration(defaultConfiguration, service, new NullLogService()));
+		await config.initialize();
+		return { policyService: service, managed };
+	}
+
+	test('gate inactive: behaves identically to today', async () => {
+		const { policyService } = await setupGate({ gateOn: false, account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false); // account policy still flows
+	});
+
+	test('gate active, no account signed in: restricted', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: null });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.NoAccount);
+		// Restricted values applied to policies that opt into the gate.
+		// PolicySettingD has a `value` callback → falls back to type-default `false`.
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false);
+		// PolicySettingA does NOT opt in (no `value`, no `restrictedValue`) → unchanged.
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingA'), undefined);
+	});
+
+	test('gate active, signed in but org not approved: restricted', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
+	});
+
+	test('gate active, account in approved org but policyData null (pre-resolution): restricted', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'approvedorg', account: APPROVED_ORG_ACCOUNT, policyData: null });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.PolicyNotResolved);
+	});
+
+	test('gate active, satisfied (case-insensitive org match): account policy values flow normally', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: ' approvedorg , Other ', account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false); // from account policy data, not restricted
+		assert.strictEqual(policyService.getPolicyValue('PolicySettingA'), undefined); // not driven by account
+	});
+
+	test('gate active, wildcard "*" satisfies any signed-in account', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: '*', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
+	});
+
+	test('gate active, approved org list empty: restricted with OrgNotApproved', async () => {
+		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: '', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
+	});
+
+	test('managed policy change re-evaluates the gate and fires onDidChange', async () => {
+		const { policyService, managed } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
+
+		const changes: string[] = [];
+		disposables.add(policyService.onDidChange(names => changes.push(...names)));
+
+		// Removing approved orgs should flip the gate and emit changes for the (now-restricted) gated policies.
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, '');
+		// `_updatePolicyDefinitions` is async — wait one turn for it to resolve.
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.ok(changes.length > 0, 'expected onDidChange to fire when gate flips');
+	});
+
+	// Ensure unused import does not warn
+	void Emitter;
 });

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -268,7 +268,8 @@ suite('AccountPolicyService', () => {
 
 		const accountService = disposables.add(new DefaultAccountService(TestProductService));
 		if (opts.account !== null && opts.account !== undefined) {
-			accountService.setDefaultAccountProvider(new DefaultAccountProvider(opts.account, 'policyData' in opts ? opts.policyData as IPolicyData | null : {}));
+			const policyData = opts.policyData === undefined ? {} : opts.policyData;
+			accountService.setDefaultAccountProvider(new DefaultAccountProvider(opts.account, policyData));
 			await accountService.refresh();
 		}
 

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -16,7 +16,7 @@ import { AbstractPolicyService, IPolicyService, PolicyValue } from '../../../../
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
 import { DefaultAccountService } from '../../../accounts/browser/defaultAccount.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, AccountPolicyService, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, REQUIRE_APPROVED_ACCOUNT_POLICY_NAME } from '../../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, AccountPolicyService, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME } from '../../common/accountPolicyService.js';
 
 const BASE_DEFAULT_ACCOUNT: IDefaultAccount = {
 	authenticationProvider: {
@@ -257,15 +257,11 @@ suite('AccountPolicyService', () => {
 	}
 
 	async function setupGate(opts: {
-		gateOn: boolean;
 		approvedOrgs?: string;
 		account?: IDefaultAccount | null;
 		policyData?: IPolicyData | null;
 	}): Promise<{ policyService: AccountPolicyService; managed: FakeManagedPolicyService }> {
 		const managed = disposables.add(new FakeManagedPolicyService());
-		if (opts.gateOn) {
-			managed.setPolicy(REQUIRE_APPROVED_ACCOUNT_POLICY_NAME, true);
-		}
 		if (opts.approvedOrgs !== undefined) {
 			managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, opts.approvedOrgs);
 		}
@@ -284,14 +280,14 @@ suite('AccountPolicyService', () => {
 		return { policyService: service, managed };
 	}
 
-	test('gate inactive: behaves identically to today', async () => {
-		const { policyService } = await setupGate({ gateOn: false, account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
+	test('gate inactive (no approved orgs set): behaves identically to today', async () => {
+		const { policyService } = await setupGate({ account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false); // account policy still flows
 	});
 
 	test('gate active, no account signed in: restricted', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: null });
+		const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: null });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.NoAccount);
 		// Restricted values applied to policies that opt into the gate.
@@ -302,44 +298,44 @@ suite('AccountPolicyService', () => {
 	});
 
 	test('gate active, signed in but org not approved: restricted', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
 	});
 
 	test('gate active, account in approved org but policyData null (pre-resolution): restricted', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: 'approvedorg', account: APPROVED_ORG_ACCOUNT, policyData: null });
+		const { policyService } = await setupGate({ approvedOrgs: 'approvedorg', account: APPROVED_ORG_ACCOUNT, policyData: null });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.PolicyNotResolved);
 	});
 
 	test('gate active, satisfied (case-insensitive org match): account policy values flow normally', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: ' approvedorg , Other ', account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
+		const { policyService } = await setupGate({ approvedOrgs: ' approvedorg , Other ', account: APPROVED_ORG_ACCOUNT, policyData: { chat_preview_features_enabled: false } });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingD'), false); // from account policy data, not restricted
 		assert.strictEqual(policyService.getPolicyValue('PolicySettingA'), undefined); // not driven by account
 	});
 
 	test('gate active, wildcard "*" satisfies any signed-in account', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: '*', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService } = await setupGate({ approvedOrgs: '*', account: UNAPPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 	});
 
-	test('gate active, approved org list empty: restricted with OrgNotApproved', async () => {
-		const { policyService } = await setupGate({ gateOn: true, approvedOrgs: '', account: APPROVED_ORG_ACCOUNT, policyData: {} });
-		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
-		assert.strictEqual(policyService.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
+	test('approved org list empty (or whitespace-only): gate inactive', async () => {
+		const { policyService } = await setupGate({ approvedOrgs: '   ', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
 	});
 
 	test('managed policy change re-evaluates the gate and fires onDidChange', async () => {
-		const { policyService, managed } = await setupGate({ gateOn: true, approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		const { policyService, managed } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
 
 		const changes: string[] = [];
 		disposables.add(policyService.onDidChange(names => changes.push(...names)));
 
-		// Removing approved orgs should flip the gate and emit changes for the (now-restricted) gated policies.
-		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, '');
+		// Change the approved-org list to one the account is NOT in → flip Satisfied → Restricted,
+		// which forces restricted values onto opted-in policies and emits onDidChange.
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'OnlyOtherOrg');
 		// `_updatePolicyDefinitions` is async — wait one turn for it to resolve.
 		await new Promise(resolve => setTimeout(resolve, 0));
 

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -16,7 +16,7 @@ import { AbstractPolicyService, IPolicyService, PolicyValue } from '../../../../
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
 import { DefaultAccountService } from '../../../accounts/browser/defaultAccount.js';
-import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, AccountPolicyService, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME } from '../../common/accountPolicyService.js';
+import { AccountPolicyGateState, AccountPolicyGateUnsatisfiedReason, AccountPolicyService, APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateInfo } from '../../common/accountPolicyService.js';
 
 const BASE_DEFAULT_ACCOUNT: IDefaultAccount = {
 	authenticationProvider: {
@@ -324,6 +324,129 @@ suite('AccountPolicyService', () => {
 	test('approved org list empty (or whitespace-only): gate inactive', async () => {
 		const { policyService } = await setupGate({ approvedOrgs: '   ', account: APPROVED_ORG_ACCOUNT, policyData: {} });
 		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Inactive);
+	});
+
+	test('gate active, signed in with non-GitHub provider: WrongProvider reason', async () => {
+		// Custom provider whose configured GitHub provider differs from the account's actual provider.
+		class MismatchedProvider extends DefaultAccountProvider {
+			override getDefaultAccountAuthenticationProvider(): IDefaultAccountAuthenticationProvider {
+				return { id: 'github', name: 'GitHub', enterprise: false };
+			}
+		}
+		const NON_GITHUB_ACCOUNT: IDefaultAccount = {
+			...APPROVED_ORG_ACCOUNT,
+			authenticationProvider: { id: 'microsoft', name: 'Microsoft', enterprise: false },
+		};
+
+		const managed = disposables.add(new FakeManagedPolicyService());
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'ApprovedOrg');
+		const accountService = disposables.add(new DefaultAccountService(TestProductService));
+		accountService.setDefaultAccountProvider(new MismatchedProvider(NON_GITHUB_ACCOUNT, {}));
+		await accountService.refresh();
+		const service = disposables.add(new AccountPolicyService(logService, accountService, managed));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		const config = disposables.add(new PolicyConfiguration(defaultConfiguration, service, new NullLogService()));
+		await config.initialize();
+
+		assert.strictEqual(service.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(service.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.WrongProvider);
+	});
+
+	test('explicit `restrictedValue` is honored when gate is restricted', async () => {
+		const node: IConfigurationNode = {
+			id: 'restrictedValueConfig',
+			order: 2,
+			title: 'r',
+			type: 'object',
+			properties: {
+				'setting.RV': {
+					type: 'string',
+					default: 'open',
+					policy: {
+						name: 'PolicySettingRV',
+						category: PolicyCategory.Extensions,
+						minimumVersion: '1.0.0',
+						localization: { description: { key: '', value: '' } },
+						restrictedValue: 'locked',
+					}
+				}
+			}
+		};
+		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration(node);
+		try {
+			const { policyService } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: null });
+			assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Restricted);
+			assert.strictEqual(policyService.getPolicyValue('PolicySettingRV'), 'locked');
+		} finally {
+			Registry.as<IConfigurationRegistry>(Extensions.Configuration).deregisterConfigurations([node]);
+		}
+	});
+
+	test('onDidChangeGateInfo fires on state/reason transitions', async () => {
+		const { policyService, managed } = await setupGate({ approvedOrgs: 'ApprovedOrg', account: APPROVED_ORG_ACCOUNT, policyData: {} });
+		assert.strictEqual(policyService.gateInfo.state, AccountPolicyGateState.Satisfied);
+
+		const events: IAccountPolicyGateInfo[] = [];
+		disposables.add(policyService.onDidChangeGateInfo(info => events.push(info)));
+
+		// Satisfied → Restricted (org no longer approved)
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, 'OnlyOtherOrg');
+		await new Promise(resolve => setTimeout(resolve, 0));
+		// Restricted → Inactive (gate disabled)
+		managed.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, '');
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.deepStrictEqual(
+			events.map(e => ({ state: e.state, reason: e.reason })),
+			[
+				{ state: AccountPolicyGateState.Restricted, reason: AccountPolicyGateUnsatisfiedReason.OrgNotApproved },
+				{ state: AccountPolicyGateState.Inactive, reason: undefined },
+			]
+		);
+	});
+
+	test('boot race: gate is fail-closed until async managed policy service resolves', async () => {
+		// Simulate the IPC boundary: managed service only knows about its policies AFTER
+		// `updatePolicyDefinitions` has resolved. Before that, `getPolicyValue` returns undefined.
+		class AsyncManagedPolicyService extends FakeManagedPolicyService {
+			private _seeded = false;
+			private readonly _seedValue: string;
+			constructor(seedValue: string) {
+				super();
+				this._seedValue = seedValue;
+			}
+			override getPolicyValue(name: string): PolicyValue | undefined {
+				if (!this._seeded) {
+					return undefined;
+				}
+				return super.getPolicyValue(name);
+			}
+			protected override async _updatePolicyDefinitions(): Promise<void> {
+				// Yield, then seed (mimics IPC round-trip).
+				await new Promise(resolve => setTimeout(resolve, 0));
+				if (!this._seeded) {
+					this._seeded = true;
+					this.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, this._seedValue);
+				}
+			}
+		}
+
+		const managed = disposables.add(new AsyncManagedPolicyService('OnlyOtherOrg'));
+		const accountService = disposables.add(new DefaultAccountService(TestProductService));
+		accountService.setDefaultAccountProvider(new DefaultAccountProvider(APPROVED_ORG_ACCOUNT, {}));
+		await accountService.refresh();
+
+		const service = disposables.add(new AccountPolicyService(logService, accountService, managed));
+		const defaultConfiguration = disposables.add(new DefaultConfiguration(new NullLogService()));
+		await defaultConfiguration.initialize();
+		const config = disposables.add(new PolicyConfiguration(defaultConfiguration, service, new NullLogService()));
+		await config.initialize();
+
+		// Gate must reflect the admin policy that was unknown at construction time;
+		// without the boot-race fix, this would be Inactive (false-open).
+		assert.strictEqual(service.gateInfo.state, AccountPolicyGateState.Restricted);
+		assert.strictEqual(service.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
 	});
 
 	test('managed policy change re-evaluates the gate and fires onDidChange', async () => {

--- a/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
+++ b/src/vs/workbench/services/policies/test/browser/accountPolicyService.test.ts
@@ -419,7 +419,8 @@ suite('AccountPolicyService', () => {
 
 	test('boot race: gate is fail-closed until async managed policy service resolves', async () => {
 		// Simulate the IPC boundary: managed service only knows about its policies AFTER
-		// `updatePolicyDefinitions` has resolved. Before that, `getPolicyValue` returns undefined.
+		// `updatePolicyDefinitions` has been called by the MultiplexPolicyService.
+		// Before that, `getPolicyValue` returns undefined.
 		class AsyncManagedPolicyService extends FakeManagedPolicyService {
 			private _seeded = false;
 			private readonly _seedValue: string;
@@ -433,13 +434,12 @@ suite('AccountPolicyService', () => {
 				}
 				return super.getPolicyValue(name);
 			}
-			protected override async _updatePolicyDefinitions(): Promise<void> {
-				// Yield, then seed (mimics IPC round-trip).
+			async seed(): Promise<void> {
+				// Simulate the MultiplexPolicyService calling updatePolicyDefinitions,
+				// which in production triggers the IPC round-trip and then fires onDidChange.
 				await new Promise(resolve => setTimeout(resolve, 0));
-				if (!this._seeded) {
-					this._seeded = true;
-					this.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, this._seedValue);
-				}
+				this._seeded = true;
+				this.setPolicy(APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, this._seedValue);
 			}
 		}
 
@@ -454,8 +454,15 @@ suite('AccountPolicyService', () => {
 		const config = disposables.add(new PolicyConfiguration(defaultConfiguration, service, new NullLogService()));
 		await config.initialize();
 
-		// Gate must reflect the admin policy that was unknown at construction time;
-		// without the boot-race fix, this would be Inactive (false-open).
+		// Before managed service resolves, the gate sees no approved-org policy → Inactive.
+		assert.strictEqual(service.gateInfo.state, AccountPolicyGateState.Inactive);
+
+		// Simulate the multiplex seeding the managed service (IPC completes).
+		// This fires onDidChange on the managed service, which AccountPolicyService
+		// listens to and re-evaluates the gate.
+		await managed.seed();
+
+		// Gate must now reflect the admin policy; account is NOT in 'OnlyOtherOrg'.
 		assert.strictEqual(service.gateInfo.state, AccountPolicyGateState.Restricted);
 		assert.strictEqual(service.gateInfo.reason, AccountPolicyGateUnsatisfiedReason.OrgNotApproved);
 	});

--- a/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/fixtureUtils.ts
@@ -420,6 +420,7 @@ export function createEditorServices(disposables: DisposableStore, options?: Cre
 		onDidChangeDefaultAccount: new Emitter<null>().event,
 		onDidChangePolicyData: new Emitter<null>().event,
 		policyData: null,
+		currentDefaultAccount: null,
 		copilotTokenInfo: null,
 		onDidChangeCopilotTokenInfo: new Emitter<null>().event,
 		getDefaultAccount: async () => null,

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -812,6 +812,7 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs = observableValue({}, false);
 
 	markAnonymousRateLimited(): void { }
+	setForceHidden(): void { }
 
 	readonly previewFeaturesDisabled = false;
 	readonly clientByokEnabled = false;

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -812,7 +812,7 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	readonly anonymousObs = observableValue({}, false);
 
 	markAnonymousRateLimited(): void { }
-	setForceHidden(): void { }
+	setForceHidden(_hidden: boolean): void { }
 
 	readonly previewFeaturesDisabled = false;
 	readonly clientByokEnabled = false;

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -193,6 +193,9 @@ registerSingleton(IAllowedMcpServersService, AllowedMcpServersService, Instantia
 // Default Account
 import './services/accounts/browser/defaultAccount.js';
 
+// Account Policy Gate
+import './services/policies/browser/accountPolicyGate.contribution.js';
+
 // Telemetry
 import './contrib/telemetry/browser/telemetry.contribution.js';
 


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-internalbacklog/issues/6435

Introduces an **Account Policy Gate** that disables AI/chat features until:

1. The user is signed into a GitHub account in an admin-approved organization, AND
2. Account-side policy data has resolved.

Activated by the `ChatApprovedAccountOrganizations` MDM policy (JSON array of org logins; `*` is a wildcard). When unset, behavior is unchanged. **Fail-closed**: any unresolved state restricts.

## How it works

- **`AccountPolicyService.computeGateInfo()`** returns `{ state, reason, approvedOrganizations }` with reasons `noAccount` / `wrongProvider` / `orgNotApproved` / `policyNotResolved` (transient).
- **Three enforcement layers**: `setForceHidden(true)` on `IChatEntitlementService`, the `chatAccountPolicyGateActive` context key wrapping the chat view's `when` clause, and `restrictedValue` on policy definitions as defense-in-depth.
- **Sessions app**: full-screen `SessionsPolicyBlockedOverlay` (Sign In button + approved-org list) for the wrong-account state; defers to the welcome screen for noAccount/wrongProvider; progress bar for the transient loading state.
- **Core VS Code**: workbench notification with Sign In + Learn More actions; deferred until the default account resolves to avoid startup flash.
- **Policy Diagnostics**: new "Account Policy Gate" section.

## Validation

-  tsc + valid-layers-check clean
-  16/16 unit tests pass
-  Manual testing: gate blocks chat, notification shows, account swap re-triggers, sessions overlay renders correctly

## Manual test

```bash
defaults write com.microsoft.VSCodeInsiders ChatApprovedAccountOrganizations -string '["my-org"]'
# Restart, then run "Developer: Policy Diagnostics"
defaults delete com.microsoft.VSCodeInsiders ChatApprovedAccountOrganizations
```
