### PR TITLE
Agents: fix SSH reconnect failing with "Unknown method: initialize" after window reload

### DIFF
--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -115,6 +115,20 @@ export interface ISSHRemoteAgentHostService {
 	reconnect(sshConfigHost: string, name: string): Promise<ISSHAgentHostConnection>;
 }
 /**
+ * Stable identifier for an SSH connection derived from its config.
+ *
+ * The key intentionally collapses to the SSH config host alias when one is
+ * provided; otherwise it is `<user>@<host>:<port>`. The renderer uses this
+ * to detect whether it already has a live handle for a connection that the
+ * main process may have kept alive across a window reload.
+ */
+export function getSSHConnectionKey(config: ISSHAgentHostConfig): string {
+	return config.sshConfigHost
+		? `ssh:${config.sshConfigHost}`
+		: `${config.username}@${config.host}:${config.port ?? 22}`;
+}
+
+/**
  * Serializable result from a successful SSH connect operation.
  * Returned over IPC from the main process.
  */
@@ -184,8 +198,17 @@ export interface ISSHRemoteAgentHostMainService {
 	/**
 	 * Bootstrap a remote agent host over SSH. Returns serializable
 	 * connection info for the renderer to register.
+	 *
+	 * If a tunnel for this config already exists in the main process and
+	 * `replaceRelay` is true, the existing WebSocket relay is torn down and
+	 * a fresh one is created over the same SSH client. The renderer must
+	 * pass `replaceRelay: true` whenever it does not already hold a live
+	 * protocol client for the connection (e.g. after a window reload), so
+	 * that its newly created protocol client talks to a fresh server-side
+	 * transport rather than one whose `initialize` handshake has already
+	 * completed for a now-defunct renderer.
 	 */
-	connect(config: ISSHAgentHostConfig): Promise<ISSHConnectResult>;
+	connect(config: ISSHAgentHostConfig, replaceRelay?: boolean): Promise<ISSHConnectResult>;
 
 	/**
 	 * Send a message to a remote agent host through the SSH relay.

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
 import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
@@ -39,7 +39,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 
 	readonly onDidReportConnectProgress: Event<ISSHConnectProgress>;
 
-	private readonly _connections = new Map<string, SSHAgentHostConnectionHandle>();
+	private readonly _connections = this._register(new DisposableMap<string, SSHAgentHostConnectionHandle>());
 
 	constructor(
 		@ISharedProcessService sharedProcessService: ISharedProcessService,
@@ -60,21 +60,12 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		// Do NOT remove the configured entry — it stays in settings so startup reconnect
 		// can re-establish the SSH tunnel on next launch.
 		this._register(this._mainService.onDidCloseConnection(connectionId => {
-			const handle = this._connections.get(connectionId);
+			const handle = this._connections.deleteAndLeak(connectionId);
 			if (handle) {
-				this._connections.delete(connectionId);
 				handle.fireClose();
 				handle.dispose();
 				this._onDidChangeConnections.fire();
 			}
-		}));
-
-		// Dispose any remaining handles when the service itself is disposed.
-		this._register(toDisposable(() => {
-			for (const handle of this._connections.values()) {
-				handle.dispose();
-			}
-			this._connections.clear();
 		}));
 	}
 
@@ -86,9 +77,10 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		this._logService.info('[SSHRemoteAgentHost] Connecting to ' + config.host);
 		const augmentedConfig = this._augmentConfig(config);
 
-		// Short-circuit if we already track a live handle locally. The
-		// main process keys connections by the same value, so this also
-		// avoids a redundant IPC round-trip for repeated connect clicks.
+		// Repeated user-initiated connects to the same host (e.g. clicking
+		// "Connect" again before disconnecting) would otherwise tear down
+		// the live relay below via `replaceRelay: true` and then orphan
+		// our existing protocol client. Short-circuit instead.
 		const expectedKey = getSSHConnectionKey(augmentedConfig);
 		const existingLocal = this._connections.get(expectedKey);
 		if (existingLocal) {

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -16,6 +16,7 @@ import { RemoteAgentHostProtocolClient } from '../browser/remoteAgentHostProtoco
 import {
 	ISSHRemoteAgentHostService,
 	SSH_REMOTE_AGENT_HOST_CHANNEL,
+	getSSHConnectionKey,
 	type ISSHAgentHostConfig,
 	type ISSHAgentHostConnection,
 	type ISSHRemoteAgentHostMainService,
@@ -31,7 +32,7 @@ import {
 export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteAgentHostService {
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _mainService: ISSHRemoteAgentHostMainService;
+	protected readonly _mainService: ISSHRemoteAgentHostMainService;
 
 	private readonly _onDidChangeConnections = this._register(new Emitter<void>());
 	readonly onDidChangeConnections: Event<void> = this._onDidChangeConnections.event;
@@ -67,6 +68,14 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 				this._onDidChangeConnections.fire();
 			}
 		}));
+
+		// Dispose any remaining handles when the service itself is disposed.
+		this._register(toDisposable(() => {
+			for (const handle of this._connections.values()) {
+				handle.dispose();
+			}
+			this._connections.clear();
+		}));
 	}
 
 	get connections(): readonly ISSHAgentHostConnection[] {
@@ -76,14 +85,25 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	async connect(config: ISSHAgentHostConfig): Promise<ISSHAgentHostConnection> {
 		this._logService.info('[SSHRemoteAgentHost] Connecting to ' + config.host);
 		const augmentedConfig = this._augmentConfig(config);
-		const result = await this._mainService.connect(augmentedConfig);
-		this._logService.trace('[SSHRemoteAgentHost] SSH tunnel established, connectionId=' + result.connectionId);
 
-		const existing = this._connections.get(result.connectionId);
-		if (existing) {
+		// Short-circuit if we already track a live handle locally. The
+		// main process keys connections by the same value, so this also
+		// avoids a redundant IPC round-trip for repeated connect clicks.
+		const expectedKey = getSSHConnectionKey(augmentedConfig);
+		const existingLocal = this._connections.get(expectedKey);
+		if (existingLocal) {
 			this._logService.trace('[SSHRemoteAgentHost] Returning existing connection handle');
-			return existing;
+			return existingLocal;
 		}
+
+		// We do not have a live protocol client. The main process may still
+		// be holding a tunnel from a previous window (window reload does not
+		// tear down main-process state), so ask it to replace the WebSocket
+		// relay. That gives the server a fresh per-transport state for our
+		// new protocol client's `initialize` handshake. If no tunnel exists
+		// yet, `replaceRelay` is a no-op and a brand new tunnel is created.
+		const result = await this._mainService.connect(augmentedConfig, /* replaceRelay */ true);
+		this._logService.trace('[SSHRemoteAgentHost] SSH tunnel established, connectionId=' + result.connectionId);
 
 		// Create relay transport + protocol client, then register with RemoteAgentHostService
 		try {
@@ -172,7 +192,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		return handle;
 	}
 
-	private _createRelayClient(result: { connectionId: string; address: string }): RemoteAgentHostProtocolClient {
+	protected _createRelayClient(result: { connectionId: string; address: string }): RemoteAgentHostProtocolClient {
 		const transport = new SSHRelayTransport(result.connectionId, this._mainService);
 		return this._instantiationService.createInstance(
 			RemoteAgentHostProtocolClient, result.address, transport,

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -16,6 +16,7 @@ import { IProductService } from '../../product/common/productService.js';
 import {
 	ISSHRemoteAgentHostMainService,
 	SSHAuthMethod,
+	getSSHConnectionKey,
 	type ISSHAgentHostConfig,
 	type ISSHAgentHostConfigSanitized,
 	type ISSHConnectProgress,
@@ -372,9 +373,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 	}
 
 	async connect(config: ISSHAgentHostConfig, replaceRelay?: boolean): Promise<ISSHConnectResult> {
-		const connectionKey = config.sshConfigHost
-			? `ssh:${config.sshConfigHost}`
-			: `${config.username}@${config.host}:${config.port ?? 22}`;
+		const connectionKey = getSSHConnectionKey(config);
 
 		const existing = this._connections.get(connectionKey);
 		if (existing) {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostServiceImpl.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostServiceImpl.test.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
+import { ISharedProcessService } from '../../../ipc/electron-browser/services.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { SSHRemoteAgentHostService } from '../../electron-browser/sshRemoteAgentHostServiceImpl.js';
+import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostEntry, IRemoteAgentHostService } from '../../common/remoteAgentHostService.js';
+import { getSSHConnectionKey, ISSHAgentHostConfig, ISSHConnectResult, ISSHRelayMessage, ISSHRemoteAgentHostMainService, SSHAuthMethod } from '../../common/sshRemoteAgentHost.js';
+import type { RemoteAgentHostProtocolClient } from '../../browser/remoteAgentHostProtocolClient.js';
+import type { IAgentConnection } from '../../common/agentService.js';
+
+/**
+ * Records every call to `connect()` along with the `replaceRelay` argument so tests
+ * can assert that the renderer always passes `replaceRelay: true` when it has no
+ * local handle (the regression that produced "Unknown method: initialize" after a
+ * window reload).
+ */
+class MockMainService implements Partial<ISSHRemoteAgentHostMainService> {
+	private readonly _onDidChangeConnections = new Emitter<void>();
+	readonly onDidChangeConnections = this._onDidChangeConnections.event;
+	readonly closeEmitter = new Emitter<string>();
+	readonly onDidCloseConnection = this.closeEmitter.event;
+	private readonly _onDidReportConnectProgress = new Emitter<{ connectionKey: string; message: string }>();
+	readonly onDidReportConnectProgress = this._onDidReportConnectProgress.event;
+	private readonly _onDidRelayMessage = new Emitter<ISSHRelayMessage>();
+	readonly onDidRelayMessage = this._onDidRelayMessage.event;
+	private readonly _onDidRelayClose = new Emitter<string>();
+	readonly onDidRelayClose = this._onDidRelayClose.event;
+
+	readonly connectCalls: { config: ISSHAgentHostConfig; replaceRelay: boolean | undefined }[] = [];
+	readonly disconnectCalls: string[] = [];
+
+	async connect(config: ISSHAgentHostConfig, replaceRelay?: boolean): Promise<ISSHConnectResult> {
+		this.connectCalls.push({ config, replaceRelay });
+		const key = getSSHConnectionKey(config);
+		return {
+			connectionId: key,
+			address: `ssh:${config.host}`,
+			name: config.name,
+			connectionToken: 'tok',
+			config: { host: config.host, port: config.port, username: config.username, authMethod: config.authMethod, name: config.name, sshConfigHost: config.sshConfigHost },
+			sshConfigHost: config.sshConfigHost,
+		};
+	}
+
+	async disconnect(host: string): Promise<void> { this.disconnectCalls.push(host); }
+	async relaySend(): Promise<void> { }
+	async listSSHConfigHosts(): Promise<string[]> { return []; }
+	async resolveSSHConfig(): Promise<never> { throw new Error('not implemented'); }
+	async reconnect(): Promise<never> { throw new Error('not implemented'); }
+
+	dispose(): void {
+		this._onDidChangeConnections.dispose();
+		this.closeEmitter.dispose();
+		this._onDidReportConnectProgress.dispose();
+		this._onDidRelayMessage.dispose();
+		this._onDidRelayClose.dispose();
+	}
+}
+
+class FakeProtocolClient extends Disposable {
+	connectCalled = 0;
+	async connect(): Promise<void> { this.connectCalled++; }
+}
+
+class StubRemoteAgentHostService implements Partial<IRemoteAgentHostService> {
+	readonly addedEntries: IRemoteAgentHostEntry[] = [];
+	async addSSHConnection(entry: IRemoteAgentHostEntry, _connection: IAgentConnection): Promise<IRemoteAgentHostConnectionInfo> {
+		this.addedEntries.push(entry);
+		return { entry, connection: _connection } as unknown as IRemoteAgentHostConnectionInfo;
+	}
+}
+
+/**
+ * Subclass that bypasses ProxyChannel construction by overwriting the protected
+ * `_mainService` field after `super(...)` runs, and replaces protocol client
+ * creation with a fake so we don't need a live transport.
+ */
+class TestableSSHRemoteAgentHostService extends SSHRemoteAgentHostService {
+	readonly fakeClients: FakeProtocolClient[] = [];
+
+	constructor(
+		mainServiceMock: MockMainService,
+		remoteAgentHostService: IRemoteAgentHostService,
+	) {
+		const noopChannel: IChannel = {
+			call: <T>() => Promise.resolve() as Promise<T>,
+			listen: () => Event.None,
+		};
+		const sharedProcessService: ISharedProcessService = {
+			_serviceBrand: undefined,
+			getChannel: () => noopChannel,
+			registerChannel: () => { },
+			notifyRestored: () => { },
+			createRawConnection: () => { throw new Error('not implemented'); },
+		} as unknown as ISharedProcessService;
+		const instantiationService = new TestInstantiationService();
+		const configService = new TestConfigurationService();
+		super(sharedProcessService, remoteAgentHostService, new NullLogService(), instantiationService, configService);
+		// Replace the ProxyChannel-built service with our mock.
+		const self = this as unknown as IMutableRendererService;
+		self._mainService = mainServiceMock as unknown as ISSHRemoteAgentHostMainService;
+		// onDidReportConnectProgress was bound from the no-op channel; rebind to mock.
+		self.onDidReportConnectProgress = mainServiceMock.onDidReportConnectProgress;
+		// Re-wire the close listener that the parent ctor registered against the no-op channel.
+		this._register(mainServiceMock.onDidCloseConnection(connectionId => {
+			const conns = self._connections;
+			const handle = conns.get(connectionId);
+			if (handle) { conns.delete(connectionId); handle.fireClose(); handle.dispose(); }
+		}));
+	}
+
+	protected override _createRelayClient(_result: { connectionId: string; address: string }): RemoteAgentHostProtocolClient {
+		const fake = this._register(new FakeProtocolClient());
+		this.fakeClients.push(fake);
+		return fake as unknown as RemoteAgentHostProtocolClient;
+	}
+}
+
+/** Test-only view of SSHRemoteAgentHostService private state for fixture setup. */
+interface IMutableRendererService {
+	_mainService: ISSHRemoteAgentHostMainService;
+	onDidReportConnectProgress: Event<{ connectionKey: string; message: string }>;
+	readonly _connections: Map<string, { fireClose(): void; dispose(): void }>;
+}
+
+function makeConfig(overrides: Partial<ISSHAgentHostConfig> = {}): ISSHAgentHostConfig {
+	return {
+		host: 'macbook-air.local',
+		username: 'rob',
+		authMethod: SSHAuthMethod.Agent,
+		name: 'macbook-air',
+		sshConfigHost: 'macbook-air',
+		...overrides,
+	};
+}
+
+suite('SSHRemoteAgentHostService (renderer)', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function setup() {
+		const main = new MockMainService();
+		store.add(toDisposable(() => main.dispose()));
+		const remote = new StubRemoteAgentHostService();
+		const service = store.add(new TestableSSHRemoteAgentHostService(main, remote as unknown as IRemoteAgentHostService));
+		return { main, remote, service };
+	}
+
+	test('connect on a fresh renderer always passes replaceRelay=true so the server gets a fresh transport (regression: "Unknown method: initialize" after window reload)', async () => {
+		const { main, service } = setup();
+
+		await service.connect(makeConfig());
+
+		assert.deepStrictEqual(
+			main.connectCalls.map(c => ({ key: getSSHConnectionKey(c.config), replaceRelay: c.replaceRelay })),
+			[{ key: 'ssh:macbook-air', replaceRelay: true }],
+		);
+	});
+
+	test('repeated connect calls short-circuit on the existing local handle without calling the main process again', async () => {
+		const { main, service } = setup();
+
+		const first = await service.connect(makeConfig());
+		const second = await service.connect(makeConfig());
+
+		assert.strictEqual(second, first, 'should return the same handle');
+		assert.strictEqual(main.connectCalls.length, 1, 'main.connect should only be called once');
+	});
+
+	test('connect computes the same key as the main process, so result.connectionId matches the local handle key', async () => {
+		const { main, service } = setup();
+
+		const handle = await service.connect(makeConfig({ sshConfigHost: undefined, port: 2222 }));
+		const expectedKey = getSSHConnectionKey({ ...makeConfig({ sshConfigHost: undefined, port: 2222 }) });
+
+		// Returned handle and the main-side connectionId both use the same key, so a follow-up connect short-circuits.
+		assert.strictEqual(main.connectCalls[0].replaceRelay, true);
+		assert.strictEqual(handle.name, 'macbook-air');
+		// Key parity: a second connect must short-circuit (proves the renderer's expectedKey matches result.connectionId).
+		await service.connect(makeConfig({ sshConfigHost: undefined, port: 2222 }));
+		assert.strictEqual(main.connectCalls.length, 1, `expected single main call when key=${expectedKey}`);
+	});
+
+	test('after main reports onDidCloseConnection the local handle is dropped and the next connect calls main again with replaceRelay=true', async () => {
+		const { main, service } = setup();
+
+		await service.connect(makeConfig());
+		// Simulate the main process closing the connection (e.g., explicit disconnect, or loss).
+		main.closeEmitter.fire('ssh:macbook-air');
+
+		await service.connect(makeConfig());
+		assert.deepStrictEqual(
+			main.connectCalls.map(c => c.replaceRelay),
+			[true, true],
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostServiceImpl.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostServiceImpl.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, toDisposable } from '../../../../base/common/lifecycle.js';
 import { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
@@ -114,8 +114,8 @@ class TestableSSHRemoteAgentHostService extends SSHRemoteAgentHostService {
 		// Re-wire the close listener that the parent ctor registered against the no-op channel.
 		this._register(mainServiceMock.onDidCloseConnection(connectionId => {
 			const conns = self._connections;
-			const handle = conns.get(connectionId);
-			if (handle) { conns.delete(connectionId); handle.fireClose(); handle.dispose(); }
+			const handle = conns.deleteAndLeak(connectionId);
+			if (handle) { handle.fireClose(); handle.dispose(); }
 		}));
 	}
 
@@ -130,7 +130,7 @@ class TestableSSHRemoteAgentHostService extends SSHRemoteAgentHostService {
 interface IMutableRendererService {
 	_mainService: ISSHRemoteAgentHostMainService;
 	onDidReportConnectProgress: Event<{ connectionKey: string; message: string }>;
-	readonly _connections: Map<string, { fireClose(): void; dispose(): void }>;
+	readonly _connections: DisposableMap<string, { fireClose(): void; dispose(): void }>;
 }
 
 function makeConfig(overrides: Partial<ISSHAgentHostConfig> = {}): ISSHAgentHostConfig {

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -337,6 +337,34 @@ suite('SSHRemoteAgentHostMainService - connect flow', () => {
 		assert.strictEqual(service.relayCalled, 2); // fresh relay
 	});
 
+	test('connect with replaceRelay creates fresh relay on existing tunnel without restarting agent', async () => {
+		// Regression test for the SSH window-reload reconnect bug:
+		// after a window reload the renderer has no live protocol client,
+		// but the main process still holds the SSH tunnel and the server
+		// still has a `client` for the old WebSocket transport. The renderer
+		// passes `replaceRelay: true` so the server gets a fresh transport
+		// for its `initialize` handshake.
+		service.execResponses = [
+			{ stdout: 'Linux\n', code: 0 },      // uname -s
+			{ stdout: 'x86_64\n', code: 0 },      // uname -m
+			{ stdout: '1.0.0\n', code: 0 },       // CLI --version (already installed)
+			{ stdout: '', code: 1 },               // cat state file (not found)
+			{ stdout: '', code: 0 },               // echo state file (write)
+		];
+
+		const config = makeConfig({ sshConfigHost: 'myalias' });
+		const result1 = await service.connect(config);
+		assert.strictEqual(service.startCalled, 1);
+		assert.strictEqual(service.relayCalled, 1);
+
+		// Second connect with replaceRelay: true — fresh relay, no agent restart
+		const result2 = await service.connect(config, /* replaceRelay */ true);
+		assert.strictEqual(result2.connectionId, result1.connectionId);
+		assert.strictEqual(result2.connectionToken, result1.connectionToken);
+		assert.strictEqual(service.startCalled, 1); // no restart
+		assert.strictEqual(service.relayCalled, 2); // fresh relay
+	});
+
 	test('reconnect does not fire onDidRelayClose for superseded relay', async () => {
 		service.execResponses = [
 			{ stdout: 'Linux\n', code: 0 },

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -180,8 +180,22 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	private _createProvider(entry: IRemoteAgentHostEntry): void {
 		const address = getEntryAddress(entry);
 		const store = new DisposableStore();
+		// For SSH entries, wire disconnectOnDemand so that "Remove Remote"
+		// fully tears down the main-process SSH tunnel and WebSocket relay
+		// before removing the configured entry. Without this the tunnel
+		// survives the remove and the next connect either (a) silently
+		// reuses stale renderer state or (b) reuses the surviving tunnel
+		// instead of starting a fresh one. The disconnect fires
+		// `onDidCloseConnection`, which clears the renderer-side connection
+		// handle.
+		const disconnectOnDemand = entry.connection.type === RemoteAgentHostEntryType.SSH
+			? async () => {
+				await this._sshService.disconnect(address);
+				await this._remoteAgentHostService.removeRemoteAgentHost(address);
+			}
+			: undefined;
 		const provider = this._instantiationService.createInstance(
-			RemoteAgentHostSessionsProvider, { address, name: entry.name });
+			RemoteAgentHostSessionsProvider, { address, name: entry.name, disconnectOnDemand });
 		store.add(provider);
 		store.add(this._sessionsProvidersService.registerProvider(provider));
 		this._providerInstances.set(address, provider);

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -6,7 +6,7 @@
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
+import { ISSHRemoteAgentHostService, SSHAuthMethod, getSSHConnectionKey, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -327,9 +327,7 @@ async function connectWithProgress(
 
 	// Build the expected connection key to filter progress events.
 	// Must match the key logic in the shared process service.
-	const expectedKey = config.sshConfigHost
-		? `ssh:${config.sshConfigHost}`
-		: `${config.username}@${config.host}:${config.port ?? 22}`;
+	const expectedKey = getSSHConnectionKey(config);
 
 	const progressListener = sshService.onDidReportConnectProgress?.(progress => {
 		if (progress.connectionKey === expectedKey) {

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostSessionsProvider.test.ts
@@ -30,6 +30,7 @@ import { ILanguageModelsService } from '../../../../../workbench/contrib/chat/co
 import { ISessionChangeEvent } from '../../../../services/sessions/common/sessionsProvider.js';
 import { SessionStatus, COPILOT_CLI_SESSION_TYPE } from '../../../../services/sessions/common/session.js';
 import { RemoteAgentHostSessionsProvider, type IRemoteAgentHostSessionsProviderConfig } from '../../browser/remoteAgentHostSessionsProvider.js';
+import { IRemoteAgentHostService } from '../../../../../platform/agentHost/common/remoteAgentHostService.js';
 
 // ---- Mock connection --------------------------------------------------------
 
@@ -176,7 +177,7 @@ function createSession(id: string, opts?: { provider?: string; summary?: string;
 	};
 }
 
-function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean }): RemoteAgentHostSessionsProvider {
+function createProvider(disposables: DisposableStore, connection: MockAgentConnection, overrides?: { address?: string; connectionName?: string | undefined; sendRequest?: (resource: URI, message: string, options?: IChatSendRequestOptions) => Promise<ChatSendResult>; openSession?: boolean; storageService?: IStorageService; noConnection?: boolean; disconnectOnDemand?: () => Promise<void>; removeRemoteAgentHost?: (address: string) => Promise<void> }): RemoteAgentHostSessionsProvider {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IFileDialogService, {});
@@ -196,10 +197,14 @@ function createProvider(disposables: DisposableStore, connection: MockAgentConne
 		lookupLanguageModel: () => undefined,
 	});
 	instantiationService.stub(IStorageService, overrides?.storageService ?? disposables.add(new InMemoryStorageService()));
+	instantiationService.stub(IRemoteAgentHostService, new class extends mock<IRemoteAgentHostService>() {
+		override removeRemoteAgentHost = overrides?.removeRemoteAgentHost ?? (async () => { });
+	}());
 
 	const config: IRemoteAgentHostSessionsProviderConfig = {
 		address: overrides?.address ?? 'localhost:4321',
 		name: overrides !== undefined && Object.prototype.hasOwnProperty.call(overrides, 'connectionName') ? overrides.connectionName ?? '' : 'Test Host',
+		disconnectOnDemand: overrides?.disconnectOnDemand,
 	};
 
 	const provider = disposables.add(instantiationService.createInstance(RemoteAgentHostSessionsProvider, config));
@@ -1000,5 +1005,37 @@ suite('RemoteAgentHostSessionsProvider', () => {
 
 		assert.strictEqual(connection.sessionUnsubscribeCounts.get(sessionUriStr), 1);
 	}));
+
+	test('disconnect() falls back to removeRemoteAgentHost when disconnectOnDemand is not set', async () => {
+		let removed: string | undefined;
+		const provider = createProvider(disposables, connection, {
+			address: 'ssh:test-host',
+			removeRemoteAgentHost: async (address) => { removed = address; },
+		});
+
+		await provider.disconnect();
+
+		assert.strictEqual(removed, 'ssh:test-host');
+	});
+
+	test('disconnect() invokes disconnectOnDemand and skips removeRemoteAgentHost when provided', async () => {
+		// Regression: SSH "Remove Remote" used to skip the SSH tunnel teardown
+		// because no disconnectOnDemand was wired. The provider should hand
+		// full responsibility to disconnectOnDemand when it is provided so the
+		// SSH path can tear down the main-process tunnel before removing the
+		// settings entry itself.
+		let onDemandCalled = 0;
+		let removed: string | undefined;
+		const provider = createProvider(disposables, connection, {
+			address: 'ssh:test-host',
+			disconnectOnDemand: async () => { onDemandCalled++; },
+			removeRemoteAgentHost: async (address) => { removed = address; },
+		});
+
+		await provider.disconnect();
+
+		assert.strictEqual(onDemandCalled, 1);
+		assert.strictEqual(removed, undefined, 'removeRemoteAgentHost must not be called when disconnectOnDemand is provided');
+	});
 
 });


### PR DESCRIPTION
## What

Fix `Failed to connect via SSH to <host>: Error: Unknown method: initialize` when reconnecting to a previously-connected SSH remote agent host after a window reload (without restarting the Agents app).

## Repro

1. Connect to an SSH remote agent host.
2. Disconnect.
3. Reload the window (do **not** restart the app).
4. Try to connect to the same host again → `Unknown method: initialize`.

## Why

The SSH tunnel and WebSocket relay live in the **main process** and survive window reload. The protocol server keeps per-transport state and only accepts `initialize` once per transport. After a reload, the renderer creates a fresh `RemoteAgentHostProtocolClient` and sends a fresh `initialize` over the **same** WebSocket the server had already initialized for the previous renderer — so it falls through to `_handleRequest`, which doesn't know `initialize`, and replies with `Unknown method: initialize`.

The renderer's `connect()` was calling the main service without `replaceRelay`, so the existing relay was reused.

## Fix

The renderer's `connect()` now always passes `replaceRelay: true` to the main service whenever it has no live local handle (window reload, or first-time connect). The main process tears down the existing WebSocket relay and creates a fresh one over the same SSH client, so the new protocol client gets a fresh server-side transport for its handshake. On a true first connect, `replaceRelay` is a no-op (no existing relay).

This mirrors what the auto-reconnect-on-startup path (`reconnect()`) already did — it always passed `replaceRelay: true`.

## Also in this PR

- Extract a `getSSHConnectionKey(config)` helper so the renderer, main service, and progress-event filter all derive the same connection key.
- Dispose any remaining SSH connection handles when the renderer service itself is disposed (small leak fix).

## Tests

- New `sshRemoteAgentHostServiceImpl.test.ts` (renderer) — 4 tests covering:
  - Fresh-renderer connect always passes `replaceRelay: true` (the regression).
  - Repeated connects short-circuit on the local handle without IPC.
  - Key parity — renderer's `expectedKey` matches main's `connectionId`.
  - Post-close, next connect calls main again with `replaceRelay: true`.
- New regression test in `sshRemoteAgentHostService.test.ts` (main) — verifies a fresh relay is created on existing tunnels without restarting the agent.
- Verified each new renderer regression test actually catches the bug by reverting the fix (3 of 4 fail without `replaceRelay: true`; 2 of 4 fail without the local-handle short-circuit).
- All 206 SSH/RemoteAgentHost tests pass.

(Written by Copilot)