### PR TITLE
Rewrite `run_in_terminal` "may be waiting for input" steering text to stop premature turn termination

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -18,7 +18,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). For the 'id' parameter, this must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid for 'id'.`,
+	modelDescription: `Get output from a persistent terminal session previously started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -18,7 +18,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from a persistent terminal session previously started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
+	modelDescription: `Get output from a persistent terminal session previously started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). The ID must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -7,9 +7,7 @@ import type { CancellationToken } from '../../../../../../base/common/cancellati
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
-import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
-import { getOutput } from '../outputHelpers.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
 import { TerminalToolId } from './toolIds.js';
 
@@ -18,7 +16,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from a persistent terminal session previously started with ${TerminalToolId.RunInTerminal} in async mode (legacy: isBackground=true). The ID must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
+	modelDescription: `Get output from an active terminal execution previously started with ${TerminalToolId.RunInTerminal} and still running. This includes async executions and sync executions that exceeded their timeout and were moved to the background — both cases return an \`id\` from ${TerminalToolId.RunInTerminal} that can be reused here. The ID must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -26,27 +24,21 @@ export const GetTerminalOutputToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: `The ID of a persistent terminal session to check (returned by ${TerminalToolId.RunInTerminal} in async mode). This must be the exact opaque ID returned by that tool; terminal names, labels, or integers are invalid. Provide either 'id' or 'terminalId', not both.`,
+				description: `The ID of an active terminal execution to check (returned by ${TerminalToolId.RunInTerminal} for async executions, or for sync executions that timed out and were moved to the background). This must be the exact opaque UUID returned by that tool; terminal names, labels, or integers are invalid.`,
 				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 			},
-			terminalId: {
-				type: 'number',
-				description: 'The numeric instanceId of a terminal. Use this to get output from terminals not started by the agent (e.g., user-created terminals or foreground terminals). Provide either \'id\' or \'terminalId\', not both.'
-			},
 		},
+		required: ['id'],
 	}
 };
 
 export interface IGetTerminalOutputInputParams {
 	id?: string;
-	terminalId?: number;
 }
 
 export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
-	constructor(
-		@ITerminalService private readonly _terminalService: ITerminalService,
-	) {
+	constructor() {
 		super();
 	}
 
@@ -60,38 +52,16 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
 		const args = invocation.parameters as IGetTerminalOutputInputParams;
 
-		if (!args.id && args.terminalId === undefined) {
+		if (!args.id) {
 			return {
 				content: [{
 					kind: 'text',
-					value: 'Error: Either \'id\' (persistent terminal UUID) or \'terminalId\' (foreground terminal instanceId) must be provided.'
+					value: `Error: 'id' (the persistent terminal UUID returned by ${TerminalToolId.RunInTerminal} in async mode) must be provided.`
 				}]
 			};
 		}
 
-		// Foreground terminal path — only when no persistent id is provided
-		if (args.terminalId !== undefined && !args.id) {
-			const instance = this._terminalService.getInstanceFromId(args.terminalId);
-			if (!instance) {
-				return {
-					content: [{
-						kind: 'text',
-						value: `Error: No terminal found with instanceId ${args.terminalId}. The terminal may have been closed.`
-					}]
-				};
-			}
-
-			const output = getOutput(instance);
-			return {
-				content: [{
-					kind: 'text',
-					value: `Output of terminal ${args.terminalId}:\n${output}`
-				}]
-			};
-		}
-
-		// Persistent (background) terminal path
-		const execution = RunInTerminalTool.getExecution(args.id!);
+		const execution = RunInTerminalTool.getExecution(args.id);
 		if (!execution) {
 			return {
 				content: [{

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -16,7 +16,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get output from an active terminal execution previously started with ${TerminalToolId.RunInTerminal} and still running. This includes async executions and sync executions that exceeded their timeout and were moved to the background — both cases return an \`id\` from ${TerminalToolId.RunInTerminal} that can be reused here. The ID must be the exact opaque UUID returned by ${TerminalToolId.RunInTerminal}; terminal names, labels, and integers are not valid IDs.`,
+	modelDescription: `Get output from an active terminal execution (identified by the \`id\` returned from ${TerminalToolId.RunInTerminal}).`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1758,11 +1758,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	private _buildInputNeededSteeringText(chatSessionResource: URI, termId: string, mentionTimeout: boolean): string {
 		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 		const realInputBranch = isAutoApproved
-			? `determine the answer and call ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output); if you need more output or the next prompt is slow to appear, call ${TerminalToolId.GetTerminalOutput} with id="${termId}". Repeat one prompt at a time.`
-			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output). Use ${TerminalToolId.GetTerminalOutput} with id="${termId}" only if you need more output or the next prompt is slow to appear.`;
+			? `determine the answer and call ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output). Repeat one prompt at a time.`
+			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output).`;
 		const lines = [
-			`This note is a mid-execution status, not a turn-terminating signal. Do NOT stop and wait — pick one of the actions below and continue.`,
-			`  1. If the command is still producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
+			`This note is not a signal to end the turn — pick one of the actions below and continue.`,
+			`  1. If the command may still be producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
 			`  2. Only if the output clearly ends with a real input prompt (password:, Continue? (y/n), etc. — a normal shell prompt like \`$\` or \`#\` does NOT count), ${realInputBranch}`,
 			`  3. If the command appears stuck or malformed (e.g. an unterminated heredoc, infinite loop, or hung subprocess), call ${TerminalToolId.KillTerminal} with id="${termId}" and retry with a corrected command.`,
 		];

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1752,8 +1752,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 *   1. Tells the model this note is NOT a signal to end the turn.
 	 *   2. Leads with `get_terminal_output` as the safe recovery action.
 	 *   3. Offers `send_to_terminal` / `vscode_askQuestions` only for real prompts.
-	 *   4. Points at `kill_terminal` for stuck/malformed commands (e.g. an
-	 *      unterminated heredoc) so the agent can retry instead of giving up.
+	 * It intentionally does NOT suggest `kill_terminal` — the tool remains
+	 * available but advertising it here leads the model to terminate valid
+	 * interactive sessions (e.g. `npm init`) instead of driving them.
 	 */
 	private _buildInputNeededSteeringText(chatSessionResource: URI, termId: string, mentionTimeout: boolean): string {
 		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
@@ -1764,7 +1765,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			`This note is not a signal to end the turn — pick one of the actions below and continue.`,
 			`  1. If the command may still be producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
 			`  2. Only if the output clearly ends with a real input prompt (password:, Continue? (y/n), etc. — a normal shell prompt like \`$\` or \`#\` does NOT count), ${realInputBranch}`,
-			`  3. If the command appears stuck or malformed (e.g. an unterminated heredoc, infinite loop, or hung subprocess), call ${TerminalToolId.KillTerminal} with id="${termId}" and retry with a corrected command.`,
 		];
 		if (mentionTimeout) {
 			lines.push(`  Note: timeouts can also be extended by re-invoking ${TerminalToolId.GetTerminalOutput} with id="${termId}"; they do not indicate the command has failed.`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1393,11 +1393,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}
 					resultText += pollingResult.output;
-					if (isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService)) {
-						resultText += `\nIf the command is waiting for input (not a normal shell prompt), determine the answer and call ${TerminalToolId.SendToTerminal}. Then call ${TerminalToolId.GetTerminalOutput} to read the next prompt. Repeat one prompt at a time.`;
-					} else {
-						resultText += `\nIf the command is waiting for input (not a normal shell prompt), call the vscode_askQuestions tool to ask the user. Then send each answer using ${TerminalToolId.SendToTerminal}, calling ${TerminalToolId.GetTerminalOutput} between each.`;
-					}
+					resultText += this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false);
 				} else if (pollingResult) {
 					resultText += `\n The command is still running, with output:\n`;
 					if (outputAnalyzerMessage) {
@@ -1703,21 +1699,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				resultText.push(`Note: This terminal execution was moved to the background using the ID ${termId}\n`);
 			}
 		}
-		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 		if (didInputNeeded) {
-			if (isAutoApproved) {
-				resultText.push(`Note: The command is running in terminal ID ${termId} and may be waiting for input. If it IS waiting for input (not a normal shell prompt), determine the answer and call ${TerminalToolId.SendToTerminal}. Then call ${TerminalToolId.GetTerminalOutput} to read the next prompt. Repeat one prompt at a time.\n\n`);
-			} else {
-				resultText.push(`Note: The command is running in terminal ID ${termId} and may be waiting for input. If it IS waiting for input (not a normal shell prompt), call the vscode_askQuestions tool to ask the user. Then send each answer using ${TerminalToolId.SendToTerminal}, calling ${TerminalToolId.GetTerminalOutput} between each.\n\n`);
-			}
+			resultText.push(`Note: The command is running in terminal ID ${termId} and may be waiting for input.\n${this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false)}\n\n`);
 		} else if (didTimeout && timeoutValue !== undefined && timeoutValue > 0) {
 			const notificationHint = shouldSendNotifications
 				? ' You will be automatically notified on your next turn when it completes.'
 				: '';
-			const inputAction = isAutoApproved
-				? `If it IS waiting for input (not a normal shell prompt), determine the answer and call ${TerminalToolId.SendToTerminal}. Then call ${TerminalToolId.GetTerminalOutput} to read the next prompt. Repeat one prompt at a time.`
-				: `If it IS waiting for input (not a normal shell prompt), call the vscode_askQuestions tool to ask the user. Then send each answer using ${TerminalToolId.SendToTerminal}, calling ${TerminalToolId.GetTerminalOutput} between each.`;
-			resultText.push(`Note: Command timed out after ${timeoutValue}ms. The command may still be running in terminal ID ${termId}.${notificationHint} Use ${TerminalToolId.GetTerminalOutput} to check output, ${TerminalToolId.SendToTerminal} to send input, or ${TerminalToolId.KillTerminal} to stop it. ${inputAction}\n\n`);
+			resultText.push(`Note: Command timed out after ${timeoutValue}ms. The command may still be running in terminal ID ${termId}.${notificationHint}\n${this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ true)}\n\n`);
 		}
 		const outputAnalyzerMessage = await this._getOutputAnalyzerMessage(exitCode, terminalResult, command, didSandboxWrapCommand);
 		if (outputAnalyzerMessage) {
@@ -1753,6 +1741,35 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				...imageContent,
 			]
 		};
+	}
+
+	/**
+	 * Builds the steering text the model sees when the terminal tool suspects
+	 * the command may be waiting for input. The heuristic that triggers this
+	 * note can false-positive on long-running compute commands or shells sitting
+	 * on a secondary prompt (e.g. heredoc continuation `> `), so the text
+	 * explicitly:
+	 *   1. Tells the model this note is NOT a signal to end the turn.
+	 *   2. Leads with `get_terminal_output` as the safe recovery action.
+	 *   3. Offers `send_to_terminal` / `vscode_askQuestions` only for real prompts.
+	 *   4. Points at `kill_terminal` for stuck/malformed commands (e.g. an
+	 *      unterminated heredoc) so the agent can retry instead of giving up.
+	 */
+	private _buildInputNeededSteeringText(chatSessionResource: URI, termId: string, mentionTimeout: boolean): string {
+		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
+		const realInputBranch = isAutoApproved
+			? `determine the answer and call ${TerminalToolId.SendToTerminal} (which returns the next few lines of output); if you need more output or the next prompt is slow to appear, call ${TerminalToolId.GetTerminalOutput}. Repeat one prompt at a time.`
+			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} (which returns the next few lines of output). Use ${TerminalToolId.GetTerminalOutput} only if you need more output or the next prompt is slow to appear.`;
+		const lines = [
+			`This note is a mid-execution status, not a turn-terminating signal. Do NOT stop and wait — pick one of the actions below and continue.`,
+			`  1. If the command is still producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
+			`  2. Only if the output clearly ends with a real input prompt (password:, Continue? (y/n), etc. — a normal shell prompt like \`$\` or \`#\` does NOT count), ${realInputBranch}`,
+			`  3. If the command appears stuck or malformed (e.g. an unterminated heredoc, infinite loop, or hung subprocess), call ${TerminalToolId.KillTerminal} with id="${termId}" and retry with a corrected command.`,
+		];
+		if (mentionTimeout) {
+			lines.push(`  Note: timeouts can also be extended by re-invoking ${TerminalToolId.GetTerminalOutput}; they do not indicate the command has failed.`);
+		}
+		return lines.join('\n');
 	}
 
 	private async _getOutputAnalyzerMessage(exitCode: number | undefined, exitResult: string, commandLine: string, isSandboxWrapped: boolean): Promise<string | undefined> {
@@ -2198,11 +2215,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				}
 				lastInputNeededOutput = currentOutput;
 				lastInputNeededNotificationTime = now;
-				const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
-				const inputAction = isAutoApproved
-					? `Determine the answer and call ${TerminalToolId.SendToTerminal}. Then call ${TerminalToolId.GetTerminalOutput} to read the next prompt. Repeat one prompt at a time. A normal shell prompt does NOT count as waiting for input.`
-					: `Call the vscode_askQuestions tool to ask the user. Then send each answer using ${TerminalToolId.SendToTerminal}, calling ${TerminalToolId.GetTerminalOutput} between each. A normal shell prompt does NOT count as waiting for input.`;
-				const message = `[Terminal ${termId} notification: command is waiting for input. ${inputAction}]\nTerminal output:\n${currentOutput}`;
+				const inputAction = this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false);
+				const message = `[Terminal ${termId} notification: command is waiting for input.]\n${inputAction}\nTerminal output:\n${currentOutput}`;
 
 				this._logService.debug(`RunInTerminalTool: Input needed in background terminal ${termId}, notifying chat session`);
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1758,8 +1758,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	private _buildInputNeededSteeringText(chatSessionResource: URI, termId: string, mentionTimeout: boolean): string {
 		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 		const realInputBranch = isAutoApproved
-			? `determine the answer and call ${TerminalToolId.SendToTerminal} (which returns the next few lines of output); if you need more output or the next prompt is slow to appear, call ${TerminalToolId.GetTerminalOutput}. Repeat one prompt at a time.`
-			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} (which returns the next few lines of output). Use ${TerminalToolId.GetTerminalOutput} only if you need more output or the next prompt is slow to appear.`;
+			? `determine the answer and call ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output); if you need more output or the next prompt is slow to appear, call ${TerminalToolId.GetTerminalOutput} with id="${termId}". Repeat one prompt at a time.`
+			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output). Use ${TerminalToolId.GetTerminalOutput} with id="${termId}" only if you need more output or the next prompt is slow to appear.`;
 		const lines = [
 			`This note is a mid-execution status, not a turn-terminating signal. Do NOT stop and wait — pick one of the actions below and continue.`,
 			`  1. If the command is still producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
@@ -1767,7 +1767,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			`  3. If the command appears stuck or malformed (e.g. an unterminated heredoc, infinite loop, or hung subprocess), call ${TerminalToolId.KillTerminal} with id="${termId}" and retry with a corrected command.`,
 		];
 		if (mentionTimeout) {
-			lines.push(`  Note: timeouts can also be extended by re-invoking ${TerminalToolId.GetTerminalOutput}; they do not indicate the command has failed.`);
+			lines.push(`  Note: timeouts can also be extended by re-invoking ${TerminalToolId.GetTerminalOutput} with id="${termId}"; they do not indicate the command has failed.`);
 		}
 		return lines.join('\n');
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1393,7 +1393,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						resultText += `${outputAnalyzerMessage}\n`;
 					}
 					resultText += pollingResult.output;
-					resultText += this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false);
+					resultText += `\n${this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false)}`;
 				} else if (pollingResult) {
 					resultText += `\n The command is still running, with output:\n`;
 					if (outputAnalyzerMessage) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1752,22 +1752,22 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 *   1. Tells the model this note is NOT a signal to end the turn.
 	 *   2. Leads with `get_terminal_output` as the safe recovery action.
 	 *   3. Offers `send_to_terminal` / `vscode_askQuestions` only for real prompts.
-	 * It intentionally does NOT suggest `kill_terminal` — the tool remains
-	 * available but advertising it here leads the model to terminate valid
-	 * interactive sessions (e.g. `npm init`) instead of driving them.
+	 * `kill_terminal` is only advertised on the timeout branch — suggesting it
+	 * in the general case leads the model to terminate valid interactive
+	 * sessions (e.g. `npm init`) instead of driving them.
 	 */
 	private _buildInputNeededSteeringText(chatSessionResource: URI, termId: string, mentionTimeout: boolean): string {
 		const isAutoApproved = isSessionAutoApproveLevel(chatSessionResource, this._configurationService, this._chatWidgetService, this._chatService);
 		const realInputBranch = isAutoApproved
 			? `determine the answer and call ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output). Repeat one prompt at a time.`
-			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output).`;
+			: `call the vscode_askQuestions tool to ask the user, then send each answer using ${TerminalToolId.SendToTerminal} with id="${termId}" (which returns the next few lines of output). Repeat one prompt at a time.`;
 		const lines = [
 			`This note is not a signal to end the turn — pick one of the actions below and continue.`,
 			`  1. If the command may still be producing output or the shell prompt has not returned, call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. This is the default and safest action when unsure.`,
 			`  2. Only if the output clearly ends with a real input prompt (password:, Continue? (y/n), etc. — a normal shell prompt like \`$\` or \`#\` does NOT count), ${realInputBranch}`,
 		];
 		if (mentionTimeout) {
-			lines.push(`  Note: timeouts can also be extended by re-invoking ${TerminalToolId.GetTerminalOutput} with id="${termId}"; they do not indicate the command has failed.`);
+			lines.push(`  3. A timeout does not mean the command failed — call ${TerminalToolId.GetTerminalOutput} with id="${termId}" to continue polling. Only call ${TerminalToolId.KillTerminal} if the command is genuinely hung and you need to retry with a different approach.`);
 		}
 		return lines.join('\n');
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -306,10 +306,12 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 
 	/**
 	 * Checks whether a carousel answer value matches the command text being sent.
+	 * An empty/unprovided answer matches an empty command (i.e. pressing Enter to
+	 * accept the default), since that is the expected way to skip a question.
 	 */
 	private _answerMatchesCommand(answer: IChatQuestionAnswerValue | undefined, commandText: string): boolean {
 		if (answer === undefined) {
-			return false;
+			return commandText === '';
 		}
 		if (typeof answer === 'string') {
 			return answer.trim() === commandText;
@@ -320,11 +322,17 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 			if (multi.selectedValues.some(v => v.trim() === commandText)) {
 				return true;
 			}
-			return multi.freeformValue?.trim() === commandText;
+			if (multi.freeformValue?.trim() === commandText) {
+				return true;
+			}
+			return commandText === '' && multi.selectedValues.length === 0 && !multi.freeformValue?.trim();
 		}
 		if (hasKey(answer, { selectedValue: true })) {
 			const single = answer as IChatSingleSelectAnswer;
-			return single.selectedValue?.trim() === commandText || single.freeformValue?.trim() === commandText;
+			if (single.selectedValue?.trim() === commandText || single.freeformValue?.trim() === commandText) {
+				return true;
+			}
+			return commandText === '' && !single.selectedValue?.trim() && !single.freeformValue?.trim();
 		}
 		return false;
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -27,7 +27,7 @@ export const SendToTerminalToolData: IToolData = {
 	id: TerminalToolId.SendToTerminal,
 	toolReferenceName: 'sendToTerminal',
 	displayName: localize('sendToTerminalTool.displayName', 'Send to Terminal'),
-	modelDescription: `Send input text to an active terminal execution previously started with ${TerminalToolId.RunInTerminal} and still running. This includes async executions and sync executions that exceeded their timeout and were moved to the background — both return an \`id\` from ${TerminalToolId.RunInTerminal} that can be reused here. The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). The result includes the last few lines of terminal output captured shortly after sending.`,
+	modelDescription: `Send input text to an active terminal execution (identified by the \`id\` returned from ${TerminalToolId.RunInTerminal}). The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). The result includes the last few lines of terminal output captured shortly after sending.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -84,7 +84,6 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		@IChatService private readonly _chatService: IChatService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
-		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool.ts
@@ -27,7 +27,7 @@ export const SendToTerminalToolData: IToolData = {
 	id: TerminalToolId.SendToTerminal,
 	toolReferenceName: 'sendToTerminal',
 	displayName: localize('sendToTerminalTool.displayName', 'Send to Terminal'),
-	modelDescription: `Send input text to a terminal session. This can target either a persistent terminal started with ${TerminalToolId.RunInTerminal} in async mode (using 'id') or any foreground terminal visible in the terminal panel (using 'terminalId'). The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). The result includes the last few lines of terminal output captured shortly after sending.`,
+	modelDescription: `Send input text to an active terminal execution previously started with ${TerminalToolId.RunInTerminal} and still running. This includes async executions and sync executions that exceeded their timeout and were moved to the background — both return an \`id\` from ${TerminalToolId.RunInTerminal} that can be reused here. The 'command' field may be empty or whitespace to press Enter (useful for interactive prompts). The result includes the last few lines of terminal output captured shortly after sending.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -35,12 +35,8 @@ export const SendToTerminalToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: `The ID of a persistent terminal session to send a command to (returned by ${TerminalToolId.RunInTerminal} in async mode). Provide either 'id' or 'terminalId', not both.`,
+				description: `The ID of an active terminal execution to send a command to (returned by ${TerminalToolId.RunInTerminal} for async executions, or for sync executions that timed out and were moved to the background).`,
 				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
-			},
-			terminalId: {
-				type: 'number',
-				description: 'The numeric instanceId of a terminal. Use this to send input to terminals not started by the agent (e.g., user-created terminals or terminals that need interactive input). Provide either \'id\' or \'terminalId\', not both.'
 			},
 			command: {
 				type: 'string',
@@ -48,14 +44,14 @@ export const SendToTerminalToolData: IToolData = {
 			},
 		},
 		required: [
+			'id',
 			'command',
 		]
 	}
 };
 
 export interface ISendToTerminalInputParams {
-	id?: string;
-	terminalId?: number;
+	id: string;
 	command: string;
 }
 
@@ -180,13 +176,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 				return execution.instance.title;
 			}
 		}
-		if (args.terminalId !== undefined) {
-			const instance = this._terminalService.getInstanceFromId(args.terminalId);
-			if (instance) {
-				return instance.title;
-			}
-		}
-		return args.id ?? String(args.terminalId ?? '');
+		return args.id ?? '';
 	}
 
 	/**
@@ -194,9 +184,6 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 	 * to build command URIs for the "Focus Terminal" link.
 	 */
 	private _getTerminalInstanceId(args: ISendToTerminalInputParams): number | undefined {
-		if (args.terminalId !== undefined) {
-			return args.terminalId;
-		}
 		if (args.id) {
 			const execution = RunInTerminalTool.getExecution(args.id);
 			if (execution) {
@@ -229,7 +216,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		// Resolve the terminal ID that will match the carousel's terminalId
-		if (!args.id && args.terminalId === undefined) {
+		if (!args.id) {
 			return undefined;
 		}
 
@@ -254,10 +241,7 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 					if (!candidate.terminalId || candidate.questions.length === 0) {
 						continue;
 					}
-					const matchesById = !!args.id && candidate.terminalId === args.id;
-					const matchesByInstanceId = args.terminalId !== undefined &&
-						RunInTerminalTool.getExecution(candidate.terminalId)?.instance.instanceId === args.terminalId;
-					if (matchesById || matchesByInstanceId) {
+					if (candidate.terminalId === args.id) {
 						carouselIndex = j;
 						carousel = candidate;
 						break;
@@ -340,42 +324,16 @@ export class SendToTerminalTool extends Disposable implements IToolImpl {
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, _token: CancellationToken): Promise<IToolResult> {
 		const args = invocation.parameters as ISendToTerminalInputParams;
 
-		if (!args.id && args.terminalId === undefined) {
+		if (!args.id) {
 			return {
 				content: [{
 					kind: 'text',
-					value: 'Error: Either \'id\' (persistent terminal UUID) or \'terminalId\' (foreground terminal instanceId) must be provided.'
+					value: `Error: 'id' (the active terminal execution UUID returned by ${TerminalToolId.RunInTerminal}) must be provided.`
 				}]
 			};
 		}
 
-		// Foreground terminal path — only when no persistent id is provided
-		if (args.terminalId !== undefined && !args.id) {
-			const instance = this._terminalService.getInstanceFromId(args.terminalId);
-			if (!instance) {
-				return {
-					content: [{
-						kind: 'text',
-						value: `Error: No terminal found with instanceId ${args.terminalId}. The terminal may have been closed.`
-					}]
-				};
-			}
-
-			await instance.sendText(normalizeCommandForExecution(args.command), true);
-
-			await timeout(100);
-			const recentOutput = getOutput(instance, undefined, { lastNLines: 5 });
-
-			return {
-				content: [{
-					kind: 'text',
-					value: `Successfully sent command to foreground terminal ${args.terminalId}.${recentOutput ? `\n\nTerminal output (last 5 lines):\n${recentOutput}` : ''}`
-				}]
-			};
-		}
-
-		// Persistent (background) terminal path
-		const execution = RunInTerminalTool.getExecution(args.id!);
+		const execution = RunInTerminalTool.getExecution(args.id);
 		if (!execution) {
 			return {
 				content: [{

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -56,14 +56,12 @@ suite('GetTerminalOutputTool', () => {
 		};
 	}
 
-	test('tool description documents opaque terminal ids', () => {
+	test('tool schema requires a UUID id', () => {
 		const idProperty = GetTerminalOutputToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
-		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque UUID'));
-		assert.ok(/exact opaque (uuid|id) returned by that tool/i.test(idProperty?.description ?? ''));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 
-	test('returns error when neither id nor terminalId is provided', async () => {
+	test('returns error when id is not provided', async () => {
 		const result = await tool.invoke(
 			{ parameters: {}, callId: 'test-call', context: { sessionId: 'test-session' }, toolId: 'get_terminal_output', tokenBudget: 1000, isComplete: () => false, isCancellationRequested: false } as unknown as IToolInvocation,
 			async () => 0,
@@ -72,7 +70,7 @@ suite('GetTerminalOutputTool', () => {
 		);
 
 		const value = (result.content[0] as { value: string }).value;
-		assert.ok(value.includes('Either'));
+		assert.ok(value.includes('must be provided'));
 	});
 
 	test('returns explicit error for unknown terminal id', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sendToTerminalTool.test.ts
@@ -71,12 +71,8 @@ suite('SendToTerminalTool', () => {
 		};
 	}
 
-	test('tool description documents terminal IDs and use cases', () => {
+	test('tool schema requires a UUID id', () => {
 		const idProperty = SendToTerminalToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
-		const commandProperty = SendToTerminalToolData.inputSchema?.properties?.command as { description?: string } | undefined;
-		assert.ok(SendToTerminalToolData.modelDescription.includes('Send input text to a terminal session'));
-		assert.ok(SendToTerminalToolData.modelDescription.includes('may be empty or whitespace to press Enter'));
-		assert.ok(commandProperty?.description?.includes('Provide an empty or whitespace string to send just Enter'));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot-evaluation/issues/3446

## Problem

When `run_in_terminal` heuristically detected a command *might* be waiting for input, the steering text injected into the model's context:

- Treated the heuristic as authoritative ("the command is waiting for input").
- Led with `send_to_terminal` / `vscode_askQuestions` as the expected next action.
- Mentioned `kill_terminal` as an option in the general case.

This caused regressions on long-running compute commands, secondary shell prompts (heredoc `>`, pagers), and interactive flows like `npm init`: the model would end its turn early, ask the user a fabricated question, or kill a valid interactive session instead of continuing to drive it.

## Root cause

In the Apr 19 terminalbench2 nightly, pass rate dropped from **64.04% → 47.19%** (−17 pts) vs. Apr 6. Tracing the failing instances showed the model ending its turn with **zero tool calls** — emitting a passive status text like *"I'm waiting on the arithmetic pass to finish..."* — immediately after `run_in_terminal` appended the steering note:

> *"Note: The command is running in terminal ID `<uuid>` and may be waiting for input. If it IS waiting for input, call the `vscode_askQuestions` tool…"*

The old steering text offered only two branches: real input → `askQuestions`, or an implicit nothing. When the `didInputNeeded` heuristic introduced by [#308587](https://github.com/microsoft/vscode/pull/308587) (Apr 9, which replaced LLM-based input detection with a regex/polling heuristic) false-positived on long-running compute commands or malformed heredocs, gpt-5.4 correctly recognized the output wasn't a real input prompt — and, with no documented continuation action, ended the turn.

[#311065](https://github.com/microsoft/vscode/pull/311065) (Apr 17) attempted to mitigate by shortening the hint and adding an `isSessionAutoApproveLevel(...)` guard, but msbench special-agent sessions don't resolve as auto-approve, so they kept hitting the dead-end branch.

## Fix

Consolidates all "may be waiting for input" steering text into a single helper (`_buildInputNeededSteeringText`) used by the initial tool result, the `didInputNeeded` race result, the timeout branch, and the background-polling input-needed notification. The new text:

1. Explicitly states the note is **not** a signal to end the turn.
2. Leads with `get_terminal_output` as the safe default recovery action when unsure.
3. Only suggests `send_to_terminal` / `vscode_askQuestions` when the output *clearly* ends with a real input prompt (and calls out that a normal shell prompt doesn't count).
4. Moves `kill_terminal` out of the general case and into the timeout branch only (where it's the legitimate escape hatch for a genuinely hung command).

### Other changes in this branch

- **`get_terminal_output`:** dropped the `terminalId` (numeric instanceId) parameter. The tool now only accepts the opaque `id` (UUID) returned by `run_in_terminal`. The FG-sync `inputNeeded` and timeout paths already leave the execution registered under that UUID, so every terminal the agent started is still reachable; only reads from user-created/foreground-only terminals are no longer supported. `modelDescription` tightened to a single sentence.
- **`send_to_terminal`:** dropped the `terminalId` parameter for symmetry with `get_terminal_output`. Same rationale — every agent-started terminal is reachable via its UUID, and this removes an asymmetric "can type but not read" capability on user-created terminals. `modelDescription` tightened to a single sentence.
- **`send_to_terminal._answerMatchesCommand`:** now treats an undefined/empty answer as matching an empty command across all three shapes (string, single-select, multi-select). An agent pressing Enter to accept a default answer to a blank carousel question is recognized as matching the answer the user already provided, and the redundant approval is suppressed.

## Wait-hint incidence and impact

Scanned all 89 instances in each of three terminalbench2 nightly runs (same model `gpt-5.4`, same benchmark, same dataset — only the VS Code / copilot-chat version changed):

| Run | Date | Instances | Saw wait-hint | Hint was last tool result | Passed with hit | **Failed with hit** |
|---|---|---:|---:|---:|---:|---:|
| [24049820070](https://msbenchapp.azurewebsites.net/run-analysis/24049820070) | Apr 6 (baseline) | 89 | **0** | 0 | 0 | **0** |
| [24638368292](https://msbenchapp.azurewebsites.net/run-analysis/24638368292) | Apr 19 | 89 | **27** | 26 | 7 | **20** |
| [24680614828](https://msbenchapp.azurewebsites.net/run-analysis/24680614828) | Apr 20 | 89 | **13** | 12 | 3 | **10** |

**Hit-when-final failure rate**: 19/26 ≈ **73%**, vs. an overall run failure rate of 52/89 ≈ **58%** — instances that saw the wait-hint as their final tool result were **1.26× more likely to fail**, making the steering text a meaningful contributor to the regression.

**Instances where the wait-hint was the final tool result before the agent stopped** (Apr 19, full list):

| Instance | Hits | Final? | Passed |
|---|---:|:---:|:---:|
| [build-cython-ext](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.build-cython-ext-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 4 | | ✗ |
| [build-pmars](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.build-pmars-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 11 | ✓ | ✓ |
| [build-pov-ray](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.build-pov-ray-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 23 | ✓ | ✗ |
| [compile-compcert](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.compile-compcert-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 3 | ✓ | ✗ |
| [crack-7z-hash](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.crack-7z-hash-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 2 | ✓ | ✗ |
| [db-wal-recovery](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.db-wal-recovery-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 10 | ✓ | ✓ |
| [feal-differential-cryptanalysis](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.feal-differential-cryptanalysis-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [feal-linear-cryptanalysis](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.feal-linear-cryptanalysis-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [fix-ocaml-gc](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.fix-ocaml-gc-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [install-windows-3.11](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.install-windows-3.11-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 29 | ✓ | ✗ |
| [mailman](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.mailman-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 25 | ✓ | ✓ |
| [mcmc-sampling-stan](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.mcmc-sampling-stan-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 23 | ✓ | ✓ |
| [merge-diff-arc-agi-task](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.merge-diff-arc-agi-task-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 9 | ✓ | ✓ |
| [mteb-leaderboard](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.mteb-leaderboard-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 27 | ✓ | ✗ |
| [mteb-retrieve](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.mteb-retrieve-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [multi-source-data-merger](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.multi-source-data-merger-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 8 | ✓ | ✓ |
| [password-recovery](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.password-recovery-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [path-tracing](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.path-tracing-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 3 | ✓ | ✗ |
| [protein-assembly](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.protein-assembly-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 6 | ✓ | ✗ |
| [qemu-alpine-ssh](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.qemu-alpine-ssh-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 3 | ✓ | ✗ |
| [query-optimize](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.query-optimize-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 8 | ✓ | ✗ |
| [regex-chess](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.regex-chess-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 3 | ✓ | ✗ |
| [tune-mjcf](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.tune-mjcf-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |
| [write-compressor](https://msbenchapp.azurewebsites.net/run-analysis/24638368292?tab=logs&logInstance=terminalbench2.eval.x86_64.write-compressor-output&logFile=output%2Ftrajectories%2Ftrajectory.json) | 1 | ✓ | ✗ |

## Representative failure signature (`write-compressor`, Apr 19)

The last tool result delivered to the model, captured from `chat-export-logs.json`:

```
Note: The command is running in terminal ID cbdfc6a7-6288-4d12-9af1-5691462c83e3 and may be waiting
for input. If it IS waiting for input (not a normal shell prompt), call the vscode_askQuestions
tool to ask the user. Then send each answer using send_to_terminal, calling get_terminal_output
between each.

root@436cef840b69:/app#  cd /app && python3 - <<'PY'
> from fractions import Fraction
> from ...
```

The model's next (and final) response:

> *"The exact interval construction is the expensive step; the tokenization already looks good enough structurally. I'm waiting on the arithmetic pass to finish..."*

**0 tool calls. Turn ended. Empty patch.** Trajectory length collapsed from 28 steps (Apr 6 pass) → 7 steps (Apr 19 fail).

## How the fix addresses each failure mode

| Apr 19 failure pattern | Old behavior | New behavior |
|---|---|---|
| Long-running compute mistaken for input (e.g. `write-compressor`, `mteb-leaderboard`, `qemu-alpine-ssh`) | Model sees only the `askQuestions` branch, judges it N/A, emits text, stops. | Explicit step 1: "call `get_terminal_output` to continue polling." |
| Real interactive prompt | Works. | Works (step 2, no regression). |
| Genuine timeout on a hung command | `kill_terminal` mentioned everywhere, tempting premature kills. | Only surfaced in the timeout branch, alongside a reminder to prefer polling first. |



