### PR TITLE
webview: respect default localResourceRoots for custom editors

### DIFF
--- a/src/vs/workbench/api/common/extHostCustomEditors.ts
+++ b/src/vs/workbench/api/common/extHostCustomEditors.ts
@@ -271,6 +271,11 @@ export class ExtHostCustomEditors implements extHostProtocol.ExtHostCustomEditor
 		const viewColumn = typeConverters.ViewColumn.to(position);
 
 		const webview = this._extHostWebview.createNewWebview(handle, initData.contentOptions, entry.extension);
+		// The main thread starts the custom editor's webview with empty content
+		// options. Ensure `localResourceRoots` defaults to the workspace folders
+		// and the providing extension's install directory, as documented on
+		// `WebviewOptions.localResourceRoots`.
+		this._extHostWebview.ensureDefaultContentOptions(handle, initData.contentOptions, entry.extension);
 		const panel = this._extHostWebviewPanels.createNewWebviewPanel(handle, viewType, initData.title, viewColumn, initData.options, webview, initData.active);
 
 		const revivedResource = URI.revive(resource);

--- a/src/vs/workbench/api/common/extHostWebview.ts
+++ b/src/vs/workbench/api/common/extHostWebview.ts
@@ -246,6 +246,26 @@ export class ExtHostWebviews extends Disposable implements extHostProtocol.ExtHo
 		return webview;
 	}
 
+	/**
+	 * Ensures that the main thread side of the webview has `localResourceRoots`
+	 * populated when the caller did not supply any.
+	 *
+	 * This honors the documented `WebviewOptions.localResourceRoots` contract
+	 * ("Default to ... the workspace folders and the extension's install
+	 * directory") for code paths that construct the webview's content options
+	 * outside of the extension host (e.g. custom editors), where the main
+	 * thread starts with empty content options.
+	 */
+	public ensureDefaultContentOptions(handle: extHostProtocol.WebviewHandle, contentOptions: extHostProtocol.IWebviewContentOptions, extension: IExtensionDescription): void {
+		if (contentOptions.localResourceRoots) {
+			return;
+		}
+		this._webviewProxy.$setOptions(handle, {
+			...contentOptions,
+			localResourceRoots: getDefaultLocalResourceRoots(extension, this.workspace),
+		});
+	}
+
 	public deleteWebview(handle: string) {
 		this._webviews.delete(handle);
 	}

--- a/src/vs/workbench/api/test/browser/extHostWebview.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostWebview.test.ts
@@ -14,8 +14,10 @@ import { NullLogService } from '../../../../platform/log/common/log.js';
 import { MainThreadWebviewManager } from '../../browser/mainThreadWebviewManager.js';
 import { NullApiDeprecationService } from '../../common/extHostApiDeprecationService.js';
 import { IExtHostRpcService } from '../../common/extHostRpcService.js';
+import { IWebviewContentOptions } from '../../common/extHost.protocol.js';
 import { ExtHostWebviews } from '../../common/extHostWebview.js';
 import { ExtHostWebviewPanels } from '../../common/extHostWebviewPanels.js';
+import { IExtHostWorkspace } from '../../common/extHostWorkspace.js';
 import { SingleProxyRPCProtocol } from '../common/testRPCProtocol.js';
 import { decodeAuthority, webviewResourceBaseHost } from '../../../contrib/webview/common/webview.js';
 import { EditorGroupColumn } from '../../../services/editor/common/editorGroupColumn.js';
@@ -194,6 +196,85 @@ suite('ExtHostWebview', () => {
 			`vscode-remote+${authority}.vscode-resource.vscode-cdn.net`,
 			'Check decoded authority'
 		);
+	});
+
+	suite('ensureDefaultContentOptions', () => {
+		function createExtHostWebviewsWithCapture(workspaceFolders: URI[] | undefined) {
+			const setOptionsCalls: { handle: string; options: IWebviewContentOptions }[] = [];
+
+			const shape = new class extends mock<MainThreadWebviewManager>() {
+				$setOptions(handle: string, options: IWebviewContentOptions) {
+					setOptionsCalls.push({ handle, options });
+				}
+			};
+
+			const captureRpc = SingleProxyRPCProtocol(shape);
+
+			const workspace: IExtHostWorkspace | undefined = workspaceFolders
+				? new class extends mock<IExtHostWorkspace>() {
+					override getWorkspaceFolders() {
+						return workspaceFolders.map((uri, index) => ({ uri, name: `f${index}`, index })) as unknown as vscode.WorkspaceFolder[];
+					}
+				}
+				: undefined;
+
+			const extHostWebviews = disposables.add(new ExtHostWebviews(
+				captureRpc,
+				{ authority: undefined, isRemote: false },
+				workspace,
+				new NullLogService(),
+				NullApiDeprecationService));
+
+			return { extHostWebviews, setOptionsCalls };
+		}
+
+		const extension = {
+			extensionLocation: URI.file('/ext/install/path'),
+		} as IExtensionDescription;
+
+		test('fills default localResourceRoots from workspace folders and extension location when caller did not supply them', () => {
+			const folderA = URI.file('/workspace/a');
+			const folderB = URI.file('/workspace/b');
+			const { extHostWebviews, setOptionsCalls } = createExtHostWebviewsWithCapture([folderA, folderB]);
+
+			disposables.add(extHostWebviews.createNewWebview('handle-1', { enableScripts: true }, extension));
+			extHostWebviews.ensureDefaultContentOptions('handle-1', { enableScripts: true }, extension);
+
+			assert.strictEqual(setOptionsCalls.length, 1, 'expected $setOptions to be called once');
+			const call = setOptionsCalls[0];
+			assert.strictEqual(call.handle, 'handle-1');
+			assert.strictEqual(call.options.enableScripts, true);
+			const roots = call.options.localResourceRoots;
+			assert.ok(roots, 'expected localResourceRoots to be set');
+			const rootStrings = roots!.map(r => URI.from(r).toString());
+			assert.deepStrictEqual(rootStrings, [
+				folderA.toString(),
+				folderB.toString(),
+				extension.extensionLocation.toString(),
+			]);
+		});
+
+		test('does nothing when caller already supplied localResourceRoots', () => {
+			const { extHostWebviews, setOptionsCalls } = createExtHostWebviewsWithCapture([URI.file('/workspace/a')]);
+			const explicit = [URI.file('/explicit/root')];
+
+			disposables.add(extHostWebviews.createNewWebview('handle-2', { localResourceRoots: explicit }, extension));
+			extHostWebviews.ensureDefaultContentOptions('handle-2', { localResourceRoots: explicit }, extension);
+
+			assert.strictEqual(setOptionsCalls.length, 0, 'expected $setOptions not to be called');
+		});
+
+		test('falls back to just the extension location when there are no workspace folders', () => {
+			const { extHostWebviews, setOptionsCalls } = createExtHostWebviewsWithCapture(undefined);
+
+			disposables.add(extHostWebviews.createNewWebview('handle-3', {}, extension));
+			extHostWebviews.ensureDefaultContentOptions('handle-3', {}, extension);
+
+			assert.strictEqual(setOptionsCalls.length, 1);
+			const roots = setOptionsCalls[0].options.localResourceRoots!;
+			const rootStrings = roots.map(r => URI.from(r).toString());
+			assert.deepStrictEqual(rootStrings, [extension.extensionLocation.toString()]);
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #282495

## Problem

Per the [`WebviewOptions.localResourceRoots` docs](https://code.visualstudio.com/api/references/vscode-api#WebviewOptions), if the option is left unset the webview should default to allowing the workspace folder roots plus the extension's install directory. `vscode.window.createWebviewPanel` honors this contract — `ExtHostWebviewPanels.createWebviewPanel` fills in the default before the create RPC.

Custom editors do not. The main thread builds the overlay with `contentOptions: {}` and then calls `$resolveCustomEditor` on the extension host. Because the extension host never receives a chance to fill in the default, `asWebviewUri` returns HTTP 401 for resources under the workspace or the extension folder unless the extension explicitly sets `webview.options = { localResourceRoots: [...] }`. This silently breaks custom-editor extensions that follow the documented default.

## Fix

Added `ExtHostWebviews.ensureDefaultContentOptions(handle, contentOptions, extension)`. When `contentOptions.localResourceRoots` is `undefined`, it calls `$setOptions` with the documented default (workspace folders + extension install directory, mirroring the logic in `ExtHostWebviewPanels.createWebviewPanel`). When the extension provided explicit roots — including an empty array — the helper does nothing.

`MainThreadCustomEditors.$resolveCustomEditor` invokes the helper from `ExtHostCustomEditors` immediately after `createNewWebview`, before the provider's `resolveCustomTextEditor` / `resolveCustomEditor` runs. Existing `webview.options = ...` assignments inside provider callbacks continue to work — those go through `serializeWebviewOptions`, which already re-applies the default.

## Tests

Added three unit tests in `src/vs/workbench/api/test/browser/extHostWebview.test.ts`:

- default fills in workspace folders + extension install directory when `localResourceRoots` is omitted
- explicit `localResourceRoots` (even `[]`) is respected — `$setOptions` is not called
- with no workspace open, the default is just the extension install directory