### PR TITLE
Add randomized placeholders for new-session chat input

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -61,27 +61,35 @@ interface IDraftState {
 
 /**
  * Randomized, friendly placeholders shown in the new-session chat input
- * to add a bit of personality. One is picked per widget instance.
+ * to add a bit of personality. One is picked per widget instance, avoiding
+ * an immediate repeat of the previous pick.
  */
+const RANDOM_PLACEHOLDERS = [
+	localize('sessionsChatInput.placeholder.whatAreYouBuilding', "What are you building?"),
+	localize('sessionsChatInput.placeholder.whatWillYouShipToday', "What will you ship today?"),
+	localize('sessionsChatInput.placeholder.describeWhatYouWantToBuild', "Describe what you want to build..."),
+	localize('sessionsChatInput.placeholder.whatsYourNextMilestone', "What's your next milestone?"),
+	localize('sessionsChatInput.placeholder.whatAreYouTryingToAchieve', "What are you trying to achieve?"),
+	localize('sessionsChatInput.placeholder.pitchYourIdea', "Pitch your idea..."),
+	localize('sessionsChatInput.placeholder.whatsTheGoal', "What's the goal?"),
+	localize('sessionsChatInput.placeholder.whatWillYouCreate', "What will you create?"),
+	localize('sessionsChatInput.placeholder.whatFeatureAreYouDreamingUp', "What feature are you dreaming up?"),
+	localize('sessionsChatInput.placeholder.describeTheOutcome', "Describe the outcome you want..."),
+	localize('sessionsChatInput.placeholder.whatProblemAreYouSolving', "What problem are you solving?"),
+	localize('sessionsChatInput.placeholder.whatsNextOnYourRoadmap', "What's next on your roadmap?"),
+	localize('sessionsChatInput.placeholder.whatWouldYouLikeToAutomate', "What would you like to automate?"),
+	localize('sessionsChatInput.placeholder.whatWillYouLaunch', "What will you launch?"),
+	localize('sessionsChatInput.placeholder.describeYourMission', "Describe your mission..."),
+];
+
+let lastPlaceholderIndex = -1;
 function getRandomChatInputPlaceholder(): string {
-	const placeholders = [
-		localize('sessionsChatInput.placeholder.whatAreYouBuilding', "What are you building?"),
-		localize('sessionsChatInput.placeholder.whatWillYouShipToday', "What will you ship today?"),
-		localize('sessionsChatInput.placeholder.describeWhatYouWantToBuild', "Describe what you want to build..."),
-		localize('sessionsChatInput.placeholder.whatsYourNextMilestone', "What's your next milestone?"),
-		localize('sessionsChatInput.placeholder.whatAreYouTryingToAchieve', "What are you trying to achieve?"),
-		localize('sessionsChatInput.placeholder.pitchYourIdea', "Pitch your idea..."),
-		localize('sessionsChatInput.placeholder.whatsTheGoal', "What's the goal?"),
-		localize('sessionsChatInput.placeholder.whatWillYouCreate', "What will you create?"),
-		localize('sessionsChatInput.placeholder.whatFeatureAreYouDreamingUp', "What feature are you dreaming up?"),
-		localize('sessionsChatInput.placeholder.describeTheOutcome', "Describe the outcome you want..."),
-		localize('sessionsChatInput.placeholder.whatProblemAreYouSolving', "What problem are you solving?"),
-		localize('sessionsChatInput.placeholder.whatsNextOnYourRoadmap', "What's next on your roadmap?"),
-		localize('sessionsChatInput.placeholder.whatWouldYouLikeToAutomate', "What would you like to automate?"),
-		localize('sessionsChatInput.placeholder.whatWillYouLaunch', "What will you launch?"),
-		localize('sessionsChatInput.placeholder.describeYourMission', "Describe your mission..."),
-	];
-	return placeholders[Math.floor(Math.random() * placeholders.length)];
+	let index = Math.floor(Math.random() * RANDOM_PLACEHOLDERS.length);
+	if (index === lastPlaceholderIndex) {
+		index = (index + 1) % RANDOM_PLACEHOLDERS.length;
+	}
+	lastPlaceholderIndex = index;
+	return RANDOM_PLACEHOLDERS[index];
 }
 
 // #region --- New Chat Widget ---

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -67,19 +67,19 @@ interface IDraftState {
 const RANDOM_PLACEHOLDERS = [
 	localize('sessionsChatInput.placeholder.whatAreYouBuilding', "What are you building?"),
 	localize('sessionsChatInput.placeholder.whatWillYouShipToday', "What will you ship today?"),
-	localize('sessionsChatInput.placeholder.describeWhatYouWantToBuild', "Describe what you want to build..."),
+	localize('sessionsChatInput.placeholder.describeWhatYouWantToBuild', "Describe what you want to build"),
 	localize('sessionsChatInput.placeholder.whatsYourNextMilestone', "What's your next milestone?"),
 	localize('sessionsChatInput.placeholder.whatAreYouTryingToAchieve', "What are you trying to achieve?"),
-	localize('sessionsChatInput.placeholder.pitchYourIdea', "Pitch your idea..."),
+	localize('sessionsChatInput.placeholder.pitchYourIdea', "Pitch your idea"),
 	localize('sessionsChatInput.placeholder.whatsTheGoal', "What's the goal?"),
 	localize('sessionsChatInput.placeholder.whatWillYouCreate', "What will you create?"),
 	localize('sessionsChatInput.placeholder.whatFeatureAreYouDreamingUp', "What feature are you dreaming up?"),
-	localize('sessionsChatInput.placeholder.describeTheOutcome', "Describe the outcome you want..."),
+	localize('sessionsChatInput.placeholder.describeTheOutcome', "Describe the outcome you want"),
 	localize('sessionsChatInput.placeholder.whatProblemAreYouSolving', "What problem are you solving?"),
 	localize('sessionsChatInput.placeholder.whatsNextOnYourRoadmap', "What's next on your roadmap?"),
 	localize('sessionsChatInput.placeholder.whatWouldYouLikeToAutomate', "What would you like to automate?"),
 	localize('sessionsChatInput.placeholder.whatWillYouLaunch', "What will you launch?"),
-	localize('sessionsChatInput.placeholder.describeYourMission', "Describe your mission..."),
+	localize('sessionsChatInput.placeholder.describeYourMission', "Describe your mission"),
 ];
 
 let lastPlaceholderIndex = -1;

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -59,6 +59,31 @@ interface IDraftState {
 	attachments: readonly IChatRequestVariableEntry[];
 }
 
+/**
+ * Randomized, friendly placeholders shown in the new-session chat input
+ * to add a bit of personality. One is picked per widget instance.
+ */
+function getRandomChatInputPlaceholder(): string {
+	const placeholders = [
+		localize('sessionsChatInput.placeholder.whatAreYouBuilding', "What are you building?"),
+		localize('sessionsChatInput.placeholder.whatWillYouShipToday', "What will you ship today?"),
+		localize('sessionsChatInput.placeholder.describeWhatYouWantToBuild', "Describe what you want to build..."),
+		localize('sessionsChatInput.placeholder.whatsYourNextMilestone', "What's your next milestone?"),
+		localize('sessionsChatInput.placeholder.whatAreYouTryingToAchieve', "What are you trying to achieve?"),
+		localize('sessionsChatInput.placeholder.pitchYourIdea', "Pitch your idea..."),
+		localize('sessionsChatInput.placeholder.whatsTheGoal', "What's the goal?"),
+		localize('sessionsChatInput.placeholder.whatWillYouCreate', "What will you create?"),
+		localize('sessionsChatInput.placeholder.whatFeatureAreYouDreamingUp', "What feature are you dreaming up?"),
+		localize('sessionsChatInput.placeholder.describeTheOutcome', "Describe the outcome you want..."),
+		localize('sessionsChatInput.placeholder.whatProblemAreYouSolving', "What problem are you solving?"),
+		localize('sessionsChatInput.placeholder.whatsNextOnYourRoadmap', "What's next on your roadmap?"),
+		localize('sessionsChatInput.placeholder.whatWouldYouLikeToAutomate', "What would you like to automate?"),
+		localize('sessionsChatInput.placeholder.whatWillYouLaunch', "What will you launch?"),
+		localize('sessionsChatInput.placeholder.describeYourMission', "Describe your mission..."),
+	];
+	return placeholders[Math.floor(Math.random() * placeholders.length)];
+}
+
 // #region --- New Chat Widget ---
 
 export class NewChatInputWidget extends Disposable implements IHistoryNavigationWidget {
@@ -232,7 +257,7 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 			...getSimpleEditorOptions(this.configurationService),
 			readOnly: false,
 			ariaLabel: this._getAriaLabel(),
-			placeholder: this.options.placeholder,
+			placeholder: this.options.placeholder ?? getRandomChatInputPlaceholder(),
 			fontFamily: 'system-ui, -apple-system, sans-serif',
 			fontSize: 13,
 			lineHeight: 20,


### PR DESCRIPTION
This pull request enhances the user experience in the new chat input widget by introducing a set of randomized, friendly placeholder texts. Each chat input instance now displays a different, personality-infused prompt to inspire users, avoiding immediate repetition.

**User experience improvements:**

* Added a `RANDOM_PLACEHOLDERS` array containing a variety of engaging placeholder prompts for the chat input, aiming to spark user creativity and provide a more welcoming interface.
* Implemented the `getRandomChatInputPlaceholder()` function to select a random placeholder, ensuring that the same prompt is not shown consecutively.
* Updated the `NewChatInputWidget` to use a random placeholder from the new set if no specific placeholder is provided, instead of relying on a static default.