### PR TITLE
cli plan widget improvements

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -136,8 +136,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		if (review.planUri) {
 			const fileName = basename(URI.revive(review.planUri));
 			const editButton = this._register(new Button(this._titleActionsEl, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chat.planReview.editTooltip', 'Edit {0}', fileName) }));
-			editButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-edit');
-			editButton.label = `$(${Codicon.edit.id}) ${localize('chat.planReview.edit', 'Edit {0}', fileName)}`;
+			editButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button');
+			editButton.label = `$(${Codicon.edit.id})`;
 			this._register(editButton.onDidClick(() => this.openPlanFile()));
 		}
 
@@ -219,8 +219,14 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 	private renderFeedback(section: HTMLElement): void {
 		dom.clearNode(section);
-		const label = dom.append(section, dom.$('.chat-plan-review-feedback-label'));
+		const header = dom.append(section, dom.$('.chat-plan-review-feedback-header'));
+		const label = dom.append(header, dom.$('.chat-plan-review-feedback-label'));
 		label.textContent = localize('chat.planReview.feedbackLabel', 'Additional feedback');
+
+		const closeButton = this._register(new Button(header, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chat.planReview.exitFeedback', "Cancel feedback") }));
+		closeButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button', 'chat-plan-review-feedback-close');
+		closeButton.label = `$(${Codicon.close.id})`;
+		this._register(closeButton.onDidClick(() => this.exitFeedbackMode()));
 
 		const textarea = dom.append(section, dom.$<HTMLTextAreaElement>('textarea.chat-plan-review-feedback-textarea'));
 		textarea.rows = 1;
@@ -237,6 +243,9 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		this._register(dom.addDisposableListener(textarea, dom.EventType.INPUT, () => {
 			autoResize();
+			// Auto-resize fires _onDidChangeHeight which can shift sibling
+			// layout; rescan so the body's scrollbar geometry stays accurate.
+			this._messageScrollable.scanDomNode();
 			if (this.review instanceof ChatPlanReviewData) {
 				this.review.draftFeedback = textarea.value;
 			}
@@ -358,8 +367,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this.domNode.classList.toggle('chat-plan-review-collapsed', this._isCollapsed);
 		this._restoreButton.element.classList.toggle('chat-plan-review-hidden', this._isCollapsed);
 		this._collapseButton.label = this._isCollapsed
-			? `$(${Codicon.chevronDown.id})`
-			: `$(${Codicon.chevronUp.id})`;
+			? `$(${Codicon.chevronUp.id})`
+			: `$(${Codicon.chevronDown.id})`;
 		const collapseTooltip = this._isCollapsed
 			? localize('chat.planReview.expand', 'Expand')
 			: localize('chat.planReview.collapse', 'Collapse');
@@ -434,8 +443,30 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		if (this._feedbackSection) {
 			dom.show(this._feedbackSection);
 		}
+		this.domNode.classList.add('chat-plan-review-feedback-mode');
 		this.renderActionButtons(this._footerButtonsEl, { includeReject: true });
 		this._feedbackTextarea?.focus();
+		this._messageScrollable.scanDomNode();
+		this._onDidChangeHeight.fire();
+	}
+
+	private exitFeedbackMode(): void {
+		if (!this._isFeedbackMode) {
+			return;
+		}
+		this._isFeedbackMode = false;
+		if (this._feedbackTextarea) {
+			this._feedbackTextarea.value = '';
+			if (this.review instanceof ChatPlanReviewData) {
+				this.review.draftFeedback = '';
+			}
+		}
+		if (this._feedbackSection) {
+			dom.hide(this._feedbackSection);
+		}
+		this.domNode.classList.remove('chat-plan-review-feedback-mode');
+		this.renderActionButtons(this._footerButtonsEl, { includeReject: true });
+		this._messageScrollable.scanDomNode();
 		this._onDidChangeHeight.fire();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -382,11 +382,11 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		// slot so the user can approve while collapsed. Reject is omitted in
 		// the collapsed view (matches chatToolConfirmationCarouselPart).
 		if (!this._isSubmitted) {
+			// Collapsing implicitly cancels feedback mode. Route through
+			// `exitFeedbackMode` so the CSS class, draft, and section
+			// visibility teardown stays centralized.
 			if (this._isCollapsed && this._isFeedbackMode) {
-				this._isFeedbackMode = false;
-				if (this._feedbackSection) {
-					dom.hide(this._feedbackSection);
-				}
+				this.exitFeedbackMode();
 			}
 			const target = this._isCollapsed ? this._inlineActionsEl : this._footerButtonsEl;
 			const other = this._isCollapsed ? this._footerButtonsEl : this._inlineActionsEl;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -135,7 +135,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		// Optional Edit button.
 		if (review.planUri) {
 			const fileName = basename(URI.revive(review.planUri));
-			const editButton = this._register(new Button(this._titleActionsEl, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chat.planReview.editTooltip', 'Edit {0}', fileName) }));
+			const editButtonLabel = localize('chat.planReview.editTooltip', 'Edit {0}', fileName);
+			const editButton = this._register(new Button(this._titleActionsEl, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: editButtonLabel, ariaLabel: editButtonLabel }));
 			editButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button');
 			editButton.label = `$(${Codicon.edit.id})`;
 			this._register(editButton.onDidClick(() => this.openPlanFile()));
@@ -223,7 +224,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		const label = dom.append(header, dom.$('.chat-plan-review-feedback-label'));
 		label.textContent = localize('chat.planReview.feedbackLabel', 'Additional feedback');
 
-		const closeButton = this._register(new Button(header, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chat.planReview.exitFeedback', "Cancel feedback") }));
+		const closeButtonAriaLabel = localize('chat.planReview.exitFeedback', "Cancel feedback");
+		const closeButton = this._register(new Button(header, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: closeButtonAriaLabel, ariaLabel: closeButtonAriaLabel }));
 		closeButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button', 'chat-plan-review-feedback-close');
 		closeButton.label = `$(${Codicon.close.id})`;
 		this._register(closeButton.onDidClick(() => this.exitFeedbackMode()));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
@@ -52,9 +52,6 @@
 	max-height: min(720px, 75vh);
 }
 
-.interactive-session .chat-plan-review-container.chat-plan-review-expanded .chat-confirmation-widget-message.chat-plan-review-body {
-	max-height: min(600px, 65vh);
-}
 /* ---------- Title bar ---------- */
 .interactive-session .chat-plan-review-container .chat-plan-review-title {
 	display: flex;
@@ -101,16 +98,11 @@
 	background: var(--vscode-toolbar-hoverBackground) !important;
 }
 
-/* Icon-only square buttons (restore, chevron). Exactly 22x22 with no padding,
- * matching `.monaco-button.chat-question-collapse-toggle`. */
+/* Icon-only square buttons (restore, chevron, edit). Exactly 22x22 with no
+ * padding, matching `.monaco-button.chat-question-collapse-toggle`. */
 .interactive-session .chat-plan-review-container .monaco-button.chat-plan-review-title-icon-button {
 	width: 22px;
 	padding: 0;
-}
-
-.interactive-session .chat-plan-review-container .monaco-button.chat-plan-review-edit {
-	font-size: var(--vscode-chat-font-size-body-s);
-	color: var(--vscode-foreground) !important;
 }
 
 /* Inline slot in the title bar. The action buttons (Approve + Reject) get
@@ -129,15 +121,44 @@
 	display: flex;
 }
 
-.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button {
+/* Action button row sizing — shared between the inline (collapsed) action
+ * slot in the title bar and the footer. Keep these two rule sets together so
+ * any tweaks stay in sync. */
+.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button,
+.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button {
 	width: auto;
 	min-width: auto;
 	padding: 0 10px;
 	height: 22px;
 }
 
-.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button-dropdown {
+.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button-dropdown,
+.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button-dropdown {
 	width: auto;
+	height: 22px;
+	align-items: center;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button-dropdown > .monaco-button,
+.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button-dropdown > .monaco-button {
+	height: 22px;
+	box-sizing: border-box;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button-dropdown > .monaco-button.monaco-dropdown-button,
+.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button-dropdown > .monaco-button.monaco-dropdown-button {
+	padding: 0 4px;
+}
+
+/* The default-colors separator has `padding: 4px 0` plus 1px top/bottom
+ * borders; with content-box sizing it would visually overflow the 22px
+ * dropdown wrapper and make the chevron half look taller than the primary
+ * button. Force border-box and a fixed height so it matches. */
+.interactive-session .chat-plan-review-container .chat-plan-review-inline-actions .monaco-button-dropdown > .monaco-button-dropdown-separator,
+.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button-dropdown > .monaco-button-dropdown-separator {
+	box-sizing: border-box;
+	height: 22px;
+	padding: 3px 0;
 }
 
 /* ---------- Scrollable markdown body ----------
@@ -146,17 +167,36 @@
  * to clip and display its scrollbar against. DomScrollableElement sets the
  * inner element's `overflow: hidden` inline, so we don't set overflow here. */
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message-scrollable.chat-plan-review-body-scrollable {
-	flex: 1;
+	flex: 1 1 auto;
 	min-height: 0;
 }
 
+/* The inner message element must have its own bounded height so that
+ * `scrollHeight > clientHeight` and DomScrollableElement renders a scrollbar.
+ * Without this the element grows to its natural content size and never
+ * scrolls (parity with .chat-confirmation-widget-message in the tool
+ * confirmation carousel). */
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message.chat-plan-review-body {
-	flex: 1;
-	min-height: 0;
-	max-height: min(300px, 40vh);
 	padding: 6px 12px;
 	background: transparent;
 	border-bottom: none;
+	max-height: min(320px, 40vh);
+}
+
+.interactive-session .chat-plan-review-container.chat-plan-review-expanded .chat-confirmation-widget-message.chat-plan-review-body {
+	max-height: min(620px, 65vh);
+}
+
+/* When the feedback section is open it claims ~80px below the body. Shrink
+ * the body's cap so the widget's overall max-height isn't exceeded and the
+ * footer buttons + textarea remain visible (otherwise the bottom of the
+ * widget gets clipped by the widget's own `overflow: hidden`). */
+.interactive-session .chat-plan-review-container.chat-plan-review-feedback-mode .chat-confirmation-widget-message.chat-plan-review-body {
+	max-height: min(220px, 28vh);
+}
+
+.interactive-session .chat-plan-review-container.chat-plan-review-expanded.chat-plan-review-feedback-mode .chat-confirmation-widget-message.chat-plan-review-body {
+	max-height: min(520px, 55vh);
 }
 
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message.chat-plan-review-body .rendered-markdown p:first-child {
@@ -177,7 +217,17 @@
 	flex-shrink: 0;
 }
 
+.interactive-session .chat-plan-review-container .chat-plan-review-feedback-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 6px;
+	min-width: 0;
+}
+
 .interactive-session .chat-plan-review-container .chat-plan-review-feedback-label {
+	flex: 1;
+	min-width: 0;
 	font-size: var(--vscode-chat-font-size-body-s);
 	color: var(--vscode-descriptionForeground);
 }
@@ -221,17 +271,6 @@
 	display: flex;
 	column-gap: 6px;
 	align-items: center;
-}
-
-.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button {
-	width: auto;
-	min-width: auto;
-	padding: 0 10px;
-	height: 22px;
-}
-
-.interactive-session .chat-plan-review-container .chat-plan-review-footer .monaco-button-dropdown {
-	width: auto;
 }
 
 /* ---------- Hidden helper ---------- */

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1061,6 +1061,16 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return undefined;
 		}
 
+		// Never show working progress while an unresolved plan review is in
+		// the response. The plan review widget surfaces its own "Plan review
+		// required" progress row and is blocking on user input, so a second
+		// working indicator below it is redundant. This must run before any
+		// settings/mode-driven branches so it applies regardless of
+		// persistent-progress / shimmer / progressMessageAtBottomOfResponse.
+		if (partsToRender.some(part => part.kind === 'planReview' && !part.isUsed)) {
+			return undefined;
+		}
+
 		const showProgressDetails = this.configService.getValue<boolean>(ChatConfiguration.ChatPersistentProgressEnabled) !== false
 			&& this.configService.getValue<boolean>(ChatConfiguration.ProgressBorder) !== true;
 		if (element.isComplete) {
@@ -2226,7 +2236,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'questionCarousel') {
 				return this.renderQuestionCarousel(context, content, templateData);
 			} else if (content.kind === 'planReview') {
-				return this.renderPlanReview(context, content);
+				return this.renderPlanReview(context, content, templateData);
 			} else if (content.kind === 'changesSummary') {
 				return this.renderChangesSummary(content, context, templateData);
 			} else if (content.kind === 'mcpServersStarting') {
@@ -2886,10 +2896,14 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// OS toast notification is handled by ChatWindowNotifier
 	}
 
-	private renderPlanReview(context: IChatContentPartRenderContext, review: IChatPlanReview): IChatContentPart {
+	private renderPlanReview(context: IChatContentPartRenderContext, review: IChatPlanReview, templateData: IChatListItemTemplate): IChatContentPart {
 		const widget = isResponseVM(context.element) ? this.chatWidgetService.getWidgetBySessionResource(context.element.sessionResource) : undefined;
 		const responseId = isResponseVM(context.element) ? context.element.requestId : undefined;
 		const reviewKey = review.resolveId ?? `${responseId ?? ''}_${context.contentIndex}`;
+
+		// A pending plan review blocks the agent on user input, so stop any
+		// active thinking part — parity with elicitation / question carousel.
+		this.finalizeCurrentThinkingPart(context, templateData);
 
 		const handleSubmit = (result: IChatPlanReviewResult) => {
 			review.data = result;
@@ -2900,23 +2914,80 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			widget?.input.clearPlanReview(undefined, reviewKey);
 		};
 
-		// Once the review has been answered (or the response is complete),
-		// render nothing in the chat stream. The docked widget was already
-		// removed from the input part when the user submitted, and we don't
-		// want a lingering summary in the response (parity with
-		// ChatToolConfirmationCarouselPart behaviour).
+		// Once the response is complete without a user response, mark the
+		// review as used and clear any docked widget. This matches the
+		// no-answer cancellation path in ChatToolConfirmationCarouselPart.
 		const responseIsComplete = isResponseVM(context.element) && context.element.isComplete;
-		if (review.isUsed || responseIsComplete) {
-			if (responseIsComplete && !review.isUsed) {
-				review.isUsed = true;
-				if (review instanceof ChatPlanReviewData) {
-					review.completion.complete(undefined);
-				}
-				if (responseId) {
-					widget?.input.clearPlanReview(responseId);
-				}
+		if (responseIsComplete && !review.isUsed) {
+			review.isUsed = true;
+			if (review instanceof ChatPlanReviewData) {
+				review.completion.complete(undefined);
 			}
-			return this.renderNoContent(other => other.kind === 'planReview');
+			if (responseId) {
+				widget?.input.clearPlanReview(responseId);
+			}
+		}
+
+		// Build the inline progress message for the response stream. While
+		// pending, this is "Plan review required" with a spinner. Once the
+		// user has answered, it transitions to the action that was taken
+		// (e.g. "Approved plan", "Started implementation with autopilot"),
+		// and — when the user provided feedback — folds the feedback into
+		// the same progress row as a blockquote so the transcript captures
+		// what was said.
+		const renderProgress = (): IChatContentPart => {
+			const message = this.getPlanReviewProgressMessage(review);
+			if (!message) {
+				return this.renderNoContent(other => other.kind === 'planReview');
+			}
+			// Capture the used state at render time. `other` and `review`
+			// are typically the same mutable object, so comparing
+			// `other.isUsed` against `review.isUsed` would always match.
+			// Snapshotting here lets `hasSameContent` detect the
+			// pending → used transition and trigger a re-render.
+			const renderedAsUsed = !!review.isUsed;
+			const isPending = !renderedAsUsed;
+			const feedbackText = renderedAsUsed && !review.data?.rejected ? review.data?.feedback?.trim() : undefined;
+			const fullMessage = feedbackText
+				? localize('chat.planReview.feedbackInline', "{0}: {1}", message, feedbackText.replace(/\s+/g, ' '))
+				: message;
+			const content = new MarkdownString(undefined, { supportThemeIcons: true });
+			content.appendText(fullMessage);
+			const progressPart = this.instantiationService.createInstance(
+				ChatProgressContentPart,
+				{ content },
+				this.chatContentMarkdownRenderer,
+				context,
+				/* forceShowSpinner */ isPending,
+				/* forceShowMessage */ true,
+				/* icon */ isPending ? undefined : Codicon.check,
+				undefined,
+				/* shimmer */ isPending,
+			);
+			return {
+				domNode: progressPart.domNode,
+				dispose: () => progressPart.dispose(),
+				hasSameContent: (other, _followingContent, _element) => {
+					if (other.kind !== 'planReview') {
+						return false;
+					}
+					// Re-render when the used state flips so we transition
+					// from "Plan review required" to the final action label.
+					if (!!review.isUsed !== renderedAsUsed) {
+						return false;
+					}
+					if (review.resolveId && other.resolveId) {
+						return review.resolveId === other.resolveId;
+					}
+					return other === review;
+				},
+			};
+		};
+
+		// If the review has been answered (or the response is complete), the
+		// docked widget is gone. Render only the final progress line.
+		if (review.isUsed) {
+			return renderProgress();
 		}
 
 		// Dock the active review above the chat input (not while editing).
@@ -2933,20 +3004,31 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return fallbackPart;
 		}
 
-		// Return a placeholder. Re-render when the review is used/complete so
-		// we can transition to the no-content path above and drop the widget.
-		return this.renderNoContent((other, _followingContent, element) => {
-			if (review.isUsed || (isResponseVM(element) && element.isComplete)) {
-				return false;
-			}
-			if (other.kind === 'planReview') {
-				if (review.resolveId && other.resolveId) {
-					return review.resolveId === other.resolveId;
-				}
-				return other === review;
-			}
-			return false;
-		});
+		return renderProgress();
+	}
+
+	private getPlanReviewProgressMessage(review: IChatPlanReview): string | undefined {
+		if (!review.isUsed) {
+			return localize('chat.planReview.required', "Plan review required");
+		}
+		const result = review.data;
+		if (!result) {
+			return undefined;
+		}
+		if (result.rejected) {
+			return localize('chat.planReview.rejected', "Rejected plan");
+		}
+		if (result.feedback) {
+			return localize('chat.planReview.feedback', "Provided feedback");
+		}
+		const action = review.actions.find(a => a.label === result.action);
+		if (action?.permissionLevel === 'autopilot') {
+			return localize('chat.planReview.autopilot', "Started implementation with Autopilot");
+		}
+		if (action && /implement/i.test(action.label)) {
+			return localize('chat.planReview.approvedAndImplement', "Approved plan and beginning implementation");
+		}
+		return localize('chat.planReview.approved', "Approved plan");
 	}
 
 	private removeCarouselFromTracking(context: IChatContentPartRenderContext, part: ChatQuestionCarouselPart): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2932,9 +2932,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// pending, this is "Plan review required" with a spinner. Once the
 		// user has answered, it transitions to the action that was taken
 		// (e.g. "Approved plan", "Started implementation with autopilot"),
-		// and — when the user provided feedback — folds the feedback into
-		// the same progress row as a blockquote so the transcript captures
-		// what was said.
+		// and — when the user provided feedback — appends that feedback
+		// inline in the same progress row after a colon, collapsing
+		// whitespace so the transcript reads as a single line.
 		const renderProgress = (): IChatContentPart => {
 			const message = this.getPlanReviewProgressMessage(review);
 			if (!message) {
@@ -3024,9 +3024,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const action = review.actions.find(a => a.label === result.action);
 		if (action?.permissionLevel === 'autopilot') {
 			return localize('chat.planReview.autopilot', "Started implementation with Autopilot");
-		}
-		if (action && /implement/i.test(action.label)) {
-			return localize('chat.planReview.approvedAndImplement', "Approved plan and beginning implementation");
 		}
 		return localize('chat.planReview.approved', "Approved plan");
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
@@ -229,6 +229,40 @@ suite('ChatPlanReviewPart', () => {
 			assert.deepStrictEqual(lastSubmitResult, { rejected: false, feedback: 'Please also add tests' });
 		});
 
+		test('clicking feedback close button exits feedback mode, hides section, restores buttons, and clears draft', () => {
+			const data = new ChatPlanReviewData('Title', 'Content', [{ label: 'Autopilot', default: true }], true);
+			createWidget(data);
+
+			// Enter feedback mode
+			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
+			feedbackButton!.click();
+
+			// Type some draft feedback
+			const textarea = widget.domNode.querySelector('.chat-plan-review-feedback-textarea') as HTMLTextAreaElement;
+			textarea.value = 'draft feedback';
+			textarea.dispatchEvent(new Event('input'));
+
+			// Click the close button inside the feedback header
+			const closeButton = widget.domNode.querySelector('.chat-plan-review-feedback-close') as HTMLElement;
+			assert.ok(closeButton, 'feedback close button should exist');
+			closeButton.click();
+
+			// Feedback section should be hidden
+			const feedbackSection = widget.domNode.querySelector('.chat-plan-review-feedback') as HTMLElement;
+			assert.strictEqual(feedbackSection.style.display, 'none', 'feedback section should be hidden');
+
+			// Footer buttons should be back to the normal set
+			const buttons = getFooterButtons(widget);
+			assert.ok(buttons.some(b => b.textContent?.includes('Autopilot')), 'approve button should be back');
+			assert.ok(buttons.some(b => b.textContent?.includes('Provide Feedback')), 'provide feedback button should be back');
+			assert.ok(buttons.some(b => b.textContent?.includes('Reject')), 'reject button should be back');
+			assert.ok(!buttons.some(b => b.textContent?.includes('Submit')), 'submit button should be gone');
+
+			// Draft feedback should be cleared
+			assert.strictEqual(textarea.value, '', 'textarea should be cleared');
+			assert.strictEqual(data.draftFeedback, '', 'draft feedback should be cleared');
+		});
+
 		test('submit does nothing when feedback textarea is empty', () => {
 			createWidget(createMockReview({ canProvideFeedback: true }));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

https://github.com/user-attachments/assets/733bb832-e366-4b2e-8ad8-33a158884104

monaco scrollable, so things should render and scroll a bit better and not get hidden behind the provide feedback stuff
"edit plan.md" label removed - i think the pencil is enough tbh
swapped the chevron buttons (these were switched before. chevron up should be to expand. chevron down should be to close)
x next to "Additional feedback" so if you change ur mind, you can go back to the main widget to approve or continue.
better progress in the chat while a review item is shown
when an option is selected, we show in the chat what was selected (ie, "continued with autopilot", "rejected plan")
when we provide feedback, we show the feedback that was sent.