### PR TITLE
fix: use source to parse ID from /etc/os-release for Rocky Linux compatibility

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## Summary
This PR fixes issue #232159 where the devcontainer setup script fails to parse the OS ID on Rocky Linux 8.5 (and potentially other distros that use quoted values in /etc/os-release like `ID="rocky"`).

## Problem
The original script used grep to extract the ID value:
```bash
OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
```
This pattern only matched unquoted values (e.g., `ID=rocky`) but failed on quoted values (e.g., `ID="rocky"`), resulting in an empty `OS_ID` value and exit code 1.

## Solution
Changed to use `source` in a subshell to parse the variables:
```bash
OS_ID=$(source /etc/os-release && echo $ID)
```
This approach:
- Removes any surrounding quotes automatically
- Works with both quoted and unquoted values
- Does not pollute the current shell environment

## Testing
- Verified the fix handles both `ID=rocky` and `ID="rocky"`
- Confirmed the subshell approach doesn't affect the parent environment

## Changes
- `resources/server/bin/helpers/check-requirements-linux.sh`: Changed the OS_ID parsing logic

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee