### PR TITLE
Fix remote agent host protocol client lifecycle

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -9,7 +9,7 @@
 
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
-import { Disposable, IReference } from '../../../base/common/lifecycle.js';
+import { Disposable, IReference, toDisposable } from '../../../base/common/lifecycle.js';
 import { Schemas } from '../../../base/common/network.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -19,15 +19,41 @@ import { FileSystemProviderErrorCode, IFileService, toFileSystemProviderErrorCod
 import { AgentSession, IAgentConnection, IAgentCreateSessionConfig, IAgentResolveSessionConfigParams, IAgentSessionConfigCompletionsParams, IAgentSessionMetadata, IAuthenticateParams, IAuthenticateResult } from '../common/agentService.js';
 import { AgentSubscriptionManager, type IAgentSubscription } from '../common/state/agentSubscription.js';
 import { agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../common/agentHostUri.js';
-import type { IClientNotificationMap, ICommandMap } from '../common/state/protocol/messages.js';
+import type { IClientNotificationMap, ICommandMap, IJsonRpcErrorResponse, IJsonRpcRequest } from '../common/state/protocol/messages.js';
 import type { IActionEnvelope, INotification, ISessionAction, ITerminalAction } from '../common/state/sessionActions.js';
 import { ISessionSummary, ROOT_STATE_URI, StateComponents, type IRootState } from '../common/state/sessionState.js';
 import { PROTOCOL_VERSION } from '../common/state/sessionCapabilities.js';
-import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, type IJsonRpcResponse, type IProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
+import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse, type IProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { isClientTransport, type IProtocolTransport } from '../common/state/sessionTransport.js';
 import { AhpErrorCodes } from '../common/state/protocol/errors.js';
 import { ContentEncoding, type ICreateTerminalParams, type IResolveSessionConfigResult, type ISessionConfigCompletionsResult } from '../common/state/protocol/commands.js';
 import { decodeBase64, encodeBase64, VSBuffer } from '../../../base/common/buffer.js';
+
+const AHP_CLIENT_CONNECTION_CLOSED = -32000;
+
+export class RemoteAgentHostProtocolError extends Error {
+
+	readonly code: number;
+	readonly data: unknown | undefined;
+
+	constructor(error: IJsonRpcErrorResponse['error']) {
+		super(error.message);
+		this.code = error.code;
+		this.data = error.data;
+	}
+
+	static connectionClosed(address: string): RemoteAgentHostProtocolError {
+		return new RemoteAgentHostProtocolError({ code: AHP_CLIENT_CONNECTION_CLOSED, message: `Connection closed: ${address}` });
+	}
+
+	static disposed(address: string): RemoteAgentHostProtocolError {
+		return new RemoteAgentHostProtocolError({ code: AHP_CLIENT_CONNECTION_CLOSED, message: `Connection disposed: ${address}` });
+	}
+}
+
+interface IRemoteAgentHostExtensionCommandMap {
+	'shutdown': { params: undefined; result: void };
+}
 
 /**
  * A protocol-level client for a single remote agent host connection.
@@ -62,6 +88,8 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	/** Pending JSON-RPC requests keyed by request id. */
 	private readonly _pendingRequests = new Map<number, DeferredPromise<unknown>>();
 	private _nextRequestId = 1;
+	private _isClosed = false;
+	private _closeError: RemoteAgentHostProtocolError | undefined;
 
 	get clientId(): string {
 		return this._clientId;
@@ -85,9 +113,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._address = address;
 		this._connectionAuthority = agentHostAuthority(address);
 		this._transport = transport;
+		this._register(toDisposable(() => this._handleClose(RemoteAgentHostProtocolError.disposed(this._address))));
 		this._register(this._transport);
 		this._register(this._transport.onMessage(msg => this._handleMessage(msg)));
-		this._register(this._transport.onClose(() => this._onDidClose.fire()));
+		this._register(this._transport.onClose(() => this._handleClose(RemoteAgentHostProtocolError.connectionClosed(this._address))));
 
 		this._subscriptionManager = this._register(new AgentSubscriptionManager(
 			this._clientId,
@@ -108,7 +137,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 */
 	async connect(): Promise<void> {
 		if (isClientTransport(this._transport)) {
-			await this._transport.connect();
+			await this._raceClose(this._transport.connect());
 		}
 
 		const result = await this._sendRequest('initialize', {
@@ -317,7 +346,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 				this._pendingRequests.delete(msg.id);
 				if (hasKey(msg, { error: true })) {
 					this._logService.warn(`[RemoteAgentHostProtocol] Request ${msg.id} failed:`, msg.error);
-					pending.error(new Error(msg.error.message));
+					pending.error(this._toProtocolError(msg.error));
 				} else {
 					pending.complete(msg.result);
 				}
@@ -345,6 +374,34 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			}
 		} else {
 			this._logService.warn(`[RemoteAgentHostProtocol] Unrecognized message:`, JSON.stringify(msg));
+		}
+	}
+
+	private _handleClose(error: RemoteAgentHostProtocolError): void {
+		if (this._isClosed) {
+			return;
+		}
+
+		this._isClosed = true;
+		this._closeError = error;
+		this._rejectPendingRequests(error);
+		this._onDidClose.fire();
+	}
+
+	private async _raceClose<T>(promise: Promise<T>): Promise<T> {
+		if (this._closeError) {
+			return Promise.reject(this._closeError);
+		}
+
+		let closeListener = Disposable.None;
+		const closePromise = new Promise<never>((_resolve, reject) => {
+			closeListener = this.onDidClose(() => reject(this._closeError));
+		});
+
+		try {
+			return await Promise.race([promise, closePromise]);
+		} finally {
+			closeListener.dispose();
 		}
 	}
 
@@ -419,6 +476,10 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	/** Send a typed JSON-RPC request for a protocol-defined method. */
 	private _sendRequest<M extends keyof ICommandMap>(method: M, params: ICommandMap[M]['params']): Promise<ICommandMap[M]['result']> {
+		if (this._closeError) {
+			return Promise.reject(this._closeError);
+		}
+
 		const id = this._nextRequestId++;
 		const deferred = new DeferredPromise<unknown>();
 		this._pendingRequests.set(id, deferred);
@@ -429,14 +490,28 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	}
 
 	/** Send a JSON-RPC request for a VS Code extension method (not in the protocol spec). */
-	private _sendExtensionRequest(method: string, params?: unknown): Promise<unknown> {
+	private _sendExtensionRequest<M extends keyof IRemoteAgentHostExtensionCommandMap>(method: M, params?: IRemoteAgentHostExtensionCommandMap[M]['params']): Promise<IRemoteAgentHostExtensionCommandMap[M]['result']> {
+		if (this._closeError) {
+			return Promise.reject(this._closeError);
+		}
+
 		const id = this._nextRequestId++;
 		const deferred = new DeferredPromise<unknown>();
 		this._pendingRequests.set(id, deferred);
-		// Cast: extension methods aren't in the typed protocol maps yet
-		// eslint-disable-next-line local/code-no-dangerous-type-assertions
-		this._transport.send({ jsonrpc: '2.0', id, method, params } as unknown as IJsonRpcResponse);
-		return deferred.p;
+		const request: IJsonRpcRequest = { jsonrpc: '2.0', id, method, params };
+		this._transport.send(request);
+		return deferred.p as Promise<IRemoteAgentHostExtensionCommandMap[M]['result']>;
+	}
+
+	private _toProtocolError(error: IJsonRpcErrorResponse['error']): RemoteAgentHostProtocolError {
+		return new RemoteAgentHostProtocolError(error);
+	}
+
+	private _rejectPendingRequests(error: RemoteAgentHostProtocolError): void {
+		for (const pending of this._pendingRequests.values()) {
+			pending.error(error);
+		}
+		this._pendingRequests.clear();
 	}
 
 	/**

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -9,7 +9,7 @@
 
 import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
-import { Disposable, IReference, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, IReference } from '../../../base/common/lifecycle.js';
 import { Schemas } from '../../../base/common/network.js';
 import { hasKey } from '../../../base/common/types.js';
 import { URI } from '../../../base/common/uri.js';
@@ -113,7 +113,6 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._address = address;
 		this._connectionAuthority = agentHostAuthority(address);
 		this._transport = transport;
-		this._register(toDisposable(() => this._handleClose(RemoteAgentHostProtocolError.disposed(this._address))));
 		this._register(this._transport);
 		this._register(this._transport.onMessage(msg => this._handleMessage(msg)));
 		this._register(this._transport.onClose(() => this._handleClose(RemoteAgentHostProtocolError.connectionClosed(this._address))));
@@ -130,6 +129,11 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		this._register(this.onDidAction(envelope => {
 			this._subscriptionManager.receiveEnvelope(envelope);
 		}));
+	}
+
+	override dispose(): void {
+		this._handleClose(RemoteAgentHostProtocolError.disposed(this._address));
+		super.dispose();
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { RemoteAgentHostProtocolClient, RemoteAgentHostProtocolError } from '../../browser/remoteAgentHostProtocolClient.js';
+import { AhpErrorCodes } from '../../common/state/protocol/errors.js';
+import type { IAhpServerNotification, IJsonRpcNotification, IJsonRpcRequest, IJsonRpcResponse, IProtocolMessage } from '../../common/state/sessionProtocol.js';
+import type { IClientTransport, IProtocolTransport } from '../../common/state/sessionTransport.js';
+
+type ProtocolTransportMessage = IProtocolMessage | IAhpServerNotification | IJsonRpcNotification | IJsonRpcResponse | IJsonRpcRequest;
+
+class TestProtocolTransport extends Disposable implements IProtocolTransport {
+	private readonly _onMessage = this._register(new Emitter<IProtocolMessage>());
+	readonly onMessage = this._onMessage.event;
+
+	private readonly _onClose = this._register(new Emitter<void>());
+	readonly onClose = this._onClose.event;
+
+	readonly sentMessages: ProtocolTransportMessage[] = [];
+
+	send(message: ProtocolTransportMessage): void {
+		this.sentMessages.push(message);
+	}
+
+	fireMessage(message: IProtocolMessage): void {
+		this._onMessage.fire(message);
+	}
+
+	fireClose(): void {
+		this._onClose.fire();
+	}
+}
+
+class TestClientProtocolTransport extends TestProtocolTransport implements IClientTransport {
+	readonly connectDeferred = new DeferredPromise<void>();
+
+	connect(): Promise<void> {
+		return this.connectDeferred.p;
+	}
+}
+
+class CloseOnDisposeProtocolTransport extends TestProtocolTransport {
+	override dispose(): void {
+		this.fireClose();
+		super.dispose();
+	}
+}
+
+suite('RemoteAgentHostProtocolClient', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createClient(transport = disposables.add(new TestProtocolTransport())): { client: RemoteAgentHostProtocolClient; transport: TestProtocolTransport } {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		const client = disposables.add(new RemoteAgentHostProtocolClient('test.example:1234', transport, new NullLogService(), fileService));
+		return { client, transport };
+	}
+
+	async function assertRemoteProtocolError(promise: Promise<unknown>, expected: { code: number; message: string; data?: unknown }): Promise<void> {
+		try {
+			await promise;
+			assert.fail('Expected promise to reject');
+		} catch (error) {
+			if (!(error instanceof RemoteAgentHostProtocolError)) {
+				assert.fail(`Expected RemoteAgentHostProtocolError, got ${String(error)}`);
+			}
+			assert.strictEqual(error.code, expected.code);
+			assert.strictEqual(error.message, expected.message);
+			assert.deepStrictEqual(error.data, expected.data);
+		}
+	}
+
+	test('completes matching response and removes it from pending requests', async () => {
+		const { client, transport } = createClient();
+		const resultPromise = client.resourceList(URI.file('/workspace'));
+
+		assert.deepStrictEqual(transport.sentMessages[0], {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'resourceList',
+			params: { uri: URI.file('/workspace').toString() },
+		});
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, result: { entries: [] } });
+		assert.deepStrictEqual(await resultPromise, { entries: [] });
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, result: { entries: [{ name: 'late', type: 'file' }] } });
+		assert.strictEqual(transport.sentMessages.length, 1);
+	});
+
+	test('preserves JSON-RPC error code and data', async () => {
+		const { client, transport } = createClient();
+		const resultPromise = client.resourceRead(URI.file('/missing'));
+		const data = { uri: URI.file('/missing').toString() };
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, error: { code: AhpErrorCodes.NotFound, message: 'Missing resource', data } });
+
+		await assertRemoteProtocolError(resultPromise, { code: AhpErrorCodes.NotFound, message: 'Missing resource', data });
+	});
+
+	test('ignores response for unknown request id', () => {
+		const { transport } = createClient();
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 99, result: null });
+
+		assert.strictEqual(transport.sentMessages.length, 0);
+	});
+
+	test('rejects all pending requests on transport close', async () => {
+		const { client, transport } = createClient();
+		const first = client.resourceList(URI.file('/one'));
+		const second = client.resourceRead(URI.file('/two'));
+		let closeCount = 0;
+		disposables.add(client.onDidClose(() => closeCount++));
+		const firstRejected = assertRemoteProtocolError(first, { code: -32000, message: 'Connection closed: test.example:1234' });
+		const secondRejected = assertRemoteProtocolError(second, { code: -32000, message: 'Connection closed: test.example:1234' });
+
+		transport.fireClose();
+		transport.fireClose();
+
+		await firstRejected;
+		await secondRejected;
+		assert.strictEqual(closeCount, 1);
+	});
+
+	test('rejects pending requests on dispose', async () => {
+		const { client } = createClient();
+		const resultPromise = client.resourceList(URI.file('/workspace'));
+		const rejected = assertRemoteProtocolError(resultPromise, { code: -32000, message: 'Connection disposed: test.example:1234' });
+
+		client.dispose();
+
+		await rejected;
+	});
+
+	test('dispose rejection wins when transport emits close while disposing', async () => {
+		const transport = disposables.add(new CloseOnDisposeProtocolTransport());
+		const { client } = createClient(transport);
+		const resultPromise = client.resourceList(URI.file('/workspace'));
+		const rejected = assertRemoteProtocolError(resultPromise, { code: -32000, message: 'Connection disposed: test.example:1234' });
+
+		client.dispose();
+
+		await rejected;
+	});
+
+	test('late response after close does not complete rejected request', async () => {
+		const { client, transport } = createClient();
+		const resultPromise = client.resourceList(URI.file('/workspace'));
+		const rejected = assertRemoteProtocolError(resultPromise, { code: -32000, message: 'Connection closed: test.example:1234' });
+
+		transport.fireClose();
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, result: { entries: [] } });
+
+		await rejected;
+	});
+
+	test('rejects requests started after transport close', async () => {
+		const { client, transport } = createClient();
+
+		transport.fireClose();
+
+		await assertRemoteProtocolError(client.resourceList(URI.file('/workspace')), { code: -32000, message: 'Connection closed: test.example:1234' });
+		assert.strictEqual(transport.sentMessages.length, 0);
+	});
+
+	test('rejects requests started after dispose', async () => {
+		const { client, transport } = createClient();
+
+		client.dispose();
+
+		await assertRemoteProtocolError(client.resourceList(URI.file('/workspace')), { code: -32000, message: 'Connection disposed: test.example:1234' });
+		assert.strictEqual(transport.sentMessages.length, 0);
+	});
+
+	test('rejects connect when transport closes before connect completes', async () => {
+		const transport = disposables.add(new TestClientProtocolTransport());
+		const { client } = createClient(transport);
+		const rejected = assertRemoteProtocolError(client.connect(), { code: -32000, message: 'Connection closed: test.example:1234' });
+
+		transport.fireClose();
+		transport.connectDeferred.complete();
+
+		await rejected;
+		assert.strictEqual(transport.sentMessages.length, 0);
+	});
+
+	test('rejects connect when disposed before transport connect completes', async () => {
+		const transport = disposables.add(new TestClientProtocolTransport());
+		const { client } = createClient(transport);
+		const rejected = assertRemoteProtocolError(client.connect(), { code: -32000, message: 'Connection disposed: test.example:1234' });
+
+		client.dispose();
+		transport.connectDeferred.complete();
+
+		await rejected;
+		assert.strictEqual(transport.sentMessages.length, 0);
+	});
+
+	test('sends shutdown as a JSON-RPC request shape', async () => {
+		const { client, transport } = createClient();
+		const resultPromise = client.shutdown();
+
+		assert.deepStrictEqual(transport.sentMessages[0], {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'shutdown',
+			params: undefined,
+		});
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, result: null });
+		await resultPromise;
+	});
+
+	test('rejects shutdown with structured JSON-RPC error', async () => {
+		const { client, transport } = createClient();
+		const resultPromise = client.shutdown();
+
+		transport.fireMessage({ jsonrpc: '2.0', id: 1, error: { code: AhpErrorCodes.TurnInProgress, message: 'Turn in progress' } });
+
+		await assertRemoteProtocolError(resultPromise, { code: AhpErrorCodes.TurnInProgress, message: 'Turn in progress' });
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostProtocolClient.test.ts
@@ -199,7 +199,6 @@ suite('RemoteAgentHostProtocolClient', () => {
 		const rejected = assertRemoteProtocolError(client.connect(), { code: -32000, message: 'Connection disposed: test.example:1234' });
 
 		client.dispose();
-		transport.connectDeferred.complete();
 
 		await rejected;
 		assert.strictEqual(transport.sentMessages.length, 0);


### PR DESCRIPTION
This draft PR tightens `RemoteAgentHostProtocolClient` request lifecycle handling so remote JSON-RPC callers do not hang across close/dispose races.

Summary:
- Reject pending JSON-RPC requests when the transport closes or the client is disposed.
- Reject request attempts that start after close/dispose.
- Preserve JSON-RPC error `code` and `data` with `RemoteAgentHostProtocolError`.
- Race explicit client transport `connect()` against close/dispose before `initialize` is sent.
- Send the VS Code-only `shutdown` extension method as a request-shaped message instead of a response-shaped cast.
- Add focused unit coverage for close/dispose, post-close calls, connect races, disposal ordering, structured errors, and shutdown.

Validation:
- VS Code build task output clean.
- Focused coverage: `remoteAgentHostProtocolClient.test.ts` passed 13/13; `remoteAgentHostProtocolClient.ts` coverage 61.8%.
- `remoteAgentHostService.test.ts` passed 19/19.
- Broader Agent Host coverage slice passed 151/151.
- Hygiene on changed TS files passed with only the usual TypeScript parser version warning.

(Written by Copilot)