### PR TITLE
fix: expand Chronicle session_files/refs tracking to match VS Code tool names

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -7,25 +7,65 @@
  * Helpers for extracting file paths and refs from tool calls.
  */
 
-/** Tools whose arguments contain a file path being modified. */
-const FILE_TRACKING_TOOLS = new Set(['apply_patch', 'str_replace_editor', 'create_file', 'create']);
+/** Tools whose arguments contain a file path being modified or read. */
+const FILE_TRACKING_TOOLS = new Set([
+	// VS Code model-facing tool names (from ToolName enum)
+	'replace_string_in_file',
+	'multi_replace_string_in_file',
+	'insert_edit_into_file',
+	'create_file',
+	'edit_notebook_file',
+	'apply_patch',
+	'read_file',
+	'view_image',
+	'list_dir',
+	// CLI-agent tool names (backward compat)
+	'str_replace_editor',
+	'create',
+]);
 
-/** GitHub MCP server tool prefix. */
-const GH_MCP_PREFIX = 'github-mcp-server-';
+/** GitHub MCP server tool prefixes. */
+const GH_MCP_PREFIXES = ['mcp_github_', 'github-mcp-server-'];
 
 /**
  * Extract absolute file path from tool arguments if available.
- * Handles both CLI-style (edit/create with `path`) and VS Code-style
- * (apply_patch with `patch`, str_replace_editor with `filePath`, create_file with `filePath`).
+ * Handles both CLI-style (edit/create with `path`) and VS Code-style tools
+ * that use `filePath`, as well as `apply_patch` which encodes paths in the patch input.
  * @internal Exported for testing.
  */
 export function extractFilePath(toolName: string, toolArgs: unknown): string | undefined {
 	if (!FILE_TRACKING_TOOLS.has(toolName)) { return undefined; }
 	if (typeof toolArgs !== 'object' || toolArgs === null) { return undefined; }
 	const args = toolArgs as Record<string, unknown>;
-	// VS Code tools use 'filePath', CLI tools use 'path'
+
+	// VS Code tools use 'filePath', CLI tools use 'path', list_dir uses 'path'
 	const filePath = args.filePath ?? args.path;
-	return typeof filePath === 'string' ? filePath : undefined;
+	if (typeof filePath === 'string') { return filePath; }
+
+	// multi_replace_string_in_file stores filePath in each replacement item
+	if (toolName === 'multi_replace_string_in_file' && Array.isArray(args.replacements)) {
+		const first = args.replacements[0];
+		if (typeof first === 'object' && first !== null) {
+			const fp = (first as Record<string, unknown>).filePath;
+			if (typeof fp === 'string') { return fp; }
+		}
+	}
+
+	// apply_patch encodes file paths in the patch input text
+	if (toolName === 'apply_patch' && typeof args.input === 'string') {
+		return extractFirstFileFromPatch(args.input);
+	}
+
+	return undefined;
+}
+
+/**
+ * Extract the first file path from an apply_patch input string.
+ * Matches lines like `*** Update File: /path/to/file` or `*** Add File: /path`.
+ */
+function extractFirstFileFromPatch(input: string): string | undefined {
+	const match = input.match(/^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$/m);
+	return match?.[1]?.trim();
 }
 
 /**
@@ -137,7 +177,8 @@ export function extractRepoFromMcpTool(toolArgs: unknown): string | undefined {
 
 /**
  * Check whether a tool name is a GitHub MCP server tool.
+ * Matches both VS Code-style `mcp_github_*` and CLI-style `github-mcp-server-*` prefixes.
  */
 export function isGitHubMcpTool(toolName: string): boolean {
-	return toolName.startsWith(GH_MCP_PREFIX);
+	return GH_MCP_PREFIXES.some(prefix => toolName.startsWith(prefix));
 }

--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -14,6 +14,7 @@ const FILE_TRACKING_TOOLS = new Set([
 	'multi_replace_string_in_file',
 	'insert_edit_into_file',
 	'create_file',
+	'create_directory',
 	'edit_notebook_file',
 	'apply_patch',
 	'read_file',
@@ -38,8 +39,9 @@ export function extractFilePath(toolName: string, toolArgs: unknown): string | u
 	if (typeof toolArgs !== 'object' || toolArgs === null) { return undefined; }
 	const args = toolArgs as Record<string, unknown>;
 
-	// VS Code tools use 'filePath', CLI tools use 'path', list_dir uses 'path'
-	const filePath = args.filePath ?? args.path;
+	// VS Code tools use 'filePath', CLI tools use 'path', list_dir uses 'path',
+	// create_directory uses 'dirPath'
+	const filePath = args.filePath ?? args.path ?? args.dirPath;
 	if (typeof filePath === 'string') { return filePath; }
 
 	// multi_replace_string_in_file stores filePath in each replacement item

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
@@ -47,6 +47,11 @@ describe('extractFilePath', () => {
 			.toBe('/src');
 	});
 
+	it('extracts dirPath from create_directory', () => {
+		expect(extractFilePath('create_directory', { dirPath: '/src/new-dir' }))
+			.toBe('/src/new-dir');
+	});
+
 	it('extracts file path from apply_patch input text', () => {
 		const input = '*** Begin Patch\n*** Update File: /src/hello.ts\n@@class Foo\n-  bar\n+  baz\n*** End Patch';
 		expect(extractFilePath('apply_patch', { input }))

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { extractFilePath, extractRefsFromMcpTool, extractRefsFromTerminal, extractRepoFromMcpTool, isGitHubMcpTool } from '../sessionStoreTracking';
+
+describe('extractFilePath', () => {
+	it('extracts filePath from replace_string_in_file', () => {
+		expect(extractFilePath('replace_string_in_file', { filePath: '/src/foo.ts', oldString: 'a', newString: 'b' }))
+			.toBe('/src/foo.ts');
+	});
+
+	it('extracts filePath from multi_replace_string_in_file replacements array', () => {
+		expect(extractFilePath('multi_replace_string_in_file', {
+			explanation: 'fix imports',
+			replacements: [
+				{ filePath: '/src/bar.ts', oldString: 'a', newString: 'b' },
+				{ filePath: '/src/baz.ts', oldString: 'c', newString: 'd' },
+			]
+		})).toBe('/src/bar.ts');
+	});
+
+	it('extracts filePath from insert_edit_into_file', () => {
+		expect(extractFilePath('insert_edit_into_file', { filePath: '/src/edit.ts', code: '// new' }))
+			.toBe('/src/edit.ts');
+	});
+
+	it('extracts filePath from create_file', () => {
+		expect(extractFilePath('create_file', { filePath: '/src/new.ts', content: '' }))
+			.toBe('/src/new.ts');
+	});
+
+	it('extracts filePath from edit_notebook_file', () => {
+		expect(extractFilePath('edit_notebook_file', { filePath: '/nb.ipynb', editType: 'edit', cellId: 'c1' }))
+			.toBe('/nb.ipynb');
+	});
+
+	it('extracts filePath from read_file', () => {
+		expect(extractFilePath('read_file', { filePath: '/src/read.ts', startLine: 1, endLine: 10 }))
+			.toBe('/src/read.ts');
+	});
+
+	it('extracts path from list_dir', () => {
+		expect(extractFilePath('list_dir', { path: '/src' }))
+			.toBe('/src');
+	});
+
+	it('extracts file path from apply_patch input text', () => {
+		const input = '*** Begin Patch\n*** Update File: /src/hello.ts\n@@class Foo\n-  bar\n+  baz\n*** End Patch';
+		expect(extractFilePath('apply_patch', { input }))
+			.toBe('/src/hello.ts');
+	});
+
+	it('extracts file path from apply_patch Add File', () => {
+		const input = '*** Begin Patch\n*** Add File: /src/new.ts\n+export const x = 1;\n*** End Patch';
+		expect(extractFilePath('apply_patch', { input }))
+			.toBe('/src/new.ts');
+	});
+
+	it('extracts file path from apply_patch Delete File', () => {
+		const input = '*** Begin Patch\n*** Delete File: /src/old.ts\n*** End Patch';
+		expect(extractFilePath('apply_patch', { input }))
+			.toBe('/src/old.ts');
+	});
+
+	it('falls back to filePath arg for apply_patch when present', () => {
+		expect(extractFilePath('apply_patch', { filePath: '/from/arg.ts', input: '*** Update File: /from/input.ts' }))
+			.toBe('/from/arg.ts');
+	});
+
+	it('extracts path from CLI str_replace_editor (backward compat)', () => {
+		expect(extractFilePath('str_replace_editor', { path: '/cli/file.py' }))
+			.toBe('/cli/file.py');
+	});
+
+	it('extracts path from CLI create tool (backward compat)', () => {
+		expect(extractFilePath('create', { path: '/cli/new.py' }))
+			.toBe('/cli/new.py');
+	});
+
+	it('returns undefined for unknown tools', () => {
+		expect(extractFilePath('run_in_terminal', { command: 'ls' }))
+			.toBeUndefined();
+		expect(extractFilePath('file_search', { query: '**/*.ts' }))
+			.toBeUndefined();
+	});
+
+	it('returns undefined for null args', () => {
+		expect(extractFilePath('create_file', null))
+			.toBeUndefined();
+	});
+
+	it('returns undefined when filePath is not a string', () => {
+		expect(extractFilePath('create_file', { filePath: 42 }))
+			.toBeUndefined();
+	});
+});
+
+describe('isGitHubMcpTool', () => {
+	it('matches mcp_github_ prefix (VS Code)', () => {
+		expect(isGitHubMcpTool('mcp_github_issue_write')).toBe(true);
+		expect(isGitHubMcpTool('mcp_github_create_pull_request')).toBe(true);
+		expect(isGitHubMcpTool('mcp_github_search_issues')).toBe(true);
+	});
+
+	it('matches github-mcp-server- prefix (CLI)', () => {
+		expect(isGitHubMcpTool('github-mcp-server-create_issue')).toBe(true);
+	});
+
+	it('rejects non-GitHub MCP tools', () => {
+		expect(isGitHubMcpTool('read_file')).toBe(false);
+		expect(isGitHubMcpTool('mcp_perplexity_ask')).toBe(false);
+		expect(isGitHubMcpTool('run_in_terminal')).toBe(false);
+	});
+});
+
+describe('extractRefsFromMcpTool', () => {
+	it('extracts PR ref from mcp_github_pull_request_read', () => {
+		const refs = extractRefsFromMcpTool('mcp_github_pull_request_read', { pullNumber: 42, owner: 'ms', repo: 'vscode' });
+		expect(refs).toEqual([{ ref_type: 'pr', ref_value: '42' }]);
+	});
+
+	it('extracts issue ref from mcp_github_issue_write', () => {
+		const refs = extractRefsFromMcpTool('mcp_github_issue_write', { issue_number: 123, owner: 'ms', repo: 'vscode' });
+		expect(refs).toEqual([{ ref_type: 'issue', ref_value: '123' }]);
+	});
+
+	it('extracts commit ref from mcp_github_get_commit', () => {
+		const refs = extractRefsFromMcpTool('mcp_github_get_commit', { sha: 'abc123', owner: 'ms', repo: 'vscode' });
+		expect(refs).toEqual([{ ref_type: 'commit', ref_value: 'abc123' }]);
+	});
+
+	it('returns empty for non-matching tool name', () => {
+		expect(extractRefsFromMcpTool('mcp_github_search_code', { query: 'foo' })).toEqual([]);
+	});
+});
+
+describe('extractRepoFromMcpTool', () => {
+	it('extracts owner/repo', () => {
+		expect(extractRepoFromMcpTool({ owner: 'microsoft', repo: 'vscode' }))
+			.toBe('microsoft/vscode');
+	});
+
+	it('returns undefined when missing', () => {
+		expect(extractRepoFromMcpTool({ owner: 'microsoft' })).toBeUndefined();
+		expect(extractRepoFromMcpTool({})).toBeUndefined();
+	});
+});
+
+describe('extractRefsFromTerminal', () => {
+	it('extracts PR ref from gh pr create output', () => {
+		const refs = extractRefsFromTerminal(
+			{ command: 'gh pr create --title "fix"' },
+			'https://github.com/microsoft/vscode/pull/999',
+		);
+		expect(refs).toEqual([{ ref_type: 'pr', ref_value: '999' }]);
+	});
+
+	it('extracts issue ref from gh issue create output', () => {
+		const refs = extractRefsFromTerminal(
+			{ command: 'gh issue create --title "bug"' },
+			'https://github.com/microsoft/vscode/issues/456',
+		);
+		expect(refs).toEqual([{ ref_type: 'issue', ref_value: '456' }]);
+	});
+
+	it('extracts commit SHA from git commit output', () => {
+		const refs = extractRefsFromTerminal(
+			{ command: 'git commit -m "fix"' },
+			'[main abc1234] fix\n 1 file changed',
+		);
+		expect(refs).toEqual([{ ref_type: 'commit', ref_value: 'abc1234' }]);
+	});
+
+	it('returns empty for unrelated commands', () => {
+		expect(extractRefsFromTerminal({ command: 'ls -la' }, 'output')).toEqual([]);
+	});
+});

--- a/extensions/copilot/src/extension/chronicle/common/test/standupPrompt.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/standupPrompt.spec.ts
@@ -100,8 +100,8 @@ describe('extractFilePath', () => {
 		expect(extractFilePath('create', { path: '/src/new.ts' })).toBe('/src/new.ts');
 	});
 
-	it('returns undefined for non-file-tracking tools', () => {
-		expect(extractFilePath('read_file', { filePath: '/src/index.ts' })).toBeUndefined();
+	it('extracts filePath from read_file args', () => {
+		expect(extractFilePath('read_file', { filePath: '/src/index.ts' })).toBe('/src/index.ts');
 	});
 
 	it('returns undefined for null args', () => {


### PR DESCRIPTION
## Problem
The `session_files` and `session_refs` tables in the Chronicle local session history store are always empty (0 rows across 460+ sessions).

**Root cause**: `FILE_TRACKING_TOOLS` only recognized CLI-agent tool names (`str_replace_editor`, `create`) but VS Code emits model-facing names (`replace_string_in_file`, `insert_edit_into_file`, etc). Similarly, `isGitHubMcpTool()` only matched the `github-mcp-server-` prefix, not VS Code's `mcp_github_` prefix.

## Fix
- Expand `FILE_TRACKING_TOOLS` from 4 to 11 entries matching VS Code's `ToolName` enum
- Add extraction for `multi_replace_string_in_file` (nested `replacements` array)
- Add `apply_patch` input text parsing (`*** Update/Add/Delete File:` lines)
- Update `isGitHubMcpTool()` to match both `mcp_github_` and `github-mcp-server-` prefixes
- 29 new tests, all 119 chronicle tests pass

Fixes #312281