### PR TITLE
Use proper streams for loading webview resources

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-WhL9mQLo3KATK6RDvduN9smt1WPdn17ub5WXh9udZ5s=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-25y69Rmwe2/7r58SQN/qPNWvAcjm+OR1DVlm3D2jsXc=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -485,8 +485,12 @@
 		};
 
 		if (!disableServiceWorker) {
+			hostMessaging.onMessage('did-load-resource', (_event, data) => {
+				const transfer = data.stream ? [data.stream] : [];
+				assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel: 'did-load-resource', data }, transfer);
+			});
+
 			for (const channel of [
-				'did-load-resource',
 				'did-load-resource-end',
 				'did-load-localhost',
 			]) {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-TaWGDzV7c9rUH2q/5ygOyYUHSyHIqBMYfucPh3lnKvU=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-WhL9mQLo3KATK6RDvduN9smt1WPdn17ub5WXh9udZ5s=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -485,12 +485,18 @@
 		};
 
 		if (!disableServiceWorker) {
-			hostMessaging.onMessage('did-load-resource', (_event, data) => {
-				assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel: 'did-load-resource', data }, data.data?.buffer ? [data.data.buffer] : []);
-			});
+			for (const channel of [
+				'did-load-resource',
+				'did-load-resource-end',
+				'did-load-localhost',
+			]) {
+				hostMessaging.onMessage(channel, (_event, data) => {
+					assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel, data });
+				});
+			}
 
-			hostMessaging.onMessage('did-load-localhost', (_event, data) => {
-				assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel: 'did-load-localhost', data });
+			hostMessaging.onMessage('did-load-resource-chunk', (_event, data) => {
+				assertIsDefined(navigator.serviceWorker.controller).postMessage({ channel: 'did-load-resource-chunk', data }, data.data?.buffer ? [data.data.buffer] : []);
 			});
 
 			navigator.serviceWorker.addEventListener('message', event => {

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -116,11 +116,11 @@ class RequestStore {
 const resourceRequestStore = new RequestStore();
 
 /**
- * Map of active streaming resource responses.
+ * Safari fallback: map of active chunk-based streaming responses.
  * Maps request id to a WritableStreamDefaultWriter for piping chunks.
  * @type {Map<number, WritableStreamDefaultWriter<Uint8Array>>}
  */
-const activeResourceStreams = new Map();
+const safariResourceStreams = new Map();
 
 /**
  * Map of requested localhost origins to optional redirects.
@@ -166,18 +166,22 @@ sw.addEventListener('message', async (event) => {
 			/** @type {ResourceResponse} */
 			const response = event.data.data;
 			if (response.status === 200 || response.status === 206) {
-				// Streaming response — set up a TransformStream for incoming chunks
-				const { readable, writable } = new TransformStream();
-				const writer = writable.getWriter();
-				activeResourceStreams.set(response.id, writer);
-
-				// Clean up when the stream closes for any reason,
-				// including the browser cancelling the fetch when the client is disposed.
-				writer.closed.then(
-					() => activeResourceStreams.delete(response.id),
-					() => activeResourceStreams.delete(response.id)
-				);
-
+				/** @type {ReadableStream<Uint8Array>} */
+				let stream;
+				if (response.stream) {
+					// Transferable stream (Chromium/Firefox)
+					stream = response.stream;
+				} else {
+					// Safari fallback: set up a TransformStream for incoming chunks
+					const transform = new TransformStream();
+					const writer = transform.writable.getWriter();
+					safariResourceStreams.set(response.id, writer);
+					writer.closed.then(
+						() => safariResourceStreams.delete(response.id),
+						() => safariResourceStreams.delete(response.id)
+					);
+					stream = transform.readable;
+				}
 				resourceRequestStore.resolve(response.id, {
 					status: response.status,
 					id: response.id,
@@ -185,7 +189,7 @@ sw.addEventListener('message', async (event) => {
 					mime: response.mime,
 					etag: response.etag,
 					mtime: response.mtime,
-					stream: readable,
+					stream,
 					range: response.range,
 				});
 			} else if (!resourceRequestStore.resolve(response.id, response)) {
@@ -193,26 +197,27 @@ sw.addEventListener('message', async (event) => {
 			}
 			return;
 		}
+		// Safari fallback: chunk-based streaming for browsers without transferable streams
 		case 'did-load-resource-chunk': {
 			const data = event.data.data;
-			const writer = activeResourceStreams.get(data.id);
+			const writer = safariResourceStreams.get(data.id);
 			if (writer) {
 				writer.write(data.data).catch(() => {
-					activeResourceStreams.delete(data.id);
+					safariResourceStreams.delete(data.id);
 				});
 			}
 			return;
 		}
 		case 'did-load-resource-end': {
 			const data = event.data.data;
-			const writer = activeResourceStreams.get(data.id);
+			const writer = safariResourceStreams.get(data.id);
 			if (writer) {
 				if (data.error) {
 					writer.abort(new Error('Stream error')).catch(() => { /* already cleaning up */ });
 				} else {
 					writer.close().catch(() => { /* already cleaning up */ });
 				}
-				activeResourceStreams.delete(data.id);
+				safariResourceStreams.delete(data.id);
 			}
 			return;
 		}

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -8,7 +8,7 @@
 /** @type {ServiceWorkerGlobalScope} */
 const sw = /** @type {any} */ (self);
 
-const VERSION = 4;
+const VERSION = 5;
 
 const resourceCacheName = `vscode-resource-cache-${VERSION}`;
 
@@ -116,6 +116,13 @@ class RequestStore {
 const resourceRequestStore = new RequestStore();
 
 /**
+ * Map of active streaming resource responses.
+ * Maps request id to a WritableStreamDefaultWriter for piping chunks.
+ * @type {Map<number, WritableStreamDefaultWriter<Uint8Array>>}
+ */
+const activeResourceStreams = new Map();
+
+/**
  * Map of requested localhost origins to optional redirects.
  */
 /** @type {RequestStore<string|undefined>} */
@@ -158,8 +165,54 @@ sw.addEventListener('message', async (event) => {
 		case 'did-load-resource': {
 			/** @type {ResourceResponse} */
 			const response = event.data.data;
-			if (!resourceRequestStore.resolve(response.id, response)) {
+			if (response.status === 200 || response.status === 206) {
+				// Streaming response — set up a TransformStream for incoming chunks
+				const { readable, writable } = new TransformStream();
+				const writer = writable.getWriter();
+				activeResourceStreams.set(response.id, writer);
+
+				// Clean up when the stream closes for any reason,
+				// including the browser cancelling the fetch when the client is disposed.
+				writer.closed.then(
+					() => activeResourceStreams.delete(response.id),
+					() => activeResourceStreams.delete(response.id)
+				);
+
+				resourceRequestStore.resolve(response.id, {
+					status: response.status,
+					id: response.id,
+					path: response.path,
+					mime: response.mime,
+					etag: response.etag,
+					mtime: response.mtime,
+					stream: readable,
+					range: response.range,
+				});
+			} else if (!resourceRequestStore.resolve(response.id, response)) {
 				console.log('Could not resolve unknown resource', response.path);
+			}
+			return;
+		}
+		case 'did-load-resource-chunk': {
+			const data = event.data.data;
+			const writer = activeResourceStreams.get(data.id);
+			if (writer) {
+				writer.write(data.data).catch(() => {
+					activeResourceStreams.delete(data.id);
+				});
+			}
+			return;
+		}
+		case 'did-load-resource-end': {
+			const data = event.data.data;
+			const writer = activeResourceStreams.get(data.id);
+			if (writer) {
+				if (data.error) {
+					writer.abort(new Error('Stream error')).catch(() => { /* already cleaning up */ });
+				} else {
+					writer.close().catch(() => { /* already cleaning up */ });
+				}
+				activeResourceStreams.delete(data.id);
 			}
 			return;
 		}
@@ -309,46 +362,14 @@ async function processResourceRequest(
 			return unauthorized();
 		}
 
-		if (entry.status !== 200) {
+		if (entry.status !== 200 && entry.status !== 206) {
 			return notFound();
-		}
-
-		const byteLength = entry.data.byteLength;
-
-		const range = event.request.headers.get('range');
-		if (range) {
-			// To support seeking for videos, we need to handle range requests
-			const bytes = range.match(/^bytes\=(\d+)\-(\d+)?$/g);
-			if (bytes) {
-				// TODO: Right now we are always reading the full file content. This is a bad idea
-				// for large video files :)
-
-				const start = Number(bytes[1]);
-				const end = Number(bytes[2]) || byteLength - 1;
-				return new Response(entry.data.slice(start, end + 1), {
-					status: 206,
-					headers: {
-						...accessControlHeaders,
-						'Content-range': `bytes 0-${end}/${byteLength}`,
-					}
-				});
-			} else {
-				// We don't understand the requested bytes
-				return new Response(null, {
-					status: 416,
-					headers: {
-						...accessControlHeaders,
-						'Content-range': `*/${byteLength}`
-					}
-				});
-			}
 		}
 
 		/** @type {Record<string, string>} */
 		const headers = {
 			...accessControlHeaders,
 			'Content-Type': entry.mime,
-			'Content-Length': byteLength.toString(),
 		};
 
 		if (entry.etag) {
@@ -370,17 +391,24 @@ async function processResourceRequest(
 			headers['Cross-Origin-Opener-Policy'] = 'same-origin';
 		}
 
-		const response = new Response(entry.data, {
-			status: 200,
-			headers
-		});
+		if (entry.stream) {
+			// Range responses: the host already read only the requested range,
+			// so we just pipe the stream through with a 206 status.
+			if (entry.status === 206 && entry.range) {
+				headers['Content-Range'] = entry.range;
+				return new Response(entry.stream, { status: 206, headers });
+			}
 
-		if (shouldTryCaching && entry.etag) {
-			caches.open(resourceCacheName).then(cache => {
-				return cache.put(event.request, response);
-			});
+			const response = new Response(entry.stream, { status: 200, headers });
+
+			if (shouldTryCaching && entry.etag) {
+				const responseForCache = response.clone();
+				caches.open(resourceCacheName).then(cache => {
+					return cache.put(event.request, responseForCache);
+				});
+			}
+			return response;
 		}
-		return response.clone();
 	};
 
 	/** @type {Response|undefined} */
@@ -391,6 +419,28 @@ async function processResourceRequest(
 	}
 
 	const { requestId, promise } = resourceRequestStore.create();
+
+	// Parse range header to forward to the host so it can read only the needed bytes
+	/** @type {{ start: number, end?: number } | undefined} */
+	let range;
+	const rangeHeader = event.request.headers.get('range');
+	if (rangeHeader) {
+		const bytes = rangeHeader.match(/^bytes\=(\d+)\-(\d+)?$/);
+		if (bytes) {
+			range = {
+				start: Number(bytes[1]),
+				end: bytes[2] !== undefined ? Number(bytes[2]) : undefined,
+			};
+		} else {
+			return new Response(null, {
+				status: 416,
+				headers: {
+					'Access-Control-Allow-Origin': '*',
+					'Content-Range': '*/*',
+				}
+			});
+		}
+	}
 
 	if (webviewId) {
 		const parentClients = await getOuterIframeClient(webviewId);
@@ -408,6 +458,7 @@ async function processResourceRequest(
 				path: requestUrlComponents.path,
 				query: requestUrlComponents.query,
 				ifNoneMatch: cached?.headers.get('ETag'),
+				range,
 			});
 		}
 	} else if (client.type === 'worker' || client.type === 'sharedworker') {
@@ -419,6 +470,7 @@ async function processResourceRequest(
 			path: requestUrlComponents.path,
 			query: requestUrlComponents.query,
 			ifNoneMatch: cached?.headers.get('ETag'),
+			range,
 		});
 	}
 
@@ -536,8 +588,9 @@ async function getWorkerClientForId(clientId) {
 
 /**
  * @typedef {(
- *   | { readonly status: 200, id: number, path: string, mime: string, data: Uint8Array, etag: string|undefined, mtime: number|undefined }
- *   | { readonly status: 304, id: number, path: string, mime: string, mtime: number|undefined }
+ *   | { readonly status: 200, id: number, path: string, mime: string, stream: ReadableStream<Uint8Array>, etag: string|undefined, mtime: number | undefined }
+ *   | { readonly status: 206, id: number, path: string, mime: string, stream: ReadableStream<Uint8Array>, range: string, etag: string|undefined, mtime: number | undefined }
+ *   | { readonly status: 304, id: number, path: string, mime: string, mtime: number | undefined }
  *   | { readonly status: 401, id: number, path: string }
  *   | { readonly status: 404, id: number, path: string }
  * )} ResourceResponse

--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -24,6 +24,7 @@ export namespace WebviewResourceResponse {
 			public readonly etag: string | undefined,
 			public readonly mtime: number | undefined,
 			public readonly mimeType: string,
+			public readonly size: number,
 		) { }
 	}
 
@@ -47,6 +48,7 @@ export async function loadLocalResource(
 	options: {
 		ifNoneMatch: string | undefined;
 		roots: ReadonlyArray<URI>;
+		range?: { readonly start: number; readonly end?: number };
 	},
 	uriIdentityService: IUriIdentityService,
 	fileService: IFileService,
@@ -65,9 +67,16 @@ export async function loadLocalResource(
 	const mime = getWebviewContentMimeType(requestUri); // Use the original path for the mime
 
 	try {
-		const result = await fileService.readFileStream(resourceToLoad, { etag: options.ifNoneMatch }, token);
+		const readOptions: { etag?: string; position?: number; length?: number } = { etag: options.ifNoneMatch };
+		if (options.range) {
+			readOptions.position = options.range.start;
+			if (options.range.end !== undefined) {
+				readOptions.length = options.range.end - options.range.start + 1;
+			}
+		}
+		const result = await fileService.readFileStream(resourceToLoad, readOptions, token);
 		logService.trace(`Webview.loadLocalResource - Loaded. requestUri=${requestUri}, resourceToLoad=${resourceToLoad}`);
-		return new WebviewResourceResponse.StreamSuccess(result.value, result.etag, result.mtime, mime);
+		return new WebviewResourceResponse.StreamSuccess(result.value, result.etag, result.mtime, mime, result.size);
 	} catch (err) {
 		if (err instanceof FileOperationError) {
 			const result = err.fileOperationResult;

--- a/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
+++ b/src/vs/workbench/contrib/webview/browser/resourceLoading.ts
@@ -71,6 +71,9 @@ export async function loadLocalResource(
 		if (options.range) {
 			readOptions.position = options.range.start;
 			if (options.range.end !== undefined) {
+				if (options.range.end < options.range.start) {
+					return WebviewResourceResponse.Failed;
+				}
 				readOptions.length = options.range.end - options.range.start + 1;
 			}
 		}

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -791,7 +791,8 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 						? `bytes ${range.start}-${rangeEnd}/${result.size}`
 						: undefined;
 					if (WebviewElement._supportsTransferableStreams.value) {
-						const stream = new ReadableStream<Uint8Array>({
+						const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+							type: 'bytes',
 							start: (controller) => {
 								let closed = false;
 								const close = () => {
@@ -806,7 +807,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 									onData: (chunk) => {
 										if (!closed) {
 											try {
-												controller.enqueue(new Uint8Array(chunk.buffer.buffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
+												controller.enqueue(new Uint8Array<ArrayBuffer>(chunk.buffer.buffer as ArrayBuffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
 											} catch {
 												closed = true;
 											}

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -9,12 +9,12 @@ import { parentOriginHash } from '../../../../base/browser/iframe.js';
 import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
 import { promiseWithResolvers, ThrottledDelayer } from '../../../../base/common/async.js';
-import { streamToBuffer, VSBufferReadableStream } from '../../../../base/common/buffer.js';
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { COI } from '../../../../base/common/network.js';
 import { observableValue } from '../../../../base/common/observable.js';
+import { listenStream } from '../../../../base/common/stream.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
@@ -97,7 +97,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 
 	protected get platform(): string { return 'browser'; }
 
-	private readonly _expectedServiceWorkerVersion = 4; // Keep this in sync with the version in service-worker.js
+	private readonly _expectedServiceWorkerVersion = 5; // Keep this in sync with the version in service-worker.js
 
 	private _element: HTMLIFrameElement | undefined;
 	protected get element(): HTMLIFrameElement | undefined { return this._element; }
@@ -281,7 +281,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 					path: decodeURIComponent(entry.path), // This gets re-encoded
 					query: entry.query ? decodeURIComponent(entry.query) : entry.query,
 				});
-				this.loadResource(entry.id, uri, entry.ifNoneMatch);
+				this.loadResource(entry.id, uri, { ifNoneMatch: entry.ifNoneMatch, range: entry.range }, this._resourceLoadingCts.token);
 			} catch (e) {
 				this._send('did-load-resource', {
 					id: entry.id,
@@ -760,25 +760,42 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		}
 	}
 
-	private async loadResource(id: number, uri: URI, ifNoneMatch: string | undefined) {
+	private async loadResource(id: number, uri: URI, options: { ifNoneMatch: string | undefined; range?: { readonly start: number; readonly end?: number } }, token: CancellationToken) {
 		try {
 			const result = await loadLocalResource(uri, {
-				ifNoneMatch,
+				ifNoneMatch: options.ifNoneMatch,
 				roots: this._content.options.localResourceRoots || [],
-			}, this._uriIdentityService, this._fileService, this._logService, this._resourceLoadingCts.token);
+				range: options.range,
+			}, this._uriIdentityService, this._fileService, this._logService, token);
 
 			switch (result.type) {
 				case WebviewResourceResponse.Type.Success: {
-					const buffer = await this.streamToBuffer(result.stream);
-					return this._send('did-load-resource', {
+					const range = options.range;
+					const rangeEnd = range?.end !== undefined ? range.end : result.size - 1;
+					const rangeHeader = range
+						? `bytes ${range.start}-${rangeEnd}/${result.size}`
+						: undefined;
+					this._send('did-load-resource', {
 						id,
-						status: 200,
+						status: range ? 206 : 200,
 						path: uri.path,
 						mime: result.mimeType,
-						data: buffer,
 						etag: result.etag,
-						mtime: result.mtime
-					}, [buffer]);
+						mtime: result.mtime,
+						range: rangeHeader,
+					});
+					listenStream(result.stream, {
+						onData: (chunk) => {
+							this._send('did-load-resource-chunk', { id, data: chunk.buffer });
+						},
+						onError: () => {
+							this._send('did-load-resource-end', { id, error: true });
+						},
+						onEnd: () => {
+							this._send('did-load-resource-end', { id });
+						}
+					}, token);
+					return;
 				}
 				case WebviewResourceResponse.Type.NotModified: {
 					return this._send('did-load-resource', {
@@ -806,11 +823,6 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 			status: 404,
 			path: uri.path,
 		});
-	}
-
-	protected async streamToBuffer(stream: VSBufferReadableStream): Promise<ArrayBufferLike> {
-		const vsBuffer = await streamToBuffer(stream);
-		return vsBuffer.buffer.buffer;
 	}
 
 	private async localLocalhost(id: string, origin: string) {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -11,6 +11,7 @@ import { CodeWindow } from '../../../../base/browser/window.js';
 import { promiseWithResolvers, ThrottledDelayer } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { Lazy } from '../../../../base/common/lazy.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { COI } from '../../../../base/common/network.js';
 import { observableValue } from '../../../../base/common/observable.js';
@@ -96,6 +97,19 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 	private _encodedWebviewOrigin: string | undefined;
 
 	protected get platform(): string { return 'browser'; }
+
+	private static readonly _supportsTransferableStreams = new Lazy<boolean>(() => {
+		try {
+			const stream = new ReadableStream();
+			const mc = new MessageChannel();
+			mc.port1.postMessage(stream, [stream]);
+			mc.port1.close();
+			mc.port2.close();
+			return true;
+		} catch {
+			return false;
+		}
+	});
 
 	private readonly _expectedServiceWorkerVersion = 5; // Keep this in sync with the version in service-worker.js
 
@@ -775,26 +789,62 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 					const rangeHeader = range
 						? `bytes ${range.start}-${rangeEnd}/${result.size}`
 						: undefined;
-					this._send('did-load-resource', {
-						id,
-						status: range ? 206 : 200,
-						path: uri.path,
-						mime: result.mimeType,
-						etag: result.etag,
-						mtime: result.mtime,
-						range: rangeHeader,
-					});
-					listenStream(result.stream, {
-						onData: (chunk) => {
-							this._send('did-load-resource-chunk', { id, data: chunk.buffer });
-						},
-						onError: () => {
-							this._send('did-load-resource-end', { id, error: true });
-						},
-						onEnd: () => {
-							this._send('did-load-resource-end', { id });
-						}
-					}, token);
+					if (WebviewElement._supportsTransferableStreams.value) {
+						const stream = new ReadableStream<Uint8Array>({
+							start: (controller) => {
+								let errored = false;
+								listenStream(result.stream, {
+									onData: (chunk) => {
+										if (!errored) {
+											controller.enqueue(chunk.buffer);
+										}
+									},
+									onError: (err) => {
+										errored = true;
+										controller.error(err);
+									},
+									onEnd: () => {
+										if (!errored) {
+											controller.close();
+										}
+									}
+								}, token);
+							}
+						});
+						this._send('did-load-resource', {
+							id,
+							status: range ? 206 : 200,
+							path: uri.path,
+							mime: result.mimeType,
+							etag: result.etag,
+							mtime: result.mtime,
+							range: rangeHeader,
+							stream,
+						}, [stream]);
+					} else {
+						// Safari: transferable streams not supported, fall back to chunk messages
+						this._send('did-load-resource', {
+							id,
+							status: range ? 206 : 200,
+							path: uri.path,
+							mime: result.mimeType,
+							etag: result.etag,
+							mtime: result.mtime,
+							range: rangeHeader,
+						});
+						listenStream(result.stream, {
+							onData: (chunk) => {
+								const data = new Uint8Array(chunk.buffer.buffer, chunk.buffer.byteOffset, chunk.buffer.byteLength);
+								this._send('did-load-resource-chunk', { id, data }, [data.buffer]);
+							},
+							onError: () => {
+								this._send('did-load-resource-end', { id, error: true });
+							},
+							onEnd: () => {
+								this._send('did-load-resource-end', { id });
+							}
+						}, token);
+					}
 					return;
 				}
 				case WebviewResourceResponse.Type.NotModified: {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -792,7 +792,6 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 						: undefined;
 					if (WebviewElement._supportsTransferableStreams.value) {
 						const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
-							type: 'bytes',
 							start: (controller) => {
 								let closed = false;
 								const close = () => {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -785,7 +785,8 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 			switch (result.type) {
 				case WebviewResourceResponse.Type.Success: {
 					const range = options.range;
-					const rangeEnd = range?.end !== undefined ? range.end : result.size - 1;
+					const requestedRangeEnd = range?.end !== undefined ? range.end : result.size - 1;
+					const rangeEnd = Math.min(requestedRangeEnd, result.size - 1);
 					const rangeHeader = range
 						? `bytes ${range.start}-${rangeEnd}/${result.size}`
 						: undefined;

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -798,9 +798,10 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 									if (!closed) {
 										closed = true;
 										try { controller.close(); } catch { /* already closed */ }
+										cancellationSub.dispose();
 									}
 								};
-								token.onCancellationRequested(close);
+								const cancellationSub = token.onCancellationRequested(close);
 
 								listenStream(result.stream, {
 									onData: (chunk) => {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -810,6 +810,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 												controller.enqueue(new Uint8Array<ArrayBuffer>(chunk.buffer.buffer as ArrayBuffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
 											} catch {
 												closed = true;
+												cancellationSub.dispose();
 											}
 										}
 									},
@@ -817,6 +818,7 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 										if (!closed) {
 											closed = true;
 											try { controller.error(err); } catch { /* already closed */ }
+											cancellationSub.dispose();
 										}
 									},
 									onEnd: () => close()

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -793,22 +793,32 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 					if (WebviewElement._supportsTransferableStreams.value) {
 						const stream = new ReadableStream<Uint8Array>({
 							start: (controller) => {
-								let errored = false;
+								let closed = false;
+								const close = () => {
+									if (!closed) {
+										closed = true;
+										try { controller.close(); } catch { /* already closed */ }
+									}
+								};
+								token.onCancellationRequested(close);
+
 								listenStream(result.stream, {
 									onData: (chunk) => {
-										if (!errored) {
-											controller.enqueue(chunk.buffer);
+										if (!closed) {
+											try {
+												controller.enqueue(new Uint8Array(chunk.buffer.buffer, chunk.buffer.byteOffset, chunk.buffer.byteLength));
+											} catch {
+												closed = true;
+											}
 										}
 									},
 									onError: (err) => {
-										errored = true;
-										controller.error(err);
-									},
-									onEnd: () => {
-										if (!errored) {
-											controller.close();
+										if (!closed) {
+											closed = true;
+											try { controller.error(err); } catch { /* already closed */ }
 										}
-									}
+									},
+									onEnd: () => close()
 								}, token);
 							}
 						});

--- a/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
@@ -31,7 +31,7 @@ export type FromWebviewMessage = {
 	'did-find': { didFind: boolean };
 	'do-update-state': string;
 	'do-reload': void;
-	'load-resource': { id: number; path: string; query: string; scheme: string; authority: string; ifNoneMatch?: string };
+	'load-resource': { id: number; path: string; query: string; scheme: string; authority: string; ifNoneMatch?: string; range?: { readonly start: number; readonly end?: number } };
 	'load-localhost': { id: string; origin: string };
 	'did-scroll-wheel': IMouseWheelEvent;
 	'fatal-error': { message: string };
@@ -64,8 +64,10 @@ export type ToWebviewMessage = {
 	'did-load-resource':
 	| { id: number; status: 401 | 404; path: string }
 	| { id: number; status: 304; path: string; mime: string; mtime: number | undefined }
-	| { id: number; status: 200; path: string; mime: string; data: any; etag: string | undefined; mtime: number | undefined }
+	| { id: number; status: 200 | 206; path: string; mime: string; etag: string | undefined; mtime: number | undefined; range?: string }
 	;
+	'did-load-resource-chunk': { id: number; data: Uint8Array };
+	'did-load-resource-end': { id: number; error?: boolean };
 	'did-load-localhost': {
 		id: string;
 		origin: string;

--- a/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
@@ -64,8 +64,9 @@ export type ToWebviewMessage = {
 	'did-load-resource':
 	| { id: number; status: 401 | 404; path: string }
 	| { id: number; status: 304; path: string; mime: string; mtime: number | undefined }
-	| { id: number; status: 200 | 206; path: string; mime: string; etag: string | undefined; mtime: number | undefined; range?: string }
+	| { id: number; status: 200 | 206; path: string; mime: string; etag: string | undefined; mtime: number | undefined; range?: string; stream?: ReadableStream<Uint8Array> }
 	;
+	// Safari fallback: transferable streams not supported
 	'did-load-resource-chunk': { id: number; data: Uint8Array };
 	'did-load-resource-end': { id: number; error?: boolean };
 	'did-load-localhost': {

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Delayer } from '../../../../base/common/async.js';
-import { VSBuffer, VSBufferReadableStream } from '../../../../base/common/buffer.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { consumeStream } from '../../../../base/common/stream.js';
 import { ProxyChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -90,22 +88,6 @@ export class ElectronWebviewElement extends WebviewElement {
 
 	protected override webviewContentEndpoint(iframeId: string): string {
 		return `${Schemas.vscodeWebview}://${iframeId}`;
-	}
-
-	protected override streamToBuffer(stream: VSBufferReadableStream): Promise<ArrayBufferLike> {
-		// Join buffers from stream without using the Node.js backing pool.
-		// This lets us transfer the resulting buffer to the webview.
-		return consumeStream<VSBuffer, ArrayBufferLike>(stream, (buffers: readonly VSBuffer[]) => {
-			const totalLength = buffers.reduce((prev, curr) => prev + curr.byteLength, 0);
-			const ret = new ArrayBuffer(totalLength);
-			const view = new Uint8Array(ret);
-			let offset = 0;
-			for (const element of buffers) {
-				view.set(element.buffer, offset);
-				offset += element.byteLength;
-			}
-			return ret;
-		});
 	}
 
 	/**


### PR DESCRIPTION
Fixes #311836

Switches to stream content to webviews. Previously we always read the entire content into a buffer before sending it over. Now we use streams to transfer it as directly as possible. On Chrome and Firefox, transferable streams let us send the byte data directly from the renderer to the service worker

This speeds up loading of resources inside webview and reduces memory usage. It's most helpful for videos and other larger files

Markdown preview with many video files (cache disabled but service worker ready)

### Before
<img width="952" height="441" alt="Screenshot 2026-04-21 at 11 29 43 PM" src="https://github.com/user-attachments/assets/214594c5-82e7-47f3-ac36-ecc17c4b3ec1" />


### After
<img width="898" height="395" alt="Screenshot 2026-04-21 at 11 27 57 PM" src="https://github.com/user-attachments/assets/09a26929-394c-4261-bc5a-5e68489745ee" />