### PR TITLE
Document VS Code Extras extension

### DIFF
--- a/.vscode/extensions/vscode-extras/README.md
+++ b/.vscode/extensions/vscode-extras/README.md
@@ -1,0 +1,55 @@
+# VS Code Extras
+
+VS Code Extras provides small self-hosting utilities for contributors working in
+the [`microsoft/vscode`](https://github.com/microsoft/vscode) repository.
+
+## Features
+
+### npm install state
+
+The extension checks whether the workspace's npm dependencies match the
+dependency files in the checkout. When dependencies are stale, it shows a
+warning in the status bar:
+
+```text
+node_modules is stale - run npm i
+```
+
+Click the status bar item to run the repository's fast install command:
+
+```sh
+node build/npm/fast-install.ts --force
+```
+
+The warning tooltip can list changed dependency files since the last successful
+install and can also report a Node.js version mismatch with an entry like
+`Node.js version (... -> ...)`. For dependency files, click an entry in the
+tooltip to open a diff between the content recorded at the last install and the
+current workspace content.
+
+## Activation
+
+VS Code Extras activates only inside a VS Code source checkout. It looks for
+`src/vscode-dts/vscode.d.ts`, so it should stay inactive in unrelated workspaces.
+
+## Settings
+
+This extension contributes the following setting:
+
+- `vscode-extras.npmUpToDateFeature.enabled`: show a status bar warning when
+  npm dependencies are out of date. This setting is enabled by default.
+
+## Workspace Support
+
+VS Code Extras requires a trusted workspace. The extension reads dependency
+metadata from the workspace and runs repository scripts to inspect and install
+dependencies.
+
+VS Code Extras also requires a local workspace. Virtual workspaces, such as
+GitHub Repositories and vscode.dev, do not provide the local scripts and npm
+installation workflow that this extension uses.
+
+## Issues
+
+VS Code Extras is maintained in the VS Code repository. File issues at
+<https://github.com/microsoft/vscode/issues>.

--- a/.vscode/extensions/vscode-extras/package.json
+++ b/.vscode/extensions/vscode-extras/package.json
@@ -10,20 +10,62 @@
 	"categories": [
 		"Other"
 	],
+	"keywords": [
+		"vscode",
+		"selfhost",
+		"dependencies",
+		"npm"
+	],
+	"galleryBanner": {
+		"color": "#007ACC",
+		"theme": "dark"
+	},
 	"activationEvents": [
 		"workspaceContains:src/vscode-dts/vscode.d.ts"
 	],
+	"extensionKind": [
+		"workspace"
+	],
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": false,
+			"description": "VS Code Extras runs workspace scripts to inspect dependency state and install npm dependencies."
+		},
+		"virtualWorkspaces": {
+			"supported": false,
+			"description": "VS Code Extras requires access to local workspace scripts and npm dependency installation, which are not available in virtual workspaces."
+		}
+	},
 	"main": "./out/extension.js",
+	"homepage": "https://github.com/microsoft/vscode/tree/main/.vscode/extensions/vscode-extras",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/vscode.git"
 	},
+	"bugs": {
+		"url": "https://github.com/microsoft/vscode/issues"
+	},
 	"license": "MIT",
+	"qna": false,
 	"scripts": {
 		"compile": "gulp compile-extension:vscode-extras",
 		"watch": "gulp watch-extension:vscode-extras"
 	},
 	"contributes": {
+		"commands": [
+			{
+				"command": "vscode-extras.runNpmInstall",
+				"title": "Run npm Install",
+				"category": "VS Code Extras",
+				"icon": "$(warning)"
+			},
+			{
+				"command": "vscode-extras.showDependencyDiff",
+				"title": "Show Dependency Diff",
+				"category": "VS Code Extras",
+				"icon": "$(diff)"
+			}
+		],
 		"configuration": {
 			"title": "VS Code Extras",
 			"properties": {
@@ -33,6 +75,14 @@
 					"description": "Show a status bar warning when npm dependencies are out of date."
 				}
 			}
+		},
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "vscode-extras.showDependencyDiff",
+					"when": "false"
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add a README for the VS Code Extras selfhost extension.
- Add extension details metadata so the installed extension page explains its purpose, settings,
  commands, workspace trust, and issue location.

## Motivation

I wanted to understand why VS Code was recommending the `ms-vscode.vscode-extras` extension, but it
was undocumented and did not explain what it does. This PR documents the extension so contributors
can understand the recommendation from the extension details page.

## AI disclosure

The descriptive README text and package metadata descriptions in this PR were generated with AI
assistance and reviewed before publication.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('.vscode/extensions/vscode-extras/package.json','utf8')); console.log('package.json ok')"`
- `npx markdownlint-cli2 .vscode/extensions/vscode-extras/README.md`
- `npx @vscode/vsce ls`

Could not run `npx gulp compile-extension:vscode-extras` because root `node_modules` is not
installed in this checkout.
