### PR TITLE
sessions: preserve chat tab title casing

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -378,7 +378,7 @@ The Agent Sessions workbench uses specialized part implementations that extend t
 |---------|----------------|---------------------|
 | Activity Bar integration | Full support | No activity bar; account widget in the titlebar |
 | Composite bar position | Configurable (top/bottom/title/hidden) | Fixed: Title |
-| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. The chat composite bar that appears inside the Chat Bar preserves each chat title's original casing instead of forcing title case. |
+| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. Separately, the internal chat tab strip shown inside the Chat Bar preserves each chat title's original casing instead of forcing per-word capitalization via CSS. |
 | Auto-hide support | Configurable | Disabled |
 | Configuration listening | Many settings | Minimal |
 | Context menu actions | Full set | Simplified |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -378,7 +378,7 @@ The Agent Sessions workbench uses specialized part implementations that extend t
 |---------|----------------|---------------------|
 | Activity Bar integration | Full support | No activity bar; account widget in the titlebar |
 | Composite bar position | Configurable (top/bottom/title/hidden) | Fixed: Title |
-| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible |
+| Composite bar visibility | Configurable | Sidebar: hidden (`shouldShowCompositeBar()` returns `false`); ChatBar: hidden; Auxiliary Bar & Panel: visible. The chat composite bar that appears inside the Chat Bar preserves each chat title's original casing instead of forcing title case. |
 | Auto-hide support | Configurable | Disabled |
 | Configuration listening | Many settings | Minimal |
 | Context menu actions | Full set | Simplified |
@@ -658,6 +658,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-21 | Updated the sessions chat composite bar tabs to preserve each chat title's original casing instead of applying per-word capitalization. |
 | 2026-04-17 | Added a subtle 1px titlebar-token border around the sessions account widget's GitHub profile image, including the inactive-window variant, and documented the avatar chrome in the layout spec. |
 | 2026-04-16 | Softened the experimental sessions shell gradient by reducing the accent tint mix strength across the shared default, light-theme, and dark-theme variants so the primary color reads more subtly behind the workbench chrome. |
 | 2026-04-16 | Updated the layout visual representation to show the editor part in the top-right row and mark it as hidden by default. |

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -26,7 +26,7 @@
 	display: none;
 }
 
-/* Base tab: capitalize text + pill padding — mirrors auxiliarybar action-label */
+/* Base tab: preserve chat title casing + pill padding — mirrors auxiliarybar action-label */
 .chat-composite-bar-tab {
 	display: flex;
 	align-items: center;
@@ -35,7 +35,6 @@
 	cursor: pointer;
 	white-space: nowrap;
 	color: var(--chat-tab-inactive-foreground);
-	text-transform: capitalize;
 	font-weight: 500;
 	font-size: 12px;
 	line-height: 22px;

--- a/src/vs/sessions/browser/parts/media/chatCompositeBar.css
+++ b/src/vs/sessions/browser/parts/media/chatCompositeBar.css
@@ -26,7 +26,7 @@
 	display: none;
 }
 
-/* Base tab: preserve chat title casing + pill padding — mirrors auxiliarybar action-label */
+/* Base tab: preserve chat title casing while keeping the same pill treatment */
 .chat-composite-bar-tab {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Summary
- remove the sessions-only `text-transform: capitalize` styling from `.chat-composite-bar-tab`
- preserve the original casing of chat titles in the sessions app tab strip
- update `src/vs/sessions/LAYOUT.md` to document the behavior and record the spec revision

<img width="1085" height="378" alt="Screenshot 2026-04-22 at 12 41 47 PM" src="https://github.com/user-attachments/assets/0fcdd4b6-7be5-4d48-b451-54daa42299b8" />

## Notes
- this change is scoped to the sessions app chat composite bar styling only
- the local repo checks available in this worktree were limited by missing bootstrap dependencies earlier, but the commit completed successfully through the repo pre-commit hook