### PR TITLE
chat: fix editor change event checking by using .matches()

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -237,10 +237,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 		const enum K { Stream, Workspace }
 		const editsSeen: ({ kind: K.Stream; seen: number; stream: IStreamingEdits } | { kind: K.Workspace })[] = [];
 
-		let editorDidChange = false;
-		const editorListener = Event.once(this._editorService.onDidActiveEditorChange)(() => {
-			editorDidChange = true;
-		});
+		const initialActiveEditor = this._editorService.activeEditorPane?.input;
 		const editorOpenPromises = new ResourceMap<Promise<void>>();
 		const openChatEditedFiles = this._configurationService.getValue('accessibility.openChatEditedFiles');
 
@@ -252,6 +249,8 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 			editorOpenPromises.set(uri, (async () => {
 				if (this.notebookService.getNotebookTextModel(uri) || uri.scheme === Schemas.untitled || await this._fileService.exists(uri).catch(() => false)) {
 					const activeUri = this._editorService.activeEditorPane?.input.resource;
+					const currentActiveEditor = this._editorService.activeEditorPane?.input;
+					const editorDidChange = initialActiveEditor && currentActiveEditor ? !initialActiveEditor.matches(currentActiveEditor) : initialActiveEditor !== currentActiveEditor;
 					const inactive = editorDidChange
 						|| this._editorService.activeEditorPane?.input instanceof ChatEditorInput && isEqual(this._editorService.activeEditorPane.input.sessionResource, session.chatSessionResource)
 						|| Boolean(activeUri && session.entries.get().find(entry => isEqual(activeUri, entry.modifiedURI)));
@@ -270,7 +269,6 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 
 			editsSeen.length = 0;
 			editorOpenPromises.clear();
-			editorListener.dispose();
 		};
 
 		const handleResponseParts = async () => {


### PR DESCRIPTION
## Summary
Fixes https://github.com/microsoft/vscode/issues/311923

The listener (`onDidActiveEditorChange`) was too eager and sometimes opened files as inactive when the current sequence triggered it unexpectedly. We swapped to capturing the initial active editor's input and comparing it with the current one instead, making it more robust as the state is correctly scoped to the response processing loop.

<details>
<summary>Session Context</summary>
Key decisions from the development session:
- **Refactoring strategy**: We decided to capture the initial active editor input instead of using a global service counter or `Event.once` listener, as it's cleaner and scopes the state properly within the application loop.
- **Comparison strategy**: Using `.matches()` rather than direct identity tracking, since the exact editor `input` object reference can change even though the logical entity is the same.
</details>

## Changes
- Remove `editorDidChange` event listener block in `chatEditingServiceImpl.ts`
- Replace with `initialActiveEditor = this._editorService.activeEditorPane?.input` and `!initialActiveEditor.matches(currentActiveEditor)` check