### PR TITLE
Fix incremental renderer in paragraph buffer mode

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/buffers/paragraphBuffer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/buffers/paragraphBuffer.ts
@@ -53,14 +53,14 @@ export function lastBlockBoundary(text: string): number {
 export class ParagraphBuffer implements IIncrementalRenderingBuffer {
 	readonly handlesFlush = false;
 
-	getRenderable(fullMarkdown: string, lastRendered: string): string {
+	getRenderable(fullMarkdown: string, _lastRendered: string): string {
 		const lastBlock = lastBlockBoundary(fullMarkdown);
 		let renderable = lastBlock === -1
-			? lastRendered   // no complete block yet — keep current
+			? fullMarkdown   // no paragraph breaks — single block, render as-is
 			: fullMarkdown.slice(0, lastBlock + 2);
 
-		// Escape hatch: if too much content has accumulated without a
-		// block boundary, render what we have.
+		// Escape hatch: if too much content has accumulated beyond the
+		// last block boundary, render what we have.
 		if (fullMarkdown.length - renderable.length > MAX_BUFFERED_CHARS) {
 			renderable = fullMarkdown;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/chatIncrementalRendering.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/chatIncrementalRendering.ts
@@ -120,6 +120,15 @@ export class IncrementalDOMMorpher extends Disposable {
 		if (this._buffer instanceof WordBuffer) {
 			this._buffer.setRate(rate, isComplete);
 		}
+
+		// For buffers that don't handle their own flushing (e.g.
+		// ParagraphBuffer), force-render any remaining buffered
+		// content when the stream completes. Without this, content
+		// after the last \n\n boundary is never rendered.
+		if (isComplete && !this._buffer.handlesFlush && this._lastMarkdown.length > this._renderedMarkdown.length) {
+			this._pendingMarkdown = this._lastMarkdown;
+			this._scheduleRender();
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/chatIncrementalRendering.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatIncrementalRendering/chatIncrementalRendering.ts
@@ -114,7 +114,9 @@ export class IncrementalDOMMorpher extends Disposable {
 
 	/**
 	 * Forward the stream's word-rate estimate to the active buffer
-	 * (word buffer or line buffer).
+	 * (word buffer or line buffer). When the stream completes,
+	 * also flushes any remaining buffered content for buffers
+	 * that don't handle their own flushing (e.g. ParagraphBuffer).
 	 */
 	updateStreamRate(rate: number, isComplete: boolean): void {
 		if (this._buffer instanceof WordBuffer) {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
@@ -293,6 +293,32 @@ suite('IncrementalDOMMorpher', () => {
 			// No error should occur — rAF is cancelled
 		});
 	});
+
+	suite('updateStreamRate', () => {
+
+		test('flushes remaining buffered content on completion for paragraph buffer', () => {
+			// Use paragraph buffer (default)
+			configService.setUserConfiguration(ChatConfiguration.IncrementalRenderingBuffering, 'paragraph');
+			const morpher = createMorpher();
+			const rendered: string[] = [];
+			morpher.setRenderCallback(md => rendered.push(md));
+			morpher.seed('');
+
+			// Append content where the tail has no \n\n boundary
+			morpher.tryMorph('paragraph one\n\nparagraph two trailing');
+			// The paragraph buffer only renders up to the last \n\n,
+			// so "paragraph two trailing" stays buffered.
+
+			// Signal stream completion — should schedule a render of
+			// the full content including the unbounded tail.
+			morpher.updateStreamRate(100, true);
+
+			// The render is async (rAF), but a pending markdown should
+			// now be scheduled. Verify by checking that tryMorph still
+			// succeeds with the same content (no state corruption).
+			assert.strictEqual(morpher.tryMorph('paragraph one\n\nparagraph two trailing'), true);
+		});
+	});
 });
 
 suite('BlockAnimation', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
@@ -191,6 +191,23 @@ suite('IncrementalDOMMorpher', () => {
 			// No \n\n — content is buffered
 			assert.strictEqual(morpher.tryMorph('partial paragraph'), true);
 		});
+
+		test('schedules render for content without any paragraph breaks', () => {
+			configService.setUserConfiguration(ChatConfiguration.IncrementalRenderingBuffering, 'paragraph');
+			const morpher = createMorpher();
+			const rendered: string[] = [];
+			morpher.setRenderCallback(md => rendered.push(md));
+			morpher.seed('');
+
+			// Append content with no \n\n at all — previously this would
+			// never render because getRenderable returned lastRendered (empty seed).
+			morpher.tryMorph('single block no paragraph breaks');
+
+			// _renderedMarkdown should advance past the seed, allowing
+			// further appends to also be picked up.
+			morpher.tryMorph('single block no paragraph breaks — more words');
+			assert.strictEqual(morpher.tryMorph('single block no paragraph breaks — more words — even more'), true);
+		});
 	});
 
 	suite('seed', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatIncrementalRendering.test.ts
@@ -192,7 +192,7 @@ suite('IncrementalDOMMorpher', () => {
 			assert.strictEqual(morpher.tryMorph('partial paragraph'), true);
 		});
 
-		test('schedules render for content without any paragraph breaks', () => {
+		test('schedules render for content without any paragraph breaks', async () => {
 			configService.setUserConfiguration(ChatConfiguration.IncrementalRenderingBuffering, 'paragraph');
 			const morpher = createMorpher();
 			const rendered: string[] = [];
@@ -203,10 +203,17 @@ suite('IncrementalDOMMorpher', () => {
 			// never render because getRenderable returned lastRendered (empty seed).
 			morpher.tryMorph('single block no paragraph breaks');
 
-			// _renderedMarkdown should advance past the seed, allowing
-			// further appends to also be picked up.
+			// Flush the rAF — the full content should render since
+			// there are no paragraph boundaries to buffer at.
+			await new Promise(r => mainWindow.requestAnimationFrame(r));
+			assert.strictEqual(rendered.length, 1);
+			assert.strictEqual(rendered[0], 'single block no paragraph breaks');
+
+			// Further appends should also render
 			morpher.tryMorph('single block no paragraph breaks — more words');
-			assert.strictEqual(morpher.tryMorph('single block no paragraph breaks — more words — even more'), true);
+			await new Promise(r => mainWindow.requestAnimationFrame(r));
+			assert.strictEqual(rendered.length, 2);
+			assert.strictEqual(rendered[1], 'single block no paragraph breaks — more words');
 		});
 	});
 
@@ -313,7 +320,7 @@ suite('IncrementalDOMMorpher', () => {
 
 	suite('updateStreamRate', () => {
 
-		test('flushes remaining buffered content on completion for paragraph buffer', () => {
+		test('flushes remaining buffered content on completion for paragraph buffer', async () => {
 			// Use paragraph buffer (default)
 			configService.setUserConfiguration(ChatConfiguration.IncrementalRenderingBuffering, 'paragraph');
 			const morpher = createMorpher();
@@ -321,19 +328,24 @@ suite('IncrementalDOMMorpher', () => {
 			morpher.setRenderCallback(md => rendered.push(md));
 			morpher.seed('');
 
+			const fullContent = 'paragraph one\n\nparagraph two trailing';
 			// Append content where the tail has no \n\n boundary
-			morpher.tryMorph('paragraph one\n\nparagraph two trailing');
-			// The paragraph buffer only renders up to the last \n\n,
-			// so "paragraph two trailing" stays buffered.
+			morpher.tryMorph(fullContent);
+
+			// Flush the rAF so the paragraph-boundary render fires
+			await new Promise(r => mainWindow.requestAnimationFrame(r));
+			// Only content up to the last \n\n should have rendered
+			assert.strictEqual(rendered.length, 1);
+			assert.strictEqual(rendered[0], 'paragraph one\n\n');
 
 			// Signal stream completion — should schedule a render of
 			// the full content including the unbounded tail.
 			morpher.updateStreamRate(100, true);
+			await new Promise(r => mainWindow.requestAnimationFrame(r));
 
-			// The render is async (rAF), but a pending markdown should
-			// now be scheduled. Verify by checking that tryMorph still
-			// succeeds with the same content (no state corruption).
-			assert.strictEqual(morpher.tryMorph('paragraph one\n\nparagraph two trailing'), true);
+			// The render callback should now have the full content
+			assert.strictEqual(rendered.length, 2);
+			assert.strictEqual(rendered[1], fullContent);
 		});
 	});
 });


### PR DESCRIPTION
# Fix incremental rendering dropping content in ParagraphBuffer

Two related bugs in `ParagraphBuffer` cause words to be silently dropped during streaming:

## Bug 1: Single-block content never renders

When a markdown chunk has no `\n\n` boundaries (e.g. a single paragraph of text between tool invocations), `getRenderable` returns `lastRendered` — the stale seed content from part creation. Since `renderable.length == _renderedMarkdown.length`, no render is ever scheduled. Meanwhile `tryIncrementalUpdate` eagerly updates `this.markdown`, so `hasSameContent()` reports no diff and the content is permanently lost.

**Fix:** Return `fullMarkdown` instead of `lastRendered` when there are no paragraph breaks. If the entire content is one block, there's nothing to buffer — rAF batching already coalesces per-frame updates.

## Bug 2: Trailing content after the last `\n\n` dropped on completion

`ParagraphBuffer` only renders up to the last `\n\n` boundary. When the stream completes, `updateStreamRate` only notifies `WordBuffer` — `ParagraphBuffer` is never told to flush. The final `renderChatResponseBasic` call sees `hasSameContent() == true` (due to the eager `this.markdown` update) and skips re-rendering, so trailing words are lost.

**Fix:** In `updateStreamRate`, when the stream completes and the buffer doesn't handle its own flushing, force-render any remaining buffered content by scheduling a rAF with the full `_lastMarkdown`.

Fixes https://github.com/microsoft/vscode/issues/311448
