### PR TITLE
sessions: add developer command to kill SSH remote agent host

### DIFF
--- a/src/vs/platform/agentHost/browser/nullSshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullSshRemoteAgentHostService.ts
@@ -22,6 +22,8 @@ export class NullSSHRemoteAgentHostService implements ISSHRemoteAgentHostService
 
 	async disconnect(_host: string): Promise<void> { }
 
+	async killRemoteAgentHost(_host: string): Promise<void> { }
+
 	async listSSHConfigHosts(): Promise<string[]> {
 		return [];
 	}

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -104,6 +104,13 @@ export interface ISSHRemoteAgentHostService {
 	 */
 	disconnect(host: string): Promise<void>;
 
+	/**
+	 * Forcefully kill the remote agent host process tracked by our state file
+	 * for an active SSH connection, then tear down the SSH tunnel. Useful as
+	 * a developer escape hatch when the remote process is wedged.
+	 */
+	killRemoteAgentHost(host: string): Promise<void>;
+
 	/** List SSH config host aliases (excluding wildcards). */
 	listSSHConfigHosts(): Promise<string[]>;
 
@@ -198,6 +205,12 @@ export interface ISSHRemoteAgentHostMainService {
 	 * Disconnect an SSH-bootstrapped connection by host address.
 	 */
 	disconnect(host: string): Promise<void>;
+
+	/**
+	 * Kill the remote agent host process tracked by our state file for the
+	 * SSH connection identified by {@link host}, then tear down the tunnel.
+	 */
+	killRemoteAgentHost(host: string): Promise<void>;
 
 	/** List SSH config host aliases (excluding wildcards). */
 	listSSHConfigHosts(): Promise<string[]>;

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -87,6 +87,10 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 		await this._mainService.disconnect(host);
 	}
 
+	async killRemoteAgentHost(host: string): Promise<void> {
+		await this._mainService.killRemoteAgentHost(host);
+	}
+
 	async listSSHConfigHosts(): Promise<string[]> {
 		return this._mainService.listSSHConfigHosts();
 	}

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -590,6 +590,22 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 		}
 	}
 
+	async killRemoteAgentHost(host: string): Promise<void> {
+		for (const [key, conn] of this._connections) {
+			if (key === host || conn.connectionId === host) {
+				const exec = bindSshExec(conn.sshClient);
+				try {
+					await cleanupRemoteAgentHost(exec, this._logService, this._quality);
+				} catch (err) {
+					this._logService.warn(`${LOG_PREFIX} Error killing remote agent host for ${key}: ${err}`);
+				}
+				conn.dispose();
+				return;
+			}
+		}
+		this._logService.warn(`${LOG_PREFIX} killRemoteAgentHost: no active SSH connection found for ${host}`);
+	}
+
 	async relaySend(connectionId: string, message: string): Promise<void> {
 		for (const conn of this._connections.values()) {
 			if (conn.connectionId === connectionId) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -5,6 +5,7 @@
 
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
@@ -476,6 +477,55 @@ registerAction2(class extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		await promptToConnectViaSSH(accessor);
+	}
+});
+
+interface ISSHConnectionPickItem extends IQuickPickItem {
+	readonly localAddress: string;
+}
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.sessions.killRemoteAgentHostSSH',
+			title: localize2('killRemoteAgentHostSSH', "Kill Remote Agent Host (SSH)..."),
+			category: Categories.Developer,
+			f1: true,
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sshService = accessor.get(ISSHRemoteAgentHostService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		const connections = sshService.connections;
+		if (connections.length === 0) {
+			notificationService.info(localize('killSSHNoConnections', "No active SSH remote agent host connections."));
+			return;
+		}
+
+		const picks: ISSHConnectionPickItem[] = connections.map(conn => ({
+			label: conn.name,
+			description: conn.localAddress,
+			localAddress: conn.localAddress,
+		}));
+
+		const picked = await quickInputService.pick(picks, {
+			title: localize('killSSHTitle', "Kill Remote Agent Host (SSH)"),
+			placeHolder: localize('killSSHPlaceholder', "Select an SSH connection to kill"),
+		});
+		if (!picked) {
+			return;
+		}
+
+		try {
+			await sshService.killRemoteAgentHost(picked.localAddress);
+			notificationService.info(localize('killSSHDone', "Killed remote agent host for {0}.", picked.label));
+		} catch (err) {
+			notificationService.error(localize('killSSHFailed', "Failed to kill remote agent host for {0}: {1}", picked.label, String(err)));
+		}
 	}
 });
 


### PR DESCRIPTION
## Summary

Adds a **Developer: Kill Remote Agent Host (SSH)...** command (`workbench.action.sessions.killRemoteAgentHostSSH`) as a developer escape hatch for when a remote agent host process becomes wedged. It kills the remote process via SSH and tears down the tunnel.

## Changes

### `ISSHRemoteAgentHostService` / `ISSHRemoteAgentHostMainService` (common interface)
- Added `killRemoteAgentHost(host: string): Promise<void>` to both interfaces.

### `SSHRemoteAgentHostMainService` (shared process, node)
- Implemented `killRemoteAgentHost`: finds the matching `SSHConnection` by key or connectionId, calls `cleanupRemoteAgentHost` (existing helper that reads the remote state file, kills the PID, and removes the state file) over the connection's SSH client, then disposes the connection to tear down the tunnel.

### Renderer proxy & null impl
- `SSHRemoteAgentHostService` (electron-browser): forwards to the main service via the existing IPC proxy.
- `NullSSHRemoteAgentHostService` (browser): no-op.

### Developer command (`remoteAgentHostActions.ts`)
- Registered under the **Developer** category, visible via the command palette.
- Quick-picks from active SSH connections (label = display name, description = local address).
- Calls `killRemoteAgentHost` and shows a success/error notification.
