### PR TITLE
Add vscode-scenario-builder skill

### DIFF
--- a/.github/skills/vscode-scenario-builder/SKILL.md
+++ b/.github/skills/vscode-scenario-builder/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: vscode-scenario-builder
+description: "Build, iterate on, and run Playwright-driven scenarios that exercise VS Code from sources. Use when the user asks the agent to verify a feature end-to-end in the workbench, drive a UI flow autonomously, write a repeatable scripted scenario, or build a feature and prove it works without manual button-clicking. Pairs a long-lived Code OSS window with the agent-browser CLI for snapshot-driven selector discovery, and a Playwright runner for fast, deterministic replays."
+---
+
+# VS Code Scenario Builder
+
+Build a Playwright script that drives **VS Code from sources** through a real user scenario, iterate on it interactively with `agent-browser`, then re-run it autonomously to verify a feature you just built. The goal is a fast, deterministic alternative to clicking through the UI by hand every time you change product code.
+
+## When to Use
+
+- You just implemented a feature and want to verify it end-to-end in the workbench, repeatedly, while you keep iterating on the code.
+- You need to reproduce a user-reported bug in a scripted way, then prove a fix.
+- You want to drive a non-trivial UI flow (multi-step wizard, chat session, tree interactions, editor + panel coordination) without paying the cost of manual clicking.
+- You want a scenario the next agent session can rerun unchanged.
+
+Do **not** use this skill when:
+
+- You only need a *one-shot* exploration ("does this command exist?"). Just use `agent-browser` against a running window.
+- You're investigating performance or memory specifically. Use `auto-perf-optimize` — it's the same launch+CDP pattern with heap snapshots layered on top.
+- The scenario is well-covered by an existing integration test runner (`scripts/test-integration.sh`, smoke tests under `test/`). Use those instead.
+
+## Pick a Real Surface (Read This First)
+
+The point of this skill is to find **product bugs**. That requires running against the real product surface, not a test harness. Before writing a single line of scenario code:
+
+- **Default to Electron** (`./scripts/code.sh` / `code.bat` / `code-agents.sh`). The web shell and the Electron shell take different code paths — features you ship to users run in Electron.
+- **Default to real providers** (real Copilot, real agent host with a real agent backend, a real workspace folder). Mock agents (`MockAgent`, `ScriptedMockAgent`, `--mock`, `sessions.web.test.internal`) exist to verify the *test harness itself*. They will not exercise streaming, tool approvals, auth refresh, network drops, real LLM behavior, or any of the surfaces where real bugs live.
+- **If a launch path fails — STOP and report it.** Do not silently downgrade to a less-realistic surface. The downgrade hides the original problem AND makes the rest of the run uninformative. Common culprits and their fixes are in [Launch Gotchas](#launch-gotchas) below.
+- **Bugs found only in `test/` directories or `Mock*` classes don't count.** Pre-flight checklist before declaring a product bug:
+  1. Does the same code path exist in the non-mock provider?
+  2. Does it behave correctly there?
+  3. If yes to both, you've found a test-infra issue, not a product bug. Keep looking.
+- **Escalate complexity along the real-product axis, not the UI-automation axis.** A 26-step scripted mock conversation is less valuable than 3 steps with a real agent doing a real edit on a real file.
+
+## Launch Gotchas
+
+These have all wasted real time. Check them before pivoting away from a launch path:
+
+- **`ELECTRON_RUN_AS_NODE=1` in the environment.** When set (commonly inherited from VS Code's integrated terminal or agent runtimes), `./scripts/code.sh` launches the Electron binary as a plain Node process, and the workbench fails with cryptic ESM errors like `import { Menu } from 'electron'`. `launchCode.mts` strips this from the child env automatically, but if you spawn Electron yourself in a scenario, do the same:
+  ```ts
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  spawn(codeScript, args, { env, ... });
+  ```
+- **Built-in extensions not built.** If the extension host logs `Cannot find module '.../extensions/.../out/extension.js'`, run `npm run watch-extensions` (or `npm run compile-extensions`) once.
+- **Watch task not running.** The launcher serves files from `out/`, populated by `npm run watch`. If you only ever ran `npm run gulp transpile-client-esbuild`, you'll get stale code. Keep `npm run watch` running in another terminal during iteration.
+
+## Core Story
+
+The skill is a tight loop between **two terminals talking to the same Code window**:
+
+```
+┌─────────────────────────────┐         ┌──────────────────────────────┐
+│ Terminal A (Playwright)     │         │ Terminal B (agent-browser)   │
+│                             │         │                              │
+│ node scenario.mts           │         │ npx agent-browser connect    │
+│   --keep-open               │  CDP    │   <port>                     │
+│   --port 9229               │ <-----> │ npx agent-browser snapshot -i│
+│                             │         │ npx agent-browser screenshot │
+│ Drives the scripted scenario│         │ Discovers refs/selectors,    │
+│ Writes summary.json + PNGs  │         │ explores stuck states        │
+└─────────────────────────────┘         └──────────────────────────────┘
+              │                                       │
+              └───────────► same Code OSS ◄───────────┘
+                            (own user-data-dir,
+                             own --remote-debugging-port)
+```
+
+1. **Bootstrap a scenario script** from the [template](./scripts/scenarioTemplate.mts) into [scratchpad/](./scratchpad/) under a dated subfolder.
+2. **Launch with `--keep-open --port <free>`** so the window stays alive between script runs and agent-browser can attach.
+3. **Snapshot-driven selector discovery.** Don't guess CSS — let `agent-browser snapshot -i` tell you the accessible name and ref of the element you actually want.
+4. **Prefer commands over clicks.** Use `runCommand('workbench.action.X')` from [vscodeHelpers.mts](./scripts/vscodeHelpers.mts) whenever a command exists. Faster, more deterministic, survives UI changes.
+5. **Re-run with `--reuse --port <same>`** to replay against the still-open window. No relaunch overhead — typical iteration is ~2 seconds.
+6. **Settle waits, not sleep waits.** Wait for an observable state change (element visible, text content matches, response complete), never `setTimeout`.
+7. **Write `summary.json` incrementally** so a stuck run still gives you the last successful step.
+8. **When the script is boring and reliable,** drop `--keep-open`/`--reuse` and let it run cold for the autonomous verification pass.
+
+## Why This Beats Click-by-Click
+
+| Manual button-clicking | Scripted scenario |
+| --- | --- |
+| Re-do every step on every code change | Replay in 2s |
+| Easy to forget a step | Recorded in code |
+| Selectors drift silently | Failure points to the exact step |
+| No reproducible artifact | `summary.json` + screenshots per run |
+| Can't run while you read code | Headless runs in background |
+
+## Quick Start
+
+Build VS Code from sources first if you haven't (`npm run watch` — keep it running).
+
+```bash
+# 1. Make a dated scratchpad folder
+mkdir -p .github/skills/vscode-scenario-builder/scratchpad/$(date +%F)-my-feature
+
+# 2. Copy the template
+cp .github/skills/vscode-scenario-builder/scripts/scenarioTemplate.mts \
+   .github/skills/vscode-scenario-builder/scratchpad/$(date +%F)-my-feature/scenario.mts
+
+# 3. First run — keep the window open, pick a free port
+node .github/skills/vscode-scenario-builder/scratchpad/$(date +%F)-my-feature/scenario.mts \
+  --keep-open --port 9229
+```
+
+In a **second terminal** while that window is open:
+
+```bash
+npx agent-browser connect 9229
+npx agent-browser tab                        # confirm the workbench tab is selected
+npx agent-browser snapshot -i                # discover refs and accessible names
+npx agent-browser screenshot .build/scenario-builder/observe.png
+```
+
+Edit the scenario to use what you discovered, then **replay against the same window**:
+
+```bash
+node .github/skills/vscode-scenario-builder/scratchpad/$(date +%F)-my-feature/scenario.mts \
+  --reuse --port 9229
+```
+
+When the scenario is reliable, do the cold autonomous run:
+
+```bash
+node .github/skills/vscode-scenario-builder/scratchpad/$(date +%F)-my-feature/scenario.mts
+```
+
+The cold run launches Code, runs the scenario, writes `summary.json` + screenshots, then closes everything.
+
+## Anatomy of a Scenario
+
+A scenario imports the helpers and exports/runs an `async (page, helpers) => { ... }` function. Helpers include:
+
+- `runCommand(id)` — opens command palette, runs by command id (e.g. `workbench.action.toggleSidebar`). The fastest way to drive the workbench. **Always check if a command exists before scripting a click sequence.**
+- `openFile(relativePath)` — opens a workspace file via quick open.
+- `waitForElement(selector, opts?)` — wait for a DOM element with a sensible default timeout.
+- `waitForElementGone(selector)` — wait until something disappears (dialogs, progress, loading spinners).
+- `getText(selector)` — read text content of the first match.
+- `screenshot(label)` — write a labeled PNG into the run output dir, returned in `summary.json`.
+- `step(name, fn)` — wrap a logical step; failures attach a screenshot and the step name to `summary.json` automatically.
+
+See [scripts/scenarioTemplate.mts](./scripts/scenarioTemplate.mts) for a runnable example.
+
+## Selector Strategy (Most Important Section)
+
+**Cardinal rule: discover selectors from a live snapshot, don't invent them.** VS Code class names change. Accessible roles and labels are far more stable.
+
+Preference order:
+
+1. **Command IDs** via `runCommand('workbench.action.X')` — no DOM at all. Best.
+2. **`aria-label`, `role`, and `title` attributes** — `[aria-label="Source Control"]`, `[role="treeitem"][aria-label="src"]`. Stable across themes and refactors.
+3. **View IDs** — every workbench part has an `id` like `workbench.view.scm`, `workbench.panel.chat`. Selector: `[id="workbench.panel.chat"]`.
+4. **Container + descendant** — `[id="workbench.panel.chat"] .interactive-input-part`. Scope to a known stable container before reaching for class names.
+5. **Last resort: leaf class names** like `.monaco-list-row`. These break. If you must use one, scope it tightly and add a settle wait + assertion.
+
+Discovery loop with agent-browser:
+
+```bash
+npx agent-browser snapshot -i        # interactive refs, shows roles + names
+npx agent-browser eval 'document.activeElement.outerHTML.slice(0, 400)'
+npx agent-browser eval 'Array.from(document.querySelectorAll("[id^=workbench]")).map(e => e.id)'
+```
+
+The `eval` escape hatch is great for asking the live page "what classes are on this thing right now?" before you commit to a selector.
+
+## Screenshots Are Your Evidence (Take Lots)
+
+The user is not watching you click. The only way they can verify what you did, what you saw, and what you actually proved is by looking at the screenshots and `summary.json` you leave behind. Treat screenshots as the deliverable, not as a debugging aid.
+
+Rules:
+
+- **Take a screenshot at every meaningful step.** Use `helpers.screenshot('verb-noun')` (or rely on `step()` which captures one per step automatically). After a successful action, after an unexpected state, after the final assertion — all of them.
+- **Capture state *before* AND *after* a key interaction** when proving a behavior change (e.g. `before-send-message`, `after-send-message`). Two adjacent screenshots make a far better proof than one.
+- **Always screenshot the final asserted state.** Even on success. The user wants to see the "Hello, world!" response actually rendered — not just read your text claim that it appeared.
+- **Always screenshot on failure.** `step()` does this for you, but if you `try/catch` manually, take one yourself before re-throwing or recovering.
+- **Name them descriptively.** `01-chat-opened.png` is fine; `screenshot1.png` is not. The numeric prefix is added automatically by `step()` ordering — your label is the verb-noun part.
+- **Tell the user where to look** at the end of the run. The scenario should print the absolute output path so the user can open it. `launchCode.mts` and the template do this — keep it.
+
+Where they go (do NOT change this):
+
+```
+.build/scenario-builder/<scenario-name>/<timestamp>/
+  ├── summary.json
+  ├── 01-<step-name>.png
+  ├── 02-<step-name>.png
+  └── ...
+```
+
+Anti-patterns:
+
+- Writing screenshots into `/tmp/`, `~/Desktop`, or anywhere outside the run output dir. They get orphaned from `summary.json` and the user can't find them.
+- Skipping the final-state screenshot because "the test passed." The user has no way to audit your "pass" claim without it.
+- Taking a screenshot but never mentioning the output path in your final summary to the user. They won't go hunting.
+
+## Waits, Not Sleeps
+
+Every wait should be tied to a user-visible state change:
+
+- View opened: `waitForElement('[id="workbench.view.scm"]')`
+- Editor content settled: `getText('.editor-instance .view-line')` matches expected
+- Quick pick visible: `waitForElement('.quick-input-widget:not(.hidden)')`
+- Progress gone: `waitForElementGone('.monaco-progress-container.active')`
+- Chat response complete: `waitForElement('.interactive-response:not(.chat-response-loading)')`
+
+Never `await timeout(1000)` "just to be safe". A flaky settle wait is a real bug — fix it once and every replay benefits.
+
+If you genuinely need a small pause for DOM reflow, use `await page.waitForTimeout(50)` *after* the proper wait fired, not instead of it.
+
+## User-Data-Dir Isolation
+
+Each scenario gets its own user-data-dir under `.build/scenario-builder/<scenario-name>/user-data` by default. That means:
+
+- Multiple scenarios can run **in parallel** in different worktrees.
+- Auth (Copilot, GitHub) is preserved across runs of the same scenario.
+- A bad scenario can't pollute your real VS Code profile.
+
+Flags:
+
+- `--user-data-dir <path>` — override the default location (e.g. share auth across scenarios).
+- `--temporary-user-data` — use a fresh temp profile, deleted after the run. Use for "first-launch" scenarios.
+- `--seed-user-data-dir <path>` — copy a logged-in profile in before launching. Useful when a fresh profile needs Copilot auth.
+- `--workspace <path>` — open this folder. Default: a throwaway scratch folder under the run output dir. **Do not point at your real repo unless the scenario needs it** — scripted Chat tool calls will modify those files.
+
+## Watch / Iterate Loop
+
+Recommended for active development of a scenario:
+
+```bash
+# Terminal A — leave running
+node .github/skills/vscode-scenario-builder/scratchpad/.../scenario.mts \
+  --keep-open --port 9229 --output .build/scenario-builder/watch
+
+# Terminal B — observe
+npx agent-browser connect 9229
+npx agent-browser snapshot -i
+
+# Terminal A — replay against same window after each edit
+node .github/skills/vscode-scenario-builder/scratchpad/.../scenario.mts \
+  --reuse --port 9229 --output .build/scenario-builder/watch
+```
+
+Tips:
+
+- **Each scenario step should be idempotent or self-resetting.** Prefer "open quick pick → escape → open quick pick" over assuming a starting state. This makes `--reuse` replays robust.
+- **If the window gets into a weird state**, close it and start fresh — don't fight it. `Cmd+Q` is fine; the script will relaunch on the next non-`--reuse` run.
+- **Stuck script?** Capture a snapshot from Terminal B, read the latest `summary.json`. The last successful step + the current accessibility tree almost always identify the missing wait.
+
+## Output Contract
+
+Every run writes to `--output` (default `.build/scenario-builder/<scenario-name>/<timestamp>/`):
+
+```
+summary.json            # machine-readable: steps, timings, errors, screenshots
+00-launched.png         # workbench restored
+NN-<step-name>.png      # one per `step()` call, plus on failure
+error.log               # if the run failed
+```
+
+Inspect `summary.json` first. The shape:
+
+```json
+{
+  "scenario": "my-feature",
+  "startedAt": "2026-...",
+  "endedAt": "2026-...",
+  "ok": true,
+  "steps": [
+    { "name": "open chat", "ok": true, "durationMs": 234, "screenshot": "01-open-chat.png" },
+    { "name": "send prompt", "ok": true, "durationMs": 1820, "screenshot": "02-send-prompt.png" }
+  ],
+  "error": null
+}
+```
+
+The shape is stable enough for the agent to grep and assert on. When verifying a feature, prefer reading `summary.json` over re-running the scenario.
+
+## Anti-Patterns
+
+- **Sleep-based waits.** Always replace with a state-based wait.
+- **Inventing CSS selectors.** Snapshot first; use `aria-label`/`role`/view ids.
+- **Reusing your real user profile.** Don't. Use the default `.build/...` path.
+- **Skipping `step()` wrappers.** Without them, failures lose context.
+- **Letting screenshots pile up in `/tmp`.** They go in the run output folder, where they stay attached to the `summary.json`.
+- **Letting a `--keep-open` window leak.** Close it before the next non-reuse run, or `--reuse` will fail mysteriously when ports conflict.
+- **Silently downgrading from real → mock when launch fails.** See [Pick a Real Surface](#pick-a-real-surface-read-this-first). If you can't launch the real product, that *is* the bug — report it, don't paper over it with a mock.
+- **Fixing a "bug" that only exists in `test/` or `Mock*` code.** Run the pre-flight checklist before claiming a product bug.
+
+## Promoting a Scenario
+
+If a scratchpad scenario proves repeatedly useful (you'd rerun it next week), move the `.mts` from `scratchpad/<dated>/` into `scripts/`, add a top-of-file comment block matching the existing scripts, and reference it from this SKILL.md. Otherwise leave it in the dated scratchpad folder — that folder is gitignored on purpose so investigation cruft doesn't accumulate.
+
+## Files in This Skill
+
+- **[scripts/launchCode.mts](./scripts/launchCode.mts)** — launches Code OSS from sources with CDP enabled, returns `{ browser, page, session, dispose }`. Handles `--keep-open`, `--reuse`, `--port`, `--user-data-dir`, `--workspace`.
+- **[scripts/vscodeHelpers.mts](./scripts/vscodeHelpers.mts)** — `runCommand`, `openFile`, `waitForElement`, `step`, etc. The DSL your scenarios are written in.
+- **[scripts/scenarioTemplate.mts](./scripts/scenarioTemplate.mts)** — copy-paste starter for new scenarios.
+- **[scratchpad/](./scratchpad/)** — gitignored. New scenarios live here under dated subfolders (`YYYY-MM-DD-short-description/`).

--- a/.github/skills/vscode-scenario-builder/scratchpad/.gitignore
+++ b/.github/skills/vscode-scenario-builder/scratchpad/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/.github/skills/vscode-scenario-builder/scratchpad/README.md
+++ b/.github/skills/vscode-scenario-builder/scratchpad/README.md
@@ -1,0 +1,16 @@
+# Scratchpad
+
+Per-investigation scenario scripts live here under dated subfolders:
+
+```
+scratchpad/
+  2026-04-22-chat-attachments/
+    scenario.mts
+    notes.md
+  2026-04-22-scm-tree-bug/
+    scenario.mts
+```
+
+Everything in this folder (except this `README.md` and `.gitignore`) is gitignored.
+
+Start fresh — don't reuse another session's folder. Copy [`../scripts/scenarioTemplate.mts`](../scripts/scenarioTemplate.mts) as a starting point.

--- a/.github/skills/vscode-scenario-builder/scripts/launchCode.mts
+++ b/.github/skills/vscode-scenario-builder/scripts/launchCode.mts
@@ -1,0 +1,317 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Launches Code OSS from sources with CDP enabled and connects Playwright over it.
+ *
+ * Used by scenarios under `scratchpad/<dated>/scenario.mts`. Designed for the
+ * watch loop documented in SKILL.md:
+ *
+ *   - First launch:   --keep-open --port 9229
+ *   - Replay:         --reuse --port 9229
+ *   - Cold autonomous: (no flags)
+ *
+ * Returns Playwright handles + a `dispose` that closes the browser and, when
+ * we own the Code process, terminates it.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdir, rm } from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import { setTimeout as timeout } from 'node:timers/promises';
+import { chromium, type Browser, type CDPSession, type Page } from 'playwright-core';
+import { prepareUserDataProfile } from '../../auto-perf-optimize/scripts/userDataProfile.mts';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..', '..');
+const codeScript = process.platform === 'win32'
+	? path.join(repoRoot, 'scripts', 'code.bat')
+	: path.join(repoRoot, 'scripts', 'code.sh');
+
+export interface LaunchOptions {
+	/** Scenario name, used to build default output / user-data paths. */
+	scenario: string;
+	/** Output dir for screenshots and summary.json. */
+	outputDir: string;
+	/** Workspace folder Code should open. Required — must be a throwaway folder unless your scenario knows what it's doing. */
+	workspace: string;
+	/** CDP port. Choose something free; 9229 is a reasonable default. */
+	port: number;
+	/** Reuse an already-running Code window started with --keep-open at the same port. Skips launch. */
+	reuse: boolean;
+	/** Leave the Code window open after the scenario finishes. Pair with --reuse next time. */
+	keepOpen: boolean;
+	/** Use a fresh, disposable user-data-dir. Default reuses a per-scenario persistent profile so auth carries over. */
+	temporaryUserData: boolean;
+	/** Override the user-data-dir path. */
+	userDataDir?: string;
+	/** Seed the (empty) target user-data-dir from this profile before launch. */
+	seedUserDataDir?: string;
+	/** Override extension dir. Defaults to `<outputDir>/extensions`. */
+	extensionDir?: string;
+	/** Extra runtime args appended to the Code launch command. */
+	runtimeArgs?: string[];
+	/** Verbose: print Code stdout/stderr instead of capturing. */
+	verbose?: boolean;
+}
+
+export interface LaunchedSession {
+	browser: Browser;
+	page: Page;
+	cdp: CDPSession;
+	port: number;
+	outputDir: string;
+	dispose: () => Promise<void>;
+}
+
+interface OwnedProcess {
+	child: ChildProcess;
+	failedBeforeConnect: Promise<Error>;
+	markConnected(): void;
+	terminate(signal: NodeJS.Signals): boolean;
+}
+
+export async function launchVSCode(options: LaunchOptions): Promise<LaunchedSession> {
+	const outputDir = path.resolve(options.outputDir);
+	const extensionDir = path.resolve(options.extensionDir ?? path.join(outputDir, 'extensions'));
+	const persistentUserDataDir = path.join(repoRoot, '.build', 'scenario-builder', options.scenario, 'user-data');
+
+	await mkdir(outputDir, { recursive: true });
+
+	const { userDataDir, ownsUserDataDir } = await prepareUserDataProfile({
+		outputDir,
+		persistentUserDataDir,
+		temporaryUserData: options.temporaryUserData,
+		keepOpen: options.keepOpen,
+		keepUserData: false,
+		reuse: options.reuse,
+		userDataDir: options.userDataDir,
+		seedUserDataDir: options.seedUserDataDir,
+	});
+
+	if (!options.reuse && await isCDPAvailable(options.port)) {
+		throw new Error(
+			`Port ${options.port} already has a CDP endpoint. ` +
+			`Stop that process, pick a different --port, or pass --reuse to attach to it.`,
+		);
+	}
+
+	const ownsCode = !options.reuse;
+	const owned: OwnedProcess | undefined = ownsCode
+		? launchCodeProcess({
+			port: options.port,
+			workspace: options.workspace,
+			userDataDir,
+			extensionDir,
+			runtimeArgs: options.runtimeArgs ?? [],
+			keepOpen: options.keepOpen,
+			verbose: options.verbose ?? false,
+		})
+		: undefined;
+
+	let browser: Browser;
+	try {
+		browser = await connectWithRetry(options.port, owned?.failedBeforeConnect);
+	} catch (err) {
+		owned?.terminate('SIGTERM');
+		throw err;
+	}
+	owned?.markConnected();
+
+	const page = await findWorkbenchPage(browser);
+	const cdp = await page.context().newCDPSession(page);
+	await page.evaluate(() => (globalThis as unknown as { driver?: { whenWorkbenchRestored?: () => Promise<void> } }).driver?.whenWorkbenchRestored?.());
+
+	const shouldCloseCode = ownsCode && !options.keepOpen;
+
+	const dispose = async () => {
+		await cdp.detach().catch(() => undefined);
+		if (shouldCloseCode) {
+			await browser.newBrowserCDPSession()
+				.then(s => s.send('Browser.close'))
+				.catch(() => undefined);
+		}
+		await browser.close().catch(() => undefined);
+		if (owned && shouldCloseCode) {
+			if (!await waitForChildExit(owned.child, 10000)) {
+				owned.terminate('SIGTERM');
+				await waitForChildExit(owned.child, 5000);
+			}
+		}
+		if (ownsUserDataDir) {
+			await rm(userDataDir, { recursive: true, force: true, maxRetries: 3 }).catch(() => undefined);
+		}
+	};
+
+	return { browser, page, cdp, port: options.port, outputDir, dispose };
+}
+
+function launchCodeProcess(args: {
+	port: number;
+	workspace: string;
+	userDataDir: string;
+	extensionDir: string;
+	runtimeArgs: string[];
+	keepOpen: boolean;
+	verbose: boolean;
+}): OwnedProcess {
+	const argv = [
+		'--enable-smoke-test-driver',
+		'--disable-workspace-trust',
+		`--remote-debugging-port=${args.port}`,
+		`--user-data-dir=${args.userDataDir}`,
+		`--extensions-dir=${args.extensionDir}`,
+		'--skip-welcome',
+		'--skip-release-notes',
+		...args.runtimeArgs,
+		args.workspace,
+	];
+
+	let failBeforeConnect: (err: Error) => void = () => undefined;
+	let connected = false;
+	let terminating = false;
+	const failedBeforeConnect = new Promise<Error>(resolve => failBeforeConnect = resolve);
+
+	// Strip ELECTRON_RUN_AS_NODE — when set (commonly inherited from VS Code's
+	// integrated terminal or agent environments), Electron's binary launches as
+	// a plain Node process and the workbench fails to start with cryptic ESM
+	// import errors like `import { Menu } from 'electron'`.
+	const childEnv = { ...process.env };
+	delete childEnv.ELECTRON_RUN_AS_NODE;
+
+	const child = spawn(codeScript, argv, {
+		cwd: repoRoot,
+		detached: args.keepOpen,
+		shell: process.platform === 'win32',
+		stdio: args.keepOpen ? 'ignore' : args.verbose ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+		env: childEnv,
+	});
+	if (args.keepOpen) {
+		child.unref();
+	}
+
+	if (!args.verbose && !args.keepOpen) {
+		child.stdout?.on('data', data => process.stdout.write(`[code] ${data}`));
+		child.stderr?.on('data', data => process.stderr.write(`[code] ${data}`));
+	}
+
+	child.once('error', err => failBeforeConnect(new Error(`Failed to launch Code: ${err.message}`)));
+	child.once('exit', (code, signal) => {
+		if (!connected && !terminating) {
+			failBeforeConnect(new Error(`Code exited before CDP connect. code=${code} signal=${signal}`));
+		}
+	});
+
+	return {
+		child,
+		failedBeforeConnect,
+		markConnected: () => { connected = true; },
+		terminate: signal => { terminating = true; return child.kill(signal); },
+	};
+}
+
+async function connectWithRetry(port: number, failedBeforeConnect?: Promise<Error>): Promise<Browser> {
+	const start = Date.now();
+	const deadline = start + 60000;
+	let lastErr: unknown;
+	while (Date.now() < deadline) {
+		try {
+			return await Promise.race([
+				chromium.connectOverCDP(`http://127.0.0.1:${port}`),
+				failedBeforeConnect ? failedBeforeConnect.then(e => { throw e; }) : new Promise<Browser>(() => undefined),
+			]);
+		} catch (err) {
+			lastErr = err;
+			await timeout(500);
+		}
+	}
+	throw new Error(`Could not connect to CDP at 127.0.0.1:${port} within 60s: ${lastErr}`);
+}
+
+async function findWorkbenchPage(browser: Browser): Promise<Page> {
+	const deadline = Date.now() + 60000;
+	while (Date.now() < deadline) {
+		for (const ctx of browser.contexts()) {
+			for (const page of ctx.pages()) {
+				const url = page.url();
+				if (url.startsWith('file://') && url.includes('workbench')) {
+					return page;
+				}
+				if (url.includes('workbench.html')) {
+					return page;
+				}
+			}
+		}
+		await timeout(250);
+	}
+	throw new Error('Could not find workbench page over CDP. Is --enable-smoke-test-driver set?');
+}
+
+async function isCDPAvailable(port: number): Promise<boolean> {
+	return new Promise(resolve => {
+		const req = http.get({ host: '127.0.0.1', port, path: '/json/version', timeout: 1000 }, res => {
+			res.resume();
+			resolve(res.statusCode === 200);
+		});
+		req.on('error', () => resolve(false));
+		req.on('timeout', () => { req.destroy(); resolve(false); });
+	});
+}
+
+async function waitForChildExit(child: ChildProcess, ms: number): Promise<boolean> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return true;
+	}
+	return await Promise.race([
+		new Promise<boolean>(resolve => child.once('exit', () => resolve(true))),
+		timeout(ms).then(() => false),
+	]);
+}
+
+/**
+ * Parse the standard launch flags every scenario script accepts. Scenarios may layer
+ * additional flags on top — this just gives a consistent baseline.
+ */
+export interface CommonArgs {
+	port: number;
+	reuse: boolean;
+	keepOpen: boolean;
+	temporaryUserData: boolean;
+	verbose: boolean;
+	userDataDir?: string;
+	seedUserDataDir?: string;
+	workspace?: string;
+	output?: string;
+	rest: string[];
+}
+
+export function parseCommonArgs(argv: string[]): CommonArgs {
+	const out: CommonArgs = {
+		port: 9229,
+		reuse: false,
+		keepOpen: false,
+		temporaryUserData: false,
+		verbose: false,
+		rest: [],
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		const next = () => argv[++i];
+		switch (a) {
+			case '--port': out.port = Number(next()); break;
+			case '--reuse': out.reuse = true; break;
+			case '--keep-open': out.keepOpen = true; break;
+			case '--temporary-user-data': out.temporaryUserData = true; break;
+			case '--verbose': out.verbose = true; break;
+			case '--user-data-dir': out.userDataDir = next(); break;
+			case '--seed-user-data-dir': out.seedUserDataDir = next(); break;
+			case '--workspace': out.workspace = next(); break;
+			case '--output': out.output = next(); break;
+			default: out.rest.push(a);
+		}
+	}
+	return out;
+}

--- a/.github/skills/vscode-scenario-builder/scripts/scenarioTemplate.mts
+++ b/.github/skills/vscode-scenario-builder/scripts/scenarioTemplate.mts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Scenario template — copy this into `scratchpad/<YYYY-MM-DD>-<short-description>/scenario.mts`
+ * and edit the body of `run()`. See ../SKILL.md for the full workflow.
+ *
+ * Quick start:
+ *
+ *   # Iterate with the window kept open + agent-browser observing port 9229
+ *   node scratchpad/.../scenario.mts --keep-open --port 9229
+ *   node scratchpad/.../scenario.mts --reuse     --port 9229   # replay
+ *
+ *   # Cold autonomous run
+ *   node scratchpad/.../scenario.mts
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdir } from 'node:fs/promises';
+import { launchVSCode, parseCommonArgs } from '../../scripts/launchCode.mts';
+import { createHelpers } from '../../scripts/vscodeHelpers.mts';
+
+// ─── Edit this ───────────────────────────────────────────────────────────────
+const SCENARIO = 'example-feature';
+// ─────────────────────────────────────────────────────────────────────────────
+
+const args = parseCommonArgs(process.argv.slice(2));
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..', '..', '..');
+
+const outputDir = path.resolve(args.output ?? path.join(
+	repoRoot, '.build', 'scenario-builder', SCENARIO, new Date().toISOString().replace(/[:.]/g, '-'),
+));
+const workspace = path.resolve(args.workspace ?? path.join(outputDir, 'workspace'));
+await mkdir(workspace, { recursive: true });
+
+const session = await launchVSCode({
+	scenario: SCENARIO,
+	outputDir,
+	workspace,
+	port: args.port,
+	reuse: args.reuse,
+	keepOpen: args.keepOpen,
+	temporaryUserData: args.temporaryUserData,
+	userDataDir: args.userDataDir,
+	seedUserDataDir: args.seedUserDataDir,
+	verbose: args.verbose,
+});
+
+const helpers = createHelpers(session, { scenario: SCENARIO });
+
+try {
+	await run();
+} catch (err) {
+	console.error(`[scenario] FAILED: ${err instanceof Error ? err.message : err}`);
+	process.exitCode = 1;
+} finally {
+	const summary = await helpers.finish();
+	console.log(`[scenario] ${summary.ok ? 'OK' : 'FAIL'} — ${summary.steps.length} steps`);
+	console.log(`[scenario] output: ${outputDir}`);
+	await session.dispose();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario body. Wrap each meaningful action in a `step()` so failures attach
+// a screenshot and the run name to summary.json automatically.
+// ─────────────────────────────────────────────────────────────────────────────
+async function run(): Promise<void> {
+
+	await helpers.step('workbench restored', async () => {
+		await helpers.waitForElement('.monaco-workbench');
+	});
+
+	await helpers.step('toggle activity bar', async () => {
+		await helpers.runCommand('workbench.action.toggleActivityBarVisibility');
+		// Replace this assertion with whatever proves the feature works:
+		await helpers.page.waitForTimeout(100);
+	});
+
+	// Discover further selectors with:
+	//   npx agent-browser connect <port>
+	//   npx agent-browser snapshot -i
+	// then add more steps here.
+}

--- a/.github/skills/vscode-scenario-builder/scripts/vscodeHelpers.mts
+++ b/.github/skills/vscode-scenario-builder/scripts/vscodeHelpers.mts
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Helpers used inside scenario.mts files. Wraps the most common Playwright
+ * patterns for VS Code into one-liners and gives every scenario a consistent
+ * `summary.json` output contract.
+ *
+ * Construct one per launched session:
+ *
+ *   const helpers = createHelpers(session, { scenario: 'my-feature' });
+ *   await helpers.step('open chat', async () => {
+ *     await helpers.runCommand('workbench.panel.chat.view.copilot.focus');
+ *     await helpers.waitForElement('[id="workbench.panel.chat"]');
+ *   });
+ *   await helpers.finish();
+ */
+
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Page } from 'playwright-core';
+import type { LaunchedSession } from './launchCode.mts';
+
+export interface ScenarioOptions {
+	scenario: string;
+}
+
+export interface StepResult {
+	name: string;
+	ok: boolean;
+	durationMs: number;
+	screenshot?: string;
+	error?: string;
+}
+
+export interface ScenarioSummary {
+	scenario: string;
+	startedAt: string;
+	endedAt?: string;
+	ok: boolean;
+	steps: StepResult[];
+	error: string | null;
+}
+
+export interface WaitForOptions {
+	timeoutMs?: number;
+}
+
+export interface Helpers {
+	page: Page;
+	outputDir: string;
+	summary: ScenarioSummary;
+
+	/** Run a labeled step. Failures attach a screenshot and re-throw. */
+	step<T>(name: string, fn: () => Promise<T>): Promise<T>;
+
+	/** Open the command palette and run a command by id (e.g. 'workbench.action.toggleSidebar'). */
+	runCommand(commandId: string): Promise<void>;
+
+	/** Open a workspace file via the Files quick pick. `relPath` is shown in the picker. */
+	openFile(relPath: string): Promise<void>;
+
+	/** Wait for an element matching `selector` to be visible. */
+	waitForElement(selector: string, opts?: WaitForOptions): Promise<void>;
+
+	/** Wait for an element matching `selector` to detach or hide. */
+	waitForElementGone(selector: string, opts?: WaitForOptions): Promise<void>;
+
+	/** Read text content of the first element matching `selector`. */
+	getText(selector: string): Promise<string>;
+
+	/** Save a screenshot to the output dir. Returns the file name relative to the dir. */
+	screenshot(label: string): Promise<string>;
+
+	/** Press a key chord (e.g. 'Escape', 'Control+Shift+P'). */
+	press(key: string): Promise<void>;
+
+	/** Type into the currently focused element. */
+	type(text: string): Promise<void>;
+
+	/** Write summary.json. Called automatically by `finish` and on step failure; safe to call mid-run. */
+	writeSummary(): Promise<void>;
+
+	/** Mark the run complete, write final summary.json. */
+	finish(): Promise<ScenarioSummary>;
+}
+
+export function createHelpers(session: LaunchedSession, opts: ScenarioOptions): Helpers {
+	const summary: ScenarioSummary = {
+		scenario: opts.scenario,
+		startedAt: new Date().toISOString(),
+		ok: true,
+		steps: [],
+		error: null,
+	};
+
+	const { page, outputDir } = session;
+	let stepIndex = 0;
+
+	const writeSummary = async () => {
+		await writeFile(path.join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2));
+	};
+
+	const screenshot = async (label: string): Promise<string> => {
+		const safe = label.replace(/[^\w.-]+/g, '-');
+		const idx = String(stepIndex).padStart(2, '0');
+		const file = `${idx}-${safe}.png`;
+		await page.screenshot({ path: path.join(outputDir, file) });
+		return file;
+	};
+
+	const helpers: Helpers = {
+		page,
+		outputDir,
+		summary,
+
+		async step<T>(name: string, fn: () => Promise<T>): Promise<T> {
+			stepIndex++;
+			const start = Date.now();
+			const result: StepResult = { name, ok: false, durationMs: 0 };
+			summary.steps.push(result);
+			try {
+				const value = await fn();
+				result.ok = true;
+				result.durationMs = Date.now() - start;
+				try { result.screenshot = await screenshot(name); } catch { /* ignore */ }
+				await writeSummary();
+				return value;
+			} catch (err) {
+				result.ok = false;
+				result.durationMs = Date.now() - start;
+				result.error = err instanceof Error ? err.stack ?? err.message : String(err);
+				try { result.screenshot = await screenshot(`${name}-FAIL`); } catch { /* ignore */ }
+				summary.ok = false;
+				summary.error = result.error;
+				await writeSummary();
+				throw err;
+			}
+		},
+
+		async runCommand(commandId) {
+			// Open command palette via its command, then type ">commandId"
+			// Using the keybinding is also fine but varies by platform.
+			await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P');
+			await helpers.waitForElement('.quick-input-widget:not(.hidden) .quick-input-filter input');
+			await page.keyboard.insertText(`>${commandId}`);
+			// Wait for the picker to filter
+			await page.waitForTimeout(50);
+			await page.keyboard.press('Enter');
+			await helpers.waitForElementGone('.quick-input-widget:not(.hidden)').catch(() => undefined);
+		},
+
+		async openFile(relPath) {
+			await page.keyboard.press(process.platform === 'darwin' ? 'Meta+P' : 'Control+P');
+			await helpers.waitForElement('.quick-input-widget:not(.hidden) .quick-input-filter input');
+			await page.keyboard.insertText(relPath);
+			await page.waitForTimeout(150);
+			await page.keyboard.press('Enter');
+			await helpers.waitForElementGone('.quick-input-widget:not(.hidden)').catch(() => undefined);
+		},
+
+		async waitForElement(selector, { timeoutMs = 15000 } = {}) {
+			await page.waitForSelector(selector, { state: 'visible', timeout: timeoutMs });
+		},
+
+		async waitForElementGone(selector, { timeoutMs = 15000 } = {}) {
+			await page.waitForSelector(selector, { state: 'hidden', timeout: timeoutMs });
+		},
+
+		async getText(selector) {
+			const el = await page.waitForSelector(selector, { state: 'attached', timeout: 5000 });
+			return (await el.textContent()) ?? '';
+		},
+
+		screenshot,
+
+		async press(key) {
+			await page.keyboard.press(key);
+		},
+
+		async type(text) {
+			await page.keyboard.insertText(text);
+		},
+
+		writeSummary,
+
+		async finish() {
+			summary.endedAt = new Date().toISOString();
+			await writeSummary();
+			return summary;
+		},
+	};
+
+	return helpers;
+}


### PR DESCRIPTION
Adds a project skill for building Playwright-driven scenarios that exercise VS Code from sources end-to-end. Pairs a long-lived Code OSS window with the `agent-browser` CLI for snapshot-driven selector discovery, plus a Playwright runner for fast, deterministic replays.

## What's in the skill

- **`SKILL.md`** — usage guidance covering when to use it, selector strategy, settle waits, the watch/iterate loop, and output contract. Notable sections:
  - **Pick a Real Surface (Read This First)** — steers the agent toward Electron + real providers and explicitly warns against silently downgrading to mock agents (`MockAgent`, `--mock`, etc.) when a launch path fails. Includes a pre-flight checklist for distinguishing product bugs from test-infra bugs.
  - **Launch Gotchas** — known failure modes with fixes, including `ELECTRON_RUN_AS_NODE=1` (commonly inherited from agent runtimes) which causes Electron to launch as a plain Node process and produce cryptic ESM errors.
  - **Screenshots Are Your Evidence (Take Lots)** — frames screenshots as the deliverable rather than a debugging aid, with rules for capturing before/after states and always capturing the final asserted state on success.
- **`scripts/launchCode.mts`** — launches Code OSS with CDP enabled, supports `--keep-open` / `--reuse` / `--port` for the iterate loop, manages per-scenario user-data-dirs. Strips `ELECTRON_RUN_AS_NODE` from the child env so Electron launches as Electron.
- **`scripts/vscodeHelpers.mts`** — `runCommand`, `openFile`, `waitForElement`, `step`, `screenshot`, etc. The DSL scenarios are written in.
- **`scripts/scenarioTemplate.mts`** — copy-paste starter for new scenarios.
- **`scratchpad/`** — gitignored folder for per-investigation scenarios with a README explaining the dated-subfolder convention.

## Why a skill rather than a script

The skill format lets the agent discover this workflow whenever a user asks for end-to-end verification, scripted UI flows, or "build a feature and prove it works without manual button-clicking", and surfaces the gotchas (real-vs-mock, `ELECTRON_RUN_AS_NODE`, screenshots-as-evidence) at exactly the right point in the workflow rather than buried in a script comment.

(Written by Copilot)