### PR TITLE
sessions: restore terminal after editor maximize

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -257,6 +257,7 @@ setPartHidden(hidden: boolean, part: Parts): void
 - **Editor Part:**
     - The main editor part is hidden by default but can be shown for explicit editor workflows that target the main editor part
     - Modal editor opens do not change the current main editor visibility state
+    - The sessions **Maximize Editor** action temporarily hides the panel when the visible panel is the terminal view, and the matching **Restore Editor** action reopens that terminal panel if maximize hid it
   - All editors open via `MODAL_GROUP` into the `ModalEditorPart` overlay, which manages its own lifecycle
 
 ### 6.2 Part Sizing
@@ -668,6 +669,7 @@ interface IPartVisibilityState {
 | 2026-04-22 | Added a sessions-workbench notification offset override so the shared notification controllers no longer push top-right notifications down to `42px`; sessions now reapply a fixed `40px` top offset for top-right notification center/toast placement. |
 | 2026-04-22 | Generalized the auxiliary bar snap-close prevention to trigger whenever the main editor part is visible (any editor type), so the behavior now applies automatically without maintaining an editor-type allowlist. |
 | 2026-04-22 | Updated the sessions auxiliary bar sizing rules so attached diff editors and integrated browser editors keep the normal 270px auxiliary-bar minimum width while disabling sash snap-to-close in that state, and the titlebar toggle continues to hide/show the secondary sidebar normally. |
+| 2026-04-22 | Updated the sessions **Maximize Editor** and **Restore Editor** actions so maximize hides the panel only when the terminal view is currently visible, and restore reopens that terminal panel when maximize hid it. |
 | 2026-04-21 | Renamed the command-center "Add Chat" titlebar action to "New Sub-Session" so the plus-button tooltip matches the sub-session workflow. |
 | 2026-04-21 | Removed the remaining left-margin spacing after the titlebar's VS Code and session-picker items, and dropped the command-center "Mark as Done" checkmark button next to the active session title. |
 | 2026-04-21 | Removed the titlebar's vertical separator bars in favor of spacing-only group separation, and removed the dot separator between the active session title and its folder/worktree metadata. |

--- a/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
+++ b/src/vs/sessions/contrib/editor/browser/editor.contribution.ts
@@ -21,6 +21,9 @@ import { ChangesViewPane } from '../../changes/browser/changesView.js';
 import { prepareMoveCopyEditors } from '../../../../workbench/browser/parts/editor/editor.js';
 import { Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { MOVE_MODAL_EDITOR_TO_MAIN_COMMAND_ID } from '../../../../workbench/browser/parts/editor/editorCommands.js';
+import { TERMINAL_VIEW_ID } from '../../../../workbench/contrib/terminal/common/terminal.js';
+
+const terminalPanelHiddenForMaximizedEditor = new WeakSet<IAgentWorkbenchLayoutService>();
 
 class MaximizeMainEditorPartAction extends Action2 {
 	static readonly ID = 'workbench.action.agentSessions.maximizeMainEditorPart';
@@ -44,6 +47,20 @@ class MaximizeMainEditorPartAction extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		const viewsService = accessor.get(IViewsService);
+		let hidTerminalPanel = false;
+
+		if (layoutService.isVisible(Parts.PANEL_PART) && viewsService.isViewVisible(TERMINAL_VIEW_ID)) {
+			layoutService.setPartHidden(true, Parts.PANEL_PART);
+			hidTerminalPanel = true;
+		}
+
+		if (hidTerminalPanel) {
+			terminalPanelHiddenForMaximizedEditor.add(layoutService);
+		} else {
+			terminalPanelHiddenForMaximizedEditor.delete(layoutService);
+		}
+
 		layoutService.setEditorMaximized(true);
 	}
 }
@@ -72,7 +89,15 @@ class RestoreMainEditorPartAction extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const layoutService = accessor.get(IAgentWorkbenchLayoutService);
+		const shouldRestoreTerminalPanel = terminalPanelHiddenForMaximizedEditor.has(layoutService);
+
 		layoutService.setEditorMaximized(false);
+
+		if (shouldRestoreTerminalPanel && !layoutService.isVisible(Parts.PANEL_PART)) {
+			layoutService.setPartHidden(false, Parts.PANEL_PART);
+		}
+
+		terminalPanelHiddenForMaximizedEditor.delete(layoutService);
 	}
 }
 

--- a/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
+++ b/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
@@ -1,0 +1,195 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { Parts } from '../../../../../workbench/services/layout/browser/layoutService.js';
+import { IViewsService } from '../../../../../workbench/services/views/common/viewsService.js';
+import { TERMINAL_VIEW_ID } from '../../../../../workbench/contrib/terminal/common/terminal.js';
+import { IAgentWorkbenchLayoutService } from '../../../../browser/workbench.js';
+
+// Import editor contribution to trigger action registration.
+import '../../browser/editor.contribution.js';
+
+suite('Sessions - Editor Contribution', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('maximize editor hides the terminal panel before maximizing', async () => {
+		const instantiationService = new TestInstantiationService();
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly hiddenParts: Parts[] = [];
+			editorMaximized = false;
+			panelVisible = true;
+
+			override isVisible(part: Parts): boolean {
+				return part === Parts.PANEL_PART ? this.panelVisible : false;
+			}
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (part === Parts.PANEL_PART) {
+					this.panelVisible = !hidden;
+				}
+
+				if (hidden && part === Parts.PANEL_PART) {
+					this.hiddenParts.push(part);
+				}
+			}
+
+			override setEditorMaximized(maximized: boolean): void {
+				this.editorMaximized = maximized;
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+		instantiationService.set(IViewsService, new class extends mock<IViewsService>() {
+			override isViewVisible(id: string): boolean {
+				return id === TERMINAL_VIEW_ID;
+			}
+		});
+
+		const handler = CommandsRegistry.getCommand('workbench.action.agentSessions.maximizeMainEditorPart')?.handler;
+		assert.ok(handler, 'Command handler should be registered');
+
+		await handler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.hiddenParts, [Parts.PANEL_PART]);
+		assert.strictEqual(layoutService.editorMaximized, true);
+	});
+
+	test('maximize editor keeps non-terminal panels visible', async () => {
+		const instantiationService = new TestInstantiationService();
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly hiddenParts: Parts[] = [];
+			editorMaximized = false;
+			panelVisible = true;
+
+			override isVisible(part: Parts): boolean {
+				return part === Parts.PANEL_PART ? this.panelVisible : false;
+			}
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (part === Parts.PANEL_PART) {
+					this.panelVisible = !hidden;
+				}
+
+				if (hidden && part === Parts.PANEL_PART) {
+					this.hiddenParts.push(part);
+				}
+			}
+
+			override setEditorMaximized(maximized: boolean): void {
+				this.editorMaximized = maximized;
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+		instantiationService.set(IViewsService, new class extends mock<IViewsService>() {
+			override isViewVisible(_id: string): boolean {
+				return false;
+			}
+		});
+
+		const handler = CommandsRegistry.getCommand('workbench.action.agentSessions.maximizeMainEditorPart')?.handler;
+		assert.ok(handler, 'Command handler should be registered');
+
+		await handler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.hiddenParts, []);
+		assert.strictEqual(layoutService.editorMaximized, true);
+	});
+
+	test('restore editor reopens the terminal panel when maximize hid it', async () => {
+		const instantiationService = new TestInstantiationService();
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly hiddenParts: Parts[] = [];
+			readonly shownParts: Parts[] = [];
+			readonly maximizedStates: boolean[] = [];
+			panelVisible = true;
+
+			override isVisible(part: Parts): boolean {
+				return part === Parts.PANEL_PART ? this.panelVisible : false;
+			}
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (part === Parts.PANEL_PART) {
+					this.panelVisible = !hidden;
+					if (hidden) {
+						this.hiddenParts.push(part);
+					} else {
+						this.shownParts.push(part);
+					}
+				}
+			}
+
+			override setEditorMaximized(maximized: boolean): void {
+				this.maximizedStates.push(maximized);
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+		instantiationService.set(IViewsService, new class extends mock<IViewsService>() {
+			override isViewVisible(id: string): boolean {
+				return id === TERMINAL_VIEW_ID;
+			}
+		});
+
+		const maximizeHandler = CommandsRegistry.getCommand('workbench.action.agentSessions.maximizeMainEditorPart')?.handler;
+		const restoreHandler = CommandsRegistry.getCommand('workbench.action.agentSessions.restoreMainEditorPart')?.handler;
+		assert.ok(maximizeHandler, 'Maximize command handler should be registered');
+		assert.ok(restoreHandler, 'Restore command handler should be registered');
+
+		await maximizeHandler(instantiationService);
+		await restoreHandler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.hiddenParts, [Parts.PANEL_PART]);
+		assert.deepStrictEqual(layoutService.shownParts, [Parts.PANEL_PART]);
+		assert.deepStrictEqual(layoutService.maximizedStates, [true, false]);
+		assert.strictEqual(layoutService.panelVisible, true);
+	});
+
+	test('restore editor does not reopen the panel when maximize left it visible', async () => {
+		const instantiationService = new TestInstantiationService();
+		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly shownParts: Parts[] = [];
+			readonly maximizedStates: boolean[] = [];
+			panelVisible = true;
+
+			override isVisible(part: Parts): boolean {
+				return part === Parts.PANEL_PART ? this.panelVisible : false;
+			}
+
+			override setPartHidden(hidden: boolean, part: Parts): void {
+				if (part === Parts.PANEL_PART) {
+					this.panelVisible = !hidden;
+					if (!hidden) {
+						this.shownParts.push(part);
+					}
+				}
+			}
+
+			override setEditorMaximized(maximized: boolean): void {
+				this.maximizedStates.push(maximized);
+			}
+		};
+		instantiationService.set(IAgentWorkbenchLayoutService, layoutService);
+		instantiationService.set(IViewsService, new class extends mock<IViewsService>() {
+			override isViewVisible(_id: string): boolean {
+				return false;
+			}
+		});
+
+		const maximizeHandler = CommandsRegistry.getCommand('workbench.action.agentSessions.maximizeMainEditorPart')?.handler;
+		const restoreHandler = CommandsRegistry.getCommand('workbench.action.agentSessions.restoreMainEditorPart')?.handler;
+		assert.ok(maximizeHandler, 'Maximize command handler should be registered');
+		assert.ok(restoreHandler, 'Restore command handler should be registered');
+
+		await maximizeHandler(instantiationService);
+		await restoreHandler(instantiationService);
+
+		assert.deepStrictEqual(layoutService.shownParts, []);
+		assert.deepStrictEqual(layoutService.maximizedStates, [true, false]);
+		assert.strictEqual(layoutService.panelVisible, true);
+	});
+});

--- a/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
+++ b/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
@@ -18,10 +19,20 @@ import '../../browser/editor.contribution.js';
 
 suite('Sessions - Editor Contribution', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+	let store: DisposableStore;
+
+	setup(() => {
+		store = new DisposableStore();
+	});
+
+	teardown(() => {
+		store.dispose();
+	});
 
 	test('maximize editor hides the terminal panel before maximizing', async () => {
-		const instantiationService = new TestInstantiationService();
+		const instantiationService = store.add(new TestInstantiationService());
 		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
+			readonly calls: string[] = [];
 			readonly hiddenParts: Parts[] = [];
 			editorMaximized = false;
 			panelVisible = true;
@@ -36,11 +47,13 @@ suite('Sessions - Editor Contribution', () => {
 				}
 
 				if (hidden && part === Parts.PANEL_PART) {
+					this.calls.push('hidePanel');
 					this.hiddenParts.push(part);
 				}
 			}
 
 			override setEditorMaximized(maximized: boolean): void {
+				this.calls.push(maximized ? 'maximizeEditor' : 'restoreEditor');
 				this.editorMaximized = maximized;
 			}
 		};
@@ -56,12 +69,13 @@ suite('Sessions - Editor Contribution', () => {
 
 		await handler(instantiationService);
 
+		assert.deepStrictEqual(layoutService.calls, ['hidePanel', 'maximizeEditor']);
 		assert.deepStrictEqual(layoutService.hiddenParts, [Parts.PANEL_PART]);
 		assert.strictEqual(layoutService.editorMaximized, true);
 	});
 
 	test('maximize editor keeps non-terminal panels visible', async () => {
-		const instantiationService = new TestInstantiationService();
+		const instantiationService = store.add(new TestInstantiationService());
 		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
 			readonly hiddenParts: Parts[] = [];
 			editorMaximized = false;
@@ -102,7 +116,7 @@ suite('Sessions - Editor Contribution', () => {
 	});
 
 	test('restore editor reopens the terminal panel when maximize hid it', async () => {
-		const instantiationService = new TestInstantiationService();
+		const instantiationService = store.add(new TestInstantiationService());
 		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
 			readonly hiddenParts: Parts[] = [];
 			readonly shownParts: Parts[] = [];
@@ -150,7 +164,7 @@ suite('Sessions - Editor Contribution', () => {
 	});
 
 	test('restore editor does not reopen the panel when maximize left it visible', async () => {
-		const instantiationService = new TestInstantiationService();
+		const instantiationService = store.add(new TestInstantiationService());
 		const layoutService = new class extends mock<IAgentWorkbenchLayoutService>() {
 			readonly shownParts: Parts[] = [];
 			readonly maximizedStates: boolean[] = [];

--- a/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
+++ b/src/vs/sessions/contrib/editor/test/browser/editor.contribution.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
@@ -18,16 +17,7 @@ import { IAgentWorkbenchLayoutService } from '../../../../browser/workbench.js';
 import '../../browser/editor.contribution.js';
 
 suite('Sessions - Editor Contribution', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
-	let store: DisposableStore;
-
-	setup(() => {
-		store = new DisposableStore();
-	});
-
-	teardown(() => {
-		store.dispose();
-	});
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('maximize editor hides the terminal panel before maximizing', async () => {
 		const instantiationService = store.add(new TestInstantiationService());


### PR DESCRIPTION
## Summary
- hide the sessions panel only when **Maximize Editor** is invoked while the terminal view is visible
- restore the terminal panel when **Restore Editor** is invoked after that maximize flow hid it
- add regression coverage for the maximize/restore commands and document the sessions layout behavior

https://github.com/user-attachments/assets/c3efc781-04d6-4846-bf7b-9193558d5c8f

## Notes
- direct hygiene checks passed for the changed TypeScript files
- full repo compile/test validation was not completed in this worktree because the local environment initially lacked the expected bootstrap state and Node version