### PR TITLE
chat: don't auto-send queued prompts when confirmation is pending

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1403,7 +1403,9 @@ export class ChatService extends Disposable implements IChatService {
 						this.chatEntitlementService.markAnonymousRateLimited();
 					}
 
-					shouldProcessPending = !rawResult.errorDetails && !token.isCancellationRequested;
+					shouldProcessPending = !rawResult.errorDetails
+						&& !token.isCancellationRequested
+						&& !request.response?.response.value.some(v => v.kind === 'confirmation' && !v.isUsed);
 					request.response?.complete();
 
 					if (agentOrCommandFollowups) {


### PR DESCRIPTION
chat: don't auto-send queued prompts when confirmation is pending

- Prevents queued prompts from being automatically sent when the response
  contains a confirmation that hasn't been acted on yet
- Adds a check for unresolved confirmation parts in the response before
  processing pending requests

Fixes https://github.com/microsoft/vscode/issues/306522

(Commit message generated by Copilot)