### PR TITLE
github: resolve SSH host aliases when classifying remotes

### DIFF
--- a/extensions/github/src/extension.ts
+++ b/extensions/github/src/extension.ts
@@ -10,6 +10,7 @@ import type { API, GitExtension } from './typings/git.d.ts';
 import { registerCommands } from './commands.js';
 import { GithubCredentialProviderManager } from './credentialProvider.js';
 import { DisposableStore, repositoryHasGitHubRemote } from './util.js';
+import { sharedSshConfigHostResolver } from './sshConfig.js';
 import { GithubPushErrorHandler } from './pushErrorHandler.js';
 import { GitBaseExtension } from './typings/git-base.js';
 import { GithubRemoteSourcePublisher } from './remoteSourcePublisher.js';
@@ -38,6 +39,10 @@ export function activate(context: ExtensionContext): void {
 
 	const octokitService = new OctokitService();
 	disposables.push(octokitService);
+
+	// Pre-load `~/.ssh/config` so the synchronous remote URL parser can
+	// recognize remotes that use a custom SSH `Host` alias for github.com.
+	sharedSshConfigHostResolver.load().catch(() => { /* ignore - parser will fall back to legacy behavior */ });
 
 	disposables.push(initializeGitBaseExtension());
 	disposables.push(initializeGitExtension(context, octokitService, telemetryReporter, logger));

--- a/extensions/github/src/sshConfig.ts
+++ b/extensions/github/src/sshConfig.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Parses the textual content of an `ssh_config` file and returns a map of
+ * `Host` alias (literal, non-pattern) to the resolved `HostName`.
+ *
+ * Only literal aliases (no `*` or `?` wildcards, no negations) are recorded
+ * because we use this map to recognize that a remote like
+ * `git@my-alias:owner/repo.git` actually points at GitHub.
+ *
+ * Tokens are matched case-insensitively per the OpenSSH `ssh_config(5)` spec.
+ */
+export function parseSshConfig(content: string): Map<string, string> {
+	const result = new Map<string, string>();
+	let currentHosts: string[] = [];
+
+	for (const rawLine of content.split(/\r?\n/)) {
+		// Strip comments and whitespace
+		const line = rawLine.replace(/#.*$/, '').trim();
+		if (line.length === 0) {
+			continue;
+		}
+
+		// Keyword and value(s) are separated by whitespace and/or `=`
+		const match = /^(\S+?)\s*(?:=\s*)?(.+)$/.exec(line);
+		if (!match) {
+			continue;
+		}
+
+		const keyword = match[1].toLowerCase();
+		const value = match[2].trim();
+
+		if (keyword === 'host') {
+			// Collect literal alias names (skip patterns / negations)
+			currentHosts = value
+				.split(/\s+/)
+				.filter(host => host.length > 0 && !/[*?!]/.test(host));
+		} else if (keyword === 'hostname' && currentHosts.length > 0) {
+			for (const host of currentHosts) {
+				if (!result.has(host)) {
+					result.set(host, value);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Lazily resolves `Host` aliases declared in the user's `~/.ssh/config` to
+ * their configured `HostName`. Used by the GitHub remote URL parser so that
+ * a remote such as `git@my-alias:owner/repo.git` is recognized as a GitHub
+ * remote when `my-alias` resolves to `github.com`.
+ */
+export class SshConfigHostResolver {
+
+	private _aliasMap: Map<string, string> | undefined;
+
+	constructor(private readonly _configPaths: readonly string[] = defaultSshConfigPaths()) { }
+
+	/**
+	 * Synchronously returns the resolved `HostName` for the given alias if the
+	 * SSH configuration has already been loaded. Returns `undefined` if the
+	 * alias is unknown, or if the configuration has not been loaded yet.
+	 */
+	resolveSync(alias: string): string | undefined {
+		return this._aliasMap?.get(alias);
+	}
+
+	/**
+	 * Reads and parses the configured `ssh_config` files. Subsequent calls
+	 * are no-ops; call `reload()` to force a re-read.
+	 */
+	async load(): Promise<void> {
+		if (this._aliasMap) {
+			return;
+		}
+
+		const merged = new Map<string, string>();
+		for (const configPath of this._configPaths) {
+			try {
+				const content = await fs.promises.readFile(configPath, 'utf8');
+				for (const [alias, hostName] of parseSshConfig(content)) {
+					if (!merged.has(alias)) {
+						merged.set(alias, hostName);
+					}
+				}
+			} catch {
+				// File missing or unreadable - silently ignore. The resolver
+				// will simply not recognize aliases declared in this file.
+			}
+		}
+
+		this._aliasMap = merged;
+	}
+
+	/**
+	 * Forces a re-read of the configured `ssh_config` files on the next call
+	 * to `load()`.
+	 */
+	reload(): void {
+		this._aliasMap = undefined;
+	}
+}
+
+function defaultSshConfigPaths(): string[] {
+	const paths = [path.join(os.homedir(), '.ssh', 'config')];
+	if (process.platform !== 'win32') {
+		paths.push('/etc/ssh/ssh_config');
+	}
+	return paths;
+}
+
+/**
+ * Module-level shared resolver. Activation code calls `load()` once during
+ * extension startup so that the synchronous `resolveSync()` lookup in the
+ * remote URL parser has data available.
+ */
+export const sharedSshConfigHostResolver = new SshConfigHostResolver();

--- a/extensions/github/src/test/sshConfig.test.ts
+++ b/extensions/github/src/test/sshConfig.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import { parseSshConfig, SshConfigHostResolver } from '../sshConfig.js';
+import { getRepositoryFromUrl } from '../util.js';
+
+suite('parseSshConfig', () => {
+
+	test('extracts a simple Host -> HostName mapping', () => {
+		const map = parseSshConfig([
+			'Host gh-personal',
+			'  HostName github.com',
+			'  User git'
+		].join('\n'));
+
+		assert.strictEqual(map.get('gh-personal'), 'github.com');
+	});
+
+	test('handles multiple Host blocks', () => {
+		const map = parseSshConfig([
+			'Host work',
+			'  HostName github.com',
+			'',
+			'Host server',
+			'  HostName example.com'
+		].join('\n'));
+
+		assert.strictEqual(map.get('work'), 'github.com');
+		assert.strictEqual(map.get('server'), 'example.com');
+	});
+
+	test('records every literal alias on a `Host` line', () => {
+		const map = parseSshConfig([
+			'Host alias-a alias-b',
+			'  HostName github.com'
+		].join('\n'));
+
+		assert.strictEqual(map.get('alias-a'), 'github.com');
+		assert.strictEqual(map.get('alias-b'), 'github.com');
+	});
+
+	test('skips wildcard / negated aliases', () => {
+		const map = parseSshConfig([
+			'Host *.example.com !skip alias',
+			'  HostName github.com'
+		].join('\n'));
+
+		assert.strictEqual(map.has('*.example.com'), false);
+		assert.strictEqual(map.has('!skip'), false);
+		assert.strictEqual(map.get('alias'), 'github.com');
+	});
+
+	test('is case-insensitive for keywords and tolerates `=` separators', () => {
+		const map = parseSshConfig([
+			'host=gh',
+			'  HOSTNAME = github.com'
+		].join('\n'));
+
+		assert.strictEqual(map.get('gh'), 'github.com');
+	});
+
+	test('ignores comments and blank lines', () => {
+		const map = parseSshConfig([
+			'# top-level comment',
+			'',
+			'Host gh   # inline comment',
+			'  HostName github.com'
+		].join('\n'));
+
+		assert.strictEqual(map.get('gh'), 'github.com');
+	});
+
+	test('keeps the first HostName when an alias is declared twice', () => {
+		const map = parseSshConfig([
+			'Host gh',
+			'  HostName github.com',
+			'Host gh',
+			'  HostName other.example'
+		].join('\n'));
+
+		assert.strictEqual(map.get('gh'), 'github.com');
+	});
+});
+
+suite('getRepositoryFromUrl with SSH host alias', () => {
+
+	function resolverFor(map: Record<string, string>): Pick<SshConfigHostResolver, 'resolveSync'> {
+		return { resolveSync: (alias: string) => map[alias] };
+	}
+
+	test('still recognizes plain github.com remotes', () => {
+		const r = getRepositoryFromUrl('git@github.com:microsoft/vscode.git', resolverFor({}));
+		assert.deepStrictEqual(r, { owner: 'microsoft', repo: 'vscode' });
+	});
+
+	test('resolves a custom SSH alias mapped to github.com', () => {
+		const r = getRepositoryFromUrl(
+			'git@fancy-git-host:microsoft/vscode.git',
+			resolverFor({ 'fancy-git-host': 'github.com' })
+		);
+		assert.deepStrictEqual(r, { owner: 'microsoft', repo: 'vscode' });
+	});
+
+	test('returns undefined when the alias resolves to a non-github host', () => {
+		const r = getRepositoryFromUrl(
+			'git@internal-host:owner/repo.git',
+			resolverFor({ 'internal-host': 'gitlab.example.com' })
+		);
+		assert.strictEqual(r, undefined);
+	});
+
+	test('returns undefined when the alias is not in the SSH config', () => {
+		const r = getRepositoryFromUrl(
+			'git@unknown-alias:owner/repo.git',
+			resolverFor({})
+		);
+		assert.strictEqual(r, undefined);
+	});
+});

--- a/extensions/github/src/util.ts
+++ b/extensions/github/src/util.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import type { Repository } from './typings/git.d.ts';
+import { sharedSshConfigHostResolver, SshConfigHostResolver } from './sshConfig.js';
 
 export class DisposableStore {
 
@@ -62,10 +63,26 @@ export function groupBy<T>(data: ReadonlyArray<T>, compare: (a: T, b: T) => numb
 	return result;
 }
 
-export function getRepositoryFromUrl(url: string): { owner: string; repo: string } | undefined {
+export function getRepositoryFromUrl(url: string, sshResolver: Pick<SshConfigHostResolver, 'resolveSync'> = sharedSshConfigHostResolver): { owner: string; repo: string } | undefined {
 	const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(\.git)?$/i.exec(url)
 		|| /^git@github\.com:([^/]+)\/([^/]+?)(\.git)?$/i.exec(url);
-	return match ? { owner: match[1], repo: match[2] } : undefined;
+	if (match) {
+		return { owner: match[1], repo: match[2] };
+	}
+
+	// Fall back to resolving custom SSH `Host` aliases declared in
+	// `~/.ssh/config`. Remotes such as `git@my-alias:owner/repo.git` should
+	// be treated as GitHub remotes when `my-alias` resolves to `github.com`.
+	const sshAliasMatch = /^git@([^:/\s]+):([^/]+)\/([^/]+?)(\.git)?$/i.exec(url);
+	if (sshAliasMatch) {
+		const [, host, owner, repo] = sshAliasMatch;
+		const resolvedHost = sshResolver.resolveSync(host);
+		if (resolvedHost && resolvedHost.toLowerCase() === 'github.com') {
+			return { owner, repo };
+		}
+	}
+
+	return undefined;
 }
 
 export function getRepositoryFromQuery(query: string): { owner: string; repo: string } | undefined {


### PR DESCRIPTION
Fixes #283245

## Problem

When a user's `~/.ssh/config` defines a custom `Host` alias for github.com (e.g. `Host gh-personal` -> `HostName github.com`), their git remotes look like `git@gh-personal:owner/repo.git`. The GitHub extension's `getRepositoryFromUrl` only matched the literal `github.com`, so `repositoryHasGitHubRemote()` returned false and every GitHub feature (Open on GitHub, status-bar Copilot indexed badge, share providers, branch protection, hover commands, etc.) silently disabled for these users.

## Fix

1. **New `extensions/github/src/sshConfig.ts`**
   - `parseSshConfig(text)` - literal-alias parser; skips `*`/`?`/`!` patterns.
   - `SshConfigHostResolver` - lazily reads `~/.ssh/config` plus `/etc/ssh/ssh_config` on POSIX, caches the parsed map, exposes `resolveSync(alias)`.
   - Module-level `sharedSshConfigHostResolver` singleton.
2. **`util.ts`** - `getRepositoryFromUrl(url, sshResolver = sharedSshConfigHostResolver)` keeps its synchronous signature and gains a generic `git@<host>:<owner>/<repo>` fallback that returns `{ owner, repo }` only when `<host>` resolves to literal `github.com` via the resolver. The default-injected resolver keeps the function unit-testable.
3. **`extension.ts::activate`** - calls `sharedSshConfigHostResolver.load()` once on activation so the synchronous lookup has data.

## Scope

- Only aliases mapping to literal `github.com` are recognized - GitHub Enterprise hosts are intentionally not auto-recognized.
- Missing or unreadable `~/.ssh/config` fails silently, preserving current behavior for users without one.
- No new dependencies. Only the GitHub extension is touched.

## Tests

`extensions/github/src/test/sshConfig.test.ts` covers:
- `parseSshConfig`: simple blocks, multi-block, multi-alias `Host` lines, wildcard skip, case-insensitive `=` separators, comments, duplicate-alias precedence.
- `getRepositoryFromUrl` with an injected stub resolver: literal github.com, alias -> github.com, alias -> non-github host, unknown alias.