### PR TITLE
agentHost: use actual filename in diff editor title

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/fileEditTracker.ts
+++ b/src/vs/platform/agentHost/node/copilot/fileEditTracker.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeHex, encodeHex, VSBuffer } from '../../../../base/common/buffer.js';
+import { basename } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileService } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
@@ -21,7 +22,7 @@ export function buildSessionDbUri(sessionUri: string, toolCallId: string, filePa
 	return URI.from({
 		scheme: SESSION_DB_SCHEME,
 		authority: encodeHex(VSBuffer.fromString(sessionUri)).toString(),
-		path: `/${encodeURIComponent(toolCallId)}/${encodeHex(VSBuffer.fromString(filePath))}/${part}`,
+		path: `/${encodeURIComponent(toolCallId)}/${encodeHex(VSBuffer.fromString(filePath))}/${part}/${basename(filePath)}`,
 	}).toString();
 }
 

--- a/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
+++ b/src/vs/platform/agentHost/test/node/fileEditTracker.test.ts
@@ -164,4 +164,16 @@ suite('buildSessionDbUri / parseSessionDbUri', () => {
 		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1'), undefined);
 		assert.strictEqual(parseSessionDbUri('session-db:copilot:/s1?toolCallId=tc-1&filePath=/f&part=middle'), undefined);
 	});
+
+	test('URI path ends with the basename of the file', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/workspace/src/index.ts', 'before');
+		const parsed = URI.parse(uri);
+		assert.ok(parsed.path.endsWith('/index.ts'));
+	});
+
+	test('URI path ends with basename for files with spaces and special chars', () => {
+		const uri = buildSessionDbUri('copilot:/s1', 'tc-1', '/work space/file (1).ts', 'after');
+		const parsed = URI.parse(uri);
+		assert.ok(parsed.path.endsWith('/file (1).ts'));
+	});
 });

--- a/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -19,6 +19,7 @@ import { ILanguageModelsService } from '../../../../workbench/contrib/chat/commo
 import { BaseAgentHostSessionsProvider } from './baseAgentHostSessionsProvider.js';
 import { buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction } from '../../../services/sessions/common/session.js';
+import { toAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
 
 const LOCAL_PROVIDER_ID = 'local-agent-host';
 const LOCAL_RESOURCE_SCHEME_PREFIX = 'agent-host-';
@@ -115,6 +116,10 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 	protected _formatSessionTypeLabel(agentLabel: string): string {
 		return localize('localAgentHostSessionType', "{0} [{1}]", agentLabel, this._localLabel);
+	}
+
+	protected override _diffUriMapper(): (uri: URI) => URI {
+		return uri => toAgentHostUri(uri, 'local');
 	}
 
 	// -- Workspaces ----------------------------------------------------------


### PR DESCRIPTION
agentHost: use actual filename in diff editor title

Fixes the diff editor showing 'before' as the filename instead of the
actual file being edited when using AHP with CLI.

- Append basename(filePath) to session DB URI path in fileEditTracker
  so the diff editor tab displays the real filename.
- Add _diffUriMapper override in localAgentHostSessionsProvider to map
  URIs through toAgentHostUri for consistent diff editor titles with
  the local agent host.

Fixes https://github.com/microsoft/vscode/issues/311509

(Commit message generated by Copilot)