### PR TITLE
fix: await mode switch in executeHandoff to prevent Plan-mode race condition

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1339,7 +1339,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.acceptInput().catch(e => this.logService.error(`[Handoff] Failed to submit delegated handoff to '@${agentId}'`, e));
 		} else if (handoff.agent) {
 			// Regular handoff to specified agent
-			this._switchToAgentByName(handoff.agent);
+			const switched = await this._switchToAgentByName(handoff.agent);
+			if (!switched) {
+				return;
+			}
 			// Switch to the specified model if provided
 			if (handoff.model) {
 				this.input.switchModelByQualifiedName([handoff.model]);
@@ -1350,7 +1353,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 			// Auto-submit if send flag is true
 			if (handoff.send) {
-				this.acceptInput();
+				this.acceptInput().catch(e => this.logService.error(`[Handoff] Failed to submit handoff to '${handoff.agent}'`, e));
 			}
 		}
 	}
@@ -2824,27 +2827,32 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.agentInInput.set(!!currentAgent);
 	}
 
-	private async _switchToAgentByName(agentName: string): Promise<void> {
+	private async _switchToAgentByName(agentName: string): Promise<boolean> {
 		const currentAgent = this.input.currentModeObs.get();
 
-		// switch to appropriate agent if needed
-		if (agentName !== currentAgent.name.get()) {
-			// Find the mode object to get its kind
-			const agent = this.chatModeService.findModeByName(agentName);
-			if (agent) {
-				if (currentAgent.kind !== agent.kind) {
-					const chatModeCheck = await this.instantiationService.invokeFunction(handleModeSwitch, currentAgent.kind, agent.kind, this.viewModel?.model.getRequests().length ?? 0, this.viewModel?.model);
-					if (!chatModeCheck) {
-						return;
-					}
+		// already on the target agent
+		if (agentName === currentAgent.name.get()) {
+			return true;
+		}
 
-					if (chatModeCheck.needToClearSession) {
-						await this.clear();
-					}
-				}
-				this.input.setChatMode(agent.id);
+		// Find the mode object to get its kind
+		const agent = this.chatModeService.findModeByName(agentName);
+		if (!agent) {
+			return false;
+		}
+
+		if (currentAgent.kind !== agent.kind) {
+			const chatModeCheck = await this.instantiationService.invokeFunction(handleModeSwitch, currentAgent.kind, agent.kind, this.viewModel?.model.getRequests().length ?? 0, this.viewModel?.model);
+			if (!chatModeCheck) {
+				return false;
+			}
+
+			if (chatModeCheck.needToClearSession) {
+				await this.clear();
 			}
 		}
+		this.input.setChatMode(agent.id);
+		return true;
 	}
 
 	private async _applyPromptMetadata({ agent, tools, model }: PromptHeader, requestInput: IChatRequestInputOptions): Promise<void> {
@@ -2854,7 +2862,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 		// switch to appropriate agent if needed
 		if (agent) {
-			this._switchToAgentByName(agent);
+			const switched = await this._switchToAgentByName(agent);
+			if (!switched) {
+				return;
+			}
 		}
 
 		// if not tools to enable are present, we are done

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1341,6 +1341,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			// Regular handoff to specified agent
 			const switched = await this._switchToAgentByName(handoff.agent);
 			if (!switched) {
+				this.logService.warn(`[Handoff] Did not execute handoff '${handoff.label}' to '${handoff.agent}' because switching agents was unsuccessful`);
 				return;
 			}
 			// Switch to the specified model if provided
@@ -2296,11 +2297,15 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		});
 	}
 
-	private async _applyPromptFileIfSet(requestInput: IChatRequestInputOptions, sessionResource: URI): Promise<void> {
+	/**
+	 * @returns `false` when the prompt metadata requested an agent switch that the
+	 * user cancelled, signalling that input submission should be aborted.
+	 */
+	private async _applyPromptFileIfSet(requestInput: IChatRequestInputOptions, sessionResource: URI): Promise<boolean> {
 		// first check if the input has a prompt slash command
 		const agentSlashPromptPart = this.parsedInput.parts.find((r): r is ChatRequestSlashPromptPart => r instanceof ChatRequestSlashPromptPart);
 		if (!agentSlashPromptPart) {
-			return;
+			return true;
 		}
 
 		// Prompt slash commands are transformed out of the input before sendRequest.
@@ -2312,7 +2317,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// need to resolve the slash command to get the prompt file
 		const slashCommand = await this.customizationHarnessService.resolvePromptSlashCommand(agentSlashPromptPart.name, sessionType, CancellationToken.None);
 		if (!slashCommand) {
-			return;
+			return true;
 		}
 		const parseResult = slashCommand.parsedPromptFile;
 		// add the prompt file to the context
@@ -2332,8 +2337,13 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.telemetryService.publicLog2<ChatPromptRunEvent, ChatPromptRunClassification>('chat.promptRun', promptRunEvent);
 
 		if (parseResult.header) {
-			await this._applyPromptMetadata(parseResult.header, requestInput);
+			const applied = await this._applyPromptMetadata(parseResult.header, requestInput);
+			if (!applied) {
+				return false;
+			}
 		}
+
+		return true;
 	}
 
 	private async _acceptInput(query: { query: string } | undefined, options: IChatAcceptInputOptions = {}): Promise<IChatResponseModel | undefined> {
@@ -2422,7 +2432,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		// process the prompt command
-		await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
+		const promptApplied = await this._applyPromptFileIfSet(requestInputs, this.viewModel.sessionResource);
+		if (!promptApplied) {
+			return;
+		}
 
 		if (this.viewOptions.enableWorkingSet !== undefined && this.input.currentModeKind === ChatModeKind.Edit) {
 			const uniqueWorkingSetEntries = new ResourceSet(); // NOTE: this is used for bookkeeping so the UI can avoid rendering references in the UI that are already shown in the working set
@@ -2855,7 +2868,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return true;
 	}
 
-	private async _applyPromptMetadata({ agent, tools, model }: PromptHeader, requestInput: IChatRequestInputOptions): Promise<void> {
+	/**
+	 * @returns `false` when the agent switch was cancelled (e.g. user dismissed the
+	 * mode-switch confirmation dialog), signalling that the caller should abort the
+	 * current input submission.
+	 */
+	private async _applyPromptMetadata({ agent, tools, model }: PromptHeader, requestInput: IChatRequestInputOptions): Promise<boolean> {
 
 		if (tools !== undefined && !agent && this.input.currentModeKind !== ChatModeKind.Agent) {
 			agent = ChatMode.Agent.name.get();
@@ -2864,7 +2882,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (agent) {
 			const switched = await this._switchToAgentByName(agent);
 			if (!switched) {
-				return;
+				return false;
 			}
 		}
 
@@ -2877,6 +2895,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (model !== undefined) {
 			this.input.switchModelByQualifiedName(model);
 		}
+
+		return true;
 	}
 
 	delegateScrollFromMouseWheelEvent(browserEvent: IMouseWheelEvent): void {


### PR DESCRIPTION
## Problem

Pressing **Start Implementation** after a Plan session doesn't switch to Agent mode — the prompt is submitted while still in Plan mode. The model follows the Plan-mode system prompt ("NEVER start implementation") and refuses.

Fixes #307797, #311802, #311420

## Root Cause

`_switchToAgentByName()` is `async` but was called **without `await`** in `executeHandoff()`. The mode switch hadn't completed when `acceptInput()` fired.

## Fix

- **`_switchToAgentByName`** — returns `Promise<boolean>` instead of `Promise<void>`. Returns `true` on success, `false` when agent not found or user cancelled the mode-switch dialog.
- **`executeHandoff`** — `await`s the switch and guards `setValue`/`acceptInput` behind the boolean. Added `.catch()` to the fire-and-forget `acceptInput()` call.
- **`_applyPromptMetadata`** — `await`s the switch and early-returns on failure.