### PR TITLE
plugins: deduplicate canonical command ID when skill name matches plugin name

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -66,6 +66,13 @@ export function getCanonicalPluginCommandId(plugin: { readonly uri: URI }, comma
 		return normalizedCommand;
 	}
 
+	// When the skill name matches the plugin name, use just the plugin
+	// name so the user can invoke `/plugin-name` instead of the redundant
+	// `/plugin-name:plugin-name`.
+	if (prefix === normalizedCommand) {
+		return prefix;
+	}
+
 	return `${prefix}:${normalizedCommand}`;
 }
 


### PR DESCRIPTION
plugins: deduplicate canonical command ID when skill name matches plugin name

When a plugin's skill name matches the plugin name, the canonical command
ID was producing a redundant format like `plugin-name:plugin-name`. This
change collapses that to just `plugin-name` so users can invoke
`/plugin-name` instead of `/plugin-name:plugin-name`.

- Adds a check in getCanonicalPluginCommandId to return just the prefix
  when it equals the normalized command name

(Commit message generated by Copilot)