### PR TITLE
Fix OutputMonitor leak when foreground terminal is reused after `inputNeeded`

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1872,6 +1872,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				this._logService.debug(`RunInTerminalTool: Using cached terminal with session resource \`${chatSessionResource}\``);
 				this._terminalToolCreator.refreshShellIntegrationQuality(cachedTerminal);
 				this._terminalChatService.registerTerminalInstanceWithToolSession(terminalToolSessionId, cachedTerminal.instance);
+				// Dispose any previous background notification (e.g. from an earlier
+				// `inputNeeded` race that left an OutputMonitor attached) before reusing
+				// this terminal, so its listeners don't accumulate across invocations.
+				this._backgroundNotifications.deleteAndDispose(cachedTerminal.instance.instanceId);
 				return cachedTerminal;
 			}
 		}


### PR DESCRIPTION
Fixes #311722

#311727 disposed the prior `_backgroundNotifications` entry inside `_registerCompletionNotification`, but missed this path:

1. Invocation **A** hits `inputNeeded` → `_registerCompletionNotification` stores a `DisposableStore` (holding the `OutputMonitor` + `onDidInputData` listener) under `instance.instanceId`.
2. Invocation **B** reuses the same foreground terminal and completes normally — the `finally` block disposes only B's local `outputMonitor` and never calls `_registerCompletionNotification`, so A's entry leaks.

Fix: dispose any existing entry at the reuse site in `_initTerminal` before returning the cached terminal. Background terminals aren't reused (`isBackground` guard), so intentionally-backgrounded notifications aren't affected. `deleteAndDispose` is a no-op if the key is missing. 

