### PR TITLE
Remove fallback for anchor positioning

### DIFF
--- a/src/vs/base/browser/overlayLayoutElement.ts
+++ b/src/vs/base/browser/overlayLayoutElement.ts
@@ -3,15 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDimension, IDomPosition, setParentFlowTo } from './dom.js';
+import { setParentFlowTo } from './dom.js';
 import { IDisposable } from '../common/lifecycle.js';
-import { Lazy } from '../common/lazy.js';
 import { generateUuid } from '../common/uuid.js';
-
-/**
- * Whether CSS anchor positioning is supported
- */
-const supportsAnchorPositioning = new Lazy(() => CSS.supports('(top: anchor(top))'));
 
 /**
  * If the element already has an `anchor-name` style, return it.
@@ -32,7 +26,7 @@ function getOrCreateAnchorName(element: HTMLElement): string {
  *
  * This is useful for cases where a dom node cannot be re-parented without losing its state, such as a iframe.
  *
- * Call {@link layoutOverAnchorElement} each time the layout is recalculated. When the
+ * Call {@link setAnchorElement} each time the layout is recalculated. When the
  * same anchor element is passed again the call is a no-op (the browser keeps them in sync).
  */
 export class OverlayLayoutElement implements IDisposable {
@@ -60,14 +54,12 @@ export class OverlayLayoutElement implements IDisposable {
 	}
 
 	public reapplyLayoutStyles(): void {
-		if (supportsAnchorPositioning.value) {
-			this.content.style.position = 'fixed';
-			this.content.style.top = 'anchor(top)';
-			this.content.style.left = 'anchor(left)';
-			this.content.style.width = 'anchor-size(width)';
-			this.content.style.height = 'anchor-size(height)';
-			this.content.style.pointerEvents = 'auto';
-		}
+		this.content.style.position = 'fixed';
+		this.content.style.top = 'anchor(top)';
+		this.content.style.left = 'anchor(left)';
+		this.content.style.width = 'anchor-size(width)';
+		this.content.style.height = 'anchor-size(height)';
+		this.content.style.pointerEvents = 'auto';
 
 		this._root.style.position = 'absolute';
 		this._root.style.pointerEvents = 'none';
@@ -93,88 +85,48 @@ export class OverlayLayoutElement implements IDisposable {
 	/**
 	 * Position the content over `anchorElement`.
 	 *
-	 * For legacy browser support this should be called each time the layout is recalculated.
+	 * This only needs to be called when the anchor element or the clipping container changes.
 	 */
-	public layoutOverAnchorElement(
+	public setAnchorElement(
 		anchorElement: HTMLElement,
 		options?: {
 			readonly clippingContainer?: HTMLElement;
-			readonly fallbackDimension?: IDimension;
-			readonly fallbackPosition?: IDomPosition;
 		},
 	): void {
-		if (supportsAnchorPositioning.value) {
-			if (this._currentAnchor?.element !== anchorElement) {
-				const name = getOrCreateAnchorName(anchorElement);
-				this.content.style.setProperty('position-anchor', name);
-				setParentFlowTo(this.content, anchorElement);
-				this._currentAnchor = { element: anchorElement, name };
-			}
-		} else {
-			const cs = this.content.style;
-
-			if (options?.fallbackPosition) {
-				cs.top = `${options.fallbackPosition.top}px`;
-				cs.left = `${options.fallbackPosition.left}px`;
-			} else {
-				const anchorRect = anchorElement.getBoundingClientRect();
-				const parentRect = this.content.parentElement!.getBoundingClientRect();
-				const parentBorderTop = (parentRect.height - this.content.parentElement!.clientHeight) / 2.0;
-				const parentBorderLeft = (parentRect.width - this.content.parentElement!.clientWidth) / 2.0;
-				cs.top = `${anchorRect.top - parentRect.top - parentBorderTop}px`;
-				cs.left = `${anchorRect.left - parentRect.left - parentBorderLeft}px`;
-			}
-
+		if (this._currentAnchor?.element !== anchorElement) {
+			const name = getOrCreateAnchorName(anchorElement);
+			this.content.style.setProperty('position-anchor', name);
 			setParentFlowTo(this.content, anchorElement);
-
-			const anchorRect = anchorElement.getBoundingClientRect();
-			cs.width = `${options?.fallbackDimension ? options.fallbackDimension.width : anchorRect.width}px`;
-			cs.height = `${options?.fallbackDimension ? options.fallbackDimension.height : anchorRect.height}px`;
+			this._currentAnchor = { element: anchorElement, name };
 		}
 
-		this._updateClipping(anchorElement, options?.clippingContainer);
+		this._updateClipping(options?.clippingContainer);
 	}
 
-	private _updateClipping(anchorElement: HTMLElement, clippingContainer: HTMLElement | undefined): void {
-		if (supportsAnchorPositioning.value) {
-			if (this._clippingAnchor?.element === clippingContainer) {
-				return;
-			}
+	private _updateClipping(clippingContainer: HTMLElement | undefined): void {
+		if (this._clippingAnchor?.element === clippingContainer) {
+			return;
+		}
 
-			this._root.style.removeProperty('position-anchor');
+		this._root.style.removeProperty('position-anchor');
 
-			const ws = this._root.style;
-			if (clippingContainer) {
-				const name = getOrCreateAnchorName(clippingContainer);
-				ws.clipPath = 'content-box';
-				ws.setProperty('position-anchor', name);
-				ws.setProperty('top', 'anchor(top)');
-				ws.setProperty('left', 'anchor(left)');
-				ws.setProperty('width', `anchor-size(width)`);
-				ws.setProperty('height', `anchor-size(height)`);
-				this._clippingAnchor = { element: clippingContainer, name };
-			} else {
-				ws.clipPath = '';
-				ws.setProperty('top', '0');
-				ws.setProperty('left', '0');
-				ws.setProperty('right', '0');
-				ws.setProperty('bottom', '0');
-				this._clippingAnchor = undefined;
-			}
+		const ws = this._root.style;
+		if (clippingContainer) {
+			const name = getOrCreateAnchorName(clippingContainer);
+			ws.clipPath = 'content-box';
+			ws.setProperty('position-anchor', name);
+			ws.setProperty('top', 'anchor(top)');
+			ws.setProperty('left', 'anchor(left)');
+			ws.setProperty('width', `anchor-size(width)`);
+			ws.setProperty('height', `anchor-size(height)`);
+			this._clippingAnchor = { element: clippingContainer, name };
 		} else {
-			if (clippingContainer) {
-				const anchorRect = anchorElement.getBoundingClientRect();
-				const clipRect = clippingContainer.getBoundingClientRect();
-				const top = Math.max(clipRect.top - anchorRect.top, 0);
-				const right = Math.max(anchorRect.width - (anchorRect.right - clipRect.right), 0);
-				const bottom = Math.max(anchorRect.height - (anchorRect.bottom - clipRect.bottom), 0);
-				const left = Math.max(clipRect.left - anchorRect.left, 0);
-				this.content.style.clipPath = `polygon(${left}px ${top}px, ${right}px ${top}px, ${right}px ${bottom}px, ${left}px ${bottom}px)`;
-				this._clippingAnchor = { element: clippingContainer, name: '' };
-			} else {
-				this.content.style.clipPath = '';
-				this._clippingAnchor = undefined;
-			}
+			ws.clipPath = '';
+			ws.setProperty('top', '0');
+			ws.setProperty('left', '0');
+			ws.setProperty('right', '0');
+			ws.setProperty('bottom', '0');
+			this._clippingAnchor = undefined;
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
@@ -417,7 +417,7 @@ export class AgentPluginEditor extends EditorPane {
 
 			webview.claim(this, this.window, undefined);
 			setParentFlowTo(webview.container, container);
-			webview.layoutWebviewOverElement(container);
+			webview.setAnchorElement(container);
 
 			webview.setHtml(body);
 			webview.claim(this, this.window, undefined);
@@ -428,7 +428,7 @@ export class AgentPluginEditor extends EditorPane {
 
 			const removeLayoutParticipant = arrays.insert(this.layoutParticipants, {
 				layout: () => {
-					webview.layoutWebviewOverElement(container);
+					webview.setAnchorElement(container);
 				}
 			});
 			this.contentDisposables.add(toDisposable(removeLayoutParticipant));

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -713,7 +713,7 @@ export class ExtensionEditor extends EditorPane {
 
 			webview.claim(this, this.window, this.scopedContextKeyService);
 			setParentFlowTo(webview.container, container);
-			webview.layoutWebviewOverElement(container);
+			webview.setAnchorElement(container);
 
 			webview.setHtml(body);
 			webview.claim(this, this.window, undefined);
@@ -724,7 +724,7 @@ export class ExtensionEditor extends EditorPane {
 
 			const removeLayoutParticipant = arrays.insert(this.layoutParticipants, {
 				layout: () => {
-					webview.layoutWebviewOverElement(container);
+					webview.setAnchorElement(container);
 				}
 			});
 			this.contentDisposables.add(toDisposable(removeLayoutParticipant));

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
@@ -498,7 +498,7 @@ export class McpServerEditor extends EditorPane {
 
 			webview.claim(this, this.window, this.scopedContextKeyService);
 			setParentFlowTo(webview.container, container);
-			webview.layoutWebviewOverElement(container);
+			webview.setAnchorElement(container);
 
 			webview.setHtml(body);
 			webview.claim(this, this.window, undefined);
@@ -509,7 +509,7 @@ export class McpServerEditor extends EditorPane {
 
 			const removeLayoutParticipant = arrays.insert(this.layoutParticipants, {
 				layout: () => {
-					webview.layoutWebviewOverElement(container);
+					webview.setAnchorElement(container);
 				}
 			});
 			this.contentDisposables.add(toDisposable(removeLayoutParticipant));

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -216,7 +216,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	private _localCellStateListeners: DisposableStore[] = [];
 	private _fontInfo: FontInfo | undefined;
 	private _dimension?: DOM.Dimension;
-	private _position?: DOM.IDomPosition;
 	private _shadowElement?: HTMLElement;
 	private _cellLayoutManager: NotebookCellLayoutManager | undefined;
 
@@ -422,7 +421,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				return;
 			}
 
-			this.layoutContainerOverShadowElement(this._shadowElement, this._dimension, this._position);
+			this.layoutContainerOverShadowElement(this._shadowElement);
 		}));
 
 		this.notebookEditorService.addNotebookEditor(this);
@@ -1882,7 +1881,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	layout(dimension: DOM.Dimension, shadowElement?: HTMLElement, position?: DOM.IDomPosition): void {
 		if (!shadowElement && !this._shadowElement) {
 			this._dimension = dimension;
-			this._position = position;
 			return;
 		}
 
@@ -1896,20 +1894,19 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			// In floating windows, we need to ensure that the
 			// container is ready for us to compute certain
 			// layout related properties.
-			whenContainerStylesLoaded.then(() => this.layoutNotebook(dimension, shadowElement, position));
+			whenContainerStylesLoaded.then(() => this.layoutNotebook(dimension, shadowElement));
 		} else {
-			this.layoutNotebook(dimension, shadowElement, position);
+			this.layoutNotebook(dimension, shadowElement);
 		}
 
 	}
 
-	private layoutNotebook(dimension: DOM.Dimension, shadowElement?: HTMLElement, position?: DOM.IDomPosition) {
+	private layoutNotebook(dimension: DOM.Dimension, shadowElement?: HTMLElement) {
 		if (shadowElement) {
 			this._shadowElement = shadowElement;
 		}
 
 		this._dimension = dimension;
-		this._position = position;
 		const newBodyHeight = this.getBodyHeight(dimension.height) - this.getLayoutInfo().stickyHeight;
 		DOM.size(this._body, dimension.width, newBodyHeight);
 
@@ -1926,7 +1923,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		this._overlayContainer.inert = false;
 
-		this.layoutContainerOverShadowElement(shadowElement ?? this._shadowElement, dimension, position);
+		this.layoutContainerOverShadowElement(shadowElement ?? this._shadowElement);
 
 		if (this._webviewTransparentCover) {
 			this._webviewTransparentCover.style.height = `${dimension.height}px`;
@@ -1939,21 +1936,21 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._viewContext?.eventDispatcher.emit([new NotebookLayoutChangedEvent({ width: true, fontInfo: true }, this.getLayoutInfo())]);
 	}
 
-	private layoutContainerOverShadowElement(shadowElement: HTMLElement | undefined, dimension?: DOM.Dimension, position?: DOM.IDomPosition): void {
-		if (!shadowElement) {
+	private layoutContainerOverShadowElement(anchorElement: HTMLElement | undefined): void {
+		if (!anchorElement) {
 			return;
 		}
 
 		const modalEditorContainer = this.editorGroupsService.activeModalEditorPart?.modalElement;
 		let clippingContainer: HTMLElement | undefined;
-		if (DOM.isHTMLElement(modalEditorContainer) && modalEditorContainer.contains(shadowElement)) {
+		if (DOM.isHTMLElement(modalEditorContainer) && modalEditorContainer.contains(anchorElement)) {
 			clippingContainer = modalEditorContainer;
 		} else {
 			clippingContainer = this.layoutService.getContainer(DOM.getWindow(this.getDomNode()), Parts.EDITOR_PART);
 		}
 
 		this._overlayContainer.style.visibility = 'visible';
-		this._overlayLayout.layoutOverAnchorElement(shadowElement, { clippingContainer, fallbackDimension: dimension, fallbackPosition: position });
+		this._overlayLayout.setAnchorElement(anchorElement, { clippingContainer });
 		this._overlayLayout.reapplyLayoutStyles();
 	}
 

--- a/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
+++ b/src/vs/workbench/contrib/webview/browser/overlayWebview.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dimension, getWindowById } from '../../../../base/browser/dom.js';
+import { getWindowById } from '../../../../base/browser/dom.js';
 import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
 import { OverlayLayoutElement } from '../../../../base/browser/overlayLayoutElement.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
@@ -57,6 +57,8 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 
 	private _overlayLayout: OverlayLayoutElement | undefined;
 
+	private _anchorState: { readonly anchorElement: HTMLElement; readonly clippingContainer?: HTMLElement } | undefined;
+
 	public constructor(
 		initInfo: WebviewInitInfo,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
@@ -104,17 +106,21 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 			throw new Error(`OverlayWebview has been disposed`);
 		}
 
+		return this.overlayLayout.content;
+	}
+
+	private get overlayLayout() {
 		if (!this._overlayLayout) {
 			this._overlayLayout = new OverlayLayoutElement();
 			this._overlayLayout.content.style.visibility = 'hidden';
 
-			// // Webviews cannot be reparented in the dom as it will destroy their contents.
-			// // Mount them to a high level node to avoid this depending on the active container.
+			// Webviews cannot be reparented in the dom as it will destroy their contents.
+			// Mount them to a high level node to avoid this depending on the active container.
 			const root = this._layoutService.getContainer(this.window);
 			root.appendChild(this._overlayLayout.root);
 		}
 
-		return this._overlayLayout.content;
+		return this._overlayLayout;
 	}
 
 	public claim(owner: unknown, targetWindow: CodeWindow, scopedContextKeyService: IContextKeyService | undefined) {
@@ -137,6 +143,10 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		this._owner = owner;
 		this._windowId = targetWindow.vscodeWindowId;
 		this._show(targetWindow);
+
+		if (this._anchorState) {
+			this.overlayLayout.setAnchorElement(this._anchorState.anchorElement, { clippingContainer: this._anchorState.clippingContainer });
+		}
 
 		if (oldOwner !== owner) {
 			const contextKeyService = (scopedContextKeyService || this._baseContextKeyService);
@@ -182,12 +192,10 @@ export class OverlayWebview extends Disposable implements IOverlayWebview {
 		}
 	}
 
-	public layoutWebviewOverElement(anchorElement: HTMLElement, dimension?: Dimension, clippingContainer?: HTMLElement) {
-		if (!this._overlayLayout || !this._overlayLayout.content.parentElement) {
-			return;
-		}
-
-		this._overlayLayout?.layoutOverAnchorElement(anchorElement, { clippingContainer, fallbackDimension: dimension });
+	public setAnchorElement(anchorElement: HTMLElement, clippingContainer?: HTMLElement) {
+		this._anchorState = { anchorElement, clippingContainer };
+		// Force the overlay layout to be created if it doesn't exist
+		this.overlayLayout.setAnchorElement(anchorElement, { clippingContainer });
 	}
 
 	private _show(targetWindow: CodeWindow) {

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dimension } from '../../../../base/browser/dom.js';
 import { IMouseWheelEvent } from '../../../../base/browser/mouseEvent.js';
 import { CodeWindow } from '../../../../base/browser/window.js';
 import { equals } from '../../../../base/common/arrays.js';
@@ -331,14 +330,13 @@ export interface IOverlayWebview extends IWebview {
 	release(claimant: any): void;
 
 	/**
-	 * Absolutely position the webview on top of another element in the DOM.
+	 * Sets the webview to be absolutely positioned on top of another element in the DOM.
 	 *
 	 * @param element Element to position the webview on top of. This element should
 	 *   be an placeholder for the webview since the webview will entirely cover it.
-	 * @param dimension Optional explicit dimensions to use for sizing the webview.
 	 * @param clippingContainer Optional container to clip the webview to. This should generally be a parent of `element`.
 	 */
-	layoutWebviewOverElement(element: HTMLElement, dimension?: Dimension, clippingContainer?: HTMLElement): void;
+	setAnchorElement(element: HTMLElement, clippingContainer?: HTMLElement): void;
 }
 
 /**

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -69,7 +69,7 @@ export class WebviewEditor extends EditorPane {
 		const part = _editorGroupsService.getPart(group);
 		this._register(Event.any(part.onDidScroll, part.onDidAddGroup, part.onDidRemoveGroup, part.onDidMoveGroup)(() => {
 			if (this.webview && this._visible) {
-				this.synchronizeWebviewContainerDimensions(this.webview);
+				this.setWebviewAnchorElement(this.webview);
 			}
 		}));
 
@@ -105,7 +105,7 @@ export class WebviewEditor extends EditorPane {
 	public override layout(dimension: DOM.Dimension): void {
 		this._dimension = dimension;
 		if (this.webview && this._visible) {
-			this.synchronizeWebviewContainerDimensions(this.webview, dimension);
+			this.setWebviewAnchorElement(this.webview);
 		}
 	}
 
@@ -197,16 +197,16 @@ export class WebviewEditor extends EditorPane {
 
 		this._webviewVisibleDisposables.add(new WebviewWindowDragMonitor(this.window, () => this.webview));
 
-		this.synchronizeWebviewContainerDimensions(input.webview);
+		this.setWebviewAnchorElement(input.webview);
 		this._webviewVisibleDisposables.add(this.trackFocus(input.webview));
 	}
 
-	private synchronizeWebviewContainerDimensions(webview: IOverlayWebview, dimension?: DOM.Dimension) {
+	private setWebviewAnchorElement(webview: IOverlayWebview) {
 		if (!this._element?.isConnected) {
 			return;
 		}
 
-		webview.layoutWebviewOverElement(this._element.parentElement!, dimension, this._clippingContainer);
+		webview.setAnchorElement(this._element.parentElement!, this._clippingContainer);
 	}
 
 	private trackFocus(webview: IOverlayWebview): IDisposable {

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { addDisposableListener, Dimension, EventType, findParentWithClass, getWindow } from '../../../../base/browser/dom.js';
+import { addDisposableListener, EventType, findParentWithClass, getWindow } from '../../../../base/browser/dom.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -53,7 +53,6 @@ export class WebviewViewPane extends ViewPane {
 
 	private _container?: HTMLElement;
 	private _rootContainer?: HTMLElement;
-	private _resizeObserver?: ResizeObserver;
 
 	private readonly defaultTitle: string;
 	private setTitle: string | undefined;
@@ -64,8 +63,6 @@ export class WebviewViewPane extends ViewPane {
 	private readonly memento: Memento<WebviewViewState>;
 	private readonly viewState: WebviewViewState;
 	private readonly extensionId?: ExtensionIdentifier;
-
-	private _repositionTimeout?: Timeout;
 
 	constructor(
 		options: IViewletViewOptions,
@@ -114,8 +111,6 @@ export class WebviewViewPane extends ViewPane {
 	override dispose() {
 		this._onDispose.fire();
 
-		clearTimeout(this._repositionTimeout);
-
 		super.dispose();
 	}
 
@@ -130,18 +125,7 @@ export class WebviewViewPane extends ViewPane {
 		this._container = container;
 		this._rootContainer = undefined;
 
-		if (!this._resizeObserver) {
-			this._resizeObserver = new ResizeObserver(() => {
-				setTimeout(() => {
-					this.layoutWebview();
-				}, 0);
-			});
-
-			this._register(toDisposable(() => {
-				this._resizeObserver?.disconnect();
-			}));
-			this._resizeObserver.observe(container);
-		}
+		this.layoutWebview();
 	}
 
 	public override saveState() {
@@ -155,8 +139,7 @@ export class WebviewViewPane extends ViewPane {
 
 	protected override layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
-
-		this.layoutWebview(new Dimension(width, height));
+		this.layoutWebview();
 	}
 
 	private updateTreeVisibility() {
@@ -187,9 +170,7 @@ export class WebviewViewPane extends ViewPane {
 		webview.state = this.viewState[storageKeys.webviewState];
 		this._webview.value = webview;
 
-		if (this._container) {
-			this.layoutWebview();
-		}
+		this.layoutWebview();
 
 		this._webviewDisposables.add(toDisposable(() => {
 			this._webview.value?.release(this);
@@ -272,11 +253,7 @@ export class WebviewViewPane extends ViewPane {
 		return this.progressService.withProgress({ location: this.id, delay: 500 }, task);
 	}
 
-	override onDidScrollRoot() {
-		this.layoutWebview();
-	}
-
-	private doLayoutWebview(dimension?: Dimension) {
+	private layoutWebview() {
 		const webviewEntry = this._webview.value;
 		if (!this._container || !webviewEntry) {
 			return;
@@ -286,15 +263,7 @@ export class WebviewViewPane extends ViewPane {
 			this._rootContainer = this.findRootContainer(this._container);
 		}
 
-		webviewEntry.layoutWebviewOverElement(this._container, dimension, this._rootContainer);
-	}
-
-	private layoutWebview(dimension?: Dimension) {
-		this.doLayoutWebview(dimension);
-		// Temporary fix for https://github.com/microsoft/vscode/issues/110450
-		// There is an animation that lasts about 200ms, update the webview positioning once this animation is complete.
-		clearTimeout(this._repositionTimeout);
-		this._repositionTimeout = setTimeout(() => this.doLayoutWebview(dimension), 200);
+		webviewEntry.setAnchorElement(this._container, this._rootContainer);
 	}
 
 	private findRootContainer(container: HTMLElement): HTMLElement | undefined {


### PR DESCRIPTION
The stable safari and firefox release should both support this now

This lets up clean up a fair amount of manual layout logic and workarounds we needed previously
