### PR TITLE
Color `*_test.go` files the same way `*.test.ts` are colored

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -502,6 +502,14 @@
 			"fontCharacter": "\\E03A",
 			"fontColor": "#519aba"
 		},
+		"_go2_1_light": {
+			"fontCharacter": "\\E03A",
+			"fontColor": "#cc6d2e"
+		},
+		"_go2_1": {
+			"fontCharacter": "\\E03A",
+			"fontColor": "#e37933"
+		},
 		"_godot_light": {
 			"fontCharacter": "\\E03B",
 			"fontColor": "#498ba7"
@@ -1610,6 +1618,7 @@
 		"gitmodules": "_git",
 		"slide": "_go",
 		"article": "_go",
+		"_test.go": "_go2_1",
 		"gd": "_godot",
 		"godot": "_godot_1",
 		"tres": "_godot_2",
@@ -2040,6 +2049,7 @@
 			"gitmodules": "_git_light",
 			"slide": "_go_light",
 			"article": "_go_light",
+			"_test.go": "_go2_1_light",
 			"gd": "_godot_light",
 			"godot": "_godot_1_light",
 			"tres": "_godot_2_light",

--- a/src/vs/editor/common/services/getIconClasses.ts
+++ b/src/vs/editor/common/services/getIconClasses.ts
@@ -69,6 +69,14 @@ export function getIconClasses(modelService: IModelService, languageService: ILa
 					const dotSegments = name.split('.');
 					for (let i = 1; i < dotSegments.length; i++) {
 						classes.push(`${dotSegments.slice(i).join('.')}-ext-file-icon`); // add each combination of all found extensions if more than one
+
+						// Handle underscore-suffixed base names (e.g., foo_test.go → _test.go)
+						// to enable icon themes to target naming conventions like Go's _test.go files
+						const precedingSegment = dotSegments[i - 1];
+						const lastUnderscore = precedingSegment.lastIndexOf('_');
+						if (lastUnderscore > 0 && lastUnderscore < precedingSegment.length - 1) {
+							classes.push(`${precedingSegment.substring(lastUnderscore)}.${dotSegments.slice(i).join('.')}-ext-file-icon`);
+						}
 					}
 				}
 				classes.push(`ext-file-icon`); // extra segment to increase file-ext score

--- a/src/vs/editor/test/common/services/getIconClasses.test.ts
+++ b/src/vs/editor/test/common/services/getIconClasses.test.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ILanguageService } from '../../../common/languages/language.js';
+import { IModelService } from '../../../common/services/model.js';
+import { getIconClasses } from '../../../common/services/getIconClasses.js';
+
+/**
+ * Minimal stubs — language detection is irrelevant for the class-generation
+ * tests below, so returning null/undefined everywhere is fine.
+ */
+const nullModelService = { getModel: () => null } as unknown as IModelService;
+const nullLanguageService = {
+	getLanguageIdByMimeType: () => null,
+	guessLanguageIdByFilepathOrFirstLine: () => null,
+} as unknown as ILanguageService;
+
+function classesFor(filename: string): string[] {
+	return getIconClasses(nullModelService, nullLanguageService, URI.file(`/test/${filename}`));
+}
+
+suite('getIconClasses', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('produces dot-based compound extension classes', () => {
+		const classes = classesFor('foo.test.ts');
+		assert.ok(classes.includes('test.ts-ext-file-icon'));
+		assert.ok(classes.includes('ts-ext-file-icon'));
+	});
+
+	test('produces underscore-suffix extension class for Go test files', () => {
+		const classes = classesFor('foo_test.go');
+		assert.ok(classes.includes('_test.go-ext-file-icon'), 'should produce _test.go compound extension');
+		assert.ok(classes.includes('go-ext-file-icon'), 'should still produce base .go extension');
+	});
+
+	test('produces underscore-suffix for deeply underscored names', () => {
+		const classes = classesFor('my_app_test.go');
+		assert.ok(classes.includes('_test.go-ext-file-icon'), 'uses last underscore segment');
+		assert.ok(classes.includes('go-ext-file-icon'));
+	});
+
+	test('handles underscore suffix with compound dot extension', () => {
+		const classes = classesFor('foo_test.d.ts');
+		assert.ok(classes.includes('_test.d.ts-ext-file-icon'), 'combines underscore suffix with full dot extension');
+		assert.ok(classes.includes('d.ts-ext-file-icon'));
+		assert.ok(classes.includes('ts-ext-file-icon'));
+	});
+
+	test('handles underscore suffix in middle dot segment', () => {
+		const classes = classesFor('foo.bar_test.go');
+		assert.ok(classes.includes('_test.go-ext-file-icon'), 'detects underscore in non-first dot segment');
+		assert.ok(classes.includes('bar_test.go-ext-file-icon'));
+		assert.ok(classes.includes('go-ext-file-icon'));
+	});
+
+	test('skips leading underscore filenames', () => {
+		const classes = classesFor('_hidden.go');
+		assert.ok(!classes.includes('_hidden.go-ext-file-icon'), 'leading underscore should not produce a suffix class');
+		assert.ok(classes.includes('go-ext-file-icon'));
+	});
+
+	test('skips trailing underscore in base name', () => {
+		const classes = classesFor('__init__.py');
+		assert.ok(classes.includes('py-ext-file-icon'));
+		// Should not produce a junk class from the trailing underscore
+		const underscoreClasses = classes.filter(c => c.startsWith('_.') && c.endsWith('-ext-file-icon'));
+		assert.strictEqual(underscoreClasses.length, 0, 'trailing underscore should not produce a suffix class');
+	});
+
+	test('does not produce underscore class for hyphenated names', () => {
+		const classes = classesFor('foo-test.go');
+		assert.ok(!classes.includes('_test.go-ext-file-icon'), 'hyphens should not be treated as underscore suffix separators');
+		assert.ok(classes.includes('go-ext-file-icon'));
+	});
+
+	test('no extra classes for files without underscores', () => {
+		const classes = classesFor('main.go');
+		const extClasses = classes.filter(c => c.endsWith('-ext-file-icon') && c !== 'ext-file-icon');
+		assert.deepStrictEqual(extClasses, ['go-ext-file-icon']);
+	});
+});

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -71,7 +71,7 @@ const schema: IJSONSchema = {
 		},
 		fileExtensions: {
 			type: 'object',
-			description: nls.localize('schema.fileExtensions', 'Associates file extensions to icons. The object key is the file extension name. The extension name is the last segment of a file name after the last dot (not including the dot). Extensions are compared case insensitive.'),
+			description: nls.localize('schema.fileExtensions', 'Associates file extensions to icons. The object key is the file extension name. The extension name is the last segment of a file name after the last dot (not including the dot). Extensions are compared case insensitive. Compound extensions with dots are supported (e.g. "test.ts" matches "foo.test.ts"). Underscore-suffixed extensions are also supported (e.g. "_test.go" matches "foo_test.go").'),
 
 			additionalProperties: {
 				type: 'string',


### PR DESCRIPTION
For JS/TS, test files are shown in another color:

<img width="292" height="227" alt="image" src="https://github.com/user-attachments/assets/73bd9d1e-cea8-43d5-937f-a56adceb46b3" />

I'd love to have this for Go, where it's hard to visually find test files:

<img width="317" height="303" alt="image" src="https://github.com/user-attachments/assets/d37c7feb-e794-4069-aaef-971807f2477b" />

But, this didn't end up working out of the box as the highlighting system only looks for dot separated strings.

Adding `_` separation enables this:

<img width="286" height="328" alt="image" src="https://github.com/user-attachments/assets/fba60f29-abba-47aa-b4b8-b84bdfc4483a" />

There are other languages that use a `*_test.<ext>` convention or similar, including:

- Elixir: https://hexdocs.pm/ex_unit/ExUnit.html, https://github.com/elixir-lang/elixir/tree/main/lib/elixir/test/elixir
- Ruby: https://rspec.info/features/3-12/rspec-core/command-line/pattern-option/
- Python: https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery (though `test_*.py` is also listed, which I have not handled)

Which could benefit from a change like this, though I don't know what color to give those (TS vs Go is easy because they're both blue, so orange seems fine!)