### PR TITLE
Agents: Refactor chat experimental send button styles

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -186,9 +186,9 @@
 }
 
 /* Delightful gradient styling for the chat send (submit) button. The button
-	gets a multi-color gradient ring at rest using the same palette as the
-	working-state border, fills with a slowly cycling color on hover/focus,
-	and emits a quick colorful pulse on click. Gated behind the experimental
+	is filled at rest with a slowly rotating multi-color conic gradient using
+	the same palette as the working-state border, and emits a quick colorful
+	pulse on click. Gated behind the experimental
 	`sessions.experimental.sendButtonGradient` setting via the
 	`.sessions-experimental-send-button-gradient` class on the workbench root. */
 @property --chat-send-button-anim-angle {
@@ -309,9 +309,10 @@
 	setting via the `.sessions-experimental-send-button-gradient` class on
 	the workbench root.
 
-	Colors are darkened to match the hover treatment (60% mixed with input
-	background), and the conic stops are asymmetric so the fill has a clear
-	head and tail rather than mirroring around the mid-point. */
+	Colors are darkened (60% mixed with input background) so the gradient
+	reads as a calm fill rather than a saturated accent, and the conic stops
+	are asymmetric so the fill has a clear head and tail rather than
+	mirroring around the mid-point. */
 .monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button .monaco-button:not(.disabled) {
 	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 0deg,
@@ -369,7 +370,7 @@
 }
 
 /* Idle: fill the entire action-label with a slowly rotating conic gradient.
-	Colors darkened to match hover (60% mixed with input background), with
+	Colors darkened (60% mixed with input background) for a calm fill, with
 	asymmetric conic stops. */
 .monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up {
 	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -321,6 +321,15 @@
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 360deg);
 	color: var(--vscode-button-foreground);
 	animation: chat-send-button-spin 18s linear infinite;
+	transition: box-shadow 120ms ease;
+}
+
+/* Hover/focus: subtle dark overlay to match standard toolbar button hover
+	feedback. Uses an inset box-shadow so the rotating gradient background is
+	preserved underneath. */
+.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):hover) .monaco-button,
+.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) .monaco-button {
+	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
 }
 
 /* Click: outward color pulse on the wrapper. */
@@ -381,10 +390,19 @@
 	color: var(--vscode-button-foreground) !important;
 	border-radius: 5px;
 	animation: chat-send-button-spin 18s linear infinite;
+	transition: box-shadow 120ms ease;
 	/* Lift the label above the click pulse `::after` on the action-item parent
 		so the pulse appears to expand from behind the button, not on top of it. */
 	position: relative;
 	z-index: 1;
+}
+
+/* Hover/focus: subtle dark overlay to match standard toolbar button hover
+	feedback. Uses an inset box-shadow so the rotating gradient background is
+	preserved underneath. */
+.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
+.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
+	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
 }
 
 .monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -320,16 +320,6 @@
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 360deg);
 	color: var(--vscode-button-foreground);
 	animation: chat-send-button-spin 18s linear infinite;
-	transition: box-shadow 250ms ease;
-}
-
-/* Hover/focus: soft multi-color glow around the button (no size change). */
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):hover) .monaco-button,
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) .monaco-button {
-	box-shadow:
-		0 0 4px 0 color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 70%, transparent),
-		0 0 8px 1px color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor3) 55%, transparent);
-	animation-duration: 6s;
 }
 
 /* Click: outward color pulse on the wrapper. */
@@ -390,20 +380,10 @@
 	color: var(--vscode-button-foreground) !important;
 	border-radius: 5px;
 	animation: chat-send-button-spin 18s linear infinite;
-	transition: box-shadow 250ms ease;
 	/* Lift the label above the click pulse `::after` on the action-item parent
 		so the pulse appears to expand from behind the button, not on top of it. */
 	position: relative;
 	z-index: 1;
-}
-
-/* Hover/focus: soft multi-color glow around the button (no size change). */
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
-	box-shadow:
-		0 0 4px 0 color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 70%, transparent),
-		0 0 8px 1px color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor3) 55%, transparent);
-	animation-duration: 6s;
 }
 
 .monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {


### PR DESCRIPTION
This pull request updates the styling of the experimental chat send button gradient to create a calmer, more consistent appearance and interaction experience. The changes simplify the hover/focus effect, adjust animation transitions, and clarify documentation comments to better describe the visual intent.

**Styling and interaction improvements:**

* The send button at rest now uses a slowly rotating, darkened conic gradient fill instead of a gradient ring, providing a calmer and more modern look. [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L189-R191) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L312-R315) [[3]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L382-R382)
* On hover and focus, the button now displays a subtle dark overlay using an inset box-shadow, matching standard toolbar button feedback and preserving the gradient underneath, instead of a multi-color glow. [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L323-R332) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L393-R405)
* The transition duration for the box-shadow effect is reduced from 250ms to 120ms for a snappier response. [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L323-R332) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L393-R405)

**Documentation and comment updates:**

* CSS comments are updated to clarify that colors are darkened for a calm fill, and to better explain the visual rationale behind the gradient and overlay choices. [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L189-R191) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L312-R315) [[3]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L382-R382)

