### PR TITLE
fix: use vscode-chat integration ID for Mission Control API

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -11,6 +11,7 @@ import type * as vscode from 'vscode';
 import type { ChatParticipantToolToken } from 'vscode';
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
 import { ConfigKey, IConfigurationService } from '../../../../platform/configuration/common/configurationService';
+import { INTEGRATION_ID as MC_INTEGRATION_ID } from '../../../../platform/endpoint/common/licenseAgreement';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { GenAiMetrics } from '../../../../platform/otel/common/genAiMetrics';
 import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, ISpanHandle, SpanKind, SpanStatusCode, truncateForOTel, resolveWorkspaceOTelMetadata, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
@@ -52,9 +53,6 @@ export type CopilotCLICommand = 'compact' | 'plan' | 'fleet' | 'remote';
  * distinguish a slash-command from a regular prompt at runtime.
  */
 export const copilotCLICommands: readonly CopilotCLICommand[] = ['compact', 'plan', 'fleet', 'remote'] as const;
-
-/** Integration ID used for Mission Control API calls, including the Copilot-Integration-Id header and the session.start event producer. */
-const MC_INTEGRATION_ID = 'vscode-chat';
 
 /** Event structure sent to the Mission Control API. */
 interface McEvent {
@@ -1837,4 +1835,3 @@ function buildPromptTokenDetails(usageInfo: UsageInfoData | undefined): { catego
 	}
 	return details.length > 0 ? details : undefined;
 }
-

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -53,7 +53,7 @@ export type CopilotCLICommand = 'compact' | 'plan' | 'fleet' | 'remote';
  */
 export const copilotCLICommands: readonly CopilotCLICommand[] = ['compact', 'plan', 'fleet', 'remote'] as const;
 
-/** Integration ID sent in the Copilot-Integration-Id header for Mission Control API calls. */
+/** Integration ID used for Mission Control API calls, including the Copilot-Integration-Id header and the session.start event producer. */
 const MC_INTEGRATION_ID = 'vscode-chat';
 
 /** Event structure sent to the Mission Control API. */

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -53,6 +53,9 @@ export type CopilotCLICommand = 'compact' | 'plan' | 'fleet' | 'remote';
  */
 export const copilotCLICommands: readonly CopilotCLICommand[] = ['compact', 'plan', 'fleet', 'remote'] as const;
 
+/** Integration ID sent in the Copilot-Integration-Id header for Mission Control API calls. */
+const MC_INTEGRATION_ID = 'vscode-chat';
+
 /** Event structure sent to the Mission Control API. */
 interface McEvent {
 	id: string;
@@ -1060,7 +1063,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				headers: {
 					'Authorization': `Bearer ${githubToken}`,
 					'Content-Type': 'application/json',
-					'Copilot-Integration-Id': 'copilot-developer-cli',
+					'Copilot-Integration-Id': MC_INTEGRATION_ID,
 				},
 				body: JSON.stringify({
 					owner_id: repoData.owner.id,
@@ -1102,7 +1105,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			const sessionStartEvent = this._createMcEvent('session.start', {
 				sessionId: sharedState.mcSessionId,
 				version: 1,
-				producer: 'copilot-developer-cli',
+				producer: MC_INTEGRATION_ID,
 				copilotVersion: '1.0.0',
 				startTime: new Date().toISOString(),
 				remoteSteerable: true,
@@ -1257,7 +1260,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 					method: 'DELETE',
 					headers: {
 						'Authorization': `Bearer ${session.accessToken}`,
-						'Copilot-Integration-Id': 'copilot-developer-cli',
+						'Copilot-Integration-Id': MC_INTEGRATION_ID,
 					},
 				});
 			}
@@ -1430,7 +1433,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				headers: {
 					'Authorization': `Bearer ${state.mcGithubToken}`,
 					'Content-Type': 'application/json',
-					'Copilot-Integration-Id': 'copilot-developer-cli',
+					'Copilot-Integration-Id': MC_INTEGRATION_ID,
 				},
 				body,
 			});
@@ -1497,7 +1500,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 			const response = await fetch(`${state.mcApiUrl}/agents/sessions/${state.mcSessionId}/commands`, {
 				headers: {
 					'Authorization': `Bearer ${state.mcGithubToken}`,
-					'Copilot-Integration-Id': 'copilot-developer-cli',
+					'Copilot-Integration-Id': MC_INTEGRATION_ID,
 				},
 			});
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/missionControlApiClient.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/missionControlApiClient.ts
@@ -4,12 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IAuthenticationService } from '../../../../platform/authentication/common/authentication';
+import { INTEGRATION_ID } from '../../../../platform/endpoint/common/licenseAgreement';
 import { PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IFetcherService } from '../../../../platform/networking/common/fetcherService';
-
-/** Integration id for requests originating from VS Code chat. */
-const INTEGRATION_ID = 'vscode-chat';
 
 /** Base path for Mission Control (agent session) endpoints. */
 const SESSIONS_PATH = '/agents/sessions';

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/missionControlApiClient.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/missionControlApiClient.ts
@@ -8,8 +8,8 @@ import { PermissiveAuthRequiredError } from '../../../../platform/github/common/
 import { ILogService } from '../../../../platform/log/common/logService';
 import { IFetcherService } from '../../../../platform/networking/common/fetcherService';
 
-/** Integration id for requests originating from the Copilot CLI /remote feature. */
-const INTEGRATION_ID = 'copilot-developer-cli';
+/** Integration id for requests originating from VS Code chat. */
+const INTEGRATION_ID = 'vscode-chat';
 
 /** Base path for Mission Control (agent session) endpoints. */
 const SESSIONS_PATH = '/agents/sessions';


### PR DESCRIPTION
## Summary

Changes the `Copilot-Integration-Id` header from `copilot-developer-cli` to `vscode-chat` for all Mission Control API calls, and extracts the value into a `MC_INTEGRATION_ID` constant to avoid future duplication.

## Changes

- Added `MC_INTEGRATION_ID = 'vscode-chat'` constant
- Updated all 5 occurrences:
  - Session creation (`POST /agents/sessions`)
  - Session deletion (`DELETE /agents/sessions/:id`)
  - Event submission (`POST /agents/sessions/:id/events`)
  - Command polling (`GET /agents/sessions/:id/commands`)
  - `session.start` event `producer` field

## Context

The mobile team identified that VS Code needs to use the correct integration ID (`vscode-chat`) for MC API calls to enable reliable e2e testing. This was previously using `copilot-developer-cli` which is the copilot-agent-runtime's default.