### PR TITLE
fix: chat copy button should always copy message text

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCopyActions.ts
@@ -211,15 +211,6 @@ export function registerChatCopyActions() {
 				}
 			}
 
-			// If there is a text selection, and focus is inside the widget, copy the selected text.
-			// Otherwise, context menu with no selection -> copy the full item
-			const nativeSelection = dom.getActiveWindow().getSelection();
-			const selectedText = nativeSelection?.toString();
-			if (widget && selectedText && selectedText.length > 0 && dom.isAncestor(dom.getActiveElement(), widget.domNode)) {
-				await clipboardService.writeText(selectedText);
-				return;
-			}
-
 			if (!isRequestVM(item) && !isResponseVM(item)) {
 				return;
 			}


### PR DESCRIPTION
**Fixes:** #311690

**Changes:**
Removed the native text selection shortcut in `CopyItemAction`. The selection check used `lastFocusedWidget` scope which covers the entire chat widget, so any selection anywhere in chat would hijack the copy button regardless of which message it belongs to.

The copy button's intent is unambiguous, it should always copy its assigned message.

**Testing:**
1. Open Copilot Chat
2. Select text anywhere in the chat
3. Click the copy button on any message
4. Verify it copies the full message, not the selection