### PR TITLE
Improve workspace picker UX

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -454,14 +454,6 @@ export interface IActionListOptions {
 	readonly minWidth?: number;
 
 	/**
-	 * Fixed width for the action list. When set, DOM-based width measurement is
-	 * skipped and this value is used directly, preventing width fluctuations caused
-	 * by scrollbar presence (which changes with window height). Use this for pickers
-	 * that should have a stable, fixed width (e.g. the workspace picker at 600px).
-	 */
-	readonly fixedWidth?: number;
-
-	/**
 	 * Optional handler for markdown links activated in item descriptions or hovers.
 	 * When unset, links open via the opener service with command links allowed.
 	 */
@@ -1374,12 +1366,14 @@ export class ActionListWidget<T> extends Disposable {
 				}
 				for (let ci = 0; ci < group.actions.length; ci++) {
 					const child = group.actions[ci];
+					const icon = (child as IAction & { icon?: ThemeIcon }).icon
+						?? ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id);
 					submenuItems.push({
 						item: child,
 						kind: ActionListItemKind.Action,
 						label: child.label,
 						description: child.tooltip || undefined,
-						group: { title: '', icon: ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id) },
+						group: { title: '', icon },
 						hideIcon: false,
 						hover: {},
 					});
@@ -1616,7 +1610,6 @@ export class ActionList<T> extends Disposable {
 	private _cachedMaxWidth: number | undefined;
 	private _hasLaidOut = false;
 	private _showAbove: boolean | undefined;
-	private readonly _options: IActionListOptions | undefined;
 
 	get domNode(): HTMLElement {
 		return this._widget.domNode;
@@ -1655,7 +1648,6 @@ export class ActionList<T> extends Disposable {
 	) {
 		super();
 		this._anchor = anchor;
-		this._options = options;
 
 		this._widget = this._register(instantiationService.createInstance(
 			ActionListWidget<T>,
@@ -1760,15 +1752,7 @@ export class ActionList<T> extends Disposable {
 		const listHeight = this.computeHeight();
 		this._widget.layout(listHeight);
 
-		// When a fixedWidth is provided, skip DOM measurement entirely.
-		// DOM-based measurement varies with scrollbar presence (which depends on
-		// the list height), causing the width to fluctuate as the window is resized.
-		let computedWidth: number;
-		if (this._options?.fixedWidth !== undefined) {
-			computedWidth = this._options.fixedWidth;
-		} else {
-			computedWidth = this._widget.computeMaxWidth(minWidth);
-		}
+		const computedWidth = this._widget.computeMaxWidth(minWidth);
 		this._cachedMaxWidth = computedWidth;
 		this._widget.layout(listHeight, this._cachedMaxWidth);
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -269,6 +269,10 @@
 		text-overflow: ellipsis;
 	}
 
+	.group-title {
+		margin-left: auto;
+	}
+
 	.action-list-item-toolbar {
 		margin-left: 4px;
 		margin-right: 10px;

--- a/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -59,6 +59,8 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 		this.browseActions = [{
 			label: localize('folders', "Folders"),
+			description: this.label,
+			group: 'folders',
 			icon: Codicon.folderOpened,
 			providerId: this.id,
 			run: () => this._browseForFolder(),

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -229,8 +229,8 @@ export class WorkspacePicker extends Disposable {
 		};
 
 		const listOptions = showFilter
-			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, fixedWidth: 600 }
-			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true, fixedWidth: 600 };
+			? { showFilter: true, filterPlaceholder: localize('workspacePicker.filter', "Search Workspaces..."), reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true }
+			: { reserveSubmenuSpace: false, inlineDescription: true, showGroupTitleOnFirstItem: true };
 		triggerElement.setAttribute('aria-expanded', 'true');
 
 		this.actionWidgetService.show<IWorkspacePickerItem>(
@@ -332,12 +332,9 @@ export class WorkspacePicker extends Disposable {
 	/**
 	 * Builds the picker items list from recent workspaces.
 	 *
-	 * Ordering:
-	 * 1. Own recents (from sessions picker storage) come first, followed by
-	 *    VS Code recent folders — both retain their original storage order.
-	 * 2. Items are grouped by provider/group title. Groups are sorted by
-	 *    first-appearance index so the first group encountered stays on top.
-	 * 3. Within each group the original insertion order is preserved (stable sort).
+	 * Items are shown in a flat recency-sorted list (most recently used first)
+	 * without source grouping. Own recents come first, followed by VS Code
+	 * recent folders.
 	 */
 	protected _buildItems(): IActionListItem<IWorkspacePickerItem>[] {
 		const items: IActionListItem<IWorkspacePickerItem>[] = [];
@@ -352,52 +349,20 @@ export class WorkspacePicker extends Disposable {
 		const ownRecentCount = ownRecentWorkspaces.length;
 		const recentWorkspaces = [...ownRecentWorkspaces, ...vsCodeRecents];
 
-		// Build flat list of workspace entries with their group info
-		const workspaceEntries: { workspace: ISessionWorkspace; providerId: string; isOwnRecent: boolean; groupTitle: string; isDisconnected: boolean }[] = [];
-		const providersWithWorkspaces = allProviders.filter(p => recentWorkspaces.some(w => w.providerId === p.id));
-		for (const provider of providersWithWorkspaces) {
-			const connectionStatus = isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
+		// Build flat list in recency order (no source grouping)
+		for (let i = 0; i < recentWorkspaces.length; i++) {
+			const { workspace, providerId } = recentWorkspaces[i];
+			const isOwnRecent = i < ownRecentCount;
+			const provider = allProviders.find(p => p.id === providerId);
+			const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
 			const isDisconnected = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected;
-			const isConnecting = connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
-			const providerWorkspaces = recentWorkspaces
-				.map((w, idx) => ({ ...w, isOwnRecent: idx < ownRecentCount }))
-				.filter(w => w.providerId === provider.id);
-			for (const { workspace, providerId, isOwnRecent } of providerWorkspaces) {
-				const groupName = workspace.group ?? provider.label;
-				const groupTitle = isDisconnected
-					? localize('workspacePicker.groupOffline', "{0} (Offline)", groupName)
-					: isConnecting
-						? localize('workspacePicker.groupConnecting', "{0} (Connecting)", groupName)
-						: groupName;
-				workspaceEntries.push({ workspace, providerId, isOwnRecent, groupTitle, isDisconnected });
-			}
-		}
-
-		// Group entries by groupTitle, preserving the original order within each group
-		const groupOrder = new Map<string, number>();
-		workspaceEntries.forEach((entry, index) => {
-			if (!groupOrder.has(entry.groupTitle)) {
-				groupOrder.set(entry.groupTitle, index);
-			}
-		});
-		workspaceEntries.sort((a, b) => {
-			return (groupOrder.get(a.groupTitle) ?? 0) - (groupOrder.get(b.groupTitle) ?? 0);
-		});
-
-		// Add items with separators between groups
-		let lastGroupTitle: string | undefined;
-		for (const { workspace, providerId, isOwnRecent, groupTitle, isDisconnected } of workspaceEntries) {
-			if (lastGroupTitle !== undefined && lastGroupTitle !== groupTitle) {
-				items.push({ kind: ActionListItemKind.Separator, label: '' });
-			}
-			lastGroupTitle = groupTitle;
 			const selection: IWorkspaceSelection = { providerId, workspace };
 			const selected = this._isSelectedWorkspace(selection);
 			items.push({
 				kind: ActionListItemKind.Action,
 				label: workspace.label,
 				description: workspace.description,
-				group: { title: groupTitle, icon: workspace.icon },
+				group: { title: '', icon: workspace.icon },
 				disabled: isDisconnected,
 				item: { selection, checked: selected || undefined },
 				onRemove: isOwnRecent ? () => this._removeRecentWorkspace(selection) : () => this._removeVSCodeRecentWorkspace(selection),
@@ -412,56 +377,80 @@ export class WorkspacePicker extends Disposable {
 		if (items.length > 0 && (allBrowseActions.length > 0 || remoteProviders.length > 0)) {
 			items.push({ kind: ActionListItemKind.Separator, label: '' });
 		}
-		if (allProviders.length > 1 && (allBrowseActions.length + remoteProviders.length) > 1) {
-			// Show a single "Select..." entry with provider-grouped submenu actions
-			// that also includes remote host entries
-			const providerMap = new Map<string, { provider: typeof allProviders[0]; actions: { action: ISessionWorkspaceBrowseAction; index: number }[] }>();
-			allBrowseActions.forEach((action, i) => {
-				let entry = providerMap.get(action.providerId);
-				if (!entry) {
-					const provider = allProviders.find(p => p.id === action.providerId);
-					if (!provider) { return; }
-					entry = { provider, actions: [] };
-					providerMap.set(action.providerId, entry);
-				}
-				entry.actions.push({ action, index: i });
-			});
-			const remoteProviderIds = new Map(remoteProviders.map(p => [p.id, p]));
-			const submenuActions = [...providerMap.values()].map(({ provider, actions }) => {
-				const remoteProvider = remoteProviderIds.get(provider.id);
-				const remoteStatus = remoteProvider?.connectionStatus?.get();
-				const actionItems = actions.map(({ action, index }, ci) => toAction({
-					id: `workspacePicker.browse.${index}`,
-					label: localize(`workspacePicker.browseAction`, "{0}...", action.label),
-					tooltip: ci === 0 ? provider.label : '',
-					enabled: remoteStatus !== RemoteAgentHostConnectionStatus.Disconnected && remoteStatus !== RemoteAgentHostConnectionStatus.Connecting,
-					run: () => this._executeBrowseAction(index),
-				}));
 
-				return new SubmenuAction(
-					`workspacePicker.browse.${provider.id}`,
-					'',
-					actionItems,
-				);
-			});
+		// Group browse actions by their `group` property so that actions
+		// sharing the same group appear as a single entry with a submenu.
+		// Actions without a group are shown individually.
+		const browseByGroup = new Map<string, { label: string; icon: ThemeIcon; actions: { action: ISessionWorkspaceBrowseAction; index: number }[] }>();
+		const ungrouped: { action: ISessionWorkspaceBrowseAction; index: number }[] = [];
+		allBrowseActions.forEach((action, i) => {
+			if (!action.group) {
+				ungrouped.push({ action, index: i });
+				return;
+			}
+			let entry = browseByGroup.get(action.group);
+			if (!entry) {
+				entry = { label: action.label, icon: action.icon, actions: [] };
+				browseByGroup.set(action.group, entry);
+			}
+			entry.actions.push({ action, index: i });
+		});
 
-			items.push({
-				kind: ActionListItemKind.Action,
-				label: localize('workspacePicker.browseSelect', "Select..."),
-				group: { title: '', icon: Codicon.folderOpened },
-				item: {},
-				submenuActions,
-			});
-		} else {
-			for (let i = 0; i < allBrowseActions.length; i++) {
-				const action = allBrowseActions[i];
+		for (const [, { label, icon, actions }] of browseByGroup) {
+			if (actions.length === 1) {
+				// Single provider for this group — show directly
+				const { action, index } = actions[0];
+				const provider = allProviders.find(p => p.id === action.providerId);
+				const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
+				const isUnavailable = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected || connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
 				items.push({
 					kind: ActionListItemKind.Action,
-					label: localize(`workspacePicker.browseSelectAction`, "Select {0}...", action.label),
-					group: { title: '', icon: action.icon },
-					item: { browseActionIndex: i },
+					label: localize(`workspacePicker.browseSelectAction`, "Select {0}...", label),
+					description: action.description,
+					group: { title: '', icon },
+					disabled: isUnavailable,
+					item: { browseActionIndex: index },
+				});
+			} else {
+				// Multiple providers for this group — show submenu
+				const submenuActions = actions.map(({ action, index }) => {
+					const provider = allProviders.find(p => p.id === action.providerId);
+					const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
+					const isUnavailable = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected || connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
+					return {
+						...toAction({
+							id: `workspacePicker.browse.${index}`,
+							label: action.description ?? provider?.label ?? label,
+							tooltip: '',
+							enabled: !isUnavailable,
+							run: () => this._executeBrowseAction(index),
+						}),
+						icon: action.icon,
+					};
+				});
+				items.push({
+					kind: ActionListItemKind.Action,
+					label: localize('workspacePicker.browseSelectAction', "Select {0}...", label),
+					group: { title: '', icon },
+					item: {},
+					submenuActions: [new SubmenuAction(`workspacePicker.browse.group.${label}`, '', submenuActions)],
 				});
 			}
+		}
+
+		// Ungrouped actions shown individually
+		for (const { action, index } of ungrouped) {
+			const provider = allProviders.find(p => p.id === action.providerId);
+			const connectionStatus = provider && isAgentHostProvider(provider) ? provider.connectionStatus?.get() : undefined;
+			const isUnavailable = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected || connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: localize('workspacePicker.browseSelectAction', "Select {0}...", action.label),
+				description: action.description,
+				group: { title: '', icon: action.icon },
+				disabled: isUnavailable,
+				item: { browseActionIndex: index },
+			});
 		}
 
 		if (items.length > 0 && items[items.length - 1].kind !== ActionListItemKind.Separator && remoteProviders.length) {

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1265,12 +1265,15 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		this.browseActions = [
 			{
 				label: localize('folders', "Folders"),
+				description: localize('local', "Local"),
+				group: 'folders',
 				icon: Codicon.folderOpened,
 				providerId: this.id,
 				run: () => this._browseForFolder(),
 			},
 			{
 				label: localize('repositories', "Repositories"),
+				description: localize('github', "GitHub"),
 				icon: Codicon.repo,
 				providerId: this.id,
 				run: () => this._browseForRepo(),

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider.ts
@@ -202,6 +202,8 @@ export class RemoteAgentHostSessionsProvider extends BaseAgentHostSessionsProvid
 
 		this.browseActions = [{
 			label: localize('folders', "Folders"),
+			description: displayName,
+			group: 'folders',
 			icon: Codicon.remote,
 			providerId: this.id,
 			run: () => this._browseForFolder(),

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -237,6 +237,14 @@ export interface ISessionCapabilities {
 export interface ISessionWorkspaceBrowseAction {
 	/** Display label for the browse action. */
 	readonly label: string;
+	/** Optional description shown alongside the label in the workspace picker. */
+	readonly description?: string;
+	/**
+	 * Optional group identifier. Actions sharing the same group are merged
+	 * into a single picker entry with a submenu. The group value is also
+	 * used as the display label for that merged entry (e.g. "Folders").
+	 */
+	readonly group?: string;
 	/** Icon for the browse action. */
 	readonly icon: ThemeIcon;
 	/** The provider that owns this action. */


### PR DESCRIPTION
## Summary

Improvements to the session workspace picker UX:

### Flat recency-sorted list
Remove source/provider grouping — workspaces now appear in a flat list sorted by most recently used, so the last-used agent host workspace shows at the top regardless of provider.

### Browse actions in main list
Replace the single `Select...` submenu entry with individual browse actions shown directly in the main picker list.

### Browse action grouping by `group` property
- Add optional `description`, `group`, and icon support to `ISessionWorkspaceBrowseAction`
- Actions sharing the same `group` key are merged into one entry with a submenu (e.g. all `'folders'` actions become `Select Folders...` with provider sub-entries)
- Actions without a `group` are shown individually
- Provider descriptions: Copilot Folders → "Local", Repositories → "GitHub"; agent host providers → provider label

### Action list improvements
- Fix group-title alignment in inline-description mode (`margin-left: auto`) so titles are always right-aligned even when description is absent
- Pass icons for submenu entries via `group.icon` mechanism (read from action's `icon` property)
- Remove `fixedWidth` option (no remaining callers)