### PR TITLE
Agents web: Registering SessionsWorkspaceContextService

### DIFF
--- a/src/vs/sessions/browser/web.main.ts
+++ b/src/vs/sessions/browser/web.main.ts
@@ -3,14 +3,74 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { joinPath } from '../../base/common/resources.js';
+import { onUnexpectedError } from '../../base/common/errors.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
+import { IFileService } from '../../platform/files/common/files.js';
 import { ILogService } from '../../platform/log/common/log.js';
+import { IPolicyService } from '../../platform/policy/common/policy.js';
+import { IUriIdentityService } from '../../platform/uriIdentity/common/uriIdentity.js';
+import { IWorkspaceContextService } from '../../platform/workspace/common/workspace.js';
 import { BrowserMain, IBrowserMainWorkbench } from '../../workbench/browser/web.main.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../workbench/services/environment/browser/environmentService.js';
+import { IWorkbenchConfigurationService } from '../../workbench/services/configuration/common/configuration.js';
+import { IUserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfile.js';
+import { IWorkspaceEditingService } from '../../workbench/services/workspaces/common/workspaceEditing.js';
+import { getWorkspaceIdentifier } from '../../workbench/services/workspaces/browser/workspaces.js';
+import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
+import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
 import { Workbench as SessionsWorkbench } from './workbench.js';
 
 export class SessionsBrowserMain extends BrowserMain {
 
 	protected override createWorkbench(domElement: HTMLElement, serviceCollection: ServiceCollection, logService: ILogService): IBrowserMainWorkbench {
 		return new SessionsWorkbench(domElement, undefined, serviceCollection, logService);
+	}
+
+	protected override async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
+		const result = await super.initServices();
+		const { serviceCollection } = result;
+
+		// Replace workspace and configuration services with the sessions
+		// implementations. This mirrors what the desktop sessions entry does
+		// in electron-browser/sessions.main.ts — the agents window manages
+		// workspace folders in-memory without creating untitled workspaces
+		// or opening new windows.
+
+		const environmentService = serviceCollection.get(IBrowserWorkbenchEnvironmentService) as IBrowserWorkbenchEnvironmentService;
+		const uriIdentityService = serviceCollection.get(IUriIdentityService) as IUriIdentityService;
+		const userDataProfileService = serviceCollection.get(IUserDataProfileService) as IUserDataProfileService;
+		const fileService = serviceCollection.get(IFileService) as IFileService;
+		const policyService = serviceCollection.get(IPolicyService) as IPolicyService;
+
+		// Workspace — use a stable synthetic workspace identifier, matching
+		// the desktop pattern (environmentService.agentSessionsWorkspace).
+		const sessionsWorkspaceUri = joinPath(environmentService.userRoamingDataHome, 'agent-sessions.code-workspace');
+		const workspaceIdentifier = getWorkspaceIdentifier(sessionsWorkspaceUri);
+		const workspaceContextService = new SessionsWorkspaceContextService(workspaceIdentifier, uriIdentityService);
+
+		serviceCollection.set(IWorkspaceContextService, workspaceContextService);
+		serviceCollection.set(IWorkspaceEditingService, workspaceContextService);
+
+		// Configuration — the sessions ConfigurationService is a lighter
+		// implementation that works against the in-memory workspace model
+		// rather than a real .code-workspace file on disk.
+		const configurationService = new ConfigurationService(
+			userDataProfileService,
+			workspaceContextService,
+			uriIdentityService,
+			fileService,
+			policyService,
+			result.logService,
+		);
+		try {
+			await configurationService.initialize();
+		} catch (error) {
+			onUnexpectedError(error);
+		}
+
+		serviceCollection.set(IWorkbenchConfigurationService, configurationService);
+
+		return { serviceCollection, configurationService, logService: result.logService };
 	}
 }

--- a/src/vs/sessions/browser/web.main.ts
+++ b/src/vs/sessions/browser/web.main.ts
@@ -6,16 +6,22 @@
 import { joinPath } from '../../base/common/resources.js';
 import { onUnexpectedError } from '../../base/common/errors.js';
 import { ServiceCollection } from '../../platform/instantiation/common/serviceCollection.js';
-import { IFileService } from '../../platform/files/common/files.js';
 import { ILogService } from '../../platform/log/common/log.js';
-import { IPolicyService } from '../../platform/policy/common/policy.js';
+import { IRemoteAuthorityResolverService } from '../../platform/remote/common/remoteAuthorityResolver.js';
+import { IStorageService } from '../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../platform/uriIdentity/common/uriIdentity.js';
-import { IWorkspaceContextService } from '../../platform/workspace/common/workspace.js';
-import { BrowserMain, IBrowserMainWorkbench } from '../../workbench/browser/web.main.js';
+import { IAnyWorkspaceIdentifier, IWorkspaceContextService } from '../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustEnablementService, IWorkspaceTrustManagementService } from '../../platform/workspace/common/workspaceTrust.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../workbench/services/environment/browser/environmentService.js';
 import { IWorkbenchConfigurationService } from '../../workbench/services/configuration/common/configuration.js';
 import { IUserDataProfileService } from '../../workbench/services/userDataProfile/common/userDataProfile.js';
+import { BrowserUserDataProfilesService } from '../../platform/userDataProfile/browser/userDataProfile.js';
+import { FileService } from '../../platform/files/common/fileService.js';
+import { IPolicyService } from '../../platform/policy/common/policy.js';
+import { IRemoteAgentService } from '../../workbench/services/remote/common/remoteAgentService.js';
 import { IWorkspaceEditingService } from '../../workbench/services/workspaces/common/workspaceEditing.js';
+import { WorkspaceTrustEnablementService, WorkspaceTrustManagementService } from '../../workbench/services/workspaces/common/workspaceTrust.js';
+import { BrowserMain, IBrowserMainWorkbench } from '../../workbench/browser/web.main.js';
 import { getWorkspaceIdentifier } from '../../workbench/services/workspaces/browser/workspaces.js';
 import { SessionsWorkspaceContextService } from '../services/workspace/browser/workspaceContextService.js';
 import { ConfigurationService } from '../services/configuration/browser/configurationService.js';
@@ -27,24 +33,25 @@ export class SessionsBrowserMain extends BrowserMain {
 		return new SessionsWorkbench(domElement, undefined, serviceCollection, logService);
 	}
 
-	protected override async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
-		const result = await super.initServices();
-		const { serviceCollection } = result;
+	protected override async createWorkspaceConfigAndStorageServices(
+		serviceCollection: ServiceCollection,
+		_workspace: IAnyWorkspaceIdentifier,
+		environmentService: IBrowserWorkbenchEnvironmentService,
+		userDataProfileService: IUserDataProfileService,
+		_userDataProfilesService: BrowserUserDataProfilesService,
+		fileService: FileService,
+		_remoteAgentService: IRemoteAgentService,
+		uriIdentityService: IUriIdentityService,
+		policyService: IPolicyService,
+		logService: ILogService,
+		remoteAuthorityResolverService: IRemoteAuthorityResolverService,
+	): Promise<{ configurationService: IWorkbenchConfigurationService; storageService: IStorageService }> {
+		// Use sessions workspace/configuration services instead of the standard
+		// WorkspaceService. This mirrors what SessionsMain does on desktop:
+		// the agents window manages workspace folders in-memory without creating
+		// workspace file watchers or other resources.
 
-		// Replace workspace and configuration services with the sessions
-		// implementations. This mirrors what the desktop sessions entry does
-		// in electron-browser/sessions.main.ts — the agents window manages
-		// workspace folders in-memory without creating untitled workspaces
-		// or opening new windows.
-
-		const environmentService = serviceCollection.get(IBrowserWorkbenchEnvironmentService) as IBrowserWorkbenchEnvironmentService;
-		const uriIdentityService = serviceCollection.get(IUriIdentityService) as IUriIdentityService;
-		const userDataProfileService = serviceCollection.get(IUserDataProfileService) as IUserDataProfileService;
-		const fileService = serviceCollection.get(IFileService) as IFileService;
-		const policyService = serviceCollection.get(IPolicyService) as IPolicyService;
-
-		// Workspace — use a stable synthetic workspace identifier, matching
-		// the desktop pattern (environmentService.agentSessionsWorkspace).
+		// Workspace — use a stable synthetic workspace identifier for agents
 		const sessionsWorkspaceUri = joinPath(environmentService.userRoamingDataHome, 'agent-sessions.code-workspace');
 		const workspaceIdentifier = getWorkspaceIdentifier(sessionsWorkspaceUri);
 		const workspaceContextService = new SessionsWorkspaceContextService(workspaceIdentifier, uriIdentityService);
@@ -52,17 +59,17 @@ export class SessionsBrowserMain extends BrowserMain {
 		serviceCollection.set(IWorkspaceContextService, workspaceContextService);
 		serviceCollection.set(IWorkspaceEditingService, workspaceContextService);
 
-		// Configuration — the sessions ConfigurationService is a lighter
-		// implementation that works against the in-memory workspace model
-		// rather than a real .code-workspace file on disk.
+		// Configuration — the sessions ConfigurationService works against the
+		// in-memory workspace model rather than a real .code-workspace file on disk.
 		const configurationService = new ConfigurationService(
 			userDataProfileService,
 			workspaceContextService,
 			uriIdentityService,
 			fileService,
 			policyService,
-			result.logService,
+			logService
 		);
+
 		try {
 			await configurationService.initialize();
 		} catch (error) {
@@ -71,6 +78,17 @@ export class SessionsBrowserMain extends BrowserMain {
 
 		serviceCollection.set(IWorkbenchConfigurationService, configurationService);
 
-		return { serviceCollection, configurationService, logService: result.logService };
+		// Storage
+		const storageService = await this.createStorageService(workspaceIdentifier, logService, userDataProfileService);
+		serviceCollection.set(IStorageService, storageService);
+
+		// Workspace Trust Service
+		const workspaceTrustEnablementService = new WorkspaceTrustEnablementService(configurationService, environmentService);
+		serviceCollection.set(IWorkspaceTrustEnablementService, workspaceTrustEnablementService);
+
+		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, remoteAuthorityResolverService, storageService, uriIdentityService, environmentService, workspaceContextService, workspaceTrustEnablementService, fileService);
+		serviceCollection.set(IWorkspaceTrustManagementService, workspaceTrustManagementService);
+
+		return { configurationService, storageService };
 	}
 }

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -265,7 +265,7 @@ export class BrowserMain extends Disposable {
 		this._register(workbench.onDidShutdown(() => this.dispose()));
 	}
 
-	private async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
+	protected async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
 		const serviceCollection = new ServiceCollection();
 
 

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -265,7 +265,7 @@ export class BrowserMain extends Disposable {
 		this._register(workbench.onDidShutdown(() => this.dispose()));
 	}
 
-	protected async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
+	private async initServices(): Promise<{ serviceCollection: ServiceCollection; configurationService: IWorkbenchConfigurationService; logService: ILogService }> {
 		const serviceCollection = new ServiceCollection();
 
 
@@ -367,27 +367,27 @@ export class BrowserMain extends Disposable {
 		const policyService = new AccountPolicyService(logService, defaultAccountService);
 		serviceCollection.set(IPolicyService, policyService);
 
-		// Long running services (workspace, config, storage)
-		const [configurationService, storageService] = await Promise.all([
-			this.createWorkspaceService(workspace, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, policyService, logService).then(service => {
+		const configurationService = await this.createWorkspaceAndDependentServices(serviceCollection, workspace, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, policyService, logService, loggerService, remoteAuthorityResolverService, productService);
 
-				// Workspace
-				serviceCollection.set(IWorkspaceContextService, service);
+		return { serviceCollection, configurationService, logService };
+	}
 
-				// Configuration
-				serviceCollection.set(IWorkbenchConfigurationService, service);
-
-				return service;
-			}),
-
-			this.createStorageService(workspace, logService, userDataProfileService).then(service => {
-
-				// Storage
-				serviceCollection.set(IStorageService, service);
-
-				return service;
-			})
-		]);
+	private async createWorkspaceAndDependentServices(
+		serviceCollection: ServiceCollection,
+		workspace: IAnyWorkspaceIdentifier,
+		environmentService: IBrowserWorkbenchEnvironmentService,
+		userDataProfileService: IUserDataProfileService,
+		userDataProfilesService: BrowserUserDataProfilesService,
+		fileService: FileService,
+		remoteAgentService: IRemoteAgentService,
+		uriIdentityService: IUriIdentityService,
+		policyService: IPolicyService,
+		logService: ILogService,
+		loggerService: ILoggerService,
+		remoteAuthorityResolverService: IRemoteAuthorityResolverService,
+		productService: IProductService,
+	): Promise<IWorkbenchConfigurationService> {
+		const { configurationService, storageService } = await this.createWorkspaceConfigAndStorageServices(serviceCollection, workspace, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, policyService, logService, remoteAuthorityResolverService);
 
 		// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 		//
@@ -397,17 +397,6 @@ export class BrowserMain extends Disposable {
 		//       is web only.
 		//
 		// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-		// Workspace Trust Service
-		const workspaceTrustEnablementService = new WorkspaceTrustEnablementService(configurationService, environmentService);
-		serviceCollection.set(IWorkspaceTrustEnablementService, workspaceTrustEnablementService);
-
-		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, remoteAuthorityResolverService, storageService, uriIdentityService, environmentService, configurationService, workspaceTrustEnablementService, fileService);
-		serviceCollection.set(IWorkspaceTrustManagementService, workspaceTrustManagementService);
-
-		// Update workspace trust so that configuration is updated accordingly
-		configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkspaceTrusted());
-		this._register(workspaceTrustManagementService.onDidChangeTrust(() => configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkspaceTrusted())));
 
 		// Request Service
 		const requestService = new BrowserRequestService(remoteAgentService, configurationService, loggerService);
@@ -435,7 +424,7 @@ export class BrowserMain extends Disposable {
 		// Userdata Initialize Service
 		const userDataInitializers: IUserDataInitializer[] = [];
 		userDataInitializers.push(new UserDataSyncInitializer(environmentService, secretStorageService, userDataSyncStoreManagementService, fileService, userDataProfilesService, storageService, productService, requestService, logService, uriIdentityService));
-		if (environmentService.options.profile) {
+		if (environmentService.options?.profile) {
 			userDataInitializers.push(new UserDataProfileInitializer(environmentService, fileService, userDataProfileService, storageService, logService, uriIdentityService, requestService));
 		}
 		const userDataInitializationService = new UserDataInitializationService(userDataInitializers);
@@ -451,10 +440,55 @@ export class BrowserMain extends Disposable {
 			logService.error(error);
 		}
 
-		return { serviceCollection, configurationService, logService };
+		return configurationService;
 	}
 
-	private async initializeUserData(userDataInitializationService: UserDataInitializationService, configurationService: WorkspaceService) {
+	/**
+	 * Creates and registers the workspace context, configuration, storage,
+	 * and workspace trust services. Override this to provide different
+	 * workspace/configuration implementations (e.g., sessions in-memory
+	 * workspace). Overrides must also register workspace trust services.
+	 */
+	protected async createWorkspaceConfigAndStorageServices(
+		serviceCollection: ServiceCollection,
+		workspace: IAnyWorkspaceIdentifier,
+		environmentService: IBrowserWorkbenchEnvironmentService,
+		userDataProfileService: IUserDataProfileService,
+		userDataProfilesService: BrowserUserDataProfilesService,
+		fileService: FileService,
+		remoteAgentService: IRemoteAgentService,
+		uriIdentityService: IUriIdentityService,
+		policyService: IPolicyService,
+		logService: ILogService,
+		remoteAuthorityResolverService: IRemoteAuthorityResolverService,
+	): Promise<{ configurationService: IWorkbenchConfigurationService; storageService: IStorageService }> {
+		const [configurationService, storageService] = await Promise.all([
+			this.createWorkspaceService(workspace, environmentService, userDataProfileService, userDataProfilesService, fileService, remoteAgentService, uriIdentityService, policyService, logService).then(service => {
+				serviceCollection.set(IWorkspaceContextService, service);
+				serviceCollection.set(IWorkbenchConfigurationService, service);
+				return service;
+			}),
+			this.createStorageService(workspace, logService, userDataProfileService).then(service => {
+				serviceCollection.set(IStorageService, service);
+				return service;
+			})
+		]);
+
+		// Workspace Trust Service
+		const workspaceTrustEnablementService = new WorkspaceTrustEnablementService(configurationService, environmentService);
+		serviceCollection.set(IWorkspaceTrustEnablementService, workspaceTrustEnablementService);
+
+		const workspaceTrustManagementService = new WorkspaceTrustManagementService(configurationService, remoteAuthorityResolverService, storageService, uriIdentityService, environmentService, configurationService, workspaceTrustEnablementService, fileService);
+		serviceCollection.set(IWorkspaceTrustManagementService, workspaceTrustManagementService);
+
+		// Update workspace trust so that configuration is updated accordingly
+		configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkspaceTrusted());
+		this._register(workspaceTrustManagementService.onDidChangeTrust(() => configurationService.updateWorkspaceTrust(workspaceTrustManagementService.isWorkspaceTrusted())));
+
+		return { configurationService, storageService };
+	}
+
+	private async initializeUserData(userDataInitializationService: UserDataInitializationService, configurationService: IWorkbenchConfigurationService) {
 		if (await userDataInitializationService.requiresInitialization()) {
 			mark('code/willInitRequiredUserData');
 
@@ -463,7 +497,9 @@ export class BrowserMain extends Disposable {
 
 			// Important: Reload only local user configuration after initializing
 			// Reloading complete configuration blocks workbench until remote configuration is loaded.
-			await configurationService.reloadLocalUserConfiguration();
+			if (configurationService instanceof WorkspaceService) {
+				await configurationService.reloadLocalUserConfiguration();
+			}
 
 			mark('code/didInitRequiredUserData');
 		}
@@ -554,7 +590,7 @@ export class BrowserMain extends Disposable {
 		}));
 	}
 
-	private async createStorageService(workspace: IAnyWorkspaceIdentifier, logService: ILogService, userDataProfileService: IUserDataProfileService): Promise<IStorageService> {
+	protected async createStorageService(workspace: IAnyWorkspaceIdentifier, logService: ILogService, userDataProfileService: IUserDataProfileService): Promise<IStorageService> {
 		const storageService = new BrowserStorageService(workspace, userDataProfileService, logService);
 
 		try {


### PR DESCRIPTION
Register SessionsWorkspaceContextService and the sessions ConfigurationService in the browser agents workbench, mirroring what the desktop sessions entry does in electron-browser/sessions.main.ts.

The fix:
- Extract `createWorkspaceConfigAndStorageServices()` as a protected method in `BrowserMain` that creates workspace, configuration, storage, and trust services
- Override it in `SessionsBrowserMain` to use sessions-specific implementations (SessionsWorkspaceContextService + sessions ConfigurationService) that manage workspace folders in-memory
- No standard WorkspaceService is ever created for the agents window — avoids wasted resources on workspace file watchers and disk-based configuration
- All dependent services (request, encryption, secrets, user data sync/init) remain in the base class and are shared