### PR TITLE
Switch to esbuild's native watcher for building extensions

### DIFF
--- a/extensions/esbuild-extension-common.mts
+++ b/extensions/esbuild-extension-common.mts
@@ -12,14 +12,6 @@ type BuildOptions = Partial<esbuild.BuildOptions> & {
 	outdir: string;
 };
 
-/**
- * Build the source code once using esbuild.
- */
-async function build(options: BuildOptions, didBuild?: (outDir: string) => unknown): Promise<void> {
-	await esbuild.build(options);
-	await didBuild?.(options.outdir);
-}
-
 interface RunConfig {
 	readonly platform: 'node' | 'browser';
 	readonly format?: 'cjs' | 'esm';
@@ -80,12 +72,31 @@ export async function run(config: RunConfig, args: string[], didBuild?: (outDir:
 		if (didBuild) {
 			resolvedOptions.plugins = [
 				...(resolvedOptions.plugins || []),
-				{ name: 'did-build', setup(pluginBuild) { pluginBuild.onEnd(() => { didBuild(outdir); }); } },
+				{
+					name: 'did-build', setup(pluginBuild) {
+						pluginBuild.onEnd(async result => {
+							if (result.errors.length > 0) {
+								return;
+							}
+
+							try {
+								await didBuild(outdir);
+							} catch (error) {
+								console.error('didBuild failed:', error);
+							}
+						});
+					},
+				}
 			];
 		}
 		const ctx = await esbuild.context(resolvedOptions);
 		await ctx.watch();
 	} else {
-		return build(resolvedOptions, didBuild).catch(() => process.exit(1));
+		try {
+			await esbuild.build(resolvedOptions);
+			await didBuild?.(outdir);
+		} catch {
+			process.exit(1);
+		}
 	}
 }

--- a/extensions/esbuild-extension-common.mts
+++ b/extensions/esbuild-extension-common.mts
@@ -80,7 +80,7 @@ export async function run(config: RunConfig, args: string[], didBuild?: (outDir:
 		if (didBuild) {
 			resolvedOptions.plugins = [
 				...(resolvedOptions.plugins || []),
-				{ name: 'did-build', setup(build) { build.onEnd(() => { didBuild(outdir); }); } },
+				{ name: 'did-build', setup(pluginBuild) { pluginBuild.onEnd(() => { didBuild(outdir); }); } },
 			];
 		}
 		const ctx = await esbuild.context(resolvedOptions);

--- a/extensions/esbuild-extension-common.mts
+++ b/extensions/esbuild-extension-common.mts
@@ -20,17 +20,6 @@ async function build(options: BuildOptions, didBuild?: (outDir: string) => unkno
 	await didBuild?.(options.outdir);
 }
 
-/**
- * Build the source code once using esbuild, logging errors instead of throwing.
- */
-async function tryBuild(options: BuildOptions, didBuild?: (outDir: string) => unknown): Promise<void> {
-	try {
-		await build(options, didBuild);
-	} catch (err) {
-		console.error(err);
-	}
-}
-
 interface RunConfig {
 	readonly platform: 'node' | 'browser';
 	readonly format?: 'cjs' | 'esm';
@@ -88,9 +77,14 @@ export async function run(config: RunConfig, args: string[], didBuild?: (outDir:
 
 	const isWatch = args.indexOf('--watch') >= 0;
 	if (isWatch) {
-		await tryBuild(resolvedOptions, didBuild);
-		const watcher = await import('@parcel/watcher');
-		watcher.subscribe(config.srcDir, () => tryBuild(resolvedOptions, didBuild));
+		if (didBuild) {
+			resolvedOptions.plugins = [
+				...(resolvedOptions.plugins || []),
+				{ name: 'did-build', setup(build) { build.onEnd(() => { didBuild(outdir); }); } },
+			];
+		}
+		const ctx = await esbuild.context(resolvedOptions);
+		await ctx.watch();
 	} else {
 		return build(resolvedOptions, didBuild).catch(() => process.exit(1));
 	}

--- a/extensions/esbuild-webview-common.mts
+++ b/extensions/esbuild-webview-common.mts
@@ -10,17 +10,9 @@ import path from 'node:path';
 import esbuild from 'esbuild';
 
 export type BuildOptions = Partial<esbuild.BuildOptions> & {
-	entryPoints: string[] | Record<string, string> | { in: string; out: string }[];
-	outdir: string;
+	readonly entryPoints: esbuild.BuildOptions['entryPoints'];
+	readonly outdir: string;
 };
-
-/**
- * Build the source code once using esbuild.
- */
-async function build(options: BuildOptions, didBuild?: (outDir: string) => unknown): Promise<void> {
-	await esbuild.build(options);
-	await didBuild?.(options.outdir);
-}
 
 export async function run(
 	config: {
@@ -60,12 +52,31 @@ export async function run(
 		if (didBuild) {
 			resolvedOptions.plugins = [
 				...(resolvedOptions.plugins || []),
-				{ name: 'did-build', setup(pluginBuild) { pluginBuild.onEnd(() => { didBuild(outdir); }); } },
+				{
+					name: 'did-build', setup(pluginBuild) {
+						pluginBuild.onEnd(async result => {
+							if (result.errors.length > 0) {
+								return;
+							}
+
+							try {
+								await didBuild(outdir);
+							} catch (error) {
+								console.error('didBuild failed:', error);
+							}
+						});
+					},
+				}
 			];
 		}
 		const ctx = await esbuild.context(resolvedOptions);
 		await ctx.watch();
 	} else {
-		return build(resolvedOptions, didBuild).catch(() => process.exit(1));
+		try {
+			await esbuild.build(resolvedOptions);
+			await didBuild?.(outdir);
+		} catch {
+			process.exit(1);
+		}
 	}
 }

--- a/extensions/esbuild-webview-common.mts
+++ b/extensions/esbuild-webview-common.mts
@@ -18,28 +18,8 @@ export type BuildOptions = Partial<esbuild.BuildOptions> & {
  * Build the source code once using esbuild.
  */
 async function build(options: BuildOptions, didBuild?: (outDir: string) => unknown): Promise<void> {
-	await esbuild.build({
-		bundle: true,
-		minify: true,
-		sourcemap: false,
-		format: 'esm',
-		platform: 'browser',
-		target: ['es2024'],
-		...options,
-	});
-
+	await esbuild.build(options);
 	await didBuild?.(options.outdir);
-}
-
-/**
- * Build the source code once using esbuild, logging errors instead of throwing.
- */
-async function tryBuild(options: BuildOptions, didBuild?: (outDir: string) => unknown): Promise<void> {
-	try {
-		await build(options, didBuild);
-	} catch (err) {
-		console.error(err);
-	}
 }
 
 export async function run(
@@ -61,6 +41,12 @@ export async function run(
 	}
 
 	const resolvedOptions: BuildOptions = {
+		bundle: true,
+		minify: true,
+		sourcemap: false,
+		format: 'esm',
+		platform: 'browser',
+		target: ['es2024'],
 		entryPoints: config.entryPoints,
 		outdir,
 		logOverride: {
@@ -71,9 +57,14 @@ export async function run(
 
 	const isWatch = args.indexOf('--watch') >= 0;
 	if (isWatch) {
-		await tryBuild(resolvedOptions, didBuild);
-		const watcher = await import('@parcel/watcher');
-		watcher.subscribe(config.srcDir, () => tryBuild(resolvedOptions, didBuild));
+		if (didBuild) {
+			resolvedOptions.plugins = [
+				...(resolvedOptions.plugins || []),
+				{ name: 'did-build', setup(build) { build.onEnd(() => { didBuild(outdir); }); } },
+			];
+		}
+		const ctx = await esbuild.context(resolvedOptions);
+		await ctx.watch();
 	} else {
 		return build(resolvedOptions, didBuild).catch(() => process.exit(1));
 	}

--- a/extensions/esbuild-webview-common.mts
+++ b/extensions/esbuild-webview-common.mts
@@ -60,7 +60,7 @@ export async function run(
 		if (didBuild) {
 			resolvedOptions.plugins = [
 				...(resolvedOptions.plugins || []),
-				{ name: 'did-build', setup(build) { build.onEnd(() => { didBuild(outdir); }); } },
+				{ name: 'did-build', setup(pluginBuild) { pluginBuild.onEnd(() => { didBuild(outdir); }); } },
 			];
 		}
 		const ctx = await esbuild.context(resolvedOptions);


### PR DESCRIPTION
This should be good to use now and also lets us benefit from incremental builds. In my testing the memory and cpu usage seems reasonable but will keep an eye on this

