### PR TITLE
Fix invalid json files detected for claude hook paths

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/askForPromptSourceFolder.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/askForPromptSourceFolder.ts
@@ -60,8 +60,8 @@ export async function askForPromptSourceFolder(
 
 	// create list of source folder locations
 	const foldersList = resolvedFolders.map<IFolderQuickPickItem>(resolved => {
-		const folderUri = resolved.parent;
-		const isDefault = defaultFolder && isEqual(folderUri, defaultFolder.parent);
+		const folderUri = resolved.searchRoot;
+		const isDefault = defaultFolder && isEqual(folderUri, defaultFolder.searchRoot);
 		const sourceDescription = getSourceDescription(resolved.source);
 		const detail = (existingFolder && isEqual(folderUri, existingFolder)) ? localize('current.folder', "Current Location") : undefined;
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -128,7 +128,7 @@ export interface IPromptSourceFolder {
  */
 export interface IResolvedPromptSourceFolder {
 	readonly uri: URI;
-	readonly parent: URI; // matches the URI when no glob pattern is used
+	readonly searchRoot: URI; // matches the URI when no glob pattern is used
 	readonly filePattern: string | undefined; // the part of the path with the glob pattern, or undefined if no glob pattern is used
 	readonly source: PromptFolderSource;
 	readonly storage: PromptsStorage.local | PromptsStorage.user;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -9,7 +9,7 @@ import { ResourceSet } from '../../../../../../base/common/map.js';
 import * as nls from '../../../../../../nls.js';
 import { FileOperationError, FileOperationResult, IFileService } from '../../../../../../platform/files/common/files.js';
 import { getPromptFileLocationsConfigKey, isTildePath, PromptsConfig } from '../config/config.js';
-import { basename, dirname, isEqual, isEqualOrParent, joinPath, extname } from '../../../../../../base/common/resources.js';
+import { basename, dirname, isEqual, isEqualOrParent, joinPath } from '../../../../../../base/common/resources.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { AGENTS_SOURCE_FOLDER, getPromptFileExtension, getPromptFileType, LEGACY_MODE_FILE_EXTENSION, getCleanPromptName, AGENT_FILE_EXTENSION, getPromptFileDefaultLocations, SKILL_FILENAME, IPromptSourceFolder, IResolvedPromptSourceFolder } from '../config/promptFileLocations.js';
@@ -61,7 +61,7 @@ export class PromptFilesLocator {
 		const userDataPromptsHome = this.userDataService.currentProfile.promptsHome;
 		this.userDataFolder = {
 			uri: userDataPromptsHome,
-			parent: userDataPromptsHome,
+			searchRoot: userDataPromptsHome,
 			filePattern: undefined,
 			source: PromptFileSource.UserData,
 			storage: PromptsStorage.user,
@@ -183,10 +183,10 @@ export class PromptFilesLocator {
 
 		const paths = new ResourceSet();
 
-		for (const { parent, filePattern } of absoluteLocations) {
+		for (const { searchRoot, filePattern } of absoluteLocations) {
 			const files = (filePattern === undefined)
-				? await this.resolveFilesAtLocation(parent, type, token) // if the location does not contain a glob pattern, resolve the location directly
-				: await this.searchFilesInLocation(parent, filePattern, token);
+				? await this.resolveFilesAtLocation(searchRoot, type, token) // if the location does not contain a glob pattern, resolve the location directly
+				: await this.searchFilesInLocation(searchRoot, filePattern, token);
 			for (const file of files) {
 				if (getPromptFileType(file) === type) {
 					paths.add(file);
@@ -213,10 +213,10 @@ export class PromptFilesLocator {
 		const updateExternalFolderWatchers = () => {
 			externalFolderWatchers.clear();
 			for (const folder of parentFolders) {
-				if (!this.getWorkspaceFolder(folder.parent)) {
+				if (!this.getWorkspaceFolder(folder.searchRoot)) {
 					// if the folder is not part of the workspace, we need to watch it
 					const recursive = folder.filePattern !== undefined || type === PromptsType.instructions; // instructions can be in subfolders, so watch recursively
-					externalFolderWatchers.add(this.fileService.watch(folder.parent, { recursive, excludes: [] }));
+					externalFolderWatchers.add(this.fileService.watch(folder.searchRoot, { recursive, excludes: [] }));
 				}
 			}
 		};
@@ -253,7 +253,7 @@ export class PromptFilesLocator {
 				eventEmitter.fire();
 				return;
 			}
-			if (parentFolders.some(folder => e.affects(folder.parent))) {
+			if (parentFolders.some(folder => e.affects(folder.searchRoot))) {
 				eventEmitter.fire();
 				return;
 			}
@@ -288,9 +288,9 @@ export class PromptFilesLocator {
 			// For hook configs, entries are directories unless the path ends with .json (specific file)
 			// Default entries have filePattern, user entries don't but are still directories
 			// location.parent points to the directory in both cases, so we can just use that
-			if (!seen.has(location.parent)) {
-				seen.add(location.parent);
-				result.push({ ...location, uri: location.parent, filePattern: undefined });
+			if (!seen.has(location.searchRoot)) {
+				seen.add(location.searchRoot);
+				result.push({ ...location, uri: location.searchRoot, filePattern: undefined });
 			}
 		}
 
@@ -470,8 +470,8 @@ export class PromptFilesLocator {
 					const uri = joinPath(userHome, configuredLocation.substring(2));
 					if (!seen.has(uri)) {
 						seen.add(uri);
-						const { parent, filePattern } = getParentFolder(type, uri);
-						result.push({ uri, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
+						const { searchRoot, filePattern } = resolveSearchLocation(type, uri);
+						result.push({ uri, searchRoot: searchRoot, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 					}
 					continue;
 				}
@@ -486,16 +486,16 @@ export class PromptFilesLocator {
 					}
 					if (!seen.has(uri)) {
 						seen.add(uri);
-						const { parent, filePattern } = getParentFolder(type, uri);
-						result.push({ uri, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
+						const { searchRoot, filePattern } = resolveSearchLocation(type, uri);
+						result.push({ uri, searchRoot: searchRoot, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 					}
 				} else {
 					for (const folder of rootFolders) {
 						const absolutePath = joinPath(folder, configuredLocation);
 						if (!seen.has(absolutePath)) {
 							seen.add(absolutePath);
-							const { parent, filePattern } = getParentFolder(type, absolutePath);
-							result.push({ uri: absolutePath, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
+							const { searchRoot, filePattern } = resolveSearchLocation(type, absolutePath);
+							result.push({ uri: absolutePath, searchRoot: searchRoot, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 						}
 					}
 				}
@@ -852,8 +852,8 @@ export function isValidGlob(pattern: string): boolean {
 	return false;
 }
 
-interface IParentFolderResult {
-	readonly parent: URI;
+interface ISearchLocationResult {
+	readonly searchRoot: URI;
 	readonly filePattern?: string;
 }
 
@@ -872,13 +872,10 @@ interface IParentFolderResult {
  * );
  * ```
  */
-function getParentFolder(type: PromptsType, location: URI): IParentFolderResult {
-	if (type === PromptsType.hook && extname(location) === '.json') {
-		location = dirname(location);
-	}
+function resolveSearchLocation(type: PromptsType, location: URI): ISearchLocationResult {
 	if (type !== PromptsType.instructions && type !== PromptsType.prompt) {
 		// only instructions and prompts support glob patterns, so we can return the location as is
-		return { parent: location };
+		return { searchRoot: location };
 	}
 
 	const segments = location.path.split('/');
@@ -889,16 +886,16 @@ function getParentFolder(type: PromptsType, location: URI): IParentFolderResult 
 	if (i === segments.length) {
 		// the path does not contain a glob pattern, so we can
 		// just find all prompt files in the provided location
-		return { parent: location };
+		return { searchRoot: location };
 	}
 	const parent = location.with({ path: segments.slice(0, i).join('/') });
 	if (i === segments.length - 1 && segments[i] === '*' || segments[i] === ``) {
-		return { parent };
+		return { searchRoot: parent };
 	}
 
 	// the path contains a glob pattern, so we search in last folder that does not contain a glob pattern
 	return {
-		parent,
+		searchRoot: parent,
 		filePattern: segments.slice(i).join('/')
 	};
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -281,13 +281,13 @@ export class PromptFilesLocator {
 		// Convert to absolute locations with metadata
 		const absoluteLocations = await this.toAbsoluteLocations(PromptsType.hook, allowedHookFolders);
 
-		// Deduplicate by parent URI, keeping the first occurrence
+		// Deduplicate by search root, keeping the first occurrence
 		const seen = new ResourceSet();
 		const result: IResolvedPromptSourceFolder[] = [];
 		for (const location of absoluteLocations) {
 			// For hook configs, entries are directories unless the path ends with .json (specific file)
 			// Default entries have filePattern, user entries don't but are still directories
-			// location.parent points to the directory in both cases, so we can just use that
+			// searchRoot already points to the correct directory or specific file to use in both cases
 			if (!seen.has(location.searchRoot)) {
 				seen.add(location.searchRoot);
 				result.push({ ...location, uri: location.searchRoot, filePattern: undefined });
@@ -858,17 +858,18 @@ interface ISearchLocationResult {
 }
 
 /**
- * Finds the first parent of the provided location that does not contain a `glob pattern`.
+ * Resolves the search root and optional file pattern for the provided location.
+ * For paths with glob patterns, finds the deepest non-glob ancestor directory.
  *
- * Asumes that the location that is provided has a valid path (is abstract)
+ * Assumes that the location that is provided has a valid path (is abstract)
  *
  * ## Examples
  *
  * ```typescript
  * assert.strictDeepEqual(
- *     getParentFolder(PromptsType.prompt, URI.file('/home/user/{folder1,folder2}/file.md')),
- *     { parent: URI.file('/home/user'), filePattern: '{folder1,folder2}/file.md' },
- *     'Must find correct non-glob parent dirname.',
+ *     resolveSearchLocation(PromptsType.prompt, URI.file('/home/user/{folder1,folder2}/file.md')),
+ *     { searchRoot: URI.file('/home/user'), filePattern: '{folder1,folder2}/file.md' },
+ *     'Must find correct non-glob search root.',
  * );
  * ```
  */

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -2871,6 +2871,67 @@ suite('PromptFilesLocator', () => {
 		});
 	});
 
+	suite('listFiles with PromptsType.hook', () => {
+		testT('only returns targeted json files, not sibling json files', async () => {
+			configValues[PromptsConfig.HOOKS_LOCATION_KEY] = {
+				'.claude/settings.json': true,
+				'.claude/settings.local.json': true,
+				'~/.claude/settings.json': true,
+				'.github/hooks': true,
+				'~/.copilot/hooks': true,
+			};
+			setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+			await mockFiles(fileService, [
+				// targeted files that should be found
+				{ path: '/Users/legomushroom/repos/vscode/.claude/settings.json', contents: ['{}'] },
+				{ path: '/Users/legomushroom/repos/vscode/.claude/settings.local.json', contents: ['{}'] },
+				// sibling files in .claude/ that should NOT be found
+				{ path: '/Users/legomushroom/repos/vscode/.claude/config.json', contents: ['{}'] },
+				{ path: '/Users/legomushroom/repos/vscode/.claude/stats-cache.json', contents: ['{}'] },
+				// hook directory files that should be found
+				{ path: '/Users/legomushroom/repos/vscode/.github/hooks/pre-commit.json', contents: ['{}'] },
+			]);
+			const locator = instantiationService.createInstance(PromptFilesLocator);
+
+			const files = await locator.listFiles(PromptsType.hook, PromptsStorage.local, CancellationToken.None);
+			assert.deepStrictEqual(
+				files.map(f => f.path).sort(),
+				[
+					'/Users/legomushroom/repos/vscode/.claude/settings.json',
+					'/Users/legomushroom/repos/vscode/.claude/settings.local.json',
+					'/Users/legomushroom/repos/vscode/.github/hooks/pre-commit.json',
+				],
+			);
+		});
+
+		testT('returns hook files from user home specific json paths', async () => {
+			configValues[PromptsConfig.HOOKS_LOCATION_KEY] = {
+				'~/.claude/settings.json': true,
+				'~/.copilot/hooks': true,
+			};
+			setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+			await mockFiles(fileService, [
+				// targeted user file
+				{ path: '/Users/legomushroom/.claude/settings.json', contents: ['{}'] },
+				// sibling files that should NOT be found
+				{ path: '/Users/legomushroom/.claude/config.json', contents: ['{}'] },
+				{ path: '/Users/legomushroom/.claude/stats-cache.json', contents: ['{}'] },
+				// hook directory files
+				{ path: '/Users/legomushroom/.copilot/hooks/my-hook.json', contents: ['{}'] },
+			]);
+			const locator = instantiationService.createInstance(PromptFilesLocator);
+
+			const files = await locator.listFiles(PromptsType.hook, PromptsStorage.user, CancellationToken.None);
+			assert.deepStrictEqual(
+				files.map(f => f.path).sort(),
+				[
+					'/Users/legomushroom/.claude/settings.json',
+					'/Users/legomushroom/.copilot/hooks/my-hook.json',
+				],
+			);
+		});
+	});
+
 	suite('getSourceDescription', () => {
 		test('returns descriptions for all known folder sources', () => {
 			const folderSources: PromptFileSource[] = [


### PR DESCRIPTION
Refactor concept of `parent` to be a `searchRoot`. In the case of hook files, we just need to watch specific files (settings.json) not folders.

Fixes https://github.com/microsoft/vscode/issues/304314

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
