### PR TITLE
sessions: show pointer cursor on new session button

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -166,6 +166,9 @@
 		min-width: 0;
 		height: auto;
 		white-space: nowrap;
+	}
+
+	.agent-sessions-compact-new-button.monaco-button:not(.disabled) {
 		cursor: pointer;
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -166,6 +166,7 @@
 		min-width: 0;
 		height: auto;
 		white-space: nowrap;
+		cursor: pointer;
 	}
 
 	.agent-sessions-compact-new-button.monaco-button.default-colors:hover {


### PR DESCRIPTION
## Summary

Fixes #311982.

Related to https://github.com/microsoft/vscode/issues/310018.

Adds an explicit `cursor: pointer` style to the compact **New Session** button in the sessions sidebar so it presents the same clickable affordance as other interactive controls.

## Testing

- Verified the change is limited to the sessions sidebar button styling
- Repo pre-commit hook passed during commit