### PR TITLE
sessions: restore agents application support on Linux

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1397,7 +1397,7 @@ export class CodeApplication extends Disposable {
 		}
 
 		// Handle agents window first based on context
-		if ((process as INodeProcess).isEmbeddedApp || (!isLinux && args['agents'] && this.productService.quality !== 'stable')) {
+		if ((process as INodeProcess).isEmbeddedApp || (args['agents'] && this.productService.quality !== 'stable')) {
 			return windowsMainService.openAgentsWindow({
 				context,
 				cli: args,

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -6,7 +6,7 @@
 import { app } from 'electron';
 import { coalesce } from '../../../base/common/arrays.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { IProcessEnvironment, isLinux, isMacintosh } from '../../../base/common/platform.js';
+import { IProcessEnvironment, isMacintosh } from '../../../base/common/platform.js';
 import { URI } from '../../../base/common/uri.js';
 import { whenDeleted } from '../../../base/node/pfs.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
@@ -164,7 +164,7 @@ export class LaunchMainService implements ILaunchMainService {
 		}
 
 		// Agents window
-		else if (!isLinux && args['agents'] && this.productService.quality !== 'stable') {
+		else if (args['agents'] && this.productService.quality !== 'stable') {
 			usedWindows = await this.windowsMainService.openAgentsWindow(baseConfig);
 		}
 

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -7,7 +7,7 @@ import { Schemas } from '../../../../base/common/network.js';
 import { IChatSessionsService } from './chatSessionsService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
-import { IsDevelopmentContext, IsLinuxContext } from '../../../../platform/contextkey/common/contextkeys.js';
+import { ProductQualityContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ChatEntitlementContextKeys } from '../../../services/chat/common/chatEntitlementService.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 
@@ -198,7 +198,7 @@ export const MANAGE_CHAT_COMMAND_ID = 'workbench.action.chat.manage';
 
 export const OPEN_AGENTS_WINDOW_COMMAND_ID = 'workbench.action.openAgentsWindow';
 export const OPEN_AGENTS_WINDOW_PRECONDITION = ContextKeyExpr.and(
-	ContextKeyExpr.or(IsLinuxContext.negate(), IsDevelopmentContext),
+	ProductQualityContext.notEqualsTo('stable'),
 	ChatEntitlementContextKeys.Setup.hidden.negate(),
 	ChatEntitlementContextKeys.Setup.disabledInWorkspace.negate(),
 	IsSessionsWindowContext.negate(),


### PR DESCRIPTION
Reverts the Linux exclusion added in 683373f359067ddbdc3a63cf10c123cefe70ef22, re-enabling the agents window on Linux for non-stable builds.

### Changes
- Remove `!isLinux` guard from app startup (`app.ts`) and launch service (`launchMainService.ts`)
- Restore `ProductQualityContext.notEqualsTo('stable')` in `OPEN_AGENTS_WINDOW_PRECONDITION` instead of the Linux-specific context key expression
- Clean up unused `isLinux` / `IsLinuxContext` imports