### PR TITLE
sessions: enable Claude agent sessions by default and rename setting

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
+++ b/src/vs/sessions/contrib/copilotChatSessions/COPILOT_CHAT_SESSIONS_PROVIDER.md
@@ -2,7 +2,7 @@
 
 **File:** `src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts`
 
-The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports three session types: **Copilot CLI** (local), **Copilot Cloud** (remote), and **Claude** (local, gated by `sessions.chatSessions.claude.enabled`).
+The default sessions provider, registered with ID `'default-copilot'`. Wraps the existing agent session infrastructure into the extensible provider model. Supports three session types: **Copilot CLI** (local), **Copilot Cloud** (remote), and **Claude** (local, gated by `sessions.chat.claudeAgent.enabled`).
 
 ## Registration
 
@@ -57,7 +57,7 @@ When `createNewSession(workspace)` is called, the provider creates one of two co
 - Implements `ISession` with simplified configuration (Claude manages its own worktrees and branches)
 - No-ops for `setIsolationMode()` and `setBranch()`
 - `setOption()` writes to `selectedOptions` map; options are propagated to `IChatSessionsService` during `_sendFirstChat()` via `updateSessionOptions()`
-- Gated by the `sessions.chatSessions.claude.enabled` setting (default: `false`)
+- Gated by the `sessions.chat.claudeAgent.enabled` setting (default: `true`)
 
 ## `AgentSessionAdapter` — Wrapping Existing Sessions
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution.ts
@@ -24,10 +24,9 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		[CLAUDE_CODE_ENABLED_SETTING]: {
 			type: 'boolean',
-			default: false,
-			tags: ['experimental'],
+			default: true,
 			experiment: { mode: 'startup' },
-			description: localize('sessions.chatSessions.claude.enabled', "NOTE: This is HIGHLY experimental and under active development! Whether to enable Claude agent sessions in the sessions provider."),
+			description: localize('sessions.chat.claudeAgent.enabled', "Enable Claude Agent sessions in the Agents app. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription."),
 		},
 	},
 });

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -114,8 +114,7 @@ export const COPILOT_PROVIDER_ID = 'default-copilot';
 export const COPILOT_MULTI_CHAT_SETTING = 'sessions.github.copilot.multiChatSessions';
 
 /** Setting key controlling whether Claude agent sessions are available. */
-export const CLAUDE_CODE_ENABLED_SETTING = 'sessions.chatSessions.claude.enabled';
-
+export const CLAUDE_CODE_ENABLED_SETTING = 'sessions.chat.claudeAgent.enabled';
 
 const REPOSITORY_OPTION_ID = 'repository';
 const PARENT_SESSION_OPTION_ID = 'parentSessionId';
@@ -1249,11 +1248,11 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		super();
 
 		this._multiChatEnabled = this.configurationService.getValue<boolean>(COPILOT_MULTI_CHAT_SETTING) ?? true;
-		this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING) ?? false;
+		this._claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(CLAUDE_CODE_ENABLED_SETTING)) {
-				const claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING) ?? false;
+				const claudeEnabled = this.configurationService.getValue<boolean>(CLAUDE_CODE_ENABLED_SETTING);
 				if (this._claudeEnabled !== claudeEnabled) {
 					this._claudeEnabled = claudeEnabled;
 					this._onDidChangeSessionTypes.fire();

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -123,7 +123,7 @@ function createProviderWithConfig(
 
 	const configService = new TestConfigurationService();
 	configService.setUserConfiguration('sessions.github.copilot.multiChatSessions', opts?.multiChatEnabled ?? true);
-	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? false);
+	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? true);
 
 	instantiationService.stub(IConfigurationService, configService);
 	instantiationService.stub(IStorageService, disposables.add(new TestStorageService()));
@@ -208,7 +208,7 @@ function createProviderForSendTests(
 
 	const configService = new TestConfigurationService();
 	configService.setUserConfiguration('sessions.github.copilot.multiChatSessions', true);
-	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? false);
+	configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, opts?.claudeEnabled ?? true);
 
 	instantiationService.stub(ILogService, NullLogService);
 	instantiationService.stub(IConfigurationService, configService);
@@ -279,24 +279,24 @@ suite('CopilotChatSessionsProvider', () => {
 	test('has correct id and label', () => {
 		const provider = createProvider(disposables, model);
 		assert.strictEqual(provider.id, COPILOT_PROVIDER_ID);
-		assert.strictEqual(provider.sessionTypes.length, 2);
+		assert.strictEqual(provider.sessionTypes.length, 3);
 	});
 
-	test('sessionTypes includes Claude when setting is enabled', () => {
-		const provider = createProvider(disposables, model, { claudeEnabled: true });
-		assert.strictEqual(provider.sessionTypes.length, 3);
-		assert.ok(provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
+	test('sessionTypes excludes Claude when setting is disabled', () => {
+		const provider = createProvider(disposables, model, { claudeEnabled: false });
+		assert.strictEqual(provider.sessionTypes.length, 2);
+		assert.ok(!provider.sessionTypes.some(t => t.id === ClaudeCodeSessionType.id));
 	});
 
 	test('onDidChangeSessionTypes fires when claude setting changes', () => {
 		const { provider, configService } = createProviderWithConfig(disposables, model);
-		assert.strictEqual(provider.sessionTypes.length, 2);
+		assert.strictEqual(provider.sessionTypes.length, 3);
 
 		let fired = false;
 		disposables.add(provider.onDidChangeSessionTypes(() => { fired = true; }));
 
-		// Enable claude via config change
-		configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, true);
+		// Disable claude via config change
+		configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, false);
 		configService.onDidChangeConfigurationEmitter.fire({
 			source: ConfigurationTarget.USER,
 			affectedKeys: new Set([CLAUDE_CODE_ENABLED_SETTING]),
@@ -305,7 +305,7 @@ suite('CopilotChatSessionsProvider', () => {
 		});
 
 		assert.ok(fired, 'onDidChangeSessionTypes should have fired');
-		assert.strictEqual(provider.sessionTypes.length, 3);
+		assert.strictEqual(provider.sessionTypes.length, 2);
 	});
 
 	test('toggling claude setting refreshes sessions list', () => {
@@ -313,18 +313,7 @@ suite('CopilotChatSessionsProvider', () => {
 		model.addSession(createMockAgentSession(claudeResource, { providerType: AgentSessionProviders.Claude }));
 
 		const { provider, configService } = createProviderWithConfig(disposables, model);
-		assert.strictEqual(provider.getSessions().length, 0, 'Claude sessions should be hidden when disabled');
-
-		// Enable Claude
-		configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, true);
-		configService.onDidChangeConfigurationEmitter.fire({
-			source: ConfigurationTarget.USER,
-			affectedKeys: new Set([CLAUDE_CODE_ENABLED_SETTING]),
-			change: { keys: [CLAUDE_CODE_ENABLED_SETTING], overrides: [] },
-			affectsConfiguration: (key: string) => key === CLAUDE_CODE_ENABLED_SETTING,
-		});
-
-		assert.strictEqual(provider.getSessions().length, 1, 'Claude sessions should appear after enabling');
+		assert.strictEqual(provider.getSessions().length, 1, 'Claude sessions should appear when enabled by default');
 
 		// Disable Claude
 		configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, false);
@@ -336,6 +325,17 @@ suite('CopilotChatSessionsProvider', () => {
 		});
 
 		assert.strictEqual(provider.getSessions().length, 0, 'Claude sessions should disappear after disabling');
+
+		// Re-enable Claude
+		configService.setUserConfiguration(CLAUDE_CODE_ENABLED_SETTING, true);
+		configService.onDidChangeConfigurationEmitter.fire({
+			source: ConfigurationTarget.USER,
+			affectedKeys: new Set([CLAUDE_CODE_ENABLED_SETTING]),
+			change: { keys: [CLAUDE_CODE_ENABLED_SETTING], overrides: [] },
+			affectsConfiguration: (key: string) => key === CLAUDE_CODE_ENABLED_SETTING,
+		});
+
+		assert.strictEqual(provider.getSessions().length, 1, 'Claude sessions should reappear after re-enabling');
 	});
 
 	// ---- getSessionTypes -------
@@ -347,7 +347,7 @@ suite('CopilotChatSessionsProvider', () => {
 	});
 
 	test('getSessionTypes does not return Claude for local workspace when disabled', () => {
-		const provider = createProvider(disposables, model);
+		const provider = createProvider(disposables, model, { claudeEnabled: false });
 		const types = provider.getSessionTypes(URI.file('/test/project'));
 		assert.ok(!types.some(t => t.id === ClaudeCodeSessionType.id));
 	});
@@ -404,7 +404,7 @@ suite('CopilotChatSessionsProvider', () => {
 		const claudeResource = URI.from({ scheme: AgentSessionProviders.Claude, path: '/claude-session' });
 		model.addSession(createMockAgentSession(claudeResource, { providerType: AgentSessionProviders.Claude }));
 
-		const provider = createProvider(disposables, model);
+		const provider = createProvider(disposables, model, { claudeEnabled: false });
 		const sessions = provider.getSessions();
 
 		assert.strictEqual(sessions.length, 0);


### PR DESCRIPTION
## Summary
- Renames `sessions.chatSessions.claude.enabled` to `sessions.chat.claudeAgent.enabled` to align with the `github.copilot.chat.claudeAgent.enabled` convention
- Enables the setting by default (`true`) and removes the `experimental` tag
- Updates description to match the copilot extension's wording
- Removes redundant `?? false` fallbacks from `getValue` calls (config registry provides the default)
- Updates tests and docs to reflect the new default

## Test plan
- [x] All 56 unit tests pass (`copilotChatSessionsProvider.test.ts`)
- [x] TypeScript compilation passes
- [x] Verify Claude session type appears by default in the Agents app
- [x] Verify disabling the setting hides Claude sessions