### PR TITLE
fix: open in vscode action for agents app

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -107,6 +107,7 @@ export interface NativeParsedArgs {
 	'locate-extension'?: string[]; // undefined or array of 1 or more
 	'enable-proposed-api'?: string[]; // undefined or array of 1 or more
 	'open-url'?: boolean;
+	'open-chat-session'?: string;
 	'skip-release-notes'?: boolean;
 	'skip-welcome'?: boolean;
 	'disable-telemetry'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -196,6 +196,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'crash-reporter-id': { type: 'string' },
 	'skip-add-to-recently-opened': { type: 'boolean' },
 	'open-url': { type: 'boolean' },
+	'open-chat-session': { type: 'string' },
 	'file-write': { type: 'boolean' },
 	'file-chmod': { type: 'boolean' },
 	'install-builtin-extension': { type: 'string[]' },

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -491,6 +491,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		// Handle `<app> chat`
 		this.handleChatRequest(openConfig, usedWindows);
 
+		// Handle `<app> --open-chat-session`
+		this.handleOpenChatSession(openConfig, usedWindows);
+
 		return usedWindows;
 	}
 
@@ -532,6 +535,17 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 			windowHandlingChatRequest.sendWhenReady('vscode:handleChatRequest', CancellationToken.None, openConfig.cli.chat);
 			windowHandlingChatRequest.focus();
 		}
+	}
+
+	private handleOpenChatSession(openConfig: IOpenConfiguration, usedWindows: ICodeWindow[]): void {
+		const sessionUri = openConfig.cli['open-chat-session'];
+		if (!sessionUri || usedWindows.length === 0) {
+			return;
+		}
+
+		const window = usedWindows[0];
+		window.sendWhenReady('vscode:openChatSession', CancellationToken.None, sessionUri);
+		window.focus();
 	}
 
 	private async doOpen(

--- a/src/vs/sessions/contrib/chat/electron-browser/openInVSCode.contribution.ts
+++ b/src/vs/sessions/contrib/chat/electron-browser/openInVSCode.contribution.ts
@@ -13,7 +13,6 @@ import { AGENT_HOST_SCHEME, fromAgentHostUri } from '../../../../platform/agentH
 import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { INativeHostService } from '../../../../platform/native/common/native.js';
-import { IProductService } from '../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IsPhoneLayoutContext, SessionsWelcomeVisibleContext } from '../../../common/contextkeys.js';
@@ -54,7 +53,6 @@ registerAction2(class OpenSessionWorktreeInVSCodeAction extends Action2 {
 		logSessionsInteraction(telemetryService, 'openInVSCode');
 
 		const nativeHostService = accessor.get(INativeHostService);
-		const productService = accessor.get(IProductService);
 		const sessionsManagementService = accessor.get(ISessionsManagementService);
 		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
 		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
@@ -79,11 +77,7 @@ registerAction2(class OpenSessionWorktreeInVSCodeAction extends Action2 {
 		}
 
 		if (activeSession) {
-			const scheme = productService.parentPolicyConfig?.urlProtocol ?? productService.urlProtocol;
-			const params = new URLSearchParams();
-			params.set('windowId', '_blank');
-			params.set('session', activeSession.resource.toString());
-			args.push('--open-url', URI.from({ scheme, query: params.toString() }).toString());
+			args.push('--open-chat-session', activeSession.resource.toString());
 		}
 
 		await nativeHostService.launchSiblingApp(args);


### PR DESCRIPTION
`--open-url` short-circuits both the first-launch path and the second-instance path, preventing `--folder-uri` from being processed. This resulted in a blank window with no workspace.

Replace `--open-url` with a new `--open-chat-session <uri>` that flows through the normal window opening pipeline. After the folder is opened, windowsMainService forwards the session via IPC.
