### PR TITLE
sessions: increase GitHub profile image size in titlebar account widget

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -141,7 +141,7 @@ The account widget is rendered in the **right side of the titlebar** as a custom
 - Registered in `contrib/accountMenu/browser/account.contribution.ts`
 - Uses the `Menus.TitleBarRightLayout` menu
 - Shows the signed-in GitHub profile image when available, and falls back to the existing account codicon when it is not
-- Gives the GitHub profile image a subtle 1px circular border using the titlebar command center border tokens so the avatar stays legible against nearby chrome in both active and inactive window states
+- Renders the GitHub profile image at `18px × 18px` inside the `22px × 22px` titlebar widget, and gives it a subtle 1px circular border using the titlebar command center border tokens so the avatar stays legible against nearby chrome in both active and inactive window states
 - Opens a combined account and Copilot status hover panel with sign-in/sign-out, settings, and update actions
 
 ---
@@ -659,6 +659,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-04-22 | Increased the sessions titlebar account widget's GitHub profile image from `16px × 16px` to `18px × 18px` while keeping the existing `22px × 22px` control footprint and avatar border treatment. |
 | 2026-04-22 | Added sessions-only toast offset overrides so notification toasts now use `right: 15px` in the default bottom-right placement and `left: 15px` in the bottom-left placement, matching the notification center spacing. |
 | 2026-04-22 | Added a sessions-workbench notification offset override so the shared notification controllers no longer push top-right notifications down to `42px`; sessions now reapply a fixed `40px` top offset for top-right notification center/toast placement. |
 | 2026-04-21 | Updated the sessions chat composite bar tabs to preserve each chat title's original casing instead of applying per-word capitalization. |

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -49,8 +49,8 @@
 .agent-sessions-workbench .sessions-account-titlebar-widget-avatar {
 	display: none;
 	flex: 0 0 auto;
-	width: 16px;
-	height: 16px;
+	width: 18px;
+	height: 18px;
 	border: 1px solid var(--vscode-commandCenter-border, transparent);
 	border-radius: 50%;
 	box-sizing: border-box;


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode/issues/310014

Increases the GitHub profile avatar image in the sessions titlebar account widget from **16×16px** to **18×18px**.

The surrounding 22×22px control footprint and the existing 1px circular border treatment are unchanged — only the image itself grows slightly to fill more of the available space.

### Changes
- `src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css` — bump `.sessions-account-titlebar-widget-avatar` `width`/`height` from `16px` → `18px`
- `src/vs/sessions/LAYOUT.md` — updated §3.6 description and revision history entry