### PR TITLE
fix: prevent tool deferral when tool_search is not in request

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -101,7 +101,8 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	const experimentationService = accessor.get(IExperimentationService);
 	const toolDeferralService = accessor.get(IToolDeferralService);
 
-	const toolSearchEnabled = !!endpoint.supportsToolSearch;
+	const toolSearchEnabled = !!endpoint.supportsToolSearch
+		&& !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
 
 	// Split tools into non-deferred and deferred up front so we can build finalTools
 	// with non-deferred first. This ensures the cache_control breakpoint on the last

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -64,7 +64,8 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const toolSearchEnabled = isResponsesApiToolSearchEnabled(endpoint, configService, expService);
 	const isAllowedConversationAgent = options.location === ChatLocation.Agent || options.location === ChatLocation.MessagesProxy;
 	const isSubagent = options.telemetryProperties?.subType?.startsWith('subagent') ?? false;
-	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent;
+	const toolSearchInRequest = !!options.requestOptions?.tools?.some(t => t.function.name === CUSTOM_TOOL_SEARCH_NAME);
+	const shouldDeferTools = toolSearchEnabled && isAllowedConversationAgent && !isSubagent && toolSearchInRequest;
 	const toolDeferralService = shouldDeferTools ? accessor.get(IToolDeferralService) : undefined;
 
 	type ResponsesFunctionTool = OpenAI.Responses.FunctionTool & OpenAiResponsesFunctionTool;

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -57,6 +57,7 @@ function createMockOptions(overrides: Partial<ICreateEndpointBodyOptions> = {}):
 				{ type: 'function', function: { name: 'grep_search', description: 'Search for text', parameters: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } } },
 				{ type: 'function', function: { name: 'some_mcp_tool', description: 'An MCP tool', parameters: { type: 'object', properties: { input: { type: 'string' } }, required: ['input'] } } },
 				{ type: 'function', function: { name: 'another_deferred_tool', description: 'Another tool', parameters: { type: 'object', properties: {} } } },
+				{ type: 'function', function: { name: 'tool_search', description: 'Search tools', parameters: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } } },
 			]
 		},
 		...overrides,
@@ -147,6 +148,35 @@ describe('createResponsesRequestBody tools', () => {
 		const tools = body.tools as any[];
 		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
 		expect(tools.every(t => !t.defer_loading)).toBe(true);
+	});
+
+	it('does not defer tools when tool_search is not in the request tool list', () => {
+		// Repro for https://github.com/microsoft/vscode/issues/311946: a custom agent with
+		// `tools: ['my-mcp-server/*']` filters out tool_search. Without this gate, every
+		// MCP tool would be marked deferred and stripped from the request, leaving the
+		// agent with nothing to call.
+		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+
+		const options = createMockOptions({
+			requestOptions: {
+				tools: [
+					{ type: 'function', function: { name: 'some_mcp_tool', description: 'An MCP tool', parameters: { type: 'object', properties: {} } } },
+					{ type: 'function', function: { name: 'another_mcp_tool', description: 'Another MCP tool', parameters: { type: 'object', properties: {} } } },
+				]
+			}
+		});
+		const body = accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, options, endpoint.model, endpoint
+		);
+
+		const tools = body.tools as any[];
+		// No client tool_search should be added.
+		expect(tools.find(t => t.type === 'tool_search')).toBeUndefined();
+		// All user-listed tools should be sent to the model, not stripped.
+		expect(tools.find(t => t.name === 'some_mcp_tool')).toBeDefined();
+		expect(tools.find(t => t.name === 'another_mcp_tool')).toBeDefined();
 	});
 
 	it('always filters tool_search function tool from tools array', () => {

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -819,3 +819,112 @@ describe('createMessagesRequestBody reasoning effort', () => {
 		expect(body.output_config).toEqual({ effort: 'low' });
 	});
 });
+
+describe('createMessagesRequestBody tool search deferral', () => {
+	let disposables: DisposableStore;
+	let instantiationService: IInstantiationService;
+
+	function createMockEndpoint(supportsToolSearch: boolean): IChatEndpoint {
+		return {
+			model: 'claude-sonnet-4.6',
+			family: 'claude-sonnet-4.6',
+			modelProvider: 'Anthropic',
+			maxOutputTokens: 8192,
+			modelMaxPromptTokens: 200000,
+			supportsToolCalls: true,
+			supportsVision: true,
+			supportsPrediction: false,
+			supportsToolSearch,
+			showInModelPicker: true,
+			isFallback: false,
+			name: 'test',
+			version: '1.0',
+			policy: 'enabled',
+			urlOrRequestMetadata: 'https://test.com',
+			tokenizer: 0,
+			isDefault: false,
+			processResponseFromChatEndpoint: () => { throw new Error('not implemented'); },
+			acceptChatPolicy: () => { throw new Error('not implemented'); },
+			makeChatRequest2: () => { throw new Error('not implemented'); },
+			createRequestBody: () => { throw new Error('not implemented'); },
+			cloneWithTokenOverride: () => { throw new Error('not implemented'); },
+			interceptBody: () => { },
+			getExtraHeaders: () => ({}),
+		} as unknown as IChatEndpoint;
+	}
+
+	function makeTool(name: string) {
+		return { type: 'function' as const, function: { name, description: `${name} tool`, parameters: { type: 'object', properties: {} } } };
+	}
+
+	function createOptions(tools: ReturnType<typeof makeTool>[]): ICreateEndpointBodyOptions {
+		return {
+			debugName: 'test',
+			requestId: 'test-request-id',
+			finishedCb: undefined,
+			messages: [{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }],
+			}],
+			postOptions: { max_tokens: 8192 },
+			location: ChatLocation.Agent,
+			modelCapabilities: { enableToolSearch: true },
+			requestOptions: { tools },
+		} as ICreateEndpointBodyOptions;
+	}
+
+	beforeEach(() => {
+		disposables = new DisposableStore();
+		const services = disposables.add(createPlatformServices(disposables));
+		// Non-deferred allowlist matches production: core tools + tool_search itself.
+		const nonDeferred = new Set(['read_file', 'grep_search', CUSTOM_TOOL_SEARCH_NAME]);
+		services.define(IToolDeferralService, {
+			_serviceBrand: undefined,
+			isNonDeferredTool: (name: string) => nonDeferred.has(name),
+		});
+		const accessor = services.createTestingAccessor();
+		instantiationService = accessor.get(IInstantiationService);
+	});
+
+	test('does not set defer_loading when tool_search is not in the request tool list', () => {
+		// Repro for https://github.com/microsoft/vscode/issues/311946: a custom agent
+		// with `tools: ['my-mcp-server/*']` filters out tool_search. Without this gate,
+		// every MCP tool gets defer_loading=true and Anthropic rejects the request with
+		// "At least one tool must have defer_loading=false."
+		const endpoint = createMockEndpoint(true);
+		const options = createOptions([makeTool('some_mcp_tool'), makeTool('another_mcp_tool')]);
+
+		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
+
+		const tools = body.tools as AnthropicMessagesTool[];
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+		expect(tools.find(t => t.name === 'some_mcp_tool')).toBeDefined();
+		expect(tools.find(t => t.name === 'another_mcp_tool')).toBeDefined();
+	});
+
+	test('defers MCP tools when tool_search is in the request tool list', () => {
+		const endpoint = createMockEndpoint(true);
+		const options = createOptions([
+			makeTool('read_file'),
+			makeTool('some_mcp_tool'),
+			makeTool(CUSTOM_TOOL_SEARCH_NAME),
+		]);
+
+		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
+
+		const tools = body.tools as AnthropicMessagesTool[];
+		expect(tools.find(t => t.name === 'read_file')?.defer_loading).toBeUndefined();
+		expect(tools.find(t => t.name === CUSTOM_TOOL_SEARCH_NAME)?.defer_loading).toBeUndefined();
+		expect(tools.find(t => t.name === 'some_mcp_tool')?.defer_loading).toBe(true);
+	});
+
+	test('does not defer when endpoint does not support tool search', () => {
+		const endpoint = createMockEndpoint(false);
+		const options = createOptions([makeTool('read_file'), makeTool('some_mcp_tool'), makeTool(CUSTOM_TOOL_SEARCH_NAME)]);
+
+		const body = instantiationService.invokeFunction(createMessagesRequestBody, options, endpoint.model, endpoint);
+
+		const tools = body.tools as AnthropicMessagesTool[];
+		expect(tools.every(t => !t.defer_loading)).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #311946

## Problem

When a custom agent (via `.agent.md`) restricts tools to only MCP tools (e.g., `tools: ['my-mcp-server/*']`), the `tool_search` tool gets filtered out of the available tools list. However, the Messages API and Responses API paths still treated tool search as enabled based on model capability alone, causing **all** tools to be marked as deferred:
