### PR TITLE
aux window - fix setTimeout leak

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -154,6 +154,8 @@ export abstract class BaseWindow extends Disposable {
 					didClear = true;
 					(window as { vscodeOriginalClearTimeout?: typeof window.clearTimeout }).vscodeOriginalClearTimeout?.apply(this, [handle]);
 					timeoutDisposables.delete(timeoutDisposable);
+					// Remove from the window's DisposableStore without re-disposing (we're already inside dispose)
+					disposables.deleteAndLeak(timeoutDisposable);
 				});
 
 				disposables.add(timeoutDisposable);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/311823

Normally when the window is defocused, the browser will throttle any timeouts set on it. In VSCode there is a concept of aux windows, and timeouts set on the main window must not be throttled when the user is working in the aux window. There is some special code to do this in enableMultiWindowAwareTimeout by monkey-patching setTimeout in the main window + aux windows.

This code contained a memory leak where any call to setTimeout with >0 auxwindows would insert a dispose function into the main window's disposables table and never clean it up, even after calling it. I work on Cursor which is built on VSCode, and our app calls setTimeout something like 400 times per second and this was causing my app to have 230MB+ retained just by the main window disposables table.

<img width="2734" height="566" alt="image" src="https://github.com/user-attachments/assets/1e6a0c28-76cf-4b7a-b894-4188a37dd912" />


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
