### PR TITLE
Rebase attachment URIs onto worktree working directory

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -12,7 +12,7 @@ import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableResourceMap, DisposableStore, IReference, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { autorun, derived, IObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
-import { isEqual } from '../../../../../../base/common/resources.js';
+import { extUriBiasedIgnorePathCase, isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
 import { AgentProvider, AgentSession, IAgentAttachment, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -2261,9 +2261,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	/** Creates a new backend session and subscribes to its state. */
 	private async _createAndSubscribe(sessionResource: URI, model: ModelSelection | undefined, fork?: { session: URI; turnIndex: number; turnId: string }, sessionConfig?: Record<string, unknown>, branchNameHint?: string): Promise<URI> {
 		const config = branchNameHint ? { ...sessionConfig, [SessionConfigKey.BranchNameHint]: branchNameHint } : sessionConfig;
-		const workingDirectory = this._config.resolveWorkingDirectory?.(sessionResource)
-			?? this._workingDirectoryResolver.resolve(sessionResource)
-			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
+		const workingDirectory = this._resolveRequestedWorkingDirectory(sessionResource);
 
 		this._logService.trace(`[AgentHost] Creating new session, model=${model?.id ?? '(default)'}, provider=${this._config.provider}${fork ? `, fork from ${fork.session.toString()} at index ${fork.turnIndex}` : ''}`);
 
@@ -2421,23 +2419,32 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		return rawModelId.startsWith(prefix) ? rawModelId : `${prefix}${rawModelId}`;
 	}
 
+	private _resolveRequestedWorkingDirectory(sessionResource: URI): URI | undefined {
+		return this._config.resolveWorkingDirectory?.(sessionResource)
+			?? this._workingDirectoryResolver.resolve(sessionResource)
+			?? this._workspaceContextService.getWorkspace().folders[0]?.uri;
+	}
+
 	private _convertVariablesToAttachments(request: IChatAgentRequest): IAgentAttachment[] {
 		const attachments: IAgentAttachment[] = [];
 		for (const v of request.variables.variables) {
 			if (v.kind === 'file') {
 				const uri = v.value instanceof URI ? v.value : undefined;
 				if (uri?.scheme === 'file') {
-					attachments.push({ type: AttachmentType.File, path: uri.fsPath, displayName: v.name });
+					const rebased = this._rebaseAttachmentUri(uri, request.sessionResource);
+					attachments.push({ type: AttachmentType.File, path: rebased.fsPath, displayName: v.name });
 				}
 			} else if (v.kind === 'directory') {
 				const uri = v.value instanceof URI ? v.value : undefined;
 				if (uri?.scheme === 'file') {
-					attachments.push({ type: AttachmentType.Directory, path: uri.fsPath, displayName: v.name });
+					const rebased = this._rebaseAttachmentUri(uri, request.sessionResource);
+					attachments.push({ type: AttachmentType.Directory, path: rebased.fsPath, displayName: v.name });
 				}
 			} else if (v.kind === 'implicit' && v.isSelection) {
 				const uri = v.uri;
 				if (uri?.scheme === 'file') {
-					attachments.push({ type: AttachmentType.Selection, path: uri.fsPath, displayName: v.name });
+					const rebased = this._rebaseAttachmentUri(uri, request.sessionResource);
+					attachments.push({ type: AttachmentType.Selection, path: rebased.fsPath, displayName: v.name });
 				}
 			}
 		}
@@ -2445,6 +2452,42 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			this._logService.trace(`[AgentHost] Converted ${attachments.length} attachments from ${request.variables.variables.length} variables`);
 		}
 		return attachments;
+	}
+
+	/**
+	 * Rebase a `file:`-scheme attachment URI from the session's requested
+	 * working directory onto the server-resolved working directory. This
+	 * matters on the first turn of a worktree-isolated session, where the
+	 * provider creates a worktree under a different path than the workspace
+	 * folder the workbench attached the file from. Returns the URI unchanged
+	 * if the requested and resolved directories match, the URI is not under
+	 * the requested directory, or either side is unavailable.
+	 */
+	private _rebaseAttachmentUri(uri: URI, sessionResource: URI): URI {
+		const requestedDir = this._resolveRequestedWorkingDirectory(sessionResource);
+		if (!requestedDir || requestedDir.scheme !== 'file') {
+			return uri;
+		}
+		const backendSession = this._sessionToBackend.get(sessionResource);
+		const rawResolvedDir = backendSession ? this._getSessionState(backendSession.toString())?.summary.workingDirectory : undefined;
+		const resolvedDir = typeof rawResolvedDir === 'string' ? URI.parse(rawResolvedDir) : rawResolvedDir;
+		if (!resolvedDir || resolvedDir.scheme !== 'file') {
+			return uri;
+		}
+		if (extUriBiasedIgnorePathCase.isEqual(requestedDir, resolvedDir)) {
+			return uri;
+		}
+		if (!extUriBiasedIgnorePathCase.isEqualOrParent(uri, requestedDir)) {
+			return uri;
+		}
+		const rel = extUriBiasedIgnorePathCase.relativePath(requestedDir, uri);
+		if (rel === undefined) {
+			return uri;
+		}
+		if (rel === '') {
+			return resolvedDir;
+		}
+		return URI.joinPath(resolvedDir, ...rel.split('/'));
 	}
 
 	// ---- Lifecycle ----------------------------------------------------------

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -79,6 +79,15 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	public disposedSessions: URI[] = [];
 	public agents = [{ provider: 'copilot' as const, displayName: 'Agent Host - Copilot', description: 'test', requiresAuth: true }];
 
+	/**
+	 * If set, the next {@link createSession} call seeds the session summary's
+	 * `workingDirectory` to this URI instead of echoing back
+	 * `config.workingDirectory`. Used to simulate the server resolving the
+	 * working directory to a worktree path that differs from the requested
+	 * directory.
+	 */
+	public nextResolvedWorkingDirectory?: URI;
+
 	override async listSessions(): Promise<IAgentSessionMetadata[]> {
 		return [...this._sessions.values()];
 	}
@@ -100,6 +109,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 				status: SessionStatus.Idle,
 				createdAt: Date.now(),
 				modifiedAt: Date.now(),
+				workingDirectory: (this.nextResolvedWorkingDirectory ?? config.workingDirectory)?.toString(),
 			};
 			const state: SessionState = {
 				...createSessionState(summary),
@@ -108,6 +118,7 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 			};
 			this.sessionStates.set(session.toString(), state);
 		}
+		this.nextResolvedWorkingDirectory = undefined;
 		return session;
 	}
 
@@ -384,8 +395,8 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	return { instantiationService, agentHostService, chatAgentService };
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService> }) {
-	const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables, undefined, opts?.authServiceOverride);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined } }) {
+	const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride);
 
 	const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -1753,6 +1764,94 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(agentHostService.turnActions.length, 1);
 			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
 			assert.strictEqual(turnAction.userMessage.attachments, undefined);
+		}));
+
+		// ---- Working-directory rebasing -----------------------------------
+		// On the first turn of a worktree-isolated session, the workbench
+		// resolves attachments under the original workspace folder, but the
+		// agent server has resolved its working directory to a freshly
+		// created worktree path. The handler rebases attachment paths so the
+		// agent receives URIs under its own working directory.
+
+		test('rebases file/directory/selection attachments under requested working dir onto resolved working dir', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const requestedDir = URI.file('/source');
+			const resolvedDir = URI.file('/worktree');
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				workingDirectoryResolver: { resolve: () => requestedDir },
+			});
+			agentHostService.nextResolvedWorkingDirectory = resolvedDir;
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'rebase me',
+				variables: {
+					variables: [
+						upcastPartial({ kind: 'file', id: 'v-file', name: 'a.ts', value: URI.file('/source/a.ts') }),
+						upcastPartial({ kind: 'directory', id: 'v-dir', name: 'lib', value: URI.file('/source/lib') }),
+						upcastPartial({ kind: 'implicit', id: 'v-implicit', name: 'selection', isFile: true as const, isSelection: true, uri: URI.file('/source/sub/foo.ts'), enabled: true, value: undefined }),
+					],
+				},
+			});
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.deepStrictEqual(turnAction.userMessage.attachments, [
+				{ type: 'file', path: URI.file('/worktree/a.ts').fsPath, displayName: 'a.ts' },
+				{ type: 'directory', path: URI.file('/worktree/lib').fsPath, displayName: 'lib' },
+				{ type: 'selection', path: URI.file('/worktree/sub/foo.ts').fsPath, displayName: 'selection' },
+			]);
+		}));
+
+		test('does not rebase when requested and resolved working dirs match', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const dir = URI.file('/source');
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				workingDirectoryResolver: { resolve: () => dir },
+			});
+			agentHostService.nextResolvedWorkingDirectory = dir;
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'no rebase',
+				variables: {
+					variables: [
+						upcastPartial({ kind: 'file', id: 'v-file', name: 'a.ts', value: URI.file('/source/a.ts') }),
+					],
+				},
+			});
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.deepStrictEqual(turnAction.userMessage.attachments, [
+				{ type: 'file', path: URI.file('/source/a.ts').fsPath, displayName: 'a.ts' },
+			]);
+		}));
+
+		test('attachments outside the requested working dir pass through unchanged', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const requestedDir = URI.file('/source');
+			const resolvedDir = URI.file('/worktree');
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables, {
+				workingDirectoryResolver: { resolve: () => requestedDir },
+			});
+			agentHostService.nextResolvedWorkingDirectory = resolvedDir;
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
+				message: 'outside',
+				variables: {
+					variables: [
+						upcastPartial({ kind: 'file', id: 'v-file', name: 'elsewhere.ts', value: URI.file('/elsewhere/elsewhere.ts') }),
+					],
+				},
+			});
+			fire({ type: 'session/turnComplete', session, turnId } as SessionAction);
+			await turnPromise;
+
+			assert.strictEqual(agentHostService.turnActions.length, 1);
+			const turnAction = agentHostService.turnActions[0].action as ITurnStartedAction;
+			assert.deepStrictEqual(turnAction.userMessage.attachments, [
+				{ type: 'file', path: URI.file('/elsewhere/elsewhere.ts').fsPath, displayName: 'elsewhere.ts' },
+			]);
 		}));
 	});
 


### PR DESCRIPTION
## Problem

When starting a new agent session that resolves to a git worktree (i.e. the server creates a worktree and sets `SessionSummary.workingDirectory` to a path different from the one requested), file/directory/selection attachments submitted on the first turn still reference paths under the original source directory. This causes the agent to look for files in the wrong location.

## Fix

Modified `_convertVariablesToAttachments` in `AgentHostSessionHandler` to rebase each attachment URI from the *requested* working directory onto the *server-resolved* working directory before converting to a filesystem path.

The rebase logic (`_rebaseAttachmentUri`):
- Reads the resolved working directory from `SessionSummary.workingDirectory` (already set by the time the first turn is processed, populated during `_createAndSubscribe`)
- Reads the requested working directory via the existing `_resolveRequestedWorkingDirectory` helper
- Is a no-op when the two directories are the same, when the attachment lies outside the requested directory, or when either directory is not a `file://` URI

## Tests

Added 3 new tests to `agentHostChatContribution.test.ts` in the `attachment context` suite:
- Rebases file/directory/selection attachments under the requested working dir onto the resolved working dir
- Does not rebase when requested and resolved working dirs match
- Attachments outside the requested working dir pass through unchanged

(Written by Copilot)