### PR TITLE
Launch agent host terminals as login shells on macOS

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -9,6 +9,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { dirname, parse as pathParse } from '../../../base/common/path.js';
 import * as platform from '../../../base/common/platform.js';
+import { getSystemShell } from '../../../base/node/shell.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
@@ -184,7 +185,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		const cols = params.cols ?? 80;
 		const rows = params.rows ?? 24;
 
-		const shell = options?.shell ?? this._getDefaultShell();
+		const shell = options?.shell ?? await this._getDefaultShell();
 		const name = platform.isWindows ? 'cmd' : 'xterm-256color';
 
 		this._logService.info(`[TerminalManager] Creating terminal ${uri}: shell=${shell}, cwd=${cwd}, cols=${cols}, rows=${rows}`);
@@ -217,7 +218,7 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		let shellArgs: string[] = [];
 		if (platform.isMacintosh) {
 			const shellName = pathParse(shell).name;
-			if (shellName === 'zsh' || shellName === 'bash') {
+			if (shellName.match(/(zsh|bash)/)) {
 				shellArgs = ['--login'];
 			}
 		}
@@ -668,11 +669,8 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 		}
 	}
 
-	private _getDefaultShell(): string {
-		if (platform.isWindows) {
-			return process.env['COMSPEC'] || 'cmd.exe';
-		}
-		return process.env['SHELL'] || '/bin/sh';
+	private _getDefaultShell(): Promise<string> {
+		return getSystemShell(platform.OS, process.env);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -212,9 +212,6 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			env['GIT_TERMINAL_PROMPT'] = '0';
 			env['DEBIAN_FRONTEND'] = 'noninteractive';
 		}
-		// macOS should launch a login shell by default so that /etc/zprofile
-		// (which runs path_helper) and ~/.zprofile are sourced. This matches
-		// the regular VS Code terminal profile resolver behavior.
 		let shellArgs: string[] = [];
 		if (platform.isMacintosh) {
 			const shellName = pathParse(shell).name;

--- a/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostTerminalManager.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import { DeferredPromise, raceCancellablePromises, timeout } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
-import { dirname } from '../../../base/common/path.js';
+import { dirname, parse as pathParse } from '../../../base/common/path.js';
 import * as platform from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
@@ -211,10 +211,19 @@ export class AgentHostTerminalManager extends Disposable implements IAgentHostTe
 			env['GIT_TERMINAL_PROMPT'] = '0';
 			env['DEBIAN_FRONTEND'] = 'noninteractive';
 		}
+		// macOS should launch a login shell by default so that /etc/zprofile
+		// (which runs path_helper) and ~/.zprofile are sourced. This matches
+		// the regular VS Code terminal profile resolver behavior.
 		let shellArgs: string[] = [];
+		if (platform.isMacintosh) {
+			const shellName = pathParse(shell).name;
+			if (shellName === 'zsh' || shellName === 'bash') {
+				shellArgs = ['--login'];
+			}
+		}
 
 		const injection = await getShellIntegrationInjection(
-			{ executable: shell, args: [], forceShellIntegration: true },
+			{ executable: shell, args: shellArgs, forceShellIntegration: true },
 			{
 				shellIntegration: { enabled: true, suggestEnabled: false, nonce },
 				windowsUseConptyDll: false,


### PR DESCRIPTION
Fixes #312059 + shell detection (see my review comments

The agent host terminal manager spawns zsh/bash without `--login` on macOS, which means things like zprofile and bash profile do not run and can lead to missing reference for node, cargo, etc.

This is what we do in terminal profile:
https://github.com/microsoft/vscode/blob/0a8abf6b2b34c122d0764dac98dffe9f278d8dda/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts#L245-L247

However, the agent host was passing empty args here, skipping the login variant:
https://github.com/microsoft/vscode/blob/0a8abf6b2b34c122d0764dac98dffe9f278d8dda/src/vs/platform/agentHost/node/agentHostTerminalManager.ts#L214-L217

The shell integration injection maps empty args to `-i` instead of `-il` 
https://github.com/microsoft/vscode/blob/0a8abf6b2b34c122d0764dac98dffe9f278d8dda/src/vs/platform/terminal/node/terminalEnvironment.ts#L197-L205



/cc @meganrogge @connor4312 