### PR TITLE
Show line range in agent host file-read tool display

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -71,26 +71,30 @@ interface ICopilotFileToolArgs {
 /**
  * Parameters for the `view` tool. The Copilot CLI accepts an optional
  * `view_range: [startLine, endLine]` (1-based, inclusive). `endLine` may be
- * `-1` to mean "to end of file".
+ * `-1` to mean "to end of file"; we treat that (and any other invalid range)
+ * as "no range" and fall back to the path-only display.
  */
 interface ICopilotViewToolArgs extends ICopilotFileToolArgs {
 	view_range?: number[];
 }
 
 /**
- * Formats a `view_range` array into a human-readable line range string,
- * or returns `undefined` if the range is not a usable two-element array.
+ * Normalizes a `view_range` array into a `{ startLine, endLine }` pair.
+ * Returns `undefined` unless the array has exactly two integer elements with
+ * `startLine >= 0` and `endLine >= startLine`. Mirrors the validation in the
+ * Copilot Chat extension's `formatViewToolInvocation`.
  */
-function formatViewRange(view_range: number[] | undefined): { startLine: number; endLine: number | undefined } | undefined {
-	if (!Array.isArray(view_range) || view_range.length < 1) {
+function formatViewRange(view_range: number[] | undefined): { startLine: number; endLine: number } | undefined {
+	if (!Array.isArray(view_range) || view_range.length !== 2) {
 		return undefined;
 	}
-	const startLine = view_range[0];
-	if (typeof startLine !== 'number' || !isFinite(startLine)) {
+	const [startLine, endLine] = view_range;
+	if (!Number.isInteger(startLine) || !Number.isInteger(endLine)) {
 		return undefined;
 	}
-	const rawEnd = view_range.length >= 2 ? view_range[1] : undefined;
-	const endLine = typeof rawEnd === 'number' && isFinite(rawEnd) && rawEnd >= 0 ? rawEnd : undefined;
+	if (startLine < 0 || endLine < startLine) {
+		return undefined;
+	}
 	return { startLine, endLine };
 }
 
@@ -243,7 +247,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 				const link = formatPathAsMarkdownLink(args.path);
 				const range = formatViewRange(args.view_range);
 				if (range) {
-					if (range.endLine !== undefined && range.endLine !== range.startLine) {
+					if (range.endLine !== range.startLine) {
 						return md(localize('toolInvoke.viewFileRange', "Reading {0}, lines {1} to {2}", link, range.startLine, range.endLine));
 					}
 					return md(localize('toolInvoke.viewFileLine', "Reading {0}, line {1}", link, range.startLine));
@@ -306,7 +310,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 				const link = formatPathAsMarkdownLink(args.path);
 				const range = formatViewRange(args.view_range);
 				if (range) {
-					if (range.endLine !== undefined && range.endLine !== range.startLine) {
+					if (range.endLine !== range.startLine) {
 						return md(localize('toolComplete.viewFileRange', "Read {0}, lines {1} to {2}", link, range.startLine, range.endLine));
 					}
 					return md(localize('toolComplete.viewFileLine', "Read {0}, line {1}", link, range.startLine));

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -71,18 +71,17 @@ interface ICopilotFileToolArgs {
 /**
  * Parameters for the `view` tool. The Copilot CLI accepts an optional
  * `view_range: [startLine, endLine]` (1-based, inclusive). `endLine` may be
- * `-1` to mean "to end of file"; we treat that (and any other invalid range)
- * as "no range" and fall back to the path-only display.
+ * `-1` to mean "to end of file".
  */
 interface ICopilotViewToolArgs extends ICopilotFileToolArgs {
 	view_range?: number[];
 }
 
 /**
- * Normalizes a `view_range` array into a `{ startLine, endLine }` pair.
- * Returns `undefined` unless the array has exactly two integer elements with
- * `startLine >= 0` and `endLine >= startLine`. Mirrors the validation in the
- * Copilot Chat extension's `formatViewToolInvocation`.
+ * Normalizes a `view_range` array. Returns `undefined` unless the array has
+ * exactly two integer elements with `startLine >= 0`. `endLine === -1` is
+ * preserved as the "to end of file" sentinel; otherwise `endLine` must be
+ * `>= startLine`.
  */
 function formatViewRange(view_range: number[] | undefined): { startLine: number; endLine: number } | undefined {
 	if (!Array.isArray(view_range) || view_range.length !== 2) {
@@ -92,7 +91,10 @@ function formatViewRange(view_range: number[] | undefined): { startLine: number;
 	if (!Number.isInteger(startLine) || !Number.isInteger(endLine)) {
 		return undefined;
 	}
-	if (startLine < 0 || endLine < startLine) {
+	if (startLine < 0) {
+		return undefined;
+	}
+	if (endLine !== -1 && endLine < startLine) {
 		return undefined;
 	}
 	return { startLine, endLine };
@@ -247,6 +249,9 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 				const link = formatPathAsMarkdownLink(args.path);
 				const range = formatViewRange(args.view_range);
 				if (range) {
+					if (range.endLine === -1) {
+						return md(localize('toolInvoke.viewFileFromLine', "Reading {0}, from line {1} to the end", link, range.startLine));
+					}
 					if (range.endLine !== range.startLine) {
 						return md(localize('toolInvoke.viewFileRange', "Reading {0}, lines {1} to {2}", link, range.startLine, range.endLine));
 					}
@@ -310,6 +315,9 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 				const link = formatPathAsMarkdownLink(args.path);
 				const range = formatViewRange(args.view_range);
 				if (range) {
+					if (range.endLine === -1) {
+						return md(localize('toolComplete.viewFileFromLine', "Read {0}, from line {1} to the end", link, range.startLine));
+					}
 					if (range.endLine !== range.startLine) {
 						return md(localize('toolComplete.viewFileRange', "Read {0}, lines {1} to {2}", link, range.startLine, range.endLine));
 					}

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -250,7 +250,7 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 				const range = formatViewRange(args.view_range);
 				if (range) {
 					if (range.endLine === -1) {
-						return md(localize('toolInvoke.viewFileFromLine', "Reading {0}, from line {1} to the end", link, range.startLine));
+						return md(localize('toolInvoke.viewFileFromLine', "Reading {0}, line {1} to the end", link, range.startLine));
 					}
 					if (range.endLine !== range.startLine) {
 						return md(localize('toolInvoke.viewFileRange', "Reading {0}, lines {1} to {2}", link, range.startLine, range.endLine));
@@ -316,7 +316,7 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 				const range = formatViewRange(args.view_range);
 				if (range) {
 					if (range.endLine === -1) {
-						return md(localize('toolComplete.viewFileFromLine', "Read {0}, from line {1} to the end", link, range.startLine));
+						return md(localize('toolComplete.viewFileFromLine', "Read {0}, line {1} to the end", link, range.startLine));
 					}
 					if (range.endLine !== range.startLine) {
 						return md(localize('toolComplete.viewFileRange', "Read {0}, lines {1} to {2}", link, range.startLine, range.endLine));

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -68,6 +68,32 @@ interface ICopilotFileToolArgs {
 	path: string;
 }
 
+/**
+ * Parameters for the `view` tool. The Copilot CLI accepts an optional
+ * `view_range: [startLine, endLine]` (1-based, inclusive). `endLine` may be
+ * `-1` to mean "to end of file".
+ */
+interface ICopilotViewToolArgs extends ICopilotFileToolArgs {
+	view_range?: number[];
+}
+
+/**
+ * Formats a `view_range` array into a human-readable line range string,
+ * or returns `undefined` if the range is not a usable two-element array.
+ */
+function formatViewRange(view_range: number[] | undefined): { startLine: number; endLine: number | undefined } | undefined {
+	if (!Array.isArray(view_range) || view_range.length < 1) {
+		return undefined;
+	}
+	const startLine = view_range[0];
+	if (typeof startLine !== 'number' || !isFinite(startLine)) {
+		return undefined;
+	}
+	const rawEnd = view_range.length >= 2 ? view_range[1] : undefined;
+	const endLine = typeof rawEnd === 'number' && isFinite(rawEnd) && rawEnd >= 0 ? rawEnd : undefined;
+	return { startLine, endLine };
+}
+
 /** Parameters for the `grep` tool. */
 interface ICopilotGrepToolArgs {
 	pattern: string;
@@ -212,9 +238,17 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 
 	switch (toolName) {
 		case CopilotToolName.View: {
-			const args = parameters as ICopilotFileToolArgs | undefined;
+			const args = parameters as ICopilotViewToolArgs | undefined;
 			if (args?.path) {
-				return md(localize('toolInvoke.viewFile', "Reading {0}", formatPathAsMarkdownLink(args.path)));
+				const link = formatPathAsMarkdownLink(args.path);
+				const range = formatViewRange(args.view_range);
+				if (range) {
+					if (range.endLine !== undefined && range.endLine !== range.startLine) {
+						return md(localize('toolInvoke.viewFileRange', "Reading {0}, lines {1} to {2}", link, range.startLine, range.endLine));
+					}
+					return md(localize('toolInvoke.viewFileLine', "Reading {0}, line {1}", link, range.startLine));
+				}
+				return md(localize('toolInvoke.viewFile', "Reading {0}", link));
 			}
 			return localize('toolInvoke.view', "Reading file");
 		}
@@ -267,9 +301,17 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 
 	switch (toolName) {
 		case CopilotToolName.View: {
-			const args = parameters as ICopilotFileToolArgs | undefined;
+			const args = parameters as ICopilotViewToolArgs | undefined;
 			if (args?.path) {
-				return md(localize('toolComplete.viewFile', "Read {0}", formatPathAsMarkdownLink(args.path)));
+				const link = formatPathAsMarkdownLink(args.path);
+				const range = formatViewRange(args.view_range);
+				if (range) {
+					if (range.endLine !== undefined && range.endLine !== range.startLine) {
+						return md(localize('toolComplete.viewFileRange', "Read {0}, lines {1} to {2}", link, range.startLine, range.endLine));
+					}
+					return md(localize('toolComplete.viewFileLine', "Read {0}, line {1}", link, range.startLine));
+				}
+				return md(localize('toolComplete.viewFile', "Read {0}", link));
 			}
 			return localize('toolComplete.view', "Read file");
 		}

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getPermissionDisplay, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+import { getInvocationMessage, getPastTenseMessage, getPermissionDisplay, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
 
 suite('getPermissionDisplay — cd-prefix stripping', () => {
 
@@ -73,5 +73,54 @@ suite('getPermissionDisplay — cd-prefix stripping', () => {
 		} as ITypedPermissionRequest;
 		const display = getPermissionDisplay(request, wd);
 		assert.strictEqual(display.toolInput, 'dir');
+	});
+});
+
+suite('view tool — view_range display', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function invocation(parameters: Record<string, unknown> | undefined): string {
+		const result = getInvocationMessage('view', 'View File', parameters);
+		return typeof result === 'string' ? result : result.markdown;
+	}
+
+	function pastTense(parameters: Record<string, unknown> | undefined): string {
+		const result = getPastTenseMessage('view', 'View File', parameters, true);
+		return typeof result === 'string' ? result : result.markdown;
+	}
+
+	test('renders path-only when view_range is absent', () => {
+		assert.ok(invocation({ path: '/repo/file.ts' }).startsWith('Reading ['));
+		assert.ok(pastTense({ path: '/repo/file.ts' }).startsWith('Read ['));
+	});
+
+	test('renders "lines X to Y" for a valid two-element range', () => {
+		assert.ok(invocation({ path: '/repo/file.ts', view_range: [10, 20] }).endsWith(', lines 10 to 20'));
+		assert.ok(pastTense({ path: '/repo/file.ts', view_range: [10, 20] }).endsWith(', lines 10 to 20'));
+	});
+
+	test('renders "line X" when start === end', () => {
+		assert.ok(invocation({ path: '/repo/file.ts', view_range: [10, 10] }).endsWith(', line 10'));
+		assert.ok(pastTense({ path: '/repo/file.ts', view_range: [10, 10] }).endsWith(', line 10'));
+	});
+
+	test('renders "line X to the end" for the -1 EOF sentinel', () => {
+		assert.ok(invocation({ path: '/repo/file.ts', view_range: [10, -1] }).endsWith(', line 10 to the end'));
+		assert.ok(pastTense({ path: '/repo/file.ts', view_range: [10, -1] }).endsWith(', line 10 to the end'));
+	});
+
+	test('falls back to path-only for invalid ranges', () => {
+		// end < start (and not -1)
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [20, 10] }).includes(','));
+		// negative start
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [-5, 10] }).includes(','));
+		// non-integer
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [1.5, 10] }).includes(','));
+		// wrong arity
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [10] }).includes(','));
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [10, 20, 30] }).includes(','));
+		// non-array
+		assert.ok(!invocation({ path: '/repo/file.ts', view_range: 'whatever' }).includes(','));
 	});
 });


### PR DESCRIPTION
When the Copilot CLI's `view` tool is called with a `view_range` argument, the agent host now surfaces the line range in both the invocation message and the past-tense message, instead of just showing the file name.

**Before:** "Reading file.ts" / "Read file.ts"
**After:** "Reading file.ts, lines 10 to 20" / "Read file.ts, lines 10 to 20" (or "line 10" for a single line)

All changes are in `src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts`:
- Added `ICopilotViewToolArgs` extending `ICopilotFileToolArgs` with optional `view_range?: number[]`.
- Added a `formatViewRange` helper that defensively parses the `[start, end]` array (handling missing/`-1` end-of-file sentinels).
- Updated the `View` cases in `getInvocationMessage` and `getPastTenseMessage` to render the range when present.

The `read` permission display path is unchanged — the Copilot SDK's `read` permission request only carries `path` + `intention`, not `view_range`. The line range only flows through the `tool.execution_start` parsed `parameters`.

(Written by Copilot)