### PR TITLE
chat: improve RTL handling in chat input and markdown content

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -137,6 +137,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		let globalCodeBlockIndexStart = codeBlockStartIndex;
 
 		this.domNode = $('div.chat-markdown-part');
+		this.domNode.dir = 'auto';
 
 		if (this.rendererOptions.accessibilityOptions?.statusMessage) {
 			this.domNode.ariaLabel = this.rendererOptions.accessibilityOptions.statusMessage;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2224,6 +2224,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const editorOptions = getSimpleCodeEditorWidgetOptions();
 		editorOptions.contributions?.push(...EditorExtensionsRegistry.getSomeEditorContributions([ContentHoverController.ID, GlyphHoverController.ID, DropIntoEditorController.ID, CopyPasteController.ID, LinkDetector.ID]));
 		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, this._inputEditorElement, options, editorOptions));
+		this._inputEditorElement.dir = 'auto';
 
 		SuggestController.get(this._inputEditor)?.forceRenderingAbove();
 		options.overflowWidgetsDomNode?.classList.add('hideSuggestTextIcons');

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -359,7 +359,7 @@
 }
 
 .interactive-item-container .value .rendered-markdown table {
-	text-align: left;
+	text-align: start;
 	border-radius: var(--vscode-cornerRadius-medium);
 	overflow: hidden;
 	border-collapse: separate;
@@ -534,6 +534,15 @@
 	line-height: 1.5em;
 	font-size: var(--vscode-chat-font-size-body-m);
 	font-family: var(--vscode-chat-font-family, inherit);
+	unicode-bidi: plaintext;
+	text-align: start;
+}
+
+.interactive-item-container .value .rendered-markdown pre,
+.interactive-item-container .value .rendered-markdown code,
+.interactive-item-container .value .rendered-markdown [data-code] {
+	direction: ltr;
+	unicode-bidi: isolate;
 }
 
 .interactive-item-container .value > .rendered-markdown p {


### PR DESCRIPTION
Fixes #273696

This change improves RTL handling in chat input and rendered markdown.
- Sets dir=auto on the chat input editor container.
- Sets dir=auto on chat markdown content parts.
- Uses unicode-bidi: plaintext and text-align: start for chat markdown.
- Forces code blocks to LTR with unicode-bidi: isolate to avoid regressions.