### PR TITLE
feat: add leakWarningName to emitters for better leak error telemetry grouping

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -1030,12 +1030,13 @@ class LeakageMonitor {
 			this._warnCountdown = threshold * 0.5;
 
 			const [topStack, topCount] = this.getMostFrequentStack()!;
+			const emitterName = /^[0-9a-f]+$/i.test(this.name) ? undefined : this.name;
 			const message = `[${this.name}] potential listener LEAK detected, having ${listenerCount} listeners already. MOST frequent listener (${topCount}):`;
 			console.warn(message);
 			console.warn(topStack);
 
 			const kind = topCount / listenerCount > 0.3 ? 'dominated' : 'popular';
-			const error = new ListenerLeakError(kind, message, topStack, listenerCount, this.name);
+			const error = new ListenerLeakError(kind, message, topStack, listenerCount, emitterName);
 			this._errorHandler(error);
 		}
 
@@ -1082,7 +1083,8 @@ export class ListenerLeakError extends Error {
 	/**
 	 * The detailed message including listener count and most frequent stack.
 	 * Available locally for debugging but intentionally not used as the error
-	 * `message` so that all leak errors group under the same title in telemetry.
+	 * `message`. When `emitterName` is provided, errors group by emitter name
+	 * and kind in telemetry; otherwise they group by kind alone.
 	 */
 	readonly details: string;
 	constructor(kind: 'dominated' | 'popular', details: string, stack: string, listenerCount: number, emitterName?: string) {
@@ -1245,7 +1247,7 @@ export class Emitter<T> {
 
 				const tuple = this._leakageMon.getMostFrequentStack() ?? ['UNKNOWN stack', -1];
 				const kind = tuple[1] / this._size > 0.3 ? 'dominated' : 'popular';
-				const error = new ListenerRefusalError(kind, `${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0], this._size, this._leakageMon.name);
+				const error = new ListenerRefusalError(kind, `${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0], this._size, this._options?.leakWarningName);
 				const errorHandler = this._options?.onListenerError || onUnexpectedError;
 				errorHandler(error);
 

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -932,6 +932,11 @@ export interface EmitterOptions {
 	 */
 	leakWarningThreshold?: number;
 	/**
+	 * Human-readable name for the emitter, included in leak warning error
+	 * messages to help identify which emitter is leaking in telemetry.
+	 */
+	leakWarningName?: string;
+	/**
 	 * Pass in a delivery queue, which is useful for ensuring
 	 * in order event delivery across multiple emitters.
 	 */
@@ -1030,7 +1035,7 @@ class LeakageMonitor {
 			console.warn(topStack);
 
 			const kind = topCount / listenerCount > 0.3 ? 'dominated' : 'popular';
-			const error = new ListenerLeakError(kind, message, topStack, listenerCount);
+			const error = new ListenerLeakError(kind, message, topStack, listenerCount, this.name);
 			this._errorHandler(error);
 		}
 
@@ -1080,8 +1085,10 @@ export class ListenerLeakError extends Error {
 	 * `message` so that all leak errors group under the same title in telemetry.
 	 */
 	readonly details: string;
-	constructor(kind: 'dominated' | 'popular', details: string, stack: string, listenerCount: number) {
-		super(`potential listener LEAK detected, ${kind}`);
+	constructor(kind: 'dominated' | 'popular', details: string, stack: string, listenerCount: number, emitterName?: string) {
+		super(emitterName
+			? `[${emitterName}] potential listener LEAK detected, ${kind}`
+			: `potential listener LEAK detected, ${kind}`);
 		this.name = 'ListenerLeakError';
 		this.kind = kind;
 		this.listenerCount = listenerCount;
@@ -1098,8 +1105,8 @@ export class ListenerLeakError extends Error {
 // SEVERE error that is logged when having gone way over the configured listener
 // threshold so that the emitter refuses to accept more listeners
 export class ListenerRefusalError extends ListenerLeakError {
-	constructor(kind: 'dominated' | 'popular', details: string, stack: string, listenerCount: number) {
-		super(kind, details, stack, listenerCount);
+	constructor(kind: 'dominated' | 'popular', details: string, stack: string, listenerCount: number, emitterName?: string) {
+		super(kind, details, stack, listenerCount, emitterName);
 		this.name = 'ListenerRefusalError';
 	}
 }
@@ -1187,7 +1194,7 @@ export class Emitter<T> {
 	constructor(options?: EmitterOptions) {
 		this._options = options;
 		this._leakageMon = (_globalLeakWarningThreshold > 0 || this._options?.leakWarningThreshold)
-			? new LeakageMonitor(options?.onListenerError ?? onUnexpectedError, this._options?.leakWarningThreshold ?? _globalLeakWarningThreshold) :
+			? new LeakageMonitor(options?.onListenerError ?? onUnexpectedError, this._options?.leakWarningThreshold ?? _globalLeakWarningThreshold, this._options?.leakWarningName) :
 			undefined;
 		this._perfMon = this._options?._profName ? new EventProfiling(this._options._profName) : undefined;
 		this._deliveryQueue = this._options?.deliveryQueue as EventDeliveryQueuePrivate | undefined;
@@ -1238,7 +1245,7 @@ export class Emitter<T> {
 
 				const tuple = this._leakageMon.getMostFrequentStack() ?? ['UNKNOWN stack', -1];
 				const kind = tuple[1] / this._size > 0.3 ? 'dominated' : 'popular';
-				const error = new ListenerRefusalError(kind, `${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0], this._size);
+				const error = new ListenerRefusalError(kind, `${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0], this._size, this._leakageMon.name);
 				const errorHandler = this._options?.onListenerError || onUnexpectedError;
 				errorHandler(error);
 

--- a/src/vs/editor/common/services/languageService.ts
+++ b/src/vs/editor/common/services/languageService.ts
@@ -23,7 +23,7 @@ export class LanguageService extends Disposable implements ILanguageService {
 	private readonly _onDidRequestRichLanguageFeatures = this._register(new Emitter<string>());
 	public readonly onDidRequestRichLanguageFeatures = this._onDidRequestRichLanguageFeatures.event;
 
-	protected readonly _onDidChange = this._register(new Emitter<void>({ leakWarningThreshold: 200 /* https://github.com/microsoft/vscode/issues/119968 */ }));
+	protected readonly _onDidChange = this._register(new Emitter<void>({ leakWarningThreshold: 200, leakWarningName: 'LanguageService._onDidChange' /* https://github.com/microsoft/vscode/issues/119968 */ }));
 	public readonly onDidChange: Event<void> = this._onDidChange.event;
 
 	private readonly _requestedBasicLanguages = new Set<string>();

--- a/src/vs/workbench/common/editor/editorGroupModel.ts
+++ b/src/vs/workbench/common/editor/editorGroupModel.ts
@@ -188,7 +188,7 @@ export class EditorGroupModel extends Disposable implements IEditorGroupModel {
 
 	//#region events
 
-	private readonly _onDidModelChange = this._register(new Emitter<IGroupModelChangeEvent>({ leakWarningThreshold: 500 /* increased for users with hundreds of inputs opened */ }));
+	private readonly _onDidModelChange = this._register(new Emitter<IGroupModelChangeEvent>({ leakWarningThreshold: 500, leakWarningName: 'EditorGroupModel._onDidModelChange' /* increased for users with hundreds of inputs opened */ }));
 	readonly onDidModelChange = this._onDidModelChange.event;
 
 	//#endregion

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -116,7 +116,7 @@ export class DisassemblyView extends EditorPane {
 		this.menu = menuService.createMenu(MenuId.DebugDisassemblyContext, contextKeyService);
 		this._register(this.menu);
 		this._disassembledInstructions = undefined;
-		this._onDidChangeStackFrame = this._register(new Emitter<void>({ leakWarningThreshold: 1000 }));
+		this._onDidChangeStackFrame = this._register(new Emitter<void>({ leakWarningThreshold: 1000, leakWarningName: 'DisassemblyView._onDidChangeStackFrame' }));
 		this._previousDebuggingState = _debugService.state;
 		this._register(_configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('debug')) {

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -70,7 +70,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 	private readonly _onDidChangeExtensionsStatus = this._register(new Emitter<ExtensionIdentifier[]>());
 	public readonly onDidChangeExtensionsStatus = this._onDidChangeExtensionsStatus.event;
 
-	private readonly _onDidChangeExtensions = this._register(new Emitter<{ readonly added: ReadonlyArray<IExtensionDescription>; readonly removed: ReadonlyArray<IExtensionDescription> }>({ leakWarningThreshold: 400 }));
+	private readonly _onDidChangeExtensions = this._register(new Emitter<{ readonly added: ReadonlyArray<IExtensionDescription>; readonly removed: ReadonlyArray<IExtensionDescription> }>({ leakWarningThreshold: 400, leakWarningName: 'ExtensionService._onDidChangeExtensions' }));
 	public readonly onDidChangeExtensions = this._onDidChangeExtensions.event;
 
 	private readonly _onWillActivateByEvent = this._register(new Emitter<IWillActivateEvent>());

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -135,7 +135,7 @@ export class LabelService extends Disposable implements ILabelService {
 
 	private formatters: ResourceLabelFormatter[];
 
-	private readonly _onDidChangeFormatters = this._register(new Emitter<IFormatterChangeEvent>({ leakWarningThreshold: 400 }));
+	private readonly _onDidChangeFormatters = this._register(new Emitter<IFormatterChangeEvent>({ leakWarningThreshold: 400, leakWarningName: 'LabelService._onDidChangeFormatters' }));
 	readonly onDidChangeFormatters = this._onDidChangeFormatters.event;
 
 	private readonly storedFormattersMemento: Memento<IStoredFormatters>;

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -39,7 +39,7 @@ interface ITextFileEditorModelToRestore {
 
 export class TextFileEditorModelManager extends Disposable implements ITextFileEditorModelManager {
 
-	private readonly _onDidCreate = this._register(new Emitter<TextFileEditorModel>({ leakWarningThreshold: 500 /* increased for users with hundreds of inputs opened */ }));
+	private readonly _onDidCreate = this._register(new Emitter<TextFileEditorModel>({ leakWarningThreshold: 500, leakWarningName: 'TextFileEditorModelManager._onDidCreate' /* increased for users with hundreds of inputs opened */ }));
 	readonly onDidCreate = this._onDidCreate.event;
 
 	private readonly _onDidResolve = this._register(new Emitter<ITextFileResolveEvent>());

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -123,14 +123,14 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 		this.colorThemeRegistry = this._register(new ThemeRegistry(colorThemesExtPoint, ColorThemeData.fromExtensionTheme));
 		this.colorThemeWatcher = this._register(new ThemeFileWatcher(fileService, environmentService, this.reloadCurrentColorTheme.bind(this)));
-		this.onColorThemeChange = this._register(new Emitter<IWorkbenchColorTheme>({ leakWarningThreshold: 400 }));
+		this.onColorThemeChange = this._register(new Emitter<IWorkbenchColorTheme>({ leakWarningThreshold: 400, leakWarningName: 'ThemeService.onColorThemeChange' }));
 		this.currentColorTheme = ColorThemeData.createUnloadedTheme('');
 		this.colorThemeSequencer = new Sequencer();
 
 		this.fileIconThemeWatcher = this._register(new ThemeFileWatcher(fileService, environmentService, this.reloadCurrentFileIconTheme.bind(this)));
 		this.fileIconThemeRegistry = this._register(new ThemeRegistry(fileIconThemesExtPoint, FileIconThemeData.fromExtensionTheme, true, FileIconThemeData.noIconTheme));
 		this.fileIconThemeLoader = new FileIconThemeLoader(extensionResourceLoaderService, languageService);
-		this.onFileIconThemeChange = this._register(new Emitter<IWorkbenchFileIconTheme>({ leakWarningThreshold: 400 }));
+		this.onFileIconThemeChange = this._register(new Emitter<IWorkbenchFileIconTheme>({ leakWarningThreshold: 400, leakWarningName: 'ThemeService.onFileIconThemeChange' }));
 		this.currentFileIconTheme = FileIconThemeData.createUnloadedTheme('');
 		this.fileIconThemeSequencer = new Sequencer();
 


### PR DESCRIPTION
## Summary

Add human-readable emitter names to ListenerLeakError and ListenerRefusalError messages, improving error telemetry grouping for listener leak buckets.

Ref: #305051

## Problem

Listener leak errors produce non-deterministic stack traces (due to subscriber rotation and stack drift across builds), causing the same underlying leak to generate many different error bucket IDs in telemetry. Without an emitter identifier in the error message, it's impossible to reliably group related buckets.

## Changes

### Core infrastructure (src/vs/base/common/event.ts)

- Add leakWarningName?: string to EmitterOptions
- Thread leakWarningName through Emitter constructor to LeakageMonitor
- Add optional mitterName parameter to ListenerLeakError and ListenerRefusalError constructors
- When mitterName is provided, prefix the error message: [EmitterName] potential listener LEAK detected, {kind}

### Emitter annotations (all emitters with custom leakWarningThreshold)

| File | Emitter | Threshold |
|------|---------|-----------|
| languageService.ts | LanguageService._onDidChange | 200 |
| bstractExtensionService.ts | ExtensionService._onDidChangeExtensions | 400 |
| workbenchThemeService.ts | ThemeService.onColorThemeChange | 400 |
| workbenchThemeService.ts | ThemeService.onFileIconThemeChange | 400 |
| 	extFileEditorModelManager.ts | TextFileEditorModelManager._onDidCreate | 500 |
| ditorGroupModel.ts | EditorGroupModel._onDidModelChange | 500 |
| labelService.ts | LabelService._onDidChangeFormatters | 400 |
| disassemblyView.ts | DisassemblyView._onDidChangeStackFrame | 1000 |

### Backward compatibility

Emitters without leakWarningName continue to produce the original message format. The name is opt-in.

> _Written by Copilot_
