### PR TITLE
extensions: split devtoolsExtensionHost action into its own contribution

### DIFF
--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -94,6 +94,9 @@ import '../workbench/services/browserView/electron-browser/playwrightWorkbenchSe
 import '../workbench/services/process/electron-browser/processService.js';
 import '../workbench/services/power/electron-browser/powerService.js';
 
+// Contributions
+import '../workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.js';
+
 import { registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { IUserDataInitializationService, UserDataInitializationService } from '../workbench/services/userData/browser/userDataInit.js';
 import { SyncDescriptor } from '../platform/instantiation/common/descriptors.js';

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -94,9 +94,6 @@ import '../workbench/services/browserView/electron-browser/playwrightWorkbenchSe
 import '../workbench/services/process/electron-browser/processService.js';
 import '../workbench/services/power/electron-browser/powerService.js';
 
-// Contributions
-import '../workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.js';
-
 import { registerSingleton } from '../platform/instantiation/common/extensions.js';
 import { IUserDataInitializationService, UserDataInitializationService } from '../workbench/services/userData/browser/userDataInit.js';
 import { SyncDescriptor } from '../platform/instantiation/common/descriptors.js';
@@ -123,6 +120,9 @@ import '../workbench/contrib/codeEditor/electron-browser/codeEditor.contribution
 
 // Debug
 import '../workbench/contrib/debug/electron-browser/extensionHostDebugService.js';
+
+// Extension devtools
+import '../workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.js';
 
 
 // Issues

--- a/src/vs/workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { DebugExtensionHostInDevToolsAction } from './debugExtensionHostAction.js';
+
+registerAction2(DebugExtensionHostInDevToolsAction);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -19,7 +19,7 @@ import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { RuntimeExtensionsInput } from '../common/runtimeExtensionsInput.js';
-import { DebugExtensionHostInNewWindowAction, DebugExtensionsContribution, DebugExtensionHostInDevToolsAction, DebugRendererInNewWindowAction, DebugExtensionHostAndRendererAction } from './debugExtensionHostAction.js';
+import { DebugExtensionHostInNewWindowAction, DebugExtensionsContribution, DebugRendererInNewWindowAction, DebugExtensionHostAndRendererAction } from './debugExtensionHostAction.js';
 import { ExtensionHostProfileService } from './extensionProfileService.js';
 import { CleanUpExtensionsFolderAction, OpenExtensionsFolderAction } from './extensionsActions.js';
 import { ExtensionsAutoProfiler } from './extensionsAutoProfiler.js';
@@ -83,4 +83,3 @@ registerAction2(StartExtensionHostProfileAction);
 registerAction2(StopExtensionHostProfileAction);
 registerAction2(SaveExtensionHostProfileAction);
 registerAction2(OpenExtensionHostProfileACtion);
-registerAction2(DebugExtensionHostInDevToolsAction);

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -125,6 +125,7 @@ import './contrib/debug/electron-browser/extensionHostDebugService.js';
 
 // Extensions Management
 import './contrib/extensions/electron-browser/extensions.contribution.js';
+import './contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.js';
 
 // Issues
 import './contrib/issue/electron-browser/issue.contribution.js';


### PR DESCRIPTION
Pulls `DebugExtensionHostInDevToolsAction` registration out of `extensions.contribution.ts` into a new `devtoolsExtensionHost.contribution.ts` so the Agents app (`vs/sessions`) can opt into just this action without importing the full electron-browser extensions contribution.

Mirrors the recent timeline split in [#311882](https://github.com/microsoft/vscode/pull/311882).

### What changed

- New: `src/vs/workbench/contrib/extensions/electron-browser/devtoolsExtensionHost.contribution.ts` — registers `DebugExtensionHostInDevToolsAction`.
- `extensions.contribution.ts` no longer imports/registers that action.
- `workbench.desktop.main.ts` now imports the new contribution (no behavior change for VS Code).
- `sessions.desktop.main.ts` imports the new contribution, so the **Debug Extension Host In Dev Tools** command is now available in the Agents app.

### Why

The command is genuinely useful when debugging the extension host inside the Agents app, but it had never been wired up there. The other debug actions (`DebugExtensionHostInNewWindowAction`, `DebugRendererInNewWindowAction`, `DebugExtensionHostAndRendererAction`, `DebugExtensionsContribution`) are intentionally **not** included because they require additional services not currently in Agents (`IDebugService`, `IExtensionHostDebugService`, `IProgressService`, etc.). The dev-tools action only needs services already registered:

- `IExtensionService` — via `nativeExtensionService.js`
- `INativeHostService` — via `nativeHostService.js`
- `IQuickInputService` — via `quickInputService.js`

So this brings the action over with **no new service registrations** in the Agents app.

(Written by Copilot)