### PR TITLE
sessions: respect reduced motion in chat list spinner

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -43,11 +43,11 @@ import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsListModelService } from './sessionsListModelService.js';
-import { getSessionStatusIcon, groupSessionsForList, ISessionSection, SessionsGrouping, SessionsSorting } from './sessionsListHelpers.js';
+import { getSessionStatusIcon, groupSessionsForList, type ISessionSection, SessionsGrouping, SessionsSorting } from './sessionsListHelpers.js';
 
 const $ = DOM.$;
 
-export { getSessionStatusIcon, groupByDate, groupByWorkspace, groupSessionsForList, ISessionSection, SessionsGrouping, SessionsSorting, sortSessions } from './sessionsListHelpers.js';
+export { getSessionStatusIcon, groupByDate, groupByWorkspace, groupSessionsForList, type ISessionSection, SessionsGrouping, SessionsSorting, sortSessions } from './sessionsListHelpers.js';
 
 export const SessionItemToolbarMenuId = new MenuId('SessionItemToolbar');
 export const SessionItemContextMenuId = new MenuId('SessionItemContextMenu');

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -16,7 +16,7 @@ import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/fi
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { IReader, autorun } from '../../../../../base/common/observable.js';
-import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
 import { localize } from '../../../../../nls.js';
@@ -40,10 +40,14 @@ import { Separator } from '../../../../../base/common/actions.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsListModelService } from './sessionsListModelService.js';
+import { getSessionStatusIcon, groupSessionsForList, ISessionSection, SessionsGrouping, SessionsSorting } from './sessionsListHelpers.js';
 
 const $ = DOM.$;
+
+export { getSessionStatusIcon, groupByDate, groupByWorkspace, groupSessionsForList, ISessionSection, SessionsGrouping, SessionsSorting, sortSessions } from './sessionsListHelpers.js';
 
 export const SessionItemToolbarMenuId = new MenuId('SessionItemToolbar');
 export const SessionItemContextMenuId = new MenuId('SessionItemContextMenu');
@@ -54,22 +58,6 @@ export const IsSessionReadContext = new RawContextKey<boolean>('sessionItem.isRe
 export const SessionSectionTypeContext = new RawContextKey<string>('sessionSection.type', '');
 
 //#region Types
-
-export enum SessionsGrouping {
-	Workspace = 'workspace',
-	Date = 'date',
-}
-
-export enum SessionsSorting {
-	Created = 'created',
-	Updated = 'updated',
-}
-
-export interface ISessionSection {
-	readonly id: string;
-	readonly label: string;
-	readonly sessions: ISession[];
-}
 
 export interface ISessionShowMore {
 	readonly showMore: true;
@@ -172,6 +160,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly contextKeyService: IContextKeyService,
 		private readonly markdownRendererService: IMarkdownRendererService,
 		private readonly hoverService: IHoverService,
+		private readonly accessibilityService: IAccessibilityService,
 	) { }
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
@@ -456,20 +445,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	}
 
 	private getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
-		switch (status) {
-			case SessionStatus.InProgress: return { ...ThemeIcon.modify(Codicon.loading, 'spin'), color: themeColorFromId('textLink.foreground') };
-			case SessionStatus.NeedsInput: return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
-			case SessionStatus.Error: return { ...Codicon.error, color: themeColorFromId('errorForeground') };
-			default:
-				if (pullRequestIcon) {
-					return pullRequestIcon;
-				}
-
-				if (!isRead && !isArchived) {
-					return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
-				}
-				return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
-		}
+		return getSessionStatusIcon(status, isRead, isArchived, this.accessibilityService.isMotionReduced(), pullRequestIcon);
 	}
 
 	private getWorkspaceBadgeLabel(workspace: ISessionWorkspace): string | undefined {
@@ -694,6 +670,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
 		super();
 
@@ -720,6 +697,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			contextKeyService,
 			markdownRendererService,
 			hoverService,
+			this.accessibilityService,
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();
@@ -840,6 +818,8 @@ export class SessionsList extends Disposable implements ISessionsList {
 				this.update();
 			}
 		}));
+
+		this._register(this.accessibilityService.onDidChangeReducedMotion(() => this.tree.rerender()));
 
 		this.refresh();
 	}
@@ -1224,132 +1204,6 @@ function getFirstApprovalAcrossChats(approvalModel: AgentSessionApprovalModel, s
 		}
 	}
 	return oldest;
-}
-
-//#endregion
-
-//#region Sorting & Grouping Helpers
-
-export function sortSessions(sessions: ISession[], sorting: SessionsSorting): ISession[] {
-	return [...sessions].sort((a, b) => {
-		if (sorting === SessionsSorting.Updated) {
-			return b.updatedAt.get().getTime() - a.updatedAt.get().getTime();
-		}
-		return b.createdAt.getTime() - a.createdAt.getTime();
-	});
-}
-
-export function groupSessionsForList(
-	sessions: ISession[],
-	grouping: SessionsGrouping,
-	sorting: SessionsSorting,
-	isSessionPinned: (session: ISession) => boolean,
-): ISessionSection[] {
-	const sorted = sortSessions(sessions, sorting);
-
-	// Archived always wins over pinned so done sessions stay grouped together.
-	const pinned: ISession[] = [];
-	const archived: ISession[] = [];
-	const regular: ISession[] = [];
-	for (const session of sorted) {
-		if (session.isArchived.get()) {
-			archived.push(session);
-		} else if (isSessionPinned(session)) {
-			pinned.push(session);
-		} else {
-			regular.push(session);
-		}
-	}
-
-	const sections: ISessionSection[] = [];
-	if (pinned.length > 0) {
-		sections.push({ id: 'pinned', label: localize('pinned', "Pinned"), sessions: pinned });
-	}
-
-	sections.push(...(grouping === SessionsGrouping.Workspace
-		? groupByWorkspace(regular)
-		: groupByDate(regular, sorting)));
-
-	if (archived.length > 0) {
-		sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
-	}
-
-	return sections;
-}
-
-export function groupByWorkspace(sessions: ISession[]): ISessionSection[] {
-	const groups = new Map<string, ISession[]>();
-	for (const session of sessions) {
-		const workspace = session.workspace.get();
-		const label = workspace?.label || localize('unknown', "Unknown");
-		let group = groups.get(label);
-		if (!group) {
-			group = [];
-			groups.set(label, group);
-		}
-		group.push(session);
-	}
-
-	const unknownWorkspaceLabel = localize('unknown', "Unknown");
-	const order = [...groups.keys()]
-		.filter(k => k !== unknownWorkspaceLabel)
-		.sort((a, b) => a.localeCompare(b));
-
-	const result: ISessionSection[] = order.map(label => ({
-		id: `workspace:${label}`,
-		label,
-		sessions: groups.get(label)!,
-	}));
-
-	// "Unknown Workspace" always at the bottom
-	const unknownWorkspace = groups.get(unknownWorkspaceLabel);
-	if (unknownWorkspace) {
-		result.push({ id: `workspace:${unknownWorkspaceLabel}`, label: unknownWorkspaceLabel, sessions: unknownWorkspace });
-	}
-
-	return result;
-}
-
-export function groupByDate(sessions: ISession[], sorting: SessionsSorting): ISessionSection[] {
-	const now = new Date();
-	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-	const startOfYesterday = startOfToday - 86_400_000;
-	const startOfWeek = startOfToday - 7 * 86_400_000;
-
-	const today: ISession[] = [];
-	const yesterday: ISession[] = [];
-	const week: ISession[] = [];
-	const older: ISession[] = [];
-
-	for (const session of sessions) {
-		const time = sorting === SessionsSorting.Updated
-			? session.updatedAt.get().getTime()
-			: session.createdAt.getTime();
-
-		if (time >= startOfToday) {
-			today.push(session);
-		} else if (time >= startOfYesterday) {
-			yesterday.push(session);
-		} else if (time >= startOfWeek) {
-			week.push(session);
-		} else {
-			older.push(session);
-		}
-	}
-
-	const sections: ISessionSection[] = [];
-	const addGroup = (id: string, label: string, groupSessions: ISession[]) => {
-		if (groupSessions.length > 0) {
-			sections.push({ id, label, sessions: groupSessions });
-		}
-	};
-
-	addGroup('today', localize('today', "Today"), today);
-	addGroup('yesterday', localize('yesterday', "Yesterday"), yesterday);
-	addGroup('thisWeek', localize('lastSevenDays', "Last 7 Days"), week);
-	addGroup('older', localize('older', "Older"), older);
-
-	return sections;
 }
 
 //#endregion

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsListHelpers.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsListHelpers.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
+
+export enum SessionsGrouping {
+	Workspace = 'workspace',
+	Date = 'date',
+}
+
+export enum SessionsSorting {
+	Created = 'created',
+	Updated = 'updated',
+}
+
+export interface ISessionSection {
+	readonly id: string;
+	readonly label: string;
+	readonly sessions: ISession[];
+}
+
+export function getSessionStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, motionReduced: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
+	switch (status) {
+		case SessionStatus.InProgress: {
+			const loadingIcon = motionReduced ? Codicon.loading : ThemeIcon.modify(Codicon.loading, 'spin');
+			return { ...loadingIcon, color: themeColorFromId('textLink.foreground') };
+		}
+		case SessionStatus.NeedsInput: return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
+		case SessionStatus.Error: return { ...Codicon.error, color: themeColorFromId('errorForeground') };
+		default:
+			if (pullRequestIcon) {
+				return pullRequestIcon;
+			}
+
+			if (!isRead && !isArchived) {
+				return { ...Codicon.circleFilled, color: themeColorFromId('textLink.foreground') };
+			}
+			return { ...Codicon.circleSmallFilled, color: themeColorFromId('agentSessionReadIndicator.foreground') };
+	}
+}
+
+export function sortSessions(sessions: ISession[], sorting: SessionsSorting): ISession[] {
+	return [...sessions].sort((a, b) => {
+		if (sorting === SessionsSorting.Updated) {
+			return b.updatedAt.get().getTime() - a.updatedAt.get().getTime();
+		}
+		return b.createdAt.getTime() - a.createdAt.getTime();
+	});
+}
+
+export function groupSessionsForList(
+	sessions: ISession[],
+	grouping: SessionsGrouping,
+	sorting: SessionsSorting,
+	isSessionPinned: (session: ISession) => boolean,
+): ISessionSection[] {
+	const sorted = sortSessions(sessions, sorting);
+
+	// Archived always wins over pinned so done sessions stay grouped together.
+	const pinned: ISession[] = [];
+	const archived: ISession[] = [];
+	const regular: ISession[] = [];
+	for (const session of sorted) {
+		if (session.isArchived.get()) {
+			archived.push(session);
+		} else if (isSessionPinned(session)) {
+			pinned.push(session);
+		} else {
+			regular.push(session);
+		}
+	}
+
+	const sections: ISessionSection[] = [];
+	if (pinned.length > 0) {
+		sections.push({ id: 'pinned', label: localize('pinned', "Pinned"), sessions: pinned });
+	}
+
+	sections.push(...(grouping === SessionsGrouping.Workspace
+		? groupByWorkspace(regular)
+		: groupByDate(regular, sorting)));
+
+	if (archived.length > 0) {
+		sections.push({ id: 'archived', label: localize('archived', "Done"), sessions: archived });
+	}
+
+	return sections;
+}
+
+export function groupByWorkspace(sessions: ISession[]): ISessionSection[] {
+	const groups = new Map<string, ISession[]>();
+	for (const session of sessions) {
+		const workspace = session.workspace.get();
+		const label = workspace?.label || localize('unknown', "Unknown");
+		let group = groups.get(label);
+		if (!group) {
+			group = [];
+			groups.set(label, group);
+		}
+		group.push(session);
+	}
+
+	const unknownWorkspaceLabel = localize('unknown', "Unknown");
+	const order = [...groups.keys()]
+		.filter(k => k !== unknownWorkspaceLabel)
+		.sort((a, b) => a.localeCompare(b));
+
+	const result: ISessionSection[] = order.map(label => ({
+		id: `workspace:${label}`,
+		label,
+		sessions: groups.get(label)!,
+	}));
+
+	// "Unknown Workspace" always at the bottom
+	const unknownWorkspace = groups.get(unknownWorkspaceLabel);
+	if (unknownWorkspace) {
+		result.push({ id: `workspace:${unknownWorkspaceLabel}`, label: unknownWorkspaceLabel, sessions: unknownWorkspace });
+	}
+
+	return result;
+}
+
+export function groupByDate(sessions: ISession[], sorting: SessionsSorting): ISessionSection[] {
+	const now = new Date();
+	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+	const startOfYesterday = startOfToday - 86_400_000;
+	const startOfWeek = startOfToday - 7 * 86_400_000;
+
+	const today: ISession[] = [];
+	const yesterday: ISession[] = [];
+	const week: ISession[] = [];
+	const older: ISession[] = [];
+
+	for (const session of sessions) {
+		const time = sorting === SessionsSorting.Updated
+			? session.updatedAt.get().getTime()
+			: session.createdAt.getTime();
+
+		if (time >= startOfToday) {
+			today.push(session);
+		} else if (time >= startOfYesterday) {
+			yesterday.push(session);
+		} else if (time >= startOfWeek) {
+			week.push(session);
+		} else {
+			older.push(session);
+		}
+	}
+
+	const sections: ISessionSection[] = [];
+	const addGroup = (id: string, label: string, groupSessions: ISession[]) => {
+		if (groupSessions.length > 0) {
+			sections.push({ id, label, sessions: groupSessions });
+		}
+	};
+
+	addGroup('today', localize('today', "Today"), today);
+	addGroup('yesterday', localize('yesterday', "Yesterday"), yesterday);
+	addGroup('thisWeek', localize('lastSevenDays', "Last 7 Days"), week);
+	addGroup('older', localize('older', "Older"), older);
+
+	return sections;
+}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -19,7 +19,7 @@ import { IChatWidgetService } from '../../../../../workbench/contrib/chat/browse
 import { AUX_WINDOW_GROUP } from '../../../../../workbench/services/editor/common/editorService.js';
 import { SessionsCategories } from '../../../../common/categories.js';
 import { ChatSessionProviderIdContext, IsActiveSessionArchivedContext, IsNewChatSessionContext, SessionsWelcomeVisibleContext } from '../../../../common/contextkeys.js';
-import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, ISessionSection } from './sessionsList.js';
+import { SessionItemToolbarMenuId, SessionItemContextMenuId, SessionSectionToolbarMenuId, SessionSectionTypeContext, IsSessionPinnedContext, IsSessionArchivedContext, IsSessionReadContext, SessionsGrouping, SessionsSorting, type ISessionSection } from './sessionsList.js';
 import { ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
 import { IsWorkspaceGroupCappedContext, SessionsViewFilterOptionsSubMenu, SessionsViewFilterSubMenu, SessionsViewGroupingContext, SessionsViewId, SessionsView, SessionsViewSortingContext } from './sessionsView.js';
 import { SessionsViewId as NewChatViewId, NewChatViewPane } from '../../../chat/browser/newChatViewPane.js';

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -6,10 +6,11 @@
 import assert from 'assert';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { observableValue } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { IChat, ISession, SessionStatus } from '../../../../services/sessions/common/session.js';
-import { groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsList.js';
+import { getSessionStatusIcon, groupByWorkspace, groupSessionsForList, sortSessions, SessionsGrouping, SessionsSorting } from '../../browser/views/sessionsListHelpers.js';
 
 function createSession(id: string, opts: {
 	workspaceLabel?: string;
@@ -183,6 +184,25 @@ suite('Sessions - SessionsList Helpers', () => {
 
 			assert.deepStrictEqual(sections.map(section => section.id), ['archived']);
 			assert.deepStrictEqual(sections[0].sessions.map(session => session.sessionId), ['archived-pinned']);
+		});
+	});
+
+	suite('getSessionStatusIcon', () => {
+
+		test('uses static loading icon when reduced motion is enabled', () => {
+			const icon = getSessionStatusIcon(SessionStatus.InProgress, true, false, true);
+
+			assert.strictEqual(icon.id, Codicon.loading.id);
+			assert.strictEqual(ThemeIcon.getModifier(icon), undefined);
+			assert.strictEqual(icon.color?.id, 'textLink.foreground');
+		});
+
+		test('uses spinning loading icon when reduced motion is disabled', () => {
+			const icon = getSessionStatusIcon(SessionStatus.InProgress, true, false, false);
+
+			assert.strictEqual(icon.id, `${Codicon.loading.id}~spin`);
+			assert.strictEqual(ThemeIcon.getModifier(icon), 'spin');
+			assert.strictEqual(icon.color?.id, 'textLink.foreground');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- use the static loading codicon for in-progress sessions when reduced motion is enabled
- rerender the sessions list when the reduced-motion preference changes so existing rows update immediately
- move pure sessions list helpers into a CSS-free module and cover the reduced-motion icon behavior in tests

## Context
Follow-up to #311440 so the animated sessions app chat list spinner respects reduced motion preferences.