### PR TITLE
cli: show Agents URL alongside VS Code URL in tunnel output

### DIFF
--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -78,6 +78,10 @@ pub const QUALITY: &str = match VSCODE_CLI_QUALITY {
 /// Web URL the editor is hosted at. For VS Code, this is vscode.dev.
 pub const EDITOR_WEB_URL: Option<&'static str> = option_env!("VSCODE_CLI_TUNNEL_EDITOR_WEB_URL");
 
+/// Web URL the Agents experience is hosted at. Only set for qualities that
+/// ship the Agents web surface (e.g. Insiders).
+pub const AGENTS_WEB_URL: Option<&'static str> = option_env!("VSCODE_CLI_TUNNEL_AGENTS_WEB_URL");
+
 /// Name shown in places where we need to tell a user what a process is, e.g. in sleep inhibition.
 pub const TUNNEL_ACTIVITY_NAME: &str = concatcp!(PRODUCT_NAME_LONG, " Tunnel");
 

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -5,7 +5,7 @@
 use super::paths::{InstalledServer, ServerPaths};
 use crate::async_pipe::get_socket_name;
 use crate::constants::{
-	AGENTS_WEB_URL, APPLICATION_NAME, EDITOR_WEB_URL, QUALITYLESS_PRODUCT_NAME,
+	AGENTS_WEB_URL, APPLICATION_NAME, COLORS_ENABLED, EDITOR_WEB_URL, QUALITYLESS_PRODUCT_NAME,
 	QUALITYLESS_SERVER_NAME,
 };
 use crate::download_cache::DownloadCache;
@@ -836,12 +836,48 @@ pub fn print_listening(log: &log::Logger, tunnel_name: &str) {
 		}
 	}
 
-	log.result(&format!("\nOpen VS Code in your browser {addr}"));
+	let use_colors = *COLORS_ENABLED;
+
+	// Helper to wrap a URL in an OSC 8 clickable hyperlink when colors are enabled.
+	let hyperlink = |url: &str| -> String {
+		if use_colors {
+			format!("\x1b]8;;{url}\x1b\\{url}\x1b]8;;\x1b\\")
+		} else {
+			url.to_string()
+		}
+	};
+
+	// Helper to format a labeled link line with an arrow prefix.
+	let link_line = |label: &str, url: &str| -> String {
+		if use_colors {
+			format!("  \x1b[1m\x1b[32m➜\x1b[0m  {label}  {}", hyperlink(url))
+		} else {
+			format!("  ->  {label}  {url}")
+		}
+	};
+
+	// "✔ Tunnel <name> is ready"
+	let ready_line = if use_colors {
+		format!("\n\x1b[1m\x1b[32m✔\x1b[0m Tunnel \x1b[1m{tunnel_name}\x1b[0m is ready")
+	} else {
+		format!("\nTunnel {tunnel_name} is ready")
+	};
+	log.result(&ready_line);
+	log.result("");
+
+	log.result(&link_line("Open VS Code in your browser", addr.as_str()));
 
 	if let Some(agents_url) = AGENTS_WEB_URL {
-		log.result(&format!("Open Agents in your browser {agents_url}"));
+		log.result(&link_line("Open Agents in your browser", agents_url));
 	}
 
+	// Hint: how to stop the tunnel
+	let hint = if use_colors {
+		"\n\x1b[2mPress Ctrl+C to stop the tunnel\x1b[0m".to_string()
+	} else {
+		"\nPress Ctrl+C to stop the tunnel".to_string()
+	};
+	log.result(&hint);
 	log.result("");
 }
 

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -5,7 +5,8 @@
 use super::paths::{InstalledServer, ServerPaths};
 use crate::async_pipe::get_socket_name;
 use crate::constants::{
-	APPLICATION_NAME, EDITOR_WEB_URL, QUALITYLESS_PRODUCT_NAME, QUALITYLESS_SERVER_NAME,
+	AGENTS_WEB_URL, APPLICATION_NAME, EDITOR_WEB_URL, QUALITYLESS_PRODUCT_NAME,
+	QUALITYLESS_SERVER_NAME,
 };
 use crate::download_cache::DownloadCache;
 use crate::options::{Quality, TelemetryLevel};
@@ -835,8 +836,13 @@ pub fn print_listening(log: &log::Logger, tunnel_name: &str) {
 		}
 	}
 
-	let message = &format!("\nOpen this link in your browser {addr}\n");
-	log.result(message);
+	log.result(&format!("\nOpen VS Code in your browser {addr}"));
+
+	if let Some(agents_url) = AGENTS_WEB_URL {
+		log.result(&format!("Open Agents in your browser {agents_url}"));
+	}
+
+	log.result("");
 }
 
 pub async fn download_cli_into_cache(


### PR DESCRIPTION
## Summary

Improves the `code tunnel` CLI output with a more informative and visually polished ready message, and adds an Agents URL for Insiders builds.

**Stable (plain text / piped):**
```
Tunnel my-macbook is ready

  ->  Open VS Code in your browser  https://vscode.dev/tunnel/my-macbook

Press Ctrl+C to stop the tunnel
```

**Stable (TTY with colors):**
```
✔ Tunnel my-macbook is ready        ← bold green ✔, bold tunnel name

  ➜  Open VS Code in your browser  https://vscode.dev/tunnel/my-macbook   ← clickable link

Press Ctrl+C to stop the tunnel      ← dim/muted
```

**Insiders (TTY with colors):**
```
✔ Tunnel my-macbook is ready

  ➜  Open VS Code in your browser  https://insiders.vscode.dev/tunnel/my-macbook
  ➜  Open Agents in your browser   https://insiders.vscode.dev/agents/

Press Ctrl+C to stop the tunnel
```

## Changes

- **`cli/src/constants.rs`** — Added `AGENTS_WEB_URL` compile-time constant via `option_env!("VSCODE_CLI_TUNNEL_AGENTS_WEB_URL")`, same pattern as `EDITOR_WEB_URL`.
- **`cli/src/tunnels/code_server.rs`** — Rewrote `print_listening` to:
  - Show a **`✔ Tunnel <name> is ready`** status header (tunnel name prominent, ready state clearly signalled)
  - Prefix each URL line with a **`➜`** arrow
  - Wrap URLs in **OSC 8 hyperlinks** (clickable in iTerm2, Windows Terminal, GNOME Terminal, etc.)
  - Add a dim **`Press Ctrl+C to stop the tunnel`** hint
  - Emit the Agents URL line only when `AGENTS_WEB_URL` is set (Insiders only)
  - Gate all ANSI/OSC formatting on `COLORS_ENABLED` — plain-text fallbacks for piped output and `NO_COLOR` environments

## How the Agents URL is wired up

The `agentsWebUrl` key in `tunnelApplicationConfig` (product.json) is automatically mapped to `VSCODE_CLI_TUNNEL_AGENTS_WEB_URL` by `cli/build.rs`'s existing camelCase→CONSTANT_CASE transform. Stable doesn't define this key, so `AGENTS_WEB_URL` is `None` and only the VS Code line is printed.

## Note for reviewers

`product.overrides.json` is gitignored — the `agentsWebUrl` key needs to be added to the Insiders product build configuration separately.