### PR TITLE
Load deferred repo hooks after session creation

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSessionService.ts
@@ -557,13 +557,17 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 			// to the debug panel.
 			this._installBridgeIfNeeded();
 
-
+			const promises: Promise<unknown>[] = [];
 			if (wasNewSession) {
-				const stagedTitle = await this.customSessionTitleService.getCustomSessionTitle(sdkSession.sessionId);
-				if (stagedTitle) {
-					await sdkSession.updateSessionSummary(stagedTitle);
-				}
+				promises.push(this.customSessionTitleService.getCustomSessionTitle(sdkSession.sessionId).then(stagedTitle => {
+					if (stagedTitle) {
+						sdkSession.updateSessionSummary(stagedTitle);
+					}
+				}));
 			}
+			promises.push(sessionManager.loadDeferredRepoHooks(sdkSession));
+			await Promise.all(promises);
+
 			if (sessionOptions.copilotUrl) {
 				sdkSession.setAuthInfo({
 					type: 'hmac',
@@ -769,7 +773,7 @@ export class CopilotCLISessionService extends Disposable implements ICopilotCLIS
 					this.logService.error(`[CopilotCLISession] CopilotCLI failed to get session ${options.sessionId}.`);
 					return undefined;
 				}
-
+				await sessionManager.loadDeferredRepoHooks(sdkSession);
 				const session = this.createCopilotSession(sdkSession, options.workspace, options.agent?.name, sessionManager);
 				session.object.add(mcpGateway);
 				return session;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/testHelpers.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/testHelpers.ts
@@ -92,6 +92,9 @@ export class MockCliSdkSessionManager {
 		this.sessions.set(newId, s);
 		return Promise.resolve({ sessionId: newId });
 	}
+	async loadDeferredRepoHooks(session: unknown) {
+		//
+	}
 }
 
 export class NullCopilotCLIAgents implements ICopilotCLIAgents {


### PR DESCRIPTION
Ensure that deferred repository hooks are loaded immediately after creating a session in the Copilot CLI session service. This change enhances the session initialization process.

