### PR TITLE
Inline summarization: pass conversationId/turnId for prompt caching, disable WebSocket

### DIFF
--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -853,12 +853,16 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 						...summaryMsgResult.messages,
 					];
 
+					const turnId = promptContext.conversation?.getLatestTurn()?.id;
 					const response = await this.endpoint.makeChatRequest2({
 						debugName: 'summarizeConversationHistory-inline',
 						messages,
 						finishedCb: undefined,
 						location: ChatLocation.Agent,
 						conversationId,
+						turnId,
+						useWebSocket: false,
+						ignoreStatefulMarker: true,
 						requestOptions: {
 							temperature: 0,
 							stream: false,


### PR DESCRIPTION
The inline background summarization `makeChatRequest2` call was missing `turnId` and `conversationId`, preventing Responses API content-level prompt-prefix caching from working optimally for GPT-5.4 models.

Adds `turnId` and `conversationId` for routing/telemetry, but explicitly sets `useWebSocket: false` because the OpenAI WebSocket protocol only supports one in-flight response per connection — sending the summarization request on the same connection would supersede the main agent loop's active request.

`ignoreStatefulMarker: true` is set because the summarization payload is a full prompt (with an appended summary user message), not a continuation chained via `previous_response_id`.