### PR TITLE
sessions: fix account widget missing from titlebar after IntersectionObserver optimization

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -757,6 +757,50 @@ class TitleBarUpdateWidget extends BaseActionViewItem {
 
 // --- Register custom view item --- //
 
+// These actions are registered at module level (not lazily inside AccountWidgetContribution)
+// so that Menus.TitleBarRightLayout is non-empty when the MenuWorkbenchToolBar is first
+// constructed. If they were registered lazily (WorkbenchPhase.AfterRestored), the toolbar's
+// IntersectionObserver would have already observed an empty, display:none container and
+// stopped listening for menu changes — causing the widgets to never appear.
+//
+// The actual widget rendering and interaction is handled by TitleBarUpdateWidget /
+// TitleBarAccountWidget, which are custom view items registered via IActionViewItemService
+// in AccountWidgetContribution. Those widgets attach their own DOM click handlers, so
+// run() here is intentionally a no-op.
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: SessionsTitleBarUpdateWidgetAction,
+			title: localize2('agentsUpdateTitleBar', "Agents Update"),
+			menu: {
+				id: Menus.TitleBarRightLayout,
+				group: 'navigation',
+				order: 99,
+				when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
+			}
+		});
+	}
+
+	run(): void { }
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: SessionsTitleBarAccountWidgetAction,
+			title: localize2('agentsAccountStatusTitleBar', "Agents Account and Status"),
+			menu: {
+				id: Menus.TitleBarRightLayout,
+				group: 'navigation',
+				order: 100,
+				when: IsAuxiliaryWindowContext.toNegated(),
+			}
+		});
+	}
+
+	run(): void { }
+});
+
 class AccountWidgetContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionsWidget';
@@ -768,57 +812,14 @@ class AccountWidgetContribution extends Disposable implements IWorkbenchContribu
 		super();
 
 		// Titlebar update widget (to the right of separator, left of account badge)
-		let updateWidget: TitleBarUpdateWidget | undefined;
 		this._register(actionViewItemService.register(Menus.TitleBarRightLayout, SessionsTitleBarUpdateWidgetAction, (action, options) => {
-			updateWidget = instantiationService.createInstance(TitleBarUpdateWidget, action, options);
-			return updateWidget;
+			return instantiationService.createInstance(TitleBarUpdateWidget, action, options);
 		}, undefined));
-
-		this._register(registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: SessionsTitleBarUpdateWidgetAction,
-					title: localize2('agentsUpdateTitleBar', "Agents Update"),
-					menu: {
-						id: Menus.TitleBarRightLayout,
-						group: 'navigation',
-						order: 99,
-						when: ContextKeyExpr.and(IsAuxiliaryWindowContext.toNegated(), SessionsWelcomeVisibleContext.toNegated()),
-					}
-				});
-			}
-
-			async run(): Promise<void> {
-				updateWidget?.onClick();
-			}
-		}));
 
 		// Titlebar account widget (rightmost in titlebar)
-		let accountWidget: TitleBarAccountWidget | undefined;
 		this._register(actionViewItemService.register(Menus.TitleBarRightLayout, SessionsTitleBarAccountWidgetAction, (action, options) => {
-			accountWidget = instantiationService.createInstance(TitleBarAccountWidget, action, options);
-			return accountWidget;
+			return instantiationService.createInstance(TitleBarAccountWidget, action, options);
 		}, undefined));
-
-		this._register(registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: SessionsTitleBarAccountWidgetAction,
-					title: localize2('agentsAccountStatusTitleBar', "Agents Account and Status"),
-					menu: {
-						id: Menus.TitleBarRightLayout,
-						group: 'navigation',
-						order: 100,
-						when: IsAuxiliaryWindowContext.toNegated(),
-					}
-				});
-			}
-
-			async run(): Promise<void> {
-				accountWidget?.onClick();
-			}
-		}));
-
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the account widget (avatar/sign-in button) disappearing from the Agent Sessions desktop titlebar after PR #312317.

## Root Cause

PR #312317 introduced an `IntersectionObserver` optimization in `MenuWorkbenchToolBar` that only subscribes to `IMenu.onDidChange` and `IActionViewItemService.onDidChange` while the toolbar container is **visible** (`isIntersecting === true`).

This created a chicken-and-egg deadlock for `Menus.TitleBarRightLayout`:

1. The `.titlebar-right-layout-container` starts with CSS `display: none` (empty menu → `.has-no-actions` class)
2. Both `registerAction2` calls for the account/update actions lived **inside `AccountWidgetContribution`** (`WorkbenchPhase.AfterRestored`)
3. By the time `AccountWidgetContribution` ran, the `IntersectionObserver` had already fired with `isIntersecting: false` and **unsubscribed** from menu changes
4. The newly registered menu items were never picked up → container stayed hidden → account widget never appeared

The session actions toolbar (Run, Terminal, Open in VS Code) was unaffected because its actions are all registered at module level and are present during the toolbar's first render.

## Fix

Move the two `registerAction2` calls to **module level** so both actions exist in `Menus.TitleBarRightLayout` when `MenuWorkbenchToolBar` first calls `_updateToolbar()`. The container has items from the start, remains visible, and the `IntersectionObserver` stays subscribed — so the subsequent `actionViewItemService.register` calls from `AccountWidgetContribution` (which require `instantiationService`) are correctly picked up and trigger a toolbar rebuild with the custom widgets.

The `actionViewItemService.register` calls remain inside the contribution. Module-level variables (`_updateWidget`, `_accountWidget`) bridge the dispatch from the module-level `run()` methods to the widget instances once they're created.