### PR TITLE
agentHost: add url permission request handling and refine confirmation titles

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -425,6 +425,8 @@ export interface ITypedPermissionRequest extends PermissionRequest {
 	toolName?: string;
 	/** Tool arguments — set for `custom-tool` permission requests. */
 	args?: Record<string, unknown>;
+	/** URL — set for `url` permission requests. */
+	url?: string;
 	/** Unified diff of the proposed change — set for `write` permission requests. */
 	diff?: string;
 	/** New file contents that will be written — set for `write` permission requests. */
@@ -457,7 +459,7 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 	switch (request.kind) {
 		case 'shell':
 			return {
-				confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal"),
+				confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal?"),
 				invocationMessage: intention ?? getInvocationMessage(CopilotToolName.Bash, getToolDisplayName(CopilotToolName.Bash), fullCommandText ? { command: fullCommandText } : undefined),
 				toolInput: fullCommandText,
 				permissionKind: 'shell',
@@ -471,7 +473,7 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 			const sdkToolName = str(request.toolName);
 			if (command && sdkToolName && isShellTool(sdkToolName)) {
 				return {
-					confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal"),
+					confirmationTitle: localize('copilot.permission.shell.title', "Run in terminal?"),
 					invocationMessage: getInvocationMessage(sdkToolName, getToolDisplayName(sdkToolName), { command }),
 					toolInput: command,
 					permissionKind: 'shell',
@@ -479,8 +481,8 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 				};
 			}
 			return {
-				confirmationTitle: toolName ?? localize('copilot.permission.default.title', "Permission request"),
-				invocationMessage: localize('copilot.permission.default.message', "Permission request"),
+				confirmationTitle: localize('copilot.permission.default.title', "Allow tool call?"),
+				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", request.toolName)),
 				toolInput: args ? tryStringify(args) : tryStringify(request),
 				permissionKind: request.kind,
 				permissionPath: path,
@@ -488,7 +490,7 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 		}
 		case 'write':
 			return {
-				confirmationTitle: localize('copilot.permission.write.title', "Write file"),
+				confirmationTitle: localize('copilot.permission.write.title', "Write file?"),
 				invocationMessage: getInvocationMessage(CopilotToolName.Edit, getToolDisplayName(CopilotToolName.Edit), path ? { path } : undefined),
 				toolInput: tryStringify(path ? { path } : request) ?? undefined,
 				permissionKind: 'write',
@@ -497,7 +499,7 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 		case 'mcp': {
 			const title = toolName ?? localize('copilot.permission.mcp.defaultTool', "MCP Tool");
 			return {
-				confirmationTitle: serverName ? `${serverName}: ${title}` : title,
+				confirmationTitle: localize('copilot.permission.mcp.title', "Allow tool from {0}?", serverName),
 				invocationMessage: serverName ? `${serverName}: ${title}` : title,
 				toolInput: tryStringify({ serverName, toolName }) ?? undefined,
 				permissionKind: 'mcp',
@@ -506,16 +508,26 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 		}
 		case 'read':
 			return {
-				confirmationTitle: localize('copilot.permission.read.title', "Read file"),
+				confirmationTitle: localize('copilot.permission.read.title', "Read file?"),
 				invocationMessage: intention ?? getInvocationMessage(CopilotToolName.View, getToolDisplayName(CopilotToolName.View), path ? { path } : undefined),
 				toolInput: tryStringify(path ? { path, intention } : request) ?? undefined,
 				permissionKind: 'read',
 				permissionPath: path,
 			};
+		case 'url': {
+			const url = str(request.url);
+			return {
+				confirmationTitle: localize('copilot.permission.url.title', "Fetch URL?"),
+				invocationMessage: md(localize('copilot.permission.url.message', "Allow fetching web content?")),
+				// parse through URL for punycode escaping
+				toolInput: JSON.stringify({ url: url && URL.canParse(url) ? new URL(url).href : undefined }),
+				permissionKind: 'url',
+			};
+		}
 		default:
 			return {
-				confirmationTitle: localize('copilot.permission.default.title', "Permission request"),
-				invocationMessage: localize('copilot.permission.default.message', "Permission request"),
+				confirmationTitle: localize('copilot.permission.default.title', "Allow tool call?"),
+				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", request.toolName || request.kind)),
 				toolInput: tryStringify(request) ?? undefined,
 				permissionKind: request.kind,
 				permissionPath: path,

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -482,7 +482,7 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 			}
 			return {
 				confirmationTitle: localize('copilot.permission.default.title', "Allow tool call?"),
-				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", request.toolName)),
+				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", appendEscapedMarkdownInlineCode(toolName ?? request.kind))),
 				toolInput: args ? tryStringify(args) : tryStringify(request),
 				permissionKind: request.kind,
 				permissionPath: path,
@@ -499,7 +499,9 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 		case 'mcp': {
 			const title = toolName ?? localize('copilot.permission.mcp.defaultTool', "MCP Tool");
 			return {
-				confirmationTitle: localize('copilot.permission.mcp.title', "Allow tool from {0}?", serverName),
+				confirmationTitle: serverName
+					? localize('copilot.permission.mcp.title', "Allow tool from {0}?", serverName)
+					: localize('copilot.permission.default.title', "Allow tool call?"),
 				invocationMessage: serverName ? `${serverName}: ${title}` : title,
 				toolInput: tryStringify({ serverName, toolName }) ?? undefined,
 				permissionKind: 'mcp',
@@ -516,18 +518,19 @@ export function getPermissionDisplay(request: ITypedPermissionRequest): {
 			};
 		case 'url': {
 			const url = str(request.url);
+			// Parse through URL for punycode escaping, but preserve the raw value if parsing fails.
+			const normalizedUrl = url ? (URL.canParse(url) ? new URL(url).href : url) : undefined;
 			return {
 				confirmationTitle: localize('copilot.permission.url.title', "Fetch URL?"),
 				invocationMessage: md(localize('copilot.permission.url.message', "Allow fetching web content?")),
-				// parse through URL for punycode escaping
-				toolInput: JSON.stringify({ url: url && URL.canParse(url) ? new URL(url).href : undefined }),
+				toolInput: normalizedUrl ? JSON.stringify({ url: normalizedUrl }) : undefined,
 				permissionKind: 'url',
 			};
 		}
 		default:
 			return {
 				confirmationTitle: localize('copilot.permission.default.title', "Allow tool call?"),
-				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", request.toolName || request.kind)),
+				invocationMessage: md(localize('copilot.permission.default.message', "Allow the model to call {0}?", appendEscapedMarkdownInlineCode(toolName ?? request.kind))),
 				toolInput: tryStringify(request) ?? undefined,
 				permissionKind: request.kind,
 				permissionPath: path,


### PR DESCRIPTION
agentHost: add url permission request handling and refine confirmation titles

- Add handling for 'url' kind permission requests in getPermissionDisplay,
  with URL sanitization via the URL constructor for punycode escaping
- Add 'url' property to ITypedPermissionRequest interface
- Improve confirmation titles to use question format for consistency
  (e.g. 'Run in terminal?' instead of 'Run in terminal')
- Improve custom-tool and default permission display to use markdown
  invocation messages with the tool name for richer rendering
- Refine MCP permission confirmation title to use localized format

Fixes https://github.com/microsoft/vscode/issues/311504

(Commit message generated by Copilot)