### PR TITLE
Gray out remembered folders for offline agent hosts

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -343,17 +343,17 @@ export class WorkspacePicker extends Disposable {
 		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
 		// Build flat list of workspace entries with their group info
-		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isOffline: boolean }[] = [];
+		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isUnavailable: boolean }[] = [];
 		const providersWithWorkspaces = allProviders.filter(p => recentWorkspaces.some(w => w.providerId === p.id));
 		for (const provider of providersWithWorkspaces) {
-			const isOffline = this._isProviderUnavailable(provider.id);
+			const isUnavailable = this._isProviderUnavailable(provider.id);
 			const providerWorkspaces = recentWorkspaces
 				.map((w, idx) => ({ ...w, isOwnRecent: idx < ownRecentCount }))
 				.filter(w => w.providerId === provider.id);
 			for (const { workspace, providerId, isOwnRecent } of providerWorkspaces) {
 				const groupName = workspace.group ?? provider.label;
-				const groupTitle = isOffline ? localize('workspacePicker.groupOffline', "{0} (Offline)", groupName) : groupName;
-				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isOffline });
+				const groupTitle = isUnavailable ? localize('workspacePicker.groupUnavailable', "{0} (Unavailable)", groupName) : groupName;
+				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isUnavailable });
 			}
 		}
 
@@ -368,7 +368,7 @@ export class WorkspacePicker extends Disposable {
 
 		// Add items with separators between groups
 		let lastGroupTitle: string | undefined;
-		for (const { workspace, providerId, isOwnRecent, groupTitle, isOffline } of workspaceEntries) {
+		for (const { workspace, providerId, isOwnRecent, groupTitle, isUnavailable } of workspaceEntries) {
 			if (lastGroupTitle !== undefined && lastGroupTitle !== groupTitle) {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
@@ -380,7 +380,7 @@ export class WorkspacePicker extends Disposable {
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: groupTitle, icon: workspace.icon },
-				disabled: isOffline,
+				disabled: isUnavailable,
 				item: { selection, checked: selected || undefined },
 				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(selection) : () => this._removeVSCodeRecentWorkspace(selection),
 			});

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -343,7 +343,7 @@ export class WorkspacePicker extends Disposable {
 		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
 		// Build flat list of workspace entries with their group info
-		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string }[] = [];
+		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isOffline: boolean }[] = [];
 		const providersWithWorkspaces = allProviders.filter(p => recentWorkspaces.some(w => w.providerId === p.id));
 		for (const provider of providersWithWorkspaces) {
 			const isOffline = this._isProviderUnavailable(provider.id);
@@ -353,7 +353,7 @@ export class WorkspacePicker extends Disposable {
 			for (const { workspace, providerId, isOwnRecent } of providerWorkspaces) {
 				const groupName = workspace.group ?? provider.label;
 				const groupTitle = isOffline ? localize('workspacePicker.groupOffline', "{0} (Offline)", groupName) : groupName;
-				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle });
+				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isOffline });
 			}
 		}
 
@@ -368,7 +368,7 @@ export class WorkspacePicker extends Disposable {
 
 		// Add items with separators between groups
 		let lastGroupTitle: string | undefined;
-		for (const { workspace, providerId, isOwnRecent, groupTitle } of workspaceEntries) {
+		for (const { workspace, providerId, isOwnRecent, groupTitle, isOffline } of workspaceEntries) {
 			if (lastGroupTitle !== undefined && lastGroupTitle !== groupTitle) {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
@@ -380,6 +380,7 @@ export class WorkspacePicker extends Disposable {
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: groupTitle, icon: workspace.icon },
+				disabled: isOffline,
 				item: { selection, checked: selected || undefined },
 				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(selection) : () => this._removeVSCodeRecentWorkspace(selection),
 			});

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -343,17 +343,23 @@ export class WorkspacePicker extends Disposable {
 		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
 		// Build flat list of workspace entries with their group info
-		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isUnavailable: boolean }[] = [];
+		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isDisconnected: boolean }[] = [];
 		const providersWithWorkspaces = allProviders.filter(p => recentWorkspaces.some(w => w.providerId === p.id));
 		for (const provider of providersWithWorkspaces) {
-			const isUnavailable = this._isProviderUnavailable(provider.id);
+			const connectionStatus = isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
+			const isDisconnected = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected;
+			const isConnecting = connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
 			const providerWorkspaces = recentWorkspaces
 				.map((w, idx) => ({ ...w, isOwnRecent: idx < ownRecentCount }))
 				.filter(w => w.providerId === provider.id);
 			for (const { workspace, providerId, isOwnRecent } of providerWorkspaces) {
 				const groupName = workspace.group ?? provider.label;
-				const groupTitle = isUnavailable ? localize('workspacePicker.groupUnavailable', "{0} (Unavailable)", groupName) : groupName;
-				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isUnavailable });
+				const groupTitle = isDisconnected
+					? localize('workspacePicker.groupOffline', "{0} (Offline)", groupName)
+					: isConnecting
+						? localize('workspacePicker.groupConnecting', "{0} (Connecting)", groupName)
+						: groupName;
+				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isDisconnected });
 			}
 		}
 
@@ -368,7 +374,7 @@ export class WorkspacePicker extends Disposable {
 
 		// Add items with separators between groups
 		let lastGroupTitle: string | undefined;
-		for (const { workspace, providerId, isOwnRecent, groupTitle, isUnavailable } of workspaceEntries) {
+		for (const { workspace, providerId, isOwnRecent, groupTitle, isDisconnected } of workspaceEntries) {
 			if (lastGroupTitle !== undefined && lastGroupTitle !== groupTitle) {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
@@ -380,7 +386,7 @@ export class WorkspacePicker extends Disposable {
 				label: workspace.label,
 				description: workspace.description,
 				group: { title: groupTitle, icon: workspace.icon },
-				disabled: isUnavailable,
+				disabled: isDisconnected,
 				item: { selection, checked: selected || undefined },
 				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(selection) : () => this._removeVSCodeRecentWorkspace(selection),
 			});


### PR DESCRIPTION
In the session workspace picker, the agent host row for a disconnected remote host is shown grayed out, but the remembered (previously used) folders for that host were still rendered as enabled.

This threads the existing `isOffline` flag through to each remembered-folder item and sets `disabled: isOffline`, so they visually match the offline host row. Clicking these items was already a no-op via `_isProviderUnavailable`; this just brings the visual state in line.

(Written by Copilot)