### PR TITLE
agentHost: fix duplicate edits being shown in chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -698,10 +698,16 @@ export function finalizeToolInvocation(invocation: ChatToolInvocation, tc: ToolC
 	const isFailure = (isCompleted && !tc.success) || isCancelled;
 	const errorMessage = isCompleted ? tc.error?.message : (isCancelled ? tc.reasonMessage : undefined);
 	const errorString = typeof errorMessage === 'string' ? errorMessage : errorMessage?.markdown;
+	const fileEdits = isCompleted ? fileEditsToExternalEdits(tc) : [];
+
+	// Hide the tool widget when file edits are shown separately via onFileEdits
+	if (fileEdits.length > 0 && !isFailure) {
+		invocation.presentation = ToolInvocationPresentation.Hidden;
+	}
+
 	invocation.didExecuteTool(isFailure ? { content: [], toolResultError: errorString } : undefined);
 
-	// Extract file edits for the editing session pipeline
-	return isCompleted ? fileEditsToExternalEdits(tc) : [];
+	return fileEdits;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -114,7 +114,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 		const render = () => {
 			partStore.clear();
 
-			if (toolInvocation.presentation === ToolInvocationPresentation.HiddenAfterComplete && IChatToolInvocation.isComplete(toolInvocation)) {
+			if (toolInvocation.presentation === ToolInvocationPresentation.Hidden || (toolInvocation.presentation === ToolInvocationPresentation.HiddenAfterComplete && IChatToolInvocation.isComplete(toolInvocation))) {
 				dom.hide(this.domNode);
 				return;
 			}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ToolCallStatus, ToolCallConfirmationReason, ToolResultContentType, TurnState, ResponsePartKind, type ActiveTurn, type ICompletedToolCall, type ToolCallRunningState, type Turn, type ToolCallResponsePart, ToolCallCancellationReason } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatToolInvocationSerialized, type IChatMarkdownContent } from '../../../common/chatService/chatService.js';
-import { ToolDataSource } from '../../../common/tools/languageModelToolsService.js';
+import { ToolDataSource, ToolInvocationPresentation } from '../../../common/tools/languageModelToolsService.js';
 import { turnsToHistory as rawTurnsToHistory, activeTurnToProgress as rawActiveTurnToProgress, toolCallStateToInvocation as rawToolCallStateToInvocation, finalizeToolInvocation as rawFinalizeToolInvocation, updateRunningToolSpecificData as rawUpdateRunningToolSpecificData } from '../../../browser/agentSessions/agentHost/stateToProgressAdapter.js';
 
 // ---- Helper factories -------------------------------------------------------
@@ -504,6 +504,33 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(fileEdits[0].beforeContentUri?.toString(), URI.parse('agenthost-content:///session/snap/before').toString());
 			assert.strictEqual(fileEdits[0].afterContentUri?.toString(), URI.parse('agenthost-content:///session/snap/after').toString());
 			assert.ok(fileEdits[0].undoStopId);
+			assert.strictEqual(invocation.presentation, ToolInvocationPresentation.Hidden);
+		});
+
+		test('does not hide presentation when tool with file edits fails', () => {
+			const tc = createToolCallState({ status: ToolCallStatus.Running });
+			const invocation = toolCallStateToInvocation(tc);
+
+			finalizeToolInvocation(invocation, {
+				status: ToolCallStatus.Completed,
+				toolCallId: 'tc-1',
+				toolName: 'edit_file',
+				displayName: 'Edit File',
+				invocationMessage: 'Editing file...',
+				confirmed: ToolCallConfirmationReason.NotNeeded,
+				success: false,
+				pastTenseMessage: 'Failed to edit',
+				error: { message: 'write error' },
+				content: [{
+					type: ToolResultContentType.FileEdit,
+					after: {
+						uri: URI.file('/home/user/file.ts').toString(),
+						content: { uri: 'agenthost-content:///snap/after' },
+					},
+				}],
+			});
+
+			assert.notStrictEqual(invocation.presentation, ToolInvocationPresentation.Hidden);
 		});
 
 		test('returns empty file edits for cancelled tool call', () => {


### PR DESCRIPTION
agentHost: fix duplicate edits being shown in chat

When a tool call produces file edits, the onFileEdits callback already
hydrates edit pills into the chat response. However, the tool invocation
widget was also remaining visible, leading to duplicate UI.

- Set presentation to Hidden on tool invocations that complete
  successfully with file edits in finalizeToolInvocation
- Move file edit extraction before didExecuteTool so the presentation
  is set before the completion state transition triggers re-render
- Add handling for ToolInvocationPresentation.Hidden in the render
  function of ChatToolInvocationPart (previously only checked
  HiddenAfterComplete)

(Commit message generated by Copilot)