### PR TITLE
terminal: fix duplicate agent host terminals and hide tool-created ones

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/agentHostTerminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/agentHostTerminalService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SequencerByKey } from '../../../../base/common/async.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -103,6 +104,7 @@ export class AgentHostTerminalService extends Disposable implements IAgentHostTe
 
 	/** Revived terminal instances, keyed by terminal URI string. */
 	private readonly _revivedInstances = new Map<string, ITerminalInstance>();
+	private readonly _reviveSequencer = new SequencerByKey<string>();
 
 	constructor(
 		@ITerminalService private readonly _terminalService: ITerminalService,
@@ -300,11 +302,14 @@ export class AgentHostTerminalService extends Disposable implements IAgentHostTe
 
 	async reviveTerminal(connection: IAgentConnection, terminalUri: URI, terminalToolSessionId: string): Promise<ITerminalInstance> {
 		const key = terminalUri.toString();
+		return this._reviveSequencer.queue(key, () => this._doReviveTerminal(connection, terminalUri, terminalToolSessionId, key));
+	}
+
+	private async _doReviveTerminal(connection: IAgentConnection, terminalUri: URI, terminalToolSessionId: string, key: string): Promise<ITerminalInstance> {
 		const existing = this._revivedInstances.get(key);
 		if (existing) {
 			return existing;
 		}
-
 		const store = new DisposableStore();
 		const commandSource = store.add(new AhpTerminalCommandSource());
 		store.add(this._terminalChatService.registerAhpCommandSource(terminalToolSessionId, commandSource));
@@ -327,6 +332,7 @@ export class AgentHostTerminalService extends Disposable implements IAgentHostTe
 				},
 				name: localize('agentHostTerminal.tool', "Agent Host Terminal"),
 				isFeatureTerminal: true,
+				hideFromUser: true,
 			},
 		});
 		this._terminalChatService.registerTerminalInstanceWithToolSession(terminalToolSessionId, instance);


### PR DESCRIPTION
terminal: fix duplicate agent host terminals and hide tool-created ones

- Fix race condition in reviveTerminal where concurrent calls for the
  same terminal URI could create duplicate terminal instances. Use a
  SequencerByKey to serialize revive calls per URI key so the second
  caller finds the already-created instance.
- Add hideFromUser: true to revived agent host tool terminals so they
  are routed into backgrounded instances instead of terminal groups.
  This makes them appear in the hidden chat terminals UI entry
  (TerminalTabsChatEntry) consistent with regular chat tool terminals.

Fixes https://github.com/microsoft/vscode/issues/311709

(Commit message generated by Copilot)