### PR TITLE
agentHost: don't use a AH terminal by default for local connections

### DIFF
--- a/src/vs/sessions/common/agentHostSessionsProvider.ts
+++ b/src/vs/sessions/common/agentHostSessionsProvider.ts
@@ -68,8 +68,10 @@ export interface IAgentHostSessionsProvider extends ISessionsProvider {
 	clearSessionConfig(sessionId: string): void;
 }
 
-const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
-const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
+export const LOCAL_AGENT_HOST_PROVIDER_ID = 'local-agent-host';
+export const REMOTE_AGENT_HOST_PROVIDER_PREFIX = 'agenthost-';
+export const REMOTE_AGENT_HOST_PROVIDER_RE = /^agenthost-/;
+export const ANY_AGENT_HOST_PROVIDER_RE = /^(local-agent-host|agenthost-)/;
 
 /**
  * Checks whether a provider is an agent host provider based on its

--- a/src/vs/sessions/contrib/agentHost/browser/agentSessionSettings.contribution.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentSessionSettings.contribution.ts
@@ -16,6 +16,7 @@ import { ChatSessionProviderIdContext } from '../../../common/contextkeys.js';
 import { ISession } from '../../../services/sessions/common/session.js';
 import { SessionItemContextMenuId } from '../../sessions/browser/views/sessionsList.js';
 import { agentSessionSettingsUri, AGENT_SESSION_SETTINGS_SCHEME, AgentSessionSettingsFileSystemProvider, AgentSessionSettingsSchemaRegistrar } from './agentSessionSettingsFileSystemProvider.js';
+import { ANY_AGENT_HOST_PROVIDER_RE } from '../../../common/agentHostSessionsProvider.js';
 
 /**
  * Registers the {@link AgentSessionSettingsFileSystemProvider} with the
@@ -57,7 +58,7 @@ registerAction2(class OpenSessionSettingsAction extends Action2 {
 				id: SessionItemContextMenuId,
 				group: '2_settings',
 				order: 1,
-				when: ContextKeyExpr.regex(ChatSessionProviderIdContext.key, /^(local-agent-host|agenthost-)/),
+				when: ContextKeyExpr.regex(ChatSessionProviderIdContext.key, ANY_AGENT_HOST_PROVIDER_RE),
 			}]
 		});
 	}

--- a/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -22,8 +22,8 @@ import { BaseAgentHostSessionsProvider } from './baseAgentHostSessionsProvider.j
 import { buildAgentHostSessionWorkspace } from '../../../common/agentHostSessionWorkspace.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction } from '../../../services/sessions/common/session.js';
 import { toAgentHostUri } from '../../../../platform/agentHost/common/agentHostUri.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../common/agentHostSessionsProvider.js';
 
-const LOCAL_PROVIDER_ID = 'local-agent-host';
 const LOCAL_RESOURCE_SCHEME_PREFIX = 'agent-host-';
 
 /**
@@ -36,7 +36,7 @@ const LOCAL_RESOURCE_SCHEME_PREFIX = 'agent-host-';
  */
 export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvider {
 
-	readonly id = LOCAL_PROVIDER_ID;
+	readonly id = LOCAL_AGENT_HOST_PROVIDER_ID;
 	readonly label: string;
 	readonly icon: ThemeIcon = Codicon.vm;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];

--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostModelPicker.ts
@@ -21,10 +21,11 @@ import { type ISession } from '../../../../services/sessions/common/session.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { Menus } from '../../../../browser/menus.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 
 const IsActiveSessionAgentHost = ContextKeyExpr.or(
-	ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host'),
-	ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/),
+	ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID),
+	ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, REMOTE_AGENT_HOST_PROVIDER_RE),
 );
 
 // -- Agent Host Model Picker Action --

--- a/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/agentHost/agentHostSessionConfigPicker.ts
@@ -34,13 +34,13 @@ import { ActiveSessionProviderIdContext } from '../../../../common/contextkeys.j
 import { ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import type { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
-import { type IAgentHostSessionsProvider, isAgentHostProvider } from '../../../../common/agentHostSessionsProvider.js';
+import { type IAgentHostSessionsProvider, isAgentHostProvider, LOCAL_AGENT_HOST_PROVIDER_ID, REMOTE_AGENT_HOST_PROVIDER_RE } from '../../../../common/agentHostSessionsProvider.js';
 import { PermissionPicker } from '../../../copilotChatSessions/browser/permissionPicker.js';
 import { AgentHostPermissionPickerActionItem } from './agentHostPermissionPickerActionItem.js';
 import { AgentHostPermissionPickerDelegate, AUTO_APPROVE_PROPERTY, isWellKnownAutoApproveSchema } from './agentHostPermissionPickerDelegate.js';
 
-const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, /^agenthost-/);
-const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, 'local-agent-host');
+const IsActiveSessionRemoteAgentHost = ContextKeyExpr.regex(ActiveSessionProviderIdContext.key, REMOTE_AGENT_HOST_PROVIDER_RE);
+const IsActiveSessionLocalAgentHost = ContextKeyExpr.equals(ActiveSessionProviderIdContext.key, LOCAL_AGENT_HOST_PROVIDER_ID);
 
 registerAction2(class extends Action2 {
 	constructor() {

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -18,7 +18,7 @@ import { ITerminalInstance, ITerminalService } from '../../../../workbench/contr
 import { TerminalCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { Menus } from '../../../browser/menus.js';
-import { isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { isAgentHostProvider, LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../common/agentHostSessionsProvider.js';
 import { SessionsWelcomeVisibleContext, IsPhoneLayoutContext } from '../../../common/contextkeys.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { CopilotCLISessionType, ISession } from '../../../services/sessions/common/session.js';
@@ -86,13 +86,17 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		super();
 
 		const profileOverride = derived(reader => {
-			const profiles = this._agentHostTerminalService.profiles.read(reader);
 			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (!session || session.providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
+				return; // no need to override local default profiles with the local AH
+			}
+
 			const address = this._getSessionAgentHostAddress(session);
 			if (!address) {
 				return;
 			}
 
+			const profiles = this._agentHostTerminalService.profiles.read(reader);
 			return profiles.find(p => p.address === address) ?? this._agentHostTerminalService.getProfileForConnection(address);
 		});
 


### PR DESCRIPTION
Downside is that it's not shared with clients by default. But in exchange it uses the richer shell features we have through VS Code. Probably worth it?

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
