### PR TITLE
SSH agent host: add agent forwarding setting & fix encrypted key failures

### DIFF
--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -42,6 +42,8 @@ export interface ISSHAgentHostConfig {
 	readonly sshConfigHost?: string;
 	/** Dev override: custom command to start the remote agent host instead of the default CLI. */
 	readonly remoteAgentHostCommand?: string;
+	/** When true, enables OpenSSH agent forwarding (auth-agent@openssh.com) for this connection. Requires {@link authMethod} to be Agent. */
+	readonly agentForward?: boolean;
 }
 
 /**
@@ -208,5 +210,5 @@ export interface ISSHRemoteAgentHostMainService {
 	 * Resolves the SSH config alias, connects, and returns fresh
 	 * connection info with a new local forwarded port.
 	 */
-	reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string): Promise<ISSHConnectResult>;
+	reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean): Promise<ISSHConnectResult>;
 }

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -68,6 +68,7 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 				this._onDidChangeConnections.fire();
 			}
 		}));
+
 	}
 
 	get connections(): readonly ISSHAgentHostConnection[] {
@@ -75,8 +76,8 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	}
 
 	async connect(config: ISSHAgentHostConfig): Promise<ISSHAgentHostConnection> {
-		this._logService.info('[SSHRemoteAgentHost] Connecting to ' + config.host);
 		const augmentedConfig = this._augmentConfig(config);
+		this._logService.info(`[SSHRemoteAgentHost] Connecting to ${config.host}`);
 		const result = await this._mainService.connect(augmentedConfig);
 		this._logService.trace('[SSHRemoteAgentHost] SSH tunnel established, connectionId=' + result.connectionId);
 		return this._setupConnection(result);
@@ -96,7 +97,9 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 
 	async reconnect(sshConfigHost: string, name: string): Promise<ISSHAgentHostConnection> {
 		const commandOverride = this._getRemoteAgentHostCommand();
-		const result = await this._mainService.reconnect(sshConfigHost, name, commandOverride);
+		const agentForward = this._isSSHAgentForwardingEnabled();
+		this._logService.info(`[SSHRemoteAgentHost] Reconnecting to ${sshConfigHost}`);
+		const result = await this._mainService.reconnect(sshConfigHost, name, commandOverride, agentForward);
 		return this._setupConnection(result);
 	}
 
@@ -192,15 +195,25 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 	}
 
 	private _augmentConfig(config: ISSHAgentHostConfig): ISSHAgentHostConfig {
+		const result = { ...config };
 		const commandOverride = this._getRemoteAgentHostCommand();
 		if (commandOverride) {
-			return { ...config, remoteAgentHostCommand: commandOverride };
+			result.remoteAgentHostCommand = commandOverride;
 		}
-		return config;
+		// Agent forwarding requires both the global setting (security opt-in)
+		// and the per-host SSH config `ForwardAgent yes` to be enabled.
+		if (this._isSSHAgentForwardingEnabled() && config.agentForward) {
+			result.agentForward = true;
+		}
+		return result;
 	}
 
 	private _getRemoteAgentHostCommand(): string | undefined {
 		return this._configurationService.getValue<string>('chat.sshRemoteAgentHostCommand') || undefined;
+	}
+
+	private _isSSHAgentForwardingEnabled(): boolean | undefined {
+		return this._configurationService.getValue<boolean>('chat.agentHost.forwardSSHAgent') || undefined;
 	}
 }
 

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -445,7 +445,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			};
 		}
 
-		this._logService.info(`${LOG_PREFIX} Connecting to ${connectionKey}...`);
+		this._logService.info(`${LOG_PREFIX} ${replaceRelay ? 'Reconnecting' : 'Connecting'} to ${connectionKey}`);
 		let sshClient: SSHClient | undefined;
 
 		try {
@@ -599,13 +599,17 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		}
 	}
 
-	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string): Promise<ISSHConnectResult> {
+	async reconnect(sshConfigHost: string, name: string, remoteAgentHostCommand?: string, agentForward?: boolean): Promise<ISSHConnectResult> {
 		this._logService.info(`${LOG_PREFIX} Reconnecting via SSH config host: ${sshConfigHost}`);
 		const resolved = await this.resolveSSHConfig(sshConfigHost);
 
 		let authMethod: SSHAuthMethod = SSHAuthMethod.Agent;
 		let privateKeyPath: string | undefined;
-		if (resolved.identityFile.length > 0 && !SSHRemoteAgentHostMainService._defaultKeyPaths.includes(resolved.identityFile[0])) {
+		// Only fall back to KeyFile auth if there's no SSH agent available.
+		// When an agent is present the key should be loaded in it, and reading
+		// the key file directly will fail if it's passphrase-encrypted.
+		const hasAgent = !!process.env['SSH_AUTH_SOCK'];
+		if (!hasAgent && resolved.identityFile.length > 0 && !SSHRemoteAgentHostMainService._defaultKeyPaths.includes(resolved.identityFile[0])) {
 			authMethod = SSHAuthMethod.KeyFile;
 			privateKeyPath = resolved.identityFile[0];
 		}
@@ -620,6 +624,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			name,
 			sshConfigHost,
 			remoteAgentHostCommand,
+			agentForward: agentForward && resolved.forwardAgent ? true : undefined,
 		}, /* replaceRelay */ true);
 	}
 
@@ -775,6 +780,11 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				this._logService.error(`${LOG_PREFIX} SSH connection error: ${err.message}`);
 				reject(err);
 			});
+
+			if (config.agentForward && connectConfig.agent) {
+				connectConfig.agentForward = true;
+				this._logService.info(`${LOG_PREFIX} SSH agent forwarding enabled`);
+			}
 
 			client.connect(connectConfig);
 		});

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -609,6 +609,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			authMethod = SSHAuthMethod.KeyFile;
 			privateKeyPath = resolved.identityFile[0];
 		}
+		this._logService.info(`${LOG_PREFIX} reconnect: hasAgent=${hasAgent}, identityFiles=${JSON.stringify(resolved.identityFile)}, chose authMethod=${authMethod}`);
 
 		return this.connect({
 			host: resolved.hostname,
@@ -737,16 +738,21 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				const agentSock = process.env['SSH_AUTH_SOCK'];
 				this._logService.info(`${LOG_PREFIX} Using SSH agent: ${agentSock ?? '(not set)'}`);
 				connectConfig.agent = agentSock;
-				// Also provide a default key file as fallback so ssh2 can try
-				// publickey auth if the agent doesn't have the key loaded.
-				const fallbackKey = await this._findDefaultKeyFile();
-				if (fallbackKey) {
-					this._logService.info(`${LOG_PREFIX} Also using fallback key: ${fallbackKey.path}`);
-					connectConfig.privateKey = fallbackKey.contents;
+				// Only load a fallback key file if no SSH agent is available.
+				// If an agent is present, skip this — ssh2 parses the private key
+				// eagerly and will fail immediately if the key is passphrase-encrypted,
+				// before ever trying the agent.
+				if (!agentSock) {
+					const fallbackKey = await this._findDefaultKeyFile();
+					if (fallbackKey) {
+						this._logService.info(`${LOG_PREFIX} No SSH agent; using fallback key: ${fallbackKey.path}`);
+						connectConfig.privateKey = fallbackKey.contents;
+					}
 				}
 				break;
 			}
 			case SSHAuthMethod.KeyFile:
+				this._logService.info(`${LOG_PREFIX} Using key file: ${config.privateKeyPath ?? '(none)'}`);
 				if (config.privateKeyPath) {
 					const keyPath = config.privateKeyPath.replace(/^~/, os.homedir());
 					connectConfig.privateKey = await fsp.readFile(keyPath);

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -1053,6 +1053,10 @@ class ConnectSSHTestService extends SSHRemoteAgentHostMainService {
 				break;
 		}
 
+		if (config.agentForward && connectConfig.agent) {
+			connectConfig.agentForward = true;
+		}
+
 		this.lastConnectConfig = connectConfig;
 		return new MockSSHClient() as never;
 	}
@@ -1104,5 +1108,21 @@ suite('SSHRemoteAgentHostMainService - _connectSSH auth config', () => {
 
 		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
 		assert.strictEqual(service.lastConnectConfig.privateKey, keyContents, 'should load fallback key when no agent');
+	});
+
+	test('agent auth with agentForward sets agentForward', async () => {
+		service.agentSock = '/tmp/ssh-agent.sock';
+		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.Agent, agentForward: true }));
+
+		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
+		assert.ok(Object.hasOwn(service.lastConnectConfig, 'agent'), 'should set agent');
+		assert.strictEqual(service.lastConnectConfig.agentForward, true, 'should set agentForward');
+	});
+
+	test('agentForward without agent auth is ignored', async () => {
+		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.Password, password: 'pw', agentForward: true }));
+
+		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
+		assert.strictEqual(service.lastConnectConfig.agentForward, undefined, 'should not set agentForward without agent');
 	});
 });

--- a/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/node/sshRemoteAgentHostService.test.ts
@@ -1019,6 +1019,7 @@ class ConnectSSHTestService extends SSHRemoteAgentHostMainService {
 
 	lastConnectConfig: Record<string, unknown> | undefined;
 	fallbackKeyResult: { path: string; contents: Buffer } | undefined;
+	agentSock: string | undefined = undefined;
 
 	async testConnectSSH(config: ISSHAgentHostConfig) {
 		return this._connectSSH(config);
@@ -1035,10 +1036,12 @@ class ConnectSSHTestService extends SSHRemoteAgentHostMainService {
 
 		switch (config.authMethod) {
 			case SSHAuthMethod.Agent: {
-				connectConfig.agent = process.env['SSH_AUTH_SOCK'];
-				const fallbackKey = await this._findDefaultKeyFile();
-				if (fallbackKey) {
-					connectConfig.privateKey = fallbackKey.contents;
+				connectConfig.agent = this.agentSock;
+				if (!this.agentSock) {
+					const fallbackKey = await this._findDefaultKeyFile();
+					if (fallbackKey) {
+						connectConfig.privateKey = fallbackKey.contents;
+					}
 				}
 				break;
 			}
@@ -1081,33 +1084,25 @@ suite('SSHRemoteAgentHostMainService - _connectSSH auth config', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('agent auth includes fallback privateKey when default key exists', async () => {
-		const keyContents = Buffer.from('fake-key-contents');
+	test('agent auth with agent present does not load fallback key', async () => {
+		service.agentSock = '/tmp/ssh-agent.sock';
+		service.fallbackKeyResult = { path: '~/.ssh/id_ed25519', contents: Buffer.from('encrypted-key') };
+
+		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.Agent }));
+
+		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
+		assert.ok(Object.hasOwn(service.lastConnectConfig, 'agent'), 'should set agent');
+		assert.strictEqual(service.lastConnectConfig.privateKey, undefined, 'should not load fallback key when agent is present');
+	});
+
+	test('agent auth without agent socket loads fallback key', async () => {
+		service.agentSock = undefined;
+		const keyContents = Buffer.from('unencrypted-key');
 		service.fallbackKeyResult = { path: '~/.ssh/id_ed25519', contents: keyContents };
 
 		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.Agent }));
 
 		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
-		assert.ok(Object.hasOwn(service.lastConnectConfig, 'agent'), 'should set agent');
-		assert.strictEqual(service.lastConnectConfig.privateKey, keyContents, 'should include fallback privateKey');
-	});
-
-	test('agent auth omits privateKey when no default key found', async () => {
-		service.fallbackKeyResult = undefined;
-
-		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.Agent }));
-
-		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
-		assert.ok(Object.hasOwn(service.lastConnectConfig, 'agent'), 'should set agent');
-		assert.strictEqual(service.lastConnectConfig.privateKey, undefined, 'should not include privateKey');
-	});
-
-	test('keyfile auth does not use fallback key', async () => {
-		service.fallbackKeyResult = { path: '~/.ssh/id_ed25519', contents: Buffer.from('should-not-be-used') };
-
-		await service.testConnectSSH(makeConfig({ authMethod: SSHAuthMethod.KeyFile }));
-
-		assert.ok(service.lastConnectConfig, 'connectConfig should be captured');
-		assert.strictEqual(service.lastConnectConfig.privateKey, undefined, 'should not include fallback key for KeyFile auth');
+		assert.strictEqual(service.lastConnectConfig.privateKey, keyContents, 'should load fallback key when no agent');
 	});
 });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -627,6 +627,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental', 'advanced'],
 		},
+		'chat.agentHost.forwardSSHAgent': {
+			type: 'boolean',
+			description: nls.localize('chat.agentHost.forwardSSHAgent', "When enabled, forwards the local SSH agent to the remote machine during SSH agent host connections to hosts whose SSH config has `ForwardAgent yes`. Only enable this for trusted hosts. The remote agent host process must be restarted for this setting to take effect."),
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			tags: ['experimental', 'advanced'],
+		},
 		[RemoteAgentHostsSettingId]: {
 			type: 'array',
 			items: {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -151,12 +151,17 @@ async function promptToConnectViaSSH(
 			port = resolvedConfig.port !== 22 ? resolvedConfig.port : undefined;
 			suggestedName = picked.hostAlias;
 
-			// Determine auth method from resolved config
+			// Pre-fill the auth method picker based on the resolved SSH config.
+			// We never auto-select KeyFile because ssh2 eagerly parses the
+			// key file, which fails for passphrase-encrypted keys. The SSH
+			// agent (if running) already has the key loaded and handles this
+			// transparently. We only record the identity file path so the
+			// KeyFile picker can pre-fill it if the user manually selects
+			// that option.
 			if (resolvedConfig.identityFile.length > 0) {
 				const firstKey = resolvedConfig.identityFile[0];
 				const defaultKeys = ['~/.ssh/id_rsa', '~/.ssh/id_ecdsa', '~/.ssh/id_ed25519', '~/.ssh/id_dsa', '~/.ssh/id_xmss'];
 				if (!defaultKeys.includes(firstKey)) {
-					defaultAuthMethod = SSHAuthMethod.KeyFile;
 					defaultKeyPath = firstKey;
 				}
 			}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -151,13 +151,10 @@ async function promptToConnectViaSSH(
 			port = resolvedConfig.port !== 22 ? resolvedConfig.port : undefined;
 			suggestedName = picked.hostAlias;
 
-			// Pre-fill the auth method picker based on the resolved SSH config.
-			// We never auto-select KeyFile because ssh2 eagerly parses the
-			// key file, which fails for passphrase-encrypted keys. The SSH
-			// agent (if running) already has the key loaded and handles this
-			// transparently. We only record the identity file path so the
-			// KeyFile picker can pre-fill it if the user manually selects
-			// that option.
+			// Determine auth method from resolved config.
+			// Always prefer Agent auth (the SSH agent may already have the key
+			// loaded). Record a non-default IdentityFile as a fallback path for
+			// the manual picker only.
 			if (resolvedConfig.identityFile.length > 0) {
 				const firstKey = resolvedConfig.identityFile[0];
 				const defaultKeys = ['~/.ssh/id_rsa', '~/.ssh/id_ecdsa', '~/.ssh/id_ed25519', '~/.ssh/id_dsa', '~/.ssh/id_xmss'];
@@ -165,7 +162,7 @@ async function promptToConnectViaSSH(
 					defaultKeyPath = firstKey;
 				}
 			}
-			// If no explicit key, default to SSH agent
+			// Default to SSH agent
 			if (!defaultAuthMethod) {
 				defaultAuthMethod = SSHAuthMethod.Agent;
 			}
@@ -178,6 +175,7 @@ async function promptToConnectViaSSH(
 					username,
 					authMethod: defaultAuthMethod,
 					privateKeyPath: defaultKeyPath,
+					agentForward: resolvedConfig.forwardAgent || undefined,
 					name: suggestedName,
 					sshConfigHost: picked.hostAlias,
 				};


### PR DESCRIPTION
Two changes to the SSH remote agent host:

### 1. Skip fallback privateKey when SSH agent socket is present

`ssh2` eagerly parses `privateKey` at connect time — before attempting any auth. If the key is passphrase-encrypted this immediately throws `"Cannot parse privateKey: Encrypted private OpenSSH key detected, but no passphrase given"`, even when the key is already loaded in the SSH agent.

### 2. Add `chat.agentHost.forwardSSHAgent` setting

Adds an opt-in setting that enables OpenSSH agent forwarding on SSH connections, allowing tools running under the remote agent host to authenticate using the local user's SSH keys.
