### PR TITLE
Agents: Remove experimental send button gradient configuration

### DIFF
--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -61,7 +61,7 @@ import { IMarkdownRendererService } from '../../platform/markdown/browser/markdo
 import { EditorMarkdownCodeBlockRenderer } from '../../editor/browser/widget/markdownRenderer/browser/editorMarkdownCodeBlockRenderer.js';
 import { SyncDescriptor } from '../../platform/instantiation/common/descriptors.js';
 import { TitleService } from './parts/titlebarPart.js';
-import { SessionsExperimentalSendButtonGradientSettingId, SessionsExperimentalShellGradientBackgroundSettingId } from '../common/configuration.js';
+import { SessionsExperimentalShellGradientBackgroundSettingId } from '../common/configuration.js';
 import { IContextKeyService } from '../../platform/contextkey/common/contextkey.js';
 import { EditorMaximizedContext } from '../common/contextkeys.js';
 import {
@@ -91,7 +91,6 @@ enum LayoutClasses {
 	CHATBAR_HIDDEN = 'nochatbar',
 	STATUSBAR_HIDDEN = 'nostatusbar',
 	EXPERIMENTAL_SHELL_GRADIENT_BACKGROUND = 'experimental-shell-gradient-background',
-	EXPERIMENTAL_SEND_BUTTON_GRADIENT = 'sessions-experimental-send-button-gradient',
 	FULLSCREEN = 'fullscreen',
 	MAXIMIZED = 'maximized'
 }
@@ -447,7 +446,6 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		// Configuration changes
 		this._register(configurationService.onDidChangeConfiguration(e => this.updateFontAliasing(e, configurationService)));
 		this._register(configurationService.onDidChangeConfiguration(e => this.updateShellGradientBackground(e, configurationService)));
-		this._register(configurationService.onDidChangeConfiguration(e => this.updateSendButtonGradient(e, configurationService)));
 
 		// Font Info
 		if (isNative) {
@@ -542,17 +540,6 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		);
 	}
 
-	private updateSendButtonGradient(e: IConfigurationChangeEvent | undefined, configurationService: IConfigurationService): void {
-		if (e && !e.affectsConfiguration(SessionsExperimentalSendButtonGradientSettingId)) {
-			return;
-		}
-
-		this.mainContainer.classList.toggle(
-			LayoutClasses.EXPERIMENTAL_SEND_BUTTON_GRADIENT,
-			configurationService.getValue<boolean>(SessionsExperimentalSendButtonGradientSettingId)
-		);
-	}
-
 	//#endregion
 
 	private renderWorkbench(instantiationService: IInstantiationService, notificationService: NotificationService, storageService: IStorageService, configurationService: IConfigurationService): void {
@@ -577,7 +564,6 @@ export class Workbench extends Disposable implements IAgentWorkbenchLayoutServic
 		// Apply font aliasing
 		this.updateFontAliasing(undefined, configurationService);
 		this.updateShellGradientBackground(undefined, configurationService);
-		this.updateSendButtonGradient(undefined, configurationService);
 
 		// Warm up font cache information before building up too many dom elements
 		this.restoreFontInfo(storageService, configurationService);

--- a/src/vs/sessions/common/configuration.ts
+++ b/src/vs/sessions/common/configuration.ts
@@ -4,4 +4,3 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const SessionsExperimentalShellGradientBackgroundSettingId = 'sessions.experimental.shellGradientBackground';
-export const SessionsExperimentalSendButtonGradientSettingId = 'sessions.experimental.sendButtonGradient';

--- a/src/vs/sessions/contrib/chat/browser/media/chatInput.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatInput.css
@@ -188,9 +188,7 @@
 /* Delightful gradient styling for the chat send (submit) button. The button
 	is filled at rest with a slowly rotating multi-color conic gradient using
 	the same palette as the working-state border, and emits a quick colorful
-	pulse on click. Gated behind the experimental
-	`sessions.experimental.sendButtonGradient` setting via the
-	`.sessions-experimental-send-button-gradient` class on the workbench root. */
+	pulse on click. */
 @property --chat-send-button-anim-angle {
 	syntax: '<angle>';
 	inherits: false;
@@ -268,15 +266,9 @@
 	cursor: default;
 }
 
-/* Default hover feedback when the gradient experiment is off. The gradient-on
-	rules below override this with the cycling color treatment. */
-.sessions-chat-send-button .monaco-button:not(.disabled):hover {
-	background-color: var(--vscode-toolbar-hoverBackground);
-}
-
 /* Focus indicator drawn on the wrapper so it sits cleanly around the
 	22x22 button surface (the inner Button widget doesn't draw its own
-	focus border). Works in both gradient-on and gradient-off states. */
+	focus border). */
 .sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 1px;
@@ -305,15 +297,13 @@
 }
 
 /* Idle: fill the entire button with a slowly rotating conic gradient (no
-	border ring). Gated behind the experimental `sessions.experimental.sendButtonGradient`
-	setting via the `.sessions-experimental-send-button-gradient` class on
-	the workbench root.
+	border ring).
 
 	Colors are darkened (60% mixed with input background) so the gradient
 	reads as a calm fill rather than a saturated accent, and the conic stops
 	are asymmetric so the fill has a clear head and tail rather than
 	mirroring around the mid-point. */
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button .monaco-button:not(.disabled) {
+.sessions-chat-send-button .monaco-button:not(.disabled) {
 	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 0deg,
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 60%, var(--vscode-input-background)) 90deg,
@@ -327,13 +317,13 @@
 /* Hover/focus: subtle dark overlay to match standard toolbar button hover
 	feedback. Uses an inset box-shadow so the rotating gradient background is
 	preserved underneath. */
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):hover) .monaco-button,
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) .monaco-button {
+.sessions-chat-send-button:has(.monaco-button:not(.disabled):hover) .monaco-button,
+.sessions-chat-send-button:has(.monaco-button:not(.disabled):focus-visible) .monaco-button {
 	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
 }
 
 /* Click: outward color pulse on the wrapper. */
-.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
+.sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after {
 	content: '';
 	position: absolute;
 	inset: -2px;
@@ -353,35 +343,35 @@
 	Gradient styling for the standard chat-input send button (the one rendered
 	inside session views by the shared ChatInputPart). Mirrors the wrapper
 	rules above but targets the toolbar action-item that hosts the arrow-up
-	codicon. Gated by the same `.sessions-experimental-send-button-gradient` class on
-	the sessions workbench root so only Sessions/Agents UI is affected.
+	codicon. Scoped to the sessions workbench root so only Sessions/Agents UI
+	is affected.
 	---------------------------------------------------------------------------- */
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) {
 	position: relative;
 	border-radius: 5px;
 }
 
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up {
 	transition: background-color 250ms ease, color 250ms ease;
 }
 
 /* Focus indicator drawn on the action-item wrapper so it sits cleanly around
 	the button surface with a small offset, matching the new-session button. */
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:focus-visible) {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:focus-visible) {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 1px;
 	border-radius: 5px;
 }
 
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up:focus,
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up:focus-visible {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up:focus,
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:has(> .action-label.codicon-arrow-up) > .action-label.codicon-arrow-up:focus-visible {
 	outline: none;
 }
 
 /* Idle: fill the entire action-label with a slowly rotating conic gradient.
 	Colors darkened (60% mixed with input background) for a calm fill, with
 	asymmetric conic stops. */
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up {
 	background: conic-gradient(from var(--chat-send-button-anim-angle) at 0% 0%,
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor1) 60%, var(--vscode-input-background)) 0deg,
 		color-mix(in srgb, var(--vscode-chat-inputWorkingBorderColor2) 60%, var(--vscode-input-background)) 90deg,
@@ -400,12 +390,12 @@
 /* Hover/focus: subtle dark overlay to match standard toolbar button hover
 	feedback. Uses an inset box-shadow so the rotating gradient background is
 	preserved underneath. */
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:hover,
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up:focus-visible {
 	box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.12);
 }
 
-.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
+.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
 	content: '';
 	position: absolute;
 	inset: -2px;
@@ -422,10 +412,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button .monaco-button:not(.disabled),
-	.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up,
-	.monaco-workbench.sessions-experimental-send-button-gradient .sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after,
-	.monaco-workbench.sessions-experimental-send-button-gradient .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
+	.sessions-chat-send-button .monaco-button:not(.disabled),
+	.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled) > .action-label.codicon-arrow-up,
+	.sessions-chat-send-button:has(.monaco-button:not(.disabled):active)::after,
+	.agent-sessions-workbench .interactive-session .chat-input-toolbars > .chat-execute-toolbar .monaco-action-bar .action-item:not(.disabled):has(> .action-label.codicon-arrow-up:active)::after {
 		animation: none;
 	}
 }

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -6,7 +6,7 @@
 import { ConfigurationScope, Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { localize } from '../../../../nls.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
-import { SessionsExperimentalSendButtonGradientSettingId, SessionsExperimentalShellGradientBackgroundSettingId } from '../../../common/configuration.js';
+import { SessionsExperimentalShellGradientBackgroundSettingId } from '../../../common/configuration.js';
 import { ThemeSettingDefaults } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
@@ -18,13 +18,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
 			description: localize('sessions.experimental.shellGradientBackground', "Whether to enable the experimental accent-tinted shell background in the Sessions window."),
-		},
-		[SessionsExperimentalSendButtonGradientSettingId]: {
-			type: 'boolean',
-			default: false,
-			scope: ConfigurationScope.APPLICATION,
-			tags: ['experimental'],
-			description: localize('sessions.experimental.sendButtonGradient', "Whether to show a colorful animated gradient on the chat send button in the Sessions window. The button shows a slowly rotating gradient ring at rest, fills with a cycling color on hover, and emits a color pulse on click."),
 		},
 	},
 });


### PR DESCRIPTION
This pull request removes the experimental feature flag for the chat send button gradient, making the animated gradient styling always enabled in the Sessions UI. The related configuration setting and associated code paths have been deleted, and the CSS selectors have been updated to apply the gradient styles by default.

**Removal of send button gradient experiment:**

* Deleted the `sessions.experimental.sendButtonGradient` setting and all references to it, including its definition in `configuration.ts`, registration in `configuration.contribution.ts`, and usage in `workbench.ts`. [[1]](diffhunk://#diff-07636cbe6b7a5768ca51fc8af6daa8c83e6cf2884acbd73119867480bf0a91ccL7) [[2]](diffhunk://#diff-e4f1a1993c276d77fd1f91145e94d8accb613ed368910aacac099cba663b2951L9-R9) [[3]](diffhunk://#diff-e4f1a1993c276d77fd1f91145e94d8accb613ed368910aacac099cba663b2951L22-L28) [[4]](diffhunk://#diff-7106f358346284cdd6fb87800fcba0a78ca83f3b07a6ae350cc6805e28ff3f3fL64-R64) [[5]](diffhunk://#diff-7106f358346284cdd6fb87800fcba0a78ca83f3b07a6ae350cc6805e28ff3f3fL450) [[6]](diffhunk://#diff-7106f358346284cdd6fb87800fcba0a78ca83f3b07a6ae350cc6805e28ff3f3fL545-L555) [[7]](diffhunk://#diff-7106f358346284cdd6fb87800fcba0a78ca83f3b07a6ae350cc6805e28ff3f3fL580) [[8]](diffhunk://#diff-7106f358346284cdd6fb87800fcba0a78ca83f3b07a6ae350cc6805e28ff3f3fL94)

**CSS updates for always-on gradient:**

* Removed all gating of chat send button gradient styles behind the experimental class, so the gradient is now always applied. Updated CSS selectors in `chatInput.css` to target the buttons directly and use `.agent-sessions-workbench` for scoping, instead of `.sessions-experimental-send-button-gradient`. [[1]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L191-R191) [[2]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L271-R271) [[3]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L308-R306) [[4]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L330-R326) [[5]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L356-R374) [[6]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L403-R398) [[7]](diffhunk://#diff-c4e0b42ac094b12a8e55ac366e26fd40ba6bf584ad01e1ca6828bf1a87c4bf33L425-R418)

These changes simplify the codebase and ensure the animated gradient is always present on chat send buttons in the Sessions UI.