### PR TITLE
Add CommandLineMultilineWrapRewriter to handle multi-line POSIX commands

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineMultilineWrapRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineMultilineWrapRewriter.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../../../base/common/lifecycle.js';
+import { OperatingSystem } from '../../../../../../../base/common/platform.js';
+import { isFish, isPowerShell } from '../../runInTerminalHelpers.js';
+import type { ICommandLineRewriter, ICommandLineRewriterOptions, ICommandLineRewriterResult } from './commandLineRewriter.js';
+
+/**
+ * Wraps multi-line POSIX commands in `<shell> -c '...'` so shell integration sees a single
+ * command end marker instead of one per line.
+ *
+ * Without this, a command like:
+ *   set -e
+ *   apt-get update
+ *   apt-get install -y foo
+ * is pasted into the terminal as three separate commands. The execute strategy resolves on the
+ * first `onCommandFinished` (after `set -e`) and returns to the agent before `apt-get` has even
+ * started, leaving the remaining work running unattended and colliding with subsequent tool calls.
+ *
+ * Input detection via `OutputMonitor` is unaffected: interactive prompts (passwords, y/n, etc.)
+ * emitted by the wrapped process still surface through the same regex-based detectors.
+ */
+export class CommandLineMultilineWrapRewriter extends Disposable implements ICommandLineRewriter {
+	rewrite(options: ICommandLineRewriterOptions): ICommandLineRewriterResult | undefined {
+		// Only applies to POSIX shells. PowerShell multi-line handling is different and
+		// the background detach rewriter already wraps PowerShell separately.
+		if (options.os === OperatingSystem.Windows || isPowerShell(options.shell, options.os)) {
+			return undefined;
+		}
+
+		const command = options.commandLine;
+		// Detect a "real" newline that separates top-level statements. We require a bare LF
+		// that is NOT line-continuation (preceded by `\`). A single-line command with escaped
+		// newlines continues to be a single command; we must not wrap it.
+		if (!/(^|[^\\])\n\s*\S/.test(command)) {
+			return undefined;
+		}
+
+		if (isFish(options.shell, options.os)) {
+			// Fish does not support the POSIX `'\''` escape inside single-quoted strings.
+			// Use double quotes and escape backslash and double-quote.
+			const escaped = command.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+			return {
+				rewritten: `${options.shell} -c "${escaped}"`,
+				reasoning: 'Wrapped multi-line command with `fish -c` so shell integration sees a single command',
+				forDisplay: command,
+			};
+		}
+
+		// bash/zsh: escape single quotes using the standard `'\''` sequence so the entire
+		// command can live inside a single-quoted `-c` argument without further interpretation.
+		const escaped = command.replace(/'/g, `'\\''`);
+		return {
+			rewritten: `${options.shell} -c '${escaped}'`,
+			reasoning: 'Wrapped multi-line command with `<shell> -c` so shell integration sees a single command',
+			forDisplay: command,
+		};
+	}
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -63,6 +63,7 @@ import { TerminalToolId } from './toolIds.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import type { ICommandLineRewriter } from './commandLineRewriter/commandLineRewriter.js';
 import { CommandLineCdPrefixRewriter } from './commandLineRewriter/commandLineCdPrefixRewriter.js';
+import { CommandLineMultilineWrapRewriter } from './commandLineRewriter/commandLineMultilineWrapRewriter.js';
 import { CommandLinePreventHistoryRewriter } from './commandLineRewriter/commandLinePreventHistoryRewriter.js';
 import { CommandLinePwshChainOperatorRewriter } from './commandLineRewriter/commandLinePwshChainOperatorRewriter.js';
 import { CommandLineBackgroundDetachRewriter } from './commandLineRewriter/commandLineBackgroundDetachRewriter.js';
@@ -569,6 +570,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		this._commandLineRewriters = [
 			this._register(this._instantiationService.createInstance(CommandLineCdPrefixRewriter)),
+			// MultilineWrapRewriter must come before BackgroundDetachRewriter so that multi-line
+			// commands are wrapped in `<shell> -c '...'` first. Without this, shell integration
+			// sees each line as a separate command and the execute strategy resolves on the first
+			// `onCommandFinished`, returning partial output to the agent while later lines run
+			// unattended in the terminal.
+			this._register(this._instantiationService.createInstance(CommandLineMultilineWrapRewriter)),
 			this._register(this._instantiationService.createInstance(CommandLinePwshChainOperatorRewriter, this._treeSitterCommandParser)),
 		];
 		if (this._enableCommandLineSandboxRewriting) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineMultilineWrapRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineMultilineWrapRewriter.test.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual, strictEqual } from 'assert';
+import { OperatingSystem } from '../../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import type { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
+import { CommandLineMultilineWrapRewriter } from '../../browser/tools/commandLineRewriter/commandLineMultilineWrapRewriter.js';
+import type { ICommandLineRewriterOptions } from '../../browser/tools/commandLineRewriter/commandLineRewriter.js';
+
+suite('CommandLineMultilineWrapRewriter', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let rewriter: CommandLineMultilineWrapRewriter;
+
+	function createOptions(command: string, shell: string, os: OperatingSystem): ICommandLineRewriterOptions {
+		return {
+			commandLine: command,
+			cwd: undefined,
+			shell,
+			os,
+		};
+	}
+
+	setup(() => {
+		instantiationService = workbenchInstantiationService({}, store);
+		rewriter = store.add(instantiationService.createInstance(CommandLineMultilineWrapRewriter));
+	});
+
+	test('single-line bash command is not rewritten', () => {
+		strictEqual(rewriter.rewrite(createOptions('echo hello', '/bin/bash', OperatingSystem.Linux)), undefined);
+	});
+
+	test('escaped newline (line continuation) is not treated as multi-line', () => {
+		strictEqual(rewriter.rewrite(createOptions('echo foo \\\n  bar', '/bin/bash', OperatingSystem.Linux)), undefined);
+	});
+
+	test('Windows is skipped', () => {
+		strictEqual(rewriter.rewrite(createOptions('echo a\necho b', 'powershell.exe', OperatingSystem.Windows)), undefined);
+	});
+
+	test('PowerShell on POSIX is skipped', () => {
+		strictEqual(rewriter.rewrite(createOptions('Write-Host a\nWrite-Host b', 'pwsh', OperatingSystem.Linux)), undefined);
+	});
+
+	test('bash: multi-line command is wrapped in <shell> -c', () => {
+		deepStrictEqual(
+			rewriter.rewrite(createOptions('set -e\napt-get update\napt-get install -y r-base', '/bin/bash', OperatingSystem.Linux)),
+			{
+				rewritten: `/bin/bash -c 'set -e\napt-get update\napt-get install -y r-base'`,
+				reasoning: 'Wrapped multi-line command with `<shell> -c` so shell integration sees a single command',
+				forDisplay: 'set -e\napt-get update\napt-get install -y r-base',
+			}
+		);
+	});
+
+	test('zsh: multi-line command is wrapped', () => {
+		deepStrictEqual(
+			rewriter.rewrite(createOptions('cd /tmp\nls -la', '/bin/zsh', OperatingSystem.Macintosh)),
+			{
+				rewritten: `/bin/zsh -c 'cd /tmp\nls -la'`,
+				reasoning: 'Wrapped multi-line command with `<shell> -c` so shell integration sees a single command',
+				forDisplay: 'cd /tmp\nls -la',
+			}
+		);
+	});
+
+	test('bash: single quotes in the command are escaped', () => {
+		deepStrictEqual(
+			rewriter.rewrite(createOptions(`echo 'a'\necho 'b'`, '/bin/bash', OperatingSystem.Linux)),
+			{
+				rewritten: `/bin/bash -c 'echo '\\''a'\\''\necho '\\''b'\\'''`,
+				reasoning: 'Wrapped multi-line command with `<shell> -c` so shell integration sees a single command',
+				forDisplay: `echo 'a'\necho 'b'`,
+			}
+		);
+	});
+
+	test('fish: multi-line command is wrapped with double-quote escaping', () => {
+		deepStrictEqual(
+			rewriter.rewrite(createOptions('echo "a b"\necho c', '/usr/bin/fish', OperatingSystem.Linux)),
+			{
+				rewritten: `/usr/bin/fish -c "echo \\"a b\\"\necho c"`,
+				reasoning: 'Wrapped multi-line command with `fish -c` so shell integration sees a single command',
+				forDisplay: 'echo "a b"\necho c',
+			}
+		);
+	});
+});


### PR DESCRIPTION
Fixes #312260.

## Problem

`RichExecuteStrategy.execute()` resolves on the **first** `onCommandFinished` shell-integration marker:

```ts
// richExecuteStrategy.ts
Event.toPromise(this._commandDetection.onCommandFinished, store).then(...)
```

When the chat agent pastes a multi-line POSIX command, shell integration fires one marker per top-level statement. The tool returns partial/empty output after line 1 while the rest of the command keeps running unattended.

## Fix

New `CommandLineMultilineWrapRewriter` that wraps multi-line POSIX commands in `<shell> -c '...'` before execution, so shell integration sees exactly one command end marker. Skips Windows/PowerShell and line-continuations (`\<LF>`). Not gated on `detachBackgroundProcesses` — the race affects foreground commands too. `OutputMonitor` input detection is unaffected (it reads the PTY directly).

## Proof — eval run `24857589683`, terminalbench2, vscode agent, gpt-5.4

Affected failing instances whose first tool call was a multi-line heredoc that returned early (`patch=0B` after wasted follow-up turns):

| Test | `systemInitiatedLabel` (first line of submission) |
|---|---|
| `bn-fit-modify` | `cd /app && python3 - <<'PY'` |
| `distribution-search` | `cd /app && python - <<'PY'` |
| `gcode-to-text` | `cd /app && python - <<'PY'` |
| `protein-assembly` | `python - <<'PY'` |
| `raman-fitting` | `cd /app && python - <<'PY'` |
| `rstan-to-pystan` | `cd /app && .venv/bin/python - <<'PY'` |
| `regex-chess` | `python - <<'PY'` |
| `schemelike-metacircular-eval` | `pushd /app >/dev/null && python3 interp.py eval.scm <<'EOF'` |

All 8 produced 0-byte patches after the first `run_in_terminal` call returned before the heredoc body finished. Logs under `.vscode-eval/24857589683/<test>/output/vsc-output/chat-turns/chat-export-step-0.json`.

## Tests

commandLineMultilineWrapRewriter.test.ts — 8/8 green:

```
✔ single-line bash command is not rewritten
✔ escaped newline (line continuation) is not treated as multi-line
✔ Windows is skipped
✔ PowerShell on POSIX is skipped
✔ bash: multi-line command is wrapped in <shell> -c
✔ zsh: multi-line command is wrapped
✔ bash: single quotes in the command are escaped
✔ fish: multi-line command is wrapped with double-quote escaping
```
