### PR TITLE
Don't prompt on terminal close for reattached processes with exited children

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1524,6 +1524,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					this.setShellType(value as IProcessPropertyMap[ProcessPropertyType.ShellType]);
 					break;
 				case ProcessPropertyType.HasChildProcesses:
+					// The live process manager is now authoritative for child process state.
+					// Clear the persisted snapshot captured before reload so `hasChildProcesses`
+					// doesn't stay `true` forever when the reattached child has since exited.
+					if (this._shellLaunchConfig.attachPersistentProcess) {
+						this._shellLaunchConfig.attachPersistentProcess.hasChildProcesses = value as IProcessPropertyMap[ProcessPropertyType.HasChildProcesses];
+					}
 					this._onDidChangeHasChildProcesses.fire(value as IProcessPropertyMap[ProcessPropertyType.HasChildProcesses]);
 					break;
 				case ProcessPropertyType.UsedShellIntegrationInjection:


### PR DESCRIPTION
Fixes #197387

## Problem

With `terminal.integrated.confirmOnExit` set to `hasChildProcesses`, after a window reload the "Do you want to terminate the active terminal session?" dialog appears even when the reattached child process has already exited.

Repro:
1. Set `terminal.integrated.confirmOnExit` to `hasChildProcesses`
2. Start a running process in the integrated terminal
3. Reload window via `workbench.action.reloadWindow`
4. In the restored terminal, exit the process started in step 2
5. `workbench.action.closeWindow` -- dialog appears (bug)

## Root cause

`ITerminalInstance.hasChildProcesses` in `terminalInstance.ts` was:

```ts
get hasChildProcesses(): boolean {
    return this.shellLaunchConfig.attachPersistentProcess?.hasChildProcesses
        || this._processManager.hasChildProcesses;
}
```

`attachPersistentProcess.hasChildProcesses` is a snapshot captured in the pty service at persistence time (see `ptyService.ts` `serializeTerminalState`). If the child was running when the snapshot was taken, this value stays `true` for the lifetime of the reattached instance. The `||` short-circuits on the stale snapshot, so the subsequent live `ProcessPropertyType.HasChildProcesses` update (fired from `childProcessMonitor` through `terminalProcessManager.ts`) is ignored.

## Fix

Keep the snapshot in sync with the live `HasChildProcesses` property event. Once the live process manager reports a value, it is authoritative, so overwrite the persisted snapshot in `_shellLaunchConfig.attachPersistentProcess.hasChildProcesses` inside the existing `onDidChangeProperty` handler in `TerminalInstance`. The getter keeps its current shape; the short-circuit simply no longer masks stale state.

This is a narrow single-file change. `attachPersistentProcess.hasChildProcesses` is only consulted in this one getter (verified by grep); nothing else depends on the snapshot remaining frozen. The intended "warn when a child IS still running" behavior is preserved -- if the live state reports `true`, the snapshot is updated to `true` and the dialog still fires.

## Test plan

- [ ] Set `terminal.integrated.confirmOnExit` to `hasChildProcesses`
- [ ] Run `sleep 60` in the integrated terminal, then reload the window
- [ ] Wait for the process to exit in the restored terminal, then close the window -- no dialog should appear
- [ ] Run `sleep 60` in the integrated terminal, reload, then immediately close the window -- dialog should still appear (child still running)
- [ ] Run `sleep 60` without a reload, then close the window -- dialog should still appear (existing behavior unchanged)