### PR TITLE
Tear down SSH tunnel when removing a remote

### DIFF
--- a/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostServiceImpl.ts
@@ -8,7 +8,7 @@
 // and maintains connections, reconnecting as the setting changes.
 
 import { Emitter } from '../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { DeferredPromise, raceTimeout } from '../../../base/common/async.js';
 import { ConfigurationTarget, IConfigurationService } from '../../configuration/common/configuration.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -59,7 +59,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	private readonly _tokens = new Map<string, string | undefined>();
 	/**
 	 * Stores the original {@link IRemoteAgentHostEntry} for connections
-	 * registered via {@link addSSHConnection}. This is needed because
+	 * registered via {@link addManagedConnection}. This is needed because
 	 * tunnel entries are not persisted to settings and therefore don't
 	 * appear in {@link configuredEntries}.
 	 */
@@ -206,7 +206,7 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		return connection;
 	}
 
-	async addSSHConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection): Promise<IRemoteAgentHostConnectionInfo> {
+	async addManagedConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection, transportDisposable?: IDisposable): Promise<IRemoteAgentHostConnectionInfo> {
 		const address = getEntryAddress(entry);
 
 		// Dispose any existing entry for this address to avoid leaking
@@ -222,6 +222,12 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		// Create a connection entry wrapping the pre-connected client
 		const protocolClient = connection as RemoteAgentHostProtocolClient;
 		store.add(protocolClient);
+		// Tear the underlying transport (e.g. SSH/tunnel relay) down with
+		// the entry. This is what makes "Remove Remote" actually close the
+		// shared-process tunnel and stop the remote agent host process.
+		if (transportDisposable) {
+			store.add(transportDisposable);
+		}
 		const connEntry: IConnectionEntry = { store, client: protocolClient, connected: true, status: RemoteAgentHostConnectionStatus.Connected };
 		this._entries.set(address, connEntry);
 		this._names.set(address, entry.name);

--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+import { IDisposable } from '../../../base/common/lifecycle.js';
 import { connectionTokenQueryName } from '../../../base/common/network.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { IAgentConnection } from './agentService.js';
@@ -169,8 +170,18 @@ export interface IRemoteAgentHostService {
 	 * Register a pre-connected agent connection.
 	 * Used by the SSH and tunnel services to inject relay-backed connections
 	 * without going through the WebSocket connect flow.
+	 *
+	 * The optional `transportDisposable` represents the underlying transport
+	 * (e.g. an SSH tunnel relay or tunnel-relay session) and is owned by this
+	 * service for the lifetime of the entry. It will be disposed when:
+	 *   - the entry is removed via {@link removeRemoteAgentHost}
+	 *   - the entry is reconciled away (config-driven removal)
+	 *   - this service itself is disposed
+	 * Callers should put any teardown that needs to happen on entry removal
+	 * (e.g. closing the shared-process tunnel, dropping renderer-side handles)
+	 * into this disposable, so a single removal path tears down the whole stack.
 	 */
-	addSSHConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection): Promise<IRemoteAgentHostConnectionInfo>;
+	addManagedConnection(entry: IRemoteAgentHostEntry, connection: IAgentConnection, transportDisposable?: IDisposable): Promise<IRemoteAgentHostConnectionInfo>;
 
 	/**
 	 * Look up the {@link IRemoteAgentHostEntry} for a given address.
@@ -200,7 +211,7 @@ export class NullRemoteAgentHostService implements IRemoteAgentHostService {
 	}
 	async removeRemoteAgentHost(_address: string): Promise<void> { }
 	reconnect(_address: string): void { }
-	async addSSHConnection(): Promise<IRemoteAgentHostConnectionInfo> {
+	async addManagedConnection(): Promise<IRemoteAgentHostConnectionInfo> {
 		throw new Error('Remote agent host connections are not supported in this environment.');
 	}
 	getEntryByAddress(): IRemoteAgentHostEntry | undefined { return undefined; }

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../base/common/event.js';
-import { Disposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
@@ -86,23 +86,11 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		}
 
 		// Create relay transport + protocol client, then register with RemoteAgentHostService
+		let protocolClient: RemoteAgentHostProtocolClient;
 		try {
-			const protocolClient = this._createRelayClient(result);
+			protocolClient = this._createRelayClient(result);
 			await protocolClient.connect();
 			this._logService.trace('[SSHRemoteAgentHost] Protocol handshake completed');
-
-			await this._remoteAgentHostService.addSSHConnection({
-				name: result.name,
-				connectionToken: result.connectionToken,
-				connection: {
-					type: RemoteAgentHostEntryType.SSH,
-					address: result.address,
-					sshConfigHost: result.sshConfigHost,
-					hostName: result.config.host,
-					user: result.config.username || undefined,
-					port: result.config.port,
-				},
-			}, protocolClient);
 		} catch (err) {
 			this._logService.error('[SSHRemoteAgentHost] Connection setup failed', err);
 			this._mainService.disconnect(result.connectionId).catch(() => { /* best effort */ });
@@ -118,6 +106,19 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 
 		this._connections.set(result.connectionId, handle);
 		this._onDidChangeConnections.fire();
+
+		await this._remoteAgentHostService.addManagedConnection({
+			name: result.name,
+			connectionToken: result.connectionToken,
+			connection: {
+				type: RemoteAgentHostEntryType.SSH,
+				address: result.address,
+				sshConfigHost: result.sshConfigHost,
+				hostName: result.config.host,
+				user: result.config.username || undefined,
+				port: result.config.port,
+			},
+		}, protocolClient, this._createTransportDisposable(result.connectionId, handle));
 
 		return handle;
 	}
@@ -146,19 +147,6 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		const protocolClient = this._createRelayClient(result);
 		await protocolClient.connect();
 
-		await this._remoteAgentHostService.addSSHConnection({
-			name: result.name,
-			connectionToken: result.connectionToken,
-			connection: {
-				type: RemoteAgentHostEntryType.SSH,
-				address: result.address,
-				sshConfigHost: result.sshConfigHost,
-				hostName: result.config.host,
-				user: result.config.username || undefined,
-				port: result.config.port,
-			},
-		}, protocolClient);
-
 		const handle = new SSHAgentHostConnectionHandle(
 			result.config,
 			result.address,
@@ -169,7 +157,46 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		this._connections.set(result.connectionId, handle);
 		this._onDidChangeConnections.fire();
 
+		await this._remoteAgentHostService.addManagedConnection({
+			name: result.name,
+			connectionToken: result.connectionToken,
+			connection: {
+				type: RemoteAgentHostEntryType.SSH,
+				address: result.address,
+				sshConfigHost: result.sshConfigHost,
+				hostName: result.config.host,
+				user: result.config.username || undefined,
+				port: result.config.port,
+			},
+		}, protocolClient, this._createTransportDisposable(result.connectionId, handle));
+
 		return handle;
+	}
+
+	/**
+	 * Build a disposable that the {@link IRemoteAgentHostService} will own
+	 * for the lifetime of this entry. When the entry is removed (either by
+	 * the user via "Remove Remote" or by config reconciliation), this runs
+	 * and tears down the renderer-side handle and the shared-process SSH
+	 * tunnel together. Without this hookup, the SSH tunnel would leak and
+	 * the next `connect()` would silently reuse it.
+	 */
+	private _createTransportDisposable(connectionId: string, handle: SSHAgentHostConnectionHandle): IDisposable {
+		return toDisposable(() => {
+			// Drop the renderer-side handle map entry first so a concurrent
+			// `connect()` for the same key doesn't latch onto a being-torn-down
+			// connection.
+			if (this._connections.get(connectionId) === handle) {
+				this._connections.delete(connectionId);
+				this._onDidChangeConnections.fire();
+			}
+			// Mark the handle as already closed-from-main so disposing it
+			// doesn't kick off a redundant second disconnect IPC. The actual
+			// disconnect is initiated below.
+			handle.fireClose();
+			handle.dispose();
+			this._mainService.disconnect(connectionId).catch(() => { /* best effort */ });
+		});
 	}
 
 	private _createRelayClient(result: { connectionId: string; address: string }): RemoteAgentHostProtocolClient {

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -18,6 +18,7 @@ import {
 	SSH_REMOTE_AGENT_HOST_CHANNEL,
 	type ISSHAgentHostConfig,
 	type ISSHAgentHostConnection,
+	type ISSHConnectResult,
 	type ISSHRemoteAgentHostMainService,
 	type ISSHResolvedConfig,
 	type ISSHConnectProgress,
@@ -78,49 +79,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		const augmentedConfig = this._augmentConfig(config);
 		const result = await this._mainService.connect(augmentedConfig);
 		this._logService.trace('[SSHRemoteAgentHost] SSH tunnel established, connectionId=' + result.connectionId);
-
-		const existing = this._connections.get(result.connectionId);
-		if (existing) {
-			this._logService.trace('[SSHRemoteAgentHost] Returning existing connection handle');
-			return existing;
-		}
-
-		// Create relay transport + protocol client, then register with RemoteAgentHostService
-		let protocolClient: RemoteAgentHostProtocolClient;
-		try {
-			protocolClient = this._createRelayClient(result);
-			await protocolClient.connect();
-			this._logService.trace('[SSHRemoteAgentHost] Protocol handshake completed');
-		} catch (err) {
-			this._logService.error('[SSHRemoteAgentHost] Connection setup failed', err);
-			this._mainService.disconnect(result.connectionId).catch(() => { /* best effort */ });
-			throw err;
-		}
-
-		const handle = new SSHAgentHostConnectionHandle(
-			result.config,
-			result.address,
-			result.name,
-			() => this._mainService.disconnect(result.connectionId),
-		);
-
-		this._connections.set(result.connectionId, handle);
-		this._onDidChangeConnections.fire();
-
-		await this._remoteAgentHostService.addManagedConnection({
-			name: result.name,
-			connectionToken: result.connectionToken,
-			connection: {
-				type: RemoteAgentHostEntryType.SSH,
-				address: result.address,
-				sshConfigHost: result.sshConfigHost,
-				hostName: result.config.host,
-				user: result.config.username || undefined,
-				port: result.config.port,
-			},
-		}, protocolClient, this._createTransportDisposable(result.connectionId, handle));
-
-		return handle;
+		return this._setupConnection(result);
 	}
 
 	async disconnect(host: string): Promise<void> {
@@ -138,39 +97,65 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	async reconnect(sshConfigHost: string, name: string): Promise<ISSHAgentHostConnection> {
 		const commandOverride = this._getRemoteAgentHostCommand();
 		const result = await this._mainService.reconnect(sshConfigHost, name, commandOverride);
+		return this._setupConnection(result);
+	}
 
+	/**
+	 * Build the renderer-side handle, do the protocol handshake, and register
+	 * with IRemoteAgentHostService. Any failure after the shared-process tunnel
+	 * was established tears it back down so we don't leak it.
+	 */
+	private async _setupConnection(result: ISSHConnectResult): Promise<ISSHAgentHostConnection> {
 		const existing = this._connections.get(result.connectionId);
 		if (existing) {
+			this._logService.trace('[SSHRemoteAgentHost] Returning existing connection handle');
 			return existing;
 		}
 
-		const protocolClient = this._createRelayClient(result);
-		await protocolClient.connect();
+		let protocolClient: RemoteAgentHostProtocolClient | undefined;
+		let handle: SSHAgentHostConnectionHandle | undefined;
+		let registeredHandle = false;
+		try {
+			protocolClient = this._createRelayClient(result);
+			await protocolClient.connect();
+			this._logService.trace('[SSHRemoteAgentHost] Protocol handshake completed');
 
-		const handle = new SSHAgentHostConnectionHandle(
-			result.config,
-			result.address,
-			result.name,
-			() => this._mainService.disconnect(result.connectionId),
-		);
+			handle = new SSHAgentHostConnectionHandle(
+				result.config,
+				result.address,
+				result.name,
+				() => this._mainService.disconnect(result.connectionId),
+			);
 
-		this._connections.set(result.connectionId, handle);
-		this._onDidChangeConnections.fire();
+			this._connections.set(result.connectionId, handle);
+			registeredHandle = true;
+			this._onDidChangeConnections.fire();
 
-		await this._remoteAgentHostService.addManagedConnection({
-			name: result.name,
-			connectionToken: result.connectionToken,
-			connection: {
-				type: RemoteAgentHostEntryType.SSH,
-				address: result.address,
-				sshConfigHost: result.sshConfigHost,
-				hostName: result.config.host,
-				user: result.config.username || undefined,
-				port: result.config.port,
-			},
-		}, protocolClient, this._createTransportDisposable(result.connectionId, handle));
+			await this._remoteAgentHostService.addManagedConnection({
+				name: result.name,
+				connectionToken: result.connectionToken,
+				connection: {
+					type: RemoteAgentHostEntryType.SSH,
+					address: result.address,
+					sshConfigHost: result.sshConfigHost,
+					hostName: result.config.host,
+					user: result.config.username || undefined,
+					port: result.config.port,
+				},
+			}, protocolClient, this._createTransportDisposable(result.connectionId, handle));
 
-		return handle;
+			return handle;
+		} catch (err) {
+			this._logService.error('[SSHRemoteAgentHost] Connection setup failed', err);
+			if (registeredHandle && this._connections.get(result.connectionId) === handle) {
+				this._connections.delete(result.connectionId);
+				this._onDidChangeConnections.fire();
+			}
+			handle?.dispose();
+			protocolClient?.dispose();
+			this._mainService.disconnect(result.connectionId).catch(() => { /* best effort */ });
+			throw err;
+		}
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -437,4 +437,57 @@ suite('RemoteAgentHostService', () => {
 		assert.deepStrictEqual(configService.entries, []);
 		assert.strictEqual(service.connections.length, 0);
 	});
+
+	suite('addManagedConnection', () => {
+
+		// Build a transport disposable that records when it ran.
+		function makeTransportDisposable(): { disposable: { dispose(): void }; disposed: () => boolean } {
+			let disposed = false;
+			return {
+				disposable: { dispose: () => { disposed = true; } },
+				disposed: () => disposed,
+			};
+		}
+
+		// Inject a managed connection (mimicking the SSH/tunnel renderer flow).
+		async function addManaged(name: string, address: string, transport?: { dispose(): void }) {
+			const mockClient = disposables.add(new MockProtocolClient(`ws://${address}`));
+			return service.addManagedConnection(
+				{ name, connection: { type: RemoteAgentHostEntryType.WebSocket, address } },
+				mockClient as unknown as Parameters<typeof service.addManagedConnection>[1],
+				transport,
+			);
+		}
+
+		test('disposes transportDisposable when entry is removed via removeRemoteAgentHost', async () => {
+			const t = makeTransportDisposable();
+			await addManaged('Managed', 'managed:1234', t.disposable);
+			assert.strictEqual(t.disposed(), false);
+
+			await service.removeRemoteAgentHost('ws://managed:1234');
+
+			assert.strictEqual(t.disposed(), true, 'transport disposable runs when entry is removed');
+			assert.strictEqual(service.getConnection('ws://managed:1234'), undefined);
+		});
+
+		test('disposes previous transportDisposable when entry is replaced', async () => {
+			const t1 = makeTransportDisposable();
+			await addManaged('Managed', 'managed:1234', t1.disposable);
+
+			const t2 = makeTransportDisposable();
+			await addManaged('Managed', 'managed:1234', t2.disposable);
+
+			assert.strictEqual(t1.disposed(), true, 'first transport disposable runs when entry is replaced');
+			assert.strictEqual(t2.disposed(), false, 'second transport disposable is still alive');
+		});
+
+		test('disposes transportDisposable when service itself is disposed', async () => {
+			const t = makeTransportDisposable();
+			await addManaged('Managed', 'managed:1234', t.disposable);
+
+			service.dispose();
+
+			assert.strictEqual(t.disposed(), true, 'transport disposable runs when service is disposed');
+		});
+	});
 });

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -169,6 +169,7 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 	let mainService: MockSSHMainService;
 	let remoteAgentHostService: MockRemoteAgentHostService;
 	let createdClients: MockProtocolClient[];
+	let waitForClient: (index: number) => Promise<MockProtocolClient>;
 	let service: SSHRemoteAgentHostService;
 
 	setup(() => {
@@ -187,6 +188,14 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 		instantiationService.stub(ISharedProcessService, sharedProcessService as ISharedProcessService);
 		instantiationService.stub(IRemoteAgentHostService, remoteAgentHostService as Partial<IRemoteAgentHostService>);
 
+		const clientWaiters: DeferredPromise<MockProtocolClient>[] = [];
+		waitForClient = (index: number): Promise<MockProtocolClient> => {
+			if (createdClients[index]) {
+				return Promise.resolve(createdClients[index]);
+			}
+			return (clientWaiters[index] ??= new DeferredPromise<MockProtocolClient>()).p;
+		};
+
 		const inner: Partial<IInstantiationService> = {
 			createInstance: (_ctor: unknown, ...args: unknown[]) => {
 				const c = new MockProtocolClient();
@@ -197,7 +206,9 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 					c.registerOwned(transport);
 				}
 				disposables.add(c);
+				const index = createdClients.length;
 				createdClients.push(c);
+				clientWaiters[index]?.complete(c);
 				return c;
 			},
 		};
@@ -219,11 +230,8 @@ suite('SSHRemoteAgentHostService (renderer)', () => {
 
 	/** Wait until the renderer has created its protocol client, then resolve its handshake. */
 	async function awaitClientThenResolve(index: number): Promise<void> {
-		for (let i = 0; i < 50 && createdClients.length <= index; i++) {
-			await new Promise<void>(r => setTimeout(r, 0));
-		}
-		assert.ok(createdClients[index], `protocol client #${index} created`);
-		createdClients[index].connectDeferred.complete();
+		const client = await waitForClient(index);
+		client.connectDeferred.complete();
 	}
 
 	test('connect registers a managed connection with a transport disposable', async () => {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -1,0 +1,295 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DeferredPromise } from '../../../../base/common/async.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import type { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../log/common/log.js';
+import { IConfigurationService } from '../../../configuration/common/configuration.js';
+import { IInstantiationService } from '../../../instantiation/common/instantiation.js';
+import { ISharedProcessService } from '../../../ipc/electron-browser/services.js';
+import { IRemoteAgentHostService } from '../../common/remoteAgentHostService.js';
+import type { IAgentConnection } from '../../common/agentService.js';
+import type {
+	ISSHAgentHostConfig,
+	ISSHConnectResult,
+	ISSHRelayMessage,
+	ISSHResolvedConfig,
+} from '../../common/sshRemoteAgentHost.js';
+import { SSHRemoteAgentHostService } from '../../electron-browser/sshRemoteAgentHostServiceImpl.js';
+
+/**
+ * In-renderer mock of the shared-process SSH service. Exposes the same
+ * surface that the renderer accesses through ProxyChannel, plus a small
+ * test API to drive close events and inspect calls.
+ */
+class MockSSHMainService {
+	private readonly _onDidChangeConnections = new Emitter<void>();
+	readonly onDidChangeConnections = this._onDidChangeConnections.event;
+
+	private readonly _onDidCloseConnection = new Emitter<string>();
+	readonly onDidCloseConnection = this._onDidCloseConnection.event;
+
+	private readonly _onDidReportConnectProgress = new Emitter<{ connectionKey: string; message: string }>();
+	readonly onDidReportConnectProgress = this._onDidReportConnectProgress.event;
+
+	private readonly _onDidRelayMessage = new Emitter<ISSHRelayMessage>();
+	readonly onDidRelayMessage = this._onDidRelayMessage.event;
+
+	private readonly _onDidRelayClose = new Emitter<string>();
+	readonly onDidRelayClose = this._onDidRelayClose.event;
+
+	readonly disconnectCalls: string[] = [];
+	private _nextConnectionId = 1;
+
+	connectResult: Partial<ISSHConnectResult> | undefined;
+
+	async connect(config: ISSHAgentHostConfig): Promise<ISSHConnectResult> {
+		const connectionId = this.connectResult?.connectionId ?? `conn-${this._nextConnectionId++}`;
+		return {
+			connectionId,
+			address: this.connectResult?.address ?? `ssh:${config.host}`,
+			name: config.name,
+			connectionToken: 'test-token',
+			config: { host: config.host, username: config.username, authMethod: config.authMethod, name: config.name, sshConfigHost: config.sshConfigHost },
+			sshConfigHost: config.sshConfigHost,
+		};
+	}
+
+	async reconnect(sshConfigHost: string, name: string): Promise<ISSHConnectResult> {
+		return {
+			connectionId: `conn-${this._nextConnectionId++}`,
+			address: `ssh:${sshConfigHost}`,
+			name,
+			connectionToken: 'test-token',
+			config: { host: sshConfigHost, username: 'u', authMethod: 0 as never, name, sshConfigHost },
+			sshConfigHost,
+		};
+	}
+
+	async relaySend(_connectionId: string, _message: string): Promise<void> { /* no-op */ }
+
+	async disconnect(connectionId: string): Promise<void> {
+		this.disconnectCalls.push(connectionId);
+	}
+
+	async listSSHConfigHosts(): Promise<string[]> { return []; }
+	async resolveSSHConfig(_host: string): Promise<ISSHResolvedConfig> {
+		return { hostname: '', user: undefined, port: 22, identityFile: [], forwardAgent: false };
+	}
+
+	dispose(): void {
+		this._onDidChangeConnections.dispose();
+		this._onDidCloseConnection.dispose();
+		this._onDidReportConnectProgress.dispose();
+		this._onDidRelayMessage.dispose();
+		this._onDidRelayClose.dispose();
+	}
+}
+
+/** Adapt a mock service object to the IChannel surface ProxyChannel expects. */
+function asChannel(target: object): IChannel {
+	return {
+		call: async <T>(method: string, args?: unknown): Promise<T> => {
+			const fn = (target as Record<string, unknown>)[method];
+			if (typeof fn !== 'function') {
+				throw new Error(`MockChannel: no method ${method}`);
+			}
+			return (fn as (...a: unknown[]) => Promise<T>).apply(target, (args as unknown[]) ?? []);
+		},
+		listen: <T>(event: string): Event<T> => {
+			const ev = (target as Record<string, unknown>)[event];
+			if (typeof ev !== 'function') {
+				throw new Error(`MockChannel: no event ${event}`);
+			}
+			return ev as Event<T>;
+		},
+	};
+}
+
+/** Captures addManagedConnection calls so tests can inspect transportDisposable. */
+class MockRemoteAgentHostService extends Disposable {
+	readonly added: Array<{ address: string; transport?: IDisposable }> = [];
+	private readonly _entries = new Map<string, { transport?: IDisposable; client: { dispose?: () => void } }>();
+
+	async addManagedConnection(entry: { name: string; connection: { address?: string; sshConfigHost?: string } }, client: IAgentConnection, transportDisposable?: IDisposable): Promise<unknown> {
+		const address = entry.connection.address ?? `ssh:${entry.connection.sshConfigHost}`;
+		this.added.push({ address, transport: transportDisposable });
+		this._entries.set(address, { client: client as { dispose?: () => void }, transport: transportDisposable });
+		return { address, name: entry.name, clientId: 'mock', defaultDirectory: undefined, status: 0 };
+	}
+
+	/** Simulate user clicking "Remove Remote": disposes the per-entry store, which runs the transport disposable. */
+	removeEntry(address: string): void {
+		const e = this._entries.get(address);
+		if (!e) {
+			return;
+		}
+		this._entries.delete(address);
+		e.client.dispose?.();
+		e.transport?.dispose();
+	}
+
+	override dispose(): void {
+		// Dispose any still-registered entries (mirrors the per-entry store cleanup
+		// done by the real RemoteAgentHostService when it itself is disposed).
+		for (const [, e] of this._entries) {
+			e.client.dispose?.();
+			e.transport?.dispose();
+		}
+		this._entries.clear();
+		super.dispose();
+	}
+}
+
+class MockProtocolClient extends Disposable {
+	readonly clientId = 'mock-protocol-client';
+	readonly onDidClose = Event.None;
+	readonly onDidAction = Event.None;
+	readonly onDidNotification = Event.None;
+	readonly connectDeferred = new DeferredPromise<void>();
+	async connect(): Promise<void> { return this.connectDeferred.p; }
+	registerOwned<T extends IDisposable>(d: T): T { return this._register(d); }
+}
+
+class TestConfigurationService {
+	readonly onDidChangeConfiguration = Event.None;
+	getValue(): unknown { return undefined; }
+}
+
+suite('SSHRemoteAgentHostService (renderer)', () => {
+
+	const disposables = new DisposableStore();
+	let mainService: MockSSHMainService;
+	let remoteAgentHostService: MockRemoteAgentHostService;
+	let createdClients: MockProtocolClient[];
+	let service: SSHRemoteAgentHostService;
+
+	setup(() => {
+		mainService = new MockSSHMainService();
+		disposables.add({ dispose: () => mainService.dispose() });
+		remoteAgentHostService = disposables.add(new MockRemoteAgentHostService());
+		createdClients = [];
+
+		const sharedProcessService: Partial<ISharedProcessService> = {
+			getChannel: () => asChannel(mainService),
+		};
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(IConfigurationService, new TestConfigurationService() as Partial<IConfigurationService>);
+		instantiationService.stub(ISharedProcessService, sharedProcessService as ISharedProcessService);
+		instantiationService.stub(IRemoteAgentHostService, remoteAgentHostService as Partial<IRemoteAgentHostService>);
+
+		const inner: Partial<IInstantiationService> = {
+			createInstance: (_ctor: unknown, ...args: unknown[]) => {
+				const c = new MockProtocolClient();
+				// The real RemoteAgentHostProtocolClient owns the transport disposable
+				// it's constructed with; mirror that here so SSHRelayTransport doesn't leak.
+				const transport = args[1] as IDisposable | undefined;
+				if (transport) {
+					c.registerOwned(transport);
+				}
+				disposables.add(c);
+				createdClients.push(c);
+				return c;
+			},
+		};
+		instantiationService.stub(IInstantiationService, inner as Partial<IInstantiationService>);
+
+		service = disposables.add(instantiationService.createInstance(SSHRemoteAgentHostService));
+	});
+
+	teardown(() => disposables.clear());
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const sampleConfig: ISSHAgentHostConfig = {
+		host: 'remote.example',
+		username: 'user',
+		authMethod: 0 as never,
+		name: 'My Remote',
+		sshConfigHost: 'remote.example',
+	};
+
+	/** Wait until the renderer has created its protocol client, then resolve its handshake. */
+	async function awaitClientThenResolve(index: number): Promise<void> {
+		for (let i = 0; i < 50 && createdClients.length <= index; i++) {
+			await new Promise<void>(r => setTimeout(r, 0));
+		}
+		assert.ok(createdClients[index], `protocol client #${index} created`);
+		createdClients[index].connectDeferred.complete();
+	}
+
+	test('connect registers a managed connection with a transport disposable', async () => {
+		const connectPromise = service.connect(sampleConfig);
+		await awaitClientThenResolve(0);
+		const handle = await connectPromise;
+
+		assert.strictEqual(remoteAgentHostService.added.length, 1);
+		assert.strictEqual(remoteAgentHostService.added[0].address, 'ssh:remote.example');
+		assert.ok(remoteAgentHostService.added[0].transport, 'a transport disposable is passed so removal can tear down the SSH tunnel');
+		assert.strictEqual(service.connections.length, 1);
+		assert.strictEqual(handle.localAddress, 'ssh:remote.example');
+	});
+
+	test('removing the entry tears down the SSH tunnel and the renderer-side handle', async () => {
+		const connectPromise = service.connect(sampleConfig);
+		await awaitClientThenResolve(0);
+		await connectPromise;
+
+		assert.strictEqual(mainService.disconnectCalls.length, 0);
+		assert.strictEqual(service.connections.length, 1);
+
+		// Simulate the user clicking "Remove Remote": IRemoteAgentHostService
+		// disposes the per-entry store, which runs our transport disposable.
+		remoteAgentHostService.removeEntry('ssh:remote.example');
+
+		assert.deepStrictEqual(mainService.disconnectCalls, ['conn-1'], 'main-process tunnel is told to disconnect');
+		assert.strictEqual(service.connections.length, 0, 'renderer-side handle is dropped');
+	});
+
+	test('connect after removal does not reuse the previous handle', async () => {
+		// First connect → entry registered, then removed.
+		const c1 = service.connect(sampleConfig);
+		await awaitClientThenResolve(0);
+		await c1;
+		remoteAgentHostService.removeEntry('ssh:remote.example');
+		assert.strictEqual(service.connections.length, 0);
+
+		// Second connect → main returns a new connectionId; renderer creates
+		// a fresh handle and registers a new managed entry.
+		mainService.connectResult = { connectionId: 'conn-2', address: 'ssh:remote.example' };
+		const c2 = service.connect(sampleConfig);
+		await awaitClientThenResolve(1);
+		await c2;
+
+		assert.strictEqual(service.connections.length, 1);
+		assert.strictEqual(remoteAgentHostService.added.length, 2, 'each connect produces a fresh managed-connection registration');
+	});
+
+	test('main-process onDidCloseConnection cleans up renderer handle without double-disconnecting', async () => {
+		const connectPromise = service.connect(sampleConfig);
+		await awaitClientThenResolve(0);
+		await connectPromise;
+		assert.strictEqual(service.connections.length, 1);
+
+		// Simulate main process closing the connection on its own (e.g. SSH dropped).
+		// We can't directly fire on the wrapped emitter through the channel because
+		// ProxyChannel is one-directional; instead we trigger via the mock service
+		// emitter that the renderer subscribed to.
+		(mainService as unknown as { _onDidCloseConnection: Emitter<string> })._onDidCloseConnection.fire('conn-1');
+
+		assert.strictEqual(service.connections.length, 0, 'handle dropped on main close');
+		// Removing the (already-gone) entry shouldn't trigger another disconnect call.
+		remoteAgentHostService.removeEntry('ssh:remote.example');
+		// One disconnect from the transport disposable is fine; we just want to make
+		// sure we're not at risk of issuing a second one against a stale id.
+		assert.ok(mainService.disconnectCalls.length <= 1, 'no duplicate disconnect against a stale connectionId');
+	});
+});

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -362,7 +362,7 @@ async function promptForRemoteFolder(
 	const sessionsProvidersService = accessor.get(ISessionsProvidersService);
 	const sessionsManagementService = accessor.get(ISessionsManagementService);
 
-	// The provider is created synchronously during addSSHConnection's
+	// The provider is created synchronously during addManagedConnection's
 	// onDidChangeConnections event, so it should exist by now.
 	const provider = sessionsProvidersService.getProviders().find((p): p is IAgentHostSessionsProvider => isAgentHostProvider(p) && p.remoteAddress === connection.localAddress);
 	if (!provider) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/webTunnelAgentHostService.ts
@@ -141,7 +141,7 @@ export class WebTunnelAgentHostService extends Disposable implements ITunnelAgen
 			await protocolClient.connect();
 			this._logService.info(`${LOG_PREFIX} Protocol handshake completed with ${address}`);
 
-			await this._remoteAgentHostService.addSSHConnection({
+			await this._remoteAgentHostService.addManagedConnection({
 				name: tunnel.name,
 				connectionToken,
 				connection: {

--- a/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl.ts
@@ -105,7 +105,7 @@ export class TunnelAgentHostService extends Disposable implements ITunnelAgentHo
 			await protocolClient.connect();
 			this._logService.info(`${LOG_PREFIX} Protocol handshake completed with ${result.address}`);
 
-			await this._remoteAgentHostService.addSSHConnection({
+			await this._remoteAgentHostService.addManagedConnection({
 				name: result.name,
 				connectionToken: result.connectionToken,
 				connection: {


### PR DESCRIPTION
Removing an SSH-backed agent host previously only disposed the renderer-side protocol client and `SSHRelayTransport`. `SSHRelayTransport.dispose()` removed the IPC listeners but did not tell the shared-process side to close the SSH tunnel, so the tunnel leaked and the next connect silently reused it.

## Fix

Give `IRemoteAgentHostService` a generic ownership hook for transport-level teardown:

- Rename `addSSHConnection` → `addManagedConnection` and add an optional `transportDisposable` parameter. The platform service registers it on the same per-entry `DisposableStore` as the protocol client, so it runs on `removeRemoteAgentHost`, on config-driven reconciliation, and on service disposal.
- `SSHRemoteAgentHostService` passes a transport disposable that synchronously drops the renderer-side handle from its `_connections` map, fires the change event, marks the handle closed, disposes it, then best-effort tells the shared-process service to `disconnect()`. The early `return existing` branches in `connect()` / `reconnect()` are now safe across remove → reconnect because the map is cleared synchronously.
- Web and desktop tunnel renderers just pick up the rename. Their existing transports (`TunnelConnectionTransport.dispose`, `TunnelRelayTransport.dispose`) already close the underlying connection, so no behavior change there.

## Tests

- New `sshRemoteAgentHostService.test.ts` covers the renderer lifecycle: connect registers a transport disposable, removal tears down both the renderer handle and the shared-process tunnel, reconnect after removal does not reuse the old handle, and main-process close cleans up without double-disconnecting.
- Extended `remoteAgentHostService.test.ts` proves the `transportDisposable` runs on entry removal, replacement, and service dispose.
- Full `**/agentHost/**/*.test.js` suite passes (714 / 1 pending / 0 failing).

(Written by Copilot)