### PR TITLE
Make `timeout` optional in `run_in_terminal` and guide model to omit it for long-running commands

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -330,7 +330,7 @@ export async function createRunInTerminalToolData(
 		toolReferenceName: TOOL_REFERENCE_NAME,
 		legacyToolReferenceFullNames: LEGACY_TOOL_REFERENCE_FULL_NAMES,
 		displayName: localize('runInTerminalTool.displayName', 'Run in Terminal'),
-		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion up to timeout; if still running, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Use ${TerminalToolId.GetTerminalOutput} to check output before then. Do NOT poll or sleep to wait for completion.`,
+		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion (optionally capped by timeout); if still running when timeout elapses, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n\nTimeout parameter: Only set 'timeout' when you want a hard cap on how long the tool tracks the command. Omit it to let the command run to completion. Package installs, builds, and long-running scripts should usually omit the timeout rather than guessing a value.\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Use ${TerminalToolId.GetTerminalOutput} to check output before then. Do NOT poll or sleep to wait for completion.`,
 		userDescription: localize('runInTerminalTool.userDescription', 'Run commands in the terminal'),
 		source: ToolDataSource.Internal,
 		icon: Codicon.terminal,
@@ -354,10 +354,10 @@ export async function createRunInTerminalToolData(
 				},
 				timeout: {
 					type: 'number',
-					description: 'Timeout in milliseconds that determines how long to wait before returning. Use 0 for no timeout.',
+					description: 'Optional hard cap in milliseconds on how long the tool tracks the command before returning. Omit to let the command run to completion (recommended for package installs, builds, and long-running scripts). Use 0 to explicitly indicate no timeout.',
 				},
 			},
-			required: ['command', 'explanation', 'goal', 'mode', 'timeout']
+			required: ['command', 'explanation', 'goal', 'mode']
 		}
 	};
 }
@@ -1177,17 +1177,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			};
 		}
 		if (executionOptions.mode === 'sync' && args.timeout === undefined) {
-			if (args.isBackground === false) {
-				// Legacy path: isBackground=false didn't require timeout, default to no timeout
-				args.timeout = 0;
-			} else {
-				return {
-					content: [{
-						kind: 'text',
-						value: 'Error: timeout is required for mode=sync and must be provided in milliseconds (use 0 for no timeout).'
-					}]
-				};
-			}
+			// Timeout is optional for mode=sync: when omitted, the tool waits for
+			// the command to complete with no hard cap. Models frequently pick
+			// timeouts that are too short for package installs, builds, and
+			// long-running scripts, which causes the command to be moved to the
+			// background unnecessarily.
+			args.timeout = 0;
 		}
 
 		const chatSessionResource = invocation.context.sessionResource;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot-evaluation/issues/3499

### Root Cause

**Commit 992a6847a28 (April 6, 2026)** made `timeout` a **required** parameter in the `run_in_terminal` tool schema:

```diff
-required: ['command', 'explanation', 'goal', 'mode']
+required: ['command', 'explanation', 'goal', 'mode', 'timeout']
```

With timeout mandatory and the only guidance being `"Use 0 for no timeout"`, models consistently picked short values (≤120s) rather than 0. Combined with `chat.tools.terminal.enforceTimeoutFromModel` defaulting to `true`, these short timeouts were always enforced — causing commands to be moved to the background mid-execution and cascading into confusion.

---

### Evidence from Eval Runs

**Run `24049820070` (April 6, 2026 — same day as the commit, VS Code `1.117.0`)**
- **16 timeout events** across **6 instances**
- Top offenders:

| Instance | Timeouts | Values used |
|---|---|---|
| `qemu-alpine-ssh` | 5 | 5s, 120s, 240s |
| `extract-moves-from-video` | 4 | 30s, 60s |
| `query-optimize` | 3 | 40s, 180s |

Example from `qemu-alpine-ssh`, step 2:
```
command: python3 /tmp/boot_alpine_vm.py
timeout: 120000ms → timed out after 120s
```

**Run `24638368292` (April 19, 2026 — VS Code commit `a947515f`, timeout still mandatory)**
- **40 timeout events** across **14 instances** — **2.5× worse**
- Top offenders:

| Instance | Timeouts | Values used |
|---|---|---|
| `install-windows-3.11` | 10 | 20s, 30s, 60s |
| `mteb-leaderboard` | 11 | 30s, 70s, 100s |
| `mcmc-sampling-stan` | 4 | 120s |
| `query-optimize` | 3 | 20s, 40s, 120s |

Example from `install-windows-3.11`, step 6:
```
command: set -e\nls -1 /usr/share/novnc | head
mode: sync, timeout: 20000ms → "Command timed out after 20000ms.
The command may still be running in terminal ID 543e922b-..."
```
Example from `mteb-leaderboard`, step 4:
```
command: python - <<'PY'\nimport urllib.request\nurls=['https://mteb-leaderboard.hf.space', ...]
mode: sync, timeout: 30000ms → "Command timed out after 30000ms"
```

**Timeout distribution across 56 total timeout events:**
| Range | Count | % |
|---|---|---|
| ≤10s | 6 | 10% |
| 11–30s | 13 | 23% |
| 31–60s | 8 | 14% |
| 61–120s | 26 | 46% |
| >120s | 3 | 5% |

46% of timeouts were at exactly 120s — the model's "safe-seeming" default that's still insufficient for builds, installs, and network-bound commands.

---

### How the Current Fix Addresses It

The uncommitted changes on the working tree make two targeted changes:

**1. Remove `timeout` from `required`:**
```diff
-required: ['command', 'explanation', 'goal', 'mode', 'timeout']
+required: ['command', 'explanation', 'goal', 'mode']
```

**2. Replace the sparse description with explicit guidance:**
```diff
-description: 'Timeout in milliseconds that determines how long to wait before returning. Use 0 for no timeout.'
+description: 'Optional hard cap in milliseconds on how long the tool tracks the command before returning. Omit to let the command run to completion (recommended for package installs, builds, and long-running scripts). Use 0 to explicitly indicate no timeout.'
```

**3. Add a "Timeout parameter" section to `modelDescription`:**
```
Timeout parameter: Only set 'timeout' when you want a hard cap on how long the tool tracks the command. Omit it to let the command run to completion. Package installs, builds, and long-running scripts should usually omit the timeout rather than guessing a value.
```

**4. When `timeout` is omitted for `mode=sync`, default to 0 (no timeout):**
```typescript
if (executionOptions.mode === 'sync' && args.timeout === undefined) {
    // Models frequently pick timeouts that are too short for builds/installs
    args.timeout = 0;
}
```

This means for the majority of `mode=sync` calls where the model omits timeout, commands will wait indefinitely — exactly right for `python3 boot_alpine_vm.py`, `apt-get install`, `make`, etc. The model can still pass an explicit timeout for cases where it truly wants a cap (e.g., `ssh` connection attempts that should fail fast).


