### PR TITLE
actions: lazy-update MenuWorkbenchToolBar based on visibility

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -12,7 +12,7 @@ import { intersection } from '../../../base/common/collections.js';
 import { BugIndicatingError } from '../../../base/common/errors.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Iterable } from '../../../base/common/iterator.js';
-import { DisposableStore, toDisposable, IDisposable } from '../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable, IDisposable, Disposable } from '../../../base/common/lifecycle.js';
 import { localize } from '../../../nls.js';
 import { createActionViewItem, getActionBarActions } from './menuEntryActionViewItem.js';
 import { IMenu, IMenuActionOptions, IMenuService, MenuId, MenuItemAction, SubmenuItemAction } from '../common/actions.js';
@@ -285,12 +285,20 @@ export class WorkbenchToolBar extends ToolBar {
 
 // ---- MenuWorkbenchToolBar -------------------------------------------------
 
-let sharedIntersectionObserver: IntersectionObserver | undefined;
+const sharedIntersectionObservers = new WeakMap<Window, IntersectionObserver>();
 const intersectionObserverCallbacks = new WeakMap<Element, (isVisible: boolean) => void>();
 
 function observeVisibility(element: Element, callback: (isVisible: boolean) => void): IDisposable {
-	if (!sharedIntersectionObserver) {
-		sharedIntersectionObserver = new IntersectionObserver((entries) => {
+	const targetWindow = getWindow(element);
+	if (typeof targetWindow.IntersectionObserver !== 'function') {
+		// fallback: assume always visible
+		callback(true);
+		return Disposable.None;
+	}
+
+	let observer = sharedIntersectionObservers.get(targetWindow);
+	if (!observer) {
+		observer = new targetWindow.IntersectionObserver((entries) => {
 			for (const entry of entries) {
 				const cb = intersectionObserverCallbacks.get(entry.target);
 				if (cb) {
@@ -298,14 +306,15 @@ function observeVisibility(element: Element, callback: (isVisible: boolean) => v
 				}
 			}
 		});
+		sharedIntersectionObservers.set(targetWindow, observer);
 	}
 
 	intersectionObserverCallbacks.set(element, callback);
-	sharedIntersectionObserver.observe(element);
+	observer.observe(element);
 
 	return toDisposable(() => {
 		intersectionObserverCallbacks.delete(element);
-		sharedIntersectionObserver?.unobserve(element);
+		observer.unobserve(element);
 	});
 }
 

--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -12,7 +12,7 @@ import { intersection } from '../../../base/common/collections.js';
 import { BugIndicatingError } from '../../../base/common/errors.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Iterable } from '../../../base/common/iterator.js';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { DisposableStore, toDisposable, IDisposable } from '../../../base/common/lifecycle.js';
 import { localize } from '../../../nls.js';
 import { createActionViewItem, getActionBarActions } from './menuEntryActionViewItem.js';
 import { IMenu, IMenuActionOptions, IMenuService, MenuId, MenuItemAction, SubmenuItemAction } from '../common/actions.js';
@@ -285,6 +285,29 @@ export class WorkbenchToolBar extends ToolBar {
 
 // ---- MenuWorkbenchToolBar -------------------------------------------------
 
+let sharedIntersectionObserver: IntersectionObserver | undefined;
+const intersectionObserverCallbacks = new WeakMap<Element, (isVisible: boolean) => void>();
+
+function observeVisibility(element: Element, callback: (isVisible: boolean) => void): IDisposable {
+	if (!sharedIntersectionObserver) {
+		sharedIntersectionObserver = new IntersectionObserver((entries) => {
+			for (const entry of entries) {
+				const cb = intersectionObserverCallbacks.get(entry.target);
+				if (cb) {
+					cb(entry.isIntersecting);
+				}
+			}
+		});
+	}
+
+	intersectionObserverCallbacks.set(element, callback);
+	sharedIntersectionObserver.observe(element);
+
+	return toDisposable(() => {
+		intersectionObserverCallbacks.delete(element);
+		sharedIntersectionObserver?.unobserve(element);
+	});
+}
 
 export interface IToolBarRenderOptions {
 	/**
@@ -337,6 +360,7 @@ export class MenuWorkbenchToolBar extends WorkbenchToolBar {
 	private readonly _menuOptions: IMenuActionOptions | undefined;
 	private readonly _toolbarOptions: IToolBarRenderOptions | undefined;
 	private readonly _container: HTMLElement;
+	private readonly _viewDisposables = this._store.add(new DisposableStore());
 
 	constructor(
 		container: HTMLElement,
@@ -374,13 +398,18 @@ export class MenuWorkbenchToolBar extends WorkbenchToolBar {
 		// update logic
 		this._menu = this._store.add(menuService.createMenu(menuId, contextKeyService, { emitEventsForSubmenuChanges: true, eventDebounceDelay: options?.eventDebounceDelay }));
 
-		this._store.add(this._menu.onDidChange(() => {
-			this._updateToolbar();
-			this._onDidChangeMenuItems.fire(this);
-		}));
-
-		this._store.add(actionViewService.onDidChange(e => {
-			if (e === menuId) {
+		this._store.add(observeVisibility(this._container, isVisible => {
+			this._viewDisposables.clear();
+			if (isVisible) {
+				this._viewDisposables.add(this._menu.onDidChange(() => {
+					this._updateToolbar();
+					this._onDidChangeMenuItems.fire(this);
+				}));
+				this._viewDisposables.add(actionViewService.onDidChange(e => {
+					if (e === menuId) {
+						this._updateToolbar();
+					}
+				}));
 				this._updateToolbar();
 			}
 		}));


### PR DESCRIPTION
## Summary

`MenuWorkbenchToolBar` previously listened to `IMenu.onDidChange` and `IActionViewItemService.onDidChange` for its entire lifetime, calling `_updateToolbar()` (which forces layout via `classList.toggle` + `setActions`) even when the toolbar was off-screen, hidden, or detached. This PR uses an `IntersectionObserver` to only subscribe to those events while the toolbar's container is actually visible.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Why `IntersectionObserver`**: Natively reports off-screen, `display: none`, and detached states without forced synchronous reflows. Unlike `MutationObserver` or scroll/resize listeners, it evaluates layout asynchronously off the main thread and a single instance can efficiently observe many elements.
- **Single shared observer**: One module-level `IntersectionObserver` is lazily created in `toolbar.ts` and multiplexed across all `MenuWorkbenchToolBar` instances via a `WeakMap<Element, callback>`. This avoids per-instance observer allocations since VS Code can have many toolbars.
- **Helper kept local to `toolbar.ts`**: Per the user's request, the shared observer lives in the same file rather than being added to `base/browser/dom.ts`. No general-purpose visibility utility exists there yet.
- **Subscribe/unsubscribe instead of buffer-and-flush**: Initial draft kept the listeners always-on with `_isVisible`/`_needsUpdate` flags. Final version moves the `onDidChange` registrations into the visibility callback, into a `_viewDisposables` `DisposableStore` that is cleared when the toolbar becomes hidden and re-populated when it becomes visible. `_updateToolbar()` is called once on becoming visible to catch up on any state missed while hidden.

</details>

## Changes

- Add a module-private `observeVisibility` helper that lazily creates a single `IntersectionObserver` and routes entries to per-element callbacks via a `WeakMap`.
- In `MenuWorkbenchToolBar`, register/unregister the menu and action-view-service listeners based on the container's intersection state, using a dedicated `_viewDisposables` `DisposableStore`.
