### PR TITLE
Fix enableThinking mismatch causing inline summarization cache misses

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -693,8 +693,13 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					const strippedMessages = ToolCallingLoop.stripInternalToolCallIds(result.messages);
 					const rawEffort = this.request.modelConfiguration?.reasoningEffort;
 					const isSubagent = !!this.request.subAgentInvocationId;
+					// Must match the main agent's enableThinking logic in
+					// toolCallingLoop.ts runOne() — thinking is only disabled
+					// on continuation turns for Anthropic when no thinking
+					// blocks exist yet in the messages.
+					const shouldDisableThinking = !!promptContext.isContinuation && isAnthropicFamily(this.endpoint) && !ToolCallingLoop.messagesContainThinking(strippedMessages);
 					this._lastModelCapabilities = {
-						enableThinking: !isAnthropicFamily(this.endpoint) || ToolCallingLoop.messagesContainThinking(strippedMessages),
+						enableThinking: !shouldDisableThinking,
 						reasoningEffort: typeof rawEffort === 'string' ? rawEffort : undefined,
 						enableToolSearch: !isSubagent && !!this.endpoint.supportsToolSearch,
 						enableContextEditing: !isSubagent && isAnthropicContextEditingEnabled(this.endpoint, this.configurationService, this.expService),


### PR DESCRIPTION
The inline summarization path computed `enableThinking` differently from the main agent loop (`toolCallingLoop.ts`). For Anthropic on non-continuation turns, the old logic (`!isAnthropicFamily || messagesContainThinking`) would set `enableThinking=false` when no thinking blocks existed yet, while the main agent always kept it `true`. Per Anthropic docs, changing thinking parameters invalidates the message cache — causing 0% cache hits on summarization requests.

Fix: mirror the main loop's `shouldDisableThinking = isContinuation && isAnthropicFamily && !messagesContainThinking` logic exactly.

cc: @kevin-m-kent who tracked down this issue! 🙏