### PR TITLE
Agents: Truncate chat input placeholder in narrow views

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1484,6 +1484,35 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-input-foreground);
 }
 
+/* Truncate the chat input placeholder with an ellipsis in narrow views
+	instead of letting it overflow off the right edge of the input.
+	The placeholder is rendered as a Monaco contentText decoration with
+	class prefix "ced-chat-session-detail" inside the view-line spans. */
+.chat-editor-container {
+	container-type: inline-size;
+}
+
+.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]) {
+	max-width: 100cqi;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--vscode-input-placeholderForeground);
+}
+
+.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]) > span {
+	display: inline-block;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: bottom;
+}
+
+.chat-editor-container .monaco-editor .view-line [class*="ced-chat-session-detail"] {
+	display: inline;
+}
+
 .interactive-session .chat-editor-container .monaco-editor .chat-prompt-spinner {
 	transform-origin: 6px 6px;
 	font-size: 12px;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1487,12 +1487,17 @@ have to be updated for changes to the rules above, or to support more deeply nes
 /* Truncate the chat input placeholder with an ellipsis in narrow views
 	instead of letting it overflow off the right edge of the input.
 	The placeholder is rendered as a Monaco contentText decoration with
-	class prefix "ced-chat-session-detail" inside the view-line spans. */
+	class prefix "ced-chat-session-detail" inside the view-line spans.
+	The :not(:has([class^="mtk"])) guard limits truncation to lines
+	that contain only placeholder decorations (no real syntax tokens),
+	so a typed "@agent " prefix with a trailing description decoration
+	is not recolored or clipped. */
 .chat-editor-container {
+	/* enables 100cqi for placeholder truncation below */
 	container-type: inline-size;
 }
 
-.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]) {
+.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]):not(:has([class^="mtk"])) {
 	max-width: 100cqi;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1500,17 +1505,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-input-placeholderForeground);
 }
 
-.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]) > span {
+.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]):not(:has([class^="mtk"])) > span {
 	display: inline-block;
 	max-width: 100%;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	vertical-align: bottom;
-}
-
-.chat-editor-container .monaco-editor .view-line [class*="ced-chat-session-detail"] {
-	display: inline;
 }
 
 .interactive-session .chat-editor-container .monaco-editor .chat-prompt-spinner {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1473,6 +1473,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-editor-container {
 	padding: 0 0 0 4px;
+	/* enables 100cqi for placeholder truncation below */
+	container-type: inline-size;
 }
 
 .interactive-session .interactive-input-part.compact .chat-editor-container {
@@ -1487,31 +1489,18 @@ have to be updated for changes to the rules above, or to support more deeply nes
 /* Truncate the chat input placeholder with an ellipsis in narrow views
 	instead of letting it overflow off the right edge of the input.
 	The placeholder is rendered as a Monaco contentText decoration with
-	class prefix "ced-chat-session-detail" inside the view-line spans.
-	The :not(:has([class^="mtk"])) guard limits truncation to lines
-	that contain only placeholder decorations (no real syntax tokens),
-	so a typed "@agent " prefix with a trailing description decoration
-	is not recolored or clipped. */
-.chat-editor-container {
-	/* enables 100cqi for placeholder truncation below */
-	container-type: inline-size;
-}
-
-.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]):not(:has([class^="mtk"])) {
+	class prefix "ced-chat-session-detail" inside the view-line spans;
+	style the decoration element directly so we don't pay :has() cost
+	across every view-line on each typed character. */
+.chat-editor-container .monaco-editor [class^="ced-chat-session-detail"] {
+	display: inline-block;
+	max-width: 100%; /* fallback for environments without container query units */
 	max-width: 100cqi;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--vscode-input-placeholderForeground);
-}
-
-.chat-editor-container .monaco-editor .view-line:has([class*="ced-chat-session-detail"]):not(:has([class^="mtk"])) > span {
-	display: inline-block;
-	max-width: 100%;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 	vertical-align: bottom;
+	color: var(--vscode-input-placeholderForeground);
 }
 
 .interactive-session .chat-editor-container .monaco-editor .chat-prompt-spinner {


### PR DESCRIPTION
Improve the chat input placeholder truncation logic to display an ellipsis in narrow views, preventing overflow. This enhances the user experience by ensuring the placeholder remains visible and properly formatted.

