### PR TITLE
Add 'Collapse All Groups' action to sessions filter menu

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -676,6 +676,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 	private workspaceGroupCapped: boolean;
 	private readonly expandedWorkspaceGroups = new Set<string>();
 	private findOpen = false;
+	private suspendCollapseStatePersistence = false;
 
 	private readonly _onDidUpdate = this._register(new Emitter<void>());
 	readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
@@ -807,6 +808,9 @@ export class SessionsList extends Disposable implements ISessionsList {
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));
 
 		this._register(this.tree.onDidChangeCollapseState(e => {
+			if (this.suspendCollapseStatePersistence) {
+				return;
+			}
 			const element = e.node.element;
 			if (element && isSessionSection(element)) {
 				this.saveSectionCollapseState(element.id, e.node.collapsed);
@@ -1189,7 +1193,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 	}
 
 	collapseAllSections(): void {
-		this.tree.collapseAll();
+		this.suspendCollapseStatePersistence = true;
+		try {
+			this.tree.collapseAll();
+		} finally {
+			this.suspendCollapseStatePersistence = false;
+		}
+		this.saveBulkCollapseState(true);
 	}
 
 	// -- Section collapse persistence --
@@ -1223,6 +1233,16 @@ export class SessionsList extends Disposable implements ISessionsList {
 			}
 		}
 		state[sectionId] = collapsed;
+		this.storageService.store(SessionsList.SECTION_COLLAPSE_STATE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
+	}
+
+	private saveBulkCollapseState(collapsed: boolean): void {
+		const state: Record<string, boolean> = {};
+		for (const child of this.tree.getNode(null).children) {
+			if (child.element && isSessionSection(child.element)) {
+				state[child.element.id] = collapsed;
+			}
+		}
 		this.storageService.store(SessionsList.SECTION_COLLAPSE_STATE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -652,6 +652,7 @@ export interface ISessionsList {
 	resetFilters(): void;
 	setWorkspaceGroupCapped(capped: boolean): void;
 	isWorkspaceGroupCapped(): boolean;
+	collapseAllSections(): void;
 }
 
 export class SessionsList extends Disposable implements ISessionsList {
@@ -1185,6 +1186,10 @@ export class SessionsList extends Disposable implements ISessionsList {
 
 	isWorkspaceGroupCapped(): boolean {
 		return this.workspaceGroupCapped;
+	}
+
+	collapseAllSections(): void {
+		this.tree.collapseAll();
 	}
 
 	// -- Section collapse persistence --

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -209,6 +209,24 @@ registerAction2(class ShowAllWorkspaceSessionsAction extends Action2 {
 	}
 });
 
+//  Collapse All Groups
+
+registerAction2(class CollapseAllGroupsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsViewPane.collapseAllGroups',
+			title: localize2('collapseAllGroups', "Collapse All Groups"),
+			category: SessionsCategories.Sessions,
+			menu: [{ id: SessionsViewFilterSubMenu, group: '4_collapse', order: 0 }]
+		});
+	}
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<SessionsView>(SessionsViewId);
+		view?.sessionsControl?.collapseAllSections();
+	}
+});
+
 //  View Toolbar Actions
 
 registerAction2(class RefreshSessionsAction extends Action2 {


### PR DESCRIPTION
Adds a **Collapse All Groups** action to the sessions view filter submenu (gear icon) in the Agents window. This lets users quickly collapse all section groups (time-based or workspace-based) with one click.

### Changes
- `sessionsList.ts`: Added `collapseAllSections()` to `ISessionsList` interface and `SessionsList` class, delegating to `tree.collapseAll()`
- `sessionsViewActions.ts`: Registered `CollapseAllGroupsAction` in `SessionsViewFilterSubMenu` (group `4_collapse`)