### PR TITLE
mcp: add .mcp.json workspace discovery and server collision handling

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -20,7 +20,7 @@ import { LogLevel } from '../../../platform/log/common/log.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { IWorkbenchMcpGatewayService } from '../../contrib/mcp/common/mcpGatewayService.js';
 import { IMcpMessageTransport, IMcpRegistry } from '../../contrib/mcp/common/mcpRegistryTypes.js';
-import { extensionPrefixedIdentifier, McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust, UserInteractionRequiredError } from '../../contrib/mcp/common/mcpTypes.js';
+import { extensionPrefixedIdentifier, McpCollectionDefinition, McpCollectionSortOrder, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust, UserInteractionRequiredError } from '../../contrib/mcp/common/mcpTypes.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { IAuthenticationMcpAccessService } from '../../services/authentication/browser/authenticationMcpAccessService.js';
 import { IAuthenticationMcpService } from '../../services/authentication/browser/authenticationMcpService.js';
@@ -148,6 +148,7 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 				handle.value ??= this._mcpRegistry.registerCollection({
 					...collection,
 					source: extensionId,
+					order: McpCollectionSortOrder.Extension,
 					resolveServerLanch: collection.canResolveLaunch ? (async def => {
 						const r = await this._proxy.$resolveMcpLaunch(collection.id, def.label);
 						return r ? McpServerLaunch.fromSerialized(r) : undefined;

--- a/src/vs/workbench/contrib/chat/browser/actions/createPluginAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/createPluginAction.ts
@@ -66,7 +66,7 @@ function isUserDefined(storage: PromptsStorage): boolean {
 }
 
 function isUserDefinedMcpCollection(collection: McpCollectionDefinition): boolean {
-	const order = collection.presentation?.order;
+	const order = collection.order;
 	return order === McpCollectionSortOrder.User
 		|| order === McpCollectionSortOrder.WorkspaceFolder
 		|| order === McpCollectionSortOrder.Workspace;

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -36,7 +36,7 @@ import { IEditorResolverService, RegisteredEditorPriority } from '../../../servi
 import { IPathService } from '../../../services/path/common/pathService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { AddConfigurationType, AssistedTypes } from '../../mcp/browser/mcpCommandsAddConfiguration.js';
-import { allDiscoverySources, discoverySourceSettingsLabel, mcpDiscoverySection, mcpServerSamplingSection } from '../../mcp/common/mcpConfiguration.js';
+import { allDiscoverySources, discoverySourceSettingsLabel, McpCollisionBehavior, mcpDiscoverySection, mcpServerCollisionBehaviorSection, mcpServerSamplingSection } from '../../mcp/common/mcpConfiguration.js';
 import { ChatAgentNameService, ChatAgentService, IChatAgentNameService, IChatAgentService } from '../common/participants/chatAgents.js';
 import { CodeMapperService, ICodeMapperService } from '../common/editing/chatCodeMapperService.js';
 import '../common/widget/chatColors.js';
@@ -736,6 +736,19 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			tags: ['experimental'],
 		},
+		[mcpServerCollisionBehaviorSection]: {
+			type: 'string',
+			description: nls.localize('chat.mcp.collisionBehavior', "Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates. 'suffix' appends numeric suffixes to disambiguate."),
+			enum: [
+				McpCollisionBehavior.Disable,
+				McpCollisionBehavior.Suffix,
+			],
+			enumDescriptions: [
+				nls.localize('chat.mcp.collisionBehavior.disable', "Disable lower-priority servers with duplicate names."),
+				nls.localize('chat.mcp.collisionBehavior.suffix', "Append numeric suffixes to servers with duplicate names."),
+			],
+			default: McpCollisionBehavior.Disable,
+		},
 		[mcpServerSamplingSection]: {
 			type: 'object',
 			description: nls.localize('chat.mcp.serverSampling', "Configures which models are exposed to MCP servers for sampling (making model requests in the background). This setting can be edited in a graphical way under the `{0}` command.", 'MCP: ' + nls.localize('mcp.list', 'List Servers')),
@@ -745,7 +758,7 @@ configurationRegistry.registerConfiguration({
 				properties: {
 					allowedDuringChat: {
 						type: 'boolean',
-						description: nls.localize('chat.mcp.serverSampling.allowedDuringChat', "Whether this server is make sampling requests during its tool calls in a chat session."),
+						description: nls.localize('chat.mcp.serverSampling.allowedDuringChat', "Whether this server is allowed to make sampling requests during its tool calls in a chat session."),
 						default: true,
 					},
 					allowedOutsideChat: {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -738,12 +738,14 @@ configurationRegistry.registerConfiguration({
 		},
 		[mcpServerCollisionBehaviorSection]: {
 			type: 'string',
-			description: nls.localize('chat.mcp.collisionBehavior', "Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates."),
+			description: nls.localize('chat.mcp.collisionBehavior', "Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates. 'suffix' appends numeric suffixes to disambiguate."),
 			enum: [
 				McpCollisionBehavior.Disable,
+				McpCollisionBehavior.Suffix,
 			],
 			enumDescriptions: [
 				nls.localize('chat.mcp.collisionBehavior.disable', "Disable lower-priority servers with duplicate names."),
+				nls.localize('chat.mcp.collisionBehavior.suffix', "Append numeric suffixes to servers with duplicate names."),
 			],
 			default: McpCollisionBehavior.Disable,
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -738,14 +738,12 @@ configurationRegistry.registerConfiguration({
 		},
 		[mcpServerCollisionBehaviorSection]: {
 			type: 'string',
-			description: nls.localize('chat.mcp.collisionBehavior', "Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates. 'suffix' appends numeric suffixes to disambiguate."),
+			description: nls.localize('chat.mcp.collisionBehavior', "Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates."),
 			enum: [
 				McpCollisionBehavior.Disable,
-				McpCollisionBehavior.Suffix,
 			],
 			enumDescriptions: [
 				nls.localize('chat.mcp.collisionBehavior.disable', "Disable lower-priority servers with duplicate names."),
-				nls.localize('chat.mcp.collisionBehavior.suffix', "Append numeric suffixes to servers with duplicate names."),
 			],
 			default: McpCollisionBehavior.Disable,
 		},

--- a/src/vs/workbench/contrib/chat/common/enablement.ts
+++ b/src/vs/workbench/contrib/chat/common/enablement.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { IReader } from '../../../../base/common/observable.js';
+import { IReader, ITransaction } from '../../../../base/common/observable.js';
 import { ObservableMemento, observableMemento } from '../../../../platform/observable/common/observableMemento.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
@@ -25,7 +25,7 @@ export function isContributionDisabled(state: ContributionEnablementState): bool
 
 export interface IEnablementModel {
 	readEnabled(key: string, reader?: IReader): ContributionEnablementState;
-	setEnabled(key: string, state: ContributionEnablementState): void;
+	setEnabled(key: string, state: ContributionEnablementState, tx?: ITransaction): void;
 	remove(key: string): void;
 }
 
@@ -93,29 +93,29 @@ export class EnablementModel extends Disposable implements IEnablementModel {
 		return ContributionEnablementState.EnabledProfile;
 	}
 
-	setEnabled(key: string, state: ContributionEnablementState): void {
+	setEnabled(key: string, state: ContributionEnablementState, tx?: ITransaction): void {
 		switch (state) {
 			case ContributionEnablementState.EnabledProfile: {
 				// Enabled-profile is the default: remove key from profile state,
 				// and also remove any workspace override.
-				this._deleteFromMap(this._profileState, key);
-				this._deleteFromMap(this._workspaceState, key);
+				this._deleteFromMap(this._profileState, key, tx);
+				this._deleteFromMap(this._workspaceState, key, tx);
 				break;
 			}
 			case ContributionEnablementState.DisabledProfile: {
 				// Store disabled in profile, remove workspace override.
-				this._setInMap(this._profileState, key, false);
-				this._deleteFromMap(this._workspaceState, key);
+				this._setInMap(this._profileState, key, false, tx);
+				this._deleteFromMap(this._workspaceState, key, tx);
 				break;
 			}
 			case ContributionEnablementState.EnabledWorkspace: {
 				// Workspace override: always store explicitly.
-				this._setInMap(this._workspaceState, key, true);
+				this._setInMap(this._workspaceState, key, true, tx);
 				break;
 			}
 			case ContributionEnablementState.DisabledWorkspace: {
 				// Workspace override: always store explicitly.
-				this._setInMap(this._workspaceState, key, false);
+				this._setInMap(this._workspaceState, key, false, tx);
 				break;
 			}
 		}
@@ -126,23 +126,23 @@ export class EnablementModel extends Disposable implements IEnablementModel {
 		this._deleteFromMap(this._workspaceState, key);
 	}
 
-	private _setInMap(memento: ObservableMemento<EnablementMap>, key: string, value: boolean): void {
+	private _setInMap(memento: ObservableMemento<EnablementMap>, key: string, value: boolean, tx?: ITransaction): void {
 		const current = memento.get();
 		if (current.get(key) === value) {
 			return;
 		}
 		const next = new Map(current);
 		next.set(key, value);
-		memento.set(next, undefined);
+		memento.set(next, tx);
 	}
 
-	private _deleteFromMap(memento: ObservableMemento<EnablementMap>, key: string): void {
+	private _deleteFromMap(memento: ObservableMemento<EnablementMap>, key: string, tx?: ITransaction): void {
 		const current = memento.get();
 		if (!current.has(key)) {
 			return;
 		}
 		const next = new Map(current);
 		next.delete(key);
-		memento.set(next, undefined);
+		memento.set(next, tx);
 	}
 }

--- a/src/vs/workbench/contrib/chat/test/browser/actions/createPluginAction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/actions/createPluginAction.test.ts
@@ -473,7 +473,7 @@ suite('writePluginToDisk', () => {
 					collection: {
 						id: 'col1',
 						label: 'Test Collection',
-						presentation: { order: McpCollectionSortOrder.User },
+						order: McpCollectionSortOrder.User,
 					} as IResourceTreeItem['mcpServer'] extends undefined ? never : NonNullable<IResourceTreeItem['mcpServer']>['collection'],
 					definition: {
 						id: 'def1',

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -23,6 +23,7 @@ import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
 import { RemoteNativeMpcDiscovery } from '../common/discovery/nativeMcpRemoteDiscovery.js';
 import { PluginMcpDiscovery } from '../common/discovery/pluginMcpDiscovery.js';
 import { CursorWorkspaceMcpDiscoveryAdapter } from '../common/discovery/workspaceMcpDiscoveryAdapter.js';
+import { WorkspaceDotMcpDiscovery } from '../common/discovery/workspaceDotMcpDiscovery.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { mcpServerSchema } from '../common/mcpConfiguration.js';
 import { McpContextKeysController } from '../common/mcpContextKeys.js';
@@ -62,6 +63,7 @@ mcpDiscoveryRegistry.register(new SyncDescriptor(RemoteNativeMpcDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(InstalledMcpServersDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(ExtensionMcpDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(CursorWorkspaceMcpDiscoveryAdapter));
+mcpDiscoveryRegistry.register(new SyncDescriptor(WorkspaceDotMcpDiscovery));
 mcpDiscoveryRegistry.register(new SyncDescriptor(PluginMcpDiscovery));
 
 registerWorkbenchContribution2('mcpDiscovery', McpDiscovery, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -53,6 +53,7 @@ import { ChatViewId, IChatWidgetService } from '../../chat/browser/chat.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { IChatElicitationRequest, IChatToolInvocation } from '../../chat/common/chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../chat/common/constants.js';
+import { ContributionEnablementState, isContributionDisabled } from '../../chat/common/enablement.js';
 import { ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../chat/common/tools/languageModelToolsService.js';
 import { extensionsFilterSubMenu, IExtensionsWorkbenchService, VIEWLET_ID } from '../../extensions/common/extensions.js';
@@ -60,11 +61,10 @@ import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState, McpStartServerInteraction } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState, McpStartServerInteraction } from '../common/mcpTypes.js';
+import { startServerAndWaitForLiveTools } from '../common/mcpTypesUtils.js';
 import { McpAddConfigurationCommand, McpInstallFromManifestCommand } from './mcpCommandsAddConfiguration.js';
 import { McpResourceQuickAccess, McpResourceQuickPick } from './mcpResourceQuickAccess.js';
-import { startServerAndWaitForLiveTools } from '../common/mcpTypesUtils.js';
-import { isContributionDisabled } from '../../chat/common/enablement.js';
 import './media/mcpServerAction.css';
 import { openPanelChatAndGetWidget } from './openPanelChatAndGetWidget.js';
 
@@ -104,7 +104,6 @@ export class ListMcpServerCommand extends Action2 {
 		const mcpService = accessor.get(IMcpService);
 		const commandService = accessor.get(ICommandService);
 		const quickInput = accessor.get(IQuickInputService);
-		const mcpWorkbenchService = accessor.get(IMcpWorkbenchService);
 
 		type ItemType = { id: string } & IQuickPickItem;
 
@@ -117,7 +116,7 @@ export class ListMcpServerCommand extends Action2 {
 		store.add(pick);
 
 		store.add(autorun(reader => {
-			const servers = groupBy(mcpService.servers.read(reader).slice().sort((a, b) => (a.collection.presentation?.order || 0) - (b.collection.presentation?.order || 0)), s => s.collection.id);
+			const servers = groupBy(mcpService.servers.read(reader).slice().sort((a, b) => a.collection.order - b.collection.order), s => s.collection.id);
 			const firstRun = pick.items.length === 0;
 			pick.items = [
 				{ id: '$add', label: localize('mcp.addServer', 'Add Server'), description: localize('mcp.addServer.description', 'Add a new server configuration'), alwaysShow: true, iconClass: ThemeIcon.asClassName(Codicon.add) },
@@ -159,21 +158,13 @@ export class ListMcpServerCommand extends Action2 {
 		} else if (picked.id === '$add') {
 			commandService.executeCommand(McpCommandIds.AddConfiguration);
 		} else {
-			const server = mcpService.servers.get().find(s => s.definition.id === picked.id);
-			if (server && isContributionDisabled(server.enablement.get())) {
-				const workbenchServer = mcpWorkbenchService.local.find(s => s.id === picked.id);
-				if (workbenchServer) {
-					mcpWorkbenchService.open(workbenchServer);
-				}
-			} else {
-				commandService.executeCommand(McpCommandIds.ServerOptions, picked.id);
-			}
+			commandService.executeCommand(McpCommandIds.ServerOptions, picked.id);
 		}
 	}
 }
 
 interface ActionItem extends IQuickPickItem {
-	action: 'start' | 'stop' | 'restart' | 'showOutput' | 'config' | 'configSampling' | 'samplingLog' | 'resources';
+	action: 'start' | 'stop' | 'restart' | 'showOutput' | 'config' | 'configSampling' | 'samplingLog' | 'resources' | 'enable';
 }
 
 interface AuthActionItem extends IQuickPickItem {
@@ -249,11 +240,17 @@ export class McpServerOptionsCommand extends Action2 {
 
 		const items: (ActionItem | AuthActionItem | IQuickPickSeparator)[] = [];
 		const serverState = server.connectionState.get();
+		const disabled = isContributionDisabled(server.enablement.get());
 
 		items.push({ type: 'separator', label: localize('mcp.actions.status', 'Status') });
 
-		// Only show start when server is stopped or in error state
-		if (McpConnectionState.canBeStarted(serverState.state)) {
+		if (disabled) {
+			items.push({
+				label: localize('mcp.enable', 'Enable Server'),
+				action: 'enable'
+			});
+		} else if (McpConnectionState.canBeStarted(serverState.state)) {
+			// Only show start when server is stopped or in error state
 			items.push({
 				label: localize('mcp.start', 'Start Server'),
 				action: 'start'
@@ -320,6 +317,9 @@ export class McpServerOptionsCommand extends Action2 {
 		}
 
 		switch (pick.action) {
+			case 'enable':
+				mcpService.enablementModel.setEnabled(server.definition.id, ContributionEnablementState.EnabledWorkspace);
+				break;
 			case 'start':
 				await server.start({ promptType: 'all-untrusted' });
 				server.showOutput();

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -246,7 +246,7 @@ export class McpServerOptionsCommand extends Action2 {
 
 		if (disabled) {
 			items.push({
-				label: localize('mcp.enable', 'Enable Server'),
+				label: localize('mcp.enableWorkspace', 'Enable Server (Workspace)'),
 				action: 'enable'
 			});
 		} else if (McpConnectionState.canBeStarted(serverState.state)) {

--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -15,19 +15,26 @@ import { CodeLens, CodeLensList, CodeLensProvider, InlayHint, InlayHintList } fr
 import { ITextModel } from '../../../../editor/common/model.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { localize } from '../../../../nls.js';
+import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { IMarkerData, IMarkerService, MarkerSeverity } from '../../../../platform/markers/common/markers.js';
+import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { ConfigurationResolverExpression, IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
+import { isContributionDisabled } from '../../chat/common/enablement.js';
 import { IMcpConfigPath, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, McpConnectionState } from '../common/mcpTypes.js';
 
 const diagnosticOwner = 'vscode.mcp';
 
+type ConfigDescriptor = Pick<IMcpConfigPath, 'section' | 'scope' | 'target'> & {
+	serversKey?: string;
+};
+
 export class McpLanguageFeatures extends Disposable implements IWorkbenchContribution {
-	private readonly _cachedMcpSection = this._register(new MutableDisposable<{ model: ITextModel; inConfig: IMcpConfigPath; tree: Node } & IDisposable>());
+	private readonly _cachedMcpSection = this._register(new MutableDisposable<{ model: ITextModel; inConfig: ConfigDescriptor; tree: Node } & IDisposable>());
 
 	constructor(
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
@@ -41,6 +48,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 
 		const patterns = [
 			{ pattern: '**/mcp.json' },
+			{ pattern: '**/.mcp.json' },
 			{ pattern: '**/workspace.json' },
 		];
 
@@ -64,7 +72,9 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 		}
 
 		const uri = model.uri;
-		const inConfig = await this._mcpWorkbenchService.getMcpConfigPath(model.uri);
+		const inConfig: ConfigDescriptor | undefined = uri.path.endsWith('/.mcp.json')
+			? { scope: StorageScope.WORKSPACE, target: ConfigurationTarget.WORKSPACE_FOLDER, serversKey: 'mcpServers' }
+			: await this._mcpWorkbenchService.getMcpConfigPath(model.uri);
 		if (!inConfig) {
 			return undefined;
 		}
@@ -88,8 +98,9 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 		};
 	}
 
-	private _addDiagnostics(tm: ITextModel, value: string, tree: Node, inConfig: IMcpConfigPath) {
-		const serversNode = findNodeAtLocation(tree, inConfig.section ? [...inConfig.section, 'servers'] : ['servers']);
+	private _addDiagnostics(tm: ITextModel, value: string, tree: Node, inConfig: ConfigDescriptor) {
+		const serversKey = inConfig.serversKey ?? 'servers';
+		const serversNode = findNodeAtLocation(tree, inConfig.section ? [...inConfig.section, serversKey] : [serversKey]);
 		if (!serversNode) {
 			return;
 		}
@@ -145,7 +156,8 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 		}
 
 		const { tree, inConfig } = parsed;
-		const serversNode = findNodeAtLocation(tree, inConfig.section ? [...inConfig.section, 'servers'] : ['servers']);
+		const serversKey = inConfig.serversKey ?? 'servers';
+		const serversNode = findNodeAtLocation(tree, inConfig.section ? [...inConfig.section, serversKey] : [serversKey]);
 		if (!serversNode) {
 			return undefined;
 		}
@@ -176,6 +188,19 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 			}
 
 			const range = Range.fromPositions(model.getPositionAt(node.children[0].offset));
+
+			if (isContributionDisabled(read(server.enablement))) {
+				lenses.push({
+					range,
+					command: {
+						id: McpCommandIds.ServerOptions,
+						title: '$(circle-slash) ' + localize('server.disabled', 'Disabled'),
+						arguments: [server.definition.id],
+					},
+				});
+				continue;
+			}
+
 			const canDebug = !!server.readDefinitions().get().server?.devMode?.debug;
 			const state = read(server.connectionState).state;
 			switch (state) {
@@ -338,7 +363,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 		const inputs = await this._mcpRegistry.getSavedInputs(inConfig.scope);
 		const hints: InlayHint[] = [];
 
-		const serversNode = findNodeAtLocation(mcpSection, ['servers']);
+		const serversNode = findNodeAtLocation(mcpSection, [inConfig.serversKey ?? 'servers']);
 		if (serversNode) {
 			annotateServers(serversNode);
 		}

--- a/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/extensionMcpDiscovery.ts
@@ -15,7 +15,7 @@ import { IExtensionService } from '../../../../services/extensions/common/extens
 import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
 import { mcpActivationEvent, mcpContributionPoint } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { extensionPrefixedIdentifier, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
+import { extensionPrefixedIdentifier, McpCollectionSortOrder, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 
 const cacheKey = 'mcp.extCachedServers';
@@ -122,6 +122,7 @@ export class ExtensionMcpDiscovery extends Disposable implements IMcpDiscovery {
 			trustBehavior: McpServerTrust.Kind.Trusted,
 			scope: StorageScope.WORKSPACE,
 			configTarget: ConfigurationTarget.USER,
+			order: McpCollectionSortOrder.Extension,
 			serverDefinitions: observableValue<McpServerDefinition[]>(this, serverDefs?.map(McpServerDefinition.fromSerialized) || []),
 			lazy: {
 				isCached: !!serverDefs,

--- a/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/installedMcpServersDiscovery.ts
@@ -18,7 +18,7 @@ import { IWorkbenchLocalMcpServer } from '../../../../services/mcp/common/mcpWor
 import { getMcpServerMapping } from '../mcpConfigFileUtils.js';
 import { mcpConfigurationSection } from '../mcpConfiguration.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
-import { IMcpConfigPath, IMcpWorkbenchService, McpCollectionDefinition, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
+import { IMcpConfigPath, IMcpWorkbenchService, McpCollectionDefinition, McpCollectionSortOrder, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
 
 interface CollectionState extends IDisposable {
@@ -131,8 +131,8 @@ export class InstalledMcpServersDiscovery extends Disposable implements IMcpDisc
 				const newCollection: McpCollectionDefinition = {
 					id,
 					label: mcpConfigPath?.label ?? '',
+					order: mcpConfigPath?.order ?? McpCollectionSortOrder.User,
 					presentation: {
-						order: serverDefinitions[0]?.presentation?.order,
 						origin: mcpConfigPath?.uri,
 					},
 					remoteAuthority: mcpConfigPath?.remoteAuthority ?? null,

--- a/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/nativeMcpDiscoveryAbstract.ts
@@ -151,9 +151,9 @@ export abstract class NativeFilesystemMcpDiscovery extends FilesystemMcpDiscover
 				scope: StorageScope.PROFILE,
 				trustBehavior: McpServerTrust.Kind.TrustedOnNonce,
 				serverDefinitions: observableValue<readonly McpServerDefinition[]>(this, []),
+				order: adapter.order + (adapter.remoteAuthority ? McpCollectionSortOrder.RemoteBoost : 0),
 				presentation: {
 					origin: file,
-					order: adapter.order + (adapter.remoteAuthority ? McpCollectionSortOrder.RemoteBoost : 0),
 				},
 			};
 

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -77,9 +77,9 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 			trustBehavior: McpServerTrust.Kind.Trusted,
 			serverDefinitions: plugin.mcpServerDefinitions.map(defs =>
 				defs.map(d => this._toServerDefinition(collectionId, d)).filter(isDefined)),
+			order: McpCollectionSortOrder.Plugin,
 			presentation: {
 				origin: manifestURI,
-				order: McpCollectionSortOrder.Plugin,
 			},
 		});
 	}

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceDotMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceDotMcpDiscovery.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
+import { IRemoteAgentService } from '../../../../services/remote/common/remoteAgentService.js';
+import { IMcpRegistry } from '../mcpRegistryTypes.js';
+import { McpCollectionSortOrder, McpServerDefinition, McpServerTrust } from '../mcpTypes.js';
+import { IMcpDiscovery } from './mcpDiscovery.js';
+import { claudeConfigToServerDefinition } from './nativeMcpDiscoveryAdapters.js';
+
+/**
+ * Discovers MCP servers defined in `.mcp.json` files at workspace folder roots.
+ * Uses the Claude-style format: `{ "mcpServers": { ... } }`.
+ */
+export class WorkspaceDotMcpDiscovery extends Disposable implements IMcpDiscovery {
+	readonly fromGallery = false;
+
+	private readonly _collections = this._register(new DisposableMap<string, IDisposable>());
+
+	constructor(
+		@IFileService private readonly _fileService: IFileService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
+	) {
+		super();
+	}
+
+	start(): void {
+		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(e => {
+			for (const removed of e.removed) {
+				this._collections.deleteAndDispose(removed.uri.toString());
+			}
+			for (const added of e.added) {
+				this._watchFolder(added);
+			}
+		}));
+
+		for (const folder of this._workspaceContextService.getWorkspace().folders) {
+			this._watchFolder(folder);
+		}
+	}
+
+	private _watchFolder(folder: IWorkspaceFolder) {
+		const configFile = joinPath(folder.uri, '.mcp.json');
+		const collectionId = `workspace-dot-mcp.${folder.index}`;
+		const serverDefinitions = observableValue<readonly McpServerDefinition[]>(this, []);
+
+		const collection = {
+			id: collectionId,
+			label: `${folder.name}/.mcp.json`,
+			remoteAuthority: this._remoteAgentService.getConnection()?.remoteAuthority || null,
+			scope: StorageScope.WORKSPACE,
+			trustBehavior: McpServerTrust.Kind.TrustedOnNonce as const,
+			serverDefinitions,
+			configTarget: ConfigurationTarget.WORKSPACE_FOLDER,
+			order: McpCollectionSortOrder.WorkspaceFolder + 1,
+			presentation: {
+				origin: configFile,
+			},
+		};
+
+		const store = new DisposableStore();
+		const collectionRegistration = store.add(new MutableDisposable());
+
+		const updateFile = async () => {
+			let definitions: McpServerDefinition[] = [];
+			try {
+				const contents = await this._fileService.readFile(configFile);
+				const defs = await claudeConfigToServerDefinition(collectionId, contents.value, folder.uri);
+				if (defs) {
+					for (const d of defs) {
+						d.roots = [folder.uri];
+					}
+					definitions = defs;
+				}
+			} catch {
+				// file doesn't exist or is malformed
+			}
+
+			if (!definitions.length) {
+				collectionRegistration.clear();
+			} else {
+				serverDefinitions.set(definitions, undefined);
+				if (!collectionRegistration.value) {
+					collectionRegistration.value = this._mcpRegistry.registerCollection(collection);
+				}
+			}
+		};
+
+		const throttler = store.add(new RunOnceScheduler(updateFile, 500));
+		const watcher = store.add(this._fileService.createWatcher(configFile, { recursive: false, excludes: [] }));
+		store.add(watcher.onDidChange(() => throttler.schedule()));
+		updateFile();
+
+		this._collections.set(folder.uri.toString(), store);
+	}
+}

--- a/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/workspaceMcpDiscoveryAdapter.ts
@@ -57,9 +57,9 @@ export class CursorWorkspaceMcpDiscoveryAdapter extends FilesystemMcpDiscovery i
 			trustBehavior: McpServerTrust.Kind.TrustedOnNonce,
 			serverDefinitions: observableValue(this, []),
 			configTarget: ConfigurationTarget.WORKSPACE_FOLDER,
+			order: McpCollectionSortOrder.WorkspaceFolder + 1,
 			presentation: {
 				origin: configFile,
-				order: McpCollectionSortOrder.WorkspaceFolder + 1,
 			},
 		};
 

--- a/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpConfiguration.ts
@@ -54,6 +54,12 @@ export const discoverySourceSettingsLabel: Record<DiscoverySource, string> = {
 export const mcpConfigurationSection = 'mcp';
 export const mcpDiscoverySection = 'chat.mcp.discovery.enabled';
 export const mcpServerSamplingSection = 'chat.mcp.serverSampling';
+export const mcpServerCollisionBehaviorSection = 'chat.mcp.collisionBehavior';
+
+export const enum McpCollisionBehavior {
+	Disable = 'disable',
+	Suffix = 'suffix',
+}
 
 export interface IMcpServerSamplingConfiguration {
 	allowedDuringChat?: boolean;

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -120,7 +120,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 			this._collections.set(currentCollections.map(c => c === toReplace ? collection : c), undefined);
 		} else {
 			this._collections.set([...currentCollections, collection]
-				.sort((a, b) => (a.presentation?.order || 0) - (b.presentation?.order || 0)), undefined);
+				.sort((a, b) => a.order - b.order), undefined);
 		}
 
 		return {

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -256,19 +256,19 @@ class McpPrefixGenerator {
  * Wraps an {@link EnablementModel} with collision-aware defaults and
  * mutual-exclusion logic for MCP servers with the same label.
  *
- * When collision behavior is `ignore`:
+ * When collision behavior is `disable`:
  * - Servers whose label collides with a higher-priority server are disabled
  *   by default (unless the user has explicitly toggled them).
  * - Enabling a colliding server disables all other servers with the same label.
  *
- * When collision behavior is `number`, delegates everything unchanged.
+ * When collision behavior is `suffix`, delegates everything unchanged.
  */
 export class McpCollisionEnablementModel implements IEnablementModel {
 
 	/**
 	 * For each server definition ID, the list of all definition IDs that share
 	 * the same (case-insensitive) label, in priority order (lowest collection
-	 * order first). Empty when collision behavior is `number`.
+	 * order first). Empty when collision behavior is `suffix`.
 	 */
 	private readonly _collisionGroups: IObservable<ReadonlyMap<string, readonly string[]>>;
 
@@ -347,14 +347,20 @@ export class McpCollisionEnablementModel implements IEnablementModel {
 		}
 
 		// Enabling a colliding server: disable all others in the group atomically
-		transaction(innerTx => {
+		const updateGroup = (innerTx: ITransaction) => {
 			this._base.setEnabled(key, state, innerTx);
 			for (const otherId of group) {
 				if (otherId !== key) {
 					this._base.setEnabled(otherId, ContributionEnablementState.DisabledWorkspace, innerTx);
 				}
 			}
-		});
+		};
+
+		if (tx) {
+			updateGroup(tx);
+		} else {
+			transaction(innerTx => updateGroup(innerTx));
+		}
 	}
 
 	remove(key: string): void {

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -6,13 +6,15 @@
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
-import { autorun, IObservable, ISettableObservable, observableValue, transaction } from '../../../../base/common/observable.js';
+import { autorun, derived, IObservable, IReader, ISettableObservable, ITransaction, observableValue, transaction } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { mcpAutoStartConfig, McpAutoStartValue } from '../../../../platform/mcp/common/mcpManagement.js';
+import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
-import { EnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
+import { ContributionEnablementState, EnablementModel, IEnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
+import { McpCollisionBehavior, mcpServerCollisionBehaviorSection } from './mcpConfiguration.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpServer, McpServerMetadataCache } from './mcpServer.js';
 import { IAutostartResult, IMcpServer, IMcpService, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, McpServerCacheState, McpServerDefinition, McpStartServerInteraction, McpToolName, UserInteractionRequiredError } from './mcpTypes.js';
@@ -30,7 +32,7 @@ export class McpService extends Disposable implements IMcpService {
 
 	public get lazyCollectionState() { return this._mcpRegistry.lazyCollectionState; }
 
-	public readonly enablementModel: EnablementModel;
+	public readonly enablementModel: McpCollisionEnablementModel;
 
 	protected readonly userCache: McpServerMetadataCache;
 	protected readonly workspaceCache: McpServerMetadataCache;
@@ -44,7 +46,9 @@ export class McpService extends Disposable implements IMcpService {
 	) {
 		super();
 
-		this.enablementModel = this._register(new EnablementModel('mcp.enablement', storageService));
+		const baseEnablement = this._register(new EnablementModel('mcp.enablement', storageService));
+		const collisionBehavior = observableConfigValue(mcpServerCollisionBehaviorSection, McpCollisionBehavior.Disable, configurationService);
+		this.enablementModel = new McpCollisionEnablementModel(baseEnablement, this._mcpRegistry, collisionBehavior);
 
 		this.userCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.PROFILE));
 		this.workspaceCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.WORKSPACE));
@@ -245,5 +249,115 @@ class McpPrefixGenerator {
 		}
 		this.seenPrefixes.add(toolPrefix);
 		return toolPrefix;
+	}
+}
+
+/**
+ * Wraps an {@link EnablementModel} with collision-aware defaults and
+ * mutual-exclusion logic for MCP servers with the same label.
+ *
+ * When collision behavior is `ignore`:
+ * - Servers whose label collides with a higher-priority server are disabled
+ *   by default (unless the user has explicitly toggled them).
+ * - Enabling a colliding server disables all other servers with the same label.
+ *
+ * When collision behavior is `number`, delegates everything unchanged.
+ */
+export class McpCollisionEnablementModel implements IEnablementModel {
+
+	/**
+	 * For each server definition ID, the list of all definition IDs that share
+	 * the same (case-insensitive) label, in priority order (lowest collection
+	 * order first). Empty when collision behavior is `number`.
+	 */
+	private readonly _collisionGroups: IObservable<ReadonlyMap<string, readonly string[]>>;
+
+	constructor(
+		private readonly _base: EnablementModel,
+		registry: IMcpRegistry,
+		collisionBehavior: IObservable<McpCollisionBehavior>,
+	) {
+		this._collisionGroups = derived(reader => {
+			if (collisionBehavior.read(reader) !== McpCollisionBehavior.Disable) {
+				return new Map<string, string[]>();
+			}
+
+			const collections = registry.collections.read(reader);
+			// label → list of server definition IDs, in priority order
+			const labelToIds = new Map<string, string[]>();
+			for (const collection of collections) {
+				for (const server of collection.serverDefinitions.read(reader)) {
+					const key = server.label.toLowerCase();
+					let ids = labelToIds.get(key);
+					if (!ids) {
+						ids = [];
+						labelToIds.set(key, ids);
+					}
+					ids.push(server.id);
+				}
+			}
+
+			const groups = new Map<string, string[]>();
+			for (const ids of labelToIds.values()) {
+				if (ids.length < 2) {
+					continue;
+				}
+				for (const id of ids) {
+					groups.set(id, ids);
+				}
+			}
+
+			return groups;
+		});
+	}
+
+	readEnabled(key: string, reader?: IReader): ContributionEnablementState {
+		const baseState = this._base.readEnabled(key, reader);
+
+		if (!isContributionEnabled(baseState)) {
+			return baseState;
+		}
+
+		const group = this._collisionGroups.read(reader).get(key);
+		if (!group) {
+			return baseState;
+		}
+
+		// This server is enabled and in a collision group. Only allow it
+		// to stay enabled if no higher-priority server in the group is
+		// also enabled.
+		for (const otherId of group) {
+			if (otherId === key) {
+				return baseState;
+			}
+			if (isContributionEnabled(this._base.readEnabled(otherId, reader))) {
+				return ContributionEnablementState.DisabledProfile;
+			}
+		}
+		return baseState;
+	}
+
+	setEnabled(key: string, state: ContributionEnablementState, tx?: ITransaction): void {
+		const isEnabling = state === ContributionEnablementState.EnabledProfile || state === ContributionEnablementState.EnabledWorkspace;
+		const group = isEnabling ? this._collisionGroups.get().get(key) : undefined;
+
+		if (!group) {
+			this._base.setEnabled(key, state, tx);
+			return;
+		}
+
+		// Enabling a colliding server: disable all others in the group atomically
+		transaction(innerTx => {
+			this._base.setEnabled(key, state, innerTx);
+			for (const otherId of group) {
+				if (otherId !== key) {
+					this._base.setEnabled(otherId, ContributionEnablementState.DisabledWorkspace, innerTx);
+				}
+			}
+		});
+	}
+
+	remove(key: string): void {
+		this._base.remove(key);
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -81,9 +81,10 @@ export interface McpCollectionDefinition {
 
 	readonly source?: IWorkbenchMcpServer | ExtensionIdentifier;
 
+	/** Sort order of the collection. Lower values have higher priority. */
+	readonly order: number;
+
 	readonly presentation?: {
-		/** Sort order of the collection. */
-		readonly order?: number;
 		/** Place where this collection is configured, used in workspace trust prompts and "show config" */
 		readonly origin?: URI;
 	};
@@ -279,6 +280,7 @@ export const IMcpService = createDecorator<IMcpService>('IMcpService');
 export interface McpCollectionReference {
 	id: string;
 	label: string;
+	order: number;
 	presentation?: McpCollectionDefinition['presentation'];
 }
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
@@ -367,7 +367,7 @@ function createServer(
 	let startCalls = 0;
 
 	return {
-		collection: { id: collectionId, label: collectionId },
+		collection: { id: collectionId, label: collectionId, order: 0 },
 		definition: { id: definitionId, label: definitionId },
 		connection: observableValue(owner, undefined),
 		connectionState,
@@ -406,7 +406,7 @@ function createNeverStartingServer(
 	let startBehavior: 'hang' | 'succeed' = 'hang';
 
 	const result: IMcpServer & { startCalls: number; startBehavior: 'hang' | 'succeed'; cacheStateValue: ReturnType<typeof observableValue<McpServerCacheState>> } = {
-		collection: { id: collectionId, label: collectionId },
+		collection: { id: collectionId, label: collectionId, order: 0 },
 		definition: { id: definitionId, label: definitionId },
 		connection: observableValue(owner, undefined),
 		connectionState,

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -794,8 +794,8 @@ suite('Workbench - MCP - Registry', () => {
 			assert.strictEqual(enablementModel.readEnabled('col-1.srv-a'), ContributionEnablementState.DisabledWorkspace);
 		});
 
-		test('no collision effect when behavior is "number"', () => {
-			configurationService.setUserConfiguration('chat.mcp.collisionBehavior', 'number');
+		test('no collision effect when behavior is "suffix"', () => {
+			configurationService.setUserConfiguration('chat.mcp.collisionBehavior', McpCollisionBehavior.Suffix);
 			configurationService.onDidChangeConfigurationEmitter.fire({
 				affectsConfiguration: (key: string) => key === 'chat.mcp.collisionBehavior',
 			} as unknown as IConfigurationChangeEvent);
@@ -806,7 +806,7 @@ suite('Workbench - MCP - Registry', () => {
 			store.add(registry.registerCollection(col2));
 			setupModel();
 
-			// Both should be enabled when collision behavior is "number"
+			// Both should be enabled when collision behavior is "suffix"
 			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
 			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
 		});

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistry.test.ts
@@ -25,15 +25,19 @@ import { IProductService } from '../../../../../platform/product/common/productS
 import { ISecretStorageService } from '../../../../../platform/secrets/common/secrets.js';
 import { TestSecretStorageService } from '../../../../../platform/secrets/test/common/testSecretStorageService.js';
 import { IStorageService, StorageScope } from '../../../../../platform/storage/common/storage.js';
+import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { IWorkspaceFolderData } from '../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationResolverService } from '../../../../services/configurationResolver/common/configurationResolver.js';
 import { ConfigurationResolverExpression, Replacement } from '../../../../services/configurationResolver/common/configurationResolverExpression.js';
 import { IOutputService } from '../../../../services/output/common/output.js';
 import { TestLoggerService, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { ContributionEnablementState, EnablementModel, isContributionEnabled } from '../../../chat/common/enablement.js';
+import { McpCollisionBehavior, mcpServerCollisionBehaviorSection } from '../../common/mcpConfiguration.js';
 import { McpRegistry } from '../../common/mcpRegistry.js';
 import { IMcpHostDelegate, IMcpMessageTransport } from '../../common/mcpRegistryTypes.js';
 import { IMcpSandboxService } from '../../common/mcpSandboxService.js';
 import { McpServerConnection } from '../../common/mcpServerConnection.js';
+import { McpCollisionEnablementModel } from '../../common/mcpService.js';
 import { McpTaskManager } from '../../common/mcpTaskManager.js';
 import { IMcpPotentialSandboxBlock, LazyCollectionState, McpCollectionDefinition, McpServerDefinition, McpServerLaunch, McpServerTransportStdio, McpServerTransportType, McpServerTrust, McpStartServerInteraction } from '../../common/mcpTypes.js';
 import { TestMcpMessageTransport } from './mcpRegistryTypes.js';
@@ -225,6 +229,7 @@ suite('Workbench - MCP - Registry', () => {
 			trustBehavior: McpServerTrust.Kind.Trusted,
 			scope: StorageScope.APPLICATION,
 			configTarget: ConfigurationTarget.USER,
+			order: 0,
 		};
 
 		// Create base definition that can be reused
@@ -698,6 +703,276 @@ suite('Workbench - MCP - Registry', () => {
 		});
 	});
 
+	suite('Server Label Collision Enablement', () => {
+		let enablementModel: McpCollisionEnablementModel;
+		let baseEnablement: EnablementModel;
+
+		function createCollectionWithServers(
+			id: string,
+			order: number,
+			servers: { id: string; label: string }[],
+		): McpCollectionDefinition & { serverDefinitions: ISettableObservable<McpServerDefinition[]> } {
+			return {
+				id,
+				label: `Collection ${id}`,
+				remoteAuthority: null,
+				order,
+				serverDefinitions: observableValue('serverDefs', servers.map(s => ({
+					...baseDefinition,
+					id: s.id,
+					label: s.label,
+				}))),
+				trustBehavior: McpServerTrust.Kind.Trusted,
+				scope: StorageScope.APPLICATION,
+				configTarget: ConfigurationTarget.USER,
+			};
+		}
+
+		function setupModel() {
+			baseEnablement = store.add(new EnablementModel('mcp.enablement.test', testStorageService));
+			const collisionBehavior = observableConfigValue(mcpServerCollisionBehaviorSection, McpCollisionBehavior.Disable, configurationService);
+			enablementModel = new McpCollisionEnablementModel(baseEnablement, registry, collisionBehavior);
+		}
+
+		test('disables lower-priority servers with same label', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-a', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('does not disable servers with different labels', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'Server A' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-b', label: 'Server B' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-b')));
+		});
+
+		test('label collision is case-insensitive', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-a', label: 'my server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('respects collection order for priority', () => {
+			const col2 = createCollectionWithServers('col-2', 200, [{ id: 'col-2.srv-a', label: 'My Server' }]);
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			store.add(registry.registerCollection(col2));
+			store.add(registry.registerCollection(col1));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('enabling a colliding server disables others with same label', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-a', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Enable the lower-priority server explicitly
+			enablementModel.setEnabled('col-2.srv-a', ContributionEnablementState.EnabledWorkspace);
+
+			// col-2 is now enabled, col-1 should be disabled (set to DisabledWorkspace)
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.strictEqual(enablementModel.readEnabled('col-1.srv-a'), ContributionEnablementState.DisabledWorkspace);
+		});
+
+		test('no collision effect when behavior is "number"', () => {
+			configurationService.setUserConfiguration('chat.mcp.collisionBehavior', 'number');
+			configurationService.onDidChangeConfigurationEmitter.fire({
+				affectsConfiguration: (key: string) => key === 'chat.mcp.collisionBehavior',
+			} as unknown as IConfigurationChangeEvent);
+
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-a', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Both should be enabled when collision behavior is "number"
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('non-winner becomes enabled when winner is explicitly disabled', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-a', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Explicitly disable the winner
+			enablementModel.setEnabled('col-1.srv-a', ContributionEnablementState.DisabledProfile);
+
+			// col-1 is disabled, col-2 becomes the first enabled server in the group
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('updates when server definitions change', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'Server A' }]);
+			const col2: McpCollectionDefinition & { serverDefinitions: ISettableObservable<McpServerDefinition[]> } = {
+				...createCollectionWithServers('col-2', 100, []),
+			};
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Initially no collision — both enabled
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+
+			// Add a conflicting server to col2
+			col2.serverDefinitions.set([{ ...baseDefinition, id: 'col-2.srv-a', label: 'Server A' }], undefined);
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+		});
+
+		test('three-way collision: only highest priority is enabled', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv', label: 'My Server' }]);
+			const col3 = createCollectionWithServers('col-3', 200, [{ id: 'col-3.srv', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			store.add(registry.registerCollection(col3));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-3.srv')));
+		});
+
+		test('three-way collision: enabling lowest disables both others', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv', label: 'My Server' }]);
+			const col3 = createCollectionWithServers('col-3', 200, [{ id: 'col-3.srv', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			store.add(registry.registerCollection(col3));
+			setupModel();
+
+			enablementModel.setEnabled('col-3.srv', ContributionEnablementState.EnabledWorkspace);
+
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-3.srv')));
+		});
+
+		test('disabling winner cascades to next in priority', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv', label: 'My Server' }]);
+			const col3 = createCollectionWithServers('col-3', 200, [{ id: 'col-3.srv', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			store.add(registry.registerCollection(col3));
+			setupModel();
+
+			// Disable the winner — col-2 (next priority) becomes the active one
+			enablementModel.setEnabled('col-1.srv', ContributionEnablementState.DisabledProfile);
+
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-3.srv')));
+		});
+
+		test('both servers in same collection with same label: only first enabled', () => {
+			const col = createCollectionWithServers('col-1', 0, [
+				{ id: 'col-1.srv-a', label: 'My Server' },
+				{ id: 'col-1.srv-b', label: 'My Server' },
+			]);
+			store.add(registry.registerCollection(col));
+			setupModel();
+
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv-b')));
+		});
+
+		test('EnabledWorkspace non-winner still suppressed if winner also enabled', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Manually set both to EnabledWorkspace in the base model
+			baseEnablement.setEnabled('col-1.srv', ContributionEnablementState.EnabledWorkspace);
+			baseEnablement.setEnabled('col-2.srv', ContributionEnablementState.EnabledWorkspace);
+
+			// Even though both are explicitly enabled, only the higher-priority one wins
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv')));
+		});
+
+		test('remove clears collision override and restores default behavior', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv', label: 'My Server' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv', label: 'My Server' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Enable col-2, which disables col-1 via DisabledWorkspace
+			enablementModel.setEnabled('col-2.srv', ContributionEnablementState.EnabledWorkspace);
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+
+			// Remove both overrides — restores default collision behavior
+			enablementModel.remove('col-1.srv');
+			enablementModel.remove('col-2.srv');
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv')));
+		});
+
+		test('non-colliding servers in same collection as colliding ones are unaffected', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [
+				{ id: 'col-1.srv-a', label: 'My Server' },
+				{ id: 'col-1.srv-b', label: 'Unique Server' },
+			]);
+			const col2 = createCollectionWithServers('col-2', 100, [
+				{ id: 'col-2.srv-a', label: 'My Server' },
+				{ id: 'col-2.srv-c', label: 'Another Unique' },
+			]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			// Colliding servers: only col-1's wins
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(!isContributionEnabled(enablementModel.readEnabled('col-2.srv-a')));
+			// Non-colliding servers: both enabled
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-b')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-c')));
+		});
+
+		test('setEnabled with non-colliding server does not affect others', () => {
+			const col1 = createCollectionWithServers('col-1', 0, [{ id: 'col-1.srv-a', label: 'Server A' }]);
+			const col2 = createCollectionWithServers('col-2', 100, [{ id: 'col-2.srv-b', label: 'Server B' }]);
+			store.add(registry.registerCollection(col1));
+			store.add(registry.registerCollection(col2));
+			setupModel();
+
+			enablementModel.setEnabled('col-2.srv-b', ContributionEnablementState.EnabledWorkspace);
+
+			// No collision group — col-1 should be unaffected
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-1.srv-a')));
+			assert.ok(isContributionEnabled(enablementModel.readEnabled('col-2.srv-b')));
+		});
+	});
+
 	suite('Trust Flow', () => {
 		/**
 		 * Helper to create a test MCP collection with a specific trust behavior
@@ -711,6 +986,7 @@ suite('Workbench - MCP - Registry', () => {
 				trustBehavior,
 				scope: StorageScope.APPLICATION,
 				configTarget: ConfigurationTarget.USER,
+				order: 0,
 			};
 		}
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpRegistryTypes.ts
@@ -168,6 +168,7 @@ export class TestMcpRegistry implements IMcpRegistry {
 		remoteAuthority: null,
 		label: 'Test Collection',
 		configTarget: ConfigurationTarget.USER,
+		order: 0,
 		serverDefinitions: observableValue(this, [{
 			id: 'test-server',
 			label: 'Test Server',

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -95,6 +95,7 @@ suite('Workbench - MCP - ServerConnection', () => {
 			trustBehavior: McpServerTrust.Kind.Trusted,
 			scope: StorageScope.APPLICATION,
 			configTarget: ConfigurationTarget.USER,
+			order: 0,
 		};
 
 		// Create server definition


### PR DESCRIPTION
mcp: add .mcp.json workspace discovery and server collision handling

Adds support for discovering MCP servers from .mcp.json files at
workspace folder roots using the Claude-style format, and introduces
collision-aware enablement logic for servers with duplicate names.

- Adds WorkspaceDotMcpDiscovery to discover servers from .mcp.json
  files in workspace folder roots, with file watching and throttled
  updates.
- Adds McpCollisionEnablementModel that disables lower-priority
  servers when multiple servers share the same label, controlled by
  a new chat.mcp.collisionBehavior setting (disable or suffix).
- Promotes collection 'order' from presentation.order to a required
  top-level field on McpCollectionDefinition for clearer priority
  semantics.
- Adds ITransaction support to EnablementModel.setEnabled for
  atomic multi-server enablement changes.
- Adds an 'Enable Server' action in the server options quick pick
  and a 'Disabled' codelens for disabled servers in config files.
- Adds language features (codelens, diagnostics, inlay hints) for
  .mcp.json files.
- Adds comprehensive tests for the collision enablement model.

(Commit message generated by Copilot)