### PR TITLE
feat: implement Copilot Context Pinning (Chat Breadcrumbs)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -32,6 +32,66 @@ export const MarkUnhelpfulActionId = 'workbench.action.chat.markUnhelpful';
 const enableFeedbackConfig = 'config.telemetry.feedback.enabled';
 
 export function registerChatTitleActions() {
+	registerAction2(class PinChatSegmentAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.chat.pinSegment',
+				title: localize2('chat.pinSegment.label', "Pin Context"),
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.pin,
+				menu: {
+					id: MenuId.ChatMessageTitle,
+					group: 'navigation',
+					order: 1,
+					when: ContextKeyExpr.and(ChatContextKeys.isResponse, ChatContextKeys.isPinned.negate())
+				}
+			});
+		}
+
+		run(accessor: ServicesAccessor, ...args: unknown[]) {
+			const item = args[0];
+			if (!isResponseVM(item)) {
+				return;
+			}
+			const chatService = accessor.get(IChatService);
+			const session = chatService.getSession(item.sessionResource);
+			if (session && 'pinSegment' in session) {
+				(session as any).pinSegment(item.id);
+			}
+		}
+	});
+
+	registerAction2(class UnpinChatSegmentAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.chat.unpinSegment',
+				title: localize2('chat.unpinSegment.label', "Unpin Context"),
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.pinned,
+				menu: {
+					id: MenuId.ChatMessageTitle,
+					group: 'navigation',
+					order: 1,
+					when: ContextKeyExpr.and(ChatContextKeys.isResponse, ChatContextKeys.isPinned)
+				}
+			});
+		}
+
+		run(accessor: ServicesAccessor, ...args: unknown[]) {
+			const item = args[0];
+			if (!isResponseVM(item)) {
+				return;
+			}
+			const chatService = accessor.get(IChatService);
+			const session = chatService.getSession(item.sessionResource);
+			if (session && 'unpinSegment' in session) {
+				(session as any).unpinSegment(item.id);
+			}
+		}
+	});
+
 	registerAction2(class MarkHelpfulAction extends Action2 {
 		constructor() {
 			super({

--- a/src/vs/workbench/contrib/chat/browser/widget/chatBreadcrumbsWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatBreadcrumbsWidget.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../base/browser/dom.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { autorun, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { IChatModel } from '../../common/model/chatModel.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+
+export class ChatBreadcrumbsWidget extends Disposable {
+	readonly domNode: HTMLElement;
+
+	private readonly _chatModel = observableValue<IChatModel | undefined>(this, undefined);
+	private readonly _modelDisposables = this._register(new DisposableStore());
+
+	constructor() {
+		super();
+		this.domNode = dom.$('.chat-breadcrumbs-widget');
+		this.domNode.style.padding = '4px 8px';
+		this.domNode.style.display = 'flex';
+		this.domNode.style.flexWrap = 'wrap';
+		this.domNode.style.gap = '6px';
+		this.domNode.style.borderBottom = '1px solid var(--vscode-chat-requestBorder)';
+
+		this._register(autorun(reader => {
+			const model = this._chatModel.read(reader);
+			this._modelDisposables.clear();
+
+			if (!model) {
+				this.domNode.style.display = 'none';
+				return;
+			}
+
+			const onDidChangeObs = observableFromEvent(this, model.onDidChange, () => model.pinnedSegments);
+			
+			this._modelDisposables.add(autorun(reader => {
+				onDidChangeObs.read(reader);
+				const currentSegments = model.pinnedSegments;
+				
+				dom.clearNode(this.domNode);
+				
+				if (!currentSegments || currentSegments.length === 0) {
+					this.domNode.style.display = 'none';
+					return;
+				}
+				
+				this.domNode.style.display = 'flex';
+				
+				for (const segment of currentSegments) {
+					const chip = dom.append(this.domNode, dom.$('.chat-breadcrumb-chip'));
+					chip.style.display = 'inline-flex';
+					chip.style.alignItems = 'center';
+					chip.style.padding = '2px 6px';
+					chip.style.borderRadius = '12px';
+					chip.style.fontSize = '12px';
+					chip.style.backgroundColor = 'var(--vscode-badge-background)';
+					chip.style.color = 'var(--vscode-badge-foreground)';
+					chip.style.cursor = 'pointer';
+					
+					const icon = dom.append(chip, dom.$('span'));
+					icon.className = ThemeIcon.asClassName(Codicon.pin);
+					icon.style.marginRight = '4px';
+					icon.style.fontSize = '10px';
+					
+					const label = dom.append(chip, dom.$('span'));
+					label.textContent = localize('pinnedContext', "Pinned Context");
+					
+					const removeBtn = dom.append(chip, dom.$('span'));
+					removeBtn.className = ThemeIcon.asClassName(Codicon.close);
+					removeBtn.style.marginLeft = '4px';
+					removeBtn.style.fontSize = '10px';
+					removeBtn.style.cursor = 'pointer';
+					removeBtn.title = localize('unpin', "Unpin");
+					
+					this._modelDisposables.add(dom.addDisposableListener(removeBtn, dom.EventType.CLICK, (e) => {
+						e.stopPropagation();
+						if ('unpinSegment' in model) {
+							(model as any).unpinSegment(segment.id);
+						}
+					}));
+				}
+			}));
+		}));
+	}
+
+	setModel(model: IChatModel | undefined): void {
+		this._chatModel.set(model, undefined);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -720,6 +720,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		ChatContextKeys.isFirstRequest.bindTo(templateData.contextKeyService).set(isRequestVM(element) && this.viewModel?.model.getRequests()[0]?.id === element.id);
 		ChatContextKeys.isPendingRequest.bindTo(templateData.contextKeyService).set(isRequestVM(element) && !!element.pendingKind);
 		ChatContextKeys.responseDetectedAgentCommand.bindTo(templateData.contextKeyService).set(isResponseVM(element) && element.agentOrSlashCommandDetected);
+		
+		const isPinned = isResponseVM(element) && this.viewModel?.model.pinnedSegments?.some(p => p.requestId === element.id);
+		ChatContextKeys.isPinned.bindTo(templateData.contextKeyService).set(!!isPinned);
+
 		if (isResponseVM(element)) {
 			ChatContextKeys.responseSupportsIssueReporting.bindTo(templateData.contextKeyService).set(!!element.agent?.metadata.supportIssueReporting);
 			ChatContextKeys.responseVote.bindTo(templateData.contextKeyService).set(element.vote === ChatAgentVoteDirection.Up ? 'up' : element.vote === ChatAgentVoteDirection.Down ? 'down' : '');

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -86,6 +86,7 @@ import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js'
 import { IChatDebugService } from '../../common/chatDebugService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { ChatBreadcrumbsWidget } from './chatBreadcrumbsWidget.js';
 
 const $ = dom.$;
 
@@ -260,6 +261,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	get domNode() { return this.container; }
 
 	private listWidget!: ChatListWidget;
+	private breadcrumbsWidget!: ChatBreadcrumbsWidget;
 	private inputPartMaxHeightOverride: number | undefined;
 
 	private readonly visibilityTimeoutDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
@@ -323,6 +325,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.viewModelDisposables.clear();
 
 		this._viewModel = viewModel;
+		this.breadcrumbsWidget?.setModel(viewModel?.model);
 		if (viewModel) {
 			this.viewModelDisposables.add(viewModel);
 			this.logService.debug('ChatWidget#setViewModel: have viewModel');
@@ -718,10 +721,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.handleNextPromptSelection(handoff, agentId, withAutopilot);
 		}));
 
+		this.breadcrumbsWidget = this._register(this.instantiationService.createInstance(ChatBreadcrumbsWidget));
+
 		if (renderInputOnTop) {
 			this.createInput(this.container, { renderFollowups, renderStyle, renderInputToolbarBelowInput });
+			dom.append(this.container, this.breadcrumbsWidget.domNode);
 			this.listContainer = dom.append(this.container, $(`.interactive-list`));
 		} else {
+			dom.append(this.container, this.breadcrumbsWidget.domNode);
 			this.listContainer = dom.append(this.container, $(`.interactive-list`));
 			dom.append(this.container, this.chatSuggestNextWidget.domNode);
 			this.createInput(this.container, { renderFollowups, renderStyle, renderInputToolbarBelowInput });

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -34,6 +34,7 @@ export namespace ChatContextKeys {
 	export const isRequest = new RawContextKey<boolean>('chatRequest', false, { type: 'boolean', description: localize('chatRequest', "The chat item is a request") });
 	export const isFirstRequest = new RawContextKey<boolean>('chatFirstRequest', false, { type: 'boolean', description: localize('chatFirstRequest', "The chat item is the first request in the session.") });
 	export const isPendingRequest = new RawContextKey<boolean>('chatRequestIsPending', false, { type: 'boolean', description: localize('chatRequestIsPending', "True when the chat request item is pending in the queue.") });
+	export const isPinned = new RawContextKey<boolean>('chatItemIsPinned', false, { type: 'boolean', description: localize('chatItemIsPinned', "True when the chat item is pinned.") });
 	export const itemId = new RawContextKey<string>('chatItemId', '', { type: 'string', description: localize('chatItemId', "The id of the chat item.") });
 	export const lastItemId = new RawContextKey<string[]>('chatLastItemId', [], { type: 'string', description: localize('chatLastItemId', "The id of the last chat item.") });
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1204,6 +1204,28 @@ export class ChatService extends Disposable implements IChatService {
 						allContext.push(...instructionEntries);
 					}
 
+					// Resolve pinned segments into a context variable
+					if (model.pinnedSegments.length > 0) {
+						let pinnedText = '';
+						for (const pin of model.pinnedSegments) {
+							const req = model.getRequests().find(r => r.id === pin.requestId);
+							if (req && req.response) {
+								pinnedText += `\n\n${req.response.response.toString()}`;
+							}
+						}
+						
+						if (pinnedText) {
+							allContext.push({
+								kind: 'promptText',
+								id: 'pinnedContext',
+								name: 'pinnedContext',
+								value: 'The following is pinned context from earlier in the conversation that you must remember and prioritize:\n' + pinnedText,
+								modelDescription: 'Pinned Context',
+								automaticallyAdded: true,
+							} as any); // cast to any to avoid importing IPromptTextVariableEntry specifically
+						}
+					}
+
 					// Store only non-instruction variables on the model.
 					// Automatically-added promptText entries (~33 KB each) are
 					// ephemeral — re-collected every turn, never rendered in

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1535,9 +1535,16 @@ export interface IChatRequestNeedsInputInfo {
 	readonly detail?: string;
 }
 
+export interface IPinnedContextItem {
+	readonly id: string;
+	readonly requestId: string;
+	readonly codeBlockIndex?: number;
+}
+
 export interface IChatModel extends IDisposable {
 	readonly onDidDispose: Event<void>;
 	readonly onDidChange: Event<IChatChangeEvent>;
+	readonly pinnedSegments: IPinnedContextItem[];
 
 	readonly sessionResource: URI;
 	/** @deprecated Use {@link sessionResource} instead */
@@ -1761,6 +1768,8 @@ export interface ISerializableChatData3 extends Omit<ISerializableChatData2, 've
 	repoData?: IExportableRepoData;
 	/** Pending requests that were queued but not yet processed */
 	pendingRequests?: ISerializablePendingRequestData[];
+	/** Pinned context segments */
+	pinnedSegments?: IPinnedContextItem[];
 }
 
 /**
@@ -1935,7 +1944,14 @@ export type IChatChangeEvent =
 	| IChatSetHiddenEvent
 	| IChatCompletedRequestEvent
 	| IChatSetCustomTitleEvent
+	| IChatPinnedContextEvent
 	;
+
+export interface IChatPinnedContextEvent {
+	kind: 'pinnedContext';
+	item: IPinnedContextItem;
+	isPinned: boolean;
+}
 
 export interface IChatAddRequestEvent {
 	kind: 'addRequest';
@@ -2090,6 +2106,27 @@ export class ChatModel extends Disposable implements IChatModel {
 	readonly onDidChangePendingRequests = this._onDidChangePendingRequests.event;
 
 	private _requests: ChatRequestModel[];
+	private _pinnedSegments: IPinnedContextItem[] = [];
+
+	public get pinnedSegments(): IPinnedContextItem[] {
+		return this._pinnedSegments;
+	}
+
+	public pinSegment(item: IPinnedContextItem): void {
+		if (!this._pinnedSegments.find(p => p.id === item.id)) {
+			this._pinnedSegments.push(item);
+			this._onDidChange.fire({ kind: 'pinnedContext', item, isPinned: true });
+		}
+	}
+
+	public unpinSegment(id: string): void {
+		const index = this._pinnedSegments.findIndex(p => p.id === id);
+		if (index !== -1) {
+			const item = this._pinnedSegments[index];
+			this._pinnedSegments.splice(index, 1);
+			this._onDidChange.fire({ kind: 'pinnedContext', item, isPinned: false });
+		}
+	}
 
 	private _repoData: IExportableRepoData | undefined;
 	public get repoData(): IExportableRepoData | undefined {
@@ -2358,6 +2395,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		this._initialResponderUsername = initialData?.responderUsername;
 
 		this._repoData = isValidFullData && initialData.repoData ? initialData.repoData : undefined;
+		this._pinnedSegments = isValidFullData && initialData.pinnedSegments ? [...initialData.pinnedSegments] : [];
 
 		// Hydrate pending requests from serialized data
 		if (isValidFullData && initialData.pendingRequests) {
@@ -2883,6 +2921,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			creationDate: this._timestamp,
 			customTitle: this._customTitle,
 			inputState: this.inputModel.toJSON(),
+			pinnedSegments: this._pinnedSegments.length > 0 ? [...this._pinnedSegments] : undefined,
 		};
 	}
 


### PR DESCRIPTION
This is a fresh submission of the "Chat Breadcrumbs" feature, resolved against the latest main branch. This feature allows users to pin critical chat segments to a persistent context bar, mitigating context decay in long-running Copilot sessions.

Key features:
- Persistent pinned segments in ChatModel.
- - UI Breadcrumbs widget above the chat input.
- - Pin/Unpin actions in chat message headers.
- - Automatic prompt injection of pinned content as high-priority context.