### PR TITLE
Agents web: scope workspace picker to selected host

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -7,6 +7,7 @@ import './media/chatWidget.css';
 import * as dom from '../../../../base/browser/dom.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { derived } from '../../../../base/common/observable.js';
+import { isWeb } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -24,6 +25,7 @@ import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { WorkspacePicker, IWorkspaceSelection } from './sessionWorkspacePicker.js';
+import { ScopedWorkspacePicker } from './scopedWorkspacePicker.js';
 import { NewChatInputWidget } from './newChatInput.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 
@@ -42,7 +44,7 @@ class NewChatWidget extends Disposable {
 		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
-		this._workspacePicker = this._register(this.instantiationService.createInstance(WorkspacePicker));
+		this._workspacePicker = this._register(this.instantiationService.createInstance(isWeb ? ScopedWorkspacePicker : WorkspacePicker));
 
 		const canSendRequest = derived(reader => {
 			const session = this.sessionsManagementService.activeSession.read(reader);

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { localize } from '../../../../nls.js';
+import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { ActionListItemKind, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IOutputService } from '../../../../workbench/services/output/common/output.js';
+import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { IAgentHostFilterService } from '../../remoteAgentHost/common/agentHostFilter.js';
+import { IWorkspacePickerItem, IWorkspaceSelection, WorkspacePicker } from './sessionWorkspacePicker.js';
+
+/**
+ * A simplified workspace picker that scopes its contents to the host
+ * currently selected in the agent host filter. It shows:
+ *
+ *  1. Recent workspaces for the selected host
+ *  2. A single "Select Folder..." entry that invokes the host's browse action
+ *
+ * Falls back to the Copilot local provider when no host is selected (e.g. on
+ * desktop, where the host filter UI is not surfaced).
+ */
+export class ScopedWorkspacePicker extends WorkspacePicker {
+
+	constructor(
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@IStorageService storageService: IStorageService,
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsManagementService sessionsManagementService: ISessionsManagementService,
+		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
+		@IQuickInputService quickInputService: IQuickInputService,
+		@IClipboardService clipboardService: IClipboardService,
+		@IPreferencesService preferencesService: IPreferencesService,
+		@IOutputService outputService: IOutputService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ICommandService commandService: ICommandService,
+		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
+	) {
+		super(
+			actionWidgetService,
+			storageService,
+			uriIdentityService,
+			sessionsProvidersService,
+			sessionsManagementService,
+			remoteAgentHostService,
+			quickInputService,
+			clipboardService,
+			preferencesService,
+			outputService,
+			configurationService,
+			commandService,
+		);
+
+		// When the scoped host changes, if the current selection no longer
+		// belongs to the selected host, reset it: prefer the most recent
+		// workspace for the new host, otherwise clear the selection.
+		this._register(this._agentHostFilterService.onDidChange(() => this._onScopedHostChanged()));
+	}
+
+	private _onScopedHostChanged(): void {
+		const scopedProviderId = this._agentHostFilterService.selectedProviderId;
+		const current = this.selectedProject;
+		if (current && scopedProviderId !== undefined && current.providerId === scopedProviderId) {
+			this._onDidChangeSelection.fire();
+			return;
+		}
+
+		const firstRecent = scopedProviderId !== undefined
+			? this._getRecentWorkspaces().find(w => w.providerId === scopedProviderId)
+			: undefined;
+		if (firstRecent) {
+			this.setSelectedWorkspace({ providerId: firstRecent.providerId, workspace: firstRecent.workspace });
+			return;
+		}
+
+		this.clearSelection();
+		this._onDidSelectWorkspace.fire(undefined);
+	}
+
+	protected override _buildItems(): IActionListItem<IWorkspacePickerItem>[] {
+		const items: IActionListItem<IWorkspacePickerItem>[] = [];
+
+		const scopedProviderId = this._agentHostFilterService.selectedProviderId;
+		if (scopedProviderId === undefined) {
+			return [];
+		}
+		const provider = this.sessionsProvidersService.getProvider(scopedProviderId);
+		if (!provider) {
+			return items;
+		}
+
+		// 1. Recent workspaces for the scoped provider
+		const recents = this._getRecentWorkspaces().filter(w => w.providerId === scopedProviderId);
+		for (const { workspace, providerId } of recents) {
+			const selection: IWorkspaceSelection = { providerId, workspace };
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: workspace.label,
+				group: { title: '', icon: workspace.icon },
+				item: { selection, checked: this._isSelectedWorkspace(selection) || undefined },
+				onRemove: () => this._removeRecentWorkspace(selection),
+			});
+		}
+
+		// 2. "Select Folder..." — dispatches the scoped provider's first browse action
+		const allBrowseActions = this._getAllBrowseActions();
+		const browseIndex = allBrowseActions.findIndex(a => a.providerId === scopedProviderId);
+		if (browseIndex >= 0 && !this._isProviderUnavailable(scopedProviderId)) {
+			if (items.length > 0) {
+				items.push({ kind: ActionListItemKind.Separator, label: '' });
+			}
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: localize('scopedWorkspacePicker.selectFolder', "Select Folder..."),
+				group: { title: '', icon: Codicon.folderOpened },
+				item: { browseActionIndex: browseIndex },
+			});
+		}
+
+		return items;
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -61,7 +61,7 @@ interface IStoredRecentWorkspace {
 /**
  * Item type used in the action list.
  */
-interface IWorkspacePickerItem {
+export interface IWorkspacePickerItem {
 	readonly selection?: IWorkspaceSelection;
 	readonly browseActionIndex?: number;
 	readonly checked?: boolean;
@@ -79,9 +79,9 @@ interface IWorkspacePickerItem {
  */
 export class WorkspacePicker extends Disposable {
 
-	private readonly _onDidSelectWorkspace = this._register(new Emitter<IWorkspaceSelection | undefined>());
+	protected readonly _onDidSelectWorkspace = this._register(new Emitter<IWorkspaceSelection | undefined>());
 	readonly onDidSelectWorkspace: Event<IWorkspaceSelection | undefined> = this._onDidSelectWorkspace.event;
-	private readonly _onDidChangeSelection = this._register(new Emitter<void>());
+	protected readonly _onDidChangeSelection = this._register(new Emitter<void>());
 	readonly onDidChangeSelection: Event<void> = this._onDidChangeSelection.event;
 
 	private _selectedWorkspace: IWorkspaceSelection | undefined;
@@ -98,7 +98,7 @@ export class WorkspacePicker extends Disposable {
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-		@ISessionsProvidersService private readonly sessionsProvidersService: ISessionsProvidersService,
+		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
@@ -284,7 +284,7 @@ export class WorkspacePicker extends Disposable {
 	/**
 	 * Executes a browse action from a provider, identified by index.
 	 */
-	private async _executeBrowseAction(actionIndex: number): Promise<void> {
+	protected async _executeBrowseAction(actionIndex: number): Promise<void> {
 		const allActions = this._getAllBrowseActions();
 		const action = allActions[actionIndex];
 		if (!action) {
@@ -316,11 +316,11 @@ export class WorkspacePicker extends Disposable {
 	/**
 	 * Collects browse actions from all registered providers.
 	 */
-	private _getAllBrowseActions(): ISessionWorkspaceBrowseAction[] {
+	protected _getAllBrowseActions(): ISessionWorkspaceBrowseAction[] {
 		return this.sessionsProvidersService.getProviders().flatMap(p => p.browseActions);
 	}
 
-	private _buildItems(): IActionListItem<IWorkspacePickerItem>[] {
+	protected _buildItems(): IActionListItem<IWorkspacePickerItem>[] {
 		const items: IActionListItem<IWorkspacePickerItem>[] = [];
 
 		// Collect recent workspaces from picker storage across all providers
@@ -636,7 +636,7 @@ export class WorkspacePicker extends Disposable {
 	 * (disconnected or still connecting).
 	 * Returns false for providers without connection status (e.g. local providers).
 	 */
-	private _isProviderUnavailable(providerId: string): boolean {
+	protected _isProviderUnavailable(providerId: string): boolean {
 		const provider = this.sessionsProvidersService.getProvider(providerId);
 		if (!provider || !isAgentHostProvider(provider) || !provider.connectionStatus) {
 			return false;
@@ -682,7 +682,7 @@ export class WorkspacePicker extends Disposable {
 		});
 	}
 
-	private _isSelectedWorkspace(selection: IWorkspaceSelection): boolean {
+	protected _isSelectedWorkspace(selection: IWorkspaceSelection): boolean {
 		if (!this._selectedWorkspace) {
 			return false;
 		}
@@ -819,7 +819,7 @@ export class WorkspacePicker extends Disposable {
 		this.storageService.store(STORAGE_KEY_RECENT_WORKSPACES, JSON.stringify(updated), StorageScope.PROFILE, StorageTarget.MACHINE);
 	}
 
-	private _getRecentWorkspaces(): { providerId: string; workspace: ISessionWorkspace }[] {
+	protected _getRecentWorkspaces(): { providerId: string; workspace: ISessionWorkspace }[] {
 		return this._getStoredRecentWorkspaces()
 			.map(stored => {
 				const uri = URI.revive(stored.uri);
@@ -841,7 +841,7 @@ export class WorkspacePicker extends Disposable {
 			});
 	}
 
-	private _removeRecentWorkspace(selection: IWorkspaceSelection): void {
+	protected _removeRecentWorkspace(selection: IWorkspaceSelection): void {
 		const uri = selection.workspace.repositories[0]?.uri;
 		if (!uri) {
 			return;


### PR DESCRIPTION
Introduces `ScopedWorkspacePicker`, a simplified workspace picker used in the Agents web chat that scopes its contents to the host currently selected in the agent host filter. The full `WorkspacePicker` remains in use on desktop.

## Changes

- **`sessionWorkspacePicker.ts`**: widen a few members to `protected` so subclasses can override `_buildItems` and reuse helpers (`_getRecentWorkspaces`, `_getAllBrowseActions`, `_isSelectedWorkspace`, `_removeRecentWorkspace`, `_executeBrowseAction`, `_isProviderUnavailable`, `sessionsProvidersService`, `_onDidChangeSelection`, `_onDidSelectWorkspace`). Exports `IWorkspacePickerItem`.
- **`scopedWorkspacePicker.ts`** (new): subclass that shows only
  1. Recent workspaces for the scoped host
  2. A single **Select Folder…** entry that dispatches the scoped provider's first browse action (the same flow as clicking a remote host row today).
  
  Reacts to host filter changes: keeps the selection if it still belongs to the new host, otherwise selects the most recent workspace for that host, or clears the selection.
- **`newChatViewPane.ts`**: uses `ScopedWorkspacePicker` when `isWeb`, otherwise the full `WorkspacePicker`.
