### PR TITLE
fix: prevent "Signed Out" flash and missing walkthrough on session expiry

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -241,10 +241,15 @@ registerAction2(class extends Action2 {
 
 		const allSessions = await authenticationService.getSessions(providerId);
 		const sessions = allSessions.filter(session => session.account.label === accountLabel);
+
+		// Show the welcome overlay immediately, before the sessions are removed,
+		// so there is no flash where the titlebar shows "Signed Out" while the
+		// workbench is still visible.
+		resetSessionsWelcome(storageService, instantiationService, layoutService, chatEntitlementService, contextKeyService, environmentService, logService, /* skipInitialComplete */ true);
+
 		await Promise.all(sessions.map(session => authenticationService.removeSession(providerId, session.id)));
 		authenticationUsageService.removeAccountUsage(providerId, accountLabel);
 		authenticationAccessService.removeAllowedExtensions(providerId, accountLabel);
-		await showSessionsWelcomeAfterSignOut(chatEntitlementService, () => resetSessionsWelcome(storageService, instantiationService, layoutService, chatEntitlementService, contextKeyService, environmentService, logService));
 	}
 });
 

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -58,6 +58,7 @@ export function resetSessionsWelcome(
 	contextKeyService: IContextKeyService,
 	environmentService: IWorkbenchEnvironmentService,
 	logService: ILogService,
+	skipInitialComplete: boolean = false,
 ): void {
 	// Clear completion marker
 	storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
@@ -77,9 +78,19 @@ export function resetSessionsWelcome(
 		layoutService.mainContainer,
 	));
 
+	// When skipInitialComplete is true, we are showing the overlay proactively
+	// (e.g. before a sign-out completes) so we skip the first synchronous autorun
+	// evaluation to avoid immediately dismissing the overlay while the user is
+	// still technically signed in.
+	let isFirstRun = skipInitialComplete;
 	store.add(autorun(reader => {
 		chatEntitlementService.sentimentObs.read(reader);
 		chatEntitlementService.entitlementObs.read(reader);
+
+		if (isFirstRun) {
+			isFirstRun = false;
+			return;
+		}
 
 		if (!needsChatSetup(chatEntitlementService)) {
 			storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
@@ -157,12 +168,35 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			if (sessions.length > 0) {
 				this.logService.info('[sessions welcome] GitHub session found on web, skipping walkthrough');
 				this.storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+				this._watchWebSessionChanges();
 				return;
 			}
 		} catch {
 			// Provider not available yet — show walkthrough
 		}
 		this.showWalkthrough();
+	}
+
+	/**
+	 * Web-only: after confirming the user is authenticated, watch for session
+	 * removals. When all GitHub sessions are gone (real sign-out or expiry),
+	 * show the sign-in walkthrough so the user is never stuck seeing "Signed Out"
+	 * with the workbench still visible.
+	 */
+	private _watchWebSessionChanges(): void {
+		this._register(this.authenticationService.onDidChangeSessions(async ({ providerId, event }) => {
+			if (providerId !== 'github' || !event.removed?.length) {
+				return;
+			}
+			// Re-check sessions asynchronously so token refreshes (which remove
+			// and immediately re-add a session) are not treated as sign-outs.
+			const remaining = await this.authenticationService.getSessions('github').catch(() => [] as { id: string }[]);
+			if (remaining.length === 0) {
+				this.logService.info('[sessions welcome] All GitHub sessions removed on web, showing walkthrough');
+				this.storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
+				this.showWalkthrough();
+			}
+		}));
 	}
 
 	private showWalkthroughIfNeeded(): void {
@@ -205,6 +239,12 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 
 	private showWalkthrough(): void {
 		if (this.overlayRef.value) {
+			return;
+		}
+
+		// Guard against a second overlay if one was already created externally
+		// (e.g. by resetSessionsWelcome called from the sign-out action).
+		if (SessionsWelcomeVisibleContext.getValue(this.contextKeyService)) {
 			return;
 		}
 


### PR DESCRIPTION
## Problem

Two auth-state bugs in the agents workbench causing users to see "Agents Signed Out" in the titlebar while the workbench content is still visible:

### 1. Sign-out race condition (explicit sign-out)

When a user clicked Sign Out, `removeSession()` was called first, which immediately flipped `entitlement` to `Unknown`. The titlebar re-rendered to show "Agents Signed Out" while the welcome overlay was still being constructed — a visible flash of the workbench behind the "Signed Out" label.

### 2. Web session expiry (natural expiry / token invalidation)

`_checkWebAuth()` only ran once at startup. If a GitHub session expired later, the entitlement would flip to `Unknown` but `watchEntitlementState()` intentionally ignores `Unknown` while `WELCOME_COMPLETE_KEY` is set (to avoid false positives from token refreshes). The user was left indefinitely stuck seeing "Signed Out" with no walkthrough.

## Fix

### `welcome.contribution.ts`

- **`resetSessionsWelcome` — `skipInitialComplete` param**: when `true`, the autorun that auto-dismisses the overlay on sign-in skips its first synchronous evaluation. This lets the overlay be shown while the user is still technically signed in (before session removal), without immediately auto-closing.
- **`showWalkthrough` — duplicate overlay guard**: checks `SessionsWelcomeVisibleContext` before creating a new overlay, preventing a second one if `resetSessionsWelcome` already created one.
- **`_watchWebSessionChanges`**: after `_checkWebAuth` confirms auth, we now watch `IAuthenticationService.onDidChangeSessions`. When all GitHub sessions are removed, `WELCOME_COMPLETE_KEY` is cleared and the sign-in walkthrough is shown. An async `getSessions()` re-check guards against token refreshes (remove + re-add) being misinterpreted as sign-outs.

### `account.contribution.ts`

- **Sign-out action**: calls `resetSessionsWelcome(..., skipInitialComplete: true)` **before** `removeSession()`, so the overlay is already covering the workbench when the entitlement flips to `Unknown`.

## Testing

- Sign out explicitly → overlay should appear immediately with no flash
- Let a session expire on web → sign-in walkthrough should appear
- Token refresh (automatic) → no spurious walkthrough should appear
