### PR TITLE
fix: handle quoted ID values in /etc/os-release parsing

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -30,7 +30,7 @@ MIN_GLIBCXX_VERSION="3.4.25"
 
 # Extract the ID value from /etc/os-release
 if [ -f /etc/os-release ]; then
-    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    OS_ID=$(source /etc/os-release && echo $ID)
     if [ "$OS_ID" = "nixos" ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0


### PR DESCRIPTION
Good day

## 🎯 Fix for Issue #232159

### Problem
The script that parses `/etc/os-release` to extract the OS ID fails when the value is quoted (e.g., `ID="rocky"`). This causes the `OS_ID` variable to be empty on systems like Rocky Linux 8.5, resulting in a non-zero exit code and failed devcontainer setups.

### Solution
Use `source` to source `/etc/os-release` in a subshell, which properly handles both quoted and unquoted values:

```bash
OS_ID=$(source /etc/os-release && echo $ID)
```

This approach:
- Properly strips surrounding quotes from values
- Works for both `ID=value` and `ID="value"` formats
- Does not pollute the current shell's environment
- Is more idiomatic for parsing `os-release` files

### Testing
Verified that the new approach correctly extracts:
- `ID="rocky"` → `rocky`
- `ID=ubuntu` → `ubuntu`

### Files Changed
- `resources/server/bin/helpers/check-requirements-linux.sh`

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee