### PR TITLE
sessions: fix spinner animation restart and respect reduced motion

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -170,6 +170,8 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 	private readonly _onDidChangeItemHeight = new Emitter<ISession>();
 	readonly onDidChangeItemHeight: Event<ISession> = this._onDidChangeItemHeight.event;
 
+	private readonly _motionReducedSignal;
+
 	constructor(
 		private readonly options: { grouping: () => SessionsGrouping; sorting: () => SessionsSorting; isPinned: (session: ISession) => boolean; isRead: (session: ISession) => boolean },
 		private readonly approvalModel: AgentSessionApprovalModel | undefined,
@@ -179,7 +181,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly hoverService: IHoverService,
 		private readonly agentSessionsService: IAgentSessionsService,
 		private readonly accessibilityService: IAccessibilityService,
-	) { }
+	) {
+		this._motionReducedSignal = observableSignalFromEvent('reduceMotion', this.accessibilityService.onDidChangeReducedMotion);
+	}
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
 		const disposables = new DisposableStore();
@@ -249,21 +253,26 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		// recreates the autorun. Without template-level tracking, the selector
 		// resets to undefined and the DOM is rebuilt every time, restarting the
 		// CSS spin animation.
-		const motionReducedSignal = observableSignalFromEvent('reduceMotion', this.accessibilityService.onDidChangeReducedMotion);
 		template.elementDisposables.add(autorun(reader => {
 			const sessionStatus = element.status.read(reader);
 			const isRead = this.options.isRead(element);
 			const isArchived = element.isArchived.read(reader);
 			const gitHubInfo = element.gitHubInfo.read(reader);
-			motionReducedSignal.read(reader);
+			this._motionReducedSignal.read(reader);
 			const icon = this.getStatusIcon(sessionStatus, isRead, isArchived, gitHubInfo?.pullRequest?.icon);
 			const iconSelector = ThemeIcon.asCSSSelector(icon);
+			const iconColor = icon.color ? asCssVariable(icon.color.id) : '';
 
 			if (iconSelector !== template.currentIconSelector) {
 				template.currentIconSelector = iconSelector;
 				DOM.clearNode(template.iconContainer);
 				const iconSpan = DOM.append(template.iconContainer, $(`span${iconSelector}`));
-				iconSpan.style.color = icon.color ? asCssVariable(icon.color.id) : '';
+				iconSpan.style.color = iconColor;
+			} else {
+				const iconSpan = template.iconContainer.firstElementChild as HTMLElement | null;
+				if (iconSpan) {
+					iconSpan.style.color = iconColor;
+				}
 			}
 			template.iconContainer.classList.toggle('session-icon-pulse', sessionStatus === SessionStatus.NeedsInput);
 			template.container.classList.toggle('in-progress', sessionStatus === SessionStatus.InProgress);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -15,7 +15,7 @@ import { HighlightedLabel } from '../../../../../base/browser/ui/highlightedlabe
 import { createMatches, FuzzyScore, IMatch } from '../../../../../base/common/filters.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { MarkdownString } from '../../../../../base/common/htmlContent.js';
-import { IReader, autorun } from '../../../../../base/common/observable.js';
+import { IReader, autorun, observableSignalFromEvent } from '../../../../../base/common/observable.js';
 import { ThemeIcon, themeColorFromId } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { fromNow } from '../../../../../base/common/date.js';
@@ -42,6 +42,7 @@ import { HoverStyle } from '../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { ISessionsListModelService } from './sessionsListModelService.js';
 import { IAgentHostFilterService } from '../../../remoteAgentHost/common/agentHostFilter.js';
 
@@ -149,6 +150,8 @@ interface ISessionItemTemplate {
 	readonly contextKeyService: IContextKeyService;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
+	/** Tracks the current icon CSS selector to avoid rebuilding the DOM (and restarting CSS animations) when the icon hasn't changed. */
+	currentIconSelector: string | undefined;
 }
 
 class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, ISessionItemTemplate> {
@@ -175,6 +178,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		private readonly markdownRendererService: IMarkdownRendererService,
 		private readonly hoverService: IHoverService,
 		private readonly agentSessionsService: IAgentSessionsService,
+		private readonly accessibilityService: IAccessibilityService,
 	) { }
 
 	renderTemplate(container: HTMLElement): ISessionItemTemplate {
@@ -201,7 +205,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, iconContainer, title, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, iconContainer, title, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables, currentIconSelector: undefined };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -238,16 +242,29 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			template.container.classList.toggle('pinned', isPinned && !isArchived);
 		}));
 
-		// Icon — reactive based on status, read state, and PR
+		// Icon — reactive based on status, read state, PR, and motion preference.
+		// The current icon CSS selector is stored on the template (not a local
+		// variable) so it survives across renderSession calls — the tree re-renders
+		// all visible rows on every splice, which clears elementDisposables and
+		// recreates the autorun. Without template-level tracking, the selector
+		// resets to undefined and the DOM is rebuilt every time, restarting the
+		// CSS spin animation.
+		const motionReducedSignal = observableSignalFromEvent('reduceMotion', this.accessibilityService.onDidChangeReducedMotion);
 		template.elementDisposables.add(autorun(reader => {
 			const sessionStatus = element.status.read(reader);
 			const isRead = this.options.isRead(element);
 			const isArchived = element.isArchived.read(reader);
 			const gitHubInfo = element.gitHubInfo.read(reader);
-			DOM.clearNode(template.iconContainer);
+			motionReducedSignal.read(reader);
 			const icon = this.getStatusIcon(sessionStatus, isRead, isArchived, gitHubInfo?.pullRequest?.icon);
-			const iconSpan = DOM.append(template.iconContainer, $(`span${ThemeIcon.asCSSSelector(icon)}`));
-			iconSpan.style.color = icon.color ? asCssVariable(icon.color.id) : '';
+			const iconSelector = ThemeIcon.asCSSSelector(icon);
+
+			if (iconSelector !== template.currentIconSelector) {
+				template.currentIconSelector = iconSelector;
+				DOM.clearNode(template.iconContainer);
+				const iconSpan = DOM.append(template.iconContainer, $(`span${iconSelector}`));
+				iconSpan.style.color = icon.color ? asCssVariable(icon.color.id) : '';
+			}
 			template.iconContainer.classList.toggle('session-icon-pulse', sessionStatus === SessionStatus.NeedsInput);
 			template.container.classList.toggle('in-progress', sessionStatus === SessionStatus.InProgress);
 		}));
@@ -466,7 +483,11 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 
 	private getStatusIcon(status: SessionStatus, isRead: boolean, isArchived: boolean, pullRequestIcon?: ThemeIcon): ThemeIcon {
 		switch (status) {
-			case SessionStatus.InProgress: return { ...ThemeIcon.modify(Codicon.loading, 'spin'), color: themeColorFromId('textLink.foreground') };
+			case SessionStatus.InProgress:
+				if (this.accessibilityService.isMotionReduced()) {
+					return { ...Codicon.sessionInProgress, color: themeColorFromId('textLink.foreground') };
+				}
+				return { ...ThemeIcon.modify(Codicon.loading, 'spin'), color: themeColorFromId('textLink.foreground') };
 			case SessionStatus.NeedsInput: return { ...Codicon.circleFilled, color: themeColorFromId('list.warningForeground') };
 			case SessionStatus.Error: return { ...Codicon.error, color: themeColorFromId('errorForeground') };
 			default:
@@ -731,6 +752,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 		const markdownRendererService = instantiationService.invokeFunction(accessor => accessor.get(IMarkdownRendererService));
 		const hoverService = instantiationService.invokeFunction(accessor => accessor.get(IHoverService));
 		const agentSessionsService = instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
+		const accessibilityService = instantiationService.invokeFunction(accessor => accessor.get(IAccessibilityService));
 		const sessionRenderer = new SessionItemRenderer(
 			{ grouping: this.options.grouping, sorting: this.options.sorting, isPinned: s => this.isSessionPinned(s), isRead: s => this.isSessionRead(s) },
 			approvalModel,
@@ -739,6 +761,7 @@ export class SessionsList extends Disposable implements ISessionsList {
 			markdownRendererService,
 			hoverService,
 			agentSessionsService,
+			accessibilityService,
 		);
 
 		const showMoreRenderer = new SessionShowMoreRenderer();


### PR DESCRIPTION
## Summary

Fixes two issues with the session list spinner icon in the agents/sessions sidebar:

### 1. Spinner animation glitch
The loading spinner (codicon-loading with spin modifier) was restarting its CSS animation on every tree re-render. The tree calls `renderElement` on all visible rows whenever the session list is spliced (e.g. when chat progress text updates), which clears `elementDisposables` and recreates the icon autorun. The icon CSS selector tracking was in a local variable that reset to `undefined` each time, causing the spinner DOM element to be destroyed and recreated — restarting the animation.

**Fix**: Move the icon selector tracking onto `ISessionItemTemplate` so it persists across `renderSession` calls for the same row. The spinner DOM element now stays alive and its animation continues smoothly.

### 2. Reduced motion preference
When the user has reduced motion enabled (via `workbench.reduceMotion` setting or OS-level `prefers-reduced-motion`), the animated spinner is now replaced with the static `session-in-progress` codicon. The icon reactively updates when the preference changes via `observableSignalFromEvent` on `onDidChangeReducedMotion`.