### PR TITLE
Defer EditorMouseEvent position computation

### DIFF
--- a/src/vs/editor/browser/editorDom.ts
+++ b/src/vs/editor/browser/editorDom.ts
@@ -119,21 +119,30 @@ export class EditorMouseEvent extends StandardMouseEvent {
 	/**
 	 * Editor's coordinates relative to the whole document.
 	 */
-	public readonly editorPos: EditorPagePosition;
+	public get editorPos(): EditorPagePosition {
+		this._editorPos ??= createEditorPagePosition(this._editorViewDomNode);
+		return this._editorPos;
+	}
+	private _editorPos: EditorPagePosition | undefined;
 
 	/**
 	 * Coordinates relative to the (top;left) of the editor.
 	 * *NOTE*: These coordinates are preferred because they take into account transformations applied to the editor.
 	 * *NOTE*: These coordinates could be negative if the mouse position is outside the editor.
-	 */
-	public readonly relativePos: CoordinatesRelativeToEditor;
+	*/
+	public get relativePos(): CoordinatesRelativeToEditor {
+		this._relativePos ??= createCoordinatesRelativeToEditor(this._editorViewDomNode, this.editorPos, this.pos);
+		return this._relativePos;
+	}
+	private _relativePos: CoordinatesRelativeToEditor | undefined;
+
+	private readonly _editorViewDomNode: HTMLElement;
 
 	constructor(e: MouseEvent, isFromPointerCapture: boolean, editorViewDomNode: HTMLElement) {
 		super(dom.getWindow(editorViewDomNode), e);
 		this.isFromPointerCapture = isFromPointerCapture;
 		this.pos = new PageCoordinates(this.posx, this.posy);
-		this.editorPos = createEditorPagePosition(editorViewDomNode);
-		this.relativePos = createCoordinatesRelativeToEditor(editorViewDomNode, this.editorPos, this.pos);
+		this._editorViewDomNode = editorViewDomNode;
 	}
 }
 


### PR DESCRIPTION
The `editorPos` and `relativePos` properties cause re-layouts because they read the target's bounding client rect. Since very few listeners actually need this, I think we should try to defer these because right now it happens during tons of mouse events

There's a chance this could cause issues if the element is moved during the handler itself but the same would happen if checking the target's dom node directly. Testing looks ok but let's see if there are any weird edge cases I missed

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
