### PR TITLE
sessions: fix chat history picker not opening selected session

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -37,6 +37,7 @@ import { ChatViewPane } from '../../../../workbench/contrib/chat/browser/widgetH
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { SessionsChatAccessibilityHelp } from './sessionsChatAccessibilityHelp.js';
+import { SessionsOpenerParticipantContribution } from './sessionsOpenerParticipant.js';
 
 
 class NewChatInSessionsWindowAction extends Action2 {
@@ -147,6 +148,7 @@ registerAction2(BranchChatSessionAction);
 // register workbench contributions
 registerWorkbenchContribution2(RegisterChatViewContainerContribution.ID, RegisterChatViewContainerContribution, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(RunScriptContribution.ID, RunScriptContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(SessionsOpenerParticipantContribution.ID, SessionsOpenerParticipantContribution, WorkbenchPhase.BlockStartup);
 
 // register services
 registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/chat/browser/sessionsOpenerParticipant.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsOpenerParticipant.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { IAgentSession } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
+import { ISessionOpenerParticipant, ISessionOpenOptions, sessionOpenerRegistry } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsOpener.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+
+/**
+ * Routes session open requests in the Agents window through the
+ * {@link ISessionsManagementService} so that the active session/chat state is
+ * properly updated. Without this, the default opener tries to load the chat
+ * directly into the `ChatViewId` view, which is hidden behind a `when` clause
+ * tied to the new-chat context keys and may simply do nothing.
+ */
+class SessionsOpenerParticipant implements ISessionOpenerParticipant {
+
+	async handleOpenSession(accessor: ServicesAccessor, session: IAgentSession, openOptions?: ISessionOpenOptions): Promise<boolean> {
+		const sessionsManagementService = accessor.get(ISessionsManagementService);
+		const target = sessionsManagementService.getSession(session.resource);
+		if (!target) {
+			return false;
+		}
+
+		await sessionsManagementService.openSession(session.resource, { preserveFocus: openOptions?.editorOptions?.preserveFocus });
+		return true;
+	}
+}
+
+export class SessionsOpenerParticipantContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.sessionOpenerParticipant';
+
+	constructor() {
+		super();
+		this._register(sessionOpenerRegistry.registerParticipant(new SessionsOpenerParticipant()));
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
@@ -12,7 +12,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ISessionOpenOptions, openSession } from './agentSessionsOpener.js';
-import { IAgentSession, isLocalAgentSessionItem } from './agentSessionsModel.js';
+import { AgentSessionStatus, IAgentSession, isLocalAgentSessionItem } from './agentSessionsModel.js';
 import { IAgentSessionsService } from './agentSessionsService.js';
 import { AgentSessionsSorter, groupAgentSessionsByDate, sessionDateFromNow } from './agentSessionsViewer.js';
 import { AGENT_SESSION_DELETE_ACTION_ID, AGENT_SESSION_RENAME_ACTION_ID } from './agentSessions.js';
@@ -141,7 +141,7 @@ export class AgentSessionsPicker {
 
 	private createPickerItems(filter: AgentSessionsFilter): (ISessionPickItem | IQuickPickSeparator)[] {
 		const sessions = this.agentSessionsService.model.sessions
-			.filter(session => !filter.exclude(session))
+			.filter(session => session.status !== AgentSessionStatus.Completed && !filter.exclude(session))
 			.sort(this.sorter.compare.bind(this.sorter));
 		const items: (ISessionPickItem | IQuickPickSeparator)[] = [];
 


### PR DESCRIPTION
In the Agents window, `workbench.action.chat.history` showed the session picker but selecting a session did nothing.

## Cause

The default session opener (`openSessionDefault` in `agentSessionsOpener.ts`) calls `IChatWidgetService.openSession(..., ChatViewPaneTarget)`, which opens `ChatViewId`. In the Agents window that view is registered with a `when` clause gated on `IsNewChatSessionContext.negate() && IsNewChatInSessionContext.negate()`, so when the user is on the new-chat view it stays hidden and nothing happens.

## Fix

Register a `SessionsOpenerParticipant` in `vs/sessions` that intercepts session opens and routes them through `ISessionsManagementService.openSession`. That service updates the active session / context keys properly, so the chat view becomes visible and loads the picked session.

(Written by Copilot)