### PR TITLE
fix: prevent endless rAF loop in layout when widget is hidden

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -526,6 +526,7 @@ export class AICustomizationListWidget extends Disposable {
 	private displayEntries: IListEntry[] = [];
 	private searchQuery: string = '';
 	private readonly collapsedGroups = new Set<string>();
+	private _layoutDeferred = false;
 	private readonly dropdownActionDisposables = this._register(new DisposableStore());
 	private _loadItemsSeq = 0;
 
@@ -1496,16 +1497,20 @@ export class AICustomizationListWidget extends Disposable {
 		this.searchInput.layout();
 
 		// Measure sibling elements to calculate the remaining space for the list.
-		// When offsetHeight returns 0 the container just became visible
-		// after display:none and the browser hasn't reflowed yet — defer
-		// layout to the next frame so measurements are accurate.
-		// Skip the retry when the element is hidden (display:none parent)
-		// since rAF will never produce a non-zero measurement.
+		// When offsetHeight returns 0 the container may have just become visible
+		// after display:none and the browser hasn't reflowed yet — defer layout
+		// once so measurements are accurate. Only retry once to avoid an endless
+		// loop when the widget is created while permanently hidden.
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight;
-		if (searchBarHeight === 0 && this.element.offsetParent !== null) {
-			DOM.getWindow(this.element).requestAnimationFrame(() => this.layout(height, width));
+		if (searchBarHeight === 0 && !this._layoutDeferred) {
+			this._layoutDeferred = true;
+			DOM.getWindow(this.element).requestAnimationFrame(() => {
+				this._layoutDeferred = false;
+				this.layout(height, width);
+			});
 			return;
 		}
+		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1505,12 +1505,14 @@ export class AICustomizationListWidget extends Disposable {
 		if (searchBarHeight === 0 && !this._layoutDeferred) {
 			this._layoutDeferred = true;
 			DOM.getWindow(this.element).requestAnimationFrame(() => {
-				this._layoutDeferred = false;
-				this.layout(height, width);
+				try {
+					this.layout(height, width);
+				} finally {
+					this._layoutDeferred = false;
+				}
 			});
 			return;
 		}
-		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -388,6 +388,7 @@ export class McpListWidget extends Disposable {
 	private browseMode: boolean = false;
 	private lastHeight: number = 0;
 	private lastWidth: number = 0;
+	private _layoutDeferred = false;
 	private readonly collapsedGroups = new Set<string>();
 	private galleryCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
@@ -953,16 +954,20 @@ export class McpListWidget extends Disposable {
 		this.element.style.height = `${height}px`;
 
 		// Measure sibling elements to calculate the list height.
-		// When offsetHeight returns 0 the container just became visible
-		// after display:none and the browser hasn't reflowed yet — defer
-		// layout to the next frame so measurements are accurate.
-		// Skip the retry when the element is hidden (display:none parent)
-		// since rAF will never produce a non-zero measurement.
+		// When offsetHeight returns 0 the container may have just become visible
+		// after display:none and the browser hasn't reflowed yet — defer layout
+		// once so measurements are accurate. Only retry once to avoid an endless
+		// loop when the widget is created while permanently hidden.
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight;
-		if (searchBarHeight === 0 && this.element.offsetParent !== null) {
-			DOM.getWindow(this.element).requestAnimationFrame(() => this.layout(this.lastHeight, this.lastWidth));
+		if (searchBarHeight === 0 && !this._layoutDeferred) {
+			this._layoutDeferred = true;
+			DOM.getWindow(this.element).requestAnimationFrame(() => {
+				this._layoutDeferred = false;
+				this.layout(this.lastHeight, this.lastWidth);
+			});
 			return;
 		}
+		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -962,12 +962,14 @@ export class McpListWidget extends Disposable {
 		if (searchBarHeight === 0 && !this._layoutDeferred) {
 			this._layoutDeferred = true;
 			DOM.getWindow(this.element).requestAnimationFrame(() => {
-				this._layoutDeferred = false;
-				this.layout(this.lastHeight, this.lastWidth);
+				try {
+					this.layout(this.lastHeight, this.lastWidth);
+				} finally {
+					this._layoutDeferred = false;
+				}
 			});
 			return;
 		}
-		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -353,6 +353,7 @@ export class PluginListWidget extends Disposable {
 	private browseMode: boolean = false;
 	private lastHeight: number = 0;
 	private lastWidth: number = 0;
+	private _layoutDeferred = false;
 	private readonly collapsedGroups = new Set<string>();
 	private marketplaceCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
@@ -846,16 +847,20 @@ export class PluginListWidget extends Disposable {
 		this.element.style.height = `${height}px`;
 
 		// Measure sibling elements to calculate the list height.
-		// When offsetHeight returns 0 the container just became visible
-		// after display:none and the browser hasn't reflowed yet — defer
-		// layout to the next frame so measurements are accurate.
-		// Skip the retry when the element is hidden (display:none parent)
-		// since rAF will never produce a non-zero measurement.
+		// When offsetHeight returns 0 the container may have just become visible
+		// after display:none and the browser hasn't reflowed yet — defer layout
+		// once so measurements are accurate. Only retry once to avoid an endless
+		// loop when the widget is created while permanently hidden.
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight;
-		if (searchBarHeight === 0 && this.element.offsetParent !== null) {
-			DOM.getWindow(this.element).requestAnimationFrame(() => this.layout(this.lastHeight, this.lastWidth));
+		if (searchBarHeight === 0 && !this._layoutDeferred) {
+			this._layoutDeferred = true;
+			DOM.getWindow(this.element).requestAnimationFrame(() => {
+				this._layoutDeferred = false;
+				this.layout(this.lastHeight, this.lastWidth);
+			});
 			return;
 		}
+		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -855,12 +855,14 @@ export class PluginListWidget extends Disposable {
 		if (searchBarHeight === 0 && !this._layoutDeferred) {
 			this._layoutDeferred = true;
 			DOM.getWindow(this.element).requestAnimationFrame(() => {
-				this._layoutDeferred = false;
-				this.layout(this.lastHeight, this.lastWidth);
+				try {
+					this.layout(this.lastHeight, this.lastWidth);
+				} finally {
+					this._layoutDeferred = false;
+				}
 			});
 			return;
 		}
-		this._layoutDeferred = false;
 		const footerHeight = this.sectionHeader.offsetHeight;
 		const listHeight = Math.max(0, height - searchBarHeight - footerHeight);
 


### PR DESCRIPTION
The `layout()` methods in `mcpListWidget`, `pluginListWidget`, and `aiCustomizationListWidget` defer to `requestAnimationFrame` when `searchAndButtonContainer.offsetHeight` is 0, assuming the browser hasn't reflowed yet after a `display:none` → visible transition.

When the widget is created while permanently hidden (e.g. in component explorer, or when the MCP servers view is created but not visible), `offsetHeight` stays 0 forever, causing an **infinite rAF loop**.

### Fix

Add a `_layoutDeferred` flag so the deferral happens **at most once**. If `offsetHeight` is still 0 after the single retry, we proceed with zero heights instead of looping — the next real `layout()` call when the widget becomes visible will compute correct dimensions.