### PR TITLE
copilot: emit router decision to restricted telemetry  full scores

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -171,6 +171,33 @@ export class RouterDecisionFetcher {
 				stickyOverride: result.sticky_override ? 1 : 0,
 			}
 		);
+
+		this._telemetryService.sendEnhancedGHTelemetryEvent('automode.routerDecisionRestricted',
+			{
+				conversationId: conversationId ?? '',
+				vscodeRequestId: vscodeRequestId ?? '',
+				predictedLabel: result.predicted_label,
+				routingMethod: result.routing_method ?? '',
+				fallback: String(result.fallback ?? false),
+				fallbackReason: result.fallback_reason ?? '',
+				candidateModel: result.candidate_models?.[0] ?? '',
+				chosenModel: result.chosen_model ?? '',
+				candidateModels: JSON.stringify(result.candidate_models ?? []),
+				stickyOverrideStr: String(result.sticky_override ?? false),
+				hydraScores: result.hydra_scores ? JSON.stringify(result.hydra_scores) : 'null',
+				binaryScores: JSON.stringify(result.scores),
+			},
+			{
+				confidence: result.confidence,
+				latencyMs: result.latency_ms,
+				e2eLatencyMs: e2eLatencyMs,
+				stickyOverride: result.sticky_override ? 1 : 0,
+				chosenShortfall: result.chosen_shortfall,
+				scoreNeedsReasoning: result.scores.needs_reasoning,
+				scoreNoReasoning: result.scores.no_reasoning,
+			}
+		);
+
 		return result;
 	}
 }

--- a/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/automodeService.spec.ts
@@ -152,6 +152,7 @@ describe('AutomodeService', () => {
 			sendTelemetryErrorEvent: vi.fn(),
 			sendMSFTTelemetryErrorEvent: vi.fn(),
 			sendSharedTelemetryEvent: vi.fn(),
+			sendEnhancedGHTelemetryEvent: vi.fn(),
 		} as unknown as ITelemetryService & { sendMSFTTelemetryEvent: ReturnType<typeof vi.fn> };
 	});
 


### PR DESCRIPTION
Add a sendEnhancedGHTelemetryEvent call (automode.routerDecisionRestricted) alongside the existing unrestricted routerDecision event. The restricted event lands in copilot_v0_restricted_copilot_event in Hydro and includes:

- hydraScores: JSON-encoded 4-dim capability scores (reasoning, code_gen, debugging, tool_use)

- binaryScores: JSON-encoded binary classifier scores (needs_reasoning, no_reasoning)

- chosenModel, candidateModels, chosenShortfall, stickyOverride

- All fields from the existing unrestricted event (confidence, latency, routingMethod, etc.)

This enables joining router quality data with user prompts in a single Hydro table without cross-cluster joins to ddtelvscode. Only available for users opted into restricted telemetry (~44%).

