### PR TITLE
Post update release notes polish

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -83,6 +83,7 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('showPostInstallInfo', "Show a post-install update tooltip in the title bar instead of opening the release notes editor."),
+			tags: ['usesOnlineServices']
 		}
 	}
 });

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -82,7 +82,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('showPostInstallInfo', "Show update information tooltip in the title bar after a new version is installed. When enabled, the Release Notes editor will not be shown automatically."),
+			description: localize('showPostInstallInfo', "Show a post-install update tooltip in the title bar instead of opening the release notes editor."),
 		}
 	}
 });

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -80,10 +80,9 @@ configurationRegistry.registerConfiguration({
 		},
 		'update.showPostInstallInfo': {
 			type: 'boolean',
-			default: true,
+			default: false,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('showPostInstallInfo', "Show update information tooltip in the title bar after a new version is installed."),
-			included: false,
+			description: localize('showPostInstallInfo', "Show update information tooltip in the title bar after a new version is installed. When enabled, the Release Notes editor will not be shown automatically."),
 		}
 	}
 });

--- a/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
+++ b/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
@@ -3,16 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Allow the hover container to size to its content (no scrollbar). */
-.monaco-hover.workbench-hover.post-update-widget-hover {
-	max-height: none !important;
-	overflow: visible !important;
-}
-
+/*
+ * The widget supplies its own padding and border-radius via `.post-update-widget`,
+ * so we strip the compact hover's contents padding. The selector below is at least as
+ * specific as `.monaco-hover.workbench-hover.compact .hover-contents` and loads after it,
+ * so it wins without `!important`.
+ */
 .monaco-hover.workbench-hover.post-update-widget-hover .hover-contents {
-	max-height: none !important;
-	overflow: visible !important;
-	padding: 0 !important;
+	padding: 0;
 }
 
 .post-update-widget {

--- a/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
+++ b/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
@@ -16,10 +16,10 @@
 }
 
 .post-update-widget {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	min-width: 320px;
-	width: 380px;
 	max-width: 420px;
 	color: var(--vscode-descriptionForeground);
 	font-size: var(--vscode-bodyFontSize-small);
@@ -30,7 +30,7 @@
 /* Banner */
 .post-update-widget .banner {
 	position: relative;
-	height: 140px;
+	min-height: 140px;
 	background-position: center;
 	background-size: cover;
 	background-repeat: no-repeat;
@@ -59,6 +59,7 @@
 	border-radius: var(--vscode-cornerRadius-small);
 	cursor: pointer;
 	padding: 0;
+	z-index: 1;
 }
 
 .post-update-widget .banner-close:hover {

--- a/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
+++ b/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
@@ -30,7 +30,8 @@
 /* Banner */
 .post-update-widget .banner {
 	position: relative;
-	min-height: 140px;
+	aspect-ratio: 16 / 5;
+	min-height: 90px;
 	background-position: center;
 	background-size: cover;
 	background-repeat: no-repeat;

--- a/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
+++ b/src/vs/workbench/contrib/update/browser/media/postUpdateWidget.css
@@ -3,27 +3,140 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* Allow the hover container to size to its content (no scrollbar). */
+.monaco-hover.workbench-hover.post-update-widget-hover {
+	max-height: none !important;
+	overflow: visible !important;
+}
+
+.monaco-hover.workbench-hover.post-update-widget-hover .hover-contents {
+	max-height: none !important;
+	overflow: visible !important;
+	padding: 0 !important;
+}
+
 .post-update-widget {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	padding: 6px 6px;
-	min-width: 300px;
-	max-width: 550px;
+	min-width: 320px;
+	width: 380px;
+	max-width: 420px;
 	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-bodyFontSize-small);
+	border-radius: var(--vscode-cornerRadius-medium);
+	overflow: hidden;
+}
+
+/* Banner */
+.post-update-widget .banner {
+	position: relative;
+	height: 140px;
+	background-position: center;
+	background-size: cover;
+	background-repeat: no-repeat;
+	/* Default: VS Code "copilot free" gradient (recreated with layered radial gradients) */
+	background-color: #0b1020;
+	background-image:
+		radial-gradient(ellipse 60% 80% at 12% 90%, rgba(132, 204, 22, 0.55), transparent 60%),
+		radial-gradient(ellipse 70% 90% at 25% 30%, rgba(56, 189, 248, 0.45), transparent 65%),
+		radial-gradient(ellipse 90% 100% at 75% 60%, rgba(99, 102, 241, 0.55), transparent 70%),
+		radial-gradient(ellipse 60% 80% at 100% 100%, rgba(30, 27, 75, 0.7), transparent 70%),
+		linear-gradient(135deg, #0b1020 0%, #1e1b4b 100%);
+}
+
+.post-update-widget .banner-close {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 22px;
+	height: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	color: var(--vscode-icon-foreground);
+	border: none;
+	border-radius: var(--vscode-cornerRadius-small);
+	cursor: pointer;
+	padding: 0;
+}
+
+.post-update-widget .banner-close:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+/* Body */
+.post-update-widget .body {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	padding: 16px;
+}
+
+/* Badge */
+.post-update-widget .badge {
+	align-self: flex-start;
+	padding: 2px 8px;
+	border-radius: var(--vscode-cornerRadius-small);
+	background-color: var(--vscode-extensionBadge-remoteBackground, var(--vscode-badge-background));
+	color: var(--vscode-extensionBadge-remoteForeground, var(--vscode-badge-foreground));
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.4;
+	text-transform: none;
+}
+
+/* Title */
+.post-update-widget .title {
+	font-weight: 600;
+	font-size: 16px;
+	line-height: 1.3;
+	color: var(--vscode-foreground);
+}
+
+/* Features */
+.post-update-widget .features {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.post-update-widget .feature {
+	display: grid;
+	grid-template-columns: 20px 1fr;
+	column-gap: 12px;
+	align-items: start;
+}
+
+.post-update-widget .feature-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--vscode-foreground);
+	margin-top: 2px;
+	font-size: 16px;
+}
+
+.post-update-widget .feature-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.post-update-widget .feature-title {
+	font-weight: 600;
+	color: var(--vscode-foreground);
 	font-size: var(--vscode-bodyFontSize-small);
 }
 
-/* Header */
-.post-update-widget .header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+.post-update-widget .feature-description {
+	color: var(--vscode-descriptionForeground);
+	font-size: var(--vscode-bodyFontSize-small);
+	line-height: 1.4;
 }
 
-.post-update-widget .header .title {
-	font-weight: 600;
-	font-size: var(--vscode-bodyFontSize);
+/* Markdown fallback */
+.post-update-widget .update-markdown {
 	color: var(--vscode-foreground);
 }
 
@@ -33,12 +146,14 @@
 	justify-content: flex-end;
 	align-items: center;
 	gap: 8px;
+	margin-top: 4px;
 }
 
 .post-update-widget .button-bar button {
-	padding: 4px 12px;
+	padding: 8px 16px;
 	border-radius: var(--vscode-cornerRadius-small);
 	font-size: var(--vscode-bodyFontSize-small);
+	font-weight: 600;
 	cursor: pointer;
 	white-space: nowrap;
 }
@@ -65,4 +180,10 @@
 
 .post-update-widget .update-button-primary:hover {
 	background-color: var(--vscode-button-hoverBackground);
+}
+
+.post-update-widget .update-button-full-width {
+	width: 100%;
+	justify-content: center;
+	text-align: center;
 }

--- a/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
+++ b/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
@@ -107,6 +107,7 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 			additionalClasses: ['post-update-widget-hover'],
 			persistence: { sticky: true },
 			appearance: { showPointer: false, compact: true, maxHeightRatio: 1 },
+			trapFocus: true,
 		}, true);
 	}
 

--- a/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
+++ b/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
@@ -27,6 +27,9 @@ import { IParsedUpdateInfoInput, parseUpdateInfoInput } from '../common/updateIn
 import { getUpdateInfoUrl, isMajorMinorVersionChange } from '../common/updateUtils.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { KeyCode } from '../../../../base/common/keyCodes.js';
+import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
+import { URI } from '../../../../base/common/uri.js';
 import './media/postUpdateWidget.css';
 
 const LAST_KNOWN_VERSION_KEY = 'postUpdateWidget/lastKnownVersion';
@@ -144,16 +147,27 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 		container.setAttribute('role', 'dialog');
 		container.setAttribute('aria-labelledby', titleId);
 
-		// Banner (decorative)
+		// Dismiss on Escape
+		disposables.add(dom.addDisposableListener(container, 'keydown', (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.keyCode === KeyCode.Escape) {
+				event.stopPropagation();
+				this.hoverService.hideHover(true);
+			}
+		}));
+
+		// Banner (decorative). Default is a CSS gradient; an image from the markdown frontmatter overrides it.
 		const banner = dom.append(container, dom.$('.banner'));
 		banner.setAttribute('aria-hidden', 'true');
-		if (bannerImageUrl) {
-			banner.style.backgroundImage = `url("${CSS.escape(bannerImageUrl)}")`;
+		const safeBannerUrl = sanitizeBannerImageUrl(bannerImageUrl);
+		if (safeBannerUrl) {
+			// Use setProperty + JSON.stringify to safely quote the URL inside CSS without breaking out.
+			banner.style.setProperty('background-image', `url(${JSON.stringify(safeBannerUrl)})`);
 		}
 
-		const closeButton = dom.append(banner, dom.$('button.banner-close')) as HTMLButtonElement;
+		// Close button is a sibling of the banner so it isn't a focusable descendant of an aria-hidden region.
+		const closeButton = dom.append(container, dom.$('button.banner-close')) as HTMLButtonElement;
 		closeButton.setAttribute('aria-label', localize('postUpdate.close', "Close"));
-		closeButton.removeAttribute('aria-hidden');
 		const closeIcon = dom.append(closeButton, dom.$(ThemeIcon.asCSSSelector(Codicon.close)));
 		closeIcon.setAttribute('aria-hidden', 'true');
 		disposables.add(dom.addDisposableListener(closeButton, 'click', () => {
@@ -273,4 +287,26 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 
 		return false;
 	}
+}
+
+/**
+ * Validates a banner image URL from update info. Only `https:` and `data:image/*` schemes are
+ * allowed to prevent CSS-injection or unexpected protocol handlers being invoked from the markdown payload.
+ */
+function sanitizeBannerImageUrl(value: string | undefined): string | undefined {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		const uri = URI.parse(value, true);
+		if (uri.scheme === 'https') {
+			return uri.toString(true);
+		}
+		if (uri.scheme === 'data' && /^image\//i.test(uri.path)) {
+			return uri.toString(true);
+		}
+	} catch {
+		// fall through
+	}
+	return undefined;
 }

--- a/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
+++ b/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
@@ -27,8 +27,6 @@ import { IParsedUpdateInfoInput, parseUpdateInfoInput } from '../common/updateIn
 import { getUpdateInfoUrl, isMajorMinorVersionChange } from '../common/updateUtils.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { KeyCode } from '../../../../base/common/keyCodes.js';
-import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { URI } from '../../../../base/common/uri.js';
 import './media/postUpdateWidget.css';
 
@@ -146,15 +144,8 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 		const titleId = `post-update-widget-title-${PostUpdateWidgetContribution.idCounter++}`;
 		container.setAttribute('role', 'dialog');
 		container.setAttribute('aria-labelledby', titleId);
-
-		// Dismiss on Escape
-		disposables.add(dom.addDisposableListener(container, 'keydown', (e: KeyboardEvent) => {
-			const event = new StandardKeyboardEvent(e);
-			if (event.keyCode === KeyCode.Escape) {
-				event.stopPropagation();
-				this.hoverService.hideHover(true);
-			}
-		}));
+		// Escape-to-dismiss is handled by the hover widget itself (HoverWidget listens for Escape
+		// on its container and disposes the hover).
 
 		// Banner (decorative). Default is a CSS gradient; an image from the markdown frontmatter overrides it.
 		const banner = dom.append(container, dom.$('.banner'));
@@ -181,7 +172,6 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 		if (badge) {
 			const badgeEl = dom.append(body, dom.$('.badge'));
 			badgeEl.textContent = badge;
-			badgeEl.setAttribute('aria-label', localize('postUpdate.badgeLabel', "{0} badge", badge));
 		}
 
 		// Title
@@ -205,7 +195,19 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 				const featureTitle = dom.append(text, dom.$('.feature-title'));
 				featureTitle.textContent = feature.title;
 				const featureDescription = dom.append(text, dom.$('.feature-description'));
-				featureDescription.textContent = feature.description;
+				// Render description as markdown so it can include inline links and emphasis.
+				const rendered = disposables.add(this.markdownRendererService.render(
+					new MarkdownString(feature.description, {
+						isTrusted: true,
+						supportThemeIcons: true,
+					}),
+					{
+						actionHandler: (link, mdStr) => {
+							openLinkFromMarkdown(this.openerService, link, mdStr.isTrusted);
+							this.hoverService.hideHover(true);
+						},
+					}));
+				featureDescription.appendChild(rendered.element);
 			}
 		} else if (markdown) {
 			const markdownContainer = dom.append(body, dom.$('.update-markdown'));

--- a/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
+++ b/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts
@@ -25,6 +25,8 @@ import { IHostService } from '../../../services/host/browser/host.js';
 import { ShowCurrentReleaseNotesActionId } from '../common/update.js';
 import { IParsedUpdateInfoInput, parseUpdateInfoInput } from '../common/updateInfoParser.js';
 import { getUpdateInfoUrl, isMajorMinorVersionChange } from '../common/updateUtils.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 import './media/postUpdateWidget.css';
 
 const LAST_KNOWN_VERSION_KEY = 'postUpdateWidget/lastKnownVersion';
@@ -39,6 +41,8 @@ interface ILastKnownVersion {
  * Displays post-update call-to-action widget after a version change is detected.
  */
 export class PostUpdateWidgetContribution extends Disposable implements IWorkbenchContribution {
+
+	private static idCounter = 0;
 
 	constructor(
 		@ICommandService private readonly commandService: ICommandService,
@@ -88,7 +92,7 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 		const contentDisposables = new DisposableStore();
 		const target = this.layoutService.mainContainer;
 		const { clientWidth } = target;
-		const maxWidth = 550;
+		const maxWidth = 420;
 		const x = Math.max(clientWidth - maxWidth - 80, 16);
 
 		this.hoverService.showInstantHover({
@@ -99,8 +103,9 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 				y: 40,
 				dispose: () => contentDisposables.dispose()
 			},
+			additionalClasses: ['post-update-widget-hover'],
 			persistence: { sticky: true },
-			appearance: { showPointer: false, compact: true, maxHeightRatio: 0.8 },
+			appearance: { showPointer: false, compact: true, maxHeightRatio: 1 },
 		}, true);
 	}
 
@@ -132,33 +137,83 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 		return info;
 	}
 
-	private buildContent({ markdown, buttons }: IParsedUpdateInfoInput, disposables: DisposableStore): HTMLElement {
+	private buildContent(info: IParsedUpdateInfoInput, disposables: DisposableStore): HTMLElement {
+		const { markdown, buttons, bannerImageUrl, badge, title, features } = info;
 		const container = dom.$('.post-update-widget');
+		const titleId = `post-update-widget-title-${PostUpdateWidgetContribution.idCounter++}`;
+		container.setAttribute('role', 'dialog');
+		container.setAttribute('aria-labelledby', titleId);
 
-		// Header
-		const header = dom.append(container, dom.$('.header'));
-		const title = dom.append(header, dom.$('.title'));
-		title.textContent = localize('postUpdate.title', "New in {0}", this.productService.version);
+		// Banner (decorative)
+		const banner = dom.append(container, dom.$('.banner'));
+		banner.setAttribute('aria-hidden', 'true');
+		if (bannerImageUrl) {
+			banner.style.backgroundImage = `url("${CSS.escape(bannerImageUrl)}")`;
+		}
 
-		// Markdown
-		const markdownContainer = dom.append(container, dom.$('.update-markdown'));
-		const rendered = disposables.add(this.markdownRendererService.render(
-			new MarkdownString(markdown, {
-				isTrusted: true,
-				supportHtml: true,
-				supportThemeIcons: true,
-			}),
-			{
-				actionHandler: (link, mdStr) => {
-					openLinkFromMarkdown(this.openerService, link, mdStr.isTrusted);
-					this.hoverService.hideHover(true);
-				},
-			}));
-		markdownContainer.appendChild(rendered.element);
+		const closeButton = dom.append(banner, dom.$('button.banner-close')) as HTMLButtonElement;
+		closeButton.setAttribute('aria-label', localize('postUpdate.close', "Close"));
+		closeButton.removeAttribute('aria-hidden');
+		const closeIcon = dom.append(closeButton, dom.$(ThemeIcon.asCSSSelector(Codicon.close)));
+		closeIcon.setAttribute('aria-hidden', 'true');
+		disposables.add(dom.addDisposableListener(closeButton, 'click', () => {
+			this.hoverService.hideHover(true);
+		}));
+
+		// Body
+		const body = dom.append(container, dom.$('.body'));
+
+		// Badge
+		if (badge) {
+			const badgeEl = dom.append(body, dom.$('.badge'));
+			badgeEl.textContent = badge;
+			badgeEl.setAttribute('aria-label', localize('postUpdate.badgeLabel', "{0} badge", badge));
+		}
+
+		// Title
+		const titleEl = dom.append(body, dom.$('.title'));
+		titleEl.id = titleId;
+		titleEl.textContent = title ?? localize('postUpdate.title', "New in {0}", this.productService.version);
+
+		// Features (preferred) or markdown body
+		if (features?.length) {
+			const list = dom.append(body, dom.$('.features'));
+			list.setAttribute('role', 'list');
+			for (const feature of features) {
+				const row = dom.append(list, dom.$('.feature'));
+				row.setAttribute('role', 'listitem');
+				const iconEl = dom.append(row, dom.$('.feature-icon'));
+				const iconId = feature.icon ?? Codicon.sparkle.id;
+				const themeIcon = ThemeIcon.fromId(iconId);
+				iconEl.classList.add(...ThemeIcon.asClassNameArray(themeIcon));
+				iconEl.setAttribute('aria-hidden', 'true');
+				const text = dom.append(row, dom.$('.feature-text'));
+				const featureTitle = dom.append(text, dom.$('.feature-title'));
+				featureTitle.textContent = feature.title;
+				const featureDescription = dom.append(text, dom.$('.feature-description'));
+				featureDescription.textContent = feature.description;
+			}
+		} else if (markdown) {
+			const markdownContainer = dom.append(body, dom.$('.update-markdown'));
+			const rendered = disposables.add(this.markdownRendererService.render(
+				new MarkdownString(markdown, {
+					isTrusted: true,
+					supportHtml: true,
+					supportThemeIcons: true,
+				}),
+				{
+					actionHandler: (link, mdStr) => {
+						openLinkFromMarkdown(this.openerService, link, mdStr.isTrusted);
+						this.hoverService.hideHover(true);
+					},
+				}));
+			markdownContainer.appendChild(rendered.element);
+		}
 
 		// Buttons
 		if (buttons?.length) {
-			const buttonBar = dom.append(container, dom.$('.button-bar'));
+			const buttonBar = dom.append(body, dom.$('.button-bar'));
+			const isSingleButton = buttons.length === 1;
 			let seenSecondary = false;
 
 			for (const { label, style, commandId, args } of buttons) {
@@ -173,6 +228,10 @@ export class PostUpdateWidgetContribution extends Disposable implements IWorkben
 					}
 				} else {
 					button.classList.add('update-button-primary');
+				}
+
+				if (isSingleButton) {
+					button.classList.add('update-button-full-width');
 				}
 
 				disposables.add(dom.addDisposableListener(button, 'click', () => {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -176,10 +176,11 @@ export class ProductContribution implements IWorkbenchContribution {
 			const lastVersion = tryParseVersion(storageService.get(ProductContribution.KEY, StorageScope.APPLICATION, ''));
 			const currentVersion = tryParseVersion(productService.version);
 			const shouldShowReleaseNotes = configurationService.getValue<boolean>('update.showReleaseNotes');
+			const shouldShowPostInstallInfo = configurationService.getValue<boolean>('update.showPostInstallInfo');
 			const releaseNotesUrl = productService.releaseNotesUrl;
 
-			// was there a major/minor update? if so, open release notes
-			if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes && releaseNotesUrl && lastVersion && currentVersion && isMajorMinorUpdate(lastVersion, currentVersion)) {
+			// was there a major/minor update? if so, open release notes (unless post-install info is enabled, which takes over)
+			if (shouldShowReleaseNotes && !shouldShowPostInstallInfo && !environmentService.skipReleaseNotes && releaseNotesUrl && lastVersion && currentVersion && isMajorMinorUpdate(lastVersion, currentVersion)) {
 				showReleaseNotesInEditor(instantiationService, productService.version, false)
 					.then(undefined, () => {
 						notificationService.prompt(

--- a/src/vs/workbench/contrib/update/common/updateInfoParser.ts
+++ b/src/vs/workbench/contrib/update/common/updateInfoParser.ts
@@ -17,17 +17,35 @@ export interface IUpdateInfoButton {
 }
 
 export interface IUpdateInfoFeature {
+	/**
+	 * Optional Codicon icon identifier (e.g. `$(sparkle)` or `$(lightbulb)`) displayed
+	 * alongside the feature title.
+	 */
 	readonly icon?: string;
+	/** Short title for the feature highlight. */
 	readonly title: string;
+	/** One-line description of the feature. */
 	readonly description: string;
 }
 
 export interface IParsedUpdateInfoInput {
+	/** Markdown body rendered in the update-info widget. */
 	readonly markdown: string;
+	/** Optional action buttons shown below the markdown content. */
 	readonly buttons?: IUpdateInfoButton[];
+	/**
+	 * Optional URL for a banner/hero image shown at the top of the widget.
+	 * Must be an `https://` URL; non-HTTPS URLs are ignored.
+	 */
 	readonly bannerImageUrl?: string;
+	/** Optional short badge label (e.g. `"New"`) displayed on the widget. */
 	readonly badge?: string;
+	/** Optional heading title rendered above the markdown body. */
 	readonly title?: string;
+	/**
+	 * Optional list of feature highlights. At most {@link MAX_FEATURES} entries
+	 * (currently 5) are displayed; any additional entries are silently dropped.
+	 */
 	readonly features?: IUpdateInfoFeature[];
 }
 
@@ -36,13 +54,19 @@ export interface IParsedUpdateInfoInput {
  *
  * Supported formats:
  *
- * **JSON envelope** - a single JSON object with `markdown` and optional `buttons`:
+ * **JSON envelope** - a single JSON object with `markdown` and optional fields:
  * ```json
  * {
  *   "markdown": "$(info) **Feature**<br>Description...",
+ *   "title": "What's New",
+ *   "badge": "New",
+ *   "bannerImageUrl": "https://example.com/banner.png",
  *   "buttons": [
  *     { "label": "Release Notes", "commandId": "update.showCurrentReleaseNotes", "style": "secondary" },
  *     { "label": "Open Sessions", "commandId": "workbench.action.chat.open", "style": "primary" }
+ *   ],
+ *   "features": [
+ *     { "icon": "$(sparkle)", "title": "Feature", "description": "Short description" }
  *   ]
  * }
  * ```
@@ -50,7 +74,7 @@ export interface IParsedUpdateInfoInput {
  * **Block frontmatter** - YAML-style `---` delimiters wrapping a JSON metadata block:
  * ```
  * ---
- * { "buttons": [...] }
+ * { "buttons": [...], "features": [...] }
  * ---
  * $(info) **Feature**<br>Description...
  * ```
@@ -60,6 +84,8 @@ export interface IParsedUpdateInfoInput {
  * --- { "buttons": [...] } ---
  * $(info) **Feature**<br>Description...
  * ```
+ *
+ * At most 5 feature entries are retained; any additional ones are silently dropped.
  */
 export function parseUpdateInfoInput(text: string): IParsedUpdateInfoInput {
 	const normalized = text.replace(/^\uFEFF/, '');
@@ -148,6 +174,12 @@ function parseUpdateInfoButtons(buttons: unknown): IUpdateInfoButton[] | undefin
 	return parsedButtons.length ? parsedButtons : undefined;
 }
 
+/**
+ * Parses an array of feature-highlight objects from raw update-info metadata.
+ * Only the first {@link MAX_FEATURES} valid entries are returned; the rest are
+ * discarded. Each entry must have at minimum a `title` and `description` string.
+ * The optional `icon` field accepts a Codicon identifier (e.g. `$(sparkle)`).
+ */
 function parseUpdateInfoFeatures(features: unknown): IUpdateInfoFeature[] | undefined {
 	if (!Array.isArray(features)) {
 		return undefined;

--- a/src/vs/workbench/contrib/update/common/updateInfoParser.ts
+++ b/src/vs/workbench/contrib/update/common/updateInfoParser.ts
@@ -5,6 +5,8 @@
 
 import { hasKey, Mutable } from '../../../../base/common/types.js';
 
+const MAX_FEATURES = 5;
+
 export type UpdateInfoButtonStyle = 'primary' | 'secondary';
 
 export interface IUpdateInfoButton {
@@ -156,11 +158,15 @@ function parseUpdateInfoFeatures(features: unknown): IUpdateInfoFeature[] | unde
 		if (typeof feature !== 'object' || feature === null) {
 			continue;
 		}
-		if (!hasKey(feature, { title: true, description: true }) || typeof feature.title !== 'string' || typeof feature.description !== 'string') {
+		const candidate = feature as { title?: unknown; description?: unknown; icon?: unknown };
+		if (typeof candidate.title !== 'string' || typeof candidate.description !== 'string') {
 			continue;
 		}
-		const icon = hasKey(feature, { icon: true }) && typeof feature.icon === 'string' ? feature.icon : undefined;
-		parsed.push({ icon, title: feature.title, description: feature.description });
+		const icon = typeof candidate.icon === 'string' ? candidate.icon : undefined;
+		parsed.push({ icon, title: candidate.title, description: candidate.description });
+		if (parsed.length >= MAX_FEATURES) {
+			break;
+		}
 	}
 
 	return parsed.length ? parsed : undefined;

--- a/src/vs/workbench/contrib/update/common/updateInfoParser.ts
+++ b/src/vs/workbench/contrib/update/common/updateInfoParser.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { hasKey } from '../../../../base/common/types.js';
+import { hasKey, Mutable } from '../../../../base/common/types.js';
 
 export type UpdateInfoButtonStyle = 'primary' | 'secondary';
 
@@ -14,9 +14,19 @@ export interface IUpdateInfoButton {
 	readonly style?: UpdateInfoButtonStyle;
 }
 
+export interface IUpdateInfoFeature {
+	readonly icon?: string;
+	readonly title: string;
+	readonly description: string;
+}
+
 export interface IParsedUpdateInfoInput {
 	readonly markdown: string;
 	readonly buttons?: IUpdateInfoButton[];
+	readonly bannerImageUrl?: string;
+	readonly badge?: string;
+	readonly title?: string;
+	readonly features?: IUpdateInfoFeature[];
 }
 
 /**
@@ -61,18 +71,28 @@ function tryParseUpdateInfoEnvelope(text: string): IParsedUpdateInfoInput | unde
 	}
 
 	try {
-		const value = JSON.parse(trimmed) as { markdown?: string; buttons?: unknown };
+		const value = JSON.parse(trimmed) as { markdown?: string; buttons?: unknown; bannerImageUrl?: unknown; badge?: unknown; title?: unknown; features?: unknown };
 		if (typeof value.markdown !== 'string') {
 			return undefined;
 		}
 
-		return {
-			markdown: value.markdown,
-			buttons: parseUpdateInfoButtons(value.buttons),
-		};
+		return buildParsedInput(value.markdown, value);
 	} catch {
 		return undefined;
 	}
+}
+
+function buildParsedInput(markdown: string, meta: { buttons?: unknown; bannerImageUrl?: unknown; badge?: unknown; title?: unknown; features?: unknown }): IParsedUpdateInfoInput {
+	const result: Mutable<IParsedUpdateInfoInput> = {
+		markdown,
+		buttons: parseUpdateInfoButtons(meta.buttons),
+	};
+	if (typeof meta.bannerImageUrl === 'string') { result.bannerImageUrl = meta.bannerImageUrl; }
+	if (typeof meta.badge === 'string') { result.badge = meta.badge; }
+	if (typeof meta.title === 'string') { result.title = meta.title; }
+	const features = parseUpdateInfoFeatures(meta.features);
+	if (features) { result.features = features; }
+	return result;
 }
 
 function parseUpdateInfoFrontmatter(text: string): IParsedUpdateInfoInput {
@@ -91,11 +111,8 @@ function parseUpdateInfoFrontmatter(text: string): IParsedUpdateInfoInput {
 
 function parseUpdateInfoFrontmatterMatch(text: string, jsonText: string, markdown: string): IParsedUpdateInfoInput {
 	try {
-		const meta = JSON.parse(jsonText) as { buttons?: unknown };
-		return {
-			markdown,
-			buttons: parseUpdateInfoButtons(meta.buttons),
-		};
+		const meta = JSON.parse(jsonText) as { buttons?: unknown; bannerImageUrl?: unknown; badge?: unknown; title?: unknown; features?: unknown };
+		return buildParsedInput(markdown, meta);
 	} catch {
 		return { markdown: text };
 	}
@@ -127,4 +144,24 @@ function parseUpdateInfoButtons(buttons: unknown): IUpdateInfoButton[] | undefin
 	}
 
 	return parsedButtons.length ? parsedButtons : undefined;
+}
+
+function parseUpdateInfoFeatures(features: unknown): IUpdateInfoFeature[] | undefined {
+	if (!Array.isArray(features)) {
+		return undefined;
+	}
+
+	const parsed: IUpdateInfoFeature[] = [];
+	for (const feature of features) {
+		if (typeof feature !== 'object' || feature === null) {
+			continue;
+		}
+		if (!hasKey(feature, { title: true, description: true }) || typeof feature.title !== 'string' || typeof feature.description !== 'string') {
+			continue;
+		}
+		const icon = hasKey(feature, { icon: true }) && typeof feature.icon === 'string' ? feature.icon : undefined;
+		parsed.push({ icon, title: feature.title, description: feature.description });
+	}
+
+	return parsed.length ? parsed : undefined;
 }

--- a/src/vs/workbench/contrib/update/test/common/updateInfoParser.test.ts
+++ b/src/vs/workbench/contrib/update/test/common/updateInfoParser.test.ts
@@ -155,5 +155,117 @@ suite('updateInfoParser', () => {
 				buttons: [{ label: 'X', commandId: 'cmd', style: undefined, args: undefined }],
 			});
 		});
+
+		test('JSON envelope with bannerImageUrl, badge, title, and features', () => {
+			const input = JSON.stringify({
+				markdown: 'Body',
+				bannerImageUrl: 'https://example.com/banner.png',
+				badge: 'New',
+				title: 'What\'s New',
+				features: [
+					{ icon: '$(sparkle)', title: 'Feature A', description: 'Does A' },
+					{ title: 'Feature B', description: 'Does B' },
+				],
+			});
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'Body',
+				buttons: undefined,
+				bannerImageUrl: 'https://example.com/banner.png',
+				badge: 'New',
+				title: 'What\'s New',
+				features: [
+					{ icon: '$(sparkle)', title: 'Feature A', description: 'Does A' },
+					{ icon: undefined, title: 'Feature B', description: 'Does B' },
+				],
+			});
+		});
+
+		test('block frontmatter with bannerImageUrl, badge, title, and features', () => {
+			const meta = {
+				bannerImageUrl: 'https://example.com/banner.png',
+				badge: 'Preview',
+				title: 'Highlights',
+				features: [{ title: 'Feature', description: 'Desc' }],
+			};
+			const input = `---\n${JSON.stringify(meta)}\n---\nBody text`;
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'Body text',
+				buttons: undefined,
+				bannerImageUrl: 'https://example.com/banner.png',
+				badge: 'Preview',
+				title: 'Highlights',
+				features: [{ icon: undefined, title: 'Feature', description: 'Desc' }],
+			});
+		});
+
+		test('ignores non-string bannerImageUrl, badge, and title', () => {
+			const input = JSON.stringify({
+				markdown: 'text',
+				bannerImageUrl: 123,
+				badge: { not: 'a string' },
+				title: ['nope'],
+			});
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'text',
+				buttons: undefined,
+			});
+		});
+
+		test('caps features at 5 entries and skips invalid ones', () => {
+			const input = JSON.stringify({
+				markdown: 'text',
+				features: [
+					{ title: 'F1', description: 'D1' },
+					{ title: 'F2' }, // missing description
+					'not an object',
+					null,
+					{ title: 'F3', description: 'D3', icon: '$(star)' },
+					{ title: 'F4', description: 'D4' },
+					{ title: 'F5', description: 'D5' },
+					{ title: 'F6', description: 'D6' },
+					{ title: 'F7', description: 'D7' }, // dropped (over cap)
+				],
+			});
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'text',
+				buttons: undefined,
+				features: [
+					{ icon: undefined, title: 'F1', description: 'D1' },
+					{ icon: '$(star)', title: 'F3', description: 'D3' },
+					{ icon: undefined, title: 'F4', description: 'D4' },
+					{ icon: undefined, title: 'F5', description: 'D5' },
+					{ icon: undefined, title: 'F6', description: 'D6' },
+				],
+			});
+		});
+
+		test('returns undefined features when all features are invalid', () => {
+			const input = JSON.stringify({
+				markdown: 'text',
+				features: [{ title: 'OnlyTitle' }, 'string', null],
+			});
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'text',
+				buttons: undefined,
+			});
+		});
+
+		test('ignores non-string feature icon', () => {
+			const input = JSON.stringify({
+				markdown: 'text',
+				features: [{ icon: 42, title: 'F', description: 'D' }],
+			});
+
+			assert.deepStrictEqual(parseUpdateInfoInput(input), {
+				markdown: 'text',
+				buttons: undefined,
+				features: [{ icon: undefined, title: 'F', description: 'D' }],
+			});
+		});
 	});
 });


### PR DESCRIPTION

**UI/UX Improvements to Post-Update Widget:**
* Redesigned the post-update widget with a new layout, including a decorative banner (with optional image), badge, title, feature list, and improved button styling; also made the widget more accessible and responsive, with keyboard navigation and ARIA roles. [[1]](diffhunk://#diff-a50281511e1367d79879359558838f28c46c047cba69b14cda1c6f60976edcdbR6-R141) [[2]](diffhunk://#diff-a50281511e1367d79879359558838f28c46c047cba69b14cda1c6f60976edcdbR151-R158) [[3]](diffhunk://#diff-a50281511e1367d79879359558838f28c46c047cba69b14cda1c6f60976edcdbR186-R191) [[4]](diffhunk://#diff-643819d426e1cda0f21f4c5ede6e5154b02490d886fabded59a9a0646e9f6693L135-R211) [[5]](diffhunk://#diff-643819d426e1cda0f21f4c5ede6e5154b02490d886fabded59a9a0646e9f6693R225-R230) [[6]](diffhunk://#diff-643819d426e1cda0f21f4c5ede6e5154b02490d886fabded59a9a0646e9f6693R247-R250)
* Added logic to allow a single button to span the full width of the widget for better visual emphasis.

**Configuration and Behavior Changes:**
* Changed the default for `update.showPostInstallInfo` to `false` and clarified its description to indicate that enabling it suppresses automatic opening of the Release Notes editor.
* Modified update logic to show release notes in the editor only if post-install info is disabled, preventing both from appearing simultaneously.

**Feature Highlight and Metadata Support:**
* Extended the update info parser and widget to support new metadata fields: `bannerImageUrl`, `badge`, `title`, and a list of up to five structured features (each with icon, title, and description), allowing richer and more customizable update presentations. [[1]](diffhunk://#diff-2a74a98a22f49dc1596805b718ad42a713c4eaa576c3120de6fd491d016ee8d3L6-R8) [[2]](diffhunk://#diff-2a74a98a22f49dc1596805b718ad42a713c4eaa576c3120de6fd491d016ee8d3R19-R31) [[3]](diffhunk://#diff-2a74a98a22f49dc1596805b718ad42a713c4eaa576c3120de6fd491d016ee8d3L64-R99) [[4]](diffhunk://#diff-2a74a98a22f49dc1596805b718ad42a713c4eaa576c3120de6fd491d016ee8d3L94-R117) [[5]](diffhunk://#diff-2a74a98a22f49dc1596805b718ad42a713c4eaa576c3120de6fd491d016ee8d3R150-R173) [[6]](diffhunk://#diff-643819d426e1cda0f21f4c5ede6e5154b02490d886fabded59a9a0646e9f6693L135-R211)

**Security and Robustness:**
* Added a sanitizer for banner image URLs to allow only `https:` and `data:image/*` URLs, preventing injection or misuse from untrusted markdown payloads.

**Technical and Accessibility Enhancements:**
* Improved ARIA labeling, keyboard navigation (Escape to close), and ensured the widget is announced as a dialog for screen readers.

These changes collectively modernize the post-update experience, provide more flexibility for update authors, and improve accessibility and security.
