### PR TITLE
fix: DisableGloballyAction should not be enabled when extension is workspace-enabled only

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1780,7 +1780,7 @@ export class DisableGloballyAction extends ExtensionAction {
 				return;
 			}
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
## Description

When an extension is enabled for workspace (not globally), DisableGloballyAction was incorrectly showing as enabled in the dropdown. This caused the dropdown to display both 'Disable' and 'Disable (Workspace)' options when only the latter should appear.

The DisableGloballyAction.update() method was checking for both EnabledGlobally and EnabledWorkspace states, but it should only be enabled when the extension is actually EnabledGlobally, since you cannot disable something globally when it is not globally enabled.

## Fixes #244138

## Testing

The existing test 'Test DisableGloballyAction when the extension is disabled for workspace' already validates that DisableGloballyAction is disabled when the extension is workspace-disabled, which is consistent with this fix.

Good day

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee