### PR TITLE
chat: replace embedded MCP/plugin editors with compact detail widgets

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -228,7 +228,7 @@ Skills that are directly invoked by UI elements (toolbar buttons, menu items) ar
 
 ### Embedded Detail Editors
 
-The management editor opens inline detail panes for prompt files, MCP servers, and plugins. Prompt-file details use the standard text editor pane. MCP and plugin details render dedicated compact widgets — `EmbeddedMcpServerDetail` and `EmbeddedAgentPluginDetail` — purpose-built for the narrow split-pane host. They show the icon, name, scope/source, description, and an "Open in editor" link that launches the full standalone `McpServerEditor` / `AgentPluginEditor` for advanced flows (configuration tabs, contributed items, etc.). Do **not** embed the full extension-editor panes inside the split-pane host: they assume a wide page-level layout and don't shrink cleanly.
+The management editor opens inline detail panes for prompt files, MCP servers, and plugins. Prompt-file details use the standard text editor pane. MCP and plugin details render dedicated compact widgets — `EmbeddedMcpServerDetail` and `EmbeddedAgentPluginDetail` — purpose-built for the narrow split-pane host. They show the icon, name, scope/source, and description. Do **not** embed the full extension-editor panes inside the split-pane host: they assume a wide page-level layout and don't shrink cleanly.
 
 The MCP detail fixture in `src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts` must open a real server row (not a group header) and use a local server with concrete config so the compact widget's scope/description rendering is covered by screenshots.
 

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -226,6 +226,12 @@ Skills that are directly invoked by UI elements (toolbar buttons, menu items) ar
 
 `IAICustomizationListItem.badge` is an optional string that renders as a small inline tag next to the item name (same visual style as the MCP "Bridged" badge). For context instructions, this badge shows the raw `applyTo` pattern (e.g. a glob like `**/*.ts`), while the tooltip (`badgeTooltip`) explains the behavior. For skills with UI integrations, the badge reads "UI Integration" with a tooltip describing which UI surface invokes the skill. The badge text is also included in search filtering.
 
+### Embedded Detail Editors
+
+The management editor opens inline detail panes for prompt files, MCP servers, and plugins. Prompt-file details use the standard text editor pane. MCP and plugin details render dedicated compact widgets — `EmbeddedMcpServerDetail` and `EmbeddedAgentPluginDetail` — purpose-built for the narrow split-pane host. They show the icon, name, scope/source, description, and an "Open in editor" link that launches the full standalone `McpServerEditor` / `AgentPluginEditor` for advanced flows (configuration tabs, contributed items, etc.). Do **not** embed the full extension-editor panes inside the split-pane host: they assume a wide page-level layout and don't shrink cleanly.
+
+The MCP detail fixture in `src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts` must open a real server row (not a group header) and use a local server with concrete config so the compact widget's scope/description rendering is covered by screenshots.
+
 ### Debug Panel
 
 Toggle via Command Palette: "Toggle Customizations Debug Panel". Shows a diagnostic view of the item pipeline:

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -76,13 +76,11 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { Action } from '../../../../../base/common/actions.js';
-import { McpServerEditorInput } from '../../../mcp/browser/mcpServerEditorInput.js';
-import { McpServerEditor } from '../../../mcp/browser/mcpServerEditor.js';
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
-import { AgentPluginEditor } from '../agentPluginEditor/agentPluginEditor.js';
-import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
 import { IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
+import { EmbeddedMcpServerDetail } from './embeddedMcpServerDetail.js';
+import { EmbeddedAgentPluginDetail } from './embeddedAgentPluginDetail.js';
 import { ICustomizationHarnessService, matchesWorkspaceSubpath } from '../../common/customizationHarnessService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { AICustomizationWelcomePage } from './aiCustomizationWelcomePage.js';
@@ -294,12 +292,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 	// Embedded MCP server detail view
 	private mcpDetailContainer: HTMLElement | undefined;
-	private embeddedMcpEditor: McpServerEditor | undefined;
+	private embeddedMcpDetail: EmbeddedMcpServerDetail | undefined;
 	private readonly mcpDetailDisposables = this._register(new DisposableStore());
 
 	// Embedded plugin detail view
 	private pluginDetailContainer: HTMLElement | undefined;
-	private embeddedPluginEditor: AgentPluginEditor | undefined;
+	private embeddedPluginDetail: EmbeddedAgentPluginDetail | undefined;
 	private readonly pluginDetailDisposables = this._register(new DisposableStore());
 	/** Section to restore when navigating back from plugin detail (when opened from a non-plugin section). */
 	private pluginDetailReturnSection: AICustomizationManagementSection | undefined;
@@ -457,14 +455,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 						const padding = 24;
 						this.embeddedEditor.layout({ width: Math.max(0, width - padding), height: Math.max(0, height - editorHeaderHeight - padding) });
 					}
-					if (this.viewMode === 'mcpDetail' && this.embeddedMcpEditor) {
-						const backHeaderHeight = 40;
-						this.embeddedMcpEditor.layout(new DOM.Dimension(width, Math.max(0, height - backHeaderHeight)));
-					}
-					if (this.viewMode === 'pluginDetail' && this.embeddedPluginEditor) {
-						const backHeaderHeight = 40;
-						this.embeddedPluginEditor.layout(new DOM.Dimension(width, Math.max(0, height - backHeaderHeight)));
-					}
+					// Embedded MCP/plugin detail panes use a plain DOM widget that flows with
+					// the container; no explicit layout call is needed here.
 				}
 			},
 		}, Sizing.Distribute, undefined, true);
@@ -1946,32 +1938,22 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.goBackFromMcpDetail();
 		}));
 
-		// Container for the MCP server editor
-		const editorContainer = DOM.append(this.mcpDetailContainer, $('.mcp-detail-editor-container'));
+		// Container for the compact MCP detail component
+		const detailBody = DOM.append(this.mcpDetailContainer, $('.mcp-detail-editor-container'));
 
-		// Create the embedded MCP server editor pane
-		this.embeddedMcpEditor = this.editorDisposables.add(this.instantiationService.createInstance(McpServerEditor, this.group));
-		this.embeddedMcpEditor.create(editorContainer);
+		this.embeddedMcpDetail = this.editorDisposables.add(this.instantiationService.createInstance(EmbeddedMcpServerDetail, detailBody));
 	}
 
 	private async showEmbeddedMcpDetail(server: IWorkbenchMcpServer): Promise<void> {
-		if (!this.embeddedMcpEditor) {
+		if (!this.embeddedMcpDetail) {
 			return;
 		}
 
 		this.viewMode = 'mcpDetail';
 		this.updateContentVisibility();
 
-		const input = this.instantiationService.createInstance(McpServerEditorInput, server);
 		this.mcpDetailDisposables.clear();
-		this.mcpDetailDisposables.add(input);
-
-		try {
-			await this.embeddedMcpEditor.setInput(input, undefined, {}, CancellationToken.None);
-		} catch {
-			this.goBackFromMcpDetail();
-			return;
-		}
+		this.embeddedMcpDetail.setInput(server);
 
 		if (this.dimension) {
 			this.layout(this.dimension);
@@ -1980,7 +1962,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 	private goBackFromMcpDetail(): void {
 		this.mcpDetailDisposables.clear();
-		this.embeddedMcpEditor?.clearInput();
+		this.embeddedMcpDetail?.clearInput();
 		this.viewMode = 'list';
 		this.updateContentVisibility();
 
@@ -2010,32 +1992,22 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.goBackFromPluginDetail();
 		}));
 
-		// Container for the plugin editor
-		const editorContainer = DOM.append(this.pluginDetailContainer, $('.plugin-detail-editor-container'));
+		// Container for the compact plugin detail component
+		const detailBody = DOM.append(this.pluginDetailContainer, $('.plugin-detail-editor-container'));
 
-		// Create the embedded plugin editor pane
-		this.embeddedPluginEditor = this.editorDisposables.add(this.instantiationService.createInstance(AgentPluginEditor, this.group));
-		this.embeddedPluginEditor.create(editorContainer);
+		this.embeddedPluginDetail = this.editorDisposables.add(this.instantiationService.createInstance(EmbeddedAgentPluginDetail, detailBody));
 	}
 
 	private async showEmbeddedPluginDetail(item: IAgentPluginItem): Promise<void> {
-		if (!this.embeddedPluginEditor) {
+		if (!this.embeddedPluginDetail) {
 			return;
 		}
 
 		this.viewMode = 'pluginDetail';
 		this.updateContentVisibility();
 
-		const input = new AgentPluginEditorInput(item);
 		this.pluginDetailDisposables.clear();
-		this.pluginDetailDisposables.add(input);
-
-		try {
-			await this.embeddedPluginEditor.setInput(input, undefined, {}, CancellationToken.None);
-		} catch {
-			this.goBackFromPluginDetail();
-			return;
-		}
+		this.embeddedPluginDetail.setInput(item);
 
 		if (this.dimension) {
 			this.layout(this.dimension);
@@ -2055,7 +2027,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 	private goBackFromPluginDetail(): void {
 		this.pluginDetailDisposables.clear();
-		this.embeddedPluginEditor?.clearInput();
+		this.embeddedPluginDetail?.clearInput();
 
 		const returnSection = this.pluginDetailReturnSection;
 		this.pluginDetailReturnSection = undefined;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
+import { AgentPluginItemKind, IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
+import { extensionIcon, pluginIcon } from './aiCustomizationIcons.js';
+
+const $ = DOM.$;
+
+/**
+ * Compact detail view for an agent plugin inside the AI Customizations management editor's
+ * split-pane host. Renders identity (icon + name + source) and description, plus an
+ * "Open in editor" link that opens the full {@link AgentPluginEditor} in the main editor area.
+ *
+ * Advanced actions (enable / disable / uninstall) remain accessible via the row's existing
+ * context menu, so this component intentionally stays small.
+ */
+export class EmbeddedAgentPluginDetail extends Disposable {
+
+	private readonly root: HTMLElement;
+	private readonly iconEl: HTMLElement;
+	private readonly nameEl: HTMLElement;
+	private readonly sourceEl: HTMLElement;
+	private readonly descriptionEl: HTMLElement;
+	private readonly openLink: HTMLAnchorElement;
+	private readonly emptyEl: HTMLElement;
+
+	private current: IAgentPluginItem | undefined;
+
+	constructor(
+		parent: HTMLElement,
+		@IEditorService private readonly editorService: IEditorService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super();
+
+		this.root = DOM.append(parent, $('.ai-customization-embedded-detail.embedded-plugin-detail'));
+
+		const header = DOM.append(this.root, $('.embedded-detail-header'));
+		this.iconEl = DOM.append(header, $('.embedded-detail-icon'));
+		const headerText = DOM.append(header, $('.embedded-detail-header-text'));
+		this.nameEl = DOM.append(headerText, $('h2.embedded-detail-name'));
+		this.nameEl.setAttribute('role', 'heading');
+		this.sourceEl = DOM.append(headerText, $('.embedded-detail-scope'));
+
+		this.descriptionEl = DOM.append(this.root, $('.embedded-detail-description'));
+
+		const actions = DOM.append(this.root, $('.embedded-detail-actions'));
+		this.openLink = DOM.append(actions, $<HTMLAnchorElement>('a.embedded-detail-open-link'));
+		this.openLink.textContent = localize('pluginOpenInEditor', "Open in editor");
+		this.openLink.setAttribute('role', 'button');
+		this.openLink.setAttribute('tabindex', '0');
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.openLink, localize('pluginOpenInEditorTooltip', "Open this plugin in the full editor")));
+		this._register(DOM.addDisposableListener(this.openLink, 'click', e => {
+			e.preventDefault();
+			this.openInFullEditor();
+		}));
+		this._register(DOM.addDisposableListener(this.openLink, 'keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this.openInFullEditor();
+			}
+		}));
+
+		this.emptyEl = DOM.append(this.root, $('.embedded-detail-empty'));
+		this.emptyEl.textContent = localize('pluginDetailEmpty', "No plugin selected.");
+
+		this.renderItem();
+	}
+
+	get element(): HTMLElement {
+		return this.root;
+	}
+
+	setInput(item: IAgentPluginItem): void {
+		this.current = item;
+		this.renderItem();
+	}
+
+	clearInput(): void {
+		this.current = undefined;
+		this.renderItem();
+	}
+
+	private openInFullEditor(): void {
+		if (!this.current) {
+			return;
+		}
+		const input = this.instantiationService.createInstance(AgentPluginEditorInput, this.current);
+		this.editorService.openEditor(input);
+	}
+
+	private renderItem(): void {
+		const item = this.current;
+		const hasItem = !!item;
+		this.emptyEl.style.display = hasItem ? 'none' : '';
+		this.root.classList.toggle('is-empty', !hasItem);
+		if (!item) {
+			this.nameEl.textContent = '';
+			this.sourceEl.textContent = '';
+			this.descriptionEl.textContent = '';
+			this.iconEl.className = 'embedded-detail-icon';
+			return;
+		}
+
+		this.nameEl.textContent = item.name;
+
+		const isMarketplace = item.kind === AgentPluginItemKind.Marketplace;
+		const iconId = isMarketplace ? extensionIcon.id : pluginIcon.id;
+		this.iconEl.className = `embedded-detail-icon codicon codicon-${iconId}`;
+
+		const sourceLabel = item.marketplace
+			? (isMarketplace
+				? localize('pluginSourceMarketplace', "From {0}", item.marketplace)
+				: localize('pluginSourceInstalled', "Installed from {0}", item.marketplace))
+			: (isMarketplace
+				? localize('pluginSourceMarketplaceUnknown', "Marketplace plugin")
+				: localize('pluginSourceLocal', "Installed plugin"));
+		const iconSpan = $(`span.codicon.codicon-${iconId}`);
+		this.sourceEl.replaceChildren(iconSpan, document.createTextNode(' ' + sourceLabel));
+
+		const description = (item.description || '').trim();
+		this.descriptionEl.textContent = description;
+		this.descriptionEl.style.display = description ? '' : 'none';
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.ts
@@ -4,13 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../../base/browser/dom.js';
-import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../nls.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
-import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
 import { AgentPluginItemKind, IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
 import { extensionIcon, pluginIcon } from './aiCustomizationIcons.js';
 
@@ -18,8 +13,7 @@ const $ = DOM.$;
 
 /**
  * Compact detail view for an agent plugin inside the AI Customizations management editor's
- * split-pane host. Renders identity (icon + name + source) and description, plus an
- * "Open in editor" link that opens the full {@link AgentPluginEditor} in the main editor area.
+ * split-pane host. Renders identity (icon + name + source) and description.
  *
  * Advanced actions (enable / disable / uninstall) remain accessible via the row's existing
  * context menu, so this component intentionally stays small.
@@ -31,16 +25,12 @@ export class EmbeddedAgentPluginDetail extends Disposable {
 	private readonly nameEl: HTMLElement;
 	private readonly sourceEl: HTMLElement;
 	private readonly descriptionEl: HTMLElement;
-	private readonly openLink: HTMLAnchorElement;
 	private readonly emptyEl: HTMLElement;
 
 	private current: IAgentPluginItem | undefined;
 
 	constructor(
 		parent: HTMLElement,
-		@IEditorService private readonly editorService: IEditorService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 
@@ -54,23 +44,6 @@ export class EmbeddedAgentPluginDetail extends Disposable {
 		this.sourceEl = DOM.append(headerText, $('.embedded-detail-scope'));
 
 		this.descriptionEl = DOM.append(this.root, $('.embedded-detail-description'));
-
-		const actions = DOM.append(this.root, $('.embedded-detail-actions'));
-		this.openLink = DOM.append(actions, $<HTMLAnchorElement>('a.embedded-detail-open-link'));
-		this.openLink.textContent = localize('pluginOpenInEditor', "Open in editor");
-		this.openLink.setAttribute('role', 'button');
-		this.openLink.setAttribute('tabindex', '0');
-		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.openLink, localize('pluginOpenInEditorTooltip', "Open this plugin in the full editor")));
-		this._register(DOM.addDisposableListener(this.openLink, 'click', e => {
-			e.preventDefault();
-			this.openInFullEditor();
-		}));
-		this._register(DOM.addDisposableListener(this.openLink, 'keydown', (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				this.openInFullEditor();
-			}
-		}));
 
 		this.emptyEl = DOM.append(this.root, $('.embedded-detail-empty'));
 		this.emptyEl.textContent = localize('pluginDetailEmpty', "No plugin selected.");
@@ -90,14 +63,6 @@ export class EmbeddedAgentPluginDetail extends Disposable {
 	clearInput(): void {
 		this.current = undefined;
 		this.renderItem();
-	}
-
-	private openInFullEditor(): void {
-		if (!this.current) {
-			return;
-		}
-		const input = this.instantiationService.createInstance(AgentPluginEditorInput, this.current);
-		this.editorService.openEditor(input);
 	}
 
 	private renderItem(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
@@ -4,12 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../../base/browser/dom.js';
-import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
-import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
 import { mcpServerIcon, userIcon, workspaceIcon } from './aiCustomizationIcons.js';
@@ -18,8 +16,7 @@ const $ = DOM.$;
 
 /**
  * Compact detail view for an MCP server inside the AI Customizations management editor's
- * split-pane host. Renders identity (icon + name + scope) and description, plus an
- * "Open in editor" link that opens the full {@link McpServerEditor} in the main editor area.
+ * split-pane host. Renders identity (icon + name + scope) and description.
  *
  * Advanced actions (enable / disable / uninstall / configure) remain accessible via the
  * row's existing context menu, so this component intentionally stays small.
@@ -31,7 +28,6 @@ export class EmbeddedMcpServerDetail extends Disposable {
 	private readonly nameEl: HTMLElement;
 	private readonly scopeEl: HTMLElement;
 	private readonly descriptionEl: HTMLElement;
-	private readonly openLink: HTMLAnchorElement;
 	private readonly emptyEl: HTMLElement;
 
 	private current: IWorkbenchMcpServer | undefined;
@@ -39,7 +35,6 @@ export class EmbeddedMcpServerDetail extends Disposable {
 	constructor(
 		parent: HTMLElement,
 		@IMcpWorkbenchService private readonly mcpWorkbenchService: IMcpWorkbenchService,
-		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 
@@ -53,23 +48,6 @@ export class EmbeddedMcpServerDetail extends Disposable {
 		this.scopeEl = DOM.append(headerText, $('.embedded-detail-scope'));
 
 		this.descriptionEl = DOM.append(this.root, $('.embedded-detail-description'));
-
-		const actions = DOM.append(this.root, $('.embedded-detail-actions'));
-		this.openLink = DOM.append(actions, $<HTMLAnchorElement>('a.embedded-detail-open-link'));
-		this.openLink.textContent = localize('mcpOpenInEditor', "Open in editor");
-		this.openLink.setAttribute('role', 'button');
-		this.openLink.setAttribute('tabindex', '0');
-		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.openLink, localize('mcpOpenInEditorTooltip', "Open this MCP server in the full editor")));
-		this._register(DOM.addDisposableListener(this.openLink, 'click', e => {
-			e.preventDefault();
-			this.openInFullEditor();
-		}));
-		this._register(DOM.addDisposableListener(this.openLink, 'keydown', (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				this.openInFullEditor();
-			}
-		}));
 
 		this.emptyEl = DOM.append(this.root, $('.embedded-detail-empty'));
 		this.emptyEl.textContent = localize('mcpDetailEmpty', "No MCP server selected.");
@@ -97,13 +75,6 @@ export class EmbeddedMcpServerDetail extends Disposable {
 	clearInput(): void {
 		this.current = undefined;
 		this.renderItem();
-	}
-
-	private openInFullEditor(): void {
-		if (!this.current) {
-			return;
-		}
-		this.mcpWorkbenchService.open(this.current);
 	}
 
 	private renderItem(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../../base/browser/dom.js';
-import { Codicon } from '../../../../../base/common/codicons.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
@@ -92,11 +91,9 @@ export class EmbeddedMcpServerDetail extends Disposable {
 
 		this.nameEl.textContent = server.label || server.name;
 
-		// Icon: prefer codicon hint, fall back to the standard MCP server icon.
-		const iconClasses = ['embedded-detail-icon', 'codicon'];
-		const codiconId = server.codicon && (Codicon as Record<string, unknown>)[server.codicon] ? server.codicon : mcpServerIcon.id;
-		iconClasses.push(`codicon-${codiconId}`);
-		this.iconEl.className = iconClasses.join(' ');
+		// Icon: server.codicon (when set) is the full codicon class (e.g. "codicon-foo");
+		// fall back to the standard MCP server themed icon otherwise.
+		this.iconEl.className = `embedded-detail-icon ${server.codicon ? `codicon ${server.codicon}` : ThemeIcon.asClassName(mcpServerIcon)}`;
 
 		// Scope label
 		const scope = server.local?.scope;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.ts
@@ -1,0 +1,159 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { localize } from '../../../../../nls.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
+import { IMcpWorkbenchService, IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
+import { mcpServerIcon, userIcon, workspaceIcon } from './aiCustomizationIcons.js';
+
+const $ = DOM.$;
+
+/**
+ * Compact detail view for an MCP server inside the AI Customizations management editor's
+ * split-pane host. Renders identity (icon + name + scope) and description, plus an
+ * "Open in editor" link that opens the full {@link McpServerEditor} in the main editor area.
+ *
+ * Advanced actions (enable / disable / uninstall / configure) remain accessible via the
+ * row's existing context menu, so this component intentionally stays small.
+ */
+export class EmbeddedMcpServerDetail extends Disposable {
+
+	private readonly root: HTMLElement;
+	private readonly iconEl: HTMLElement;
+	private readonly nameEl: HTMLElement;
+	private readonly scopeEl: HTMLElement;
+	private readonly descriptionEl: HTMLElement;
+	private readonly openLink: HTMLAnchorElement;
+	private readonly emptyEl: HTMLElement;
+
+	private current: IWorkbenchMcpServer | undefined;
+
+	constructor(
+		parent: HTMLElement,
+		@IMcpWorkbenchService private readonly mcpWorkbenchService: IMcpWorkbenchService,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super();
+
+		this.root = DOM.append(parent, $('.ai-customization-embedded-detail.embedded-mcp-detail'));
+
+		const header = DOM.append(this.root, $('.embedded-detail-header'));
+		this.iconEl = DOM.append(header, $('.embedded-detail-icon'));
+		const headerText = DOM.append(header, $('.embedded-detail-header-text'));
+		this.nameEl = DOM.append(headerText, $('h2.embedded-detail-name'));
+		this.nameEl.setAttribute('role', 'heading');
+		this.scopeEl = DOM.append(headerText, $('.embedded-detail-scope'));
+
+		this.descriptionEl = DOM.append(this.root, $('.embedded-detail-description'));
+
+		const actions = DOM.append(this.root, $('.embedded-detail-actions'));
+		this.openLink = DOM.append(actions, $<HTMLAnchorElement>('a.embedded-detail-open-link'));
+		this.openLink.textContent = localize('mcpOpenInEditor', "Open in editor");
+		this.openLink.setAttribute('role', 'button');
+		this.openLink.setAttribute('tabindex', '0');
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), this.openLink, localize('mcpOpenInEditorTooltip', "Open this MCP server in the full editor")));
+		this._register(DOM.addDisposableListener(this.openLink, 'click', e => {
+			e.preventDefault();
+			this.openInFullEditor();
+		}));
+		this._register(DOM.addDisposableListener(this.openLink, 'keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this.openInFullEditor();
+			}
+		}));
+
+		this.emptyEl = DOM.append(this.root, $('.embedded-detail-empty'));
+		this.emptyEl.textContent = localize('mcpDetailEmpty', "No MCP server selected.");
+
+		// Refresh when the underlying server changes (install state, enablement, etc.).
+		this._register(this.mcpWorkbenchService.onChange(server => {
+			if (this.current && server && server.id === this.current.id) {
+				this.current = server;
+				this.renderItem();
+			}
+		}));
+
+		this.renderItem();
+	}
+
+	get element(): HTMLElement {
+		return this.root;
+	}
+
+	setInput(server: IWorkbenchMcpServer): void {
+		this.current = server;
+		this.renderItem();
+	}
+
+	clearInput(): void {
+		this.current = undefined;
+		this.renderItem();
+	}
+
+	private openInFullEditor(): void {
+		if (!this.current) {
+			return;
+		}
+		this.mcpWorkbenchService.open(this.current);
+	}
+
+	private renderItem(): void {
+		const server = this.current;
+		const hasItem = !!server;
+		this.emptyEl.style.display = hasItem ? 'none' : '';
+		this.root.classList.toggle('is-empty', !hasItem);
+		if (!server) {
+			this.nameEl.textContent = '';
+			this.scopeEl.textContent = '';
+			this.descriptionEl.textContent = '';
+			this.iconEl.className = 'embedded-detail-icon';
+			return;
+		}
+
+		this.nameEl.textContent = server.label || server.name;
+
+		// Icon: prefer codicon hint, fall back to the standard MCP server icon.
+		const iconClasses = ['embedded-detail-icon', 'codicon'];
+		const codiconId = server.codicon && (Codicon as Record<string, unknown>)[server.codicon] ? server.codicon : mcpServerIcon.id;
+		iconClasses.push(`codicon-${codiconId}`);
+		this.iconEl.className = iconClasses.join(' ');
+
+		// Scope label
+		const scope = server.local?.scope;
+		const scopeInfo = describeMcpScope(scope);
+		if (scopeInfo) {
+			const scopeIcon = DOM.$(`span.codicon.codicon-${scopeInfo.icon.id}`);
+			this.scopeEl.replaceChildren(scopeIcon, document.createTextNode(' ' + scopeInfo.label));
+			this.scopeEl.style.display = '';
+		} else {
+			this.scopeEl.replaceChildren();
+			this.scopeEl.style.display = 'none';
+		}
+
+		// Description (single line, but allow wrapping in CSS)
+		const description = (server.description || '').trim();
+		this.descriptionEl.textContent = description;
+		this.descriptionEl.style.display = description ? '' : 'none';
+	}
+}
+
+function describeMcpScope(scope: LocalMcpServerScope | undefined): { label: string; icon: ThemeIcon } | undefined {
+	switch (scope) {
+		case LocalMcpServerScope.Workspace:
+			return { label: localize('mcpScopeWorkspace', "Workspace"), icon: workspaceIcon };
+		case LocalMcpServerScope.User:
+		case LocalMcpServerScope.RemoteUser:
+			return { label: localize('mcpScopeUser', "User"), icon: userIcon };
+		default:
+			return undefined;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -702,11 +702,13 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	min-height: 0;
 }
 
 .ai-customization-management-editor .mcp-detail-editor-container {
 	flex: 1;
-	overflow: hidden;
+	overflow: auto;
+	min-height: 0;
 }
 
 /* Embedded plugin detail view */
@@ -714,11 +716,111 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	min-height: 0;
 }
 
 .ai-customization-management-editor .plugin-detail-editor-container {
 	flex: 1;
-	overflow: hidden;
+	overflow: auto;
+	min-height: 0;
+}
+
+/* Compact embedded detail component (shared by MCP / plugin) */
+.ai-customization-management-editor .ai-customization-embedded-detail {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 16px 24px 24px 24px;
+	max-width: 720px;
+	min-width: 0;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-header,
+.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-description,
+.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-actions {
+	display: none;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	min-width: 0;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-icon {
+	flex: 0 0 auto;
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-icon.codicon::before {
+	font-size: 28px;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-header-text {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-name {
+	margin: 0;
+	font-size: 18px;
+	line-height: 22px;
+	font-weight: 600;
+	word-break: break-word;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-scope {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-scope .codicon {
+	font-size: 12px;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-description {
+	color: var(--vscode-foreground);
+	font-size: 13px;
+	line-height: 1.4;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link:hover,
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link:focus {
+	color: var(--vscode-textLink-activeForeground);
+	text-decoration: underline;
+	outline: none;
+}
+
+.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-empty {
+	color: var(--vscode-descriptionForeground);
+	font-size: 13px;
+	padding: 8px 0;
 }
 
 /* Models section footer */

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -736,8 +736,7 @@
 }
 
 .ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-header,
-.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-description,
-.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-actions {
+.ai-customization-management-editor .ai-customization-embedded-detail.is-empty .embedded-detail-description {
 	display: none;
 }
 
@@ -796,25 +795,6 @@
 	line-height: 1.4;
 	white-space: pre-wrap;
 	word-break: break-word;
-}
-
-.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-actions {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-}
-
-.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link {
-	color: var(--vscode-textLink-foreground);
-	cursor: pointer;
-	text-decoration: none;
-}
-
-.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link:hover,
-.ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-open-link:focus {
-	color: var(--vscode-textLink-activeForeground);
-	text-decoration: underline;
-	outline: none;
 }
 
 .ai-customization-management-editor .ai-customization-embedded-detail .embedded-detail-empty {

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -199,6 +199,9 @@ function createMockHarnessService(activeHarnessId: string, descriptors: readonly
 		override getActiveDescriptor() {
 			return descriptors.find(h => h.id === active.get()) ?? descriptors[0];
 		}
+		override findHarnessById(id: string) {
+			return descriptors.find(h => h.id === id);
+		}
 		override setActiveHarness(id: string) { active.set(id, undefined); }
 		override registerExternalHarness() { return { dispose() { } }; }
 	}();

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -44,7 +44,6 @@ import { AICustomizationManagementEditor } from '../../../../contrib/chat/browse
 import { EmbeddedMcpServerDetail } from '../../../../contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.js';
 import { EmbeddedAgentPluginDetail } from '../../../../contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.js';
 import { AgentPluginItemKind, IAgentPluginItem } from '../../../../contrib/chat/browser/agentPluginEditor/agentPluginItems.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ContributionEnablementState } from '../../../../contrib/chat/common/enablement.js';
 import { AICustomizationManagementEditorInput } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { IConfigurationService, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
@@ -1000,9 +999,6 @@ function renderEmbeddedPluginDetail(ctx: ComponentFixtureContext, item: IAgentPl
 		colorTheme: ctx.theme,
 		additionalServices: (reg) => {
 			registerWorkbenchServices(reg);
-			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() {
-				override async openEditor(): Promise<undefined> { return undefined; }
-			}());
 		},
 	});
 

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -41,6 +41,10 @@ import { IPluginMarketplaceService, IMarketplacePlugin, MarketplaceType, PluginS
 import { MarketplaceReferenceKind } from '../../../../contrib/chat/common/plugins/marketplaceReference.js';
 import { IPluginInstallService } from '../../../../contrib/chat/common/plugins/pluginInstallService.js';
 import { AICustomizationManagementEditor } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
+import { EmbeddedMcpServerDetail } from '../../../../contrib/chat/browser/aiCustomization/embeddedMcpServerDetail.js';
+import { EmbeddedAgentPluginDetail } from '../../../../contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail.js';
+import { AgentPluginItemKind, IAgentPluginItem } from '../../../../contrib/chat/browser/agentPluginEditor/agentPluginItems.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { ContributionEnablementState } from '../../../../contrib/chat/common/enablement.js';
 import { AICustomizationManagementEditorInput } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { IConfigurationService, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
@@ -952,6 +956,99 @@ function renderPluginDisabled(ctx: ComponentFixtureContext, byPolicy: boolean): 
 }
 
 // ============================================================================
+// Embedded compact detail widgets — standalone (no host editor)
+// ============================================================================
+
+function renderEmbeddedMcpDetail(ctx: ComponentFixtureContext, server: IWorkbenchMcpServer | undefined): void {
+	const width = 480;
+	const height = 320;
+	ctx.container.style.width = `${width}px`;
+	ctx.container.style.height = `${height}px`;
+
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.defineInstance(IMcpWorkbenchService, new class extends mock<IMcpWorkbenchService>() {
+				override readonly onChange = Event.None;
+				override readonly onReset = Event.None;
+				override readonly local: IWorkbenchMcpServer[] = server ? [server] : [];
+				override async open() { /* no-op in fixture */ }
+			}());
+		},
+	});
+
+	// Mirror the host editor's class so the scoped CSS selectors apply.
+	const host = DOM.append(ctx.container, DOM.$('.ai-customization-management-editor'));
+	host.style.height = '100%';
+	host.style.width = '100%';
+	host.style.overflow = 'auto';
+
+	const detail = ctx.disposableStore.add(instantiationService.createInstance(EmbeddedMcpServerDetail, host));
+	if (server) {
+		detail.setInput(server);
+	}
+}
+
+function renderEmbeddedPluginDetail(ctx: ComponentFixtureContext, item: IAgentPluginItem | undefined): void {
+	const width = 480;
+	const height = 320;
+	ctx.container.style.width = `${width}px`;
+	ctx.container.style.height = `${height}px`;
+
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			registerWorkbenchServices(reg);
+			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() {
+				override async openEditor(): Promise<undefined> { return undefined; }
+			}());
+		},
+	});
+
+	const host = DOM.append(ctx.container, DOM.$('.ai-customization-management-editor'));
+	host.style.height = '100%';
+	host.style.width = '100%';
+	host.style.overflow = 'auto';
+
+	const detail = ctx.disposableStore.add(instantiationService.createInstance(EmbeddedAgentPluginDetail, host));
+	if (item) {
+		detail.setInput(item);
+	}
+}
+
+function makeInstalledPluginItem(name: string, description: string): IAgentPluginItem {
+	return {
+		kind: AgentPluginItemKind.Installed,
+		name,
+		description,
+		marketplace: 'GitHub',
+		plugin: makeInstalledPlugin(name, URI.file(`/workspace/.copilot/plugins/${name.toLowerCase()}`), true),
+	};
+}
+
+function makeMarketplacePluginItem(name: string, description: string): IAgentPluginItem {
+	return {
+		kind: AgentPluginItemKind.Marketplace,
+		name,
+		description,
+		source: 'GitHub',
+		sourceDescriptor: { kind: PluginSourceKind.GitHub, repo: `acme/${name.toLowerCase()}` },
+		marketplace: 'GitHub',
+		marketplaceType: MarketplaceType.Copilot,
+		marketplaceReference: {
+			rawValue: `acme/${name.toLowerCase()}`,
+			displayLabel: `acme/${name.toLowerCase()}`,
+			cloneUrl: `https://github.com/acme/${name.toLowerCase()}`,
+			canonicalId: `github:acme/${name.toLowerCase()}`,
+			cacheSegments: ['github', 'acme', name.toLowerCase()],
+			kind: MarketplaceReferenceKind.GitHubShorthand,
+			githubRepo: `acme/${name.toLowerCase()}`,
+		},
+	};
+}
+
+// ============================================================================
 // Fixtures
 // ============================================================================
 
@@ -1228,5 +1325,42 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 			width: 550,
 			height: 400,
 		}),
+	}),
+
+	// Standalone embedded MCP detail widget (compact split-pane component).
+	// Workspace-scope server with a description.
+	EmbeddedMcpDetailWorkspace: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedMcpDetail(ctx, makeLocalMcpServer('mcp-postgres', 'PostgreSQL', LocalMcpServerScope.Workspace, 'Database access for the active workspace')),
+	}),
+
+	// Standalone embedded MCP detail widget — user-scope server.
+	EmbeddedMcpDetailUser: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedMcpDetail(ctx, makeLocalMcpServer('mcp-web-search', 'Web Search', LocalMcpServerScope.User, 'Search the web from any session')),
+	}),
+
+	// Standalone embedded MCP detail widget — empty / no input state.
+	EmbeddedMcpDetailEmpty: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedMcpDetail(ctx, undefined),
+	}),
+
+	// Standalone embedded plugin detail widget — installed plugin.
+	EmbeddedPluginDetailInstalled: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedPluginDetail(ctx, makeInstalledPluginItem('Linear', 'Issue tracking and project management integration')),
+	}),
+
+	// Standalone embedded plugin detail widget — marketplace plugin.
+	EmbeddedPluginDetailMarketplace: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedPluginDetail(ctx, makeMarketplacePluginItem('Sentry', 'Error monitoring and performance tracing')),
+	}),
+
+	// Standalone embedded plugin detail widget — empty / no input state.
+	EmbeddedPluginDetailEmpty: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEmbeddedPluginDetail(ctx, undefined),
 	}),
 });

--- a/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/sessions/aiCustomizationManagementEditor.fixture.ts
@@ -45,6 +45,7 @@ import { ContributionEnablementState } from '../../../../contrib/chat/common/ena
 import { AICustomizationManagementEditorInput } from '../../../../contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { IConfigurationService, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
 import { mcpAccessConfig, McpAccessValue } from '../../../../../platform/mcp/common/mcpManagement.js';
+import { McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { ChatConfiguration } from '../../../../contrib/chat/common/constants.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, IMcpService, McpServerInstallState } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { IMcpRegistry } from '../../../../contrib/mcp/common/mcpRegistryTypes.js';
@@ -200,12 +201,13 @@ function createMockHarnessService(activeHarnessId: string, descriptors: readonly
 	}();
 }
 
-function makeLocalMcpServer(id: string, label: string, scope: LocalMcpServerScope, description?: string): IWorkbenchMcpServer {
+function makeLocalMcpServer(id: string, label: string, scope: LocalMcpServerScope, description?: string, config?: IWorkbenchMcpServer['config']): IWorkbenchMcpServer {
 	return new class extends mock<IWorkbenchMcpServer>() {
 		override readonly id = id;
 		override readonly name = id;
 		override readonly label = label;
 		override readonly description = description ?? '';
+		override readonly config = config;
 		override readonly installState = McpServerInstallState.Installed;
 		override readonly local = new class extends mock<IWorkbenchLocalMcpServer>() {
 			override readonly id = id;
@@ -327,6 +329,17 @@ const agentInstructions: IAgentInstructionFile[] = [
 ];
 
 const mcpWorkspaceServers = [
+	makeLocalMcpServer(
+		'component-explorer',
+		'component-explorer',
+		LocalMcpServerScope.Workspace,
+		'Component fixtures and screenshot tooling',
+		{
+			type: McpServerType.LOCAL,
+			command: 'npm',
+			args: ['exec', '--no', '--', 'component-explorer', 'mcp', '-p', './test/componentFixtures/component-explorer.json', '--use-daemon', '-vv'],
+		}
+	),
 	makeLocalMcpServer('mcp-postgres', 'PostgreSQL', LocalMcpServerScope.Workspace, 'Database access'),
 	makeLocalMcpServer('mcp-github', 'GitHub', LocalMcpServerScope.Workspace, 'GitHub API'),
 	makeLocalMcpServer('mcp-redis', 'Redis', LocalMcpServerScope.Workspace, 'In-memory data store'),
@@ -580,7 +593,7 @@ async function renderEditor(ctx: ComponentFixtureContext, options: IRenderEditor
 	if (options.openFirstItem) {
 		const visibleContent = [...ctx.container.querySelectorAll('.prompts-content-container, .mcp-content-container, .plugin-content-container')]
 			.find(node => node instanceof HTMLElement && node.style.display !== 'none') as HTMLElement | undefined;
-		const firstRow = visibleContent?.querySelector('.monaco-list-row') as HTMLElement | undefined;
+		const firstRow = visibleContent?.querySelector('.monaco-list-row.ai-customization-list-item, .monaco-list-row.mcp-server-item') as HTMLElement | undefined;
 		if (firstRow) {
 			firstRow.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
 			firstRow.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
@@ -1183,6 +1196,19 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 		}),
 	}),
 
+	// MCP server detail view in a narrow viewport — catches embedded header overflow
+	// and the single-tab configuration layout used by local workspace servers.
+	McpServerDetailNarrow: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEditor(ctx, {
+			harnessId: SessionType.Local,
+			selectedSection: AICustomizationManagementSection.McpServers,
+			openFirstItem: true,
+			width: 550,
+			height: 400,
+		}),
+	}),
+
 	// Plugin detail view — same alignment check for the detail back button.
 	PluginDetail: defineComponentFixture({
 		labels: { kind: 'screenshot' },
@@ -1190,6 +1216,17 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 			harnessId: SessionType.Local,
 			selectedSection: AICustomizationManagementSection.Plugins,
 			openFirstItem: true,
+		}),
+	}),
+
+	PluginDetailNarrow: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderEditor(ctx, {
+			harnessId: SessionType.Local,
+			selectedSection: AICustomizationManagementSection.Plugins,
+			openFirstItem: true,
+			width: 550,
+			height: 400,
 		}),
 	}),
 });


### PR DESCRIPTION
## What

Replaces the full-page `McpServerEditor` and `AgentPluginEditor` that were embedded inside the Chat Customizations management editor's split-pane detail host with two small dedicated widgets:

- `EmbeddedMcpServerDetail` — icon + name + scope + description for an MCP server
- `EmbeddedAgentPluginDetail` — icon + name + source + description for an agent plugin

Both are plain `Disposable` widgets (no `EditorPane` plumbing) that flow with their container.

## Why

The two extension-style editors are designed for a wide standalone editor area. When embedded in the narrow split pane they rendered visually broken — overflowing headers, misaligned chrome, and stretched layouts — no matter how much CSS was layered on top. After repeated attempts to scope `extensionEditor.css` overrides failed, the cleaner fix is to render purpose-built compact components in the split pane.

Advanced actions (enable / disable / uninstall / configure, contributed items, README) remain accessible via the existing row context menu and from the standalone editors when opened directly. The compact widget intentionally surfaces only identity + description.

## Notes for reviewers

- ~160 lines of `.extension-editor` CSS overrides removed in favor of focused `.ai-customization-embedded-detail` styles.
- An "Open in editor" link initially shipped with the widgets but was removed in a follow-up commit — the full-page editors are still visually broken in several flows, so linking out to them did more harm than good and the link looked out of place in an otherwise minimal header.
- `aiCustomizationManagementEditor.ts` no longer calls `.layout(Dimension)` on the detail widgets during split-view layout (the new components don't need it).
- 6 new standalone component-explorer fixtures cover the widgets in isolation (workspace/user/empty for MCP, installed/marketplace/empty for plugin), in addition to the existing `McpServerDetail` / `PluginDetail` host-editor fixtures.
- Design doc updated: `src/vs/sessions/AI_CUSTOMIZATIONS.md`.

## Validation

- ✅ `npm run compile-check-ts-native`
- ✅ `npm run valid-layers-check`
- ✅ hygiene
- ✅ code-review subagent (no significant issues)

Visual verification was blocked locally by an unrelated pre-existing Electron module load error.
