### PR TITLE
Plan agent: 3-tier graceful degradation for Explore and search subagent

### DIFF
--- a/extensions/copilot/src/extension/agents/vscode-node/planAgentProvider.ts
+++ b/extensions/copilot/src/extension/agents/vscode-node/planAgentProvider.ts
@@ -9,6 +9,7 @@ import { AGENT_FILE_EXTENSION } from '../../../platform/customInstructions/commo
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IFileSystemService } from '../../../platform/filesystem/common/fileSystemService';
 import { ILogService } from '../../../platform/log/common/logService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 import { AgentConfig, AgentHandoff, buildAgentMarkdown, DEFAULT_READ_TOOLS } from './agentTypes';
 
@@ -22,10 +23,8 @@ const BASE_PLAN_AGENT_CONFIG: AgentConfig = {
 	argumentHint: 'Outline the goal or problem to research',
 	target: 'vscode',
 	disableModelInvocation: true,
-	agents: ['Explore'],
 	tools: [
 		...DEFAULT_READ_TOOLS,
-		'agent',
 	],
 	handoffs: [], // Handoffs are generated dynamically in buildCustomizedConfig
 	body: '' // Body is generated dynamically in buildCustomizedConfig
@@ -52,6 +51,7 @@ export class PlanAgentProvider extends Disposable implements vscode.ChatCustomAg
 		@IVSCodeExtensionContext private readonly extensionContext: IVSCodeExtensionContext,
 		@IFileSystemService private readonly fileSystemService: IFileSystemService,
 		@ILogService private readonly logService: ILogService,
+		@IExperimentationService private readonly experimentationService: IExperimentationService,
 	) {
 		super();
 
@@ -63,7 +63,8 @@ export class PlanAgentProvider extends Disposable implements vscode.ChatCustomAg
 			if (e.affectsConfiguration(ConfigKey.PlanAgentAdditionalTools.fullyQualifiedId) ||
 				e.affectsConfiguration(ConfigKey.Deprecated.PlanAgentModel.fullyQualifiedId) ||
 				e.affectsConfiguration('chat.planAgent.defaultModel') ||
-				e.affectsConfiguration(ConfigKey.ImplementAgentModel.fullyQualifiedId)) {
+				e.affectsConfiguration(ConfigKey.ImplementAgentModel.fullyQualifiedId) ||
+				e.affectsConfiguration(ConfigKey.ExploreAgentEnabled.fullyQualifiedId)) {
 				this._onDidChangeCustomAgents.fire();
 			}
 		}));
@@ -103,10 +104,16 @@ export class PlanAgentProvider extends Disposable implements vscode.ChatCustomAg
 		return fileUri;
 	}
 
-	static buildAgentBody(): string {
-		const discoverySection = `## 1. Discovery
+	static buildAgentBody(exploreEnabled: boolean): string {
+		const discoverySection = exploreEnabled
+			? `## 1. Discovery
 
 Run the *Explore* subagent to gather context, analogous existing features to use as implementation templates, and potential blockers or ambiguities. When the task spans multiple independent areas (e.g., frontend + backend, different features, separate repos), launch **2-3 *Explore* subagents in parallel** — one per area — to speed up discovery.
+
+Update the plan with your findings.`
+			: `## 1. Discovery
+
+Use #tool:searchSubagent to gather context, analogous existing features to use as implementation templates, and potential blockers or ambiguities. When the task spans multiple independent areas (e.g., frontend + backend, different features, separate repos), launch **2-3 search subagents in parallel** — one per area — to speed up discovery.
 
 Update the plan with your findings.`;
 
@@ -197,6 +204,7 @@ Rules:
 
 	private buildCustomizedConfig(): AgentConfig {
 		const additionalTools = this.configurationService.getConfig(ConfigKey.PlanAgentAdditionalTools);
+		const isExploreEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, this.experimentationService);
 		const coreDefaultModel = this.configurationService.getNonExtensionConfig<string>('chat.planAgent.defaultModel');
 		const modelOverride = coreDefaultModel || this.configurationService.getConfig(ConfigKey.Deprecated.PlanAgentModel);
 
@@ -225,6 +233,11 @@ Rules:
 		// Always include askQuestions tool (now provided by core)
 		toolsToAdd.push('vscode/askQuestions');
 
+		// When explore agent is enabled, include the 'agent' tool to allow sub-agent calls
+		if (isExploreEnabled) {
+			toolsToAdd.push('agent');
+		}
+
 		// Merge additional tools (deduplicated)
 		const tools = toolsToAdd.length > 0
 			? [...new Set([...BASE_PLAN_AGENT_CONFIG.tools, ...toolsToAdd])]
@@ -233,9 +246,11 @@ Rules:
 		// Start with base config
 		return {
 			...BASE_PLAN_AGENT_CONFIG,
+			// When explore agent is enabled, allow the Explore subagent
+			...(isExploreEnabled ? { agents: ['Explore'] } : {}),
 			tools,
 			handoffs: [startImplementationHandoff, openInEditorHandoff, ...(BASE_PLAN_AGENT_CONFIG.handoffs ?? [])],
-			body: PlanAgentProvider.buildAgentBody(),
+			body: PlanAgentProvider.buildAgentBody(isExploreEnabled),
 			...(modelOverride ? { model: modelOverride } : {}),
 		};
 	}

--- a/extensions/copilot/src/extension/agents/vscode-node/planAgentProvider.ts
+++ b/extensions/copilot/src/extension/agents/vscode-node/planAgentProvider.ts
@@ -64,7 +64,8 @@ export class PlanAgentProvider extends Disposable implements vscode.ChatCustomAg
 				e.affectsConfiguration(ConfigKey.Deprecated.PlanAgentModel.fullyQualifiedId) ||
 				e.affectsConfiguration('chat.planAgent.defaultModel') ||
 				e.affectsConfiguration(ConfigKey.ImplementAgentModel.fullyQualifiedId) ||
-				e.affectsConfiguration(ConfigKey.ExploreAgentEnabled.fullyQualifiedId)) {
+				e.affectsConfiguration(ConfigKey.ExploreAgentEnabled.fullyQualifiedId) ||
+				e.affectsConfiguration(ConfigKey.Advanced.SearchSubagentToolEnabled.fullyQualifiedId)) {
 				this._onDidChangeCustomAgents.fire();
 			}
 		}));
@@ -104,18 +105,27 @@ export class PlanAgentProvider extends Disposable implements vscode.ChatCustomAg
 		return fileUri;
 	}
 
-	static buildAgentBody(exploreEnabled: boolean): string {
-		const discoverySection = exploreEnabled
-			? `## 1. Discovery
+	static buildAgentBody(exploreEnabled: boolean, searchSubagentEnabled: boolean): string {
+		let discoverySection: string;
+		if (exploreEnabled) {
+			discoverySection = `## 1. Discovery
 
 Run the *Explore* subagent to gather context, analogous existing features to use as implementation templates, and potential blockers or ambiguities. When the task spans multiple independent areas (e.g., frontend + backend, different features, separate repos), launch **2-3 *Explore* subagents in parallel** — one per area — to speed up discovery.
 
-Update the plan with your findings.`
-			: `## 1. Discovery
+Update the plan with your findings.`;
+		} else if (searchSubagentEnabled) {
+			discoverySection = `## 1. Discovery
 
 Use #tool:searchSubagent to gather context, analogous existing features to use as implementation templates, and potential blockers or ambiguities. When the task spans multiple independent areas (e.g., frontend + backend, different features, separate repos), launch **2-3 search subagents in parallel** — one per area — to speed up discovery.
 
 Update the plan with your findings.`;
+		} else {
+			discoverySection = `## 1. Discovery
+
+Search the codebase to gather context, analogous existing features to use as implementation templates, and potential blockers or ambiguities.
+
+Update the plan with your findings.`;
+		}
 
 		return `You are a PLANNING AGENT, pairing with the user to create a detailed, actionable plan.
 
@@ -205,6 +215,7 @@ Rules:
 	private buildCustomizedConfig(): AgentConfig {
 		const additionalTools = this.configurationService.getConfig(ConfigKey.PlanAgentAdditionalTools);
 		const isExploreEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, this.experimentationService);
+		const isSearchSubagentEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, this.experimentationService);
 		const coreDefaultModel = this.configurationService.getNonExtensionConfig<string>('chat.planAgent.defaultModel');
 		const modelOverride = coreDefaultModel || this.configurationService.getConfig(ConfigKey.Deprecated.PlanAgentModel);
 
@@ -250,7 +261,7 @@ Rules:
 			...(isExploreEnabled ? { agents: ['Explore'] } : {}),
 			tools,
 			handoffs: [startImplementationHandoff, openInEditorHandoff, ...(BASE_PLAN_AGENT_CONFIG.handoffs ?? [])],
-			body: PlanAgentProvider.buildAgentBody(isExploreEnabled),
+			body: PlanAgentProvider.buildAgentBody(isExploreEnabled, isSearchSubagentEnabled),
 			...(modelOverride ? { model: modelOverride } : {}),
 		};
 	}

--- a/extensions/copilot/src/extension/agents/vscode-node/test/planAgentProvider.spec.ts
+++ b/extensions/copilot/src/extension/agents/vscode-node/test/planAgentProvider.spec.ts
@@ -362,6 +362,70 @@ suite('PlanAgentProvider', () => {
 
 		assert.equal(eventFired, true);
 	});
+
+	test('fires onDidChangeCustomAgents when SearchSubagentToolEnabled setting changes', async () => {
+		const provider = createProvider();
+
+		let eventFired = false;
+		provider.onDidChangeCustomAgents(() => {
+			eventFired = true;
+		});
+
+		await mockConfigurationService.setConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, true);
+
+		assert.equal(eventFired, true);
+	});
+
+	test('buildAgentBody uses Explore discovery when explore is enabled', () => {
+		const body = PlanAgentProvider.buildAgentBody(true, true);
+		assert.ok(body.includes('Run the *Explore* subagent'));
+		assert.ok(!body.includes('#tool:searchSubagent'));
+	});
+
+	test('buildAgentBody uses search subagent discovery when explore is disabled but search is enabled', () => {
+		const body = PlanAgentProvider.buildAgentBody(false, true);
+		assert.ok(body.includes('#tool:searchSubagent'));
+		assert.ok(!body.includes('Run the *Explore* subagent'));
+	});
+
+	test('buildAgentBody uses generic discovery when both explore and search are disabled', () => {
+		const body = PlanAgentProvider.buildAgentBody(false, false);
+		assert.ok(body.includes('Search the codebase to gather context'));
+		assert.ok(!body.includes('Run the *Explore* subagent'));
+		assert.ok(!body.includes('#tool:searchSubagent'));
+	});
+
+	test('excludes agent tool and Explore subagent when explore is disabled', async () => {
+		await mockConfigurationService.setConfig(ConfigKey.ExploreAgentEnabled, false);
+
+		const provider = createProvider();
+		const agents = await provider.provideCustomAgents({}, {} as any);
+		const content = await getAgentContent(agents[0]);
+
+		// Should not have the 'agent' tool
+		const toolsMatch = content.match(/tools: \[([^\]]+)\]/);
+		assert.ok(toolsMatch);
+		assert.ok(!toolsMatch[1].includes('\'agent\''), 'Should not include agent tool when explore is disabled');
+
+		// Should not have agents field
+		assert.ok(!content.includes('agents:'), 'Should not include agents field when explore is disabled');
+	});
+
+	test('includes agent tool and Explore subagent when explore is enabled', async () => {
+		await mockConfigurationService.setConfig(ConfigKey.ExploreAgentEnabled, true);
+
+		const provider = createProvider();
+		const agents = await provider.provideCustomAgents({}, {} as any);
+		const content = await getAgentContent(agents[0]);
+
+		// Should have the 'agent' tool
+		const toolsMatch = content.match(/tools: \[([^\]]+)\]/);
+		assert.ok(toolsMatch);
+		assert.ok(toolsMatch[1].includes('\'agent\''), 'Should include agent tool when explore is enabled');
+
+		// Should have agents field with Explore
+		assert.ok(content.includes('agents:'), 'Should include agents field when explore is enabled');
+	});
 });
 
 suite('buildAgentMarkdown', () => {

--- a/extensions/copilot/src/extension/tools/vscode-node/switchAgentTool.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/switchAgentTool.ts
@@ -26,7 +26,8 @@ export class SwitchAgentTool implements ICopilotTool<ISwitchAgentParams> {
 			throw new Error(vscode.l10n.t('Only "Plan" agent is supported'));
 		}
 
-		const planAgentBody = PlanAgentProvider.buildAgentBody();
+		const exploreEnabled = vscode.workspace.getConfiguration('github.copilot').get<boolean>('chat.exploreAgent.enabled', true);
+		const planAgentBody = PlanAgentProvider.buildAgentBody(exploreEnabled);
 
 		// Execute command to switch agent
 		await vscode.commands.executeCommand('workbench.action.chat.toggleAgentMode', {

--- a/extensions/copilot/src/extension/tools/vscode-node/switchAgentTool.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/switchAgentTool.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { CancellationToken } from '../../../util/vs/base/common/cancellation';
 import { LanguageModelTextPart, LanguageModelToolResult, MarkdownString } from '../../../vscodeTypes';
 import { PlanAgentProvider } from '../../agents/vscode-node/planAgentProvider';
@@ -18,6 +20,11 @@ export class SwitchAgentTool implements ICopilotTool<ISwitchAgentParams> {
 	public static readonly toolName = ToolName.SwitchAgent;
 	public static readonly nonDeferred = true;
 
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExperimentationService private readonly experimentationService: IExperimentationService,
+	) { }
+
 	async invoke(options: vscode.LanguageModelToolInvocationOptions<ISwitchAgentParams>, token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
 		const { agentName } = options.input;
 
@@ -26,8 +33,9 @@ export class SwitchAgentTool implements ICopilotTool<ISwitchAgentParams> {
 			throw new Error(vscode.l10n.t('Only "Plan" agent is supported'));
 		}
 
-		const exploreEnabled = vscode.workspace.getConfiguration('github.copilot').get<boolean>('chat.exploreAgent.enabled', true);
-		const planAgentBody = PlanAgentProvider.buildAgentBody(exploreEnabled);
+		const exploreEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.ExploreAgentEnabled, this.experimentationService);
+		const searchSubagentEnabled = this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.SearchSubagentToolEnabled, this.experimentationService);
+		const planAgentBody = PlanAgentProvider.buildAgentBody(exploreEnabled, searchSubagentEnabled);
 
 		// Execute command to switch agent
 		await vscode.commands.executeCommand('workbench.action.chat.toggleAgentMode', {


### PR DESCRIPTION
When `github.copilot.chat.exploreAgent.enabled` or `github.copilot.chat.searchSubagent.enabled` are disabled, the Plan agent now gracefully degrades with a 3-tier discovery prompt:

1. **Explore enabled** → Explore subagent discovery (parallel subagents)
2. **Search subagent enabled** (explore off) → `#tool:searchSubagent` discovery
3. **Both disabled** → generic "Search the codebase" fallback

## Changes

### `planAgentProvider.ts`
- `buildAgentBody(exploreEnabled, searchSubagentEnabled)` — 3-tier discovery section based on two booleans
- `buildCustomizedConfig()` — reads `SearchSubagentToolEnabled` via `getExperimentBasedConfig`
- Config change listener — watches `SearchSubagentToolEnabled` to regenerate the agent dynamically
- Conditional `agents` field and `agent` tool inclusion based on explore enablement

### `switchAgentTool.ts`
- Added constructor with `IConfigurationService` + `IExperimentationService` DI
- Replaced direct `vscode.workspace.getConfiguration()` read with `getExperimentBasedConfig` for both explore and search settings, matching `PlanAgentProvider`'s approach

### `planAgentProvider.spec.ts`
- 7 new tests: 3-tier discovery body variants, `SearchSubagentToolEnabled` config change listener, explore enable/disable effect on agent config (tools + agents field)