### PR TITLE
editor: preserve all multi-cursors through Copy Line Up/Down

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/copyLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/copyLinesCommand.ts
@@ -54,7 +54,30 @@ export class CopyLinesCommand implements ICommand {
 		}
 
 		if (this._noop) {
-			builder.addEditOperation(new Range(s.endLineNumber, model.getLineMaxColumn(s.endLineNumber), s.endLineNumber + 1, 1), s.endLineNumber === model.getLineCount() ? '' : '\n');
+			// Use a unique no-op edit range anchored at this cursor's column so
+			// multiple no-op commands produced for cursors on the same line do
+			// not collide in the cursor-conflict resolution (which would drop
+			// all but one of those cursors). See issue #309282. Each no-op
+			// replaces a single character on the source line with the same
+			// character — a true round-trip — but the range itself differs per
+			// cursor so the operations don't overlap.
+			const noopLine = s.endLineNumber;
+			const noopLineMaxColumn = model.getLineMaxColumn(noopLine);
+			let noopRange: Range;
+			if (noopLineMaxColumn > 1) {
+				// Clamp the cursor's column into the valid intra-line range so
+				// the round-trip range is always one character wide.
+				const cursorColumn = Math.min(Math.max(this._selection.endColumn, 1), noopLineMaxColumn);
+				const startColumn = cursorColumn < noopLineMaxColumn ? cursorColumn : noopLineMaxColumn - 1;
+				noopRange = new Range(noopLine, startColumn, noopLine, startColumn + 1);
+			} else {
+				// Empty source line — there is no character to round-trip on
+				// the line itself, so anchor the no-op across the trailing
+				// newline. Cursors on a fully empty line cannot be visually
+				// distinguished, so any residual collision is benign.
+				noopRange = new Range(noopLine, noopLineMaxColumn, noopLine === model.getLineCount() ? noopLine : noopLine + 1, 1);
+			}
+			builder.addEditOperation(noopRange, model.getValueInRange(noopRange));
 		} else {
 			if (!this._isCopyingDown) {
 				builder.addEditOperation(new Range(s.endLineNumber, model.getLineMaxColumn(s.endLineNumber), s.endLineNumber, model.getLineMaxColumn(s.endLineNumber)), '\n' + sourceText);

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -75,7 +75,7 @@ abstract class AbstractCopyLinesAction extends EditorAction {
 	}
 }
 
-class CopyLinesUpAction extends AbstractCopyLinesAction {
+export class CopyLinesUpAction extends AbstractCopyLinesAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.copyLinesUpAction',
@@ -98,7 +98,7 @@ class CopyLinesUpAction extends AbstractCopyLinesAction {
 	}
 }
 
-class CopyLinesDownAction extends AbstractCopyLinesAction {
+export class CopyLinesDownAction extends AbstractCopyLinesAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.copyLinesDownAction',

--- a/src/vs/editor/contrib/linesOperations/test/browser/copyLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/copyLinesCommand.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Selection } from '../../../../common/core/selection.js';
 import { CopyLinesCommand } from '../../browser/copyLinesCommand.js';
-import { DuplicateSelectionAction } from '../../browser/linesOperations.js';
+import { CopyLinesDownAction, CopyLinesUpAction, DuplicateSelectionAction } from '../../browser/linesOperations.js';
 import { withTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
 import { testCommand } from '../../../../test/browser/testCommand.js';
 
@@ -199,6 +199,83 @@ suite('Editor Contrib - Copy Lines Command', () => {
 			],
 			new Selection(2, 1, 1, 1)
 		);
+	});
+});
+
+suite('Editor Contrib - Copy Lines Actions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('issue #309282: copy line down preserves three multi-cursors on the same line', function () {
+		withTestCodeEditor(['foo bar baz'], {}, (editor) => {
+			editor.setSelections([
+				new Selection(1, 5, 1, 5),
+				new Selection(1, 9, 1, 9),
+				new Selection(1, 12, 1, 12),
+			]);
+			const action = new CopyLinesDownAction();
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getValue(), 'foo bar baz\nfoo bar baz');
+			assert.deepStrictEqual(editor.getSelections()!.map(s => s.toString()), [
+				new Selection(2, 5, 2, 5),
+				new Selection(2, 9, 2, 9),
+				new Selection(2, 12, 2, 12),
+			].map(s => s.toString()));
+		});
+	});
+
+	test('issue #309282: copy line up preserves three multi-cursors on the same line', function () {
+		withTestCodeEditor(['foo bar baz'], {}, (editor) => {
+			editor.setSelections([
+				new Selection(1, 5, 1, 5),
+				new Selection(1, 9, 1, 9),
+				new Selection(1, 12, 1, 12),
+			]);
+			const action = new CopyLinesUpAction();
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getValue(), 'foo bar baz\nfoo bar baz');
+			assert.deepStrictEqual(editor.getSelections()!.map(s => s.toString()), [
+				new Selection(1, 5, 1, 5),
+				new Selection(1, 9, 1, 9),
+				new Selection(1, 12, 1, 12),
+			].map(s => s.toString()));
+		});
+	});
+
+	test('issue #309282: copy line down preserves four multi-cursors on the same line', function () {
+		withTestCodeEditor(['foo bar baz qux'], {}, (editor) => {
+			editor.setSelections([
+				new Selection(1, 5, 1, 5),
+				new Selection(1, 9, 1, 9),
+				new Selection(1, 13, 1, 13),
+				new Selection(1, 16, 1, 16),
+			]);
+			const action = new CopyLinesDownAction();
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getValue(), 'foo bar baz qux\nfoo bar baz qux');
+			assert.deepStrictEqual(editor.getSelections()!.map(s => s.toString()), [
+				new Selection(2, 5, 2, 5),
+				new Selection(2, 9, 2, 9),
+				new Selection(2, 13, 2, 13),
+				new Selection(2, 16, 2, 16),
+			].map(s => s.toString()));
+		});
+	});
+
+	test('copy line down with two cursors on same line still works', function () {
+		withTestCodeEditor(['foo bar baz'], {}, (editor) => {
+			editor.setSelections([
+				new Selection(1, 5, 1, 5),
+				new Selection(1, 9, 1, 9),
+			]);
+			const action = new CopyLinesDownAction();
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getValue(), 'foo bar baz\nfoo bar baz');
+			assert.deepStrictEqual(editor.getSelections()!.map(s => s.toString()), [
+				new Selection(2, 5, 2, 5),
+				new Selection(2, 9, 2, 9),
+			].map(s => s.toString()));
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #309282

## Problem

With 3+ multi-cursors on the same line, **Copy Line Up** and **Copy Line Down** lost all but two cursors after the operation. Expected behavior: all N cursors should survive the copy.

## Root cause

`AbstractCopyLinesAction` correctly avoids duplicating the source line N times by marking N-1 of the per-cursor `CopyLinesCommand` instances as `_noop = true`. But every no-op emitted the *same* edit range:

```
(endLine, lineMaxColumn, endLine + 1, 1)  ->  '\n'
```

i.e. replacing the trailing newline with itself. With 3+ cursors on the same line, `CommandExecutor._getLoserCursorMap` (`src/vs/editor/common/cursor/cursor.ts`) sees the overlapping no-op edits and drops all but one of those cursors as "losers".

## Fix

Give each no-op command a unique, non-overlapping edit range anchored at its cursor's column on the source line. The new range is one character wide and replaces the character with itself:

```ts
builder.addEditOperation(noopRange, model.getValueInRange(noopRange));
```

A true round-trip: zero net text change, but a distinct range per cursor. All N cursors now survive cursor-conflict resolution.

Empty-source-line cursors (no character to round-trip) fall through to the original newline round-trip path; cursors on an empty line are visually indistinguishable, so the residual collision is benign.

Line-duplication count semantics are unchanged: still exactly one new copy of the line, regardless of cursor count.

## Scope

- `src/vs/editor/contrib/linesOperations/browser/copyLinesCommand.ts` — new no-op range strategy
- `src/vs/editor/contrib/linesOperations/browser/linesOperations.ts` — export the two action classes so tests can drive them end-to-end
- `src/vs/editor/contrib/linesOperations/test/browser/copyLinesCommand.test.ts` — regression tests

## Tests

4 new tests in `copyLinesCommand.test.ts`:

- 3-cursor Copy Line Down preserves all 3 cursors
- 3-cursor Copy Line Up preserves all 3 cursors
- 4-cursor Copy Line Down preserves all 4 cursors
- 2-cursor sanity baseline (regression guard for the previously-working case)

Tests drive the actions end-to-end via `withTestCodeEditor`.