### PR TITLE
Fix reasoning effort handling in Claude

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeSessionStateService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import type * as vscode from 'vscode';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { createServiceIdentifier } from '../../../../util/common/services';
@@ -22,7 +22,7 @@ export interface SessionState {
 	capturingToken: CapturingToken | undefined;
 	folderInfo: ClaudeFolderInfo | undefined;
 	usageHandler: UsageHandler | undefined;
-	reasoningEffort: string | undefined;
+	reasoningEffort: EffortLevel | undefined;
 }
 
 /**
@@ -96,12 +96,12 @@ export interface IClaudeSessionStateService {
 	/**
 	 * Gets the reasoning effort for a session (user's per-request selection from the model picker).
 	 */
-	getReasoningEffortForSession(sessionId: string): string | undefined;
+	getReasoningEffortForSession(sessionId: string): EffortLevel | undefined;
 
 	/**
 	 * Sets the reasoning effort for a session.
 	 */
-	setReasoningEffortForSession(sessionId: string, effort: string | undefined): void;
+	setReasoningEffortForSession(sessionId: string, effort: EffortLevel | undefined): void;
 }
 
 export const IClaudeSessionStateService = createServiceIdentifier<IClaudeSessionStateService>('IClaudeSessionStateService');

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { McpServerConfig, Options, PermissionMode, Query, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { EffortLevel, McpServerConfig, Options, PermissionMode, Query, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import Anthropic from '@anthropic-ai/sdk';
 import * as l10n from '@vscode/l10n';
 import type * as vscode from 'vscode';
@@ -161,6 +161,7 @@ export class ClaudeCodeSession extends Disposable {
 	private _settingsChangeTracker: ClaudeSettingsChangeTracker;
 	private _currentModelId: ParsedClaudeModelId;
 	private _currentPermissionMode: PermissionMode;
+	private _currentEffort: EffortLevel | undefined;
 	private _isResumed: boolean;
 	private _yieldInProgress = false;
 	private _sessionStarting: Promise<void> | undefined;
@@ -337,7 +338,15 @@ export class ClaudeCodeSession extends Disposable {
 		// Do this BEFORE starting a session so the Options are correct from the start
 		const modelId = this.sessionStateService.getModelIdForSession(this.sessionId);
 		const permissionMode = this.sessionStateService.getPermissionModeForSession(this.sessionId);
+		const effortLevel = this.sessionStateService.getReasoningEffortForSession(this.sessionId);
 
+		if (effortLevel !== this._currentEffort) {
+			this._currentEffort = effortLevel;
+			// Effort doesn't have a direct setter on the query generator, so we need to restart the session
+			if (this._queryGenerator) {
+				this._restartSession();
+			}
+		}
 		// Update model and permission mode on active session if they changed
 		if (modelId) {
 			await this._setModel(modelId);
@@ -427,6 +436,7 @@ export class ClaudeCodeSession extends Disposable {
 			// the permission mode ourselves in the options
 			allowDangerouslySkipPermissions: true,
 			abortController: this._abortController,
+			effort: this._currentEffort,
 			executable: process.execPath as 'node', // get it to fork the EH node process
 			// TODO: CAPI does not yet support the WebSearch tool
 			// Once it does, we can re-enable it.
@@ -662,6 +672,7 @@ export class ClaudeCodeSession extends Disposable {
 		this._queryGenerator = undefined;
 		this._abortController = new AbortController();
 		this._currentRequest = undefined;
+		this._currentEffort = undefined;
 	}
 
 	/**

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts
@@ -13,6 +13,7 @@ import { Emitter } from '../../../../util/vs/base/common/event';
 import { Disposable } from '../../../../util/vs/base/common/lifecycle';
 import type { ParsedClaudeModelId } from '../common/claudeModelId';
 import { tryParseClaudeModelId } from './claudeModelId';
+import { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
 
 export const CLAUDE_REASONING_EFFORT_PROPERTY = 'reasoningEffort';
 
@@ -24,7 +25,13 @@ export interface IClaudeCodeModels {
 	 * then to the newest Sonnet, newest Haiku, or any Claude endpoint.
 	 * Returns `undefined` if no Claude endpoint can be found.
 	 */
-	resolveEndpoint(requestedModel: string | undefined, fallbackModelId: ParsedClaudeModelId | undefined): Promise<IChatEndpoint | undefined>;
+	resolveEndpoint(requestedModel: ParsedClaudeModelId | string | undefined, fallbackModelId: ParsedClaudeModelId | undefined): Promise<IChatEndpoint | undefined>;
+
+	/**
+	 * Resolves the reasoning effort level for the given requested model ID and requested reasoning effort.
+	 */
+	resolveReasoningEffort(requestedModel: ParsedClaudeModelId | string | undefined, requestedReasoningEffort: string | undefined): Promise<EffortLevel | undefined>;
+
 	/**
 	 * Registers a LanguageModelChatProvider so that Claude models appear in
 	 * VS Code's built-in model picker for the claude-code session type.
@@ -101,12 +108,32 @@ export class ClaudeCodeModels extends Disposable implements IClaudeCodeModels {
 		});
 	}
 
-	public async resolveEndpoint(requestedModel: string | undefined, fallbackModelId: ParsedClaudeModelId | undefined): Promise<IChatEndpoint | undefined> {
+	public async resolveReasoningEffort(requestedModel: ParsedClaudeModelId | string | undefined, requestedReasoningEffort: string | undefined): Promise<EffortLevel | undefined> {
+		const endpoint = await this.resolveEndpoint(requestedModel, undefined);
+		if (!endpoint || !endpoint.supportsReasoningEffort || endpoint.supportsReasoningEffort.length === 0) {
+			return undefined;
+		}
+		if (requestedReasoningEffort && isEffortLevel(requestedReasoningEffort) && endpoint.supportsReasoningEffort.includes(requestedReasoningEffort)) {
+			return requestedReasoningEffort;
+		}
+		if (endpoint.supportsReasoningEffort.length === 1 && isEffortLevel(endpoint.supportsReasoningEffort[0])) {
+			return endpoint.supportsReasoningEffort[0];
+		}
+		return undefined;
+	}
+
+	public async resolveEndpoint(requestedModel: ParsedClaudeModelId | string | undefined, fallbackModelId: ParsedClaudeModelId | undefined): Promise<IChatEndpoint | undefined> {
 		const endpoints = await this._getEndpoints();
 
 		// 1. Exact match for the requested model
 		if (requestedModel) {
-			const mappedModel = tryParseClaudeModelId(requestedModel)?.toEndpointModelId() ?? requestedModel;
+			let parsedModel: ParsedClaudeModelId | undefined;
+			if (typeof requestedModel === 'string') {
+				parsedModel = tryParseClaudeModelId(requestedModel);
+			} else {
+				parsedModel = requestedModel;
+			}
+			const mappedModel = parsedModel?.toEndpointModelId() ?? requestedModel;
 			const exact = endpoints.find(e => e.family === mappedModel || e.model === mappedModel);
 			if (exact) {
 				return exact;
@@ -163,14 +190,18 @@ export class ClaudeCodeModels extends Disposable implements IClaudeCodeModels {
 	}
 }
 
-const SUPPORTED_EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
+const SUPPORTED_EFFORT_LEVELS: EffortLevel[] = ['low', 'medium', 'high'];
+
+export function isEffortLevel(value: string): value is EffortLevel {
+	return SUPPORTED_EFFORT_LEVELS.includes(value as EffortLevel);
+}
 
 function buildConfigurationSchema(endpoint: IChatEndpoint): vscode.LanguageModelConfigurationSchema | undefined {
 	const effortLevels = endpoint.supportsReasoningEffort?.filter(
 		(level): level is typeof SUPPORTED_EFFORT_LEVELS[number] =>
 			(SUPPORTED_EFFORT_LEVELS as readonly string[]).includes(level)
 	);
-	if (!effortLevels || effortLevels.length <= 1) {
+	if (!effortLevels) {
 		return;
 	}
 

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
@@ -215,7 +215,10 @@ export class ClaudeLanguageModelServer extends Disposable {
 			}
 
 			const capturingToken = sessionId ? this.sessionStateService.getCapturingTokenForSession(sessionId) : undefined;
-			const reasoningEffort = sessionId ? this.sessionStateService.getReasoningEffortForSession(sessionId) : undefined;
+			const sessionReasoningEffort = sessionId ? this.sessionStateService.getReasoningEffortForSession(sessionId) : undefined;
+			const reasoningEffort = sessionReasoningEffort && selectedEndpoint.supportsReasoningEffort?.includes(sessionReasoningEffort)
+				? sessionReasoningEffort
+				: undefined;
 
 			const doRequest = () => streamingEndpoint.makeChatRequest2({
 				debugName: 'Claude Copilot Proxy',

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeSessionStateService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+import { EffortLevel, PermissionMode } from '@anthropic-ai/claude-agent-sdk';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { arrayEquals } from '../../../../util/vs/base/common/equals';
 import { Emitter } from '../../../../util/vs/base/common/event';
@@ -122,11 +122,11 @@ export class ClaudeSessionStateService extends Disposable implements IClaudeSess
 		});
 	}
 
-	getReasoningEffortForSession(sessionId: string): string | undefined {
+	getReasoningEffortForSession(sessionId: string): EffortLevel | undefined {
 		return this._sessionState.get(sessionId)?.reasoningEffort;
 	}
 
-	setReasoningEffortForSession(sessionId: string, effort: string | undefined): void {
+	setReasoningEffortForSession(sessionId: string, effort: EffortLevel | undefined): void {
 		const existing = this._sessionState.get(sessionId);
 		if (existing?.reasoningEffort === effort) {
 			return;

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgent.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeAgent.spec.ts
@@ -500,6 +500,79 @@ describe('ClaudeCodeSession', () => {
 		expect(mockService.lastQueryOptions?.resume).toBe('existing-session');
 		expect(mockService.lastQueryOptions?.sessionId).toBeUndefined();
 	});
+
+	it('passes effort in SDK options when reasoning effort is set in session state', async () => {
+		const serverConfig = { port: 8080, nonce: 'test-nonce' };
+		const mockServer = createMockLangModelServer();
+		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
+
+		commitTestState(sessionStateService, 'test-session', TEST_MODEL_ID);
+		sessionStateService.setReasoningEffortForSession('test-session', 'low');
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, true));
+		const stream = new MockChatResponseStream();
+
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None);
+
+		expect(mockService.lastQueryOptions?.effort).toBe('low');
+	});
+
+	it('does not include effort in SDK options when reasoning effort is not set', async () => {
+		const serverConfig = { port: 8080, nonce: 'test-nonce' };
+		const mockServer = createMockLangModelServer();
+		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
+
+		commitTestState(sessionStateService, 'test-session', TEST_MODEL_ID);
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, true));
+		const stream = new MockChatResponseStream();
+
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream, CancellationToken.None);
+
+		expect(mockService.lastQueryOptions?.effort).toBeUndefined();
+	});
+
+	it('restarts session when effort level changes', async () => {
+		const serverConfig = { port: 8080, nonce: 'test-nonce' };
+		const mockServer = createMockLangModelServer();
+		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
+		mockService.queryCallCount = 0;
+
+		commitTestState(sessionStateService, 'test-session', TEST_MODEL_ID);
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, true));
+
+		// First request with no effort
+		const stream1 = new MockChatResponseStream();
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None);
+		expect(mockService.queryCallCount).toBe(1);
+
+		// Change effort level
+		sessionStateService.setReasoningEffortForSession('test-session', 'high');
+
+		// Second request should restart session (new query created)
+		const stream2 = new MockChatResponseStream();
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None);
+		expect(mockService.queryCallCount).toBe(2);
+	});
+
+	it('does not restart session when effort level is unchanged', async () => {
+		const serverConfig = { port: 8080, nonce: 'test-nonce' };
+		const mockServer = createMockLangModelServer();
+		const mockService = instantiationService.invokeFunction(accessor => accessor.get(IClaudeCodeSdkService)) as MockClaudeCodeSdkService;
+		mockService.queryCallCount = 0;
+
+		commitTestState(sessionStateService, 'test-session', TEST_MODEL_ID);
+		sessionStateService.setReasoningEffortForSession('test-session', 'medium');
+		const session = store.add(instantiationService.createInstance(ClaudeCodeSession, serverConfig, mockServer, 'test-session', TEST_MODEL_ID, TEST_PERMISSION_MODE, true));
+
+		// First request
+		const stream1 = new MockChatResponseStream();
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello'), {} as vscode.ChatParticipantToolToken, stream1, CancellationToken.None);
+		expect(mockService.queryCallCount).toBe(1);
+
+		// Second request with same effort level
+		const stream2 = new MockChatResponseStream();
+		await session.invoke(createMockChatRequest(), toPromptBlocks('Hello again'), {} as vscode.ChatParticipantToolToken, stream2, CancellationToken.None);
+		expect(mockService.queryCallCount).toBe(1);
+	});
 });
 
 describe('ClaudeAgentManager - error handling', () => {

--- a/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/test/claudeCodeModels.spec.ts
@@ -11,7 +11,7 @@ import { Emitter } from '../../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../../test/node/services';
-import { ClaudeCodeModels } from '../claudeCodeModels';
+import { ClaudeCodeModels, isEffortLevel } from '../claudeCodeModels';
 import { tryParseClaudeModelId } from '../claudeModelId';
 
 /**
@@ -308,7 +308,7 @@ describe('ClaudeCodeModels', () => {
 			expect(info[0].configurationSchema).toBeUndefined();
 		});
 
-		it('omits configurationSchema when endpoint has only one reasoning effort level', async () => {
+		it('includes configurationSchema when endpoint has only one reasoning effort level', async () => {
 			const { service } = createServiceWithRefreshableEndpoints([
 				createMockEndpoint({
 					model: 'claude-sonnet-4-model',
@@ -320,7 +320,139 @@ describe('ClaudeCodeModels', () => {
 			const { lm, getCapturedProvider } = createMockLm();
 
 			const info = await getProviderInfo(service, lm, getCapturedProvider);
-			expect(info[0].configurationSchema).toBeUndefined();
+			expect(info[0].configurationSchema).toBeDefined();
+			const schema = info[0].configurationSchema!;
+			expect(schema.properties?.['reasoningEffort'].enum).toEqual(['high']);
+			expect(schema.properties!['reasoningEffort'].default).toBe('high');
+		});
+	});
+
+	describe('resolveEndpoint with ParsedClaudeModelId', () => {
+		it('resolves endpoint when given a ParsedClaudeModelId', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({ model: 'claude-sonnet-4', name: 'Claude Sonnet 4', family: 'claude-sonnet-4' }),
+			]);
+
+			const parsedId = tryParseClaudeModelId('claude-sonnet-4')!;
+			const endpoint = await service.resolveEndpoint(parsedId, undefined);
+			expect(endpoint?.model).toBe('claude-sonnet-4');
+		});
+
+		it('maps ParsedClaudeModelId to endpoint format', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({ model: 'claude-opus-4.5', name: 'Claude Opus 4.5', family: 'claude-opus-4.5' }),
+			]);
+
+			const parsedId = tryParseClaudeModelId('claude-opus-4-5')!;
+			const endpoint = await service.resolveEndpoint(parsedId, undefined);
+			expect(endpoint?.model).toBe('claude-opus-4.5');
+		});
+	});
+
+	describe('resolveReasoningEffort', () => {
+		it('returns requested effort level when endpoint supports it', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['low', 'medium', 'high'],
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'high');
+			expect(result).toBe('high');
+		});
+
+		it('returns undefined when endpoint does not support reasoning effort', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'high');
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when endpoint has empty reasoning effort array', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: [],
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'high');
+			expect(result).toBeUndefined();
+		});
+
+		it('returns the single supported level when endpoint supports exactly one', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['high'],
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', undefined);
+			expect(result).toBe('high');
+		});
+
+		it('returns undefined when requested effort is not supported by the endpoint', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['low', 'medium'],
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'high');
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when requested effort is not a valid EffortLevel', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['low', 'medium', 'high'],
+				}),
+			]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'invalid-level');
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when no endpoints are available', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([]);
+
+			const result = await service.resolveReasoningEffort('claude-sonnet-4', 'high');
+			expect(result).toBeUndefined();
+		});
+
+		it('accepts a ParsedClaudeModelId for requestedModel', async () => {
+			const { service } = createServiceWithRefreshableEndpoints([
+				createMockEndpoint({
+					model: 'claude-sonnet-4',
+					name: 'Claude Sonnet 4',
+					family: 'claude-sonnet-4',
+					supportsReasoningEffort: ['low', 'medium', 'high'],
+				}),
+			]);
+
+			const parsedId = tryParseClaudeModelId('claude-sonnet-4')!;
+			const result = await service.resolveReasoningEffort(parsedId, 'medium');
+			expect(result).toBe('medium');
 		});
 	});
 
@@ -368,5 +500,20 @@ describe('ClaudeCodeModels', () => {
 			// Should only have fetched once due to caching
 			expect(fetchCount).toBe(1);
 		});
+	});
+});
+
+describe('isEffortLevel', () => {
+	it('returns true for valid effort levels', () => {
+		expect(isEffortLevel('low')).toBe(true);
+		expect(isEffortLevel('medium')).toBe(true);
+		expect(isEffortLevel('high')).toBe(true);
+	});
+
+	it('returns false for invalid effort levels', () => {
+		expect(isEffortLevel('invalid')).toBe(false);
+		expect(isEffortLevel('')).toBe(false);
+		expect(isEffortLevel('HIGH')).toBe(false);
+		expect(isEffortLevel('Low')).toBe(false);
 	});
 });

--- a/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
+++ b/extensions/copilot/src/extension/chatSessions/vscode-node/claudeChatSessionContentProvider.ts
@@ -21,7 +21,7 @@ import { generateUuid } from '../../../util/vs/base/common/uuid';
 import { ClaudeFolderInfo } from '../claude/common/claudeFolderInfo';
 import { ClaudeSessionUri } from '../claude/common/claudeSessionUri';
 import { ClaudeAgentManager } from '../claude/node/claudeCodeAgent';
-import { CLAUDE_REASONING_EFFORT_PROPERTY } from '../claude/node/claudeCodeModels';
+import { CLAUDE_REASONING_EFFORT_PROPERTY, IClaudeCodeModels } from '../claude/node/claudeCodeModels';
 import { IClaudeCodeSdkService } from '../claude/node/claudeCodeSdkService';
 import { parseClaudeModelId } from '../claude/node/claudeModelId';
 import { IClaudeSessionStateService } from '../claude/common/claudeSessionStateService';
@@ -61,6 +61,7 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 		@IClaudeSessionStateService private readonly sessionStateService: IClaudeSessionStateService,
 		@IClaudeSlashCommandService private readonly slashCommandService: IClaudeSlashCommandService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IClaudeCodeModels private readonly claudeModels: IClaudeCodeModels,
 		@IChatFolderMruService folderMruService: IChatFolderMruService,
 		@IWorkspaceService workspaceService: IWorkspaceService,
 		@INativeEnvService envService: INativeEnvService,
@@ -124,8 +125,8 @@ export class ClaudeChatSessionContentProvider extends Disposable implements vsco
 			this.sessionStateService.setFolderInfoForSession(effectiveSessionId, folderInfo);
 
 			const rawReasoningEffort = request.modelConfiguration?.[CLAUDE_REASONING_EFFORT_PROPERTY];
-			const normalizedReasoningEffort = typeof rawReasoningEffort === 'string' ? rawReasoningEffort.trim() || undefined : undefined;
-			this.sessionStateService.setReasoningEffortForSession(effectiveSessionId, normalizedReasoningEffort);
+			const reasoningEffort = await this.claudeModels.resolveReasoningEffort(modelId, rawReasoningEffort);
+			this.sessionStateService.setReasoningEffortForSession(effectiveSessionId, reasoningEffort);
 
 			// Set usage handler to report token usage for context window widget
 			this.sessionStateService.setUsageHandlerForSession(effectiveSessionId, (usage) => {


### PR DESCRIPTION
The reasoning effort wasn't really getting passed down properly. This ensures that it does and if a model only has 1 reasoning value then we use that.

Fixes https://github.com/microsoft/vscode/issues/311862

Co-authored-by: Copilot <copilot@github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
