### PR TITLE
Use stable group key for workspace picker SubmenuAction id

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -396,7 +396,7 @@ export class WorkspacePicker extends Disposable {
 			entry.actions.push({ action, index: i });
 		});
 
-		for (const [, { label, icon, actions }] of browseByGroup) {
+		for (const [groupKey, { label, icon, actions }] of browseByGroup) {
 			if (actions.length === 1) {
 				// Single provider for this group — show directly
 				const { action, index } = actions[0];
@@ -433,7 +433,7 @@ export class WorkspacePicker extends Disposable {
 					label: localize('workspacePicker.browseSelectAction', "Select {0}...", label),
 					group: { title: '', icon },
 					item: {},
-					submenuActions: [new SubmenuAction(`workspacePicker.browse.group.${label}`, '', submenuActions)],
+					submenuActions: [new SubmenuAction(`workspacePicker.browse.group.${groupKey}`, '', submenuActions)],
 				});
 			}
 		}

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -250,9 +250,10 @@ export interface ISessionWorkspaceBrowseAction {
 	/** Optional description shown alongside the label in the workspace picker. */
 	readonly description?: string;
 	/**
-	 * Optional group identifier. Actions sharing the same group are merged
-	 * into a single picker entry with a submenu. The group value is also
-	 * used as the display label for that merged entry (e.g. "Folders").
+	 * Optional non-localized group key used to merge actions in the workspace picker.
+	 * Actions sharing the same group key are combined into a single picker entry
+	 * with a submenu. The first action's label is used as the display text for
+	 * the merged entry (e.g. "Folders").
 	 */
 	readonly group?: string;
 	/** Icon for the browse action. */


### PR DESCRIPTION
Follow-up to #312245.

- **SubmenuAction id**: Use the non-localized group key from `browseByGroup` map instead of the localized `label` string to ensure stable action ids across locales
- **JSDoc**: Update `ISessionWorkspaceBrowseAction.group` comment to clarify it is a non-localized key for grouping, not a display label (the first action's `label` is used for display)