### PR TITLE
Hide 'View Extension' hover action for core chat agents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatAgentHover.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatAgentHover.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../base/browser/dom.js';
-import { IManagedHoverOptions } from '../../../../../base/browser/ui/hover/hover.js';
+import { IHoverAction, IManagedHoverOptions } from '../../../../../base/browser/ui/hover/hover.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
@@ -121,18 +121,21 @@ export class ChatAgentHover extends Disposable {
 }
 
 export function getChatAgentHoverOptions(getAgent: () => IChatAgentData | undefined, commandService: ICommandService): IManagedHoverOptions {
-	return {
-		actions: [
-			{
-				commandId: showExtensionsWithIdsCommandId,
-				label: localize('viewExtensionLabel', "View Extension"),
-				run: () => {
-					const agent = getAgent();
-					if (agent) {
-						commandService.executeCommand(showExtensionsWithIdsCommandId, [agent.extensionId.value]);
-					}
-				},
-			}
-		]
-	};
+	const actions: IHoverAction[] = [];
+
+	// Core agents (e.g. agent host) don't correspond to a real extension, so omit "View Extension".
+	if (!getAgent()?.isCore) {
+		actions.push({
+			commandId: showExtensionsWithIdsCommandId,
+			label: localize('viewExtensionLabel', "View Extension"),
+			run: () => {
+				const agent = getAgent();
+				if (agent) {
+					commandService.executeCommand(showExtensionsWithIdsCommandId, [agent.extensionId.value]);
+				}
+			},
+		});
+	}
+
+	return { actions };
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatAgentHover.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatAgentHover.ts
@@ -121,21 +121,26 @@ export class ChatAgentHover extends Disposable {
 }
 
 export function getChatAgentHoverOptions(getAgent: () => IChatAgentData | undefined, commandService: ICommandService): IManagedHoverOptions {
-	const actions: IHoverAction[] = [];
+	const viewExtensionAction: IHoverAction = {
+		commandId: showExtensionsWithIdsCommandId,
+		label: localize('viewExtensionLabel', "View Extension"),
+		run: () => {
+			const agent = getAgent();
+			if (agent) {
+				commandService.executeCommand(showExtensionsWithIdsCommandId, [agent.extensionId.value]);
+			}
+		},
+	};
 
-	// Core agents (e.g. agent host) don't correspond to a real extension, so omit "View Extension".
-	if (!getAgent()?.isCore) {
-		actions.push({
-			commandId: showExtensionsWithIdsCommandId,
-			label: localize('viewExtensionLabel', "View Extension"),
-			run: () => {
-				const agent = getAgent();
-				if (agent) {
-					commandService.executeCommand(showExtensionsWithIdsCommandId, [agent.extensionId.value]);
-				}
-			},
-		});
-	}
-
-	return { actions };
+	// `actions` is a getter so the agent is only resolved at hover-show time.
+	// Some callers (e.g. chatListRenderer) construct these options before the
+	// surrounding template is initialized, so calling `getAgent()` eagerly here
+	// would hit a TDZ on the captured `template` variable.
+	// Core agents (e.g. agent host) have a placeholder extension id and no real
+	// extension to view, so we omit the action for them.
+	return {
+		get actions() {
+			return getAgent()?.isCore ? [] : [viewExtensionAction];
+		}
+	};
 }


### PR DESCRIPTION
Core agents (e.g. the agent host) register with a placeholder extension id (`vscode.agent-host`) and have no real extension to view. The "View Extension" hover action on the response title shouldn't appear for these agents.

`getChatAgentHoverOptions` now returns `actions` as a lazy getter that checks `agent.isCore` at hover-show time rather than at construction time. This both hides the action for core agents and avoids a TDZ issue — some callers (e.g. `chatListRenderer`) construct these options before the surrounding `template` variable is initialized.

Fixes #311510

(Written by Copilot)