### PR TITLE
chat: avoid raw-text flicker for streaming HTML in markdown

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -861,7 +861,50 @@ function completeSingleLinePattern(token: marked.Tokens.Text | marked.Tokens.Par
 		}
 	}
 
-	return undefined;
+	// Fallback: if the paragraph ends with a partial HTML tag (e.g. `<sup><span`
+	// while streaming HTML content), strip the partial tag so it isn't rendered
+	// as raw escaped text. Once the rest of the tag arrives in a later chunk it
+	// will be re-tokenized correctly. See issue #239765.
+	return completeUnclosedHtmlTag(token);
+}
+
+/**
+ * Detect whether `token`'s merged raw text ends inside an unclosed HTML tag
+ * such as `<sup` or `<span style="color:red"`. If so, return a re-lexed
+ * version with the partial tag trimmed off so it isn't rendered as raw
+ * escaped text during streaming.
+ *
+ * Only trims when the trailing `<` is followed by characters that look like
+ * the start of a tag (letter, `/`, `!`, or `?`) so that markdown using `<`
+ * as a literal character (e.g. `5 < 10`) is left alone.
+ */
+function completeUnclosedHtmlTag(token: marked.Tokens.Text | marked.Tokens.Paragraph): marked.Token | undefined {
+	const merged = mergeRawTokenText(token.tokens ?? []);
+
+	// Find the last `<`. If everything after it contains a `>`, the tag is
+	// already closed and there is nothing to do.
+	const lastOpen = merged.lastIndexOf('<');
+	if (lastOpen === -1) {
+		return undefined;
+	}
+	const trailing = merged.slice(lastOpen);
+	if (trailing.includes('>')) {
+		return undefined;
+	}
+
+	// Only treat this as a partial tag if it actually looks like one.
+	// Allowed shapes: `<x...`, `</x...`, `<!...`, `<?...`. Bare `<` followed
+	// by whitespace/EOL or other non-tag characters is left as literal text.
+	if (!/^<[/!?a-zA-Z]/.test(trailing)) {
+		return undefined;
+	}
+
+	const trimmed = merged.slice(0, lastOpen).trimEnd();
+	if (!trimmed) {
+		return undefined;
+	}
+
+	return marked.lexer(trimmed)[0];
 }
 
 function hasLinkTextAndStartOfLinkTarget(str: string): boolean {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -1085,5 +1085,70 @@ suite('MarkdownRenderer', () => {
 				assert.deepStrictEqual(newTokens, tokens);
 			});
 		});
+
+		// Regression tests for issue #239765 — when a chat participant streams
+		// markdown that contains HTML, partial tags from the in-flight chunk
+		// must not be rendered as raw escaped text.
+		suite('unclosed html tag', () => {
+			test('paragraph ending mid open tag is trimmed', () => {
+				const incomplete = '<sup><span';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const expected = marked.marked.lexer('<sup>');
+				assert.deepStrictEqual(newTokens, expected);
+			});
+
+			test('paragraph ending mid open tag with attribute is trimmed', () => {
+				const incomplete = '<sup><span style="color:red"';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const expected = marked.marked.lexer('<sup>');
+				assert.deepStrictEqual(newTokens, expected);
+			});
+
+			test('paragraph ending mid closing tag is trimmed', () => {
+				const incomplete = '<sup>hello</sp';
+				const tokens = marked.marked.lexer(incomplete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				const expected = marked.marked.lexer('<sup>hello');
+				assert.deepStrictEqual(newTokens, expected);
+			});
+
+			test('complete html is left alone', () => {
+				const complete = '<sup><span>hello</span></sup>';
+				const tokens = marked.marked.lexer(complete);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				assert.deepStrictEqual(newTokens, tokens);
+			});
+
+			test('literal less-than is not treated as a tag', () => {
+				const text = '5 < 10';
+				const tokens = marked.marked.lexer(text);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				assert.deepStrictEqual(newTokens, tokens);
+			});
+
+			test('trailing bare less-than without tag chars is not trimmed', () => {
+				const text = 'hello <';
+				const tokens = marked.marked.lexer(text);
+				const newTokens = fillInIncompleteTokens(tokens);
+
+				assert.deepStrictEqual(newTokens, tokens);
+			});
+
+			test('renderMarkdown does not show partial tag as escaped text', () => {
+				const mds = new MarkdownString('<sup><span', { supportHtml: true });
+				const result = store.add(renderMarkdown(mds, { fillInIncompleteTokens: true })).element;
+
+				// The dangling `<span` must not surface as escaped text.
+				assert.ok(!result.innerHTML.includes('&lt;span'),
+					`Expected no escaped <span in output, got: ${result.innerHTML}`);
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fixes #239765

## Problem
Chat participants streaming markdown that contains HTML (e.g. `<sup><span>...</span></sup>`) flicker through a raw-text rendering before the final formatted output appears.

## Root Cause
While streaming, `fillInIncompleteTokens` lexes a paragraph whose value has been sliced mid-tag by `getNWords` (e.g. text ending in `<sup><span`). Marked tokenizes that as `[html('<sup>'), text('<span')]`. The `<sup>` html token renders, but the dangling `<span` becomes a `text` token that reaches the DOM as escaped `&lt;span` — exactly the raw-text flash users see. Once the full content arrives in subsequent chunks, marked produces only valid html tokens and the flicker disappears.

## Fix
Added a fallback at the end of `completeSingleLinePattern` in `src/vs/base/browser/markdownRenderer.ts`. If the merged raw text ends inside an unclosed HTML tag (`<` followed by `[/!?a-zA-Z]` with no `>` after it), strip the partial tag and re-lex the rest. Once the next chunk arrives the tag is reconstructed and tokenized correctly.

The regex is conservative so bare literal `<` (e.g. `5 < 10`, `hello <`) is preserved. The branch only runs while `fillInIncompleteTokens` is true (streaming) — it does not affect already-rendered or completed responses. Sanitization downstream (dompurify allowlist) is unchanged.

## Scope
- `src/vs/base/browser/markdownRenderer.ts` — partial-tag fallback inside `completeSingleLinePattern`.
- Streaming-only path; no change to completed-response rendering or sanitization.

## Tests
New `unclosed html tag` regression suite in `src/vs/base/test/browser/markdownRenderer.test.ts` covering:
- the bug case (`<sup><span`)
- partial attribute (`<span style=\"`)
- partial closing tag
- literal `<` non-regressions (`5 < 10`, trailing `hello <`)
- complete-html no-op
- end-to-end `renderMarkdown` assertion that escaped `&lt;span` does not appear in the streamed DOM