### PR TITLE
fix: Cmd+. and Cmd+Option+. shortcuts for picker in sessions window

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
-import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, observableValue } from '../../../../../base/common/observable.js';
 import * as nls from '../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
@@ -12,6 +12,10 @@ import { Action2, registerAction2 } from '../../../../../platform/actions/common
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ChatContextKeys } from '../../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { IsSessionsWindowContext } from '../../../../../workbench/common/contextkeys.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../../workbench/common/contributions.js';
 import { type ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../../workbench/contrib/chat/common/languageModels.js';
 import { type IChatInputPickerOptions } from '../../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
@@ -27,6 +31,9 @@ const IsActiveSessionAgentHost = ContextKeyExpr.or(
 	ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/),
 );
 
+// Module-level callback for programmatic picker invocation via keybinding.
+let _agentHostModelPickerShowCallback: (() => void) | undefined;
+
 // -- Agent Host Model Picker Action --
 
 registerAction2(class extends Action2 {
@@ -35,6 +42,11 @@ registerAction2(class extends Action2 {
 			id: 'sessions.agentHost.modelPicker',
 			title: nls.localize2('agentHostModelPicker', "Model"),
 			f1: false,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Period,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, ChatContextKeys.inChatInput, IsActiveSessionAgentHost),
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+			},
 			menu: [{
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
@@ -43,7 +55,7 @@ registerAction2(class extends Action2 {
 			}],
 		});
 	}
-	override async run(): Promise<void> { /* handled by action view item */ }
+	override async run(): Promise<void> { _agentHostModelPickerShowCallback?.(); }
 });
 
 // -- Agent Host Model Picker Contribution --
@@ -140,6 +152,13 @@ class AgentHostModelPickerContribution extends Disposable implements IWorkbenchC
 				initModelFromActiveSession();
 
 				const disposableStore = new DisposableStore();
+				const showCallback = () => modelPicker.openModelPicker();
+				_agentHostModelPickerShowCallback = showCallback;
+				disposableStore.add(toDisposable(() => {
+					if (_agentHostModelPickerShowCallback === showCallback) {
+						_agentHostModelPickerShowCallback = undefined;
+					}
+				}));
 				disposableStore.add(languageModelsService.onDidChangeLanguageModels(() => initModelFromActiveSession()));
 
 				disposableStore.add(autorun(reader => {

--- a/src/vs/sessions/contrib/chat/browser/newChatInput.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInput.ts
@@ -44,6 +44,7 @@ import { VariableCompletionHandler } from './variableCompletions.js';
 import { IChatModelInputState } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
+import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { ChatHistoryNavigator } from '../../../../workbench/contrib/chat/common/widget/chatWidgetHistoryService.js';
 import { IHistoryNavigationWidget } from '../../../../base/browser/history.js';
 import { registerAndCreateHistoryNavigationContext, IHistoryNavigationContext } from '../../../../platform/history/browser/contextScopedHistoryWidget.js';
@@ -252,6 +253,8 @@ export class NewChatInputWidget extends Disposable implements IHistoryNavigation
 		// Create scoped context key service and register history navigation
 		// BEFORE creating the editor, so the editor's context key scope is a child
 		const inputScopedContextKeyService = this._register(this.contextKeyService.createScoped(container));
+		ChatContextKeys.inChatInput.bindTo(inputScopedContextKeyService).set(true);
+		ChatContextKeys.location.bindTo(inputScopedContextKeyService).set(ChatAgentLocation.Chat);
 		const { historyNavigationBackwardsEnablement, historyNavigationForwardsEnablement } = this._register(registerAndCreateHistoryNavigationContext(inputScopedContextKeyService, this));
 		this._historyNavigationBackwardsEnablement = historyNavigationBackwardsEnablement;
 		this._historyNavigationForwardsEnablement = historyNavigationForwardsEnablement;

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce } from '../../../../base/common/arrays.js';
-import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { IReader, autorun, observableValue } from '../../../../base/common/observable.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, registerAction2, MenuId, MenuRegistry, isIMenuItem } from '../../../../platform/actions/common/actions.js';
@@ -19,6 +19,10 @@ import { ModelPickerActionItem, IModelPickerDelegate } from '../../../../workben
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { IContextKeyService, ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
+import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -33,6 +37,21 @@ import { ModePicker } from './modePicker.js';
 import { CloudModelPicker } from './modelPicker.js';
 import { CopilotPermissionPickerDelegate, PermissionPicker } from './permissionPicker.js';
 import { ClaudePermissionModePicker } from './claudePermissionModePicker.js';
+
+// -- Picker Show Callback Registry --
+// Module-level registry that maps action IDs to their picker show callbacks.
+// Populated by CopilotPickerActionViewItemContribution when pickers are created;
+// consumed by the action `run()` methods to programmatically open pickers via keybindings.
+const _pickerShowCallbacks = new Map<string, () => void>();
+
+function registerPickerShowCallback(actionId: string, callback: () => void): IDisposable {
+	_pickerShowCallbacks.set(actionId, callback);
+	return toDisposable(() => {
+		if (_pickerShowCallbacks.get(actionId) === callback) {
+			_pickerShowCallbacks.delete(actionId);
+		}
+	});
+}
 
 const IsActiveSessionCopilotCLI = ContextKeyExpr.equals(ActiveSessionTypeContext.key, COPILOT_CLI_SESSION_TYPE);
 const IsActiveSessionCopilotCloud = ContextKeyExpr.equals(ActiveSessionTypeContext.key, COPILOT_CLOUD_SESSION_TYPE);
@@ -89,6 +108,11 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.modePicker',
 			title: localize2('modePicker', "Mode"),
 			f1: false,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyCode.Period,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, ChatContextKeys.inChatInput, IsActiveSessionCopilotChatCLI),
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+			},
 			menu: [{
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
@@ -97,7 +121,7 @@ registerAction2(class extends Action2 {
 			}],
 		});
 	}
-	override async run(): Promise<void> { /* handled by action view item */ }
+	override async run(): Promise<void> { _pickerShowCallbacks.get('sessions.defaultCopilot.modePicker')?.(); }
 });
 
 registerAction2(class extends Action2 {
@@ -106,6 +130,11 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.localModelPicker',
 			title: localize2('localModelPicker', "Model"),
 			f1: false,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Period,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, ChatContextKeys.inChatInput, ContextKeyExpr.or(IsActiveSessionCopilotChatCLI, IsActiveSessionCopilotChatClaudeCode)),
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+			},
 			menu: [{
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
@@ -114,7 +143,7 @@ registerAction2(class extends Action2 {
 			}],
 		});
 	}
-	override async run(): Promise<void> { /* handled by action view item */ }
+	override async run(): Promise<void> { _pickerShowCallbacks.get('sessions.defaultCopilot.localModelPicker')?.(); }
 });
 
 registerAction2(class extends Action2 {
@@ -123,6 +152,11 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.cloudModelPicker',
 			title: localize2('cloudModelPicker', "Model"),
 			f1: false,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Period,
+				when: ContextKeyExpr.and(IsSessionsWindowContext, ChatContextKeys.inChatInput, IsActiveSessionCopilotChatCloud),
+				weight: KeybindingWeight.WorkbenchContrib + 1,
+			},
 			menu: [{
 				id: Menus.NewSessionConfig,
 				group: 'navigation',
@@ -131,7 +165,7 @@ registerAction2(class extends Action2 {
 			}],
 		});
 	}
-	override async run(): Promise<void> { /* handled by action view item */ }
+	override async run(): Promise<void> { _pickerShowCallbacks.get('sessions.defaultCopilot.cloudModelPicker')?.(); }
 });
 
 registerAction2(class extends Action2 {
@@ -222,21 +256,24 @@ class CopilotPickerActionViewItemContribution extends Disposable implements IWor
 			Menus.NewSessionConfig, 'sessions.defaultCopilot.modePicker',
 			() => {
 				const picker = instantiationService.createInstance(ModePicker);
-				return new PickerActionViewItem(picker);
+				const callbackReg = registerPickerShowCallback('sessions.defaultCopilot.modePicker', () => picker.showPicker());
+				return new PickerActionViewItem(picker, callbackReg);
 			},
 		));
 		this._register(actionViewItemService.register(
 			Menus.NewSessionConfig, 'sessions.defaultCopilot.localModelPicker',
 			() => {
 				const picker = instantiationService.createInstance(SessionModelPicker);
-				return new PickerActionViewItem(picker);
+				const callbackReg = registerPickerShowCallback('sessions.defaultCopilot.localModelPicker', () => picker.showPicker());
+				return new PickerActionViewItem(picker, callbackReg);
 			},
 		));
 		this._register(actionViewItemService.register(
 			Menus.NewSessionConfig, 'sessions.defaultCopilot.cloudModelPicker',
 			() => {
 				const picker = instantiationService.createInstance(CloudModelPicker);
-				return new PickerActionViewItem(picker);
+				const callbackReg = registerPickerShowCallback('sessions.defaultCopilot.cloudModelPicker', () => picker.showPicker());
+				return new PickerActionViewItem(picker, callbackReg);
 			},
 		));
 		this._register(actionViewItemService.register(
@@ -343,6 +380,10 @@ export class SessionModelPicker extends Disposable {
 			const remembered = rememberedModelId ? models.find(m => m.identifier === rememberedModelId) : undefined;
 			this._delegate.setModel(remembered ?? models[0]);
 		}
+	}
+
+	showPicker(): void {
+		this._modelPicker.openModelPicker();
 	}
 
 	render(container: HTMLElement): void {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modePicker.ts
@@ -99,14 +99,14 @@ export class ModePicker extends Disposable {
 		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
 			this._renderDisposables.add(dom.addDisposableListener(trigger, eventType, (e) => {
 				dom.EventHelper.stop(e, true);
-				this._showPicker();
+				this.showPicker();
 			}));
 		}
 
 		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
 			if (e.key === 'Enter' || e.key === ' ') {
 				dom.EventHelper.stop(e, true);
-				this._showPicker();
+				this.showPicker();
 			}
 		}));
 
@@ -136,7 +136,7 @@ export class ModePicker extends Disposable {
 		return result;
 	}
 
-	private _showPicker(): void {
+	showPicker(): void {
 		if (!this._triggerElement || this.actionWidgetService.isVisible) {
 			return;
 		}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/modelPicker.ts
@@ -113,14 +113,14 @@ export class CloudModelPicker extends Disposable {
 		for (const eventType of [dom.EventType.CLICK, TouchEventType.Tap]) {
 			this._renderDisposables.add(dom.addDisposableListener(trigger, eventType, (e) => {
 				dom.EventHelper.stop(e, true);
-				this._showPicker();
+				this.showPicker();
 			}));
 		}
 
 		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
 			if (e.key === 'Enter' || e.key === ' ') {
 				dom.EventHelper.stop(e, true);
-				this._showPicker();
+				this.showPicker();
 			}
 		}));
 
@@ -149,7 +149,7 @@ export class CloudModelPicker extends Disposable {
 		this._updateTriggerLabel();
 	}
 
-	private _showPicker(): void {
+	showPicker(): void {
 		if (!this._triggerElement || this.actionWidgetService.isVisible || this._models.length === 0) {
 			return;
 		}


### PR DESCRIPTION
## Problem

`Cmd+.` (open mode/agent picker) and `Cmd+Option+.` (open model picker) do not work when focused in the new chat input in the agents/sessions window.

## Root Cause

The `NewChatInputWidget` in the sessions window never set `ChatContextKeys.inChatInput` or `ChatContextKeys.location` on its scoped context key service. The workbench-level keybindings for these pickers require `inChatInput === true`, so the shortcuts silently failed.

## Fix

1. **Set missing context keys** in `NewChatInputWidget` — `inChatInput` and `location` are now bound to the input-scoped context key service, matching what `ChatInputPart` does in the main workbench.

2. **Add dedicated keybindings** on the session-specific picker actions (`modePicker`, `localModelPicker`, `cloudModelPicker`, `agentHostModelPicker`), scoped to `isSessionsWindow && inChatInput` with higher weight than the workbench-level bindings.

3. **Module-level callback registry** — Since the session picker widgets are rendered via `MenuWorkbenchToolBar` and `IActionViewItemService`, the `Action2.run()` methods don't have direct access to picker instances. A lightweight callback map bridges this gap: pickers register their `showPicker()` on creation and unregister on disposal.

4. **Public `showPicker()`** on `ModePicker`, `CloudModelPicker`, and `SessionModelPicker` so the callback registry can invoke them.

## Files Changed

| File | Change |
|------|--------|
| `sessions/contrib/chat/browser/newChatInput.ts` | Set `inChatInput` and `location` context keys |
| `sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts` | Add keybindings + callback registry for mode/model pickers |
| `sessions/contrib/copilotChatSessions/browser/modePicker.ts` | Make `showPicker()` public |
| `sessions/contrib/copilotChatSessions/browser/modelPicker.ts` | Make `showPicker()` public |
| `sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts` | Add keybinding + callback for agent host model picker |