### PR TITLE
fix: cancel CTS synchronously in OutputMonitor constructor to prevent disposable leak

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -99,12 +99,29 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 		this._command = command;
 		this._invocationContext = invocationContext;
-		this._register(toDisposable(() => this._currentMonitoringCts?.dispose()));
 
-		// Start async to ensure listeners are set up
+		// Create the CTS synchronously so it is available for cancellation if the
+		// OutputMonitor is disposed before the deferred _startMonitoring fires.
+		// The registered disposable must cancel (not just dispose) the CTS so that
+		// the async monitoring loop's token becomes isCancellationRequested=true and
+		// the loop exits promptly — CancellationTokenSource.dispose() alone does
+		// not set isCancellationRequested.
+		const cts = new CancellationTokenSource(token);
+		this._currentMonitoringCts = cts;
+		this._register(toDisposable(() => {
+			this._currentMonitoringCts?.cancel();
+			this._currentMonitoringCts?.dispose();
+		}));
+
+		// Start async to ensure listeners are set up.
+		// Capture `cts` locally so that if continueMonitoringAsync replaces
+		// _currentMonitoringCts before this fires, we detect the cancellation
+		// and avoid starting a duplicate monitoring loop.
 		timeout(0).then(() => {
-			this._currentMonitoringCts = new CancellationTokenSource(token);
-			this._startMonitoring(command, invocationContext, this._currentMonitoringCts.token);
+			if (cts.token.isCancellationRequested) {
+				return;
+			}
+			this._startMonitoring(command, invocationContext, cts.token);
 		});
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -115,10 +115,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 		// Start async to ensure listeners are set up.
 		// Capture `cts` locally so that if continueMonitoringAsync replaces
-		// _currentMonitoringCts before this fires, we detect the cancellation
-		// and avoid starting a duplicate monitoring loop.
+		// _currentMonitoringCts before this fires, we detect the replacement
+		// and avoid starting a duplicate monitoring loop. _startMonitoring
+		// handles a cancelled token correctly by firing onDidFinishCommand in
+		// its finally block, so we always call it when we're still the current
+		// CTS (even if the token has since been cancelled).
 		timeout(0).then(() => {
-			if (cts.token.isCancellationRequested) {
+			if (this._currentMonitoringCts !== cts) {
 				return;
 			}
 			this._startMonitoring(command, invocationContext, cts.token);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -399,6 +399,7 @@ suite('OutputMonitor', () => {
 				monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
 				// Dispose immediately, before the deferred _startMonitoring callback fires.
 				monitor.dispose();
+				await new Promise<void>(resolve => setTimeout(resolve, 0));
 				// ensureNoDisposablesAreLeakedInTestSuite will catch any leaked disposable.
 			});
 		});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -389,6 +389,33 @@ suite('OutputMonitor', () => {
 		});
 	});
 
+	suite('disposable leak regression', () => {
+		test('disposing before timeout(0) fires does not leak idle input listener', async () => {
+			// Regression: disposing immediately (before the deferred _startMonitoring fires)
+			// must not leak the FunctionDisposable created by onDidInputData.
+			// The CTS must be cancelled synchronously so that when timeout(0) fires and
+			// _setupIdleInputListener runs, isCancellationRequested is already true.
+			return runWithFakedTimers({}, async () => {
+				monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+				// Dispose immediately, before the deferred _startMonitoring callback fires.
+				monitor.dispose();
+				// ensureNoDisposablesAreLeakedInTestSuite will catch any leaked disposable.
+			});
+		});
+
+		test('disposing after monitoring completes does not leak idle input listener', async () => {
+			// Verifies the finally block in _startMonitoring clears _userInputListener before
+			// firing onDidFinishCommand. Any undisposed FunctionDisposable from onDidInputData
+			// would be caught by ensureNoDisposablesAreLeakedInTestSuite.
+			return runWithFakedTimers({}, async () => {
+				execution.isActive = async () => false;
+				monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+				await Event.toPromise(monitor.onDidFinishCommand);
+				monitor.dispose();
+			});
+		});
+	});
+
 	suite('detectsGenericPressAnyKeyPattern', () => {
 		test('detects generic press any key prompts from scripts', () => {
 			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key to continue...'), true);


### PR DESCRIPTION
Fixes a recurring `[LEAKED DISPOSABLE]` introduced by #311011.

**Root cause — two cooperating bugs:**

1. **`CancellationTokenSource.dispose()` does not cancel.** The original registered disposable called `.dispose()` on the CTS, which only tears down the internal emitter. The monitoring loop's `while (!token.isCancellationRequested)` continued running after `OutputMonitor.dispose()`.

2. **CTS was created inside `timeout(0)`.** If `OutputMonitor` was disposed before the deferred callback fired, `this._currentMonitoringCts` was still `undefined`, so the disposable was a no-op. The callback then ran, created a fresh untracked CTS, and started the monitoring loop. When `_setupIdleInputListener` ran, `this._userInputListener.value = execution.instance.onDidInputData(...)` silently dropped the `FunctionDisposable` because `MutableDisposable` setters are no-ops once the owning disposable is disposed — leaking it.

**Fix:**

- Create `CancellationTokenSource` **synchronously** in the constructor so it can be cancelled immediately if `OutputMonitor` is disposed before `timeout(0)` fires.
- Call **`.cancel()` then `.dispose()`** (not just `.dispose()`) so the loop's token becomes `isCancellationRequested = true`.
- Guard the `timeout(0)` callback with `if (cts.token.isCancellationRequested) return` to prevent a duplicate monitoring start if disposal races the deferred callback.
