### PR TITLE
Fix InstallFromSourceAction disposal and accessor errors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -71,6 +71,7 @@ class InstallFromSourceAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const pluginInstallService = accessor.get(IPluginInstallService);
+		const extensionsWorkbenchService = accessor.get(IExtensionsWorkbenchService);
 
 		const store = new DisposableStore();
 		const inputBox = store.add(quickInputService.createInputBox());
@@ -121,7 +122,7 @@ class InstallFromSourceAction extends Action2 {
 				} else {
 					const ref = parseMarketplaceReference(source);
 					if (ref) {
-						accessor.get(IExtensionsWorkbenchService).openSearch(`@agentPlugins ${ref.displayLabel}`);
+						extensionsWorkbenchService.openSearch(`@agentPlugins ${ref.displayLabel}`);
 					}
 					store.dispose();
 				}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -13,12 +13,12 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { IAgentPluginRepositoryService } from '../../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
 import { type IMarketplaceReference, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from '../../common/plugins/pluginMarketplaceService.js';
-import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { InstalledAgentPluginsViewId } from '../agentPluginsView.js';
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 
@@ -83,8 +83,11 @@ class InstallFromSourceAction extends Action2 {
 			inputBox.validationMessage = undefined;
 		}));
 
+		let installing = false;
 		store.add(inputBox.onDidHide(() => {
-			store.dispose();
+			if (!installing) {
+				store.dispose();
+			}
 		}));
 
 		store.add(inputBox.onDidAccept(async () => {
@@ -103,6 +106,7 @@ class InstallFromSourceAction extends Action2 {
 			// Show busy state and prevent concurrent installs.
 			inputBox.busy = true;
 			inputBox.enabled = false;
+			installing = true;
 			try {
 				// Hide the input box so it doesn't conflict with trust/progress dialogs.
 				inputBox.hide();
@@ -119,10 +123,14 @@ class InstallFromSourceAction extends Action2 {
 					if (ref) {
 						accessor.get(IExtensionsWorkbenchService).openSearch(`@agentPlugins ${ref.displayLabel}`);
 					}
+					store.dispose();
 				}
 			} finally {
-				inputBox.busy = false;
-				inputBox.enabled = true;
+				installing = false;
+				if (!store.isDisposed) {
+					inputBox.busy = false;
+					inputBox.enabled = true;
+				}
 			}
 		}));
 	}


### PR DESCRIPTION
Fixes two issues in \`InstallFromSourceAction\` (\`workbench.action.chat.installPluginFromSource\`):

### 1. "Accessor is not available after the run is complete"
The \`ServicesAccessor\` passed to \`Action2.run()\` is only valid synchronously during \`run()\`. The handler was calling \`accessor.get(IExtensionsWorkbenchService)\` inside an async \`onDidAccept\` callback that fires long after \`run()\` has returned. Resolved the service up-front and closed over it.

### 2. Accessing disposed \`inputBox\` after install completes
\`inputBox.hide()\` (called before the awaited install) triggers \`onDidHide\`, which disposes the \`DisposableStore\` and the \`inputBox\` itself. After the await, the handler would touch a disposed input box (\`show()\`, \`busy\`, \`enabled\`).

Guarded \`onDidHide\` with an \`installing\` flag so it no-ops while an install is in progress, dispose the store explicitly on the success path, and skip the finally-block writes once the store is disposed.

Split into two commits for reviewability.