### PR TITLE
Fix parentTerminal lookup after terminal already opened (#205254)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -192,7 +192,10 @@ export class MainThreadTerminalService extends Disposable implements MainThreadT
 
 	private async _deserializeParentTerminal(location?: TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: ExtHostTerminalIdentifier } | { splitActiveTerminal: boolean; location?: TerminalLocation }): Promise<TerminalLocation | TerminalEditorLocationOptions | { parentTerminal: ITerminalInstance } | { splitActiveTerminal: boolean } | undefined> {
 		if (typeof location === 'object' && hasKey(location, { parentTerminal: true })) {
-			const parentTerminal = await this._extHostTerminals.get(location.parentTerminal.toString());
+			// The identifier may be a UUID string (terminal not yet opened) or a numeric
+			// instance id (terminal already opened, see $acceptTerminalOpened reassigning
+			// `_id`). Delegate to _getTerminalInstance which handles both cases. See #205254.
+			const parentTerminal = await this._getTerminalInstance(location.parentTerminal);
 			return parentTerminal ? { parentTerminal } : undefined;
 		}
 		return location;


### PR DESCRIPTION
## Summary
Fixes #205254. `parentTerminal` location option fails when the parent terminal was already opened.

## Root cause
`ExtHostTerminal._id` starts as a UUID string and is reassigned to a numeric instance id by `$acceptTerminalOpened` (`extHostTerminalService.ts:628`). When an extension splits from an already-open parent, `_serializeParentTerminal` sends that numeric id over IPC, but the main thread's `_deserializeParentTerminal` only looked it up against the UUID-keyed `_extHostTerminals` map. `.toString()` of a number never matches a UUID, so the parent silently became `undefined` and the new terminal opened in the panel root. This also explains the "with async delay it fails" observation in the issue thread — the delay is what lets `$acceptTerminalOpened` complete before the split call.

This matches @erikmueller's diagnosis on the issue.

## Fix
4-line change in `_deserializeParentTerminal` (`src/vs/workbench/api/browser/mainThreadTerminalService.ts`): delegate to the existing `_getTerminalInstance(id)` helper, which already handles both UUID-string and numeric-instance-id forms (`$show`, `$hide`, `$dispose` etc. already use it).

## Test plan
- `tsgo --project src/tsconfig.json --noEmit --skipLibCheck` clean.
- The fix reuses an existing well-exercised helper. No new unit-test scaffolding (constructing the service in unit-isolation requires extensive DI setup).
