### PR TITLE
notebook: don't reveal previous cursor when clicking into markdown preview

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -430,6 +430,14 @@ export class MarkupCell extends Disposable {
 				return;
 			}
 
+			// When the user clicks on the markdown preview to enter edit mode,
+			// don't reveal the previously saved cursor position - the click will
+			// place the caret at the new location and any reveal here causes a
+			// jarring scroll back to where the cursor used to be (issue #232077).
+			if (this.viewCell.editStateSource === 'setMarkdownCellEditState') {
+				return;
+			}
+
 			this.notebookEditor.revealRangeInViewAsync(this.viewCell, primarySelection);
 		}
 	}


### PR DESCRIPTION
Fixes #232077

## Problem

When clicking on a notebook markdown preview to enter edit mode, the editor scrolled back to the previously saved cursor position instead of staying at the click location. This was especially noticeable when the saved cursor was off-screen.

## Root Cause

The markdown preview click/dblclick handler posts `toggleMarkupPreview` to the notebook host, which calls `_setMarkupCellEditState` (with source `'setMarkdownCellEditState'`) and then `focusNotebookCell(cell, 'editor', { skipReveal: true })`. The `skipReveal: true` was designed to suppress the reveal — but `MarkupCell.focusEditorIfNeeded()` independently calls `revealRangeInViewAsync` on the editor's primary selection (the saved cursor) every time focus mode flips to Editor, defeating the `skipReveal`.

## Fix

In `focusEditorIfNeeded`, return early when `editStateSource === 'setMarkdownCellEditState'`. The natural selection-changed reveal in `bindEditorListeners` will still scroll to wherever the click ultimately lands the caret, so the click position is honored. Mirrors the existing `editStateSource` discrimination pattern already used by the find controller.

## Scope

Local to `MarkupCell.focusEditorIfNeeded` in `src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts`. Does not touch the shared `CodeEditorWidget` or any other cell type.

## Validation

- `npm run compile-check-ts-native` passes.
- No existing `MarkupCell` unit tests; constructing one requires a full `IActiveNotebookEditorDelegate` + DOM template + real `CodeEditorWidget` harness, which isn't currently in the repo.