### PR TITLE
Agents: fix sessions workspace picker

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -459,7 +459,7 @@ export interface IActionListOptions {
 	 * by scrollbar presence (which changes with window height). Use this for pickers
 	 * that should have a stable, fixed width (e.g. the workspace picker at 600px).
 	 */
-	readonly maxWidth?: number;
+	readonly fixedWidth?: number;
 
 	/**
 	 * Optional handler for markdown links activated in item descriptions or hovers.
@@ -1729,7 +1729,7 @@ export class ActionList<T> extends Disposable {
 			const anchorTopInViewport = anchorRect.top - targetWindow.pageYOffset;
 			const bottomGap = 30;
 			const spaceBelow = viewportHeight - anchorTopInViewport - anchorRect.height - bottomGap;
-			const spaceAbove = anchorTopInViewport - bottomGap;
+			const spaceAbove = anchorTopInViewport;
 
 			// Lock the direction on first layout based on whether the full
 			// unconstrained list fits below. Once decided, the dropdown stays
@@ -1760,12 +1760,12 @@ export class ActionList<T> extends Disposable {
 		const listHeight = this.computeHeight();
 		this._widget.layout(listHeight);
 
-		// When a fixed maxWidth is provided, skip DOM measurement entirely.
+		// When a fixedWidth is provided, skip DOM measurement entirely.
 		// DOM-based measurement varies with scrollbar presence (which depends on
 		// the list height), causing the width to fluctuate as the window is resized.
 		let computedWidth: number;
-		if (this._options?.maxWidth !== undefined) {
-			computedWidth = this._options.maxWidth;
+		if (this._options?.fixedWidth !== undefined) {
+			computedWidth = this._options.fixedWidth;
 		} else {
 			computedWidth = this._widget.computeMaxWidth(minWidth);
 		}

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -454,6 +454,14 @@ export interface IActionListOptions {
 	readonly minWidth?: number;
 
 	/**
+	 * Fixed width for the action list. When set, DOM-based width measurement is
+	 * skipped and this value is used directly, preventing width fluctuations caused
+	 * by scrollbar presence (which changes with window height). Use this for pickers
+	 * that should have a stable, fixed width (e.g. the workspace picker at 600px).
+	 */
+	readonly maxWidth?: number;
+
+	/**
 	 * Optional handler for markdown links activated in item descriptions or hovers.
 	 * When unset, links open via the opener service with command links allowed.
 	 */
@@ -1608,6 +1616,7 @@ export class ActionList<T> extends Disposable {
 	private _cachedMaxWidth: number | undefined;
 	private _hasLaidOut = false;
 	private _showAbove: boolean | undefined;
+	private readonly _options: IActionListOptions | undefined;
 
 	get domNode(): HTMLElement {
 		return this._widget.domNode;
@@ -1646,6 +1655,7 @@ export class ActionList<T> extends Disposable {
 	) {
 		super();
 		this._anchor = anchor;
+		this._options = options;
 
 		this._widget = this._register(instantiationService.createInstance(
 			ActionListWidget<T>,
@@ -1710,7 +1720,6 @@ export class ActionList<T> extends Disposable {
 		const listHeight = this._widget.computeListHeight();
 
 		const filterHeight = this._widget.filterContainer ? 36 : 0;
-		const padding = 10;
 		const targetWindow = dom.getWindow(this.domNode);
 		let availableHeight;
 
@@ -1718,8 +1727,9 @@ export class ActionList<T> extends Disposable {
 			const viewportHeight = targetWindow.innerHeight;
 			const anchorRect = getAnchorRect(this._anchor);
 			const anchorTopInViewport = anchorRect.top - targetWindow.pageYOffset;
-			const spaceBelow = viewportHeight - anchorTopInViewport - anchorRect.height - padding;
-			const spaceAbove = anchorTopInViewport - padding;
+			const bottomGap = 30;
+			const spaceBelow = viewportHeight - anchorTopInViewport - anchorRect.height - bottomGap;
+			const spaceAbove = anchorTopInViewport - bottomGap;
 
 			// Lock the direction on first layout based on whether the full
 			// unconstrained list fits below. Once decided, the dropdown stays
@@ -1730,6 +1740,7 @@ export class ActionList<T> extends Disposable {
 			}
 			availableHeight = this._showAbove ? spaceAbove : spaceBelow;
 		} else {
+			const padding = 10;
 			const windowHeight = this._layoutService.getContainer(targetWindow).clientHeight;
 			const widgetTop = this.domNode.getBoundingClientRect().top;
 			availableHeight = widgetTop > 0 ? windowHeight - widgetTop - padding : windowHeight * 0.7;
@@ -1749,7 +1760,16 @@ export class ActionList<T> extends Disposable {
 		const listHeight = this.computeHeight();
 		this._widget.layout(listHeight);
 
-		this._cachedMaxWidth = this._widget.computeMaxWidth(minWidth);
+		// When a fixed maxWidth is provided, skip DOM measurement entirely.
+		// DOM-based measurement varies with scrollbar presence (which depends on
+		// the list height), causing the width to fluctuate as the window is resized.
+		let computedWidth: number;
+		if (this._options?.maxWidth !== undefined) {
+			computedWidth = this._options.maxWidth;
+		} else {
+			computedWidth = this._widget.computeMaxWidth(minWidth);
+		}
+		this._cachedMaxWidth = computedWidth;
 		this._widget.layout(listHeight, this._cachedMaxWidth);
 
 		return this._cachedMaxWidth;

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -59,8 +59,6 @@
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;
-	/* Leave clearance on the right for the vertical scrollbar track */
-	width: calc(100% - 10px);
 	border-radius: var(--vscode-cornerRadius-medium);
 }
 
@@ -273,6 +271,7 @@
 
 	.action-list-item-toolbar {
 		margin-left: 4px;
+		margin-right: 10px;
 	}
 
 	/* When description is hidden (e.g. items with only a submenu), push the
@@ -281,6 +280,7 @@
 	 * flex:1, so the auto margin has no additional effect. */
 	.action-list-submenu-indicator {
 		margin-left: auto;
+		margin-right: 10px;
 	}
 }
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -59,7 +59,8 @@
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;
-	width: 100%;
+	/* Leave clearance on the right for the vertical scrollbar track */
+	width: calc(100% - 10px);
 	border-radius: var(--vscode-cornerRadius-medium);
 }
 
@@ -233,6 +234,7 @@
 .action-widget .monaco-list-row.action .group-title {
 	color: var(--vscode-descriptionForeground);
 	margin-left: 0.5em;
+	margin-right: 6px;
 	font-size: 12px;
 	flex-shrink: 0;
 }
@@ -253,18 +255,31 @@
 
 /* Inline description mode — description rendered right after the label */
 .action-widget .inline-description .monaco-list-row.action {
+	/* Override the row gap so group-title and toolbar sit flush */
+	gap: 0;
+
 	.title {
-		flex: initial;
-		flex-shrink: 1;
+		flex: 0 1 auto;
 		min-width: 0;
+		margin-left: 6px;
 	}
 
 	.description {
 		flex: 1;
 		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.action-list-item-toolbar {
+		margin-left: 4px;
+	}
+
+	/* When description is hidden (e.g. items with only a submenu), push the
+	 * submenu chevron to the far right using an auto left margin. When
+	 * description is visible it already consumes all available space via
+	 * flex:1, so the auto margin has no additional effect. */
+	.action-list-submenu-indicator {
 		margin-left: auto;
 	}
 }

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -919,7 +919,8 @@ export class WorkspacePicker extends Disposable {
 		this._vsCodeRecentFolderUris = recentlyOpened.workspaces
 			.filter(isRecentFolder)
 			.map(f => f.folderUri)
-			.filter(uri => !this._isCopilotWorktree(uri));
+			.filter(uri => !this._isCopilotWorktree(uri))
+			.slice(0, 10);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -919,8 +919,7 @@ export class WorkspacePicker extends Disposable {
 		this._vsCodeRecentFolderUris = recentlyOpened.workspaces
 			.filter(isRecentFolder)
 			.map(f => f.folderUri)
-			.filter(uri => !this._isCopilotWorktree(uri))
-			.slice(0, 10);
+			.filter(uri => !this._isCopilotWorktree(uri));
 	}
 
 	/**
@@ -960,6 +959,9 @@ export class WorkspacePicker extends Disposable {
 				if (workspace) {
 					result.push({ providerId: provider.id, workspace });
 				}
+			}
+			if (result.length >= 10) {
+				break;
 			}
 		}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -11,7 +11,6 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
-import { Schemas } from '../../../../base/common/network.js';
 import { isNative } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
@@ -229,8 +228,8 @@ export class WorkspacePicker extends Disposable {
 		};
 
 		const listOptions = showFilter
-			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true }
-			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true };
+			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, maxWidth: 600 }
+			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, maxWidth: 600 };
 		triggerElement.setAttribute('aria-expanded', 'true');
 
 		this.actionWidgetService.show<IWorkspacePickerItem>(
@@ -329,6 +328,16 @@ export class WorkspacePicker extends Disposable {
 		return this.sessionsProvidersService.getProviders().flatMap(p => p.browseActions);
 	}
 
+	/**
+	 * Builds the picker items list from recent workspaces.
+	 *
+	 * Ordering:
+	 * 1. Own recents (from sessions picker storage) come first, followed by
+	 *    VS Code recent folders — both retain their original storage order.
+	 * 2. Items are grouped by provider/group title. Groups are sorted by
+	 *    first-appearance index so the first group encountered stays on top.
+	 * 3. Within each group the original insertion order is preserved (stable sort).
+	 */
 	protected _buildItems(): IActionListItem<IWorkspacePickerItem>[] {
 		const items: IActionListItem<IWorkspacePickerItem>[] = [];
 
@@ -363,13 +372,15 @@ export class WorkspacePicker extends Disposable {
 			}
 		}
 
-		// Sort by group name, then by label within each group
-		workspaceEntries.sort((a, b) => {
-			const groupCmp = a.groupTitle.localeCompare(b.groupTitle);
-			if (groupCmp !== 0) {
-				return groupCmp;
+		// Group entries by groupTitle, preserving the original order within each group
+		const groupOrder = new Map<string, number>();
+		workspaceEntries.forEach((entry, index) => {
+			if (!groupOrder.has(entry.groupTitle)) {
+				groupOrder.set(entry.groupTitle, index);
 			}
-			return a.workspace.label.localeCompare(b.workspace.label);
+		});
+		workspaceEntries.sort((a, b) => {
+			return (groupOrder.get(a.groupTitle) ?? 0) - (groupOrder.get(b.groupTitle) ?? 0);
 		});
 
 		// Add items with separators between groups
@@ -849,16 +860,7 @@ export class WorkspacePicker extends Disposable {
 				}
 				return { providerId: stored.providerId, workspace };
 			})
-			.filter((w): w is { providerId: string; workspace: ISessionWorkspace } => w !== undefined)
-			.sort((a, b) => {
-				// Local folders first, then remote repositories, alphabetical within each group
-				const aIsLocal = a.workspace.repositories[0]?.uri.scheme === Schemas.file;
-				const bIsLocal = b.workspace.repositories[0]?.uri.scheme === Schemas.file;
-				if (aIsLocal !== bIsLocal) {
-					return aIsLocal ? -1 : 1;
-				}
-				return a.workspace.label.localeCompare(b.workspace.label);
-			});
+			.filter((w): w is { providerId: string; workspace: ISessionWorkspace } => w !== undefined);
 	}
 
 	protected _removeRecentWorkspace(selection: IWorkspaceSelection): void {
@@ -915,7 +917,19 @@ export class WorkspacePicker extends Disposable {
 		const recentlyOpened = await this.workspacesService.getRecentlyOpened();
 		this._vsCodeRecentFolderUris = recentlyOpened.workspaces
 			.filter(isRecentFolder)
-			.map(f => f.folderUri);
+			.map(f => f.folderUri)
+			.filter(uri => !this._isCopilotWorktree(uri));
+	}
+
+	/**
+	 * Returns whether the given URI points to a copilot-managed folder
+	 * (a folder whose name starts with `copilot-`).
+	 */
+	private _isCopilotWorktree(uri: URI): boolean {
+		const path = uri.path;
+		const lastSlash = path.lastIndexOf('/');
+		const folderName = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+		return folderName.startsWith('copilot-');
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -11,6 +11,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
+import { basename } from '../../../../base/common/resources.js';
 import { isNative } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
@@ -926,10 +927,7 @@ export class WorkspacePicker extends Disposable {
 	 * (a folder whose name starts with `copilot-`).
 	 */
 	private _isCopilotWorktree(uri: URI): boolean {
-		const path = uri.path;
-		const lastSlash = path.lastIndexOf('/');
-		const folderName = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
-		return folderName.startsWith('copilot-');
+		return basename(uri).startsWith('copilot-');
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -229,8 +229,8 @@ export class WorkspacePicker extends Disposable {
 		};
 
 		const listOptions = showFilter
-			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, maxWidth: 600 }
-			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, maxWidth: 600 };
+			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, fixedWidth: 600 }
+			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, fixedWidth: 600 };
 		triggerElement.setAttribute('aria-expanded', 'true');
 
 		this.actionWidgetService.show<IWorkspacePickerItem>(


### PR DESCRIPTION
Fixes several issues with the sessions workspace picker in the Agents window.

## Changes

### Filter copilot worktrees from VS Code recents
Folders whose name starts with `copilot-` are filtered out from the VS Code recent folders list, as these are internal worktrees and not user-facing workspaces.

### Preserve VS Code recents order
Removed the alphabetical sort that was previously applied to VS Code recent folders. Entries now retain the order VS Code stores them in (most recently used first).

### Stable picker width
When `maxWidth` is set on the action list options, DOM-based width measurement is now skipped entirely and the fixed value is used directly. Previously, the measured width varied with scrollbar presence (which depended on list height which depended on window height), causing the picker width to fluctuate when the window was resized.

### Scrollbar clearance
Row width is set to `calc(100% - 10px)` so content never extends under the 10px Monaco overlay scrollbar track.

### Group title / toolbar spacing
In inline-description mode, the flex row gap is set to `0` with explicit margins on individual elements. This keeps the group title ("Folders") and remove button (×) flush with just a small readable gap, while still giving the group title `margin-right` breathing room when the toolbar is hidden.

### Bottom gap
A 30px gap is maintained between the bottom of the picker and the window edge.

### Document entry ordering
Added JSDoc on `_buildItems()` explaining the sorting: own recents first, VS Code recents after, groups ordered by first appearance, within-group order preserved.