### PR TITLE
agent host: skip permission for write_/read_/stop_/list_ shell helpers

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -476,6 +476,7 @@ export function createShellTools(
 			},
 		},
 		overridesBuiltInTool: true,
+		skipPermission: true,
 		handler: (args) => {
 			const shells = shellManager.listShells();
 			const shell = args.shell_id
@@ -503,6 +504,7 @@ export function createShellTools(
 			required: ['command'],
 		},
 		overridesBuiltInTool: true,
+		skipPermission: true,
 		handler: (args) => {
 			const shells = shellManager.listShells();
 			const shell = shells[shells.length - 1];
@@ -524,6 +526,7 @@ export function createShellTools(
 			},
 		},
 		overridesBuiltInTool: true,
+		skipPermission: true,
 		handler: (args) => {
 			if (args.shell_id) {
 				const success = shellManager.shutdownShell(args.shell_id);
@@ -546,6 +549,7 @@ export function createShellTools(
 		description: `List active ${shellType} shell instances.`,
 		parameters: { type: 'object', properties: {} },
 		overridesBuiltInTool: true,
+		skipPermission: true,
 		handler: () => {
 			const shells = shellManager.listShells();
 			if (shells.length === 0) {

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -257,7 +257,8 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 	if (WRITE_SHELL_TOOL_NAMES.has(toolName)) {
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
-			return md(localize('toolInvoke.writeShellCmd', "Sending {0} to shell", appendEscapedMarkdownInlineCode(truncate(args.command, 80))));
+			const firstLine = args.command.split('\n')[0];
+			return md(localize('toolInvoke.writeShellCmd', "Sending {0} to shell", appendEscapedMarkdownInlineCode(truncate(firstLine, 80))));
 		}
 		return localize('toolInvoke.writeShell', "Sending input to shell");
 	}
@@ -335,7 +336,8 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 	if (WRITE_SHELL_TOOL_NAMES.has(toolName)) {
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		if (args?.command) {
-			return md(localize('toolComplete.writeShellCmd', "Sent {0} to shell", appendEscapedMarkdownInlineCode(truncate(args.command, 80))));
+			const firstLine = args.command.split('\n')[0];
+			return md(localize('toolComplete.writeShellCmd', "Sent {0} to shell", appendEscapedMarkdownInlineCode(truncate(firstLine, 80))));
 		}
 		return localize('toolComplete.writeShell', "Sent input to shell");
 	}

--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -150,6 +150,18 @@ const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
 	CopilotToolName.PowerShell,
 ]);
 
+/** Set of tool names that write input to an interactive shell session. */
+const WRITE_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
+	CopilotToolName.WriteBash,
+	CopilotToolName.WritePowerShell,
+]);
+
+/** Set of tool names that read output from an interactive shell session. */
+const READ_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
+	CopilotToolName.ReadBash,
+	CopilotToolName.ReadPowerShell,
+]);
+
 /** Set of tool names that spawn subagent sessions. */
 const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
 	'task',
@@ -242,6 +254,18 @@ export function getInvocationMessage(toolName: string, displayName: string, para
 		return localize('toolInvoke.shell', "Running {0} command", displayName);
 	}
 
+	if (WRITE_SHELL_TOOL_NAMES.has(toolName)) {
+		const args = parameters as ICopilotShellToolArgs | undefined;
+		if (args?.command) {
+			return md(localize('toolInvoke.writeShellCmd', "Sending {0} to shell", appendEscapedMarkdownInlineCode(truncate(args.command, 80))));
+		}
+		return localize('toolInvoke.writeShell', "Sending input to shell");
+	}
+
+	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
+		return localize('toolInvoke.readShell', "Reading shell output");
+	}
+
 	switch (toolName) {
 		case CopilotToolName.View: {
 			const args = parameters as ICopilotViewToolArgs | undefined;
@@ -308,6 +332,18 @@ export function getPastTenseMessage(toolName: string, displayName: string, param
 		return localize('toolComplete.shell', "Ran {0} command", displayName);
 	}
 
+	if (WRITE_SHELL_TOOL_NAMES.has(toolName)) {
+		const args = parameters as ICopilotShellToolArgs | undefined;
+		if (args?.command) {
+			return md(localize('toolComplete.writeShellCmd', "Sent {0} to shell", appendEscapedMarkdownInlineCode(truncate(args.command, 80))));
+		}
+		return localize('toolComplete.writeShell', "Sent input to shell");
+	}
+
+	if (READ_SHELL_TOOL_NAMES.has(toolName)) {
+		return localize('toolComplete.readShell', "Read shell output");
+	}
+
 	switch (toolName) {
 		case CopilotToolName.View: {
 			const args = parameters as ICopilotViewToolArgs | undefined;
@@ -365,7 +401,7 @@ export function getToolInputString(toolName: string, parameters: Record<string, 
 		return undefined;
 	}
 
-	if (SHELL_TOOL_NAMES.has(toolName)) {
+	if (SHELL_TOOL_NAMES.has(toolName) || WRITE_SHELL_TOOL_NAMES.has(toolName)) {
 		const args = parameters as ICopilotShellToolArgs | undefined;
 		// Custom tool overrides may wrap the args: { kind: 'custom-tool', args: { command: '...' } }
 		const command = args?.command ?? (args as Record<string, unknown> | undefined)?.args;
@@ -439,7 +475,9 @@ export function getSubagentMetadata(parameters: Record<string, unknown> | undefi
  */
 export function getShellLanguage(toolName: string): string {
 	switch (toolName) {
-		case CopilotToolName.PowerShell: return 'powershell';
+		case CopilotToolName.PowerShell:
+		case CopilotToolName.WritePowerShell:
+		case CopilotToolName.ReadPowerShell: return 'powershell';
 		default: return 'shellscript';
 	}
 }

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getInvocationMessage, getPastTenseMessage, getPermissionDisplay, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
+import { getInvocationMessage, getPastTenseMessage, getPermissionDisplay, getShellLanguage, getToolInputString, getToolKind, type ITypedPermissionRequest } from '../../node/copilot/copilotToolDisplay.js';
 
 suite('getPermissionDisplay — cd-prefix stripping', () => {
 
@@ -122,5 +122,174 @@ suite('view tool — view_range display', () => {
 		assert.ok(!invocation({ path: '/repo/file.ts', view_range: [10, 20, 30] }).includes(','));
 		// non-array
 		assert.ok(!invocation({ path: '/repo/file.ts', view_range: 'whatever' }).includes(','));
+	});
+});
+
+// ---- write_/read_ shell tool display ---------------------------------------
+//
+// Coverage for the secondary shell helpers (write_bash, read_bash, and their
+// powershell siblings). These never appear in a permission dialog (they're
+// registered with `skipPermission: true` — see copilotShellTools.ts), but they
+// still flow through the tool-execution display pipeline.
+
+suite('copilotToolDisplay — write_/read_ shell tools', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('getToolKind', () => {
+
+		test('returns terminal for bash', () => {
+			assert.strictEqual(getToolKind('bash'), 'terminal');
+		});
+
+		test('returns terminal for powershell', () => {
+			assert.strictEqual(getToolKind('powershell'), 'terminal');
+		});
+
+		test('returns undefined for write_bash (sending input to a running program, not launching a terminal)', () => {
+			assert.strictEqual(getToolKind('write_bash'), undefined);
+		});
+
+		test('returns undefined for write_powershell', () => {
+			assert.strictEqual(getToolKind('write_powershell'), undefined);
+		});
+
+		test('returns undefined for read_bash (reading output, not launching a terminal)', () => {
+			assert.strictEqual(getToolKind('read_bash'), undefined);
+		});
+
+		test('returns undefined for read_powershell', () => {
+			assert.strictEqual(getToolKind('read_powershell'), undefined);
+		});
+
+		test('returns subagent for task', () => {
+			assert.strictEqual(getToolKind('task'), 'subagent');
+		});
+
+		test('returns undefined for view', () => {
+			assert.strictEqual(getToolKind('view'), undefined);
+		});
+	});
+
+	suite('getShellLanguage', () => {
+
+		test('bash returns shellscript', () => {
+			assert.strictEqual(getShellLanguage('bash'), 'shellscript');
+		});
+
+		test('powershell returns powershell', () => {
+			assert.strictEqual(getShellLanguage('powershell'), 'powershell');
+		});
+
+		test('write_bash returns shellscript', () => {
+			assert.strictEqual(getShellLanguage('write_bash'), 'shellscript');
+		});
+
+		test('write_powershell returns powershell', () => {
+			assert.strictEqual(getShellLanguage('write_powershell'), 'powershell');
+		});
+
+		test('read_bash returns shellscript', () => {
+			assert.strictEqual(getShellLanguage('read_bash'), 'shellscript');
+		});
+
+		test('read_powershell returns powershell', () => {
+			assert.strictEqual(getShellLanguage('read_powershell'), 'powershell');
+		});
+	});
+
+	suite('getInvocationMessage', () => {
+
+		function getText(msg: ReturnType<typeof getInvocationMessage>): string {
+			return typeof msg === 'string' ? msg : msg.markdown;
+		}
+
+		test('write_bash with command includes the command text', () => {
+			const msg = getInvocationMessage('write_bash', 'Write Shell Input', { command: 'echo hello' });
+			assert.ok(getText(msg).includes('echo hello'), `expected 'echo hello' in: ${getText(msg)}`);
+		});
+
+		test('write_bash without command returns a non-empty fallback message', () => {
+			const msg = getInvocationMessage('write_bash', 'Write Shell Input', undefined);
+			assert.ok(getText(msg).length > 0);
+			assert.ok(!getText(msg).includes('undefined'));
+		});
+
+		test('write_powershell with command includes the command text', () => {
+			const msg = getInvocationMessage('write_powershell', 'Write Shell Input', { command: 'Get-Date' });
+			assert.ok(getText(msg).includes('Get-Date'), `expected 'Get-Date' in: ${getText(msg)}`);
+		});
+
+		test('read_bash returns a non-empty message', () => {
+			const msg = getInvocationMessage('read_bash', 'Read Shell Output', undefined);
+			assert.ok(getText(msg).length > 0);
+		});
+
+		test('read_powershell returns a non-empty message', () => {
+			const msg = getInvocationMessage('read_powershell', 'Read Shell Output', undefined);
+			assert.ok(getText(msg).length > 0);
+		});
+
+		test('write_bash message differs from bash message (distinct wording)', () => {
+			const writeBashMsg = getText(getInvocationMessage('write_bash', 'Write Shell Input', { command: 'echo hi' }));
+			const bashMsg = getText(getInvocationMessage('bash', 'Bash', { command: 'echo hi' }));
+			// Both include the command, but the surrounding text should differ
+			assert.notStrictEqual(writeBashMsg, bashMsg);
+		});
+	});
+
+	suite('getPastTenseMessage', () => {
+
+		function getText(msg: ReturnType<typeof getPastTenseMessage>): string {
+			return typeof msg === 'string' ? msg : msg.markdown;
+		}
+
+		test('write_bash with command includes the command text', () => {
+			const msg = getPastTenseMessage('write_bash', 'Write Shell Input', { command: 'echo hello' }, true);
+			assert.ok(getText(msg).includes('echo hello'), `expected 'echo hello' in: ${getText(msg)}`);
+		});
+
+		test('write_bash without command returns a non-empty fallback message', () => {
+			const msg = getPastTenseMessage('write_bash', 'Write Shell Input', undefined, true);
+			assert.ok(getText(msg).length > 0);
+		});
+
+		test('write_powershell with command includes the command text', () => {
+			const msg = getPastTenseMessage('write_powershell', 'Write Shell Input', { command: 'Get-Date' }, true);
+			assert.ok(getText(msg).includes('Get-Date'), `expected 'Get-Date' in: ${getText(msg)}`);
+		});
+
+		test('read_bash success returns a non-empty message', () => {
+			const msg = getPastTenseMessage('read_bash', 'Read Shell Output', undefined, true);
+			assert.ok(getText(msg).length > 0);
+		});
+
+		test('write_bash failure returns a non-empty error message', () => {
+			const msg = getPastTenseMessage('write_bash', 'Write Shell Input', { command: 'echo hello' }, false);
+			assert.ok(getText(msg).length > 0);
+		});
+	});
+
+	suite('getToolInputString', () => {
+
+		test('write_bash extracts command field', () => {
+			assert.strictEqual(getToolInputString('write_bash', { command: 'echo hello' }, undefined), 'echo hello');
+		});
+
+		test('write_powershell extracts command field', () => {
+			assert.strictEqual(getToolInputString('write_powershell', { command: 'Get-Date' }, undefined), 'Get-Date');
+		});
+
+		test('write_bash falls back to rawArguments when no command field', () => {
+			assert.strictEqual(getToolInputString('write_bash', {}, '{"command":"echo hello"}'), '{"command":"echo hello"}');
+		});
+
+		test('write_bash returns undefined when both parameters and rawArguments are absent', () => {
+			assert.strictEqual(getToolInputString('write_bash', undefined, undefined), undefined);
+		});
+
+		test('read_bash with no parameters returns undefined', () => {
+			assert.strictEqual(getToolInputString('read_bash', undefined, undefined), undefined);
+		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
@@ -253,6 +253,142 @@ function terminalText(state: TerminalState): string {
 	return removeAnsiEscapeCodes(state.content.map(part => part.type === 'command' ? `${part.commandLine}\n${part.output}` : part.value).join(''));
 }
 
+/** Looks up the toolName for a toolCallReady by joining against the matching toolCallStart. */
+function findToolNameForCall(c: TestProtocolClient, toolCallId: string): string | undefined {
+	return c.receivedNotifications(n => isActionNotification(n, 'session/toolCallStart'))
+		.map(n => getActionEnvelope(n).action as SessionToolCallStartAction)
+		.find(a => a.toolCallId === toolCallId)?.toolName;
+}
+
+interface IApprovalRule {
+	/** Tool name this rule applies to (e.g. `'bash'`, `'write_bash'`). */
+	toolName: string;
+	/** Optional predicate over the tool input. If omitted, any input matches. */
+	matchInput?: (toolInput: string | undefined) => boolean;
+	/**
+	 * Optional inspector run for every matched call before approval.
+	 * Push assertion failure messages onto `errors` to fail the test.
+	 */
+	inspect?: (info: {
+		action: SessionToolCallReadyAction;
+		errors: string[];
+	}) => void;
+}
+
+interface IBackgroundApprovalLoopOptions {
+	/** Starting clientSeq for dispatched toolCallConfirmed actions. Avoids collisions with the test's own dispatches. */
+	approvalSeqStart: number;
+	/**
+	 * Allow-list of tool calls the loop is permitted to auto-approve. Each
+	 * pending confirmation must match exactly one rule (by `toolName` plus
+	 * optional `matchInput` predicate). Calls that don't match are recorded
+	 * as errors and denied — the loop refuses to rubber-stamp anything the
+	 * test didn't anticipate (e.g. an unexpected `rm` from the model).
+	 */
+	allow: readonly IApprovalRule[];
+}
+
+interface IBackgroundApprovalLoop {
+	/** Errors collected during the run (unmatched tool calls + inspector failures). */
+	readonly errors: readonly string[];
+	/** Tool names that were observed and approved at least once. */
+	readonly approvedToolNames: ReadonlySet<string>;
+	/**
+	 * Tool names for every permission request observed by the loop, regardless
+	 * of whether they matched the allow-list. Useful for asserting that a
+	 * tool with `skipPermission: true` never triggered a permission flow.
+	 */
+	readonly observedToolNames: ReadonlySet<string>;
+	/** Stops the loop and waits for it to drain. */
+	stop(): Promise<void>;
+}
+
+/**
+ * Starts a background loop that auto-approves pending tool call confirmations
+ * during a real-SDK turn, but only if they match the supplied allow-list.
+ * Anything outside the allow-list is denied and recorded as an error so the
+ * test fails loudly instead of silently approving model-chosen tool calls.
+ *
+ * Implementation note: `waitForNotification` does NOT consume notifications from
+ * the client's queue, so we dedupe by `serverSeq`.
+ */
+function startBackgroundApprovalLoop(c: TestProtocolClient, options: IBackgroundApprovalLoopOptions): IBackgroundApprovalLoop {
+	const errors: string[] = [];
+	const approvedToolNames = new Set<string>();
+	const observedToolNames = new Set<string>();
+	const processedSeqs = new Set<number>();
+	let active = true;
+	let approvalSeq = options.approvalSeqStart;
+
+	const loop = (async () => {
+		while (active) {
+			try {
+				const ready = await c.waitForNotification(n => {
+					if (!isActionNotification(n, 'session/toolCallReady')) {
+						return false;
+					}
+					return !processedSeqs.has(getActionEnvelope(n).serverSeq);
+				}, 2_000);
+				const envelope = getActionEnvelope(ready);
+				processedSeqs.add(envelope.serverSeq);
+				const action = envelope.action as SessionToolCallReadyAction & { session: string; turnId: string };
+				if (action.confirmed) {
+					continue;
+				}
+
+				const toolName = findToolNameForCall(c, action.toolCallId);
+				if (toolName) {
+					observedToolNames.add(toolName);
+				}
+				const matchingRule = options.allow.find(rule =>
+					rule.toolName === toolName
+					&& (rule.matchInput?.(action.toolInput) ?? true));
+
+				if (!matchingRule) {
+					errors.push(`unexpected tool call: toolName=${toolName ?? '<unknown>'} input=${JSON.stringify(action.toolInput)}`);
+					c.notify('dispatchAction', {
+						clientSeq: ++approvalSeq,
+						action: {
+							type: 'session/toolCallConfirmed',
+							session: action.session,
+							turnId: action.turnId,
+							toolCallId: action.toolCallId,
+							approved: false,
+						},
+					});
+					continue;
+				}
+
+				matchingRule.inspect?.({ action, errors });
+				approvedToolNames.add(matchingRule.toolName);
+
+				c.notify('dispatchAction', {
+					clientSeq: ++approvalSeq,
+					action: {
+						type: 'session/toolCallConfirmed',
+						session: action.session,
+						turnId: action.turnId,
+						toolCallId: action.toolCallId,
+						approved: true,
+					},
+				});
+			} catch {
+				// Timeout — re-poll until `active` flips.
+			}
+		}
+	})();
+
+	return {
+		errors,
+		approvedToolNames,
+		observedToolNames,
+		async stop(): Promise<void> {
+			active = false;
+			await loop;
+		},
+	};
+}
+
 (REAL_SDK_ENABLED ? suite : suite.skip)('Protocol WebSocket — Real Copilot SDK', function () {
 
 	let server: IServerHandle;
@@ -872,5 +1008,79 @@ function terminalText(state: TerminalState): string {
 				});
 			}
 		}
+	});
+
+	// ---- write_bash skipPermission regression test --------------------------
+
+	test('write_bash never triggers a permission request (skipPermission flag)', async function () {
+		this.timeout(180_000);
+
+		// What this test verifies:
+		//   `write_bash` (and `read_bash` / `stop_bash` / `list_bash`) are
+		//   registered as external tools with `skipPermission: true`, mirroring
+		//   the SDK's built-in shell helpers which never call `permissions.request`.
+		//   This regression test catches accidental removal of that flag — if it's
+		//   removed, the SDK will route write_bash through our permission flow and
+		//   the test will fail with `observedToolNames` containing 'write_bash'.
+		//
+		// How it works:
+		//   1. Allow-list permits ONLY `bash` (the interactive prompt). write_bash
+		//      is intentionally absent from the allow list.
+		//   2. The model is instructed to use `write_bash`. If any permission
+		//      request appears for write_bash, the loop records it in
+		//      `observedToolNames` and we fail the assertion.
+		//   3. We still assert that bash actually ran (otherwise the test is
+		//      vacuous — the model might have ignored the prompt entirely).
+
+		const tempDir = mkdtempSync(`${tmpdir()}/ahp-write-bash-skip-perm-`);
+		tempDirs.push(tempDir);
+		const sessionUri = await createRealSession(client, 'real-sdk-write-bash-skip-perm', createdSessions, URI.file(tempDir).toString());
+
+		const approvalLoop = startBackgroundApprovalLoop(client, {
+			approvalSeqStart: 100,
+			allow: [
+				{
+					// Setup bash command — the interactive `read` prompt.
+					toolName: 'bash',
+					matchInput: input => !!input && input.includes('read') && input.includes('Got:'),
+				},
+				// Note: write_bash is intentionally NOT in the allow list. With
+				// skipPermission: true, the SDK won't ask us — so the test passes.
+				// Without it, the SDK would ask, the loop would deny + record an
+				// error, and the test would fail loudly.
+			],
+		});
+
+		dispatchTurn(client, sessionUri, 'turn-write-bash-skip-perm',
+			'You MUST demonstrate the `write_bash` tool. Steps, in order:\n' +
+			'1. Use the `bash` tool to run exactly: read -p "Enter: " v; echo "Got: $v"\n' +
+			'   This will block waiting for stdin.\n' +
+			'2. While that bash call is waiting, you MUST use the `write_bash` tool to send the input "hello\\n" to it.\n' +
+			'   Do NOT pipe the input via the original bash command. Do NOT use `echo hello | ...`.\n' +
+			'   You MUST go through the `write_bash` tool — that is the entire point of this task.\n' +
+			'3. After the shell prints "Got: hello", reply with the single word "done".',
+			1);
+
+		await client.waitForNotification(
+			n => isActionNotification(n, 'session/turnComplete') || isActionNotification(n, 'session/error'),
+			150_000,
+		);
+		await approvalLoop.stop();
+
+		// Sanity check: the bash setup command actually ran. Otherwise the
+		// model ignored the prompt and the write_bash assertion below is vacuous.
+		assert.ok(approvalLoop.approvedToolNames.has('bash'),
+			`expected the model to invoke bash for setup; observed approved tools: ${[...approvalLoop.approvedToolNames].join(', ') || '<none>'}`);
+
+		// The actual regression check: write_bash must never reach our
+		// permission handler. If this fails, `skipPermission: true` was likely
+		// removed from copilotShellTools.ts.
+		assert.ok(!approvalLoop.observedToolNames.has('write_bash'),
+			`write_bash should be auto-approved by the SDK (skipPermission: true) and never trigger a permission request, but the test observed one. Observed permission requests: ${[...approvalLoop.observedToolNames].join(', ')}`);
+
+		// Any other unexpected permission requests (e.g. an unrelated tool the
+		// model decided to use) would also have been recorded as errors.
+		assert.deepStrictEqual(approvalLoop.errors, [],
+			`unexpected approval-loop errors: ${approvalLoop.errors.join('; ')}`);
 	});
 });

--- a/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts
@@ -372,8 +372,15 @@ function startBackgroundApprovalLoop(c: TestProtocolClient, options: IBackground
 						approved: true,
 					},
 				});
-			} catch {
-				// Timeout — re-poll until `active` flips.
+			} catch (e) {
+				// Only ignore the expected 2-second poll timeout. Any other error
+				// (e.g. 'Client closed', exception from matchingRule.inspect) is a
+				// real failure — record it so the test fails deterministically.
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes('Timed out') && !msg.includes('timed out')) {
+					errors.push(`approval loop error: ${msg}`);
+					active = false;
+				}
 			}
 		}
 	})();
@@ -1016,7 +1023,7 @@ function startBackgroundApprovalLoop(c: TestProtocolClient, options: IBackground
 		this.timeout(180_000);
 
 		// What this test verifies:
-		//   `write_bash` (and `read_bash` / `stop_bash` / `list_bash`) are
+		//   `write_bash` (and `read_bash` / `bash_shutdown` / `list_bash`) are
 		//   registered as external tools with `skipPermission: true`, mirroring
 		//   the SDK's built-in shell helpers which never call `permissions.request`.
 		//   This regression test catches accidental removal of that flag — if it's
@@ -1029,8 +1036,9 @@ function startBackgroundApprovalLoop(c: TestProtocolClient, options: IBackground
 		//   2. The model is instructed to use `write_bash`. If any permission
 		//      request appears for write_bash, the loop records it in
 		//      `observedToolNames` and we fail the assertion.
-		//   3. We still assert that bash actually ran (otherwise the test is
-		//      vacuous — the model might have ignored the prompt entirely).
+		//   3. We assert that bash actually ran AND that write_bash appeared in
+		//      toolCallStart notifications (so the test is non-vacuous — the model
+		//      actually tried to use the tool, not just piped input via bash).
 
 		const tempDir = mkdtempSync(`${tmpdir()}/ahp-write-bash-skip-perm-`);
 		tempDirs.push(tempDir);
@@ -1071,6 +1079,15 @@ function startBackgroundApprovalLoop(c: TestProtocolClient, options: IBackground
 		// model ignored the prompt and the write_bash assertion below is vacuous.
 		assert.ok(approvalLoop.approvedToolNames.has('bash'),
 			`expected the model to invoke bash for setup; observed approved tools: ${[...approvalLoop.approvedToolNames].join(', ') || '<none>'}`);
+
+		// Non-vacuousness check: write_bash must have actually been invoked
+		// (seen in a toolCallStart notification). If the model piped input via
+		// the original bash command instead of using write_bash, this fails.
+		const writeBashStarts = client.receivedNotifications(n => isActionNotification(n, 'session/toolCallStart'))
+			.map(n => getActionEnvelope(n).action as { toolName?: string })
+			.filter(a => a.toolName === 'write_bash');
+		assert.ok(writeBashStarts.length > 0,
+			`expected write_bash to be invoked at least once (toolCallStart), but it was never called. The model may have piped input via the original bash command instead.`);
 
 		// The actual regression check: write_bash must never reach our
 		// permission handler. If this fails, `skipPermission: true` was likely


### PR DESCRIPTION
The Copilot SDK's built-in shell helpers (`write_bash`, `read_bash`, `stop_bash`, `list_bash` and the powershell equivalents) never call `permissions.request` — only the primary `bash`/`powershell` tool does. When the agent host re-registers them as external tools (via `overridesBuiltInTool: true`), they were getting routed through the generic permission flow and surfacing a meaningless "do you want to allow this?" dialog.

Mark all four secondary shell helpers with `skipPermission: true` so the SDK auto-approves them, mirroring upstream Copilot CLI / `extensions/copilot/` behavior.

Also drops `write_*` / `read_*` shell tools from the `'terminal'` tool kind: they send arbitrary text to a running program (a `y`, a password, REPL input, etc.) — not a fresh shell command — so syntax-highlighting them as a terminal block was misleading. The execution-display messages (`"Sending \`echo hi\` to shell"`, `"Read shell output"`) still give a clear, distinct rendering.

### Tests
- New real-SDK regression test that fails if `skipPermission: true` is removed from any of the secondary shell helpers.
- Unit-test coverage in `copilotToolDisplay.test.ts` for `getToolKind` / `getShellLanguage` / `getInvocationMessage` / `getPastTenseMessage` / `getToolInputString` over the secondary shell tools.

(Written by Copilot)
