### PR TITLE
sessions: register native IPluginGitService for desktop

### DIFF
--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -94,11 +94,20 @@ import '../workbench/services/browserView/electron-browser/playwrightWorkbenchSe
 import '../workbench/services/process/electron-browser/processService.js';
 import '../workbench/services/power/electron-browser/powerService.js';
 
-import { registerSingleton } from '../platform/instantiation/common/extensions.js';
+import { ILocalGitService } from '../platform/git/common/localGitService.js';
+import { InstantiationType, registerSingleton } from '../platform/instantiation/common/extensions.js';
+import { registerSharedProcessRemoteService } from '../platform/ipc/electron-browser/services.js';
+import { IPluginGitService } from '../workbench/contrib/chat/common/plugins/pluginGitService.js';
+import { NativePluginGitCommandService } from '../workbench/contrib/chat/electron-browser/pluginGitCommandService.js';
 import { IUserDataInitializationService, UserDataInitializationService } from '../workbench/services/userData/browser/userDataInit.js';
 import { SyncDescriptor } from '../platform/instantiation/common/descriptors.js';
 
 registerSingleton(IUserDataInitializationService, new SyncDescriptor(UserDataInitializationService, [[]], true));
+
+// Override the browser PluginGitCommandService with the native one that always
+// runs git locally via the shared process.
+registerSingleton(IPluginGitService, NativePluginGitCommandService, InstantiationType.Delayed);
+registerSharedProcessRemoteService(ILocalGitService, 'localGit');
 
 
 //#endregion


### PR DESCRIPTION
Verified in OSS the fix works.

## Problem

The sessions desktop app was falling through to `BrowserPluginGitCommandService` — a stub that throws `"Agent plugins are not available in this environment"` on every method call. This broke marketplace plugin operations (install, update) which require git operations (clone, pull, fetch).

The workbench desktop app overrides this stub with `NativePluginGitCommandService` via `workbench/contrib/chat/electron-browser/chat.contribution.ts`, but the sessions desktop app never imported that override.

## Fix

Register `NativePluginGitCommandService` and its `ILocalGitService` shared-process dependency in `sessions.desktop.main.ts`, mirroring the existing pattern in `workbench.desktop.main.ts`.

We intentionally don't import the full `chat/electron-browser/chat.contribution.ts` because it bundles unrelated desktop-workbench features (voice chat, CLI handler, lifecycle handler, `OpenAgentsWindowAction`, etc.) that may conflict with sessions-specific implementations.

## What works after this fix

- **Marketplace plugin install** (git clone) ✅
- **Plugin updates** (git pull/fetch) ✅
- **Locally-configured plugins** (already worked) ✅
- **Extension-contributed plugins** (already worked) ✅
