### PR TITLE
fix(search): share single Menu across result rows to fix listener leak

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsToolBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsToolBar.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ToolBar } from '../../../../base/browser/ui/toolbar/toolbar.js';
+import { IAction } from '../../../../base/common/actions.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { createActionViewItem, getActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { IMenu, IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
+import { IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+
+/**
+ * Renderer-scoped helper that owns a single `IMenu` for `MenuId.SearchActionMenu`
+ * and fans out menu changes to many lightweight per-row `ToolBar` instances.
+ *
+ * Background: search result trees instantiate a renderer per row "kind"
+ * (folder match / file match / match) and each renderer's `renderTemplate`
+ * previously created a per-row `MenuWorkbenchToolBar`. That in turn created a
+ * per-row `IMenu` and a per-row scoped `IContextKeyService`. With ~175+ visible
+ * rows the lazy listeners those Menus attach to the context-key service tripped
+ * the global leak threshold (issue #308255).
+ *
+ * This helper instead creates ONE menu, ONE scoped context-key service, and ONE
+ * scoped instantiation service per renderer; per-row `renderTemplate` then asks
+ * the pool for a lightweight `ToolBar`. A single `menu.onDidChange` subscription
+ * fans out updates to every live toolbar.
+ *
+ * Trade-off: per-row context-key bindings (e.g. `IsEditableItemKey`) used to filter
+ * action visibility per row are no longer supported. For `MenuId.SearchActionMenu`
+ * this means inline replace icons may show on rows whose underlying match is
+ * read-only when replace mode is active. The action's `run()` is responsible for
+ * a no-op in that case (read-only matches cannot be modified anyway).
+ */
+export class SearchActionsMenuPool extends Disposable {
+
+	private readonly _scopedContextKeyService: IScopedContextKeyService;
+	readonly scopedInstantiationService: IInstantiationService;
+
+	private readonly _menu: IMenu;
+	private readonly _toolbars = new Set<ToolBar>();
+
+	private _primary: IAction[] = [];
+	private _secondary: IAction[] = [];
+
+	constructor(
+		parentContextKeyService: IContextKeyService,
+		parentInstantiationService: IInstantiationService,
+		setupContextKeys: (scopedContextKeyService: IContextKeyService) => void,
+		menuService: IMenuService,
+	) {
+		super();
+
+		// Detached sentinel element: createScoped requires an IContextKeyServiceTarget.
+		// We don't want this scope tied to any tree row, so use a free-standing element.
+		// Keybinding-context DOM traversal won't find it (intentional); each row's
+		// keyboard interactions still flow through the row's own focused element.
+		const sentinel = document.createElement('div');
+		this._scopedContextKeyService = this._register(parentContextKeyService.createScoped(sentinel));
+		setupContextKeys(this._scopedContextKeyService);
+
+		this.scopedInstantiationService = this._register(parentInstantiationService.createChild(
+			new ServiceCollection([IContextKeyService, this._scopedContextKeyService])
+		));
+
+		this._menu = this._register(menuService.createMenu(MenuId.SearchActionMenu, this._scopedContextKeyService, { emitEventsForSubmenuChanges: true }));
+		this._refreshActions();
+		this._register(this._menu.onDidChange(() => {
+			this._refreshActions();
+			for (const toolbar of this._toolbars) {
+				toolbar.setActions(this._primary, this._secondary);
+			}
+		}));
+	}
+
+	private _refreshActions(): void {
+		const { primary, secondary } = getActionBarActions(
+			this._menu.getActions({ shouldForwardArgs: true }),
+			(g: string) => /^inline/.test(g)
+		);
+		this._primary = primary;
+		this._secondary = secondary;
+	}
+
+	/**
+	 * Create a lightweight per-row `ToolBar` populated with the shared menu's actions.
+	 * Caller owns the returned toolbar and must call `dispose()` (which removes it
+	 * from the pool and disposes it) when the row template is disposed.
+	 */
+	createToolBar(container: HTMLElement): { toolbar: ToolBar; dispose: () => void } {
+		const toolbar = this.scopedInstantiationService.invokeFunction(accessor => {
+			const contextMenuService = accessor.get(IContextMenuService);
+			const keybindingService = accessor.get(IKeybindingService);
+			return new ToolBar(container, contextMenuService, {
+				actionViewItemProvider: (action, options) => createActionViewItem(this.scopedInstantiationService, action, options),
+				getKeyBinding: (action) => keybindingService.lookupKeybinding(action.id) ?? undefined,
+			});
+		});
+		toolbar.setActions(this._primary, this._secondary);
+		this._toolbars.add(toolbar);
+		const dispose = () => {
+			this._toolbars.delete(toolbar);
+			toolbar.dispose();
+		};
+		return { toolbar, dispose };
+	}
+}

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -21,12 +21,15 @@ import { SearchView } from './searchView.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { ICompressibleTreeRenderer } from '../../../../base/browser/ui/tree/objectTree.js';
 import { ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
-import { MenuId } from '../../../../platform/actions/common/actions.js';
+import { IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { ISearchActionContext } from './searchActionsRemoveReplace.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { ToolBar } from '../../../../base/browser/ui/toolbar/toolbar.js';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { SearchActionsMenuPool } from './searchActionsToolBar.js';
 import { defaultCountBadgeStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { SearchContext } from '../common/constants.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
@@ -38,10 +41,9 @@ import { isSearchTreeAIFileMatch } from './AISearch/aiSearchModelBase.js';
 interface IFolderMatchTemplate {
 	label: IResourceLabel;
 	badge: CountBadge;
-	actions: MenuWorkbenchToolBar;
+	actions: ToolBar;
 	disposables: DisposableStore;
 	elementDisposables: DisposableStore;
-	contextKeyService: IContextKeyService;
 }
 
 interface ITextSearchResultTemplate {
@@ -55,10 +57,9 @@ interface IFileMatchTemplate {
 	el: HTMLElement;
 	label: IResourceLabel;
 	badge: CountBadge;
-	actions: MenuWorkbenchToolBar;
+	actions: ToolBar;
 	disposables: DisposableStore;
 	elementDisposables: DisposableStore;
-	contextKeyService: IContextKeyService;
 }
 
 interface IMatchTemplate {
@@ -68,9 +69,8 @@ interface IMatchTemplate {
 	match: HTMLElement;
 	replace: HTMLElement;
 	after: HTMLElement;
-	actions: MenuWorkbenchToolBar;
+	actions: ToolBar;
 	disposables: DisposableStore;
-	contextKeyService: IContextKeyService;
 }
 
 export class SearchDelegate implements IListVirtualDelegate<RenderableMatch> {
@@ -175,6 +175,8 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 
 	readonly templateId = FolderMatchRenderer.TEMPLATE_ID;
 
+	private _menuPool: SearchActionsMenuPool | undefined;
+
 	constructor(
 		private searchView: SearchView,
 		private labels: ResourceLabels,
@@ -182,8 +184,26 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 		@ILabelService private readonly labelService: ILabelService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IMenuService private readonly menuService: IMenuService,
 	) {
 		super();
+	}
+
+	private get menuPool(): SearchActionsMenuPool {
+		if (!this._menuPool) {
+			this._menuPool = this._register(new SearchActionsMenuPool(
+				this.contextKeyService,
+				this.instantiationService,
+				cks => {
+					SearchContext.AIResultsTitle.bindTo(cks).set(false);
+					SearchContext.MatchFocusKey.bindTo(cks).set(false);
+					SearchContext.FileFocusKey.bindTo(cks).set(false);
+					SearchContext.FolderFocusKey.bindTo(cks).set(true);
+				},
+				this.menuService,
+			));
+		}
+		return this._menuPool;
 	}
 
 	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<ISearchTreeFolderMatch>, any>, index: number, templateData: IFolderMatchTemplate): void {
@@ -217,22 +237,8 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 		const elementDisposables = new DisposableStore();
 		disposables.add(elementDisposables);
 
-		const contextKeyServiceMain = disposables.add(this.contextKeyService.createScoped(container));
-		SearchContext.AIResultsTitle.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.MatchFocusKey.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.FileFocusKey.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.FolderFocusKey.bindTo(contextKeyServiceMain).set(true);
-
-		const instantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyServiceMain])));
-		const actions = disposables.add(instantiationService.createInstance(MenuWorkbenchToolBar, actionBarContainer, MenuId.SearchActionMenu, {
-			menuOptions: {
-				shouldForwardArgs: true
-			},
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			toolbarOptions: {
-				primaryGroup: (g: string) => /^inline/.test(g),
-			},
-		}));
+		const { toolbar: actions, dispose: disposeToolbar } = this.menuPool.createToolBar(actionBarContainer);
+		disposables.add({ dispose: disposeToolbar } satisfies IDisposable);
 
 		return {
 			label,
@@ -240,7 +246,6 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 			actions,
 			disposables,
 			elementDisposables,
-			contextKeyService: contextKeyServiceMain
 		};
 	}
 
@@ -257,11 +262,10 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 			templateData.label.setLabel(nls.localize('searchFolderMatch.other.label', "Other files"));
 		}
 
-		SearchContext.IsEditableItemKey.bindTo(templateData.contextKeyService).set(!folderMatch.hasOnlyReadOnlyMatches());
-
-		templateData.elementDisposables.add(folderMatch.onChange(() => {
-			SearchContext.IsEditableItemKey.bindTo(templateData.contextKeyService).set(!folderMatch.hasOnlyReadOnlyMatches());
-		}));
+		// Note: per-row IsEditableItemKey binding was removed when this renderer
+		// switched to a renderer-shared menu pool to fix listener leak (#308255).
+		// Replace inline icons may show on read-only matches when replace mode is
+		// active; the action's run() is responsible for no-op'ing in that case.
 
 		this.renderFolderDetails(folderMatch, templateData);
 	}
@@ -292,6 +296,8 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 
 	readonly templateId = FileMatchRenderer.TEMPLATE_ID;
 
+	private _menuPool: SearchActionsMenuPool | undefined;
+
 	constructor(
 		private searchView: SearchView,
 		private labels: ResourceLabels,
@@ -299,8 +305,26 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IMenuService private readonly menuService: IMenuService,
 	) {
 		super();
+	}
+
+	private get menuPool(): SearchActionsMenuPool {
+		if (!this._menuPool) {
+			this._menuPool = this._register(new SearchActionsMenuPool(
+				this.contextKeyService,
+				this.instantiationService,
+				cks => {
+					SearchContext.AIResultsTitle.bindTo(cks).set(false);
+					SearchContext.MatchFocusKey.bindTo(cks).set(false);
+					SearchContext.FileFocusKey.bindTo(cks).set(true);
+					SearchContext.FolderFocusKey.bindTo(cks).set(false);
+				},
+				this.menuService,
+			));
+		}
+		return this._menuPool;
 	}
 
 	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<ISearchTreeFileMatch>, any>, index: number, templateData: IFileMatchTemplate): void {
@@ -318,22 +342,8 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 		disposables.add(badge);
 		const actionBarContainer = DOM.append(fileMatchElement, DOM.$('.actionBarContainer'));
 
-		const contextKeyServiceMain = disposables.add(this.contextKeyService.createScoped(container));
-		SearchContext.AIResultsTitle.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.MatchFocusKey.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.FileFocusKey.bindTo(contextKeyServiceMain).set(true);
-		SearchContext.FolderFocusKey.bindTo(contextKeyServiceMain).set(false);
-
-		const instantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyServiceMain])));
-		const actions = disposables.add(instantiationService.createInstance(MenuWorkbenchToolBar, actionBarContainer, MenuId.SearchActionMenu, {
-			menuOptions: {
-				shouldForwardArgs: true
-			},
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			toolbarOptions: {
-				primaryGroup: (g: string) => /^inline/.test(g),
-			},
-		}));
+		const { toolbar: actions, dispose: disposeToolbar } = this.menuPool.createToolBar(actionBarContainer);
+		disposables.add({ dispose: disposeToolbar } satisfies IDisposable);
 
 		return {
 			el: fileMatchElement,
@@ -342,7 +352,6 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 			actions,
 			disposables,
 			elementDisposables,
-			contextKeyService: contextKeyServiceMain
 		};
 	}
 
@@ -358,11 +367,8 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 
 		templateData.actions.context = { viewer: this.searchView.getControl(), element: fileMatch } satisfies ISearchActionContext;
 
-		SearchContext.IsEditableItemKey.bindTo(templateData.contextKeyService).set(!fileMatch.hasOnlyReadOnlyMatches());
-
-		templateData.elementDisposables.add(fileMatch.onChange(() => {
-			SearchContext.IsEditableItemKey.bindTo(templateData.contextKeyService).set(!fileMatch.hasOnlyReadOnlyMatches());
-		}));
+		// Note: per-row IsEditableItemKey binding was removed when this renderer
+		// switched to a renderer-shared menu pool to fix listener leak (#308255).
 
 		// when hidesExplorerArrows: true, then the file nodes should still have a twistie because it would otherwise
 		// be hard to tell whether the node is collapsed or expanded.
@@ -385,16 +391,37 @@ export class MatchRenderer extends Disposable implements ICompressibleTreeRender
 
 	readonly templateId = MatchRenderer.TEMPLATE_ID;
 
+	private _menuPool: SearchActionsMenuPool | undefined;
+
 	constructor(
 		private searchView: SearchView,
 		@IWorkspaceContextService protected contextService: IWorkspaceContextService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@IHoverService private readonly hoverService: IHoverService
+		@IHoverService private readonly hoverService: IHoverService,
+		@IMenuService private readonly menuService: IMenuService,
 	) {
 		super();
 	}
+
+	private get menuPool(): SearchActionsMenuPool {
+		if (!this._menuPool) {
+			this._menuPool = this._register(new SearchActionsMenuPool(
+				this.contextKeyService,
+				this.instantiationService,
+				cks => {
+					SearchContext.AIResultsTitle.bindTo(cks).set(false);
+					SearchContext.MatchFocusKey.bindTo(cks).set(true);
+					SearchContext.FileFocusKey.bindTo(cks).set(false);
+					SearchContext.FolderFocusKey.bindTo(cks).set(false);
+				},
+				this.menuService,
+			));
+		}
+		return this._menuPool;
+	}
+
 	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<ISearchTreeMatch>, void>, index: number, templateData: IMatchTemplate): void {
 		throw new Error('Should never happen since node is incompressible.');
 	}
@@ -412,22 +439,8 @@ export class MatchRenderer extends Disposable implements ICompressibleTreeRender
 
 		const disposables = new DisposableStore();
 
-		const contextKeyServiceMain = disposables.add(this.contextKeyService.createScoped(container));
-		SearchContext.AIResultsTitle.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.MatchFocusKey.bindTo(contextKeyServiceMain).set(true);
-		SearchContext.FileFocusKey.bindTo(contextKeyServiceMain).set(false);
-		SearchContext.FolderFocusKey.bindTo(contextKeyServiceMain).set(false);
-
-		const instantiationService = disposables.add(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, contextKeyServiceMain])));
-		const actions = disposables.add(instantiationService.createInstance(MenuWorkbenchToolBar, actionBarContainer, MenuId.SearchActionMenu, {
-			menuOptions: {
-				shouldForwardArgs: true
-			},
-			hiddenItemStrategy: HiddenItemStrategy.Ignore,
-			toolbarOptions: {
-				primaryGroup: (g: string) => /^inline/.test(g),
-			},
-		}));
+		const { toolbar: actions, dispose: disposeToolbar } = this.menuPool.createToolBar(actionBarContainer);
+		disposables.add({ dispose: disposeToolbar } satisfies IDisposable);
 
 		return {
 			parent,
@@ -438,7 +451,6 @@ export class MatchRenderer extends Disposable implements ICompressibleTreeRender
 			lineNumber,
 			actions,
 			disposables,
-			contextKeyService: contextKeyServiceMain
 		};
 	}
 
@@ -458,7 +470,8 @@ export class MatchRenderer extends Disposable implements ICompressibleTreeRender
 		const title = (preview.fullBefore + (replace ? match.replaceString : preview.inside) + preview.after).trim().substr(0, 999);
 		templateData.disposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), templateData.parent, title));
 
-		SearchContext.IsEditableItemKey.bindTo(templateData.contextKeyService).set(!match.isReadonly);
+		// Note: per-row IsEditableItemKey binding was removed when this renderer
+		// switched to a renderer-shared menu pool to fix listener leak (#308255).
 
 		const numLines = match.range().endLineNumber - match.range().startLineNumber;
 		const extraLinesStr = numLines > 0 ? `+${numLines}` : '';


### PR DESCRIPTION
Fixes #308255

## Problem

Search result trees instantiate a renderer per row "kind" (folder match / file match / match) and each renderer's `renderTemplate` previously created a per-row `MenuWorkbenchToolBar`. That in turn created a per-row `IMenu` and a per-row scoped `IContextKeyService`. With ~175+ visible rows the lazy `contextKeyService.onDidChangeContext` listeners those Menus attach to the (scoped) context key service tripped the global leak threshold (popular kind), producing the millions of "potential listener LEAK detected" telemetry hits tracked in #308255.

Telemetry buckets covered (v1.116.0 / v1.117.0-insider):
- \`5912c915\` — searchResultsView.ts:422 (FileMatchRenderer)
- \`ccfc3902\` — searchResultsView.ts:328 (MatchRenderer)
- \`18361d63\` — searchResultsView.ts:422 (1.114.0)
- \`a0686ebe\` — searchResultsView.ts (renderTemplate, 1.116.0)
- \`f5e0a616\` — searchResultsView.ts:422 (1.117.0-insider, 10.4x spike)

Combined: ~1.7M+ hits across the 5 buckets.

## Fix

Introduce \`SearchActionsMenuPool\` (\`searchActionsToolBar.ts\`): one \`IMenu\` for \`MenuId.SearchActionMenu\`, one scoped \`IContextKeyService\`, and one scoped \`IInstantiationService\` per renderer instance. Per-row \`renderTemplate\` asks the pool for a lightweight \`ToolBar\`; a single \`menu.onDidChange\` subscription fans out updates to every live toolbar. Refactored \`FolderMatchRenderer\`, \`FileMatchRenderer\`, and \`MatchRenderer\` to use it.

Listener accounting before vs. after, per renderer, with N visible rows:

|                                 | Before | After |
|---------------------------------|--------|-------|
| Menus created                   | N      | 1     |
| Scoped IContextKeyService       | N      | 1     |
| Scoped IInstantiationService    | N      | 1     |
| Listeners on parent IContextKeyService | N | 1   |

This drops the listener count on the search view's context-key service from O(rows visible) to O(1), well below the 175 threshold regardless of result-set size.

## Trade-off

Per-row \`IsEditableItemKey\` binding is dropped (was used to hide replace inline icons on read-only rows when replace mode is active). Replace icons may now show on read-only matches; the underlying actions' \`run()\` handlers are responsible for no-op'ing in that case (read-only matches cannot be modified anyway). The \`TextSearchResultRenderer\` (only 1-2 instances per view, can't trip the threshold) was left on \`MenuWorkbenchToolBar\`.

## Verification

- \`tsc --noEmit -p src/tsconfig.json\` clean
- \`eslint\` clean
- Manual: built and exercised search view with large result sets — toolbar actions still update on context changes (replace mode toggle, hover focus changes) via the shared \`menu.onDidChange\` path.