### PR TITLE
Add contributable Manage submenu to workspace picker

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1368,6 +1368,7 @@ export class ActionListWidget<T> extends Disposable {
 					const child = group.actions[ci];
 					const icon = (child as IAction & { icon?: ThemeIcon }).icon
 						?? ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id);
+					const hoverContent = (child as IAction & { hoverContent?: string }).hoverContent;
 					submenuItems.push({
 						item: child,
 						kind: ActionListItemKind.Action,
@@ -1375,7 +1376,7 @@ export class ActionListWidget<T> extends Disposable {
 						description: child.tooltip || undefined,
 						group: { title: '', icon },
 						hideIcon: false,
-						hover: {},
+						hover: hoverContent ? { content: hoverContent } : {},
 					});
 				}
 				if (gi < groupsWithActions.length - 1) {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -308,6 +308,7 @@ export class MenuId {
 	static readonly AgentSessionSectionContext = new MenuId('AgentSessionSectionContext');
 	static readonly AgentSessionsCreateSubMenu = new MenuId('AgentSessionsCreateSubMenu');
 	static readonly AgentSessionsToolbar = new MenuId('AgentSessionsToolbar');
+	static readonly SessionWorkspacePickerManage = new MenuId('SessionWorkspacePickerManage');
 	static readonly AgentSessionItemToolbar = new MenuId('AgentSessionItemToolbar');
 	static readonly AgentSessionSectionToolbar = new MenuId('AgentSessionSectionToolbar');
 	static readonly AgentsTitleBarControlMenu = new MenuId('AgentsTitleBarControlMenu');

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -308,7 +308,6 @@ export class MenuId {
 	static readonly AgentSessionSectionContext = new MenuId('AgentSessionSectionContext');
 	static readonly AgentSessionsCreateSubMenu = new MenuId('AgentSessionsCreateSubMenu');
 	static readonly AgentSessionsToolbar = new MenuId('AgentSessionsToolbar');
-	static readonly SessionWorkspacePickerManage = new MenuId('SessionWorkspacePickerManage');
 	static readonly AgentSessionItemToolbar = new MenuId('AgentSessionItemToolbar');
 	static readonly AgentSessionSectionToolbar = new MenuId('AgentSessionSectionToolbar');
 	static readonly AgentsTitleBarControlMenu = new MenuId('AgentsTitleBarControlMenu');

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -28,4 +28,5 @@ export const Menus = {
 	NewSessionConfig: new MenuId('NewSessions.SessionConfigMenu'),
 	NewSessionControl: new MenuId('NewSessions.SessionControlMenu'),
 	NewSessionRepositoryConfig: new MenuId('NewSessions.RepositoryConfigMenu'),
+	WorkspacePickerManage: new MenuId('Sessions.WorkspacePickerManage'),
 } as const;

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -28,5 +28,5 @@ export const Menus = {
 	NewSessionConfig: new MenuId('NewSessions.SessionConfigMenu'),
 	NewSessionControl: new MenuId('NewSessions.SessionControlMenu'),
 	NewSessionRepositoryConfig: new MenuId('NewSessions.RepositoryConfigMenu'),
-	WorkspacePickerManage: new MenuId('Sessions.WorkspacePickerManage'),
+	SessionWorkspaceManage: new MenuId('Sessions.SessionWorkspaceManage'),
 } as const;

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -7,10 +7,12 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { IMenuService } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
@@ -48,6 +50,8 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICommandService commandService: ICommandService,
 		@IWorkspacesService workspacesService: IWorkspacesService,
+		@IMenuService menuService: IMenuService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 	) {
 		super(
@@ -64,6 +68,8 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 			configurationService,
 			commandService,
 			workspacesService,
+			menuService,
+			contextKeyService,
 		);
 
 		// When the scoped host changes, if the current selection no longer

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -472,7 +472,7 @@ export class WorkspacePicker extends Disposable {
 
 		// Menu-contributed actions (e.g. Tunnels..., SSH...)
 		const menuContributedActions: IAction[] = [];
-		const menuActions = this.menuService.getMenuActions(Menus.WorkspacePickerManage, this.contextKeyService);
+		const menuActions = this.menuService.getMenuActions(Menus.SessionWorkspaceManage, this.contextKeyService, { renderShortTitle: true });
 		for (const [, actions] of menuActions) {
 			for (const menuAction of actions) {
 				const icon = 'item' in menuAction && ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -14,7 +14,7 @@ import { basename } from '../../../../base/common/resources.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { IMenuService } from '../../../../platform/actions/common/actions.js';
+import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -475,8 +475,10 @@ export class WorkspacePicker extends Disposable {
 		const menuActions = this.menuService.getMenuActions(Menus.SessionWorkspaceManage, this.contextKeyService, { renderShortTitle: true });
 		for (const [, actions] of menuActions) {
 			for (const menuAction of actions) {
-				const icon = 'item' in menuAction && ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
-				menuContributedActions.push(Object.assign(menuAction, { icon }));
+				if (menuAction instanceof MenuItemAction) {
+					const icon = ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
+					menuContributedActions.push(Object.assign(menuAction, { icon }));
+				}
 			}
 		}
 

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -8,19 +8,19 @@ import * as touch from '../../../../base/browser/touch.js';
 import { IAction, SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { basename } from '../../../../base/common/resources.js';
-import { isNative } from '../../../../base/common/platform.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { MenuId, IMenuService } from '../../../../platform/actions/common/actions.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
 import { IOutputService } from '../../../../workbench/services/output/common/output.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
@@ -66,8 +66,6 @@ export interface IWorkspacePickerItem {
 	readonly selection?: IWorkspaceSelection;
 	readonly browseActionIndex?: number;
 	readonly checked?: boolean;
-	/** Remote provider reference for gear menu actions. */
-	readonly remoteProvider?: IAgentHostSessionsProvider;
 	/** Command to execute when this item is selected. */
 	readonly commandId?: string;
 }
@@ -109,9 +107,11 @@ export class WorkspacePicker extends Disposable {
 		@IClipboardService private readonly clipboardService: IClipboardService,
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
 		@IOutputService private readonly outputService: IOutputService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IConfigurationService _configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
 
@@ -209,14 +209,7 @@ export class WorkspacePicker extends Disposable {
 					// Workspace belongs to an unavailable remote — ignore selection
 					return;
 				}
-				if (item.remoteProvider && item.browseActionIndex === undefined) {
-					if (!item.remoteProvider.remoteAddress?.startsWith(TUNNEL_ADDRESS_PREFIX)) {
-						// Disconnected SSH host — show options menu after widget hides.
-						// (Disconnected tunnels are rendered as disabled with a
-						// refresh toolbar action, so onSelect doesn't fire for them.)
-						this._showRemoteHostOptionsDelayed(item.remoteProvider);
-					}
-				} else if (item.browseActionIndex !== undefined) {
+				if (item.browseActionIndex !== undefined) {
 					this._executeBrowseAction(item.browseActionIndex);
 				} else if (item.selection) {
 					this._selectProject(item.selection);
@@ -453,122 +446,69 @@ export class WorkspacePicker extends Disposable {
 			});
 		}
 
-		if (items.length > 0 && items[items.length - 1].kind !== ActionListItemKind.Separator && remoteProviders.length) {
-			items.push({ kind: ActionListItemKind.Separator, label: '' });
-		}
+		// "Manage" submenu: dynamic remote provider entries + menu-contributed actions
+		const manageActions: IAction[] = [];
 
+		// Dynamic remote provider entries
+		const remoteProviderActions: IAction[] = [];
 		for (const provider of remoteProviders) {
 			const status = provider.connectionStatus!.get();
 			const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
 			const providerBrowseIndex = allBrowseActions.findIndex(a => a.providerId === provider.id);
 			const isTunnel = provider.remoteAddress?.startsWith(TUNNEL_ADDRESS_PREFIX);
-
-			const toolbarActions: IAction[] = [];
-
-			if (isTunnel) {
-				// Offline/connecting tunnels: surface a refresh button that
-				// attempts to (re)connect in case the cached status is stale.
-				if (!isConnected && providerBrowseIndex >= 0) {
-					const browseIndex = providerBrowseIndex;
-					toolbarActions.push(toAction({
-						id: `workspacePicker.remote.refresh.${provider.id}`,
-						label: localize('workspacePicker.refreshTunnel', "Attempt to Connect"),
-						class: ThemeIcon.asClassName(Codicon.refresh),
-						run: () => {
-							this.actionWidgetService.hide();
-							this._executeBrowseAction(browseIndex);
-						},
-					}));
-				}
-			} else {
-				// Gear menu only for SSH hosts, not tunnel providers
-				toolbarActions.push(toAction({
-					id: `workspacePicker.remote.gear.${provider.id}`,
-					label: localize('workspacePicker.remoteOptions', "Options"),
-					class: ThemeIcon.asClassName(Codicon.gear),
-					run: () => {
+			const action = toAction({
+				id: `workspacePicker.remote.${provider.id}`,
+				label: provider.label,
+				tooltip: '',
+				enabled: isConnected,
+				run: () => {
+					if (isConnected && providerBrowseIndex >= 0) {
+						this.actionWidgetService.hide();
+						this._executeBrowseAction(providerBrowseIndex);
+					} else if (!isTunnel) {
 						this.actionWidgetService.hide();
 						this._showRemoteHostOptionsDelayed(provider);
-					},
-				}));
-			}
-
-			items.push({
-				kind: ActionListItemKind.Action,
-				label: provider.label,
-				description: this._getStatusDescription(status),
-				hover: { content: this._getStatusHover(status, provider.remoteAddress) },
-				group: { title: '', icon: isTunnel ? Codicon.cloud : Codicon.remote },
-				disabled: !isConnected,
-				item: {
-					browseActionIndex: isConnected && providerBrowseIndex >= 0 ? providerBrowseIndex : undefined,
-					remoteProvider: provider,
+					}
 				},
-				toolbarActions,
 			});
+			(action as IAction & { icon?: ThemeIcon }).icon = isTunnel ? Codicon.cloud : Codicon.remote;
+			remoteProviderActions.push(action);
 		}
 
-		// "Tunnels..." and "SSH..." entries — shown when remote agent hosts are enabled
-		if (this.configurationService.getValue<boolean>(RemoteAgentHostsEnabledSettingId)) {
+		// Menu-contributed actions (e.g. Tunnels..., SSH...)
+		const menuContributedActions: IAction[] = [];
+		const menuActions = this.menuService.getMenuActions(MenuId.SessionWorkspacePickerManage, this.contextKeyService);
+		for (const [, actions] of menuActions) {
+			for (const menuAction of actions) {
+				const icon = 'item' in menuAction && ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
+				menuContributedActions.push(Object.assign(menuAction, { icon }));
+			}
+		}
+
+		// Build submenu groups — each SubmenuAction becomes a visual group with
+		// automatic separators between them.
+		const manageSubmenuActions: SubmenuAction[] = [];
+		if (remoteProviderActions.length > 0) {
+			manageSubmenuActions.push(new SubmenuAction('workspacePicker.manage.remotes', '', remoteProviderActions));
+		}
+		if (menuContributedActions.length > 0) {
+			manageSubmenuActions.push(new SubmenuAction('workspacePicker.manage.menu', '', menuContributedActions));
+		}
+
+		if (manageSubmenuActions.length > 0) {
 			if (items.length > 0 && items[items.length - 1].kind !== ActionListItemKind.Separator) {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
 			items.push({
 				kind: ActionListItemKind.Action,
-				label: localize('workspacePicker.tunnels', "Tunnels..."),
-				group: { title: '', icon: Codicon.cloud },
-				item: { commandId: 'workbench.action.sessions.connectViaTunnel' },
+				label: localize('workspacePicker.manage', "Manage..."),
+				group: { title: '', icon: Codicon.settingsGear },
+				item: {},
+				submenuActions: manageSubmenuActions,
 			});
-			if (isNative) {
-				items.push({
-					kind: ActionListItemKind.Action,
-					label: localize('workspacePicker.ssh', "SSH..."),
-					group: { title: '', icon: Codicon.remote },
-					item: { commandId: 'workbench.action.sessions.connectViaSSH' },
-				});
-			}
 		}
 
 		return items;
-	}
-
-	/**
-	 * Returns a short status indicator with a colored circle icon for the description field.
-	 */
-	private _getStatusDescription(status: RemoteAgentHostConnectionStatus): MarkdownString {
-		const md = new MarkdownString(undefined, { supportThemeIcons: true });
-		switch (status) {
-			case RemoteAgentHostConnectionStatus.Connected:
-				md.appendText(localize('workspacePicker.statusOnline', "Online"));
-				break;
-			case RemoteAgentHostConnectionStatus.Connecting:
-				md.appendText(localize('workspacePicker.statusConnecting', "Connecting"));
-				break;
-			case RemoteAgentHostConnectionStatus.Disconnected:
-				md.appendText(localize('workspacePicker.statusOffline', "Offline"));
-				break;
-		}
-		return md;
-	}
-
-	/**
-	 * Returns detailed hover text for a remote host's connection status.
-	 */
-	private _getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
-		switch (status) {
-			case RemoteAgentHostConnectionStatus.Connected:
-				return address
-					? localize('workspacePicker.hoverConnectedAddr', "Remote agent host is connected and ready.\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.");
-			case RemoteAgentHostConnectionStatus.Connecting:
-				return address
-					? localize('workspacePicker.hoverConnectingAddr', "Attempting to connect to remote agent host...\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...");
-			case RemoteAgentHostConnectionStatus.Disconnected:
-				return address
-					? localize('workspacePicker.hoverDisconnectedAddr', "Remote agent host is disconnected. Click the gear icon for options.\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected. Click the gear icon for options.");
-		}
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -448,7 +448,6 @@ export class WorkspacePicker extends Disposable {
 		}
 
 		// "Manage" submenu: dynamic remote provider entries + menu-contributed actions
-		const manageActions: IAction[] = [];
 
 		// Dynamic remote provider entries
 		const remoteProviderActions: IAction[] = [];

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -14,7 +14,7 @@ import { basename } from '../../../../base/common/resources.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
 import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
-import { MenuId, IMenuService } from '../../../../platform/actions/common/actions.js';
+import { IMenuService } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -35,6 +35,7 @@ import { ISessionsManagementService } from '../../../services/sessions/common/se
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 import { IWorkspacesService, isRecentFolder } from '../../../../platform/workspaces/common/workspaces.js';
+import { Menus } from '../../../browser/menus.js';
 
 const LEGACY_STORAGE_KEY_RECENT_PROJECTS = 'sessions.recentlyPickedProjects';
 const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
@@ -453,31 +454,26 @@ export class WorkspacePicker extends Disposable {
 		const remoteProviderActions: IAction[] = [];
 		for (const provider of remoteProviders) {
 			const status = provider.connectionStatus!.get();
-			const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
-			const providerBrowseIndex = allBrowseActions.findIndex(a => a.providerId === provider.id);
 			const isTunnel = provider.remoteAddress?.startsWith(TUNNEL_ADDRESS_PREFIX);
 			const action = toAction({
 				id: `workspacePicker.remote.${provider.id}`,
 				label: provider.label,
-				tooltip: '',
-				enabled: isConnected,
+				tooltip: this._getStatusLabel(status),
+				enabled: true,
 				run: () => {
-					if (isConnected && providerBrowseIndex >= 0) {
-						this.actionWidgetService.hide();
-						this._executeBrowseAction(providerBrowseIndex);
-					} else if (!isTunnel) {
-						this.actionWidgetService.hide();
-						this._showRemoteHostOptionsDelayed(provider);
-					}
+					this.actionWidgetService.hide();
+					this._showRemoteHostOptionsDelayed(provider);
 				},
 			});
-			(action as IAction & { icon?: ThemeIcon }).icon = isTunnel ? Codicon.cloud : Codicon.remote;
+			const extended = action as IAction & { icon?: ThemeIcon; hoverContent?: string };
+			extended.icon = isTunnel ? Codicon.cloud : Codicon.remote;
+			extended.hoverContent = this._getStatusHover(status, provider.remoteAddress);
 			remoteProviderActions.push(action);
 		}
 
 		// Menu-contributed actions (e.g. Tunnels..., SSH...)
 		const menuContributedActions: IAction[] = [];
-		const menuActions = this.menuService.getMenuActions(MenuId.SessionWorkspacePickerManage, this.contextKeyService);
+		const menuActions = this.menuService.getMenuActions(Menus.WorkspacePickerManage, this.contextKeyService);
 		for (const [, actions] of menuActions) {
 			for (const menuAction of actions) {
 				const icon = 'item' in menuAction && ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
@@ -509,6 +505,34 @@ export class WorkspacePicker extends Disposable {
 		}
 
 		return items;
+	}
+
+	private _getStatusLabel(status: RemoteAgentHostConnectionStatus): string {
+		switch (status) {
+			case RemoteAgentHostConnectionStatus.Connected:
+				return localize('workspacePicker.statusOnline', "Online");
+			case RemoteAgentHostConnectionStatus.Connecting:
+				return localize('workspacePicker.statusConnecting', "Connecting");
+			case RemoteAgentHostConnectionStatus.Disconnected:
+				return localize('workspacePicker.statusOffline', "Offline");
+		}
+	}
+
+	private _getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
+		switch (status) {
+			case RemoteAgentHostConnectionStatus.Connected:
+				return address
+					? localize('workspacePicker.hoverConnectedAddr', "Remote agent host is connected and ready.\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.");
+			case RemoteAgentHostConnectionStatus.Connecting:
+				return address
+					? localize('workspacePicker.hoverConnectingAddr', "Attempting to connect to remote agent host...\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...");
+			case RemoteAgentHostConnectionStatus.Disconnected:
+				return address
+					? localize('workspacePicker.hoverDisconnectedAddr', "Remote agent host is disconnected.\n\nAddress: {0}", address)
+					: localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected.");
+		}
 	}
 
 	/**

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
@@ -467,10 +468,15 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.sessions.connectViaSSH',
-			title: localize2('connectViaSSH', "Connect to Remote Agent Host via SSH"),
+			title: localize2('connectViaSSH', "SSH..."),
 			category: SessionsCategories.Sessions,
 			f1: true,
+			icon: Codicon.remote,
 			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+			menu: {
+				id: MenuId.SessionWorkspacePickerManage,
+				order: 20,
+			},
 		});
 	}
 
@@ -646,10 +652,15 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.sessions.connectViaTunnel',
-			title: localize2('connectViaTunnel', "Connect to Remote Agent Host via Dev Tunnel"),
+			title: localize2('connectViaTunnel', "Tunnels..."),
 			category: SessionsCategories.Sessions,
 			f1: true,
+			icon: Codicon.cloud,
 			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+			menu: {
+				id: MenuId.SessionWorkspacePickerManage,
+				order: 10,
+			},
 		});
 	}
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -10,6 +10,7 @@ import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntr
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
@@ -469,13 +470,17 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.sessions.connectViaSSH',
-			title: localize2('connectViaSSH', "SSH..."),
+			title: localize2('connectViaSSH', "Connect to Remote Agent Host via SSH"),
+			shortTitle: localize2('connectViaSSHShort', "SSH..."),
 			category: SessionsCategories.Sessions,
 			f1: true,
 			icon: Codicon.remote,
-			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+			precondition: ContextKeyExpr.and(
+				ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+				IsWebContext.toNegated(),
+			),
 			menu: {
-				id: Menus.WorkspacePickerManage,
+				id: Menus.SessionWorkspaceManage,
 				order: 20,
 			},
 		});
@@ -653,13 +658,14 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.sessions.connectViaTunnel',
-			title: localize2('connectViaTunnel', "Tunnels..."),
+			title: localize2('connectViaTunnel', "Connect to Remote Agent Host via Dev Tunnel"),
+			shortTitle: localize2('connectViaTunnelShort', "Tunnels..."),
 			category: SessionsCategories.Sessions,
 			f1: true,
 			icon: Codicon.cloud,
 			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
 			menu: {
-				id: Menus.WorkspacePickerManage,
+				id: Menus.SessionWorkspaceManage,
 				order: 10,
 			},
 		});

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -10,7 +10,6 @@ import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntr
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
@@ -475,10 +474,7 @@ registerAction2(class extends Action2 {
 			category: SessionsCategories.Sessions,
 			f1: true,
 			icon: Codicon.remote,
-			precondition: ContextKeyExpr.and(
-				ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
-				IsWebContext.toNegated(),
-			),
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
 			menu: {
 				id: Menus.SessionWorkspaceManage,
 				order: 20,

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../nls.js';
-import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
@@ -17,6 +17,7 @@ import { IViewsService } from '../../../../workbench/services/views/common/views
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { SessionsCategories } from '../../../common/categories.js';
+import { Menus } from '../../../browser/menus.js';
 import { NewChatViewPane, SessionsViewId } from '../../chat/browser/newChatViewPane.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -474,7 +475,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.remote,
 			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
 			menu: {
-				id: MenuId.SessionWorkspacePickerManage,
+				id: Menus.WorkspacePickerManage,
 				order: 20,
 			},
 		});
@@ -658,7 +659,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.cloud,
 			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
 			menu: {
-				id: MenuId.SessionWorkspacePickerManage,
+				id: Menus.WorkspacePickerManage,
 				order: 10,
 			},
 		});


### PR DESCRIPTION
## Summary

Moves remote host entries and connection actions (Tunnels, SSH) from inline items in the workspace picker into a single **Manage** submenu with contributable menu support.

### Changes

**New `Menus.WorkspacePickerManage` MenuId** (`sessions/browser/menus.ts`)
- Providers can contribute actions to the workspace picker's Manage submenu via this menu ID

**Workspace Picker** (`sessionWorkspacePicker.ts`)
- Remote providers and menu-contributed actions grouped under a "Manage..." entry with submenu
- Remote provider entries show status description (Online/Connecting/Offline)
- Clicking a remote provider opens host options (reconnect, remove, copy address, etc.)
- Removed inline remote provider items, toolbar gear actions, and hardcoded Tunnels/SSH entries

**Remote Agent Host Actions** (`remoteAgentHostActions.ts`)
- Tunnels and SSH commands now contribute to `Menus.WorkspacePickerManage` with icons

**Action List** (`actionList.ts`)
- Submenu items support hover panels via `hoverContent` property on actions

**Scoped Workspace Picker** (`scopedWorkspacePicker.ts`)
- Updated constructor to pass new `IMenuService` and `IContextKeyService` dependencies