### PR TITLE
github: stably order repository quickpick results

### DIFF
--- a/extensions/github/src/remoteSourceProvider.ts
+++ b/extensions/github/src/remoteSourceProvider.ts
@@ -18,15 +18,82 @@ type RemoteSourceResponse = {
 	readonly ssh_url: string;
 };
 
-function asRemoteSource(raw: RemoteSourceResponse): RemoteSource {
+interface RankedRemoteSource extends RemoteSource {
+	readonly fullName: string;
+	readonly stars: number;
+}
+
+function asRemoteSource(raw: RemoteSourceResponse): RankedRemoteSource {
 	const protocol = workspace.getConfiguration('github').get<'https' | 'ssh'>('gitProtocol');
 	return {
 		name: `$(github) ${raw.full_name}`,
 		description: `${raw.stargazers_count > 0 ? `$(star-full) ${raw.stargazers_count}` : ''
 			}`,
 		detail: raw.description || undefined,
-		url: protocol === 'https' ? raw.clone_url : raw.ssh_url
+		url: protocol === 'https' ? raw.clone_url : raw.ssh_url,
+		fullName: raw.full_name,
+		stars: raw.stargazers_count
 	};
+}
+
+/**
+ * Computes a match tier for a repository's full name against the query.
+ * Lower numbers indicate a better match. The tiers are designed to provide a
+ * stable, deterministic ordering as the user types so that results do not
+ * visibly shuffle when async batches arrive (see #163603).
+ *
+ * Tiers:
+ *   0 - exact match on owner/repo or repo name (case-insensitive)
+ *   1 - repo name starts with the query
+ *   2 - full name (owner/repo) starts with the query
+ *   3 - repo name or full name contains the query
+ *   4 - no textual match
+ */
+export function getMatchTier(fullName: string, query: string | undefined): number {
+	if (!query) {
+		return 4;
+	}
+
+	const q = query.toLowerCase();
+	const full = fullName.toLowerCase();
+	const slash = full.indexOf('/');
+	const repo = slash >= 0 ? full.slice(slash + 1) : full;
+
+	if (repo === q || full === q) {
+		return 0;
+	}
+	if (repo.startsWith(q)) {
+		return 1;
+	}
+	if (full.startsWith(q)) {
+		return 2;
+	}
+	if (repo.includes(q) || full.includes(q)) {
+		return 3;
+	}
+	return 4;
+}
+
+/**
+ * Stably orders the merged set of remote sources so that the displayed list
+ * does not jump around as new async results arrive. The previous code relied
+ * on Map insertion order combined with the GitHub search API's relevance
+ * ranking, which changes per keystroke and surfaces forks above canonical
+ * repositories. This function applies a deterministic local ordering driven
+ * by the query rather than the API response order.
+ */
+export function sortRemoteSources<T extends RankedRemoteSource>(sources: T[], query: string | undefined): T[] {
+	return sources.slice().sort((a, b) => {
+		const tierA = getMatchTier(a.fullName, query);
+		const tierB = getMatchTier(b.fullName, query);
+		if (tierA !== tierB) {
+			return tierA - tierB;
+		}
+		if (a.stars !== b.stars) {
+			return b.stars - a.stars;
+		}
+		return a.fullName.localeCompare(b.fullName);
+	});
 }
 
 export class GithubRemoteSourceProvider implements RemoteSourceProvider {
@@ -35,7 +102,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 	readonly icon = 'github';
 	readonly supportsQuery = true;
 
-	private userReposCache: RemoteSource[] = [];
+	private userReposCache: RankedRemoteSource[] = [];
 
 	async getRemoteSources(query?: string): Promise<RemoteSource[]> {
 		const octokit = await getOctokit();
@@ -54,7 +121,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 			this.getUserRemoteSources(octokit, query),
 		]);
 
-		const map = new Map<string, RemoteSource>();
+		const map = new Map<string, RankedRemoteSource>();
 
 		for (const group of all) {
 			for (const remoteSource of group) {
@@ -62,10 +129,12 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 			}
 		}
 
-		return [...map.values()];
+		// Apply a deterministic local sort so that results do not visibly
+		// shuffle as async batches arrive while the user is typing (#163603).
+		return sortRemoteSources([...map.values()], query);
 	}
 
-	private async getUserRemoteSources(octokit: Octokit, query?: string): Promise<RemoteSource[]> {
+	private async getUserRemoteSources(octokit: Octokit, query?: string): Promise<RankedRemoteSource[]> {
 		if (!query) {
 			const user = await octokit.users.getAuthenticated({});
 			const username = user.data.login;
@@ -76,7 +145,7 @@ export class GithubRemoteSourceProvider implements RemoteSourceProvider {
 		return this.userReposCache;
 	}
 
-	private async getQueryRemoteSources(octokit: Octokit, query?: string): Promise<RemoteSource[]> {
+	private async getQueryRemoteSources(octokit: Octokit, query?: string): Promise<RankedRemoteSource[]> {
 		if (!query) {
 			return [];
 		}

--- a/extensions/github/src/test/github.test.ts
+++ b/extensions/github/src/test/github.test.ts
@@ -7,6 +7,7 @@ import 'mocha';
 import * as assert from 'assert';
 import { workspace, extensions, Uri, commands } from 'vscode';
 import { findPullRequestTemplates, pickPullRequestTemplate } from '../pushErrorHandler.js';
+import { getMatchTier, sortRemoteSources } from '../remoteSourceProvider.js';
 
 suite('github smoke test', function () {
 	const cwd = workspace.workspaceFolders![0].uri;
@@ -61,5 +62,93 @@ suite('github smoke test', function () {
 		await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
 
 		assert.ok(await pick === undefined);
+	});
+});
+
+suite('GitHub remote source ordering (#163603)', function () {
+	test('getMatchTier ranks exact match best, prefix next, substring after', () => {
+		assert.strictEqual(getMatchTier('microsoft/vscode-pull-request-github', 'vscode-pull-request-github'), 0);
+		assert.strictEqual(getMatchTier('microsoft/vscode-pull-request-github', 'vscode-pull'), 1);
+		assert.strictEqual(getMatchTier('microsoft/vscode-pull-request-github', 'microsoft/vscode'), 2);
+		assert.strictEqual(getMatchTier('someuser/awesome-vscode-pull-tool', 'vscode-pull'), 3);
+		assert.strictEqual(getMatchTier('microsoft/vscode-pull-request-github', 'completely-unrelated'), 4);
+		assert.strictEqual(getMatchTier('microsoft/vscode-pull-request-github', undefined), 4);
+	});
+
+	test('getMatchTier is case insensitive', () => {
+		assert.strictEqual(getMatchTier('Microsoft/VSCode-Pull-Request-GitHub', 'vscode-pull'), 1);
+		assert.strictEqual(getMatchTier('Microsoft/VSCode-Pull-Request-GitHub', 'VSCODE-PULL'), 1);
+	});
+
+	test('sortRemoteSources surfaces canonical repo over forks even when forks have higher API rank', () => {
+		// Simulates the bug: GitHub search API returns a fork before the canonical
+		// repo for query "vscode-pull". Without a stable local sort, the displayed
+		// list matches the API response order. With our sort, the canonical repo
+		// (whose name starts with the query) should appear first.
+		const fork = {
+			name: '$(github) someuser/my-vscode-pull-fork',
+			url: 'https://github.com/someuser/my-vscode-pull-fork.git',
+			fullName: 'someuser/my-vscode-pull-fork',
+			stars: 5
+		};
+		const canonical = {
+			name: '$(github) microsoft/vscode-pull-request-github',
+			url: 'https://github.com/microsoft/vscode-pull-request-github.git',
+			fullName: 'microsoft/vscode-pull-request-github',
+			stars: 2000
+		};
+		const unrelated = {
+			name: '$(github) other/totally-different',
+			url: 'https://github.com/other/totally-different.git',
+			fullName: 'other/totally-different',
+			stars: 50000
+		};
+
+		// API returned them in this (relevance) order; without our fix the user
+		// would see the fork first because it comes first in the merged map.
+		const sorted = sortRemoteSources([fork, canonical, unrelated], 'vscode-pull');
+		assert.deepStrictEqual(sorted.map(s => s.fullName), [
+			'microsoft/vscode-pull-request-github',
+			'someuser/my-vscode-pull-fork',
+			'other/totally-different'
+		]);
+	});
+
+	test('sortRemoteSources is deterministic across reorderings of the input', () => {
+		// Each keystroke produces a new merged array in a different order because
+		// the GitHub search API ranks results by fuzzy relevance. Our local sort
+		// must produce the same display order regardless of input order.
+		const a = { name: 'a', url: 'a', fullName: 'org/alpha', stars: 10 };
+		const b = { name: 'b', url: 'b', fullName: 'org/beta', stars: 100 };
+		const c = { name: 'c', url: 'c', fullName: 'org/gamma', stars: 1 };
+
+		const order1 = sortRemoteSources([a, b, c], 'org').map(s => s.fullName);
+		const order2 = sortRemoteSources([c, a, b], 'org').map(s => s.fullName);
+		const order3 = sortRemoteSources([b, c, a], 'org').map(s => s.fullName);
+
+		assert.deepStrictEqual(order1, order2);
+		assert.deepStrictEqual(order2, order3);
+	});
+
+	test('sortRemoteSources falls back to stars then name when match tier ties', () => {
+		const high = { name: 'h', url: 'h', fullName: 'org/zeta', stars: 100 };
+		const mid = { name: 'm', url: 'm', fullName: 'org/alpha', stars: 50 };
+		const low = { name: 'l', url: 'l', fullName: 'org/beta', stars: 50 };
+
+		const sorted = sortRemoteSources([mid, low, high], 'org');
+		assert.deepStrictEqual(sorted.map(s => s.fullName), [
+			'org/zeta',  // highest stars
+			'org/alpha', // tied stars, alphabetically first
+			'org/beta'   // tied stars, alphabetically second
+		]);
+	});
+
+	test('sortRemoteSources with no query orders by stars then name', () => {
+		const a = { name: 'a', url: 'a', fullName: 'org/a', stars: 5 };
+		const b = { name: 'b', url: 'b', fullName: 'org/b', stars: 100 };
+		const c = { name: 'c', url: 'c', fullName: 'org/c', stars: 100 };
+
+		const sorted = sortRemoteSources([a, b, c], undefined);
+		assert.deepStrictEqual(sorted.map(s => s.fullName), ['org/b', 'org/c', 'org/a']);
 	});
 });


### PR DESCRIPTION
Fixes #163603

## Problem

When typing in the **Clone from GitHub** / **Open Repository on GitHub** quickpick, the result list visibly re-orders on every keystroke. Forks displace canonical repos as the GitHub Search API's relevance ranking shifts per keystroke; merged with the user's repo cache via `Map` insertion order, the displayed list shuffles mid-type.

## Root cause

`GithubRemoteSourceProvider.getRemoteSources()` in `extensions/github/src/remoteSourceProvider.ts` merged search-API results with the user-repos cache into a `Map<string, RemoteSource>` keyed by display name and returned `[...map.values()]`. The throttled `query()` in `extensions/git-base/src/remoteSource.ts` reassigns `quickpick.items` wholesale on every batch, so the order changes are immediately visible to the user.

## Fix

Apply a deterministic local sort to the merged map values before returning, so display order converges on the same ordering for the same query regardless of API-relevance fluctuations.

- Internal `RankedRemoteSource` type extends the public `RemoteSource` with `fullName` and `stars` so a deterministic local sort can be applied without leaking into the public `git-base` API.
- Two exported pure helpers:
  - `getMatchTier(fullName, query)` — tier 0 exact > 1 repo-name prefix > 2 full-name prefix > 3 substring > 4 no match.
  - `sortRemoteSources(sources, query)` — sorts by tier, then `stars desc`, then `localeCompare(fullName)` for stable tiebreaks.
- `getRemoteSources` calls `sortRemoteSources` on the merged values before returning.

The GitHub search API still does the heavy textual search — this PR doesn't reimplement search. Display order is now driven by a query-deterministic local key rather than the API's per-request relevance score, which favors canonical repos with names that match the query over high-relevance forks (matching the user expectation in the issue).

## Scope

- `extensions/github/src/remoteSourceProvider.ts` — add helpers, wire them into `getRemoteSources`.
- No public API change. The `git-base` `RemoteSource` shape is untouched.

## Tests

6 new unit tests in `extensions/github/src/test/github.test.ts` under `GitHub remote source ordering (#163603)`:

- tier classification (exact / repo-name prefix / full-name prefix / substring / none)
- case-insensitive matching
- canonical-vs-fork scenario from the bug report
- determinism across reordered inputs
- stars and name tiebreakers
- empty-query path falls through to stars-then-name ordering

The helpers are pure, so the tests don't touch VS Code APIs.