### PR TITLE
fix: prevent duplicate Simple Browser panels on rapid show/restore race

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -23,7 +23,7 @@ export class SimpleBrowserManager {
 		const url = typeof inputUri === 'string' ? inputUri : inputUri.toString(true);
 		if (this._activeView) {
 			this._activeView.show(url, options);
-		} else {
+		} else if (!this._simpleBrowserAlreadyOpen()) {
 			const view = SimpleBrowserView.create(this.extensionUri, url, options);
 			this.registerWebviewListeners(view);
 
@@ -33,9 +33,17 @@ export class SimpleBrowserManager {
 
 	public restore(panel: vscode.WebviewPanel, state: any): void {
 		const url = state?.url ?? '';
+		if (this._activeView) {
+			panel.dispose();
+			return;
+		}
 		const view = SimpleBrowserView.restore(this.extensionUri, url, panel);
 		this.registerWebviewListeners(view);
-		this._activeView ??= view;
+		this._activeView = view;
+	}
+
+	private _simpleBrowserAlreadyOpen(): boolean {
+		return vscode.window.tabGroups.all.some(group => group.tabs.some(tab => tab.label === SimpleBrowserView.title));
 	}
 
 	private registerWebviewListeners(view: SimpleBrowserView) {

--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -16,7 +16,7 @@ export interface ShowOptions {
 export class SimpleBrowserView extends Disposable {
 
 	public static readonly viewType = 'simpleBrowser.view';
-	private static readonly title = vscode.l10n.t("Simple Browser");
+	public static readonly title = vscode.l10n.t("Simple Browser");
 
 	private static getWebviewLocalResourceRoots(extensionUri: vscode.Uri): readonly vscode.Uri[] {
 		return [


### PR DESCRIPTION
When `show()` is called multiple times rapidly during window reload, multiple Simple Browser panels could be created before `_activeView` was set. Similarly, `restore()` could revive an old panel even when a new one already existed. This fix adds a `_simpleBrowserAlreadyOpen()` check in `show()` that scans all tab groups (not just the active one) to prevent duplicate panel creation. It also updates `restore()` to dispose the restored panel if an active view already exists.