### PR TITLE
Revert "Don't add agent-host worktree as workspace folder (#310888)"

### DIFF
--- a/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
+++ b/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
@@ -14,7 +14,6 @@ import { URI } from '../../../../base/common/uri.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IWorkspaceFolderCreationData } from '../../../../platform/workspaces/common/workspaces.js';
 import { Queue } from '../../../../base/common/async.js';
-import { AGENT_HOST_SCHEME } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 
 export class WorkspaceFolderManagementContribution extends Disposable implements IWorkbenchContribution {
@@ -80,11 +79,6 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		}
 
 		if (repository) {
-			// Remote agent host sessions use a read-only FS provider that
-			// should not be added as a workspace folder.
-			if (repository.scheme === AGENT_HOST_SCHEME) {
-				return undefined;
-			}
 			return {
 				uri: repository,
 				name: workspace?.label,

--- a/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
+++ b/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
@@ -72,12 +72,6 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		const worktree = repo?.workingDirectory;
 		const branchName = repo?.detail;
 
-		// Remote agent host sessions use a read-only FS provider that
-		// should not be added as a workspace folder.
-		if (worktree?.scheme === AGENT_HOST_SCHEME || repository?.scheme === AGENT_HOST_SCHEME) {
-			return undefined;
-		}
-
 		if (worktree) {
 			return {
 				uri: worktree,
@@ -86,6 +80,11 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		}
 
 		if (repository) {
+			// Remote agent host sessions use a read-only FS provider that
+			// should not be added as a workspace folder.
+			if (repository.scheme === AGENT_HOST_SCHEME) {
+				return undefined;
+			}
 			return {
 				uri: repository,
 				name: workspace?.label,


### PR DESCRIPTION
Reverts #310888, and removes the remaining `AGENT_HOST_SCHEME` guard (and its now-unused import) in `getActiveSessionFolderData` so that agent-host repository URIs are once again added as workspace folders too.

Fixes #311383.

(Written by Copilot)