### PR TITLE
tools: fix run task tool not finding tools consistently

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -104,9 +104,10 @@ export async function getTaskForTool(id: string | undefined, taskDefinition: { t
 	}
 
 	let tasksForWorkspace;
-	const workspaceFolderPath = URI.file(workspaceFolder).path;
+	const getPathForCompare = (uri: URI) => uri.path.replace(/\/$/, '').toLowerCase();
+	const workspaceFolderPath = getPathForCompare(URI.file(workspaceFolder));
 	for (const [folder, tasks] of workspaceFolderToTaskMap) {
-		if (URI.parse(folder).path === workspaceFolderPath) {
+		if (getPathForCompare(URI.parse(folder)) === workspaceFolderPath) {
 			tasksForWorkspace = tasks;
 			break;
 		}


### PR DESCRIPTION
This path comparison sometimes failed on a trailing slash of case differences on case-insensitive systems

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
