### PR TITLE
Improve tunnel connection reliability: malformed-frame hardening, auth short-circuit, host-online resume

### DIFF
--- a/src/vs/platform/agentHost/browser/webSocketClientTransport.ts
+++ b/src/vs/platform/agentHost/browser/webSocketClientTransport.ts
@@ -96,7 +96,24 @@ export class WebSocketClientTransport extends Disposable implements IClientTrans
 
 			// Wire up long-lived listeners after connection
 			ws.addEventListener('message', (event: MessageEvent) => {
-				const text = typeof event.data === 'string' ? event.data : '';
+				if (typeof event.data !== 'string') {
+					this._malformedFrames++;
+					if (this._malformedFrames <= MALFORMED_FRAMES_LOG_CAP) {
+						const dataType = event.data instanceof ArrayBuffer ? 'ArrayBuffer' : event.data instanceof Blob ? 'Blob' : typeof event.data;
+						const byteLen = event.data instanceof ArrayBuffer ? event.data.byteLength : event.data instanceof Blob ? event.data.size : 0;
+						console.warn(
+							`[WebSocketClientTransport] Non-string frame #${this._malformedFrames} (type=${dataType}, bytes=${byteLen})`
+						);
+					}
+					if (this._malformedFrames > MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD) {
+						console.warn(
+							`[WebSocketClientTransport] Malformed frame threshold exceeded; forcing close of ${this._address}.`
+						);
+						this._ws?.close(4002, 'malformed-frames');
+					}
+					return;
+				}
+				const text = event.data;
 				let message: IProtocolMessage;
 				try {
 					message = JSON.parse(text) as IProtocolMessage;

--- a/src/vs/platform/agentHost/browser/webSocketClientTransport.ts
+++ b/src/vs/platform/agentHost/browser/webSocketClientTransport.ts
@@ -11,6 +11,7 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import { connectionTokenQueryName } from '../../../base/common/network.js';
 import type { IAhpServerNotification, IJsonRpcResponse, IProtocolMessage } from '../common/state/sessionProtocol.js';
 import type { IClientTransport } from '../common/state/sessionTransport.js';
+import { MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD, MALFORMED_FRAMES_LOG_CAP } from '../common/transportConstants.js';
 
 // ---- Client transport -------------------------------------------------------
 
@@ -31,6 +32,7 @@ export class WebSocketClientTransport extends Disposable implements IClientTrans
 	readonly onOpen = this._onOpen.event;
 
 	private _ws: WebSocket | undefined;
+	private _malformedFrames = 0;
 
 	get isOpen(): boolean {
 		return this._ws?.readyState === WebSocket.OPEN;
@@ -94,13 +96,28 @@ export class WebSocketClientTransport extends Disposable implements IClientTrans
 
 			// Wire up long-lived listeners after connection
 			ws.addEventListener('message', (event: MessageEvent) => {
+				const text = typeof event.data === 'string' ? event.data : '';
+				let message: IProtocolMessage;
 				try {
-					const text = typeof event.data === 'string' ? event.data : '';
-					const message = JSON.parse(text) as IProtocolMessage;
-					this._onMessage.fire(message);
-				} catch {
-					// Malformed message - drop.
+					message = JSON.parse(text) as IProtocolMessage;
+				} catch (err) {
+					this._malformedFrames++;
+					if (this._malformedFrames <= MALFORMED_FRAMES_LOG_CAP) {
+						const preview = text.length > 80 ? text.slice(0, 80) + '…' : text;
+						console.warn(
+							`[WebSocketClientTransport] Malformed frame #${this._malformedFrames} (len=${text.length}): ${preview}`,
+							err instanceof Error ? err.message : String(err)
+						);
+					}
+					if (this._malformedFrames > MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD) {
+						console.warn(
+							`[WebSocketClientTransport] Malformed frame threshold exceeded; forcing close of ${this._address}.`
+						);
+						this._ws?.close(4002, 'malformed-frames');
+					}
+					return;
 				}
+				this._onMessage.fire(message);
 			});
 
 			ws.addEventListener('close', () => {

--- a/src/vs/platform/agentHost/common/transportConstants.ts
+++ b/src/vs/platform/agentHost/common/transportConstants.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Shared constants for agent-host protocol transports. Kept in a common
+ * module so browser, electron-browser, and sessions-layer transports all
+ * apply the same malformed-frame policy without duplicating values.
+ */
+
+/**
+ * Force-close the transport once more than this many malformed inbound
+ * frames have been observed. A handful of bad frames can be tolerated
+ * (e.g. a proxy momentarily corrupts a message), but a sustained stream
+ * almost always indicates a protocol mismatch or a broken relay, and is
+ * best surfaced as a hard disconnect so the reconnect loop can take over.
+ */
+export const MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD = 10;
+
+/** Cap warn-level logs per connection for malformed frames to avoid spam. */
+export const MALFORMED_FRAMES_LOG_CAP = 5;

--- a/src/vs/platform/agentHost/electron-browser/tunnelRelayTransport.ts
+++ b/src/vs/platform/agentHost/electron-browser/tunnelRelayTransport.ts
@@ -8,6 +8,7 @@ import { Disposable } from '../../../base/common/lifecycle.js';
 import type { IAhpServerNotification, IJsonRpcResponse, IProtocolMessage } from '../common/state/sessionProtocol.js';
 import type { IProtocolTransport } from '../common/state/sessionTransport.js';
 import type { ITunnelAgentHostMainService, ITunnelRelayMessage } from '../common/tunnelAgentHost.js';
+import { MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD, MALFORMED_FRAMES_LOG_CAP } from '../common/transportConstants.js';
 
 /**
  * A protocol transport that relays messages through the shared process
@@ -24,6 +25,8 @@ export class TunnelRelayTransport extends Disposable implements IProtocolTranspo
 	private readonly _onClose = this._register(new Emitter<void>());
 	readonly onClose = this._onClose.event;
 
+	private _malformedFrames = 0;
+
 	constructor(
 		private readonly _connectionId: string,
 		private readonly _tunnelService: ITunnelAgentHostMainService,
@@ -32,14 +35,28 @@ export class TunnelRelayTransport extends Disposable implements IProtocolTranspo
 
 		// Listen for relay messages from the shared process
 		this._register(this._tunnelService.onDidRelayMessage((msg: ITunnelRelayMessage) => {
-			if (msg.connectionId === this._connectionId) {
-				try {
-					const parsed = JSON.parse(msg.data) as IProtocolMessage;
-					this._onMessage.fire(parsed);
-				} catch {
-					// Malformed message — drop
-				}
+			if (msg.connectionId !== this._connectionId) {
+				return;
 			}
+			let parsed: IProtocolMessage;
+			try {
+				parsed = JSON.parse(msg.data) as IProtocolMessage;
+			} catch (err) {
+				this._malformedFrames++;
+				if (this._malformedFrames <= MALFORMED_FRAMES_LOG_CAP) {
+					const preview = msg.data.length > 80 ? msg.data.slice(0, 80) + '…' : msg.data;
+					console.warn(
+						`[TunnelRelayTransport] Malformed frame #${this._malformedFrames} (len=${msg.data.length}): ${preview}`,
+						err instanceof Error ? err.message : String(err)
+					);
+				}
+				if (this._malformedFrames > MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD) {
+					console.warn('[TunnelRelayTransport] Malformed frame threshold exceeded; closing relay.');
+					this._tunnelService.disconnect(this._connectionId).catch(() => { /* best effort */ });
+				}
+				return;
+			}
+			this._onMessage.fire(parsed);
 		}));
 
 		// Listen for relay close

--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -124,6 +124,7 @@ export type TunnelConnectErrorCategory =
 export type TunnelConnectFailureReason =
 	| 'hostOffline'
 	| 'maxAttemptsReached'
+	| 'auth'
 	| 'authExpired';
 
 type TunnelConnectAttemptEvent = {
@@ -141,7 +142,7 @@ type TunnelConnectAttemptClassification = {
 	attempt: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Attempt number within the current connect session (1-based).' };
 	durationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration of this individual attempt in milliseconds.' };
 	success: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether this individual attempt succeeded.' };
-	errorCategory: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Category of error when the attempt failed (relayConnectionFailed, auth, network, other); empty on success.' };
+	errorCategory: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Category of error when the attempt failed (relayConnectionFailed, auth, authExpired, network, other); empty on success.' };
 };
 
 export function logTunnelConnectAttempt(telemetryService: ITelemetryService, data: { isReconnect: boolean; attempt: number; durationMs: number; success: boolean; errorCategory?: TunnelConnectErrorCategory }): void {
@@ -169,7 +170,7 @@ type TunnelConnectResolvedClassification = {
 	totalAttempts: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total number of attempts made before resolution.' };
 	totalDurationMs: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Total elapsed time from session start to resolution in milliseconds.' };
 	success: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the connect session ultimately succeeded.' };
-	failureReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Reason the session terminated without connecting (hostOffline, maxAttemptsReached); empty on success.' };
+	failureReason: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Reason the session terminated without connecting (hostOffline, maxAttemptsReached, auth, authExpired); empty on success.' };
 };
 
 export function logTunnelConnectResolved(telemetryService: ITelemetryService, data: { isReconnect: boolean; totalAttempts: number; totalDurationMs: number; success: boolean; failureReason?: TunnelConnectFailureReason }): void {

--- a/src/vs/sessions/common/sessionsTelemetry.ts
+++ b/src/vs/sessions/common/sessionsTelemetry.ts
@@ -114,8 +114,17 @@ export function logChangesViewReviewCommentAdded(telemetryService: ITelemetrySer
 
 // --- Tunnel agent host connect ---
 
-export type TunnelConnectErrorCategory = 'relayConnectionFailed' | 'auth' | 'network' | 'other';
-export type TunnelConnectFailureReason = 'hostOffline' | 'maxAttemptsReached';
+export type TunnelConnectErrorCategory =
+	| 'relayConnectionFailed'
+	| 'auth'
+	| 'authExpired'
+	| 'network'
+	| 'other';
+
+export type TunnelConnectFailureReason =
+	| 'hostOffline'
+	| 'maxAttemptsReached'
+	| 'authExpired';
 
 type TunnelConnectAttemptEvent = {
 	isReconnect: boolean;

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -15,7 +15,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
-import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
+import { AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory, TunnelConnectFailureReason } from '../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
@@ -34,6 +34,9 @@ const RECONNECT_MAX_DELAY = 30_000;
  */
 const RECONNECT_MAX_ATTEMPTS = 10;
 
+/** Minimum gap between wake/visibility-triggered resumes. */
+const RESUME_RATE_LIMIT_MS = 10_000;
+
 export class TunnelAgentHostContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'sessions.contrib.tunnelAgentHostContribution';
@@ -51,6 +54,8 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private readonly _reconnectAttempts = new Map<string, number>();
 	/** Addresses whose auto-reconnect loop has paused after too many failures. */
 	private readonly _reconnectPaused = new Set<string>();
+	/** Addresses paused specifically because the remote host is offline. */
+	private readonly _hostOfflinePaused = new Set<string>();
 	/** Timestamp of the last wake-triggered resume, to rate-limit rapid tab toggles. */
 	private _lastResumeAt = 0;
 
@@ -91,13 +96,14 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 			this._pruneReconnectState();
 		}));
 
-		// Re-run discovery when a GitHub session becomes available
-		// (e.g. after the walkthrough completes sign-in).
+		// Re-run discovery when a GitHub session becomes available,
+		// and tear down tunnel state bound to that provider if its session
+		// is removed.
 		this._register(this._authenticationService.onDidChangeSessions(e => {
-			if (e.providerId === 'github') {
-				this._logService.info('[TunnelAgentHost] GitHub sessions changed, retrying discovery...');
-				this._silentStatusCheck();
+			if (e.providerId !== 'github') {
+				return;
 			}
+			this._handleSessionsChange(e);
 		}));
 
 		// Wake-triggered retry: when the browser regains connectivity or
@@ -263,12 +269,22 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				this._finishConnectAttempt(address, { success: true, attemptNumber, attemptStart, session, isReconnect });
 			} catch (err) {
 				this._logService.warn(`[TunnelAgentHost] Connect to ${cached.name} failed:`, err);
+				const errorCategory = this._categorizeError(err);
 				this._finishConnectAttempt(address, { success: false, attemptNumber, attemptStart, session, isReconnect, error: err });
 				// Clear the pending-connect entry BEFORE deciding what to do
 				// next; otherwise `_scheduleReconnect`'s in-flight guard
 				// (`_pendingConnects.has(address)`) would silently bail and
 				// we'd never re-arm the timer, leaving the tunnel stuck.
 				this._pendingConnects.delete(address);
+
+				// Auth failures are not worth retrying — a fresh token must
+				// be acquired by the user or by a session-change event. Pause
+				// immediately and let `_handleSessionsChange` resume us when
+				// a new session appears.
+				if (errorCategory === 'authExpired' || errorCategory === 'auth') {
+					this._pauseReconnect(address, 'authExpired');
+					throw err;
+				}
 
 				const hostOnline = await this._probeHostOnline(cached.tunnelId);
 				if (hostOnline === false) {
@@ -450,6 +466,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	private _clearReconnectBackoff(address: string): void {
 		this._reconnectAttempts.delete(address);
 		this._reconnectPaused.delete(address);
+		this._hostOfflinePaused.delete(address);
 	}
 
 	/** Drop all reconnect + telemetry state for an address (e.g. on removal). */
@@ -460,6 +477,39 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	}
 
 	/**
+	 * React to auth session add/remove. Additions re-run discovery (a fresh
+	 * token may unblock a previously auth-paused tunnel). Removals drop any
+	 * tunnel state that depended on that provider — otherwise we'd sit on a
+	 * stale auth pause forever, or hammer a provider whose session is gone.
+	 */
+	private _handleSessionsChange(e: { providerId: string; label: string; event: AuthenticationSessionsChangeEvent }): void {
+		const added = (e.event.added?.length ?? 0) > 0;
+		const removed = (e.event.removed?.length ?? 0) > 0;
+
+		if (removed) {
+			const cached = this._tunnelService.getCachedTunnels();
+			for (const tunnel of cached) {
+				if (tunnel.authProvider !== e.providerId) {
+					continue;
+				}
+				const address = `${TUNNEL_ADDRESS_PREFIX}${tunnel.tunnelId}`;
+				this._logService.info(
+					`[TunnelAgentHost] Auth session removed for ${e.providerId}; tearing down ${address}.`
+				);
+				this._resetReconnectState(address);
+				// Best-effort disconnect — the transport may already be dead.
+				this._tunnelService.disconnect(address).catch(() => { /* ignore */ });
+			}
+		}
+
+		if (added) {
+			this._logService.info(`[TunnelAgentHost] ${e.providerId} session added; resuming reconnects and rediscovering.`);
+			this._resumeReconnects('sessionAdded');
+			this._silentStatusCheck();
+		}
+	}
+
+	/**
 	 * Stop auto-reconnecting for an address until a wake/online/visibility
 	 * event resumes us, and close out any active telemetry session.
 	 */
@@ -467,9 +517,14 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		this._cancelReconnect(address);
 		this._reconnectAttempts.delete(address);
 		this._reconnectPaused.add(address);
+		if (reason === 'hostOffline') {
+			this._hostOfflinePaused.add(address);
+		} else {
+			this._hostOfflinePaused.delete(address);
+		}
 		this._logService.info(
 			`[TunnelAgentHost] Pausing auto-reconnect for ${address} (${reason}); ` +
-			`will resume on network-online, tab-visible, or next status check.`
+			`will resume on network-online, tab-visible, session change, or next status check.`
 		);
 		const session = this._connectSessions.get(address);
 		if (session) {
@@ -527,13 +582,18 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 	private _categorizeError(err: unknown): TunnelConnectErrorCategory {
 		const message = err instanceof Error ? err.message : String(err);
-		if (/WebSocket relay connection failed/i.test(message)) {
-			return 'relayConnectionFailed';
+		// Expired / invalid credential — callers short-circuit this category
+		// to avoid burning retry budget on a token the user has to refresh.
+		if (/\b(401|403)\b|token.*expired|expired.*token|unauthoriz|invalid[_ -]?grant/i.test(message)) {
+			return 'authExpired';
 		}
-		if (/authenticat|token|unauthor/i.test(message)) {
+		if (/authenticat|\btoken\b|unauthoriz/i.test(message)) {
 			return 'auth';
 		}
-		if (/network|fetch|offline/i.test(message)) {
+		if (/WebSocket relay connection failed|failed to connect to relay/i.test(message)) {
+			return 'relayConnectionFailed';
+		}
+		if (/network|fetch|offline|ECONN|ENOTFOUND|ETIMEDOUT/i.test(message)) {
 			return 'network';
 		}
 		return 'other';
@@ -549,12 +609,15 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 	 * sequence (by clearing the pause flag) rather than zeroing the
 	 * attempt counter.
 	 */
-	private _resumeReconnects(trigger: 'wake' | 'visible'): void {
+	private _resumeReconnects(trigger: 'wake' | 'visible' | 'sessionAdded'): void {
 		if (!this._configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
 			return;
 		}
 
-		const RESUME_RATE_LIMIT_MS = 10_000;
+		// Rate-limit rapid wake/visibility events (e.g. alt-tab bursts or
+		// flaky Wi-Fi toggling online/offline) so we don't hammer the relay
+		// with immediate retries. This is an event-smoothing gate, not an
+		// error-backoff — that's handled by `_scheduleReconnect`.
 		const now = Date.now();
 		if (now - this._lastResumeAt < RESUME_RATE_LIMIT_MS) {
 			return;
@@ -658,6 +721,19 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				const info = onlineTunnelMap.get(tunnelId);
 				if (info && info.hostConnectionCount > 0) {
 					provider.setConnectionStatus(RemoteAgentHostConnectionStatus.Connected);
+
+					// If we paused reconnects because the host had gone
+					// offline, the status check is our cue to resume —
+					// don't wait for a wake/visibility event. Covers the
+					// common "my laptop came back, the remote host came
+					// back first" scenario deterministically.
+					if (this._hostOfflinePaused.has(address)) {
+						this._logService.info(
+							`[TunnelAgentHost] Host came back online for ${address}; auto-resuming reconnect.`
+						);
+						this._clearReconnectBackoff(address);
+						this._scheduleReconnect(address, /*immediate*/ true);
+					}
 				} else {
 					provider.setConnectionStatus(RemoteAgentHostConnectionStatus.Disconnected);
 				}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -584,10 +584,12 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		const message = err instanceof Error ? err.message : String(err);
 		// Expired / invalid credential — callers short-circuit this category
 		// to avoid burning retry budget on a token the user has to refresh.
-		if (/\b(401|403)\b|token.*expired|expired.*token|unauthoriz|invalid[_ -]?grant/i.test(message)) {
+		if (/\b(401|403)\b|token.*expired|expired.*token|invalid[_ -]?grant/i.test(message)) {
 			return 'authExpired';
 		}
-		if (/authenticat|\btoken\b|unauthoriz/i.test(message)) {
+		// Match authentication-specific language but NOT "connection token"
+		// or other protocol uses of the word "token".
+		if (/authenticat|unauthoriz|auth.*(fail|error|invalid)/i.test(message)) {
 			return 'auth';
 		}
 		if (/WebSocket relay connection failed|failed to connect to relay/i.test(message)) {
@@ -696,10 +698,12 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 
 			// Auto-cache online tunnels that aren't cached yet so they
 			// appear in the UI on first discovery (e.g. fresh web session).
+			// Pass 'github' as authProvider so _handleSessionsChange can
+			// match these tunnels for teardown on session removal.
 			const cachedIds = new Set(cached.map(t => t.tunnelId));
 			for (const tunnel of onlineTunnels) {
 				if (!cachedIds.has(tunnel.tunnelId) && tunnel.hostConnectionCount > 0) {
-					this._tunnelService.cacheTunnel(tunnel);
+					this._tunnelService.cacheTunnel(tunnel, 'github');
 				}
 			}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -282,7 +282,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 				// immediately and let `_handleSessionsChange` resume us when
 				// a new session appears.
 				if (errorCategory === 'authExpired' || errorCategory === 'auth') {
-					this._pauseReconnect(address, 'authExpired');
+					this._pauseReconnect(address, errorCategory);
 					throw err;
 				}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -9,6 +9,7 @@ import { RemoteAgentHostProtocolClient } from '../../../../platform/agentHost/br
 import { RemoteAgentHostEntryType, IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import type { IProtocolTransport } from '../../../../platform/agentHost/common/state/sessionTransport.js';
 import type { IProtocolMessage, IAhpServerNotification, IJsonRpcResponse } from '../../../../platform/agentHost/common/state/sessionProtocol.js';
+import { MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD, MALFORMED_FRAMES_LOG_CAP } from '../../../../platform/agentHost/common/transportConstants.js';
 import {
 	ITunnelAgentHostService,
 	TUNNEL_ADDRESS_PREFIX,
@@ -130,7 +131,7 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 		// Derive connection token from tunnel ID (same convention as CLI and desktop)
 		const connectionToken = await deriveConnectionToken(tunnelId);
 
-		const transport = new TunnelConnectionTransport(connection);
+		const transport = new TunnelConnectionTransport(connection, this._logService);
 		const address = `${TUNNEL_ADDRESS_PREFIX}${tunnelId}`;
 		const protocolClient = this._instantiationService.createInstance(
 			RemoteAgentHostProtocolClient, address, transport,
@@ -233,14 +234,35 @@ class TunnelConnectionTransport extends Disposable implements IProtocolTransport
 	private readonly _onClose = this._register(new Emitter<void>());
 	readonly onClose = this._onClose.event;
 
-	constructor(private readonly _connection: ITunnelConnection) {
+	private _malformedFrames = 0;
+
+	constructor(
+		private readonly _connection: ITunnelConnection,
+		private readonly _logService: ILogService,
+	) {
 		super();
 		this._register(_connection.onMessage((data: string) => {
+			let message: IProtocolMessage;
 			try {
-				this._onMessage.fire(JSON.parse(data) as IProtocolMessage);
-			} catch {
-				// Malformed message - drop.
+				message = JSON.parse(data) as IProtocolMessage;
+			} catch (err) {
+				this._malformedFrames++;
+				if (this._malformedFrames <= MALFORMED_FRAMES_LOG_CAP) {
+					const preview = data.length > 80 ? data.slice(0, 80) + '…' : data;
+					this._logService.warn(
+						`[TunnelConnectionTransport] Malformed frame #${this._malformedFrames} (len=${data.length}): ${preview}`,
+						err instanceof Error ? err.message : String(err)
+					);
+				}
+				if (this._malformedFrames > MALFORMED_FRAMES_FORCE_CLOSE_THRESHOLD) {
+					this._logService.warn(
+						'[TunnelConnectionTransport] Malformed frame threshold exceeded; forcing tunnel close.'
+					);
+					this._connection.close();
+				}
+				return;
 			}
+			this._onMessage.fire(message);
 		}));
 		this._register(_connection.onClose(() => {
 			this._onClose.fire();


### PR DESCRIPTION
## Summary

Improves tunnel agent host connection reliability with targeted fixes for specific failure modes identified during a deep comparison of the vscode.dev/agents connection stack vs codespaces-web.

**Companion PR:** microsoft/vscode-dev#1410 (server-side structured close codes + SDK client pool)

## Changes

### Transport malformed-frame hardening
All three transports (`WebSocketClientTransport`, `TunnelConnectionTransport`, `TunnelRelayTransport`) now detect and surface malformed JSON frames instead of silently dropping them:
- Warn log the first 5 per connection with a data preview for diagnostics
- Force-close the transport after >10 malformed frames — surfaces protocol mismatch or corrupt relay as a reconnect instead of a silent hang
- Shared constants in new `transportConstants.ts`

### Auth-error short-circuit
`_categorizeError` now distinguishes `authExpired` (401/403, expired tokens) from generic `auth` errors. Both immediately pause reconnects instead of burning 10 retry slots with guaranteed-failing attempts. Resume is driven by `onDidChangeSessions` when a fresh GitHub session appears.

### Host-online auto-resume
`_silentStatusCheck` detects when a tunnel paused for host-offline has its host come back online, and auto-resumes reconnect without requiring a wake/visibility event. Covers the common "laptop came back, remote host came back first" scenario.

### Session-removal cleanup
Reacts to GitHub auth session removal by tearing down matching tunnel state (reconnect timers, backoff, telemetry sessions) and best-effort disconnect. Previously, signing out left stale reconnect loops running.

### Telemetry
Added `authExpired` to `TunnelConnectErrorCategory` and `TunnelConnectFailureReason` types.

## Validation
- `npm run compile-check-ts-native` ✅
- `npm run valid-layers-check` ✅