### PR TITLE
fix(build): use Bearer auth for GitHub API requests in fetch.ts

### DIFF
--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -109,7 +109,7 @@ const ghApiHeaders: Record<string, string> = {
 	'User-Agent': 'VSCode Build',
 };
 if (process.env.GITHUB_TOKEN) {
-	ghApiHeaders.Authorization = 'Basic ' + Buffer.from(process.env.GITHUB_TOKEN).toString('base64');
+	ghApiHeaders.Authorization = 'Bearer ' + process.env.GITHUB_TOKEN;
 }
 const ghDownloadHeaders = {
 	...ghApiHeaders,


### PR DESCRIPTION
## Problem

`core-ci` fails on every PR with HTTP 403 when fetching `microsoft/vscode-js-debug`, `vscode-js-debug-companion`, and `vscode-js-profile-visualizer` releases from `api.github.com`. Example: https://github.com/microsoft/vscode/actions/runs/24804987512/job/72596862029?pr=312019

The fetch wrapper logs `(you may be rate limited)`, but the real cause is auth, not rate limiting.

## Root Cause

`build/lib/fetch.ts` constructs the `Authorization` header as:

```ts
ghApiHeaders.Authorization = 'Basic ' + Buffer.from(process.env.GITHUB_TOKEN).toString('base64');
```

GitHub's Basic scheme requires `base64(username:password)`. With no `username:` prefix the credential is malformed and GitHub returns 403. The "may be rate limited" suffix is added by the wrapper for *any* 403, masking the actual auth failure.

## Why this surfaced now (1ES runners)

On GitHub-hosted runners the outbound IP range gets generous treatment, so even with broken auth the unauthenticated 60 req/hr per-IP limit was rarely hit. On the new 1ES Azure-hosted runners (e.g. `20.109.121.176`), many concurrent CI jobs share the same outbound IP pool — without working auth the unauthenticated rate limit is exhausted immediately and every PR's `Compile & Hygiene` step fails.

## Fix

Switch to the `Bearer` scheme, which is correct for both `GITHUB_TOKEN` and PATs:

```ts
ghApiHeaders.Authorization = 'Bearer ' + process.env.GITHUB_TOKEN;
```

This is the same fix as the abandoned draft #304889 (which targeted the wrong base branch).

## PATs / Tokens

Investigation confirms no separate PAT is needed — `secrets.GITHUB_TOKEN` is already passed through to the `Compile & Hygiene` step in `.github/workflows/pr.yml`. The token was just being formatted incorrectly. Fixing the header is sufficient; no secret/token configuration changes required.