### PR TITLE
sessions: prevent attached secondary sidebar snap-close

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -179,7 +179,7 @@ This structure places the sidebar at the root level spanning the full window hei
 
 The sessions sidebar can be resized down to a minimum width of 170px (desktop) or 270px (web, sized to fit the titlebar's left toolbar which includes the host filter combo).
 
-The sessions auxiliary bar can generally be resized down to 270px. When the main editor area is hosting an attached diff editor or integrated browser next to the auxiliary bar, the auxiliary bar keeps that same 270px minimum width and the sash no longer snaps it closed; the titlebar toggle action still hides and shows the auxiliary bar as before.
+The sessions auxiliary bar can generally be resized down to 270px. When the main editor part is visible (i.e. any editor is open in the main editor area adjacent to the auxiliary bar), the sash no longer snaps it closed; the titlebar toggle action still hides and shows the auxiliary bar as before. This behavior is automatic and applies to all editor types without requiring an explicit allowlist.
 
 ### 4.3 Editor Modal
 
@@ -663,6 +663,7 @@ interface IPartVisibilityState {
 |------|--------|
 | 2026-04-22 | Added sessions-only toast offset overrides so notification toasts now use `right: 15px` in the default bottom-right placement and `left: 15px` in the bottom-left placement, matching the notification center spacing. |
 | 2026-04-22 | Added a sessions-workbench notification offset override so the shared notification controllers no longer push top-right notifications down to `42px`; sessions now reapply a fixed `40px` top offset for top-right notification center/toast placement. |
+| 2026-04-22 | Generalized the auxiliary bar snap-close prevention to trigger whenever the main editor part is visible (any editor type), and increased the editor part minimum width from 220px to 300px. |
 | 2026-04-22 | Updated the sessions auxiliary bar sizing rules so attached diff editors and integrated browser editors keep the normal 270px auxiliary-bar minimum width while disabling sash snap-to-close in that state, and the titlebar toggle continues to hide/show the secondary sidebar normally. |
 | 2026-04-21 | Updated the sessions chat composite bar tabs to preserve each chat title's original casing instead of applying per-word capitalization. |
 | 2026-04-21 | Moved the sessions-only default notification placement to bottom-right and documented the sessions-specific notification center offsets: `15px` from the bottom/right or bottom/left edges, and `top: 40px; right: 15px;` for top-right placement. |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -172,12 +172,14 @@ This structure places the sidebar at the root level spanning the full window hei
 | Part | Default Size |
 |------|--------------|
 | Sidebar | 300px width |
-| Auxiliary Bar | 300px width |
+| Auxiliary Bar | 380px width |
 | Chat Bar | Remaining space |
 | Panel | 300px height |
 | Titlebar | Determined by `minimumHeight` (~30px) |
 
 The sessions sidebar can be resized down to a minimum width of 170px (desktop) or 270px (web, sized to fit the titlebar's left toolbar which includes the host filter combo).
+
+The sessions auxiliary bar can generally be resized down to 270px. When the main editor area is hosting an attached diff editor or integrated browser next to the auxiliary bar, the auxiliary bar keeps that same 270px minimum width and the sash no longer snaps it closed; the titlebar toggle action still hides and shows the auxiliary bar as before.
 
 ### 4.3 Editor Modal
 
@@ -661,6 +663,7 @@ interface IPartVisibilityState {
 |------|--------|
 | 2026-04-22 | Added sessions-only toast offset overrides so notification toasts now use `right: 15px` in the default bottom-right placement and `left: 15px` in the bottom-left placement, matching the notification center spacing. |
 | 2026-04-22 | Added a sessions-workbench notification offset override so the shared notification controllers no longer push top-right notifications down to `42px`; sessions now reapply a fixed `40px` top offset for top-right notification center/toast placement. |
+| 2026-04-22 | Updated the sessions auxiliary bar sizing rules so attached diff editors and integrated browser editors keep the normal 270px auxiliary-bar minimum width while disabling sash snap-to-close in that state, and the titlebar toggle continues to hide/show the secondary sidebar normally. |
 | 2026-04-21 | Updated the sessions chat composite bar tabs to preserve each chat title's original casing instead of applying per-word capitalization. |
 | 2026-04-21 | Moved the sessions-only default notification placement to bottom-right and documented the sessions-specific notification center offsets: `15px` from the bottom/right or bottom/left edges, and `top: 40px; right: 15px;` for top-right placement. |
 | 2026-04-17 | Added a subtle 1px titlebar-token border around the sessions account widget's GitHub profile image, including the inactive-window variant, and documented the avatar chrome in the layout spec. |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -663,7 +663,7 @@ interface IPartVisibilityState {
 |------|--------|
 | 2026-04-22 | Added sessions-only toast offset overrides so notification toasts now use `right: 15px` in the default bottom-right placement and `left: 15px` in the bottom-left placement, matching the notification center spacing. |
 | 2026-04-22 | Added a sessions-workbench notification offset override so the shared notification controllers no longer push top-right notifications down to `42px`; sessions now reapply a fixed `40px` top offset for top-right notification center/toast placement. |
-| 2026-04-22 | Generalized the auxiliary bar snap-close prevention to trigger whenever the main editor part is visible (any editor type), and increased the editor part minimum width from 220px to 300px. |
+| 2026-04-22 | Generalized the auxiliary bar snap-close prevention to trigger whenever the main editor part is visible (any editor type), so the behavior now applies automatically without maintaining an editor-type allowlist. |
 | 2026-04-22 | Updated the sessions auxiliary bar sizing rules so attached diff editors and integrated browser editors keep the normal 270px auxiliary-bar minimum width while disabling sash snap-to-close in that state, and the titlebar toggle continues to hide/show the secondary sidebar normally. |
 | 2026-04-21 | Updated the sessions chat composite bar tabs to preserve each chat title's original casing instead of applying per-word capitalization. |
 | 2026-04-21 | Moved the sessions-only default notification placement to bottom-right and documented the sessions-specific notification center offsets: `15px` from the bottom/right or bottom/left edges, and `top: 40px; right: 15px;` for top-right placement. |

--- a/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
@@ -36,8 +36,6 @@ import { getFlatContextMenuActions } from '../../../platform/actions/browser/men
 import { IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { Extensions } from '../../../workbench/browser/panecomposite.js';
 import { mainWindow } from '../../../base/browser/window.js';
-import { IEditorService } from '../../../workbench/services/editor/common/editorService.js';
-import { DiffEditorInput } from '../../../workbench/common/editor/diffEditorInput.js';
 
 /**
  * Auxiliary bar part specifically for agent sessions workbench.
@@ -59,12 +57,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	private static readonly RUN_SCRIPT_ACTION_ID = 'workbench.action.agentSessions.runScript';
 	private static readonly RUN_SCRIPT_DROPDOWN_MENU_ID = MenuId.for('AgentSessionsRunScriptDropdown');
 	private static readonly DEFAULT_MINIMUM_WIDTH = 270;
-	private static readonly MULTI_DIFF_EDITOR_INPUT_ID = 'workbench.input.multiDiffEditor';
-	private static readonly INTEGRATED_BROWSER_EDITOR_IDS = new Set([
-		'mainThreadWebview-browserPreview',
-		'mainThreadWebview-simpleBrowser.view',
-		'workbench.editor.browser', // BrowserEditorInput used by workbench.browser.openLocalhostLinks
-	]);
 
 	// Run script dropdown management
 	private readonly _runScriptDropdown = this._register(new MutableDisposable<DropdownWithPrimaryActionViewItem>());
@@ -116,7 +108,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IExtensionService extensionService: IExtensionService,
 		@IMenuService menuService: IMenuService,
-		@IEditorService private readonly editorService: IEditorService,
 	) {
 		super(
 			Parts.AUXILIARYBAR_PART,
@@ -154,7 +145,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 				this._onDidChange.fire(undefined);
 			}
 		}));
-		this._register(this.editorService.onDidVisibleEditorsChange(() => this._onDidChange.fire(undefined)));
 	}
 
 	override create(parent: HTMLElement): void {
@@ -275,13 +265,8 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	}
 
 	private hasAttachedEditorRequiringSidebarSpace(): boolean {
-		if (!this.layoutService.isVisible(Parts.AUXILIARYBAR_PART) || !this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
-			return false;
-		}
-
-		return this.editorService.visibleEditors.some(editor => editor.typeId === DiffEditorInput.ID
-			|| editor.typeId === AuxiliaryBarPart.MULTI_DIFF_EDITOR_INPUT_ID
-			|| (typeof editor.editorId === 'string' && AuxiliaryBarPart.INTEGRATED_BROWSER_EDITOR_IDS.has(editor.editorId)));
+		return this.layoutService.isVisible(Parts.AUXILIARYBAR_PART)
+			&& this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow);
 	}
 
 	private fillExtraContextMenuActions(_actions: IAction[]): void { }

--- a/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
@@ -35,6 +35,9 @@ import { IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/a
 import { getFlatContextMenuActions } from '../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { Extensions } from '../../../workbench/browser/panecomposite.js';
+import { mainWindow } from '../../../base/browser/window.js';
+import { IEditorService } from '../../../workbench/services/editor/common/editorService.js';
+import { DiffEditorInput } from '../../../workbench/common/editor/diffEditorInput.js';
 
 /**
  * Auxiliary bar part specifically for agent sessions workbench.
@@ -55,6 +58,12 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	// Action ID for run script - defined here to avoid layering issues
 	private static readonly RUN_SCRIPT_ACTION_ID = 'workbench.action.agentSessions.runScript';
 	private static readonly RUN_SCRIPT_DROPDOWN_MENU_ID = MenuId.for('AgentSessionsRunScriptDropdown');
+	private static readonly DEFAULT_MINIMUM_WIDTH = 270;
+	private static readonly MULTI_DIFF_EDITOR_INPUT_ID = 'workbench.input.multiDiffEditor';
+	private static readonly INTEGRATED_BROWSER_EDITOR_IDS = new Set([
+		'mainThreadWebview-browserPreview',
+		'mainThreadWebview-simpleBrowser.view',
+	]);
 
 	// Run script dropdown management
 	private readonly _runScriptDropdown = this._register(new MutableDisposable<DropdownWithPrimaryActionViewItem>());
@@ -62,10 +71,15 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	private readonly _runScriptMenuListener = this._register(new MutableDisposable<IDisposable>());
 
 	// Sessions-specific auxiliary bar dimensions (intentionally not tied to the sessions SidebarPart values)
-	override readonly minimumWidth: number = 270;
+	override get minimumWidth(): number {
+		return AuxiliaryBarPart.DEFAULT_MINIMUM_WIDTH;
+	}
 	override readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	override readonly minimumHeight: number = 0;
 	override readonly maximumHeight: number = Number.POSITIVE_INFINITY;
+	override get snap(): boolean {
+		return this.hasAttachedEditorRequiringSidebarSpace() ? false : super.snap;
+	}
 
 	get preferredHeight(): number | undefined {
 		return this.layoutService.mainContainerDimension.height * 0.4;
@@ -101,6 +115,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IExtensionService extensionService: IExtensionService,
 		@IMenuService menuService: IMenuService,
+		@IEditorService private readonly editorService: IEditorService,
 	) {
 		super(
 			Parts.AUXILIARYBAR_PART,
@@ -133,6 +148,12 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			menuService,
 		);
 
+		this._register(this.layoutService.onDidChangePartVisibility(e => {
+			if (e.partId === Parts.AUXILIARYBAR_PART || e.partId === Parts.EDITOR_PART) {
+				this._onDidChange.fire(undefined);
+			}
+		}));
+		this._register(this.editorService.onDidVisibleEditorsChange(() => this._onDidChange.fire(undefined)));
 	}
 
 	override create(parent: HTMLElement): void {
@@ -250,6 +271,16 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			};
 			this._runScriptDropdown.value.update(dropdownAction, dropdownActions);
 		}
+	}
+
+	private hasAttachedEditorRequiringSidebarSpace(): boolean {
+		if (!this.layoutService.isVisible(Parts.AUXILIARYBAR_PART) || !this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow)) {
+			return false;
+		}
+
+		return this.editorService.visibleEditors.some(editor => editor.typeId === DiffEditorInput.ID
+			|| editor.typeId === AuxiliaryBarPart.MULTI_DIFF_EDITOR_INPUT_ID
+			|| (typeof editor.editorId === 'string' && AuxiliaryBarPart.INTEGRATED_BROWSER_EDITOR_IDS.has(editor.editorId)));
 	}
 
 	private fillExtraContextMenuActions(_actions: IAction[]): void { }

--- a/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
+++ b/src/vs/sessions/browser/parts/auxiliaryBarPart.ts
@@ -63,6 +63,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	private static readonly INTEGRATED_BROWSER_EDITOR_IDS = new Set([
 		'mainThreadWebview-browserPreview',
 		'mainThreadWebview-simpleBrowser.view',
+		'workbench.editor.browser', // BrowserEditorInput used by workbench.browser.openLocalhostLinks
 	]);
 
 	// Run script dropdown management

--- a/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
+++ b/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
 import { Emitter } from '../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, Parts } from '../../../workbench/services/layout/browser/layoutService.js';
+import { IViewDescriptorService } from '../../../workbench/common/views.js';
+import { ViewDescriptorService } from '../../../workbench/services/views/browser/viewDescriptorService.js';
 import { TestLayoutService, workbenchInstantiationService } from '../../../workbench/test/browser/workbenchTestServices.js';
 import { AuxiliaryBarPart } from '../../browser/parts/auxiliaryBarPart.js';
 
@@ -37,25 +38,20 @@ class MutableTestLayoutService extends TestLayoutService {
 }
 
 suite('Sessions - Auxiliary Bar Part', () => {
-	const disposables = new DisposableStore();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
 	let layoutService: MutableTestLayoutService;
 	let auxiliaryBarPart: AuxiliaryBarPart;
 
 	setup(() => {
-		layoutService = new MutableTestLayoutService();
+		layoutService = disposables.add(new MutableTestLayoutService());
 		instantiationService = workbenchInstantiationService({}, disposables);
 		instantiationService.stub(IWorkbenchLayoutService, layoutService as IWorkbenchLayoutService);
+		const viewDescriptorService = disposables.add(instantiationService.createInstance(ViewDescriptorService));
+		instantiationService.stub(IViewDescriptorService, viewDescriptorService);
 		auxiliaryBarPart = disposables.add(instantiationService.createInstance(AuxiliaryBarPart));
 	});
-
-	teardown(() => {
-		layoutService.dispose();
-		disposables.clear();
-	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('keeps the default minimum width and disables sash snap when the editor part is visible', () => {
 		layoutService.setVisible(Parts.EDITOR_PART, true);

--- a/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
+++ b/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { EditorInput } from '../../../workbench/common/editor/editorInput.js';
+import { DiffEditorInput } from '../../../workbench/common/editor/diffEditorInput.js';
+import { IEditorService } from '../../../workbench/services/editor/common/editorService.js';
+import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, Parts } from '../../../workbench/services/layout/browser/layoutService.js';
+import { TestLayoutService, workbenchInstantiationService } from '../../../workbench/test/browser/workbenchTestServices.js';
+import { AuxiliaryBarPart } from '../../browser/parts/auxiliaryBarPart.js';
+
+const MULTI_DIFF_EDITOR_INPUT_ID = 'workbench.input.multiDiffEditor';
+
+class MutableTestLayoutService extends TestLayoutService {
+
+	private readonly _visibleParts = new Map<Parts, boolean>([
+		[Parts.AUXILIARYBAR_PART, true],
+		[Parts.EDITOR_PART, false],
+	]);
+
+	private readonly _onDidChangePartVisibility = new Emitter<IPartVisibilityChangeEvent>();
+	override readonly onDidChangePartVisibility = this._onDidChangePartVisibility.event;
+
+	override isVisible(part: Parts, _targetWindow?: Window): boolean {
+		return this._visibleParts.get(part) ?? false;
+	}
+
+	setVisible(part: Parts, visible: boolean): void {
+		this._visibleParts.set(part, visible);
+		this._onDidChangePartVisibility.fire({ partId: part, visible });
+	}
+
+	dispose(): void {
+		this._onDidChangePartVisibility.dispose();
+	}
+}
+
+class MutableTestEditorService implements Partial<IEditorService> {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidVisibleEditorsChange = new Emitter<void>();
+	readonly onDidVisibleEditorsChange = this._onDidVisibleEditorsChange.event;
+	readonly onDidActiveEditorChange = Event.None;
+	readonly onDidEditorsChange = Event.None;
+	readonly onWillOpenEditor = Event.None;
+	readonly onDidCloseEditor = Event.None;
+	readonly visibleEditorPanes = [];
+	readonly visibleTextEditorControls = [];
+	visibleEditors: readonly EditorInput[] = [];
+
+	setVisibleEditors(editors: readonly EditorInput[]): void {
+		this.visibleEditors = editors;
+		this._onDidVisibleEditorsChange.fire();
+	}
+
+	dispose(): void {
+		this._onDidVisibleEditorsChange.dispose();
+	}
+}
+
+function createEditorInput(typeId: string, editorId?: string): EditorInput {
+	return { typeId, editorId } as EditorInput;
+}
+
+suite('Sessions - Auxiliary Bar Part', () => {
+	const disposables = new DisposableStore();
+
+	let instantiationService: TestInstantiationService;
+	let layoutService: MutableTestLayoutService;
+	let editorService: MutableTestEditorService;
+	let auxiliaryBarPart: AuxiliaryBarPart;
+
+	setup(() => {
+		layoutService = new MutableTestLayoutService();
+		editorService = new MutableTestEditorService();
+		instantiationService = workbenchInstantiationService({
+			editorService: () => editorService as unknown as IEditorService
+		}, disposables);
+		instantiationService.stub(IWorkbenchLayoutService, layoutService as IWorkbenchLayoutService);
+		auxiliaryBarPart = disposables.add(instantiationService.createInstance(AuxiliaryBarPart));
+	});
+
+	teardown(() => {
+		layoutService.dispose();
+		editorService.dispose();
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('keeps the default minimum width and disables sash snap for diff editors', () => {
+		layoutService.setVisible(Parts.EDITOR_PART, true);
+		editorService.setVisibleEditors([createEditorInput(DiffEditorInput.ID)]);
+
+		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		assert.strictEqual(auxiliaryBarPart.snap, false);
+	});
+
+	test('keeps the default minimum width and disables sash snap for integrated browser editors', () => {
+		layoutService.setVisible(Parts.EDITOR_PART, true);
+		editorService.setVisibleEditors([createEditorInput('workbench.input.webview', 'mainThreadWebview-simpleBrowser.view')]);
+
+		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		assert.strictEqual(auxiliaryBarPart.snap, false);
+	});
+
+	test('restores the default auxiliary bar constraints for other editor states', () => {
+		layoutService.setVisible(Parts.EDITOR_PART, true);
+		editorService.setVisibleEditors([createEditorInput(MULTI_DIFF_EDITOR_INPUT_ID)]);
+		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		assert.strictEqual(auxiliaryBarPart.snap, false);
+
+		editorService.setVisibleEditors([createEditorInput('workbench.editors.textEditorInput')]);
+
+		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		assert.strictEqual(auxiliaryBarPart.snap, true);
+	});
+});

--- a/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
+++ b/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
@@ -5,17 +5,12 @@
 
 import assert from 'assert';
 import { DisposableStore } from '../../../base/common/lifecycle.js';
-import { Emitter, Event } from '../../../base/common/event.js';
+import { Emitter } from '../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { EditorInput } from '../../../workbench/common/editor/editorInput.js';
-import { DiffEditorInput } from '../../../workbench/common/editor/diffEditorInput.js';
-import { IEditorService } from '../../../workbench/services/editor/common/editorService.js';
 import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, Parts } from '../../../workbench/services/layout/browser/layoutService.js';
 import { TestLayoutService, workbenchInstantiationService } from '../../../workbench/test/browser/workbenchTestServices.js';
 import { AuxiliaryBarPart } from '../../browser/parts/auxiliaryBarPart.js';
-
-const MULTI_DIFF_EDITOR_INPUT_ID = 'workbench.input.multiDiffEditor';
 
 class MutableTestLayoutService extends TestLayoutService {
 
@@ -41,93 +36,39 @@ class MutableTestLayoutService extends TestLayoutService {
 	}
 }
 
-class MutableTestEditorService implements Partial<IEditorService> {
-
-	declare readonly _serviceBrand: undefined;
-
-	private readonly _onDidVisibleEditorsChange = new Emitter<void>();
-	readonly onDidVisibleEditorsChange = this._onDidVisibleEditorsChange.event;
-	readonly onDidActiveEditorChange = Event.None;
-	readonly onDidEditorsChange = Event.None;
-	readonly onWillOpenEditor = Event.None;
-	readonly onDidCloseEditor = Event.None;
-	readonly visibleEditorPanes = [];
-	readonly visibleTextEditorControls = [];
-	visibleEditors: readonly EditorInput[] = [];
-
-	setVisibleEditors(editors: readonly EditorInput[]): void {
-		this.visibleEditors = editors;
-		this._onDidVisibleEditorsChange.fire();
-	}
-
-	dispose(): void {
-		this._onDidVisibleEditorsChange.dispose();
-	}
-}
-
-function createEditorInput(typeId: string, editorId?: string): EditorInput {
-	return { typeId, editorId } as EditorInput;
-}
-
 suite('Sessions - Auxiliary Bar Part', () => {
 	const disposables = new DisposableStore();
 
 	let instantiationService: TestInstantiationService;
 	let layoutService: MutableTestLayoutService;
-	let editorService: MutableTestEditorService;
 	let auxiliaryBarPart: AuxiliaryBarPart;
 
 	setup(() => {
 		layoutService = new MutableTestLayoutService();
-		editorService = new MutableTestEditorService();
-		instantiationService = workbenchInstantiationService({
-			editorService: () => editorService as unknown as IEditorService
-		}, disposables);
+		instantiationService = workbenchInstantiationService({}, disposables);
 		instantiationService.stub(IWorkbenchLayoutService, layoutService as IWorkbenchLayoutService);
 		auxiliaryBarPart = disposables.add(instantiationService.createInstance(AuxiliaryBarPart));
 	});
 
 	teardown(() => {
 		layoutService.dispose();
-		editorService.dispose();
 		disposables.clear();
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('keeps the default minimum width and disables sash snap for diff editors', () => {
+	test('keeps the default minimum width and disables sash snap when the editor part is visible', () => {
 		layoutService.setVisible(Parts.EDITOR_PART, true);
-		editorService.setVisibleEditors([createEditorInput(DiffEditorInput.ID)]);
 
 		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
 		assert.strictEqual(auxiliaryBarPart.snap, false);
 	});
 
-	test('keeps the default minimum width and disables sash snap for integrated browser editors', () => {
+	test('restores sash snap when the editor part is hidden', () => {
 		layoutService.setVisible(Parts.EDITOR_PART, true);
-		editorService.setVisibleEditors([createEditorInput('workbench.input.webview', 'mainThreadWebview-simpleBrowser.view')]);
-
-		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
-		assert.strictEqual(auxiliaryBarPart.snap, false);
-	});
-
-	test('keeps the default minimum width and disables sash snap for localhost link browser editors', () => {
-		layoutService.setVisible(Parts.EDITOR_PART, true);
-		editorService.setVisibleEditors([createEditorInput('workbench.editorinputs.browser', 'workbench.editor.browser')]);
-
-		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
-		assert.strictEqual(auxiliaryBarPart.snap, false);
-	});
-
-	test('restores the default auxiliary bar constraints for other editor states', () => {
-		layoutService.setVisible(Parts.EDITOR_PART, true);
-		editorService.setVisibleEditors([createEditorInput(MULTI_DIFF_EDITOR_INPUT_ID)]);
-		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
 		assert.strictEqual(auxiliaryBarPart.snap, false);
 
-		editorService.setVisibleEditors([createEditorInput('workbench.editors.textEditorInput')]);
-
-		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		layoutService.setVisible(Parts.EDITOR_PART, false);
 		assert.strictEqual(auxiliaryBarPart.snap, true);
 	});
 });

--- a/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
+++ b/src/vs/sessions/test/browser/auxiliaryBarPart.test.ts
@@ -111,6 +111,14 @@ suite('Sessions - Auxiliary Bar Part', () => {
 		assert.strictEqual(auxiliaryBarPart.snap, false);
 	});
 
+	test('keeps the default minimum width and disables sash snap for localhost link browser editors', () => {
+		layoutService.setVisible(Parts.EDITOR_PART, true);
+		editorService.setVisibleEditors([createEditorInput('workbench.editorinputs.browser', 'workbench.editor.browser')]);
+
+		assert.strictEqual(auxiliaryBarPart.minimumWidth, 270);
+		assert.strictEqual(auxiliaryBarPart.snap, false);
+	});
+
 	test('restores the default auxiliary bar constraints for other editor states', () => {
 		layoutService.setVisible(Parts.EDITOR_PART, true);
 		editorService.setVisibleEditors([createEditorInput(MULTI_DIFF_EDITOR_INPUT_ID)]);

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -25,7 +25,7 @@ export interface IEditorPartCreationOptions {
 	readonly restorePreviousState: boolean;
 }
 
-export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(220, 70);
+export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(300, 70);
 export const DEFAULT_EDITOR_MAX_DIMENSIONS = new Dimension(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
 
 export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -25,7 +25,7 @@ export interface IEditorPartCreationOptions {
 	readonly restorePreviousState: boolean;
 }
 
-export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(300, 70);
+export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(220, 70);
 export const DEFAULT_EDITOR_MAX_DIMENSIONS = new Dimension(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
 
 export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {


### PR DESCRIPTION
## Summary
- keep the sessions auxiliary bar from snapping closed when an attached diff editor or integrated browser is visible beside it
- preserve the normal 270px auxiliary bar minimum width and leave the titlebar secondary-sidebar toggle behavior unchanged
- add focused sessions tests for the attached-editor constraint and document the layout behavior in `src/vs/sessions/LAYOUT.md`

https://github.com/user-attachments/assets/16d06a46-979f-446d-8029-88e08cf74c7a

## Why
Dragging the auxiliary bar sash all the way closed while attached editors are still visible leaves the sessions layout in a broken visual state. This keeps the sash from collapsing the sidebar in that specific attached-editor scenario without changing the explicit toggle action.