### PR TITLE
agent-host: Allow listening on all network interfaces and skip chat response resource validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -406,7 +406,7 @@
 			"name": "VS Code Agent Host",
 			"outputCapture": "std",
 			"program": "./scripts/code-agent-host.js",
-			"args": ["--port", "7777", "--without-connection-token"],
+			"args": ["--port", "7777", "--host", "0.0.0.0", "--without-connection-token"],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],

--- a/extensions/copilot/src/extension/tools/node/toolUtils.ts
+++ b/extensions/copilot/src/extension/tools/node/toolUtils.ts
@@ -199,6 +199,9 @@ export async function assertFileOkForTool(accessor: ServicesAccessor, uri: URI, 
 	if (sessionTranscriptService.isTranscriptUri(normalizedUri)) {
 		return;
 	}
+	if (normalizedUri.scheme === 'vscode-chat-response-resource') {
+		return;
+	}
 	if (await isExternalInstructionsFile(normalizedUri, customInstructionsService, buildPromptContext)) {
 		return;
 	}


### PR DESCRIPTION
- Configures agent host to listen on 0.0.0.0 instead of localhost only, enabling remote connections
- Skips file validation for vscode-chat-response-resource scheme in tool utilities to allow chat response resources

Fixes #312042

(Commit message generated by Copilot)