### PR TITLE
Don't restore agents window from previous session

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1017,6 +1017,18 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 					lastSessionWindows.push(this.windowsStateHandler.state.lastActiveWindow);
 				}
 
+				// Never restore the agents window from the previous session.
+				// The agents window is only opened explicitly via `--agents`; otherwise a
+				// previously-opened agents workspace would "stick" and reopen on every launch.
+				const agentSessionsWorkspaceUri = this.environmentMainService.agentSessionsWorkspace;
+				if (agentSessionsWorkspaceUri) {
+					for (let i = lastSessionWindows.length - 1; i >= 0; i--) {
+						if (lastSessionWindows[i].workspace && isEqual(lastSessionWindows[i].workspace!.configPath, agentSessionsWorkspaceUri)) {
+							lastSessionWindows.splice(i, 1);
+						}
+					}
+				}
+
 				const pathsToOpen = await Promise.all(lastSessionWindows.map(async lastSessionWindow => {
 
 					// Workspaces

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -1017,22 +1017,18 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 					lastSessionWindows.push(this.windowsStateHandler.state.lastActiveWindow);
 				}
 
-				// Never restore the agents window from the previous session.
-				// The agents window is only opened explicitly via `--agents`; otherwise a
-				// previously-opened agents workspace would "stick" and reopen on every launch.
 				const agentSessionsWorkspaceUri = this.environmentMainService.agentSessionsWorkspace;
-				if (agentSessionsWorkspaceUri) {
-					for (let i = lastSessionWindows.length - 1; i >= 0; i--) {
-						if (lastSessionWindows[i].workspace && isEqual(lastSessionWindows[i].workspace!.configPath, agentSessionsWorkspaceUri)) {
-							lastSessionWindows.splice(i, 1);
-						}
-					}
-				}
 
 				const pathsToOpen = await Promise.all(lastSessionWindows.map(async lastSessionWindow => {
 
 					// Workspaces
 					if (lastSessionWindow.workspace) {
+						// Never restore the agents window from the previous session.
+						// It is only opened explicitly via `--agents`; otherwise a
+						// previously-opened agents workspace would "stick" and reopen on every launch.
+						if (agentSessionsWorkspaceUri && isEqual(lastSessionWindow.workspace.configPath, agentSessionsWorkspaceUri)) {
+							return undefined;
+						}
 						const pathToOpen = await this.resolveOpenable({ workspaceUri: lastSessionWindow.workspace.configPath }, { remoteAuthority: lastSessionWindow.remoteAuthority, rejectTransientWorkspaces: true /* https://github.com/microsoft/vscode/issues/119695 */ });
 						if (isWorkspacePathToOpen(pathToOpen)) {
 							return pathToOpen;


### PR DESCRIPTION
The agents window should only be opened explicitly via `--agents`. Previously, when the agents workspace was the last-opened window, the `window.restoreWindows` machinery would restore it on subsequent launches — so `./scripts/code.sh` (without `--agents`) would keep launching the agents app, with no obvious way to get out of that state short of wiping `user-data-dir`.

Fix: in `WindowsMainService.doGetPathsFromLastSession()`, filter out any previously-opened window whose workspace matches `agentSessionsWorkspace` before restoring. Persisted state is left untouched so other windows still restore normally, and the `--agents` startup path itself is unaffected.

(Written by Copilot)