### PR TITLE
Add prominent "Open in Editor" button to customization editor header

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -50,6 +50,7 @@ import {
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID,
 	AI_CUSTOMIZATION_SUPPORTS_TROUBLESHOOT_KEY,
 	AICustomizationManagementCommands,
+	AICustomizationManagementEmbeddedEditorTitleMenuId,
 	AICustomizationManagementItemMenuId,
 	AICustomizationManagementSection,
 	BUILTIN_STORAGE,
@@ -221,8 +222,8 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: OPEN_AI_CUSTOMIZATION_MGMT_FILE_ID,
-			title: localize2('open', "Open"),
-			icon: Codicon.goToFile,
+			title: localize2('openInEditor', "Open in Editor"),
+			icon: Codicon.openInWindow,
 		});
 	}
 	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
@@ -504,6 +505,19 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: OPEN_AI_CUSTOMIZATION_MGMT_FILE_ID, title: localize('open', "Open") },
 	group: '1_open',
+	order: 1,
+});
+
+// Embedded editor title bar — surfaces the Open in Editor action prominently
+// so users can jump from the modal-style editor to a full editor (with file
+// explorer + chat) without losing context.
+MenuRegistry.appendMenuItem(AICustomizationManagementEmbeddedEditorTitleMenuId, {
+	command: {
+		id: OPEN_AI_CUSTOMIZATION_MGMT_FILE_ID,
+		title: localize2('openInEditor', "Open in Editor"),
+		icon: Codicon.openInWindow,
+	},
+	group: 'navigation',
 	order: 1,
 });
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -70,6 +70,15 @@ export const CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_HARNESS = new RawContextKey<str
 export const AICustomizationManagementTitleMenuId = MenuId.for('AICustomizationManagementEditorTitle');
 
 /**
+ * Menu ID for actions in the embedded editor header (shown when editing a single
+ * customization file inside the management editor). VS Code and extensions can
+ * contribute commands here. Use the standard item context keys
+ * (`aiCustomizationManagementItemType`, `aiCustomizationManagementItemStorage`,
+ * `aiCustomizationManagementItemUri`) to scope contributions.
+ */
+export const AICustomizationManagementEmbeddedEditorTitleMenuId = MenuId.for('AICustomizationManagementEmbeddedEditorTitle');
+
+/**
  * Menu ID for the AI Customization Management Editor item context menu.
  */
 export const AICustomizationManagementItemMenuId = MenuId.for('AICustomizationManagementEditorItem');

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -23,6 +23,7 @@ import { EditorPane } from '../../../../browser/parts/editor/editorPane.js';
 import { IEditorOpenContext } from '../../../../common/editor.js';
 import { IEditorGroup } from '../../../../services/editor/common/editorGroupsService.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { WorkbenchList } from '../../../../../platform/list/browser/listService.js';
 import { IListVirtualDelegate, IListRenderer } from '../../../../../base/browser/ui/list/list.js';
@@ -38,9 +39,13 @@ import { AICustomizationListWidget } from './aiCustomizationListWidget.js';
 import { McpListWidget } from './mcpListWidget.js';
 import { PluginListWidget } from './pluginListWidget.js';
 import {
+	AI_CUSTOMIZATION_ITEM_STORAGE_KEY,
+	AI_CUSTOMIZATION_ITEM_TYPE_KEY,
+	AI_CUSTOMIZATION_ITEM_URI_KEY,
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID,
 	AI_CUSTOMIZATION_MANAGEMENT_SIDEBAR_WIDTH_KEY,
 	AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY,
+	AICustomizationManagementEmbeddedEditorTitleMenuId,
 	AICustomizationManagementSection,
 	AICustomizationPromptsStorage,
 	BUILTIN_STORAGE,
@@ -71,6 +76,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
@@ -282,7 +288,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private editorItemNameElement!: HTMLElement;
 	private editorItemPathElement!: HTMLElement;
 	private editorSaveIndicator!: HTMLElement;
-	private editorOpenInEditorButton!: HTMLButtonElement;
+	private editorHeaderToolbar: MenuWorkbenchToolBar | undefined;
+	private editorHeaderToolbarKeys: { uri: IContextKey<string>; storage: IContextKey<string>; type: IContextKey<string> } | undefined;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
@@ -336,7 +343,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@IThemeService themeService: IThemeService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
@@ -1521,18 +1528,28 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		this.editorSaveIndicator = DOM.append(editorHeader, $('.editor-save-indicator'));
 
-		this.editorOpenInEditorButton = DOM.append(editorHeader, $('button.editor-open-in-editor-button'));
-		this.editorOpenInEditorButton.setAttribute('aria-label', localize('openInFullEditor', "Open in Editor"));
-		const openIcon = DOM.append(this.editorOpenInEditorButton, $(`.codicon.codicon-${Codicon.goToFile.id}`));
-		openIcon.setAttribute('aria-hidden', 'true');
-		DOM.append(this.editorOpenInEditorButton, $('span.editor-open-in-editor-button-label', undefined, localize('openInFullEditor', "Open in Editor")));
-		this.editorDisposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.editorOpenInEditorButton, localize('openInFullEditorTooltip', "Open this file in a full editor with access to the file explorer and chat.")));
-		this.editorDisposables.add(DOM.addDisposableListener(this.editorOpenInEditorButton, 'click', () => {
-			void this.openCurrentFileInFullEditor().catch(error => {
-				console.error('Failed to open customization file in full editor:', error);
-				this.notificationService.error(localize('openInFullEditorFailed', "Failed to open the file in a full editor."));
-			});
-		}));
+		const toolbarContainer = DOM.append(editorHeader, $('.editor-header-toolbar'));
+		const uriKey = AI_CUSTOMIZATION_ITEM_URI_KEY;
+		const storageKey = AI_CUSTOMIZATION_ITEM_STORAGE_KEY;
+		const typeKey = AI_CUSTOMIZATION_ITEM_TYPE_KEY;
+		const scopedContextKeyService = this.editorDisposables.add(this.contextKeyService.createScoped(toolbarContainer));
+		this.editorHeaderToolbarKeys = {
+			uri: scopedContextKeyService.createKey<string>(uriKey, ''),
+			storage: scopedContextKeyService.createKey<string>(storageKey, ''),
+			type: scopedContextKeyService.createKey<string>(typeKey, ''),
+		};
+		const scopedInstantiationService = this.editorDisposables.add(this.instantiationService.createChild(
+			new ServiceCollection([IContextKeyService, scopedContextKeyService])
+		));
+		this.editorHeaderToolbar = this.editorDisposables.add(scopedInstantiationService.createInstance(
+			MenuWorkbenchToolBar,
+			toolbarContainer,
+			AICustomizationManagementEmbeddedEditorTitleMenuId,
+			{
+				menuOptions: { shouldForwardArgs: true },
+				hiddenItemStrategy: HiddenItemStrategy.Ignore,
+			}
+		));
 
 		const embeddedEditorContainer = DOM.append(this.editorContentContainer, $('.embedded-editor-container'));
 		const overflowWidgetsDomNode = DOM.append(this.editorContentContainer, $('.embedded-editor-overflow-widgets.monaco-editor'));
@@ -1570,6 +1587,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		this.editorItemNameElement.textContent = displayName;
 		this.editorItemPathElement.textContent = basename(uri);
+		this.updateEditorHeaderToolbarContext(uri, storage, promptType, displayName);
 		this._editorContentChanged = false;
 		this.resetEditorSaveIndicator();
 		this.updateEditorActionButton();
@@ -1657,6 +1675,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.currentEditingProjectRoot = undefined;
 		this.currentEditingStorage = undefined;
 		this.currentEditingPromptType = undefined;
+		this.updateEditorHeaderToolbarContext(undefined, undefined, undefined, undefined);
 		this._editorContentChanged = false;
 		this.editorModelChangeDisposables.clear();
 		this.resetEditorSaveIndicator();
@@ -1875,17 +1894,16 @@ export class AICustomizationManagementEditor extends EditorPane {
 			&& (this.currentEditingPromptType === PromptsType.prompt || this.currentEditingPromptType === PromptsType.skill);
 	}
 
-	private async openCurrentFileInFullEditor(): Promise<void> {
-		const uri = this.currentEditingUri;
-		if (!uri) {
+	private updateEditorHeaderToolbarContext(uri: URI | undefined, storage: AICustomizationPromptsStorage | undefined, promptType: PromptsType | undefined, name: string | undefined): void {
+		if (!this.editorHeaderToolbar || !this.editorHeaderToolbarKeys) {
 			return;
 		}
-		await this.commandService.executeCommand('aiCustomizationManagement.openFile', {
-			uri,
-			storage: this.currentEditingStorage,
-			promptType: this.currentEditingPromptType,
-			name: this.editorItemNameElement?.textContent ?? undefined,
-		});
+		this.editorHeaderToolbarKeys.uri.set(uri ? uri.toString() : '');
+		this.editorHeaderToolbarKeys.storage.set(storage ? String(storage) : '');
+		this.editorHeaderToolbarKeys.type.set(promptType ?? '');
+		this.editorHeaderToolbar.context = uri
+			? { uri, storage, promptType, name }
+			: undefined;
 	}
 
 	private updateInputDirtyState(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -282,6 +282,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private editorItemNameElement!: HTMLElement;
 	private editorItemPathElement!: HTMLElement;
 	private editorSaveIndicator!: HTMLElement;
+	private editorOpenInEditorButton!: HTMLButtonElement;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
@@ -1520,6 +1521,19 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		this.editorSaveIndicator = DOM.append(editorHeader, $('.editor-save-indicator'));
 
+		this.editorOpenInEditorButton = DOM.append(editorHeader, $('button.editor-open-in-editor-button'));
+		this.editorOpenInEditorButton.setAttribute('aria-label', localize('openInFullEditor', "Open in Editor"));
+		const openIcon = DOM.append(this.editorOpenInEditorButton, $(`.codicon.codicon-${Codicon.goToFile.id}`));
+		openIcon.setAttribute('aria-hidden', 'true');
+		DOM.append(this.editorOpenInEditorButton, $('span.editor-open-in-editor-button-label', undefined, localize('openInFullEditor', "Open in Editor")));
+		this.editorDisposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.editorOpenInEditorButton, localize('openInFullEditorTooltip', "Open this file in a full editor with access to the file explorer and chat.")));
+		this.editorDisposables.add(DOM.addDisposableListener(this.editorOpenInEditorButton, 'click', () => {
+			void this.openCurrentFileInFullEditor().catch(error => {
+				console.error('Failed to open customization file in full editor:', error);
+				this.notificationService.error(localize('openInFullEditorFailed', "Failed to open the file in a full editor."));
+			});
+		}));
+
 		const embeddedEditorContainer = DOM.append(this.editorContentContainer, $('.embedded-editor-container'));
 		const overflowWidgetsDomNode = DOM.append(this.editorContentContainer, $('.embedded-editor-overflow-widgets.monaco-editor'));
 		this.editorDisposables.add(toDisposable(() => overflowWidgetsDomNode.remove()));
@@ -1859,6 +1873,19 @@ export class AICustomizationManagementEditor extends EditorPane {
 		return this._editorContentChanged
 			&& this.currentEditingStorage === BUILTIN_STORAGE
 			&& (this.currentEditingPromptType === PromptsType.prompt || this.currentEditingPromptType === PromptsType.skill);
+	}
+
+	private async openCurrentFileInFullEditor(): Promise<void> {
+		const uri = this.currentEditingUri;
+		if (!uri) {
+			return;
+		}
+		await this.commandService.executeCommand('aiCustomizationManagement.openFile', {
+			uri,
+			storage: this.currentEditingStorage,
+			promptType: this.currentEditingPromptType,
+			name: this.editorItemNameElement?.textContent ?? undefined,
+		});
 	}
 
 	private updateInputDirtyState(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1155,6 +1155,39 @@
 	opacity: 1;
 }
 
+.ai-customization-management-editor .editor-open-in-editor-button {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 10px;
+	height: 26px;
+	border-radius: 4px;
+	cursor: pointer;
+	background: var(--vscode-button-secondaryBackground);
+	color: var(--vscode-button-secondaryForeground);
+	border: 1px solid var(--vscode-button-border, transparent);
+	font-size: 12px;
+	transition: background-color 0.1s ease;
+}
+
+.ai-customization-management-editor .editor-open-in-editor-button:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.ai-customization-management-editor .editor-open-in-editor-button:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.ai-customization-management-editor .editor-open-in-editor-button .codicon {
+	font-size: 14px;
+}
+
+.ai-customization-management-editor .editor-open-in-editor-button-label {
+	white-space: nowrap;
+}
+
 .ai-customization-management-editor .embedded-editor-container {
 	flex: 1;
 	overflow: hidden;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1155,37 +1155,8 @@
 	opacity: 1;
 }
 
-.ai-customization-management-editor .editor-open-in-editor-button {
+.ai-customization-management-editor .editor-header-toolbar {
 	flex-shrink: 0;
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	padding: 4px 10px;
-	height: 26px;
-	border-radius: 4px;
-	cursor: pointer;
-	background: var(--vscode-button-secondaryBackground);
-	color: var(--vscode-button-secondaryForeground);
-	border: 1px solid var(--vscode-button-border, transparent);
-	font-size: 12px;
-	transition: background-color 0.1s ease;
-}
-
-.ai-customization-management-editor .editor-open-in-editor-button:hover {
-	background: var(--vscode-button-secondaryHoverBackground);
-}
-
-.ai-customization-management-editor .editor-open-in-editor-button:focus {
-	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: 2px;
-}
-
-.ai-customization-management-editor .editor-open-in-editor-button .codicon {
-	font-size: 14px;
-}
-
-.ai-customization-management-editor .editor-open-in-editor-button-label {
-	white-space: nowrap;
 }
 
 .ai-customization-management-editor .embedded-editor-container {

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -539,6 +539,13 @@ const apiMenus: IAPIMenu[] = [
 		proposed: 'chatSessionCustomizationProvider',
 	},
 	{
+		key: 'chat/customizations/embeddedEditor/title',
+		id: MenuId.for('AICustomizationManagementEmbeddedEditorTitle'),
+		description: localize('menus.chatCustomizationsEmbeddedEditorTitle', "The title bar of the embedded editor inside the Chat Customizations management editor."),
+		supportsSubmenus: false,
+		proposed: 'chatSessionCustomizationProvider',
+	},
+	{
 		key: 'chat/editor/inlineGutter',
 		id: MenuId.ChatEditorInlineMenu,
 		description: localize('menus.chatEditorInlineGutter', "The inline gutter menu in the chat editor."),


### PR DESCRIPTION
Refs #311433

Adds a prominent **Open in Editor** button to the embedded editor header in the AI Customizations management editor. The "Open" action already existed in the right-click context menu of list items — this surfaces it where users actually need it: while looking at the embedded editor and realizing they want the full editor experience (file explorer, chat widget, agent iteration) instead of the limited modal.

### Changes

- `aiCustomizationManagementEditor.ts`: New `editorOpenInEditorButton` (icon + label) appended to the editor header. Click invokes the existing `aiCustomizationManagement.openFile` command with the current URI / storage / promptType, preserving the read-only behavior for extension/plugin files.
- `media/aiCustomizationManagement.css`: Styled as a secondary button with both icon and visible label so it's discoverable (per @aeschli's suggestion in the issue).

### Notes

- Reuses the existing `aiCustomizationManagement.openFile` action — no duplicated open logic.
- Visible whenever the embedded editor is shown (hooks, agents, skills, instructions, prompts).
