### PR TITLE
inline edit: fix spurious console warnings for reusedInFlight outcome transitions

### DIFF
--- a/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/inlineEditLogContext.ts
@@ -392,7 +392,10 @@ export class InlineEditRequestLogContext {
 	 * (e.g., in `setIsCachedResult` which intentionally overrides any inherited outcome).
 	 */
 	private _setOutcome(outcome: LogContextOutcome): void {
-		if (this._outcome !== 'pending') {
+		// 'reusedInFlight' is an intermediate state set when joining an in-flight
+		// request (before the result arrives), so it can legitimately transition
+		// to the final outcome (skipped, errored, etc.) just like 'pending'.
+		if (this._outcome !== 'pending' && this._outcome !== 'reusedInFlight') {
 			console.warn(`[InlineEditRequestLogContext] outcome transition from '${this._outcome}' to '${outcome}' (request #${this.requestId})`);
 		}
 		this._outcome = outcome;


### PR DESCRIPTION
## Summary

Fixes spurious `console.warn` messages like:

```
[InlineEditRequestLogContext] outcome transition from 'reusedInFlight' to 'skipped' (request #14)
```

## Problem

`setIsReusedInFlightResult` sets the outcome to `reusedInFlight` via direct assignment when joining an in-flight request — **before** the result has arrived. When the joined request later resolves (e.g., doc changed → `skipped`, network error → `errored`), `_setOutcome` fires a warning because `reusedInFlight !== 'pending'`.

## Fix

Treat `reusedInFlight` as an intermediate state (like `pending`) that can legitimately transition to a final outcome without warning.