### PR TITLE
Update @github/copilot SDK to ^1.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.42",
-        "@github/copilot": "^1.0.24",
+        "@github/copilot": "^1.0.28",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -1072,26 +1072,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.24.tgz",
-      "integrity": "sha512-/nZ2GwhaGq0HeI3W+6LE0JGw25/bipC6tYVa+oQ5tIvAafBazuNt10CXkeaor+u9oBWLZtPbdTyAzE2tjy9NpQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.28.tgz",
+      "integrity": "sha512-S1Y+KnhywjIsK1DzskoCqPVC3uURohvCRyDkGPWXvMw+lXO5ryOJvHFZDDw7MSRjT7ea7T0m8e3yKdK0OxJhnw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.24",
-        "@github/copilot-darwin-x64": "1.0.24",
-        "@github/copilot-linux-arm64": "1.0.24",
-        "@github/copilot-linux-x64": "1.0.24",
-        "@github/copilot-win32-arm64": "1.0.24",
-        "@github/copilot-win32-x64": "1.0.24"
+        "@github/copilot-darwin-arm64": "1.0.28",
+        "@github/copilot-darwin-x64": "1.0.28",
+        "@github/copilot-linux-arm64": "1.0.28",
+        "@github/copilot-linux-x64": "1.0.28",
+        "@github/copilot-win32-arm64": "1.0.28",
+        "@github/copilot-win32-x64": "1.0.28"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.24.tgz",
-      "integrity": "sha512-lejn6KV+09rZEICX3nRx9a58DQFQ2kK3NJ3EICfVLngUCWIUmwn1BLezjeTQc9YNasHltA1hulvfsWqX+VjlMw==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.28.tgz",
+      "integrity": "sha512-Bkis5dkOsdgaK95j/8mgIGSxHlRuL211Wa3S4MeeYGrilZweaG20sa0jktzagL6XFxfPRKBC87E+fDFyXz1L3g==",
       "cpu": [
         "arm64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.24.tgz",
-      "integrity": "sha512-r2F3keTvr4Bunz3V+waRAvsHgqsVQGyIZFBebsNPWxBX1eh3IXgtBqxCR7vXTFyZonQ8VaiJH3YYEfAhyKsk9g==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.28.tgz",
+      "integrity": "sha512-0RIabmr05KgPPUcD4kpKNBGg/eRwJF2NrYtibDUCIRFWKZu7q0m9c9EURpW0wOO32cXZtAQ+BmJIGlqfCkt6gA==",
       "cpu": [
         "x64"
       ],
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.24.tgz",
-      "integrity": "sha512-B3oANXKKKLhnKYozXa/W+DxfCQAHJCs0QKR5rBwNrwJbf656twNgALSxWTSJk+1rEP6MrHCswUAcwjwZL7Q+FQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.28.tgz",
+      "integrity": "sha512-A/zQ4ifN+FSSEHdPHajv5UwygS5BOQ8l1AJMYdVBnnuqVX9bCcRAJJ4S/F60AnaDimzDvVuYSe3lYXRYxz3M5A==",
       "cpu": [
         "arm64"
       ],
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.24.tgz",
-      "integrity": "sha512-NGTldizY54B+4Sfhu/GWoEQNMwqqUNgMwbSgBshFv+Hqy1EwuvNWKVov1Y0Vzhp4qAHc6ZxBk/OPIW8Ato9FUg==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.28.tgz",
+      "integrity": "sha512-0VqoW9hj7qKj+eH2un9E7zn9AbassTZHkKQPsd8yPvLsmPaNJgsHMYDrCCNZNol2ZSGt/XskTfmWQaQM6BoBfg==",
       "cpu": [
         "x64"
       ],
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.24.tgz",
-      "integrity": "sha512-/pd/kgef7/HIIg1SQq4q8fext39pDSC44jHB10KkhfgG1WaDFhQbc/aSSMQfxeldkRbQh6VANp8WtGQdwtMCBA==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.28.tgz",
+      "integrity": "sha512-f28NKudBtIXTpIliHGJbRhEfCItsXKWNzXzgqgmP8FZB+JYrqG/ysU2qCUCxhpv3PLjMLWqnsWs+mIvVLTH9zw==",
       "cpu": [
         "arm64"
       ],
@@ -1192,9 +1192,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.24.tgz",
-      "integrity": "sha512-RDvOiSvyEJwELqErwANJTrdRuMIHkwPE4QK7Le7WsmaSKxiuS4H1Pa8Yxnd2FWrMsCHEbase23GJlymbnGYLXQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.28.tgz",
+      "integrity": "sha512-b9ZEx2i5P7DZTP66FXTfwf81r5kbAqs2GEJjDdevCwxH7cRexqM9eBxQGj1zGtm4qXF7JGK2eH6Ay7NC28m1Iw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.42",
-    "@github/copilot": "^1.0.24",
+    "@github/copilot": "^1.0.28",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.42",
-        "@github/copilot": "^1.0.24",
+        "@github/copilot": "^1.0.28",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -83,26 +83,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.24.tgz",
-      "integrity": "sha512-/nZ2GwhaGq0HeI3W+6LE0JGw25/bipC6tYVa+oQ5tIvAafBazuNt10CXkeaor+u9oBWLZtPbdTyAzE2tjy9NpQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.28.tgz",
+      "integrity": "sha512-S1Y+KnhywjIsK1DzskoCqPVC3uURohvCRyDkGPWXvMw+lXO5ryOJvHFZDDw7MSRjT7ea7T0m8e3yKdK0OxJhnw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.24",
-        "@github/copilot-darwin-x64": "1.0.24",
-        "@github/copilot-linux-arm64": "1.0.24",
-        "@github/copilot-linux-x64": "1.0.24",
-        "@github/copilot-win32-arm64": "1.0.24",
-        "@github/copilot-win32-x64": "1.0.24"
+        "@github/copilot-darwin-arm64": "1.0.28",
+        "@github/copilot-darwin-x64": "1.0.28",
+        "@github/copilot-linux-arm64": "1.0.28",
+        "@github/copilot-linux-x64": "1.0.28",
+        "@github/copilot-win32-arm64": "1.0.28",
+        "@github/copilot-win32-x64": "1.0.28"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.24.tgz",
-      "integrity": "sha512-lejn6KV+09rZEICX3nRx9a58DQFQ2kK3NJ3EICfVLngUCWIUmwn1BLezjeTQc9YNasHltA1hulvfsWqX+VjlMw==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.28.tgz",
+      "integrity": "sha512-Bkis5dkOsdgaK95j/8mgIGSxHlRuL211Wa3S4MeeYGrilZweaG20sa0jktzagL6XFxfPRKBC87E+fDFyXz1L3g==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.24.tgz",
-      "integrity": "sha512-r2F3keTvr4Bunz3V+waRAvsHgqsVQGyIZFBebsNPWxBX1eh3IXgtBqxCR7vXTFyZonQ8VaiJH3YYEfAhyKsk9g==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.28.tgz",
+      "integrity": "sha512-0RIabmr05KgPPUcD4kpKNBGg/eRwJF2NrYtibDUCIRFWKZu7q0m9c9EURpW0wOO32cXZtAQ+BmJIGlqfCkt6gA==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.24.tgz",
-      "integrity": "sha512-B3oANXKKKLhnKYozXa/W+DxfCQAHJCs0QKR5rBwNrwJbf656twNgALSxWTSJk+1rEP6MrHCswUAcwjwZL7Q+FQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.28.tgz",
+      "integrity": "sha512-A/zQ4ifN+FSSEHdPHajv5UwygS5BOQ8l1AJMYdVBnnuqVX9bCcRAJJ4S/F60AnaDimzDvVuYSe3lYXRYxz3M5A==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.24.tgz",
-      "integrity": "sha512-NGTldizY54B+4Sfhu/GWoEQNMwqqUNgMwbSgBshFv+Hqy1EwuvNWKVov1Y0Vzhp4qAHc6ZxBk/OPIW8Ato9FUg==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.28.tgz",
+      "integrity": "sha512-0VqoW9hj7qKj+eH2un9E7zn9AbassTZHkKQPsd8yPvLsmPaNJgsHMYDrCCNZNol2ZSGt/XskTfmWQaQM6BoBfg==",
       "cpu": [
         "x64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.24.tgz",
-      "integrity": "sha512-/pd/kgef7/HIIg1SQq4q8fext39pDSC44jHB10KkhfgG1WaDFhQbc/aSSMQfxeldkRbQh6VANp8WtGQdwtMCBA==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.28.tgz",
+      "integrity": "sha512-f28NKudBtIXTpIliHGJbRhEfCItsXKWNzXzgqgmP8FZB+JYrqG/ysU2qCUCxhpv3PLjMLWqnsWs+mIvVLTH9zw==",
       "cpu": [
         "arm64"
       ],
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.24.tgz",
-      "integrity": "sha512-RDvOiSvyEJwELqErwANJTrdRuMIHkwPE4QK7Le7WsmaSKxiuS4H1Pa8Yxnd2FWrMsCHEbase23GJlymbnGYLXQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.28.tgz",
+      "integrity": "sha512-b9ZEx2i5P7DZTP66FXTfwf81r5kbAqs2GEJjDdevCwxH7cRexqM9eBxQGj1zGtm4qXF7JGK2eH6Ay7NC28m1Iw==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.42",
-    "@github/copilot": "^1.0.24",
+    "@github/copilot": "^1.0.28",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
@@ -30,8 +30,9 @@ import { URI } from '../../../../../base/common/uri.js';
 import type { ISessionToolCallStartAction } from '../../../common/state/protocol/actions.js';
 import { ISubscribeResult } from '../../../common/state/protocol/commands.js';
 import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
-import { ResponsePartKind, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolResultContentType, isSubagentSession, type ISessionInputAnswer, type ISessionInputRequest, type ISessionState, type ITerminalState, type IToolResultContent, type IToolResultSubagentContent } from '../../../common/state/sessionState.js';
-import type { ISessionAddedNotification, ISessionInputRequestedAction, ISessionResponsePartAction, ISessionToolCallReadyAction } from '../../../common/state/sessionActions.js';
+import { ResponsePartKind, ROOT_STATE_URI, SessionInputAnswerState, SessionInputAnswerValueKind, SessionInputQuestionKind, SessionInputResponseKind, ToolResultContentType, isSubagentSession, type ISessionInputAnswer, type ISessionInputRequest, type ISessionState, type ITerminalState, type IToolResultContent, type IToolResultSubagentContent } from '../../../common/state/sessionState.js';
+import type { IRootState } from '../../../common/state/protocol/state.js';
+import type { IRootAgentsChangedAction, ISessionAddedNotification, ISessionInputRequestedAction, ISessionResponsePartAction, ISessionToolCallReadyAction } from '../../../common/state/sessionActions.js';
 import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
 import {
 	getActionEnvelope,
@@ -74,8 +75,8 @@ async function createRealSessionFull(c: TestProtocolClient, clientId: string, tr
 
 	await c.call('authenticate', { resource: 'https://api.github.com', token: resolveGitHubToken() }, 30_000);
 
-	const sessionUri = URI.from({ scheme: 'copilot', path: `/real-test-${Date.now()}` }).toString();
-	await c.call('createSession', { session: sessionUri, provider: 'copilot', workingDirectory }, 30_000);
+	const sessionUri = URI.from({ scheme: 'copilotcli', path: `/real-test-${Date.now()}` }).toString();
+	await c.call('createSession', { session: sessionUri, provider: 'copilotcli', workingDirectory }, 30_000);
 
 	const notif = await c.waitForNotification(n =>
 		n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
@@ -432,8 +433,8 @@ function terminalText(state: ITerminalState): string {
 		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'real-sdk-workdir' });
 		await client.call('authenticate', { resource: 'https://api.github.com', token: resolveGitHubToken() });
 
-		const sessionUri = URI.from({ scheme: 'copilot', path: `/real-test-wd-${Date.now()}` }).toString();
-		await client.call('createSession', { session: sessionUri, provider: 'copilot', workingDirectory: workingDirUri });
+		const sessionUri = URI.from({ scheme: 'copilotcli', path: `/real-test-wd-${Date.now()}` }).toString();
+		await client.call('createSession', { session: sessionUri, provider: 'copilotcli', workingDirectory: workingDirUri });
 
 		// 1. Verify workingDirectory in the sessionAdded notification
 		const addedNotif = await client.waitForNotification(n =>
@@ -476,10 +477,10 @@ function terminalText(state: ITerminalState): string {
 		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'real-sdk-worktree' });
 		await client.call('authenticate', { resource: 'https://api.github.com', token: resolveGitHubToken() });
 
-		const sessionUri = URI.from({ scheme: 'copilot', path: `/real-test-wt-${Date.now()}` }).toString();
+		const sessionUri = URI.from({ scheme: 'copilotcli', path: `/real-test-wt-${Date.now()}` }).toString();
 		await client.call('createSession', {
 			session: sessionUri,
-			provider: 'copilot',
+			provider: 'copilotcli',
 			workingDirectory: workingDirUri,
 			config: { isolation: 'worktree', branch: defaultBranch },
 		});
@@ -710,5 +711,53 @@ function terminalText(state: ITerminalState): string {
 		assert.ok(subagentStarts.length >= 1,
 			`subagent session should contain at least one inner tool call, got ${subagentStarts.length}. ` +
 			`Parent tool calls: ${JSON.stringify(parentStarts.map(a => a.toolName))}`);
+	});
+
+	// ---- Model discovery -----------------------------------------------------
+
+	test('listModels returns well-shaped model entries after authenticate', async function () {
+		this.timeout(60_000);
+
+		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'real-sdk-list-models' }, 30_000);
+
+		// Subscribe to root state *before* authenticating so we can observe
+		// the agentsChanged action that carries the populated model list.
+		const rootResult = await client.call<ISubscribeResult>('subscribe', { resource: ROOT_STATE_URI }, 30_000);
+		const initial = rootResult.snapshot.state as IRootState;
+		const copilotAgent = initial.agents.find(a => a.provider === 'copilotcli');
+		assert.ok(copilotAgent, `Expected copilotcli agent in root state, got: ${initial.agents.map(a => a.provider).join(', ')}`);
+
+		await client.call('authenticate', { resource: 'https://api.github.com', token: resolveGitHubToken() }, 30_000);
+
+		// Models are loaded asynchronously after authenticate. Wait for the
+		// agentsChanged action that populates them.
+		const notif = await client.waitForNotification(n => {
+			if (!isActionNotification(n, 'root/agentsChanged')) {
+				return false;
+			}
+			const action = getActionEnvelope(n).action as IRootAgentsChangedAction;
+			const agent = action.agents.find(a => a.provider === 'copilotcli');
+			return !!agent && agent.models.length > 0;
+		}, 30_000);
+
+		const action = getActionEnvelope(notif).action as IRootAgentsChangedAction;
+		const agent = action.agents.find(a => a.provider === 'copilotcli')!;
+
+		assert.ok(agent.models.length > 0, 'Expected at least one model from listModels');
+
+		// Assert every model has the shape CopilotAgent._listModels produces.
+		// If the SDK changes and any required field becomes undefined (as
+		// happened with max_context_window_tokens in @github/copilot@1.0.34),
+		// this loop surfaces the exact offending model instead of letting
+		// _refreshModels silently swallow the TypeError and set models=[].
+		for (const model of agent.models) {
+			assert.strictEqual(typeof model.id, 'string', `model.id should be a string: ${JSON.stringify(model)}`);
+			assert.ok(model.id.length > 0, `model.id should be non-empty: ${JSON.stringify(model)}`);
+			assert.strictEqual(typeof model.name, 'string', `model.name should be a string: ${JSON.stringify(model)}`);
+			assert.strictEqual(model.provider, 'copilotcli', `model.provider should be copilotcli: ${JSON.stringify(model)}`);
+			assert.strictEqual(typeof model.maxContextWindow, 'number', `model.maxContextWindow should be a number: ${JSON.stringify(model)}`);
+			assert.ok(model.maxContextWindow && model.maxContextWindow > 0, `model.maxContextWindow should be positive: ${JSON.stringify(model)}`);
+			assert.ok(model.supportsVision === undefined || typeof model.supportsVision === 'boolean', `model.supportsVision should be boolean or undefined: ${JSON.stringify(model)}`);
+		}
 	});
 });


### PR DESCRIPTION
Bumps `@github/copilot` in the root and remote `package.json` from `^1.0.24` to `^1.0.28`, matching the version pinned by the bundled copilot extension (`extensions/copilot/package.json`).

### Why not the latest (`1.0.34`)?

`@github/copilot@1.0.34` ships an `api.schema.json` whose `ModelCapabilities` makes `limits` and `supports` optional, but the companion `@github/copilot-sdk@0.2.2` `.d.ts` declares them as required. At least one model returned by 1.0.34 omits `limits` entirely, which causes `CopilotAgent._listModels` to throw `TypeError: Cannot read properties of undefined (reading 'max_context_window_tokens')`. `_refreshModels` silently catches this and sets `_models = []`, so the user sees no models in the Local Agent Host after authenticate.

`1.0.28` declares `required: ['supports', 'limits']` and `limits.required: ['max_context_window_tokens']`, which matches the SDK types. It's also the version the copilot extension already ships with, so it's known-good.

### New regression test

Adds `listModels returns well-shaped model entries after authenticate` to `toolApprovalRealSdk.integrationTest.ts`. It subscribes to root state, authenticates, waits for the `root/agentsChanged` action, and asserts every model has a string `id`/`name`, `provider === 'copilotcli'`, and a numeric `maxContextWindow > 0`. Would have caught the 1.0.34 TypeError loudly instead of producing a silent empty model list.

Run the real-SDK suite with:

```
AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh --runGlob "**/*RealSdk.integrationTest.js"
```

### Drive-by

Fixes 6 stale `'copilot'` provider-id references → `'copilotcli'` in the same test file (the rename happened a while ago and the real-SDK tests had been silently failing with `No agent provider registered for: copilot`).

### Validation

- `npm run compile-check-ts-native` clean
- All 9017 node unit tests pass
- 5/7 real-SDK integration tests pass (the same 2 pre-existing failures — `planning-mode` and `subagent` — reproduce on `1.0.24` too and are out of scope for this PR)
- New `listModels` regression test passes against `1.0.28`

(Written by Copilot)