### PR TITLE
Fix gcp-metadata license URL to unblock OSS Tool workflow

### DIFF
--- a/cglicenses.json
+++ b/cglicenses.json
@@ -909,7 +909,7 @@
 	},
 	{
 		"name": "gcp-metadata",
-		"fullLicenseTextUri": "https://github.com/googleapis/google-cloud-node-core/blob/76ba85a7f55c6e82943008b4eceb07a0f58b39e1/LICENSE"
+		"fullLicenseTextUri": "https://raw.githubusercontent.com/googleapis/google-cloud-node-core/76ba85a7f55c6e82943008b4eceb07a0f58b39e1/LICENSE"
 	},
 	{
 		"name": "randombytes",


### PR DESCRIPTION
## Problem

The OSS Tool workflow (used in the weekly endgame to regenerate third-party license files) has been silently failing. It reports "No changes in vscode/vscode-distro/vscode-build-tools" even though it actually crashed mid-run.

Root cause: the `fullLicenseTextUri` for `gcp-metadata` in [cglicenses.json](https://github.com/microsoft/vscode/blob/main/cglicenses.json) points to a `github.com/.../blob/<sha>/LICENSE` URL, which returns `text/html`. The tool's [`getLicenseTextFromUri`](https://github.com/microsoft/vscode-build-tools/blob/main/distro-tools/lib/licenseFinder.ts) requires `text/plain` and throws:

```
Error: Expected a plain text response loading license from https://github.com/googleapis/google-cloud-node-core/blob/76ba85a7.../LICENSE, got text/html; charset=utf-8
    at getLicenseTextFromUri (.../lib/licenseFinder.ts:379:9)
    at async resolveAllItems (.../lib/index.ts:253:24)
```

The thrown error does not match the workflow's `[error]` log-grep filter, so the agentic fixer is skipped and the run is reported as successful.

## Fix

Switch the URL to the `raw.githubusercontent.com` equivalent, which returns `text/plain`. Verified the content is identical (Apache-2.0, HTTP 200, `Content-Type: text/plain`).

## Note

This only unblocks the initial crash. A manual run after this fix surfaces 20 further pre-existing license errors that will need separate follow-up. Landing this lets the automated workflow at least run to completion and surface those errors properly.