### PR TITLE
sessions: add tip banner for sub-session creation

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -107,3 +107,72 @@
 .new-chat-in-session .new-chat-widget-container.revealed .new-session-workspace-picker-container {
 	animation: none;
 }
+
+/* --- Sub-session tip banner --- */
+
+.new-chat-in-session .sub-session-tip-container {
+	width: 100%;
+	max-width: 950px;
+}
+
+/* When tip is present, remove top border-radius from the input area so
+	the tip and input connect seamlessly. */
+.new-chat-in-session .sub-session-tip-container + .new-chat-input-container .new-chat-input-area {
+	border-radius: 0 0 var(--vscode-cornerRadius-large, 8px) var(--vscode-cornerRadius-large, 8px) !important;
+}
+
+.new-chat-in-session .sub-session-tip-container + .new-chat-input-container .new-chat-input-area .sessions-chat-editor .monaco-editor,
+.new-chat-in-session .sub-session-tip-container + .new-chat-input-container .new-chat-input-area .sessions-chat-editor .monaco-editor .overflow-guard,
+.new-chat-in-session .sub-session-tip-container + .new-chat-input-container .new-chat-input-area .sessions-chat-editor .monaco-editor-background {
+	border-radius: 0 !important;
+}
+
+.new-chat-in-session .sub-session-tip-widget {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+	padding: 6px 8px;
+	background-color: var(--vscode-editorWidget-background);
+	border-radius: var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0 0;
+	border: 1px solid var(--vscode-agentsChatInput-border, var(--vscode-editorWidget-border, var(--vscode-input-border, transparent)));
+	border-bottom: none;
+	font-size: var(--vscode-chat-font-size-body-s);
+	font-family: var(--vscode-chat-font-family, inherit);
+	color: var(--vscode-descriptionForeground);
+}
+
+.new-chat-in-session .sub-session-tip-icon {
+	flex-shrink: 0;
+	color: var(--vscode-descriptionForeground);
+}
+
+.new-chat-in-session .sub-session-tip-text {
+	flex: 1;
+	min-width: 0;
+	line-height: 1.4;
+}
+
+.new-chat-in-session .sub-session-tip-dismiss {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+	border-radius: var(--vscode-cornerRadius-small);
+	cursor: pointer;
+	color: var(--vscode-descriptionForeground);
+}
+
+.new-chat-in-session .sub-session-tip-dismiss:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+	color: var(--vscode-foreground);
+}
+
+.new-chat-in-session .sub-session-tip-dismiss:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}

--- a/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
+++ b/src/vs/sessions/contrib/chat/browser/media/newChatInSession.css
@@ -162,9 +162,13 @@
 	flex-shrink: 0;
 	width: 20px;
 	height: 20px;
+	border: none;
+	background: transparent;
+	padding: 0;
 	border-radius: var(--vscode-cornerRadius-small);
 	cursor: pointer;
 	color: var(--vscode-descriptionForeground);
+	touch-action: manipulation;
 }
 
 .new-chat-in-session .sub-session-tip-dismiss:hover {

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
@@ -6,7 +6,8 @@
 import './media/chatWidget.css';
 import './media/newChatInSession.css';
 import * as dom from '../../../../base/browser/dom.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { derived } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -17,8 +18,10 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
@@ -26,6 +29,8 @@ import { NewChatInputWidget } from './newChatInput.js';
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 
 // #region --- New Chat In Session Widget ---
+
+const STORAGE_KEY_SUB_SESSION_TIP_DISMISSED = 'sessions.subSessionTipDismissed';
 
 /**
  * A widget for composing a secondary chat within an existing session.
@@ -35,11 +40,13 @@ import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/co
 class NewChatInSessionWidget extends Disposable {
 
 	private readonly _newChatInput: NewChatInputWidget;
+	private readonly _tipDisposable = this._register(new MutableDisposable());
 
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILogService private readonly logService: ILogService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -67,9 +74,50 @@ class NewChatInSessionWidget extends Disposable {
 		const chatWidgetContainer = dom.append(element, dom.$('.new-chat-widget-container'));
 		const chatWidgetContent = dom.append(chatWidgetContainer, dom.$('.new-chat-widget-content'));
 
+		this._renderSubSessionTip(chatWidgetContent);
 		this._newChatInput.render(chatWidgetContent, parent);
 
 		chatWidgetContainer.classList.add('revealed');
+	}
+
+	private _renderSubSessionTip(container: HTMLElement): void {
+		if (this.storageService.getBoolean(STORAGE_KEY_SUB_SESSION_TIP_DISMISSED, StorageScope.PROFILE, false)) {
+			return;
+		}
+
+		const tipContainer = dom.append(container, dom.$('.sub-session-tip-container'));
+		const tipWidget = dom.append(tipContainer, dom.$('.sub-session-tip-widget'));
+		tipWidget.setAttribute('role', 'status');
+		tipWidget.setAttribute('aria-label', localize('subSessionTip.ariaLabel', "Sub-session tip"));
+
+		// Tip icon
+		const iconEl = dom.append(tipWidget, renderIcon(Codicon.lightbulb));
+		iconEl.classList.add('sub-session-tip-icon');
+
+		// Tip text
+		const textEl = dom.append(tipWidget, dom.$('span.sub-session-tip-text'));
+		textEl.textContent = localize(
+			'subSessionTip.message',
+			"This is a sub-session, a new chat in the same workspace. Use it to ask questions, run tasks, or explore ideas with fresh context."
+		);
+
+		// Dismiss button
+		const dismissBtn = dom.append(tipWidget, dom.$('a.sub-session-tip-dismiss'));
+		dismissBtn.setAttribute('role', 'button');
+		dismissBtn.setAttribute('aria-label', localize('subSessionTip.dismiss', "Dismiss tip"));
+		dismissBtn.tabIndex = 0;
+		dom.append(dismissBtn, renderIcon(Codicon.close));
+
+		const dismiss = () => {
+			this.storageService.store(STORAGE_KEY_SUB_SESSION_TIP_DISMISSED, true, StorageScope.PROFILE, StorageTarget.USER);
+			tipContainer.remove();
+			this._tipDisposable.clear();
+		};
+
+		this._tipDisposable.value = dom.addDisposableListener(dismissBtn, dom.EventType.CLICK, (e) => {
+			dom.EventHelper.stop(e, true);
+			dismiss();
+		});
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
@@ -9,6 +9,7 @@ import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { derived } from '../../../../base/common/observable.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -102,10 +103,9 @@ class NewChatInSessionWidget extends Disposable {
 		);
 
 		// Dismiss button
-		const dismissBtn = dom.append(tipWidget, dom.$('a.sub-session-tip-dismiss'));
-		dismissBtn.setAttribute('role', 'button');
+		const dismissBtn = dom.append(tipWidget, dom.$('button.sub-session-tip-dismiss')) as HTMLButtonElement;
+		dismissBtn.type = 'button';
 		dismissBtn.setAttribute('aria-label', localize('subSessionTip.dismiss', "Dismiss tip"));
-		dismissBtn.tabIndex = 0;
 		dom.append(dismissBtn, renderIcon(Codicon.close));
 
 		const dismiss = () => {
@@ -114,10 +114,16 @@ class NewChatInSessionWidget extends Disposable {
 			this._tipDisposable.clear();
 		};
 
-		this._tipDisposable.value = dom.addDisposableListener(dismissBtn, dom.EventType.CLICK, (e) => {
+		const handleDismiss = (e: Event) => {
 			dom.EventHelper.stop(e, true);
 			dismiss();
-		});
+		};
+
+		this._tipDisposable.value = Disposable.from(
+			Gesture.addTarget(dismissBtn),
+			dom.addDisposableListener(dismissBtn, dom.EventType.CLICK, handleDismiss),
+			dom.addDisposableListener(dismissBtn, TouchEventType.Tap, handleDismiss),
+		);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatInSessionViewPane.ts
@@ -7,7 +7,7 @@ import './media/chatWidget.css';
 import './media/newChatInSession.css';
 import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { derived } from '../../../../base/common/observable.js';
 import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -119,11 +119,11 @@ class NewChatInSessionWidget extends Disposable {
 			dismiss();
 		};
 
-		this._tipDisposable.value = Disposable.from(
-			Gesture.addTarget(dismissBtn),
-			dom.addDisposableListener(dismissBtn, dom.EventType.CLICK, handleDismiss),
-			dom.addDisposableListener(dismissBtn, TouchEventType.Tap, handleDismiss),
-		);
+		const store = new DisposableStore();
+		store.add(Gesture.addTarget(dismissBtn));
+		store.add(dom.addDisposableListener(dismissBtn, dom.EventType.CLICK, handleDismiss));
+		store.add(dom.addDisposableListener(dismissBtn, TouchEventType.Tap, handleDismiss));
+		this._tipDisposable.value = store;
 	}
 
 	/**


### PR DESCRIPTION
Shows a dismissable tip banner above the chat input when a new sub-session is created via the "New Sub-Session" button in the titlebar. The tip concisely explains what a sub-session is — a new chat within the same workspace for asking questions, running tasks, or exploring ideas with fresh context.

<img width="1556" height="1098" alt="Screenshot 2026-04-23 at 3 14 57 PM" src="https://github.com/user-attachments/assets/dc5adf99-c65d-43ea-90e0-b7e289ecdfe8" />

### Changes

- **`newChatInSessionViewPane.ts`**: Added `_renderSubSessionTip()` to render a tip widget (lightbulb icon + message + dismiss button) above the chat input. Dismissal is persisted to `StorageScope.PROFILE` so the tip only shows once.
- **`newChatInSession.css`**: Added styles for the tip banner matching the existing core chat tip pattern, with seamless visual connection to the input area below (shared border, connected border-radius).

### Visual pattern

The tip follows the same design as the existing `ChatTipContentPart` in VS Code core — a horizontal banner with icon, text, and dismiss action that sits directly above the chat input with connected borders.