### PR TITLE
inlineCompletions: tighten keybinding spacing in NES gutter menu

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css
@@ -214,13 +214,21 @@
 	border-radius: 3px;
 	cursor: pointer;
 
-	.monaco-keybinding-key {
+	.monaco-keybinding > .monaco-keybinding-key,
+	.monaco-keybinding > .monaco-keybinding-key:first-child,
+	.monaco-keybinding > .monaco-keybinding-key:last-child {
 		font-size: 13px;
 		opacity: 0.7;
 		padding: 0;
 		border: none;
 		margin: 0;
 		min-width: unset;
+	}
+
+	.monaco-keybinding > .monaco-keybinding-key-separator {
+		opacity: 0.7;
+		padding: 0;
+		margin: 0;
 	}
 
 	&.active {


### PR DESCRIPTION
Fixes #281478

## Problem

In the NES (Next Edit Suggestions) gutter menu, the `Shift + Tab` keybinding label rendered with visible whitespace around the `+` separator, making the label noticeably wider than intended.

## Root Cause

The label is produced by the shared `KeybindingLabel` component, which renders three sibling spans: `monaco-keybinding-key`, `monaco-keybinding-key-separator`, `monaco-keybinding-key`. The base `keybindingLabel.css` applies `margin: 0 2px` to `.monaco-keybinding-key`, with `:first-child { margin-left: 0 }` / `:last-child { margin-right: 0 }` overrides (specificity 0,3,0).

The existing NES override `.monaco-menu-option .monaco-keybinding-key { margin: 0 }` had specificity (0,2,0) and lost to the base `:first-child` / `:last-child` rules. Additionally, the `monaco-keybinding-key-separator` span had no NES override at all, so the surrounding margins on the key spans plus the separator's own padding produced the extra space.

## Fix

Scoped to NES only — `src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css`:

- Match `:first-child` / `:last-child` on the NES `.monaco-keybinding-key` rule so source-order resolves in the override's favor and margins collapse to zero.
- Add a sibling rule for `.monaco-keybinding-key-separator` that zeroes padding/margin and matches the muted `opacity: 0.7` used elsewhere in the menu.

The shared `keybindingLabel.css` is intentionally unchanged so other consumers (command palette, keybinding editor, etc.) are unaffected.