### PR TITLE
Add tool search support for OpenAI Responses API (client-executed)

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3776,6 +3776,15 @@
 							"onExp"
 						]
 					},
+					"github.copilot.chat.responsesApi.toolSearchTool.enabled": {
+						"type": "boolean",
+						"default": false,
+						"markdownDescription": "%github.copilot.config.responsesApi.toolSearchTool.enabled%",
+						"tags": [
+							"preview",
+							"onExp"
+						]
+					},
 					"github.copilot.chat.updated53CodexPrompt.enabled": {
 						"type": "boolean",
 						"default": true,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -344,6 +344,7 @@
 	"github.copilot.config.responsesApiReasoningSummary": "Sets the reasoning summary style used for the Responses API. Requires `#github.copilot.chat.useResponsesApi#`.",
 	"github.copilot.config.responsesApiContextManagement.enabled": "Enables context management for the Responses API. Requires `#github.copilot.chat.useResponsesApi#`.",
 	"github.copilot.config.responsesApi.promptCacheKey.enabled": "Enables prompt cache key being set for the Responses API.",
+	"github.copilot.config.responsesApi.toolSearchTool.enabled": "Enable tool search for OpenAI Responses API models. When enabled, tools are dynamically discovered and loaded on-demand using embeddings-based search, reducing context window usage when many tools are available.",
 	"github.copilot.config.updated53CodexPrompt.enabled": "Enables the updated prompt for gpt-5.3-codex model.",
 	"github.copilot.config.gpt54ConcisePrompt.enabled": "Enables the concise prompt experiment for gpt-5.4 model.",
 	"github.copilot.config.gpt54LargePrompt.enabled": "Enables the large prompt experiment for gpt-5.4 model.",

--- a/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
+++ b/extensions/copilot/src/extension/prompt/vscode-node/requestLoggerImpl.ts
@@ -667,7 +667,7 @@ export class RequestLogger extends AbstractRequestLogger {
 			result.push(`serverRequestId  : ${entry.result.serverRequestId}`);
 		}
 		if (entry.chatParams.body?.tools) {
-			const toolNames = entry.chatParams.body.tools.map(t => isOpenAiFunctionTool(t) ? t.function.name : t.name);
+			const toolNames = entry.chatParams.body.tools.map((t: any) => isOpenAiFunctionTool(t) ? t.function.name : t.name ?? t.type);
 			const numToolsString = `(${toolNames.length})`;
 			result.push(
 				`<details>`,

--- a/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
+++ b/extensions/copilot/src/extension/tools/node/toolSearchTool.ts
@@ -79,6 +79,7 @@ ToolRegistry.registerModelSpecificTool(
 			{ family: 'claude-sonnet-4.6' },
 			{ family: 'claude-opus-4.5' },
 			{ family: 'claude-opus-4.6' },
+			{ family: 'gpt-5.4' },
 		],
 	},
 	ToolSearchTool,

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -911,6 +911,8 @@ export namespace ConfigKey {
 	export const ResponsesApiContextManagementEnabled = defineSetting<boolean>('chat.responsesApiContextManagement.enabled', ConfigType.ExperimentBased, false);
 	/** Enable client-side prompt_cache_key (conversationId:modelFamily) sent to Responses API */
 	export const ResponsesApiPromptCacheKeyEnabled = defineSetting<boolean>('chat.responsesApi.promptCacheKey.enabled', ConfigType.ExperimentBased, false);
+	/** Enable tool search for Responses API (client-side deferred tool loading). */
+	export const ResponsesApiToolSearchEnabled = defineSetting<boolean>('chat.responsesApi.toolSearchTool.enabled', ConfigType.ExperimentBased, false);
 	/** Enable updated prompt for 5.3Codex model */
 	export const Updated53CodexPromptEnabled = defineSetting<boolean>('chat.updated53CodexPrompt.enabled', ConfigType.ExperimentBased, true);
 	/** Enable concise prompt experiment for GPT-5.4 model */

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -14,11 +14,14 @@ import { SSEParser } from '../../../util/vs/base/common/sseParser';
 import { isDefined } from '../../../util/vs/base/common/types';
 import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { IInstantiationService, ServicesAccessor } from '../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatLocation } from '../../chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
 import { ILogService } from '../../log/common/logService';
-import { FinishedCallback, getRequestId, IResponseDelta, OpenAiResponsesFunctionTool } from '../../networking/common/fetch';
+import { CUSTOM_TOOL_SEARCH_NAME } from '../../networking/common/anthropic';
+import { FinishedCallback, getRequestId, IResponseDelta, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OpenAiToolSearchTool } from '../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody } from '../../networking/common/networking';
-import { ChatCompletion, FinishedCompletionReason, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
+import { ChatCompletion, FinishedCompletionReason, isResponsesApiToolSearchEnabled, modelsWithoutResponsesContextManagement, openAIContextManagementCompactionType, OpenAIContextManagementResponse, rawMessageToCAPI, TokenLogProb } from '../../networking/common/openai';
+import { IToolDeferralService } from '../../networking/common/toolDeferralService';
 import { sendEngineMessagesTelemetry, sendResponsesApiCompactionTelemetry } from '../../networking/node/chatStream';
 import { IChatWebSocketManager } from '../../networking/node/chatWebSocketManager';
 import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
@@ -54,16 +57,67 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	// back to the HTTP marker lookup in that case.
 	const ignoreStatefulMarker = !!options.ignoreStatefulMarker || !!options.useWebSocket;
 
+	// Tool search: when enabled, split tools into non-deferred (always loaded) and deferred (defer_loading: true).
+	// Uses OpenAI's client-executed tool search protocol: we add { type: 'tool_search', execution: 'client' }
+	// and mark deferred tools with defer_loading. The model emits tool_search_call which we handle via
+	// our ToolSearchTool embeddings search, then round-trip as tool_search_output in the next request.
+	const toolSearchEnabled = isResponsesApiToolSearchEnabled(endpoint, configService, expService);
+	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
+	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
+	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent;
+	const toolDeferralService = shouldDeferTools ? accessor.get(IToolDeferralService) : undefined;
+
+	type ResponsesFunctionTool = OpenAI.Responses.FunctionTool & OpenAiResponsesFunctionTool & { defer_loading?: boolean };
+	const functionTools: ResponsesFunctionTool[] = [];
+	if (options.requestOptions?.tools) {
+		for (const tool of options.requestOptions.tools) {
+			if (!tool.function.name || tool.function.name.length === 0) {
+				continue;
+			}
+			const isDeferred = shouldDeferTools && !toolDeferralService!.isNonDeferredTool(tool.function.name);
+			functionTools.push({
+				...tool.function,
+				type: 'function',
+				strict: false,
+				parameters: (tool.function.parameters || {}) as Record<string, unknown>,
+				...(isDeferred ? { defer_loading: true } : {}),
+			});
+		}
+	}
+
+	// Build final tools array
+	const finalTools: Array<ResponsesFunctionTool | OpenAiToolSearchTool | ClientToolSearchTool> = [...functionTools];
+	const hasDeferredTools = functionTools.some(t => t.defer_loading);
+	if (hasDeferredTools) {
+		// Client-executed tool search: the model emits tool_search_call, our ToolSearchTool
+		// handles the embeddings search, and we return tool_search_output with full definitions.
+		finalTools.unshift({
+			type: 'tool_search',
+			execution: 'client',
+			description: 'Search for relevant tools by describing what you need. Returns tool definitions for tools matching your query.',
+			parameters: {
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description: 'Natural language description of what tool capability you are looking for.',
+					},
+				},
+				required: ['query'],
+			},
+		} as ClientToolSearchTool);
+	}
+
+	// Build tools map for rawMessagesToResponseAPI to convert tool_search round-trips
+	const toolsMap = shouldDeferTools && options.requestOptions?.tools
+		? new Map(options.requestOptions.tools.map(t => [t.function.name, t]))
+		: undefined;
+
 	const body: IEndpointBody = {
 		model,
-		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker),
+		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, toolsMap),
 		stream: true,
-		tools: options.requestOptions?.tools?.map((tool): OpenAI.Responses.FunctionTool & OpenAiResponsesFunctionTool => ({
-			...tool.function,
-			type: 'function',
-			strict: false,
-			parameters: (tool.function.parameters || {}) as Record<string, unknown>,
-		})),
+		tools: finalTools.length > 0 ? finalTools : undefined,
 		// Only a subset of completion post options are supported, and some
 		// are renamed. Handle them manually:
 		max_output_tokens: options.postOptions.max_tokens,
@@ -142,6 +196,26 @@ interface ResponseOutputItemWithPhase {
 	phase?: string;
 }
 
+// ── Responses API tool search types ──────────────────────────────────
+// These match the shapes from https://developers.openai.com/api/docs/guides/tools-tool-search
+
+/** Client-executed tool_search tool definition for the Responses API */
+interface ClientToolSearchTool {
+	type: 'tool_search';
+	execution: 'client';
+	description: string;
+	parameters: Record<string, unknown>;
+}
+
+interface ResponsesToolSearchCall {
+	type: 'tool_search_call';
+	id: string;
+	execution: 'server' | 'client';
+	call_id: string | null;
+	status: string;
+	arguments?: Record<string, unknown>;
+}
+
 interface LatestCompactionOutput {
 	readonly item: OpenAIContextManagementResponse;
 	readonly outputIndex: number;
@@ -180,7 +254,7 @@ function resolveWebSocketStatefulMarker(accessor: ServicesAccessor, options: ICr
 	return wsManager.getStatefulMarker(options.conversationId);
 }
 
-function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
+function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined, toolsMap?: Map<string, OpenAiFunctionTool>): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
 	const latestCompactionMessageIndex = getLatestCompactionMessageIndex(messages);
 	const latestCompactionMessage = latestCompactionMessageIndex !== undefined ? createCompactionRoundTripMessage(messages[latestCompactionMessageIndex]) : undefined;
 
@@ -218,6 +292,9 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 		messages = messages.slice(latestCompactionMessageIndex);
 	}
 
+	// Track which call_ids are tool_search_calls (from client-executed tool search)
+	const toolSearchCallIds = new Set<string>();
+
 	const input: OpenAI.Responses.ResponseInputItem[] = [];
 	for (const message of messages) {
 		switch (message.role) {
@@ -240,28 +317,60 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 				}
 				if (message.toolCalls) {
 					for (const toolCall of message.toolCalls) {
-						input.push({ type: 'function_call', name: toolCall.function.name, arguments: toolCall.function.arguments, call_id: toolCall.id });
+						if (toolsMap && toolCall.function.name === CUSTOM_TOOL_SEARCH_NAME) {
+							// Client-executed tool search: emit as tool_search_call instead of function_call
+							toolSearchCallIds.add(toolCall.id);
+							let parsedArgs: Record<string, unknown> = {};
+							try { parsedArgs = JSON.parse(toolCall.function.arguments || '{}'); } catch { }
+							input.push({
+								type: 'tool_search_call',
+								execution: 'client',
+								call_id: toolCall.id,
+								status: 'completed',
+								arguments: parsedArgs,
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							} as any);
+						} else {
+							input.push({ type: 'function_call', name: toolCall.function.name, arguments: toolCall.function.arguments, call_id: toolCall.id });
+						}
 					}
 				}
 				break;
 			case Raw.ChatRole.Tool:
 				if (message.toolCallId) {
-					const asText = message.content
-						.filter(c => c.type === Raw.ChatCompletionContentPartKind.Text)
-						.map(c => c.text)
-						.join('');
-					const asImages = message.content
-						.filter(c => c.type === Raw.ChatCompletionContentPartKind.Image)
-						.map((c): OpenAI.Responses.ResponseInputImage => ({
-							type: 'input_image',
-							detail: c.imageUrl.detail || 'auto',
-							image_url: c.imageUrl.url,
-						}));
+					if (toolsMap && toolSearchCallIds.has(message.toolCallId)) {
+						// Client-executed tool search result: convert tool names to tool_search_output with full definitions
+						const resultText = message.content
+							.filter(c => c.type === Raw.ChatCompletionContentPartKind.Text)
+							.map(c => c.text)
+							.join('');
+						const loadedTools = buildToolSearchOutputTools(resultText, toolsMap);
+						input.push({
+							type: 'tool_search_output',
+							execution: 'client',
+							call_id: message.toolCallId,
+							status: 'completed',
+							tools: loadedTools,
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						} as any);
+					} else {
+						const asText = message.content
+							.filter(c => c.type === Raw.ChatCompletionContentPartKind.Text)
+							.map(c => c.text)
+							.join('');
+						const asImages = message.content
+							.filter(c => c.type === Raw.ChatCompletionContentPartKind.Image)
+							.map((c): OpenAI.Responses.ResponseInputImage => ({
+								type: 'input_image',
+								detail: c.imageUrl.detail || 'auto',
+								image_url: c.imageUrl.url,
+							}));
 
-					// todod@connor4312: hack while responses API only supports text output from tools
-					input.push({ type: 'function_call_output', call_id: message.toolCallId, output: asText });
-					if (asImages.length) {
-						input.push({ role: 'user', content: [{ type: 'input_text', text: 'Image associated with the above tool call:' }, ...asImages] });
+						// todod@connor4312: hack while responses API only supports text output from tools
+						input.push({ type: 'function_call_output', call_id: message.toolCallId, output: asText });
+						if (asImages.length) {
+							input.push({ role: 'user', content: [{ type: 'input_text', text: 'Image associated with the above tool call:' }, ...asImages] });
+						}
 					}
 				}
 				break;
@@ -275,6 +384,29 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 	}
 
 	return { input, previous_response_id: previousResponseId };
+}
+
+/**
+ * Converts a JSON array of tool names (from ToolSearchTool) into full tool definitions
+ * for the tool_search_output. Falls back to an empty array on parse failure.
+ */
+function buildToolSearchOutputTools(resultText: string, toolsMap: Map<string, OpenAiFunctionTool>): unknown[] {
+	let toolNames: unknown;
+	try { toolNames = JSON.parse(resultText); } catch { return []; }
+	if (!Array.isArray(toolNames)) { return []; }
+
+	return toolNames
+		.filter((name): name is string => typeof name === 'string' && toolsMap.has(name))
+		.map(name => {
+			const tool = toolsMap.get(name)!;
+			return {
+				type: 'function',
+				name: tool.function.name,
+				description: tool.function.description || '',
+				defer_loading: true,
+				parameters: tool.function.parameters || { type: 'object', properties: {} },
+			};
+		});
 }
 
 function createCompactionRoundTripMessage(message: Raw.ChatMessage): Raw.ChatMessage | undefined {
@@ -736,6 +868,16 @@ export class OpenAIResponsesProcessor {
 						text: '',
 						beginToolCalls: [{ name: chunk.item.name, id: chunk.item.call_id }]
 					});
+				} else if (chunk.item.type.toString() === 'tool_search_call') {
+					const tsItem = chunk.item as unknown as ResponsesToolSearchCall;
+					if (tsItem.execution === 'client' && tsItem.call_id) {
+						// Client-executed tool search: treat as a regular tool call so our ToolSearchTool handles it.
+						this.toolCallInfo.set(chunk.output_index, { name: CUSTOM_TOOL_SEARCH_NAME, callId: tsItem.call_id, arguments: '' });
+						onProgress({
+							text: '',
+							beginToolCalls: [{ name: CUSTOM_TOOL_SEARCH_NAME, id: tsItem.call_id }]
+						});
+					}
 				}
 				return;
 			case 'response.function_call_arguments.delta': {
@@ -765,6 +907,20 @@ export class OpenAIResponsesProcessor {
 						}],
 						phase: (chunk.item as ResponseOutputItemWithPhase).phase
 					});
+				} else if (chunk.item.type.toString() === 'tool_search_call') {
+					const tsCall = chunk.item as unknown as ResponsesToolSearchCall;
+					if (tsCall.execution === 'client' && tsCall.call_id) {
+						// Client-executed tool search completed: emit as a completed copilotToolCall
+						this.toolCallInfo.delete(chunk.output_index);
+						onProgress({
+							text: '',
+							copilotToolCalls: [{
+								id: tsCall.call_id,
+								name: CUSTOM_TOOL_SEARCH_NAME,
+								arguments: JSON.stringify(tsCall.arguments ?? {}),
+							}],
+						});
+					}
 				} else if (chunk.item.type === 'reasoning') {
 					onProgress({
 						text: '',

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -1,0 +1,217 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Raw } from '@vscode/prompt-tsx';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
+import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatLocation } from '../../../chat/common/commonTypes';
+import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
+import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
+import { IResponseDelta } from '../../../networking/common/fetch';
+import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
+import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
+import { TelemetryData } from '../../../telemetry/common/telemetryData';
+import { SpyingTelemetryService } from '../../../telemetry/node/spyingTelemetryService';
+import { createPlatformServices } from '../../../test/node/services';
+import { createResponsesRequestBody, OpenAIResponsesProcessor } from '../responsesApi';
+
+function createMockEndpoint(model: string): IChatEndpoint {
+	return {
+		model,
+		family: model,
+		modelProvider: 'openai',
+		supportsToolCalls: true,
+		supportsVision: false,
+		supportsPrediction: false,
+		showInModelPicker: true,
+		isFallback: false,
+		maxOutputTokens: 4096,
+		modelMaxPromptTokens: 128000,
+		urlOrRequestMetadata: 'https://test',
+		name: model,
+		version: '1',
+		tokenizer: 'cl100k_base' as any,
+		acquireTokenizer: () => { throw new Error('Not implemented'); },
+		processResponseFromChatEndpoint: () => { throw new Error('Not implemented'); },
+		makeChatRequest: () => { throw new Error('Not implemented'); },
+		makeChatRequest2: () => { throw new Error('Not implemented'); },
+		createRequestBody: () => { throw new Error('Not implemented'); },
+		cloneWithTokenOverride() { return this; },
+	} as unknown as IChatEndpoint;
+}
+
+function createMockOptions(overrides: Partial<ICreateEndpointBodyOptions> = {}): ICreateEndpointBodyOptions {
+	return {
+		debugName: 'test',
+		messages: [{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }] }],
+		location: ChatLocation.Agent,
+		finishedCb: undefined,
+		requestId: 'test-req-1',
+		postOptions: { max_tokens: 4096 },
+		requestOptions: {
+			tools: [
+				{ type: 'function', function: { name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } } },
+				{ type: 'function', function: { name: 'grep_search', description: 'Search for text', parameters: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } } },
+				{ type: 'function', function: { name: 'some_mcp_tool', description: 'An MCP tool', parameters: { type: 'object', properties: { input: { type: 'string' } }, required: ['input'] } } },
+				{ type: 'function', function: { name: 'another_deferred_tool', description: 'Another tool', parameters: { type: 'object', properties: {} } } },
+			]
+		},
+		...overrides,
+	} as ICreateEndpointBodyOptions;
+}
+
+describe('createResponsesRequestBody tools', () => {
+	let disposables: DisposableStore;
+	let services: ReturnType<typeof createPlatformServices>;
+	let accessor: ReturnType<ReturnType<typeof createPlatformServices>['createTestingAccessor']>;
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		services = createPlatformServices(disposables);
+		const coreNonDeferred = new Set(['read_file', 'list_dir', 'grep_search', 'semantic_search', 'file_search',
+			'replace_string_in_file', 'create_file', 'run_in_terminal', 'get_terminal_output',
+			'get_errors', 'manage_todo_list', 'runSubagent', 'search_subagent', 'execution_subagent',
+			'runTests', 'tool_search', 'view_image', 'fetch_webpage']);
+		services.define(IToolDeferralService, { _serviceBrand: undefined, isNonDeferredTool: (name: string) => coreNonDeferred.has(name) });
+		accessor = services.createTestingAccessor();
+	});
+
+	it('passes tools through without defer_loading when tool search disabled', () => {
+		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
+
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		expect(tools).toBeDefined();
+		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+	});
+
+	it('adds client tool_search and defer_loading when enabled', () => {
+		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		expect(tools).toBeDefined();
+
+		// Should have client-executed tool_search
+		const toolSearchTool = tools.find(t => t.type === 'tool_search');
+		expect(toolSearchTool).toBeDefined();
+		expect(toolSearchTool.execution).toBe('client');
+
+		// Non-deferred tools should NOT have defer_loading
+		expect(tools.find(t => t.name === 'read_file')?.defer_loading).toBeUndefined();
+		expect(tools.find(t => t.name === 'grep_search')?.defer_loading).toBeUndefined();
+
+		// Deferred tools should have defer_loading: true
+		expect(tools.find(t => t.name === 'some_mcp_tool')?.defer_loading).toBe(true);
+		expect(tools.find(t => t.name === 'another_deferred_tool')?.defer_loading).toBe(true);
+	});
+
+	it('does not defer tools for unsupported models', () => {
+		const endpoint = createMockEndpoint('gpt-4o');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, createMockOptions(), endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+	});
+
+	it('does not defer tools for non-Agent locations', () => {
+		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+
+		const options = createMockOptions({ location: ChatLocation.Panel });
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, options, endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+	});
+});
+
+describe('OpenAIResponsesProcessor tool search events', () => {
+	function createProcessor() {
+		const telemetryData = TelemetryData.createAndMarkAsIssued({}, {});
+		const telemetryService = new SpyingTelemetryService();
+		const ds = new DisposableStore();
+		const services = createPlatformServices(ds);
+		const accessor = services.createTestingAccessor();
+		return accessor.get(IInstantiationService).createInstance(OpenAIResponsesProcessor, telemetryData, telemetryService, 'req-123', 'gh-req-456', '', undefined);
+	}
+
+	function collectDeltas(processor: OpenAIResponsesProcessor, events: any[]): IResponseDelta[] {
+		const deltas: IResponseDelta[] = [];
+		const finishedCb = async (_text: string, _index: number, delta: IResponseDelta) => {
+			deltas.push(delta);
+			return undefined;
+		};
+		for (const event of events) {
+			processor.push({ sequence_number: 0, ...event }, finishedCb);
+		}
+		return deltas;
+	}
+
+	it('handles client tool_search_call as copilotToolCall', () => {
+		const processor = createProcessor();
+		const deltas = collectDeltas(processor, [
+			{
+				type: 'response.output_item.added',
+				output_index: 0,
+				item: {
+					type: 'tool_search_call' as any,
+					id: 'ts_002',
+					execution: 'client',
+					call_id: 'call_abc',
+					status: 'in_progress',
+					arguments: {},
+				} as any,
+			},
+			{
+				type: 'response.output_item.done',
+				output_index: 0,
+				item: {
+					type: 'tool_search_call' as any,
+					id: 'ts_002',
+					execution: 'client',
+					call_id: 'call_abc',
+					status: 'completed',
+					arguments: { query: 'Find shipping tools' },
+				} as any,
+			}
+		]);
+
+		// First delta: beginToolCalls for tool_search
+		expect(deltas[0].beginToolCalls).toBeDefined();
+		expect(deltas[0].beginToolCalls![0].name).toBe('tool_search');
+		expect(deltas[0].beginToolCalls![0].id).toBe('call_abc');
+
+		// Second delta: completed copilotToolCall
+		expect(deltas[1].copilotToolCalls).toBeDefined();
+		expect(deltas[1].copilotToolCalls![0]).toMatchObject({
+			id: 'call_abc',
+			name: 'tool_search',
+			arguments: '{"query":"Find shipping tools"}',
+		});
+	});
+});

--- a/extensions/copilot/src/platform/networking/common/fetch.ts
+++ b/extensions/copilot/src/platform/networking/common/fetch.ts
@@ -288,7 +288,18 @@ export interface OpenAiResponsesFunctionTool extends OpenAiFunctionDef {
 	type: 'function';
 }
 
-export function isOpenAiFunctionTool(tool: OpenAiResponsesFunctionTool | OpenAiFunctionTool | AnthropicMessagesTool): tool is OpenAiFunctionTool {
+/** OpenAI Responses API tool_search tool declaration. See https://developers.openai.com/api/docs/guides/tools-tool-search */
+export interface OpenAiToolSearchTool {
+	type: 'tool_search';
+	/** 'server' for hosted search, 'client' for client-executed. Defaults to 'server' if omitted. */
+	execution?: 'server' | 'client';
+	/** Description for client-executed tool search. */
+	description?: string;
+	/** Parameters schema for client-executed tool search. */
+	parameters?: Record<string, unknown>;
+}
+
+export function isOpenAiFunctionTool(tool: OpenAiResponsesFunctionTool | OpenAiFunctionTool | AnthropicMessagesTool | OpenAiToolSearchTool): tool is OpenAiFunctionTool {
 	return (tool as OpenAiFunctionTool).function !== undefined;
 }
 

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -19,7 +19,7 @@ import { ILogService } from '../../log/common/logService';
 import { ITelemetryService, TelemetryProperties } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { AnthropicMessagesTool, ContextManagement } from './anthropic';
-import { FinishedCallback, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OptionalChatRequestParams, Prediction } from './fetch';
+import { FinishedCallback, OpenAiFunctionTool, OpenAiResponsesFunctionTool, OpenAiToolSearchTool, OptionalChatRequestParams, Prediction } from './fetch';
 import { FetcherId, FetchOptions, IAbortController, IFetcherService, PaginationOptions, Response } from './fetcherService';
 import { ChatCompletion, OpenAIContextManagement, RawMessageConversionCallback, rawMessageToCAPI } from './openai';
 
@@ -62,7 +62,7 @@ const requestTimeoutMs = 30 * 1000; // 30 seconds
  */
 export interface IEndpointBody {
 	/** General or completions: */
-	tools?: (OpenAiFunctionTool | OpenAiResponsesFunctionTool | AnthropicMessagesTool)[];
+	tools?: (OpenAiFunctionTool | OpenAiResponsesFunctionTool | AnthropicMessagesTool | OpenAiToolSearchTool)[];
 	model?: string;
 	previous_response_id?: string;
 	max_tokens?: number;

--- a/extensions/copilot/src/platform/networking/common/openai.ts
+++ b/extensions/copilot/src/platform/networking/common/openai.ts
@@ -10,6 +10,28 @@ import { rawPartAsThinkingData } from '../../endpoint/common/thinkingDataContain
 import { TelemetryData } from '../../telemetry/common/telemetryData';
 import { ThinkingData, ThinkingDataInMessage } from '../../thinking/common/thinking';
 import { ICopilotReference, RequestId } from './fetch';
+import { ConfigKey, IConfigurationService } from '../../configuration/common/configurationService';
+import { IExperimentationService } from '../../telemetry/common/nullExperimentationService';
+import { IChatEndpoint } from './networking';
+
+// ── Responses API tool search ─────────────────────────────────────────
+
+/** Model ID prefixes that support Responses API tool search. Per OpenAI docs: "Only gpt-5.4 and later models support tool_search." */
+export const OPENAI_TOOL_SEARCH_SUPPORTED_MODELS = [
+	'gpt-5.4',
+] as const;
+
+export function isResponsesApiToolSearchEnabled(
+	endpoint: IChatEndpoint | string,
+	configurationService: IConfigurationService,
+	experimentationService: IExperimentationService,
+): boolean {
+	const effectiveModelId = typeof endpoint === 'string' ? endpoint : endpoint.model;
+	if (!OPENAI_TOOL_SEARCH_SUPPORTED_MODELS.some(prefix => effectiveModelId.toLowerCase().startsWith(prefix))) {
+		return false;
+	}
+	return configurationService.getExperimentBasedConfig(ConfigKey.ResponsesApiToolSearchEnabled, experimentationService);
+}
 
 /**
  * How the logprobs field looks in the OpenAI API chunks.


### PR DESCRIPTION
Port from microsoft/vscode-copilot-chat#4751. Adds client-executed tool search for OpenAI gpt-5.4+ models using the Responses API `tool_search` protocol.

## What

When enabled via `chat.responsesApi.toolSearchTool.enabled` experiment flag, tools are split into non-deferred (core tools always loaded) and deferred (`defer_loading: true`). A client-executed `tool_search` tool is added to the request. The model emits `tool_search_call`, our `ToolSearchTool` handles embeddings search, and we round-trip as `tool_search_output` with full definitions.

Uses OpenAI's [client-executed tool search protocol](https://developers.openai.com/api/docs/guides/tools-tool-search).

## Key changes
- **responsesApi.ts**: Refactored `createResponsesRequestBody` to split tools into deferred/non-deferred, updated `rawMessagesToResponseAPI` to convert tool_search round-trips, added `tool_search_call` handling in `OpenAIResponsesProcessor`
- **openai.ts**: Added `isResponsesApiToolSearchEnabled` + `OPENAI_TOOL_SEARCH_SUPPORTED_MODELS`
- **fetch.ts**: Added `OpenAiToolSearchTool` interface
- **toolSearchTool.ts**: Added `gpt-5.4` to supported models
- **configurationService.ts**: Added `ResponsesApiToolSearchEnabled` config key
- Test coverage in `responsesApiToolSearch.spec.ts`
