### PR TITLE
wrap bash compound commands in `bash -c` before nohup

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -46,18 +46,50 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	}
 
 	private _rewriteForPosix(options: ICommandLineRewriterOptions): ICommandLineRewriterResult {
+		const trimmed = options.commandLine.trimEnd();
+
+		// nohup only accepts a simple external command as its argument — it cannot exec bash
+		// compound statements (for/while/if/case) or shell builtins (eval/set/export/source).
+		// Wrap those in `bash -c '...'` so the whole construct runs as a single executable.
+		let commandToWrap = trimmed;
+		if (this._needsBashCWrapper(trimmed)) {
+			// Escape single quotes for use inside a single-quoted bash -c '...' string.
+			const escaped = trimmed.replace(/'/g, `'\\''`);
+			commandToWrap = `bash -c '${escaped}'`;
+		}
+
 		// If the command already ends with a single trailing `&` (background operator,
 		// as opposed to `&&` for command chaining), don't append another one.
-		const trimmed = options.commandLine.trimEnd();
-		const endsWithBackgroundAmp = /(?:^|[^&])&$/.test(trimmed);
+		const endsWithBackgroundAmp = /(?:^|[^&])&$/.test(commandToWrap);
 		const rewritten = endsWithBackgroundAmp
-			? `nohup ${trimmed}`
-			: `nohup ${options.commandLine} &`;
+			? `nohup ${commandToWrap}`
+			: `nohup ${commandToWrap} &`;
 		return {
 			rewritten,
 			reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 			forDisplay: options.commandLine,
 		};
+	}
+
+	/**
+	 * Returns true when the command uses bash compound constructs or shell builtins that
+	 * `nohup` cannot exec directly. Such commands must be wrapped in `bash -c '...'` before
+	 * being passed to nohup.
+	 */
+	private _needsBashCWrapper(commandLine: string): boolean {
+		const trimmed = commandLine.trimStart();
+		return (
+			// Bash compound command keywords — syntax constructs that are not executables.
+			/^(for|while|until|if|case|select|function)\b/.test(trimmed) ||
+			// Shell builtins — these only run meaningfully inside the current shell; nohup
+			// cannot exec them (eval, set, export, source, unset, declare, etc.).
+			/^(eval|set|export|source|unset|declare|typeset|local|readonly|alias)\b/.test(trimmed) ||
+			// `. file` (dot-source builtin). Exclude `./script` (relative path) by requiring
+			// a space or end-of-string after the dot.
+			/^\. /.test(trimmed) ||
+			// Compound groupings: subshell `( ... )` or brace group `{ ...; }`.
+			/^[{(]/.test(trimmed)
+		);
 	}
 
 	private _rewriteForPowerShell(options: ICommandLineRewriterOptions): ICommandLineRewriterResult | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { OperatingSystem } from '../../../../../../../base/common/platform.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
-import { isPowerShell } from '../../runInTerminalHelpers.js';
+import { isFish, isPowerShell } from '../../runInTerminalHelpers.js';
 import type { ICommandLineRewriter, ICommandLineRewriterOptions, ICommandLineRewriterResult } from './commandLineRewriter.js';
 
 /**
@@ -48,14 +48,21 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	private _rewriteForPosix(options: ICommandLineRewriterOptions): ICommandLineRewriterResult {
 		const trimmed = options.commandLine.trimEnd();
 
-		// nohup only accepts a simple external command as its argument — it cannot exec bash
+		// nohup only accepts a simple external command as its argument — it cannot exec
 		// compound statements (for/while/if/case) or shell builtins (eval/set/export/source).
-		// Wrap those in `bash -c '...'` so the whole construct runs as a single executable.
+		// Wrap those in `<shell> -c '...'` so the whole construct runs as a single executable.
 		let commandToWrap = trimmed;
-		if (this._needsBashCWrapper(trimmed)) {
-			// Escape single quotes for use inside a single-quoted bash -c '...' string.
-			const escaped = trimmed.replace(/'/g, `'\\''`);
-			commandToWrap = `bash -c '${escaped}'`;
+		if (this._needsShellCWrapper(trimmed)) {
+			if (isFish(options.shell, options.os)) {
+				// Fish does not support the POSIX '\'' escape inside single-quoted strings.
+				// Use a double-quoted string and escape backslash and double-quote instead.
+				const escaped = trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+				commandToWrap = `${options.shell} -c "${escaped}"`;
+			} else {
+				// bash/zsh: escape single quotes for use inside a single-quoted shell -c '...' string.
+				const escaped = trimmed.replace(/'/g, `'\\''`);
+				commandToWrap = `${options.shell} -c '${escaped}'`;
+			}
 		}
 
 		// If the command already ends with a single trailing `&` (background operator,
@@ -72,11 +79,11 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	}
 
 	/**
-	 * Returns true when the command uses bash compound constructs or shell builtins that
-	 * `nohup` cannot exec directly. Such commands must be wrapped in `bash -c '...'` before
+	 * Returns true when the command uses shell compound constructs or builtins that
+	 * `nohup` cannot exec directly. Such commands must be wrapped in `<shell> -c '...'` before
 	 * being passed to nohup.
 	 */
-	private _needsBashCWrapper(commandLine: string): boolean {
+	private _needsShellCWrapper(commandLine: string): boolean {
 		const trimmed = commandLine.trimStart();
 		return (
 			// Bash compound command keywords — syntax constructs that are not executables.
@@ -85,8 +92,8 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 			// cannot exec them (eval, set, export, source, unset, declare, etc.).
 			/^(eval|set|export|source|unset|declare|typeset|local|readonly|alias)\b/.test(trimmed) ||
 			// `. file` (dot-source builtin). Exclude `./script` (relative path) by requiring
-			// a space or end-of-string after the dot.
-			/^\. /.test(trimmed) ||
+			// whitespace after the dot.
+			/^\.\s/.test(trimmed) ||
 			// Compound groupings: subshell `( ... )` or brace group `{ ...; }`.
 			/^[{(]/.test(trimmed)
 		);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
@@ -94,6 +94,96 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 		});
 	});
 
+	suite('POSIX bash -c wrapping for compound commands and builtins', () => {
+		test('for loop should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('for i in $(seq 1 90); do echo $i; sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'for i in $(seq 1 90); do echo $i; sleep 1; done',
+			});
+		});
+
+		test('while loop should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('while true; do sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'while true; do sleep 1; done' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'while true; do sleep 1; done',
+			});
+		});
+
+		test('if statement should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('if [ -f file ]; then cat file; fi', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'if [ -f file ]; then cat file; fi' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'if [ -f file ]; then cat file; fi',
+			});
+		});
+
+		test('eval builtin should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('eval $SETUP_ENV && opam install coq --yes', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'eval $SETUP_ENV && opam install coq --yes' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'eval $SETUP_ENV && opam install coq --yes',
+			});
+		});
+
+		test('set builtin should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('set -e; cmd1; cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'set -e; cmd1; cmd2' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'set -e; cmd1; cmd2',
+			});
+		});
+
+		test('export builtin should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('export PATH="/usr/local/bin:$PATH"; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'export PATH="/usr/local/bin:$PATH"; myapp' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'export PATH="/usr/local/bin:$PATH"; myapp',
+			});
+		});
+
+		test('dot-source builtin should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('. /etc/profile; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c '. /etc/profile; myapp' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: '. /etc/profile; myapp',
+			});
+		});
+
+		test('relative path ./script should NOT be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('./start.sh', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: 'nohup ./start.sh &',
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: './start.sh',
+			});
+		});
+
+		test('brace group should be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('{ cmd1; cmd2; }', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c '{ cmd1; cmd2; }' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: '{ cmd1; cmd2; }',
+			});
+		});
+
+		test('single quotes in command should be properly escaped', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions(`for f in *.txt; do echo 'file:' $f; done`, '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup bash -c 'for f in *.txt; do echo '\\''file:'\\'' $f; done' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: `for f in *.txt; do echo 'file:' $f; done`,
+			});
+		});
+
+		test('simple external command should NOT be wrapped in bash -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('python3 app.py', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: 'nohup python3 app.py &',
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'python3 app.py',
+			});
+		});
+	});
+
 	suite('POSIX (zsh)', () => {
 		test('should wrap with nohup', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('node server.js', '/bin/zsh', OperatingSystem.Linux, true)), {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
@@ -94,64 +94,64 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 		});
 	});
 
-	suite('POSIX bash -c wrapping for compound commands and builtins', () => {
-		test('for loop should be wrapped in bash -c', () => {
+	suite('POSIX shell -c wrapping for compound commands and builtins', () => {
+		test('for loop should be wrapped using bash shell path', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('for i in $(seq 1 90); do echo $i; sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' &`,
+				rewritten: `nohup /bin/bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'for i in $(seq 1 90); do echo $i; sleep 1; done',
 			});
 		});
 
-		test('while loop should be wrapped in bash -c', () => {
+		test('while loop should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('while true; do sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'while true; do sleep 1; done' &`,
+				rewritten: `nohup /bin/bash -c 'while true; do sleep 1; done' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'while true; do sleep 1; done',
 			});
 		});
 
-		test('if statement should be wrapped in bash -c', () => {
+		test('if statement should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('if [ -f file ]; then cat file; fi', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'if [ -f file ]; then cat file; fi' &`,
+				rewritten: `nohup /bin/bash -c 'if [ -f file ]; then cat file; fi' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'if [ -f file ]; then cat file; fi',
 			});
 		});
 
-		test('eval builtin should be wrapped in bash -c', () => {
+		test('eval builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('eval $SETUP_ENV && opam install coq --yes', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'eval $SETUP_ENV && opam install coq --yes' &`,
+				rewritten: `nohup /bin/bash -c 'eval $SETUP_ENV && opam install coq --yes' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'eval $SETUP_ENV && opam install coq --yes',
 			});
 		});
 
-		test('set builtin should be wrapped in bash -c', () => {
+		test('set builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('set -e; cmd1; cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'set -e; cmd1; cmd2' &`,
+				rewritten: `nohup /bin/bash -c 'set -e; cmd1; cmd2' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'set -e; cmd1; cmd2',
 			});
 		});
 
-		test('export builtin should be wrapped in bash -c', () => {
+		test('export builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('export PATH="/usr/local/bin:$PATH"; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'export PATH="/usr/local/bin:$PATH"; myapp' &`,
+				rewritten: `nohup /bin/bash -c 'export PATH="/usr/local/bin:$PATH"; myapp' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'export PATH="/usr/local/bin:$PATH"; myapp',
 			});
 		});
 
-		test('dot-source builtin should be wrapped in bash -c', () => {
+		test('dot-source builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('. /etc/profile; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c '. /etc/profile; myapp' &`,
+				rewritten: `nohup /bin/bash -c '. /etc/profile; myapp' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: '. /etc/profile; myapp',
 			});
 		});
 
-		test('relative path ./script should NOT be wrapped in bash -c', () => {
+		test('relative path ./script should NOT be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('./start.sh', '/bin/bash', OperatingSystem.Linux, true)), {
 				rewritten: 'nohup ./start.sh &',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
@@ -159,9 +159,9 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 			});
 		});
 
-		test('brace group should be wrapped in bash -c', () => {
+		test('brace group should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('{ cmd1; cmd2; }', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c '{ cmd1; cmd2; }' &`,
+				rewritten: `nohup /bin/bash -c '{ cmd1; cmd2; }' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: '{ cmd1; cmd2; }',
 			});
@@ -169,13 +169,13 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('single quotes in command should be properly escaped', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions(`for f in *.txt; do echo 'file:' $f; done`, '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup bash -c 'for f in *.txt; do echo '\\''file:'\\'' $f; done' &`,
+				rewritten: `nohup /bin/bash -c 'for f in *.txt; do echo '\\''file:'\\'' $f; done' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: `for f in *.txt; do echo 'file:' $f; done`,
 			});
 		});
 
-		test('simple external command should NOT be wrapped in bash -c', () => {
+		test('simple external command should NOT be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('python3 app.py', '/bin/bash', OperatingSystem.Linux, true)), {
 				rewritten: 'nohup python3 app.py &',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
@@ -192,6 +192,14 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 				forDisplay: 'node server.js',
 			});
 		});
+
+		test('for loop should be wrapped using zsh shell path', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('for i in $(seq 1 10); do echo $i; done', '/bin/zsh', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/zsh -c 'for i in $(seq 1 10); do echo $i; done' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'for i in $(seq 1 10); do echo $i; done',
+			});
+		});
 	});
 
 	suite('POSIX (fish)', () => {
@@ -200,6 +208,22 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 				rewritten: 'nohup ruby app.rb &',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'ruby app.rb',
+			});
+		});
+
+		test('for loop should be wrapped using fish shell path with double-quote escaping', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('for i in (seq 1 10); echo $i; end', '/usr/bin/fish', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /usr/bin/fish -c "for i in (seq 1 10); echo $i; end" &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'for i in (seq 1 10); echo $i; end',
+			});
+		});
+
+		test('compound command with double quotes should be escaped for fish', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('for f in *.txt; echo "file: $f"; end', '/usr/bin/fish', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /usr/bin/fish -c "for f in *.txt; echo \\"file: $f\\"; end" &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'for f in *.txt; echo "file: $f"; end',
 			});
 		});
 	});


### PR DESCRIPTION
`nohup` can only exec external commands — it cannot run bash compound
statements (`for`, `while`, `if`, `case`, `eval`, `export`, etc.) or
shell builtins directly. Commands like:

  nohup for i in $(seq 1 90); do echo $i; sleep 1; done &

fail silently because `for` is not an executable.

Adds `_needsBashCWrapper()` to detect compound constructs and builtins,
wrapping them as:

  nohup bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' &

Single quotes inside the command are escaped with the POSIX `'\''`
pattern.

Fixes eval regressions on `terminal_long_running_prompt` (confirmed
broken nohup rewrite) and improves reliability of all background
terminal commands involving shell syntax.

Only affects POSIX paths when `chat.tools.terminal.detachBackgroundProcesses`
is enabled (experimental, default off).