### PR TITLE
Exclude agent host folders from prompt-file discovery

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -27,6 +27,7 @@ import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { equalsIgnoreCase } from '../../../../../../base/common/strings.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
+import { AGENT_HOST_SCHEME } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 
 /**
  * Maximum recursion depth when traversing subdirectories for instruction files.
@@ -70,7 +71,12 @@ export class PromptFilesLocator {
 	}
 
 	protected getWorkspaceFolders(): readonly IWorkspaceFolder[] {
-		return this.workspaceService.getWorkspace().folders;
+		// Agent host workspace folders surface customizations through AHP
+		// (session state + findAgentSkills), not via filesystem scanning.
+		// Including them here would issue a `resourceList` JSON-RPC per
+		// configured location for every nonexistent `.github` / `.claude`
+		// folder on the remote.
+		return this.workspaceService.getWorkspace().folders.filter(f => f.uri.scheme !== AGENT_HOST_SCHEME);
 	}
 
 	protected getWorkspaceFolder(resource: URI): IWorkspaceFolder | undefined {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -2782,6 +2782,32 @@ suite('PromptFilesLocator', () => {
 			);
 		});
 
+		testT('excludes vscode-agent-host workspace folders', async () => {
+			// Agent host folders surface customizations through AHP, not via
+			// filesystem scanning. Including them here would issue a `resourceList`
+			// JSON-RPC per configured location for every nonexistent `.github` /
+			// `.claude` folder on the remote.
+			const localFolder = URI.file('/repos/local-project');
+			const agentHostFolder = URI.from({ scheme: 'vscode-agent-host', authority: 'remote', path: '/repos/remote-project' });
+			const folders = [localFolder, agentHostFolder].map((uri, index) => new class extends mock<IWorkspaceFolder>() {
+				override uri = uri;
+				override name = basename(uri);
+				override index = index;
+			});
+			instantiationService.stub(IWorkspaceContextService, mockWorkspaceService(folders));
+			locator = instantiationService.createInstance(PromptFilesLocator);
+			await mockFiles(fileService, [
+				{ path: '/repos/local-project/.git/HEAD', contents: ['ref: refs/heads/main'] },
+			]);
+
+			const roots = await locator.getWorkspaceFolderRoots(true);
+			assert.deepStrictEqual(
+				roots.map(r => r.toString()),
+				[localFolder.toString()],
+				'Should exclude vscode-agent-host workspace folders from prompt-file discovery roots',
+			);
+		});
+
 		testT('returns only workspace folder when no .git is found', async () => {
 			setWorkspaceFoldersForRoots(['/Users/legomushroom/my-project']);
 			await mockFiles(fileService, [


### PR DESCRIPTION
Agent host workspace folders surface customizations through AHP (session state + `findAgentSkills`), not via filesystem scanning. Including them in `PromptFilesLocator` caused a `resourceList` JSON-RPC per configured location for every nonexistent `.github` / `.claude` folder on the remote, producing noisy `[RemoteAgentHostProtocol] Request N failed` / `Failed to resolve files at location` logs every discovery cycle:

```
[RemoteAgentHostProtocol] Request 174 failed: {"code":-32008,"message":"Directory not found: file:///…/.github"}
Failed to resolve files at location: vscode-agent-host://…/.github/agents Directory not found: …
```

These repeated for `.github`, `.github/instructions`, `.github/hooks`, `.github/agents`, `.agents`, `.claude`, `.claude/agents`, `.claude/rules`, etc. on every refresh of the customization view, every workspace-folder change, and every `onDidChangeCustomAgents` / `onDidChangeSlashCommands` fire.

## Fix

Filter `vscode-agent-host://` folders out of `getWorkspaceFolders()` — the single chokepoint feeding all prompt-file discovery paths:

- `listFiles` → `toAbsoluteLocations` → `getWorkspaceFolderRoots`
- `findAgentMDsInFolder`
- the workspace-root short-circuit in `resolveFilesAtLocation`

One filter at the chokepoint covers all of them.

## Tests

Added a regression test in the `getWorkspaceFolderRoots` suite that asserts `vscode-agent-host://` folders are excluded from discovery roots. All 60 `PromptFilesLocator` tests pass.

(Written by Copilot)
