### PR TITLE
Cache auth tokens client-side to dedupe agent host authenticate RPCs

### DIFF
--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -24,7 +24,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { AgentCustomizationSyncProvider } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationSyncProvider.js';
-import { resolveTokenForResource } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
+import { resolveTokenForResource, AgentHostAuthTokenCache } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.js';
 import { AgentHostLanguageModelProvider } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider.js';
 import { AgentHostSessionHandler } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.js';
 import { LoggingAgentConnection } from '../../../../workbench/contrib/chat/browser/agentSessions/agentHost/loggingAgentConnection.js';
@@ -48,6 +48,8 @@ class ConnectionState extends Disposable {
 	readonly agents = this._register(new DisposableMap<AgentProvider, DisposableStore>());
 	readonly modelProviders = new Map<AgentProvider, AgentHostLanguageModelProvider>();
 	readonly loggedConnection: LoggingAgentConnection;
+	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
+	readonly authTokenCache = new AgentHostAuthTokenCache();
 
 	constructor(
 		readonly name: string | undefined,
@@ -429,7 +431,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			extensionId: 'vscode.remote-agent-host',
 			extensionDisplayName: 'Remote Agent Host',
 			resolveWorkingDirectory,
-			resolveAuthentication: (resources) => this._resolveAuthenticationInteractively(loggedConnection, resources),
+			resolveAuthentication: (resources) => this._resolveAuthenticationInteractively(address, loggedConnection, resources),
 			customizations,
 		}));
 		agentStore.add(this._chatSessionsService.registerChatSessionContentProvider(sessionType, sessionHandler));
@@ -511,6 +513,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	private async _authenticateWithConnection(address: string, loggedConnection: LoggingAgentConnection, agents: readonly AgentInfo[]): Promise<void> {
 		const providerId = `agenthost-${agentHostAuthority(address)}`;
 		const provider = this._sessionsProvidersService.getProvider<RemoteAgentHostSessionsProvider>(providerId);
+		const authTokenCache = this._connections.get(address)?.authTokenCache;
 		provider?.setAuthenticationPending(true);
 		try {
 			for (const agent of agents) {
@@ -518,6 +521,10 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 					const resourceUri = URI.parse(resource.resource);
 					const token = await this._resolveTokenForResource(resourceUri, resource.authorization_servers ?? [], resource.scopes_supported ?? []);
 					if (token) {
+						if (authTokenCache && !authTokenCache.updateAndIsChanged(resource.resource, token)) {
+							this._logService.trace(`[RemoteAgentHost] Auth token for ${resource.resource} unchanged; skipping authenticate RPC`);
+							continue;
+						}
 						this._logService.info(`[RemoteAgentHost] Authenticating for resource: ${resource.resource}`);
 						await loggedConnection.authenticate({ resource: resource.resource, token });
 					} else {
@@ -545,7 +552,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	 * Interactively prompt the user to authenticate when the server requires it.
 	 * Returns true if authentication succeeded.
 	 */
-	private async _resolveAuthenticationInteractively(loggedConnection: LoggingAgentConnection, protectedResources: readonly ProtectedResourceMetadata[]): Promise<boolean> {
+	private async _resolveAuthenticationInteractively(address: string, loggedConnection: LoggingAgentConnection, protectedResources: readonly ProtectedResourceMetadata[]): Promise<boolean> {
+		const authTokenCache = this._connections.get(address)?.authTokenCache;
 		try {
 			for (const resource of protectedResources) {
 				for (const server of resource.authorization_servers ?? []) {
@@ -553,6 +561,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 					const resourceUri = URI.parse(resource.resource);
 					const token = await this._resolveTokenForResource(resourceUri, resource.authorization_servers ?? [], resource.scopes_supported ?? []);
 					if (token) {
+						authTokenCache?.updateAndIsChanged(resource.resource, token);
 						await loggedConnection.authenticate({
 							resource: resource.resource,
 							token,
@@ -569,6 +578,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 							authorizationServer: serverUri,
 						});
 
+						authTokenCache?.updateAndIsChanged(resource.resource, session.accessToken);
 						await loggedConnection.authenticate({
 							resource: resource.resource,
 							token: session.accessToken,

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -526,7 +526,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 							continue;
 						}
 						this._logService.info(`[RemoteAgentHost] Authenticating for resource: ${resource.resource}`);
-						await loggedConnection.authenticate({ resource: resource.resource, token });
+						try {
+							await loggedConnection.authenticate({ resource: resource.resource, token });
+						} catch (rpcErr) {
+							authTokenCache?.clear(resource.resource);
+							throw rpcErr;
+						}
 					} else {
 						this._logService.info(`[RemoteAgentHost] No token resolved for resource: ${resource.resource}`);
 					}
@@ -561,11 +566,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 					const resourceUri = URI.parse(resource.resource);
 					const token = await this._resolveTokenForResource(resourceUri, resource.authorization_servers ?? [], resource.scopes_supported ?? []);
 					if (token) {
-						authTokenCache?.updateAndIsChanged(resource.resource, token);
 						await loggedConnection.authenticate({
 							resource: resource.resource,
 							token,
 						});
+						authTokenCache?.updateAndIsChanged(resource.resource, token);
 					} else {
 						const providerId = await this._authenticationService.getOrActivateProviderIdForServer(serverUri, resourceUri);
 						if (!providerId) {
@@ -578,11 +583,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 							authorizationServer: serverUri,
 						});
 
-						authTokenCache?.updateAndIsChanged(resource.resource, session.accessToken);
 						await loggedConnection.authenticate({
 							resource: resource.resource,
 							token: session.accessToken,
 						});
+						authTokenCache?.updateAndIsChanged(resource.resource, session.accessToken);
 					}
 
 					this._logService.info(`[RemoteAgentHost] Interactive authentication succeeded for ${resource.resource}`);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -33,8 +33,17 @@ export class AgentHostAuthTokenCache {
 		return true;
 	}
 
-	clear(): void {
-		this._lastTokens.clear();
+	/**
+	 * Clear the cached token for a specific resource, or all resources if
+	 * no argument is given. Call after a failed `authenticate` RPC (per-resource)
+	 * or when the agent host process restarts (all resources).
+	 */
+	clear(resource?: string): void {
+		if (resource !== undefined) {
+			this._lastTokens.delete(resource);
+		} else {
+			this._lastTokens.clear();
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth.ts
@@ -8,6 +8,37 @@ import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
 
 /**
+ * Tracks the last bearer token pushed to a given agent host connection
+ * for each protected resource, so that redundant `authenticate` RPCs can
+ * be suppressed when neither the resource nor the token has changed.
+ *
+ * One instance per connection. Owned by the contribution that drives
+ * authentication for that connection so the cache is dropped naturally
+ * when the connection is disposed.
+ */
+export class AgentHostAuthTokenCache {
+	private readonly _lastTokens = new Map<string, string>();
+
+	/**
+	 * Record that we just sent `token` for `resource`, and return whether
+	 * this is a change from the last token sent. When `false`, callers
+	 * should skip the `authenticate` RPC.
+	 */
+	updateAndIsChanged(resource: string, token: string): boolean {
+		const previous = this._lastTokens.get(resource);
+		if (previous === token) {
+			return false;
+		}
+		this._lastTokens.set(resource, token);
+		return true;
+	}
+
+	clear(): void {
+		this._lastTokens.clear();
+	}
+}
+
+/**
  * Resolves a bearer token for a protected resource by trying each
  * authorization server in order. First attempts an exact scope match,
  * then falls back to finding the session whose scopes are the narrowest

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -97,6 +97,12 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			this._handleRootStateChange(rootState);
 		}));
 
+		// Clear the auth cache whenever the local agent host (re)starts so the
+		// first post-restart authenticate RPC is never skipped as "unchanged".
+		this._register(this._agentHostService.onAgentHostStart(() => {
+			this._authTokenCache.clear();
+		}));
+
 		// Process initial root state if already available
 		const initialRootState = this._agentHostService.rootState.value;
 		if (initialRootState && !(initialRootState instanceof Error)) {
@@ -281,7 +287,13 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 							continue;
 						}
 						this._logService.info(`[AgentHost] Authenticating for resource: ${resource.resource}`);
-						await this._loggedConnection!.authenticate({ resource: resource.resource, token });
+						try {
+							await this._loggedConnection!.authenticate({ resource: resource.resource, token });
+						} catch (rpcErr) {
+							// Clear the cached token so the next auth pass will retry.
+							this._authTokenCache.clear(resource.resource);
+							throw rpcErr;
+						}
 					} else {
 						this._logService.info(`[AgentHost] No token resolved for resource: ${resource.resource}`);
 					}
@@ -315,11 +327,11 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 				const resourceUri = URI.parse(resource.resource);
 				const resolved = await resolveTokenForResource(resourceUri, resource.authorization_servers || [], resource.scopes_supported || [], this._authenticationService, this._logService, '[AgentHost]');
 				if (resolved) {
-					this._authTokenCache.updateAndIsChanged(resource.resource, resolved);
 					await this._loggedConnection!.authenticate({
 						resource: resource.resource,
 						token: resolved,
 					});
+					this._authTokenCache.updateAndIsChanged(resource.resource, resolved);
 					return true;
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -28,7 +28,7 @@ import { IAgentPluginService } from '../../../common/plugins/agentPluginService.
 import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 import { PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
 import { AgentCustomizationSyncProvider } from './agentCustomizationSyncProvider.js';
-import { resolveTokenForResource } from './agentHostAuth.js';
+import { resolveTokenForResource, AgentHostAuthTokenCache } from './agentHostAuth.js';
 import { AgentHostLanguageModelProvider } from './agentHostLanguageModelProvider.js';
 import { AgentHostSessionHandler } from './agentHostSessionHandler.js';
 import { AgentHostSessionListController } from './agentHostSessionListController.js';
@@ -54,6 +54,9 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	private readonly _agentRegistrations = this._register(new DisposableMap<AgentProvider, DisposableStore>());
 	/** Model providers keyed by agent provider, for pushing model updates. */
 	private readonly _modelProviders = new Map<AgentProvider, AgentHostLanguageModelProvider>();
+
+	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
+	private readonly _authTokenCache = new AgentHostAuthTokenCache();
 
 	private readonly _isSessionsWindow: boolean;
 
@@ -273,6 +276,10 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 					const resourceUri = URI.parse(resource.resource);
 					const token = await this._resolveTokenForResource(resourceUri, resource.authorization_servers ?? [], resource.scopes_supported ?? []);
 					if (token) {
+						if (!this._authTokenCache.updateAndIsChanged(resource.resource, token)) {
+							this._logService.trace(`[AgentHost] Auth token for ${resource.resource} unchanged; skipping authenticate RPC`);
+							continue;
+						}
 						this._logService.info(`[AgentHost] Authenticating for resource: ${resource.resource}`);
 						await this._loggedConnection!.authenticate({ resource: resource.resource, token });
 					} else {
@@ -308,6 +315,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 				const resourceUri = URI.parse(resource.resource);
 				const resolved = await resolveTokenForResource(resourceUri, resource.authorization_servers || [], resource.scopes_supported || [], this._authenticationService, this._logService, '[AgentHost]');
 				if (resolved) {
+					this._authTokenCache.updateAndIsChanged(resource.resource, resolved);
 					await this._loggedConnection!.authenticate({
 						resource: resource.resource,
 						token: resolved,
@@ -333,6 +341,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 						resource: resource.resource,
 						token: session.accessToken,
 					});
+					this._authTokenCache.updateAndIsChanged(resource.resource, session.accessToken);
 					this._logService.info(`[AgentHost] Interactive authentication succeeded for ${resource.resource}`);
 					return true;
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostAuth.test.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
-import { resolveTokenForResource } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
+import { resolveTokenForResource, AgentHostAuthTokenCache } from '../../../browser/agentSessions/agentHost/agentHostAuth.js';
 
 function createMockAuthService(overrides: {
 	getOrActivateProviderIdForServer?: (serverUri: URI, resourceUri: URI) => Promise<string | undefined>;
@@ -110,5 +110,47 @@ suite('resolveTokenForResource', () => {
 		);
 		assert.strictEqual(token, 'server2-token');
 		assert.strictEqual(calls.length, 2);
+	});
+});
+
+suite('AgentHostAuthTokenCache', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('first token for a resource is reported as changed', () => {
+		const cache = new AgentHostAuthTokenCache();
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), true);
+	});
+
+	test('repeating the same token for the same resource is reported as unchanged', () => {
+		const cache = new AgentHostAuthTokenCache();
+		cache.updateAndIsChanged('https://api.example.com', 'tok1');
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), false);
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), false);
+	});
+
+	test('a different token for the same resource is reported as changed', () => {
+		const cache = new AgentHostAuthTokenCache();
+		cache.updateAndIsChanged('https://api.example.com', 'tok1');
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok2'), true);
+		// And the new token is now the cached one.
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok2'), false);
+	});
+
+	test('tokens for distinct resources are tracked independently', () => {
+		const cache = new AgentHostAuthTokenCache();
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), true);
+		assert.strictEqual(cache.updateAndIsChanged('https://other.example.com', 'tok1'), true);
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), false);
+		assert.strictEqual(cache.updateAndIsChanged('https://other.example.com', 'tok1'), false);
+	});
+
+	test('clear forgets every cached token', () => {
+		const cache = new AgentHostAuthTokenCache();
+		cache.updateAndIsChanged('https://api.example.com', 'tok1');
+		cache.updateAndIsChanged('https://other.example.com', 'tok2');
+		cache.clear();
+		assert.strictEqual(cache.updateAndIsChanged('https://api.example.com', 'tok1'), true);
+		assert.strictEqual(cache.updateAndIsChanged('https://other.example.com', 'tok2'), true);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -19,7 +19,7 @@ import { AgentHostSessionConfigBranchNameHintKey, IAgentCreateSessionConfig, IAg
 import { isSessionAction, type ActionEnvelope, type INotification, type SessionAction, type TerminalAction, type IToolCallConfirmedAction, type ITurnStartedAction } from '../../../../../../platform/agentHost/common/state/sessionActions.js';
 import type { IStateSnapshot } from '../../../../../../platform/agentHost/common/state/sessionProtocol.js';
 import type { CustomizationRef } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, createSessionState, createActiveTurn, ROOT_STATE_URI, PolicyState, ResponsePartKind, StateComponents, buildSubagentSessionUri, ToolResultContentType, type SessionState, type SessionSummary, RootState, type ToolCallState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { SessionLifecycle, SessionStatus, TurnState, ToolCallStatus, ToolCallConfirmationReason, createSessionState, createActiveTurn, ROOT_STATE_URI, PolicyState, ResponsePartKind, StateComponents, buildSubagentSessionUri, ToolResultContentType, type SessionState, type SessionSummary, RootState, type ToolCallState, type AgentInfo } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { sessionReducer } from '../../../../../../platform/agentHost/common/state/sessionReducers.js';
 import { IDefaultAccountService } from '../../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IAuthenticationService } from '../../../../../services/authentication/common/authentication.js';
@@ -164,13 +164,32 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 		return this._nextSeq++;
 	}
 
-	override readonly rootState: IAgentSubscription<RootState> = {
-		value: undefined,
-		verifiedValue: undefined,
-		onDidChange: Event.None,
-		onWillApplyAction: Event.None,
-		onDidApplyAction: Event.None,
-	};
+	private _rootStateValue: RootState | undefined = undefined;
+	private readonly _rootStateOnDidChange = new Emitter<RootState>();
+
+	override readonly rootState: IAgentSubscription<RootState> = (() => {
+		const onDidChangeEmitter = this._rootStateOnDidChange;
+		const self = this;
+		return {
+			get value() { return self._rootStateValue; },
+			get verifiedValue() { return self._rootStateValue; },
+			onDidChange: onDidChangeEmitter.event,
+			onWillApplyAction: Event.None,
+			onDidApplyAction: Event.None,
+		};
+	})();
+
+	/** Test helper: set rootState value and fire onDidChange. */
+	setRootState(state: RootState): void {
+		this._rootStateValue = state;
+		this._rootStateOnDidChange.fire(state);
+	}
+
+	public authenticateCalls: { resource: string; token: string }[] = [];
+	override async authenticate(params: { resource: string; token: string }): Promise<{ authenticated: boolean }> {
+		this.authenticateCalls.push({ resource: params.resource, token: params.token });
+		return { authenticated: true };
+	}
 	override getSubscription<T>(_kind: StateComponents, resource: URI): IReference<IAgentSubscription<T>> {
 		const resourceStr = resource.toString();
 		const emitter = new Emitter<T>();
@@ -268,6 +287,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	dispose(): void {
 		this._onDidAction.dispose();
 		this._onDidNotification.dispose();
+		this._rootStateOnDidChange.dispose();
 	}
 }
 
@@ -286,7 +306,7 @@ class MockChatAgentService extends mock<IChatAgentService>() {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined }) {
+function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined }, authServiceOverride?: Partial<IAuthenticationService>) {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
 	const agentHostService = new MockAgentHostService();
@@ -306,7 +326,7 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 		registerChatSessionContribution: () => toDisposable(() => { }),
 	});
 	instantiationService.stub(IDefaultAccountService, { onDidChangeDefaultAccount: Event.None, getDefaultAccount: async () => null });
-	instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None });
+	instantiationService.stub(IAuthenticationService, { onDidChangeSessions: Event.None, ...authServiceOverride });
 	instantiationService.stub(ILanguageModelsService, {
 		deltaLanguageModelChatProviderDescriptors: () => { },
 		registerLanguageModelProvider: () => toDisposable(() => { }),
@@ -363,8 +383,8 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	return { instantiationService, agentHostService, chatAgentService };
 }
 
-function createContribution(disposables: DisposableStore) {
-	const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService> }) {
+	const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables, undefined, opts?.authServiceOverride);
 
 	const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -2790,5 +2810,96 @@ suite('AgentHostChatContribution', () => {
 			);
 		}));
 
+	});
+
+	// ---- Auth dedupe ------------------------------------------------------
+
+	suite('auth dedupe', () => {
+
+		const protectedAgents = (): AgentInfo[] => [{
+			provider: 'copilot',
+			displayName: 'Agent Host - Copilot',
+			description: 'test',
+			models: [],
+			protectedResources: [{
+				resource: 'https://api.github.com',
+				resource_name: 'GitHub',
+				authorization_servers: ['https://github.com/login/oauth'],
+				scopes_supported: ['read:user'],
+				required: true,
+			}],
+		}];
+
+		function tokenAuthService(tokenRef: { current: string }): Partial<IAuthenticationService> {
+			// Always returns whatever token is in tokenRef.current. Returning a session
+			// for the exact-scope `getSessions` call short-circuits the superset fallback.
+			return {
+				onDidChangeSessions: Event.None,
+				getOrActivateProviderIdForServer: async () => 'github',
+				getSessions: (async (_providerId: string, scopes?: ReadonlyArray<string>) => {
+					if (scopes !== undefined) {
+						return [{ scopes: [...scopes], accessToken: tokenRef.current }];
+					}
+					return [];
+				}) as unknown as IAuthenticationService['getSessions'],
+			};
+		}
+
+		test('does not re-authenticate when token unchanged across rootState changes', async () => {
+			const tokenRef = { current: 'tok-1' };
+			const { agentHostService } = createContribution(disposables, { authServiceOverride: tokenAuthService(tokenRef) });
+
+			// First rootState — kicks off the eager auth pass.
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+			assert.deepStrictEqual(agentHostService.authenticateCalls, [{ resource: 'https://api.github.com', token: 'tok-1' }]);
+
+			// Repeated rootState changes with the same token must not re-fire authenticate.
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 1 });
+			await timeout(0);
+			assert.deepStrictEqual(agentHostService.authenticateCalls, [{ resource: 'https://api.github.com', token: 'tok-1' }]);
+		});
+
+		test('re-authenticates when token rotates, then dedupes again', async () => {
+			const tokenRef = { current: 'tok-1' };
+			const { agentHostService } = createContribution(disposables, { authServiceOverride: tokenAuthService(tokenRef) });
+
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+
+			// Token rotates externally; next rootState change must push it through.
+			tokenRef.current = 'tok-2';
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+
+			// Subsequent passes with the new token must dedupe again.
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 1 });
+			await timeout(0);
+
+			assert.deepStrictEqual(agentHostService.authenticateCalls, [
+				{ resource: 'https://api.github.com', token: 'tok-1' },
+				{ resource: 'https://api.github.com', token: 'tok-2' },
+			]);
+		});
+
+		test('skips authenticate when no token is resolvable', async () => {
+			const noTokenService: Partial<IAuthenticationService> = {
+				onDidChangeSessions: Event.None,
+				getOrActivateProviderIdForServer: async () => undefined,
+				getSessions: (async () => []) as unknown as IAuthenticationService['getSessions'],
+			};
+			const { agentHostService } = createContribution(disposables, { authServiceOverride: noTokenService });
+
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+			agentHostService.setRootState({ agents: protectedAgents(), activeSessions: 0 });
+			await timeout(0);
+
+			assert.deepStrictEqual(agentHostService.authenticateCalls, []);
+		});
 	});
 });


### PR DESCRIPTION
The local and remote agent host contributions were re-firing `authenticate` RPCs on every rootState change, every default-account change, and every VS Code auth session change — even when the token had not changed. The server-side string compare absorbed this, producing repeated `[Copilot] Auth token unchanged` log lines for every redundant call.

### Fix

Add an `AgentHostAuthTokenCache` that tracks the last token sent per protected-resource URI. Skip the RPC when the token is unchanged.

- **Local** agent host: cache lifetime is per-contribution (one local host).
- **Remote** agent host: cache lives on `ConnectionState`, so it's dropped on disconnect.

The cache is also seeded from the interactive auth path so the first eager pass doesn't re-fire after an interactive sign-in.

### Tests

- 5 unit tests for `AgentHostAuthTokenCache` (first token / repeat unchanged / rotation / per-URI independence / clear)
- 3 integration tests against `AgentHostContribution` exercising the real `_authenticateWithServer` path:
  - Same token across multiple `rootState` events → exactly 1 `authenticate` call
  - Token rotation → 2nd call fires, then dedupe re-engages
  - No resolvable token → 0 calls (no spurious empty-token RPCs)

(Written by Copilot)