### PR TITLE
Document VS Code Selfhost Import Aid extension

### DIFF
--- a/.vscode/extensions/vscode-selfhost-import-aid/README.md
+++ b/.vscode/extensions/vscode-selfhost-import-aid/README.md
@@ -1,0 +1,42 @@
+# VS Code Selfhost Import Aid
+
+VS Code Selfhost Import Aid provides TypeScript import path assistance for
+contributors working in the [`microsoft/vscode`](https://github.com/microsoft/vscode)
+repository.
+
+## Features
+
+### Import path completions
+
+The extension indexes TypeScript files under `src/vs` and contributes completion
+items inside TypeScript import specifiers. Completion items insert relative ESM
+paths with `.js` file extensions, matching the import style used by the VS Code
+source tree.
+
+### ESM import quick fixes
+
+When TypeScript reports an unresolved module diagnostic, the extension can offer
+quick fixes for matching files in the VS Code source tree. The quick fix rewrites
+the import specifier to the matching relative `.js` path.
+
+The extension also contributes a source fix-all action for ESM import fixes when
+multiple unresolved imports can be matched.
+
+## Activation
+
+VS Code Selfhost Import Aid activates only inside a VS Code source checkout. It
+looks for `src/vscode-dts/vscode.d.ts` and indexes files under `src/vs`.
+
+## Workspace Support
+
+VS Code Selfhost Import Aid requires a trusted, non-virtual workspace with full
+file system access. The extension reads TypeScript files from the workspace and
+creates import edits for source files.
+
+Virtual workspaces, such as GitHub Repositories and vscode.dev, do not provide
+the full file system access this extension needs for indexing and import edits.
+
+## Issues
+
+VS Code Selfhost Import Aid is maintained in the VS Code repository. File issues
+at <https://github.com/microsoft/vscode/issues>.

--- a/.vscode/extensions/vscode-selfhost-import-aid/package.json
+++ b/.vscode/extensions/vscode-selfhost-import-aid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-selfhost-import-aid",
   "displayName": "VS Code Selfhost Import Aid",
-  "description": "Util to improve dealing with imports",
+  "description": "Import path assistance for the VS Code selfhost workspace",
   "engines": {
     "vscode": "^1.88.0"
   },
@@ -10,15 +10,44 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onLanguage:typescript"
+  "keywords": [
+    "vscode",
+    "selfhost",
+    "typescript",
+    "imports",
+    "esm"
   ],
+  "galleryBanner": {
+    "color": "#007ACC",
+    "theme": "dark"
+  },
+  "activationEvents": [
+    "workspaceContains:src/vscode-dts/vscode.d.ts"
+  ],
+  "extensionKind": [
+    "workspace"
+  ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "VS Code Selfhost Import Aid reads workspace TypeScript files and offers import edits for the VS Code source tree."
+    },
+    "virtualWorkspaces": {
+      "supported": false,
+      "description": "VS Code Selfhost Import Aid requires local workspace file access for indexing TypeScript source files."
+    }
+  },
   "main": "./out/extension.js",
+  "homepage": "https://github.com/microsoft/vscode/tree/main/.vscode/extensions/vscode-selfhost-import-aid",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
   },
+  "bugs": {
+    "url": "https://github.com/microsoft/vscode/issues"
+  },
   "license": "MIT",
+  "qna": false,
   "scripts": {
     "compile": "gulp compile-extension:vscode-selfhost-import-aid",
     "watch": "gulp watch-extension:vscode-selfhost-import-aid"

--- a/.vscode/extensions/vscode-selfhost-import-aid/src/extension.ts
+++ b/.vscode/extensions/vscode-selfhost-import-aid/src/extension.ts
@@ -18,7 +18,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		private readonly _index = new Map<string, vscode.Uri>();
 
 		constructor() {
-			const watcher = vscode.workspace.createFileSystemWatcher('**/*.ts', false, true, false);
+			const watcher = vscode.workspace.createFileSystemWatcher('src/vs/**/*.ts', false, true, false);
 			this._disposables.push(watcher.onDidChange(e => { this._index.set(e.toString(), e); }));
 			this._disposables.push(watcher.onDidDelete(e => { this._index.delete(e.toString()); }));
 			this._disposables.push(watcher);


### PR DESCRIPTION
## Summary

- Add a README for the VS Code Selfhost Import Aid extension.
- Add extension details metadata so the installed extension page explains its purpose, workspace
  requirements, and issue location.
- Narrow activation and file watching to the VS Code source workspace and `src/vs` TypeScript
  files.

## Motivation

This follows the same motivation as #312452. I wanted to understand why VS Code was recommending a
random selfhost extension, but the extension details page did not explain what it does or why it is
useful in the workspace recommendations. This PR documents `ms-vscode.vscode-selfhost-import-aid`
so contributors can understand the recommendation from the extension details page.

## AI disclosure

The descriptive README text and package metadata descriptions in this PR were generated with AI
assistance and reviewed before publication.

## Validation

- `npm install` in `.vscode/extensions/vscode-selfhost-import-aid`
- `node -e "JSON.parse(require('fs').readFileSync('.vscode/extensions/vscode-selfhost-import-aid/package.json','utf8')); console.log('package.json ok')"`
- `npx markdownlint-cli2 .vscode/extensions/vscode-selfhost-import-aid/README.md`
- `npx @vscode/vsce ls`
- `npm run compile` in `.vscode/extensions/vscode-selfhost-import-aid`

`npm test` could not run because this extension does not define a `test` script.
