### PR TITLE
agentHost: resolve user shell environment for agent host process

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1143,7 +1143,7 @@ export class CodeApplication extends Disposable {
 
 		// Agent Host
 		if (this.configurationService.getValue(AgentHostEnabledSettingId)) {
-			const agentHostStarter = new ElectronAgentHostStarter(this.environmentMainService, this.lifecycleMainService, this.logService);
+			const agentHostStarter = new ElectronAgentHostStarter(this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
 			this._register(new AgentHostProcessManager(agentHostStarter, this.logService, this.loggerService));
 		}
 

--- a/src/vs/platform/agentHost/common/agent.ts
+++ b/src/vs/platform/agentHost/common/agent.ts
@@ -23,5 +23,5 @@ export interface IAgentHostStarter extends IDisposable {
 	/**
 	 * Creates the agent host utility process and connects to it.
 	 */
-	start(): IAgentHostConnection;
+	start(): Promise<IAgentHostConnection>;
 }

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -4,23 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
+import { DeferredPromise } from '../../../base/common/async.js';
 import { Emitter } from '../../../base/common/event.js';
-import { deepClone } from '../../../base/common/objects.js';
 import { IpcMainEvent } from 'electron';
 import { validatedIpcMain } from '../../../base/parts/ipc/electron-main/ipcMain.js';
 import { Client as MessagePortClient } from '../../../base/parts/ipc/electron-main/ipc.mp.js';
+import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentMainService } from '../../environment/electron-main/environmentMainService.js';
 import { parseAgentHostDebugPort } from '../../environment/node/environmentService.js';
 import { ILifecycleMainService } from '../../lifecycle/electron-main/lifecycleMainService.js';
 import { ILogService } from '../../log/common/log.js';
 import { Schemas } from '../../../base/common/network.js';
+import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { UtilityProcess } from '../../utilityProcess/electron-main/utilityProcess.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
+import { deepClone } from '../../../base/common/objects.js';
 
 export class ElectronAgentHostStarter extends Disposable implements IAgentHostStarter {
 
 	private utilityProcess: UtilityProcess | undefined = undefined;
+	private utilityProcessStarted: DeferredPromise<void> | undefined = undefined;
 
 	private readonly _onRequestConnection = this._register(new Emitter<void>());
 	readonly onRequestConnection = this._onRequestConnection.event;
@@ -28,6 +32,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 	readonly onWillShutdown = this._onWillShutdown.event;
 
 	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEnvironmentMainService private readonly _environmentMainService: IEnvironmentMainService,
 		@ILifecycleMainService private readonly _lifecycleMainService: ILifecycleMainService,
 		@ILogService private readonly _logService: ILogService,
@@ -44,14 +49,19 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		}));
 	}
 
-	start(): IAgentHostConnection {
+	async start(): Promise<IAgentHostConnection> {
 		this.utilityProcess = new UtilityProcess(this._logService, NullTelemetryService, this._lifecycleMainService);
+		this.utilityProcessStarted = new DeferredPromise<void>();
 
 		const inspectParams = parseAgentHostDebugPort(this._environmentMainService.args, this._environmentMainService.isBuilt);
 		const execArgv = inspectParams.port ? [
 			'--nolazy',
 			`--inspect${inspectParams.break ? '-brk' : ''}=${inspectParams.port}`
 		] : undefined;
+
+		// Resolve user shell environment so spawned tools/terminals inherit
+		// PATH and other vars from the user's login shell (macOS/Linux GUI launches).
+		const shellEnv = await this._resolveShellEnv();
 
 		this.utilityProcess.start({
 			type: 'agentHost',
@@ -60,12 +70,15 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			execArgv,
 			args: ['--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath],
 			env: {
+				...shellEnv,
 				...deepClone(process.env),
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',
 				VSCODE_VERBOSE_LOGGING: 'true',
 			}
 		});
+
+		this.utilityProcessStarted.complete();
 
 		const port = this.utilityProcess.connect();
 		const client = new MessagePortClient(port, 'agentHost');
@@ -82,6 +95,7 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			this.utilityProcess?.kill();
 			this.utilityProcess?.dispose();
 			this.utilityProcess = undefined;
+			this.utilityProcessStarted = undefined;
 		}));
 
 		return {
@@ -91,8 +105,21 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 		};
 	}
 
-	private _onWindowConnection(e: IpcMainEvent, nonce: string): void {
+	private async _resolveShellEnv(): Promise<typeof process.env> {
+		try {
+			return await getResolvedShellEnv(this._configurationService, this._logService, this._environmentMainService.args, process.env);
+		} catch (error) {
+			this._logService.error('AgentHostStarter was unable to resolve shell environment', error);
+			return {};
+		}
+	}
+
+	private async _onWindowConnection(e: IpcMainEvent, nonce: string): Promise<void> {
 		this._onRequestConnection.fire();
+
+		// Wait for utilityProcess.start() to actually run before calling connect(),
+		// otherwise the MessagePort posted via connect() is silently dropped.
+		await this.utilityProcessStarted?.p;
 
 		if (!this.utilityProcess) {
 			this._logService.error('AgentHostStarter: cannot create window connection, agent host process is not running');

--- a/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/electron-main/electronAgentHostStarter.ts
@@ -70,8 +70,8 @@ export class ElectronAgentHostStarter extends Disposable implements IAgentHostSt
 			execArgv,
 			args: ['--logsPath', this._environmentMainService.logsHome.with({ scheme: Schemas.file }).fsPath],
 			env: {
-				...shellEnv,
 				...deepClone(process.env),
+				...shellEnv,
 				VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 				VSCODE_PIPE_LOGGING: 'true',
 				VSCODE_VERBOSE_LOGGING: 'true',

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -53,33 +53,38 @@ export class AgentHostProcessManager extends Disposable {
 
 	private async _start(): Promise<void> {
 		this._started = true;
-		const connection = await this._starter.start();
+		try {
+			const connection = await this._starter.start();
 
-		if (this._store.isDisposed) {
-			connection.store.dispose();
-			return;
-		}
-
-		this._logService.info('AgentHostProcessManager: agent host started');
-
-		// Connect logger channel so agent host logs appear in the output channel
-		this._register(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
-
-		// Handle unexpected exit
-		this._register(connection.onDidProcessExit(e => {
-			if (!this._wasQuitRequested && !this._store.isDisposed) {
-				if (this._restartCount <= Constants.MaxRestarts) {
-					this._logService.error(`AgentHostProcessManager: agent host terminated unexpectedly with code ${e.code}`);
-					this._restartCount++;
-					this._started = false;
-					connection.store.dispose();
-					this._start();
-				} else {
-					this._logService.error(`AgentHostProcessManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
-				}
+			if (this._store.isDisposed) {
+				connection.store.dispose();
+				return;
 			}
-		}));
 
-		this._register(toDisposable(() => connection.store.dispose()));
+			this._logService.info('AgentHostProcessManager: agent host started');
+
+			// Connect logger channel so agent host logs appear in the output channel
+			this._register(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
+
+			// Handle unexpected exit
+			this._register(connection.onDidProcessExit(e => {
+				if (!this._wasQuitRequested && !this._store.isDisposed) {
+					if (this._restartCount <= Constants.MaxRestarts) {
+						this._logService.error(`AgentHostProcessManager: agent host terminated unexpectedly with code ${e.code}`);
+						this._restartCount++;
+						this._started = false;
+						connection.store.dispose();
+						this._start();
+					} else {
+						this._logService.error(`AgentHostProcessManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
+					}
+				}
+			}));
+
+			this._register(toDisposable(() => connection.store.dispose()));
+		} catch (error) {
+			this._started = false;
+			this._logService.error('AgentHostProcessManager: failed to start agent host', error);
+		}
 	}
 }

--- a/src/vs/platform/agentHost/node/agentHostService.ts
+++ b/src/vs/platform/agentHost/node/agentHostService.ts
@@ -51,8 +51,14 @@ export class AgentHostProcessManager extends Disposable {
 		}
 	}
 
-	private _start(): void {
-		const connection = this._starter.start();
+	private async _start(): Promise<void> {
+		this._started = true;
+		const connection = await this._starter.start();
+
+		if (this._store.isDisposed) {
+			connection.store.dispose();
+			return;
+		}
 
 		this._logService.info('AgentHostProcessManager: agent host started');
 
@@ -75,6 +81,5 @@ export class AgentHostProcessManager extends Disposable {
 		}));
 
 		this._register(toDisposable(() => connection.store.dispose()));
-		this._started = true;
 	}
 }

--- a/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
+++ b/src/vs/platform/agentHost/node/nodeAgentHostStarter.ts
@@ -7,8 +7,11 @@ import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
 import { Client, IIPCOptions } from '../../../base/parts/ipc/node/ipc.cp.js';
+import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { IEnvironmentService, INativeEnvironmentService } from '../../environment/common/environment.js';
 import { parseAgentHostDebugPort } from '../../environment/node/environmentService.js';
+import { ILogService } from '../../log/common/log.js';
+import { getResolvedShellEnv } from '../../shell/node/shellEnv.js';
 import { IAgentHostConnection, IAgentHostStarter } from '../common/agent.js';
 
 /**
@@ -38,7 +41,9 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 	readonly onRequestConnection = this._onRequestConnection.event;
 
 	constructor(
-		@IEnvironmentService private readonly _environmentService: INativeEnvironmentService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IEnvironmentService private readonly _environmentService: INativeEnvironmentService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 	}
@@ -55,8 +60,13 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 		this._onRequestConnection.fire();
 	}
 
-	start(): IAgentHostConnection {
+	async start(): Promise<IAgentHostConnection> {
+		// Resolve user shell environment so spawned tools/terminals inherit
+		// PATH and other vars from the user's login shell (macOS/Linux).
+		const shellEnv = await this._resolveShellEnv();
+
 		const env: Record<string, string> = {
+			...shellEnv as Record<string, string>,
 			VSCODE_ESM_ENTRYPOINT: 'vs/platform/agentHost/node/agentHostMain',
 			VSCODE_PIPE_LOGGING: 'true',
 			VSCODE_VERBOSE_LOGGING: 'true',
@@ -103,5 +113,14 @@ export class NodeAgentHostStarter extends Disposable implements IAgentHostStarte
 			store,
 			onDidProcessExit: client.onDidProcessExit
 		};
+	}
+
+	private async _resolveShellEnv(): Promise<typeof process.env> {
+		try {
+			return await getResolvedShellEnv(this._configurationService, this._logService, this._environmentService.args, process.env);
+		} catch (error) {
+			this._logService.error('AgentHostStarter was unable to resolve shell environment', error);
+			return {};
+		}
 	}
 }

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -63,8 +63,13 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 		this._start();
 	}
 
-	private _start(): void {
-		const connection = this._starter.start();
+	private async _start(): Promise<void> {
+		const connection = await this._starter.start();
+
+		if (this._store.isDisposed) {
+			connection.store.dispose();
+			return;
+		}
 
 		this._logService.info('ServerAgentHostManager: agent host started');
 

--- a/src/vs/server/node/serverAgentHostManager.ts
+++ b/src/vs/server/node/serverAgentHostManager.ts
@@ -64,41 +64,55 @@ export class ServerAgentHostManager extends Disposable implements IServerAgentHo
 	}
 
 	private async _start(): Promise<void> {
-		const connection = await this._starter.start();
+		try {
+			const connection = await this._starter.start();
 
-		if (this._store.isDisposed) {
-			connection.store.dispose();
-			return;
-		}
-
-		this._logService.info('ServerAgentHostManager: agent host started');
-
-		// Connect logger channel so agent host logs appear in the output channel
-		connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
-
-		this._trackActiveSessions(connection);
-		this._trackClientConnections(connection);
-
-		// Handle unexpected exit
-		connection.store.add(connection.onDidProcessExit(e => {
-			if (!this._store.isDisposed) {
-				// Both signals are gone when the process exits
-				this._hasActiveSessions = false;
-				this._connectionCount = 0;
-				this._lifetimeToken.clear();
-
-				if (this._restartCount <= Constants.MaxRestarts) {
-					this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
-					this._restartCount++;
-					connection.store.dispose();
-					this._start();
-				} else {
-					this._logService.error(`ServerAgentHostManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
-				}
+			if (this._store.isDisposed) {
+				connection.store.dispose();
+				return;
 			}
-		}));
 
-		this._register(toDisposable(() => connection.store.dispose()));
+			this._logService.info('ServerAgentHostManager: agent host started');
+
+			// Connect logger channel so agent host logs appear in the output channel
+			connection.store.add(new RemoteLoggerChannelClient(this._loggerService, connection.client.getChannel(AgentHostIpcChannels.Logger)));
+
+			this._trackActiveSessions(connection);
+			this._trackClientConnections(connection);
+
+			// Handle unexpected exit
+			connection.store.add(connection.onDidProcessExit(e => {
+				if (!this._store.isDisposed) {
+					// Both signals are gone when the process exits
+					this._hasActiveSessions = false;
+					this._connectionCount = 0;
+					this._lifetimeToken.clear();
+
+					if (this._restartCount <= Constants.MaxRestarts) {
+						this._logService.error(`ServerAgentHostManager: agent host terminated unexpectedly with code ${e.code}`);
+						this._restartCount++;
+						connection.store.dispose();
+						this._start();
+					} else {
+						this._logService.error(`ServerAgentHostManager: agent host terminated with code ${e.code}, giving up after ${Constants.MaxRestarts} restarts`);
+					}
+				}
+			}));
+
+			this._register(toDisposable(() => connection.store.dispose()));
+		} catch (error) {
+			if (this._store.isDisposed) {
+				return;
+			}
+
+			if (this._restartCount <= Constants.MaxRestarts) {
+				this._logService.error('ServerAgentHostManager: agent host failed to start', error);
+				this._restartCount++;
+				this._start();
+			} else {
+				this._logService.error(`ServerAgentHostManager: agent host failed to start, giving up after ${Constants.MaxRestarts} restarts`, error);
+			}
+		}
 	}
 
 	private _trackActiveSessions(connection: IAgentHostConnection): void {

--- a/src/vs/server/test/node/serverAgentHostManager.test.ts
+++ b/src/vs/server/test/node/serverAgentHostManager.test.ts
@@ -61,7 +61,7 @@ class MockAgentHostStarter implements IAgentHostStarter {
 		this.loggerChannel.setCallResult('getRegisteredLoggers', []);
 	}
 
-	start(): IAgentHostConnection {
+	async start(): Promise<IAgentHostConnection> {
 		const store = new DisposableStore();
 		const client: IChannelClient = {
 			getChannel: <T extends IChannel>(name: string): T => {
@@ -133,6 +133,12 @@ suite('ServerAgentHostManager', () => {
 		));
 	}
 
+	// `ServerAgentHostManager._start()` is async (awaits `starter.start()`).
+	// Wait a microtask so the channel listeners are wired up before tests fire events.
+	async function waitForStart(): Promise<void> {
+		await Promise.resolve();
+	}
+
 	function fireActiveSessions(count: number): void {
 		starter.agentHostChannel.getEmitter('onDidAction').fire({
 			action: { type: 'root/activeSessionsChanged', activeSessions: count },
@@ -145,25 +151,29 @@ suite('ServerAgentHostManager', () => {
 		starter.connectionTrackerChannel.getEmitter('onDidChangeConnectionCount').fire(count);
 	}
 
-	test('no lifetime token initially', () => {
+	test('no lifetime token initially', async () => {
 		createManager();
+		await waitForStart();
 		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
 	});
 
-	test('acquires token when sessions become active', () => {
+	test('acquires token when sessions become active', async () => {
 		createManager();
+		await waitForStart();
 		fireActiveSessions(1);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
-	test('acquires token when clients connect (no active sessions)', () => {
+	test('acquires token when clients connect (no active sessions)', async () => {
 		createManager();
+		await waitForStart();
 		fireConnectionCount(2);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
 	});
 
-	test('releases token only when both sessions and connections are zero', () => {
+	test('releases token only when both sessions and connections are zero', async () => {
 		createManager();
+		await waitForStart();
 
 		// Sessions active, no connections
 		fireActiveSessions(1);
@@ -182,8 +192,9 @@ suite('ServerAgentHostManager', () => {
 		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
 	});
 
-	test('releases token only when connections drop after sessions already idle', () => {
+	test('releases token only when connections drop after sessions already idle', async () => {
 		createManager();
+		await waitForStart();
 
 		fireConnectionCount(3);
 		assert.strictEqual(lifetimeService.hasActiveConsumers, true);
@@ -192,8 +203,9 @@ suite('ServerAgentHostManager', () => {
 		assert.strictEqual(lifetimeService.hasActiveConsumers, false);
 	});
 
-	test('process exit resets both signals and clears token', () => {
+	test('process exit resets both signals and clears token', async () => {
 		createManager();
+		await waitForStart();
 
 		fireActiveSessions(2);
 		fireConnectionCount(1);


### PR DESCRIPTION
Spawn the agent host with the user's resolved shell environment merged in (PATH and friends from the login shell), matching what other VS Code processes already do via `getResolvedShellEnv`. Without this, tools and terminals launched by the agent host on macOS/Linux GUI launches don't see the user's PATH.

## What changed

- Both `ElectronAgentHostStarter` and `NodeAgentHostStarter` now call `getResolvedShellEnv` and merge the result into the spawned agent host's env. The shell env resolution is cached at module scope in `shellEnv.ts`, so reusing the same call the main process already made is essentially free.
- `IAgentHostStarter.start()` is now async (`Promise<IAgentHostConnection>`). `AgentHostProcessManager._start()` and `ServerAgentHostManager._start()` await it and guard against the manager being disposed mid-await.
- The Electron starter now also injects `IConfigurationService`.

## Race fix in `_onWindowConnection`

Once `start()` became async (with an `await` on shell-env resolution), the renderer's `vscode:createAgentHostMessageChannel` IPC could race ahead and call `utilityProcess.connect()` before `utilityProcess.start()` had actually run. `connect()` calls `postMessage(port)` which silently returns false when the underlying process isn't started — the renderer's MessagePort got dropped, and the renderer never saw any agents advertised.

`_onWindowConnection` now awaits a `DeferredPromise<void>` (`utilityProcessStarted`) that completes once `utilityProcess.start()` has run.

## Tests

- Mock `IAgentHostStarter` in `serverAgentHostManager.test.ts` updated for the async signature; all tests now await a `waitForStart()` microtask before firing channel events.

## Why pty host doesn't need this

Pty host doesn't pre-resolve shell env into the spawned child — it just inherits `process.env`. Resolved shell env is used later, on demand, only for terminal profile detection and per-terminal launch configs (which are sent to the pty host via IPC). The agent host is different: tools it spawns internally need PATH baked into its own process env, because they aren't routed through a workbench-built launch config.

(Written by Copilot)