### PR TITLE
Add toolSearch to vscode toolset

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1316,6 +1316,7 @@
 					"resolveMemoryFileUri",
 					"runCommand",
 					"switchAgent",
+					"toolSearch",
 					"vscodeAPI"
 				]
 			},


### PR DESCRIPTION
Lists `toolSearch` in the `vscode` `languageModelToolSets` contribution so it reliably attaches to the toolset (the registration-time `toolSet` field on `registerToolDefinition` doesn't retry on late-registered toolsets).