### PR TITLE
Sequence setMetadata writes per key to fix flaky session config test

### DIFF
--- a/src/vs/platform/agentHost/node/sessionDatabase.ts
+++ b/src/vs/platform/agentHost/node/sessionDatabase.ts
@@ -196,6 +196,19 @@ export class SessionDatabase implements ISessionDatabase {
 	private readonly _fileEditSequencer = new SequencerByKey<string>();
 
 	/**
+	 * Serializes `setMetadata` writes per key. `@vscode/sqlite3` runs in
+	 * parallelized mode, so two `db.run()` calls on the same connection
+	 * can be dispatched to the libuv thread pool and complete out of
+	 * submission order. For "last writer wins" keys (notably `configValues`
+	 * via {@link setMetadata}), that meant a fast-following second write
+	 * could be overtaken by the first and silently lose its value — see
+	 * the "Session Config persistence across restarts" integration test.
+	 * Sequencing by key preserves intra-key order while still allowing
+	 * writes for different keys to run concurrently.
+	 */
+	private readonly _metadataSequencer = new SequencerByKey<string>();
+
+	/**
 	 * In-flight write operations. Tracked so {@link whenIdle} can await them
 	 * before the process exits — without this, a `SIGTERM` arriving between
 	 * a fire-and-forget mutating call (e.g. `setMetadata`) being invoked and
@@ -483,10 +496,10 @@ export class SessionDatabase implements ISessionDatabase {
 	}
 
 	setMetadata(key: string, value: string): Promise<void> {
-		return this._track(async () => {
+		return this._track(() => this._metadataSequencer.queue(key, async () => {
 			const db = await this._ensureDb();
 			await dbRun(db, 'INSERT OR REPLACE INTO session_metadata (key, value) VALUES (?, ?)', [key, value]);
-		});
+		}));
 	}
 
 	remapTurnIds(mapping: ReadonlyMap<string, string>): Promise<void> {


### PR DESCRIPTION
## Symptom

The integration test `Protocol WebSocket - Session Config persistence across restarts > persisted config values are restored on subscribe after server restart` has been intermittently failing in CI:

```
+ expected - actual
 {
-  "branch": "main"
+  "branch": "release"
   "isolation": "worktree"
 }
```

The test creates a session, dispatches `SessionConfigChanged` to switch the branch from `main` to `release`, restarts the server, and then asserts that `release` is what comes back. Sometimes `main` came back instead.

## Root cause

`@vscode/sqlite3` runs in **parallelized** mode by default — `db.run()` calls on the same connection are dispatched to libuv's thread pool and can complete out of submission order.

In this scenario, two `setMetadata('configValues', …)` writes happen back-to-back on the same connection:

1. `AgentService._persistConfigValues` writes the initial config when the session is created.
2. `AgentSideEffects._persistSessionFlag` writes the updated config after `SessionConfigChanged`.

Both writes are correctly awaited via the existing `whenIdle()` flush, but the second `db.run` can finish *before* the first one inside SQLite's worker pool, so the older value ends up as the final on-disk row. Captured timing during a reproduction confirmed this:

- Write 2 (`release`) completed at dt=7ms
- Write 1 (`main`) completed at dt=13ms → `main` was the last writer to disk

This is not just a test artefact: any rapid sequence of `SessionConfigChanged` actions on the same key (e.g. fast UI toggles) could lose the latest value in production.

## Fix

Route `setMetadata` through a `SequencerByKey<string>` keyed by metadata key, so writes for the same key run in submission order while writes for different keys still run concurrently. This is the same pattern already used for `storeFileEdit` (keyed by file path) for the same reason.

The fix is intentionally narrow:
- Other write paths (`createTurn`, `deleteTurn`, `truncateFromTurn`, etc.) are not "last-writer-wins on a key" — they're inserts/deletes/transactions where out-of-order completion doesn't have the same hidden corruption mode.
- Per-key sequencing preserves concurrency for different keys.

## Validation

Stress-tested locally by running 12 parallel test processes in batches:

- **Before fix:** ~1–2 failures per 100 runs.
- **After fix:** 180 / 180 runs pass.

(Written by Copilot)