### PR TITLE
Rule files with applyTo globs are eagerly read regardless of paths pattern

### DIFF
--- a/extensions/copilot/src/extension/tools/node/toolUtils.ts
+++ b/extensions/copilot/src/extension/tools/node/toolUtils.ts
@@ -206,9 +206,6 @@ export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI, 
 }
 
 async function isExternalInstructionsFile(normalizedUri: URI, customInstructionsService: ICustomInstructionsService, buildPromptContext?: IBuildPromptContext): Promise<boolean> {
-	if (customInstructionsService.getExtensionSkillInfo(normalizedUri)) {
-		return true;
-	}
 	if (buildPromptContext) {
 		const instructionIndexFile = getInstructionsIndexFile(buildPromptContext, customInstructionsService);
 		if (instructionIndexFile) {
@@ -227,6 +224,9 @@ async function isExternalInstructionsFile(normalizedUri: URI, customInstructions
 			return true;
 		}
 	} else {
+		if (customInstructionsService.getExtensionSkillInfo(normalizedUri)) {
+			return true;
+		}
 		// Note: this fallback check does not handle scenario where model passes file:// for userData schemes.
 		if (await customInstructionsService.isExternalInstructionsFile(normalizedUri)) {
 			return true;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -357,19 +357,20 @@ export class ComputeAutomaticInstructions {
 			entries.push('<instructions>');
 			entries.push('Here is a list of instruction files that contain rules for working with this codebase.');
 			entries.push('These files are important for understanding the codebase structure, conventions, and best practices.');
-			entries.push('Please make sure to follow the rules specified in these files when working with the codebase.');
-			entries.push(`If the file is not already available as attachment, use the ${readTool.variable} tool to acquire it.`);
-			entries.push('Make sure to acquire the instructions before working with the codebase.');
+			entries.push('When an instruction file applies to your task (based on its description or applyTo pattern), follow the rules specified in it.');
+			entries.push(`If the file content is not already included in the context, use the ${readTool.variable} tool to read it before proceeding. Use the file URI as-is with the tool; do not modify the path.`);
+			entries.push('Only load instruction files when they are relevant to the current task. Do not eagerly load all instructions upfront.');
+			entries.push('When modifying or creating files, check for instructions whose applyTo pattern matches the file path and follow them.');
 			let hasContent = false;
 			for (const instruction of instructionFiles) {
 				if (!matchesSessionType(instruction.sessionTypes, currentSessionType)) {
 					continue;
 				}
+				entries.push(`<file>${filePath(instruction.uri)}</file>`);
 				entries.push('<instruction>');
 				if (instruction.description) {
 					entries.push(`<description>${instruction.description}</description>`);
 				}
-				entries.push(`<file>${filePath(instruction.uri)}</file>`);
 				if (instruction.pattern) {
 					entries.push(`<applyTo>${instruction.pattern}</applyTo>`);
 				}
@@ -382,8 +383,8 @@ export class ComputeAutomaticInstructions {
 				const folderName = this._labelService.getUriLabel(dirname(uri), { relative: true });
 				const description = folderName.trim().length === 0 ? localize('instruction.file.description.agentsmd.root', 'Instructions for the workspace') : localize('instruction.file.description.agentsmd.folder', 'Instructions for folder \'{0}\'', folderName);
 				entries.push('<instruction>');
-				entries.push(`<description>${description}</description>`);
 				entries.push(`<file>${filePath(uri)}</file>`);
+				entries.push(`<description>${description}</description>`);
 				entries.push('</instruction>');
 				hasContent = true;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -358,7 +358,7 @@ export class ComputeAutomaticInstructions {
 			entries.push('Here is a list of instruction files that contain rules for working with this codebase.');
 			entries.push('These files are important for understanding the codebase structure, conventions, and best practices.');
 			entries.push('When an instruction file applies to your task (based on its description or applyTo pattern), follow the rules specified in it.');
-			entries.push(`If the file content is not already included in the context, use the ${readTool.variable} tool to read it before proceeding. Use the file URI as-is with the tool; do not modify the path.`);
+			entries.push(`If the file content is not already included in the context, use the ${readTool.variable} tool to read it before proceeding. Use the exact value from the <file> element as-is with the tool; do not add or remove prefixes or otherwise modify it.`);
 			entries.push('Only load instruction files when they are relevant to the current task. Do not eagerly load all instructions upfront.');
 			entries.push('When modifying or creating files, check for instructions whose applyTo pattern matches the file path and follow them.');
 			let hasContent = false;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts
@@ -366,8 +366,8 @@ export class ComputeAutomaticInstructions {
 				if (!matchesSessionType(instruction.sessionTypes, currentSessionType)) {
 					continue;
 				}
-				entries.push(`<file>${filePath(instruction.uri)}</file>`);
 				entries.push('<instruction>');
+				entries.push(`<file>${filePath(instruction.uri)}</file>`);
 				if (instruction.description) {
 					entries.push(`<description>${instruction.description}</description>`);
 				}


### PR DESCRIPTION
Improves the instructions to only load instruction files that are relevant
Also adds a sentence to not modify the file URI

Fixes https://github.com/microsoft/vscode/issues/311462

