### PR TITLE
Improve browser experience in Agents app

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -115,7 +115,7 @@ export class BrowserView extends Disposable {
 		});
 
 		// Use a default size of 1024x768.
-		this._view.setBounds({ x: 0, y: 0, width: 1024, height: 768 });
+		this._view.setBounds({ x: -10000, y: -10000, width: 1024, height: 768 });
 		this._view.setBackgroundColor('#FFFFFF');
 
 		this._ownerWindow = this.windowsMainService.getWindowById(owner.mainWindowId)!;
@@ -125,7 +125,7 @@ export class BrowserView extends Disposable {
 		this._register(this._ownerWindow.onDidClose(() => this.dispose()));
 
 		this._view.setVisible(false);
-		this._ownerWindow.win?.contentView.addChildView(this._view, 0);
+		this._ownerWindow.win?.contentView.addChildView(this._view);
 
 		this._view.webContents.setWindowOpenHandler((details) => {
 			const location = (() => {

--- a/src/vs/sessions/contrib/browserView/browser/sessionBrowserView.contribution.ts
+++ b/src/vs/sessions/contrib/browserView/browser/sessionBrowserView.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { SessionBrowserViewController } from './sessionBrowserView.js';
+
+registerWorkbenchContribution2(SessionBrowserViewController.ID, SessionBrowserViewController, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/browserView/browser/sessionBrowserView.ts
+++ b/src/vs/sessions/contrib/browserView/browser/sessionBrowserView.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
+import { IBrowserViewWorkbenchService } from '../../../../workbench/contrib/browserView/common/browserView.js';
+import { BrowserEditorInput } from '../../../../workbench/contrib/browserView/common/browserEditorInput.js';
+import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IEditorGroupsService } from '../../../../workbench/services/editor/common/editorGroupsService.js';
+import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
+import { ISession } from '../../../services/sessions/common/session.js';
+import { runOnChange } from '../../../../base/common/observable.js';
+
+export class SessionBrowserViewController extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessionBrowserViewController';
+
+	/**
+	 * Tracks browser view inputs with their owning session. The
+	 * DisposableMap cleans up lifecycle listeners on deletion/disposal.
+	 */
+	private readonly _trackedInputs = this._register(new DisposableMap<string, { session: ISession; dispose: () => void }>());
+
+	constructor(
+		@ISessionsManagementService private readonly _sessionManagementService: ISessionsManagementService,
+		@IBrowserViewWorkbenchService private readonly _browserViewService: IBrowserViewWorkbenchService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
+	) {
+		super();
+
+		// Catch editors opened via normal user/tool actions.
+		this._register(this._editorService.onWillOpenEditor(e => {
+			if (e.editor instanceof BrowserEditorInput) {
+				this._attachLifecycle(e.editor);
+			}
+		}));
+
+		// Catch editors restored from a working set swap — onWillOpenEditor
+		// does not fire for deserialized editors, but onDidAddGroup fires
+		// after the group (with its editors) has been created.
+		this._register(this._editorGroupsService.onDidAddGroup(group => {
+			for (const editor of group.editors) {
+				if (editor instanceof BrowserEditorInput) {
+					this._attachLifecycle(editor);
+				}
+			}
+		}));
+
+		// Force-destroy browser views when sessions are removed.
+		this._register(this._sessionManagementService.onDidChangeSessions(e => {
+			if (e.removed.length === 0 || this._trackedInputs.size === 0) {
+				return;
+			}
+
+			const removedSessionIds = new Set(e.removed.map(s => s.resource.toString()));
+			const known = this._browserViewService.getKnownBrowserViews();
+			for (const [id, { session }] of this._trackedInputs) {
+				if (removedSessionIds.has(session.resource.toString())) {
+					const existingInput = known.get(id);
+					if (existingInput instanceof BrowserEditorInput) {
+						existingInput.dispose(true);
+					}
+				}
+			}
+		}));
+	}
+
+	private _attachLifecycle(input: BrowserEditorInput): void {
+		if (this._trackedInputs.has(input.id)) {
+			return;
+		}
+
+		const session = this._sessionManagementService.activeSession.read(undefined);
+		if (!session) {
+			return; // no session, no lifecycle management needed
+		}
+
+		const store = new DisposableStore();
+		this._trackedInputs.set(input.id, { session, dispose: () => store.dispose() });
+
+		// When the owning session is archived, force-dispose the browser view.
+		store.add(runOnChange(session.isArchived, (isArchived) => {
+			if (isArchived) {
+				input.dispose(true);
+			}
+		}));
+
+		store.add(input.onBeforeDispose(e => {
+			const activeSession = this._sessionManagementService.activeSession.read(undefined);
+
+			// If the input is being disposed, but we are not currently in the owning session,
+			// assume a session swap is happening and do not actually dispose the browser yet.
+			if (session.sessionId !== activeSession?.sessionId) {
+				e.veto();
+			}
+		}));
+
+		store.add(input.onWillDispose(() => {
+			store.dispose();
+			this._trackedInputs.deleteAndDispose(input.id);
+		}));
+	}
+}

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -80,6 +80,9 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'terminal.integrated.initialHint': false,
 
+		'workbench.browser.openLocalhostLinks': true,
+		'workbench.browser.enableChatTools': false,
+
 		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',
 		'workbench.editor.restoreEditors': false,
 		'update.showReleaseNotes': false,

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -450,6 +450,7 @@ import './contrib/applyCommitsToParentRepo/browser/applyChangesToParentRepo.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js'; // view registration disabled; filesystem provider still needed
 import './contrib/configuration/browser/configuration.contribution.js';
 import './contrib/workingSet/browser/workingSet.contribution.js';
+import './contrib/browserView/browser/sessionBrowserView.contribution.js';
 import './contrib/editor/browser/editor.contribution.js';
 
 import './contrib/terminal/browser/sessionsTerminalContribution.js';

--- a/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
@@ -22,6 +22,7 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
 import { logBrowserOpen } from '../../../../platform/browserView/common/browserViewTelemetry.js';
 import { LRUCachedFunction } from '../../../../base/common/cache.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
 
 const LOADING_SPINNER_SVG = (color: string | undefined) => `
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
@@ -44,6 +45,14 @@ export interface IBrowserEditorInputData extends IBrowserEditorViewState {
 	readonly id: string;
 }
 
+/**
+ * Fired before a {@link BrowserEditorInput} is disposed. Listeners may call
+ * {@link veto} to prevent disposal and keep the input and its model alive.
+ */
+export interface IBeforeDisposeBrowserEditorEvent {
+	veto(): void;
+}
+
 export class BrowserEditorInput extends EditorInput {
 	static readonly ID = 'workbench.editorinputs.browser';
 	static readonly EDITOR_ID = 'workbench.editor.browser';
@@ -55,6 +64,9 @@ export class BrowserEditorInput extends EditorInput {
 	private _model: IBrowserViewModel | undefined;
 	private _modelPromise: Promise<IBrowserViewModel> | undefined;
 	private _modelStore = this._register(new DisposableStore());
+
+	private readonly _onBeforeDispose = this._register(new Emitter<IBeforeDisposeBrowserEditorEvent>());
+	readonly onBeforeDispose: Event<IBeforeDisposeBrowserEditorEvent> = this._onBeforeDispose.event;
 
 	constructor(
 		options: IBrowserEditorInputData,
@@ -286,7 +298,15 @@ export class BrowserEditorInput extends EditorInput {
 		};
 	}
 
-	override dispose(): void {
+	override dispose(force?: boolean): void {
+		if (!force) {
+			let vetoed = false;
+			this._onBeforeDispose.fire({ veto: () => { vetoed = true; } });
+			if (vetoed) {
+				return;
+			}
+		}
+
 		super.dispose(); // Emit `onWillDispose` event first, then clean up the model.
 		if (this._model) {
 			// `toUntyped()` is called after disposal. Store the latest data in `_initialData` so we can still get them there.

--- a/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserEditorInput.ts
@@ -100,7 +100,7 @@ export class BrowserEditorInput extends EditorInput {
 
 		// Auto-close editor when webcontents closes
 		this._modelStore.add(this._model.onDidClose(() => {
-			this.dispose();
+			this.dispose(true);
 		}));
 
 		// Listen for label-relevant changes to fire onDidChangeLabel

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -539,17 +539,20 @@ export class BrowserEditor extends EditorPane {
 
 		this._inputDisposables.clear();
 
-		// Set initial navigation state from the input so that the UI is populated while the model is loading.
-		this.updateNavigationState({
-			url: input.url || '',
-			title: input.title || '',
-			canGoBack: false,
-			canGoForward: false,
-			certificateError: undefined
-		});
+		let model = input.model;
+		if (!model) {
+			// Set initial navigation state from the input so that the UI is populated while the model is loading.
+			this.updateNavigationState({
+				url: input.url || '',
+				title: input.title || '',
+				canGoBack: false,
+				canGoForward: false,
+				certificateError: undefined
+			});
 
-		// Resolve the browser view model from the input
-		const model = await input.resolve();
+			// Resolve the browser view model from the input
+			model = await input.resolve();
+		}
 
 		if (token.isCancellationRequested || this.input !== input) {
 			return;
@@ -1007,12 +1010,18 @@ export class BrowserEditor extends EditorPane {
 	 * Recompute the layout of the browser container and update the model with the new bounds.
 	 * This should generally only be called via layout() to ensure that the container is ready and all necessary styles are loaded.
 	 */
-	layoutBrowserContainer(): void {
+	layoutBrowserContainer(retries = 2): void {
 		if (this._model) {
 			this.checkOverlays();
 
 			const containerRect = this._browserContainer.getBoundingClientRect();
 			const cornerRadius = this.window.getComputedStyle(this._browserContainer).borderTopLeftRadius ?? '0';
+
+			// This can happen under certain conditions. Keep trying for a couple of frames to allow things to stabilize.
+			if ((containerRect.width === 0 || containerRect.height === 0) && retries > 0) {
+				this.window.requestAnimationFrame(() => this.layoutBrowserContainer(retries - 1));
+				return;
+			}
 
 			void this._model.layout({
 				windowId: this.group.windowId,

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
@@ -89,12 +89,12 @@ class BrowserTabQuickPick extends Disposable {
 		this._quickPick.buttons = [closeAllButtonItem];
 
 		this._register(this._quickPick.onDidTriggerItemButton(async ({ item }) => {
-			item.editor?.dispose();
+			item.editor?.dispose(true);
 		}));
 
 		this._register(this._quickPick.onDidTriggerButton(async () => {
 			for (const editor of this._browserViewService.getKnownBrowserViews().values()) {
-				editor.dispose();
+				editor.dispose(true);
 			}
 		}));
 


### PR DESCRIPTION
- Open localhost links by default
- Disable agentic tools (for now)
- Persist pages when switching between sessions
  - Pages are destroyed when closed by the user, or the session is archived / deleted