### PR TITLE
Document VS Code Selfhost Test Provider extension

### DIFF
--- a/.vscode/extensions/vscode-selfhost-test-provider/README.md
+++ b/.vscode/extensions/vscode-selfhost-test-provider/README.md
@@ -1,0 +1,57 @@
+# VS Code Selfhost Test Provider
+
+VS Code Selfhost Test Provider adds Test Explorer integration for contributors
+working in the [`microsoft/vscode`](https://github.com/microsoft/vscode)
+repository.
+
+## Features
+
+### Test discovery
+
+The extension discovers VS Code unit and integration tests from files matching
+`src/vs/**/*.{test,integrationTest}.ts`. It parses test files and exposes suites
+and test cases in the Testing view.
+
+The provider watches the same test file pattern for create, change, and delete
+events. It also updates the test tree from open TypeScript documents so edits in
+the editor are reflected before files are saved.
+
+### Run, debug, and coverage profiles
+
+The extension contributes Test Explorer profiles for running and debugging VS
+Code tests in Electron, Chrome, Firefox, and WebKit. Electron tests can also run
+with coverage.
+
+Runs use the VS Code repository test entry points and pass selected files or
+test names to the test process. Debug runs use the workspace launch
+configuration named `Attach to VS Code`.
+
+### Snapshot and failure helpers
+
+When a test failure includes snapshot output, the extension contributes an
+inline **Update Snapshot** action that writes the actual output to the snapshot
+file and invalidates the test result.
+
+The extension also tracks recent failing and passing test states with the
+current git state and exposes **Open Selfhost Failure Logs** to inspect the
+stored failure log.
+
+## Activation
+
+VS Code Selfhost Test Provider activates only inside a VS Code source checkout.
+It looks for `src/vscode-dts/vscode.d.ts`, so it should stay inactive in
+unrelated workspaces.
+
+## Workspace Support
+
+VS Code Selfhost Test Provider requires a trusted, non-virtual workspace with
+full file system access. The extension reads and watches test files, starts test
+processes, updates snapshot files, reads git state, and writes failure logs.
+
+Virtual workspaces, such as GitHub Repositories and vscode.dev, do not provide
+the full file system and process access this extension needs.
+
+## Issues
+
+VS Code Selfhost Test Provider is maintained in the VS Code repository. File
+issues at <https://github.com/microsoft/vscode/issues>.

--- a/.vscode/extensions/vscode-selfhost-test-provider/package.json
+++ b/.vscode/extensions/vscode-selfhost-test-provider/package.json
@@ -72,7 +72,7 @@
   "capabilities": {
     "virtualWorkspaces": {
       "supported": false,
-      "description": "VS Code Selfhost Test Provider requires full file system access to discover tests, run workspace scripts, update snapshots, and collect failure logs."
+      "description": "VS Code Selfhost Test Provider requires full file system access and process execution access to discover tests, run workspace scripts, update snapshots, and collect failure logs."
     }
   },
   "workspaceTrust": {

--- a/.vscode/extensions/vscode-selfhost-test-provider/package.json
+++ b/.vscode/extensions/vscode-selfhost-test-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-selfhost-test-provider",
   "displayName": "VS Code Selfhost Test Provider",
-  "description": "Test provider for the VS Code project",
+  "description": "Test Explorer integration for the VS Code selfhost workspace",
   "enabledApiProposals": [
     "testObserver",
     "testRelatedCode"
@@ -52,14 +52,35 @@
   "categories": [
     "Other"
   ],
+  "keywords": [
+    "vscode",
+    "selfhost",
+    "testing",
+    "test-explorer",
+    "coverage"
+  ],
+  "galleryBanner": {
+    "color": "#007ACC",
+    "theme": "dark"
+  },
   "activationEvents": [
     "workspaceContains:src/vscode-dts/vscode.d.ts"
   ],
+  "extensionKind": [
+    "workspace"
+  ],
+  "capabilities": {
+    "virtualWorkspaces": {
+      "supported": false,
+      "description": "VS Code Selfhost Test Provider requires full file system access to discover tests, run workspace scripts, update snapshots, and collect failure logs."
+    }
+  },
   "workspaceTrust": {
     "request": "onDemand",
     "description": "Trust is required to execute tests in the workspace."
   },
   "main": "./out/extension.js",
+  "homepage": "https://github.com/microsoft/vscode/tree/main/.vscode/extensions/vscode-selfhost-test-provider",
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,
@@ -70,7 +91,11 @@
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"
   },
+  "bugs": {
+    "url": "https://github.com/microsoft/vscode/issues"
+  },
   "license": "MIT",
+  "qna": false,
   "scripts": {
     "compile": "gulp compile-extension:vscode-selfhost-test-provider",
     "watch": "gulp watch-extension:vscode-selfhost-test-provider",


### PR DESCRIPTION
## Summary

- Add a README for the VS Code Selfhost Test Provider extension.
- Add extension details metadata so the installed extension page explains its purpose, workspace
  requirements, commands, and issue location.
- Declare that virtual workspaces are unsupported because the provider needs file system and
  process access to discover and run tests.

## Motivation

This follows the same motivation as #312452 and #312455. I wanted to understand why VS Code was
recommending random selfhost extensions, but the extension details pages did not explain what they
do or why they are useful in the workspace recommendations. This PR documents
`ms-vscode.vscode-selfhost-test-provider` so contributors can understand the recommendation from
the extension details page.

## AI disclosure

The descriptive README text and package metadata descriptions in this PR were generated with AI
assistance and reviewed before publication.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('.vscode/extensions/vscode-selfhost-test-provider/package.json','utf8')); console.log('package.json ok')"`
- `npx markdownlint-cli2 .vscode/extensions/vscode-selfhost-test-provider/README.md`
- `npx @vscode/vsce ls`
- `npm run compile` in `.vscode/extensions/vscode-selfhost-test-provider`
- `../../../node_modules/.bin/mocha --ui tdd "out/*.test.js"` in
  `.vscode/extensions/vscode-selfhost-test-provider`
