### PR TITLE
Fix terminal completion notification leak

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2149,13 +2149,18 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// The monitor wakes only on new terminal data (not on a fixed interval), so
 		// resource cost is proportional to actual terminal activity.
 		const store = new DisposableStore();
+		store.add(sessionRef);
+		let didHandleCompletion = false;
 
 		// Track whether the user has started replying to terminal prompts directly.
 		// Once set, all future input-needed notifications are suppressed so the agent
 		// stops asking questions and lets the user finish interacting with the terminal.
 		let userIsReplyingDirectly = false;
 
-		const disposeNotification = () => this._backgroundNotifications.deleteAndDispose(notificationKey);
+		const disposeNotification = () => {
+			this._backgroundNotifications.deleteAndDispose(notificationKey);
+			store.dispose();
+		};
 
 		// If the user manually stopped the agent, suppress background
 		// steering requests and tear down the notification listeners.
@@ -2249,9 +2254,12 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._dismissPendingCarouselsForTerminal(chatSessionResource, termId);
 		}));
 
-		store.add(sessionRef);
+		const sendCompletionNotification = (exitCode: number | undefined): void => {
+			if (store.isDisposed || didHandleCompletion) {
+				return;
+			}
+			didHandleCompletion = true;
 
-		store.add(commandDetection.onCommandFinished(command => {
 			const execution = RunInTerminalTool._activeExecutions.get(termId);
 			if (!execution) {
 				disposeNotification();
@@ -2266,7 +2274,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			// if the user runs additional commands via send_to_terminal.
 			disposeNotification();
 
-			const exitCode = command.exitCode;
 			const exitCodeText = exitCode !== undefined ? ` with exit code ${exitCode}` : '';
 			const currentOutput = execution.getOutput();
 			const message = `[Terminal ${termId} notification: command completed${exitCodeText}. Use send_to_terminal to send another command or kill_terminal to stop it.]\nTerminal output:\n${currentOutput}`;
@@ -2282,7 +2289,16 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}).catch(e => {
 				this._logService.warn(`RunInTerminalTool: Failed to send completion notification for terminal ${termId}`, e);
 			});
-		}));
+		};
+
+		store.add(commandDetection.onCommandFinished(command => sendCompletionNotification(command.exitCode)));
+
+		const execution = RunInTerminalTool._activeExecutions.get(termId);
+		execution?.completionPromise.then(result => {
+			sendCompletionNotification(result.exitCode);
+		}, () => {
+			disposeNotification();
+		});
 
 		// Clean up all background resources when the terminal is disposed
 		// (e.g. user closes the terminal) to avoid leaking listeners and monitors.
@@ -2303,7 +2319,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}));
 
-		this._backgroundNotifications.set(notificationKey, store);
+		if (!store.isDisposed) {
+			this._backgroundNotifications.set(notificationKey, store);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -71,6 +71,12 @@ class TestRunInTerminalTool extends RunInTerminalTool {
 
 type ITestRunInTerminalToolInvocationData = IChatTerminalToolInvocationData & { requiresConfirmationForRetry?: boolean };
 
+interface ITestActiveExecution {
+	readonly completionPromise: Promise<{ readonly exitCode?: number }>;
+	getOutput(): string;
+	dispose(): void;
+}
+
 suite('RunInTerminalTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -83,6 +89,8 @@ suite('RunInTerminalTool', () => {
 	let chatServiceDisposeEmitter: Emitter<{ sessionResources: URI[]; reason: 'cleared' }>;
 	let chatSessionArchivedEmitter: Emitter<IAgentSession>;
 	let capturedSteeringRequests: { sessionResource: URI; message: string }[];
+	let acquiredSessionReferenceCount: number;
+	let disposedSessionReferenceCount: number;
 	let sandboxEnabled: boolean;
 	let sandboxPrereqResult: ITerminalSandboxPrerequisiteCheckResult;
 	let terminalSandboxService: ITerminalSandboxService;
@@ -136,6 +144,8 @@ suite('RunInTerminalTool', () => {
 		chatServiceDisposeEmitter = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 		chatSessionArchivedEmitter = new Emitter<IAgentSession>();
 		capturedSteeringRequests = [];
+		acquiredSessionReferenceCount = 0;
+		disposedSessionReferenceCount = 0;
 
 		instantiationService = workbenchInstantiationService({
 			configurationService: () => configurationService,
@@ -149,14 +159,23 @@ suite('RunInTerminalTool', () => {
 				capturedSteeringRequests.push({ sessionResource, message });
 				return { kind: 'rejected', reason: 'test' };
 			},
-			acquireExistingSession: () => ({
-				object: {
-					lastRequest: undefined,
-					lastRequestObs: constObservable(undefined),
-					onDidChange: Event.None,
-				},
-				dispose: () => { },
-			}) as unknown as NonNullable<ReturnType<IChatService['acquireExistingSession']>>,
+			acquireExistingSession: () => {
+				acquiredSessionReferenceCount++;
+				let isDisposed = false;
+				return {
+					object: {
+						lastRequest: undefined,
+						lastRequestObs: constObservable(undefined),
+						onDidChange: Event.None,
+					},
+					dispose: () => {
+						if (!isDisposed) {
+							isDisposed = true;
+							disposedSessionReferenceCount++;
+						}
+					},
+				} as unknown as NonNullable<ReturnType<IChatService['acquireExistingSession']>>;
+			},
 		} as unknown as IChatService;
 		instantiationService.stub(IChatService, chatServiceStub);
 		instantiationService.stub(IAgentSessionsService, {
@@ -286,6 +305,20 @@ suite('RunInTerminalTool', () => {
 
 	function getAutomaticUnsandboxRetryTitle(tool: RunInTerminalTool, shellType: string, blockedDomains: string[] | undefined): IMarkdownString {
 		return (tool as unknown as Record<string, (shellType: string, blockedDomains: string[] | undefined) => IMarkdownString>)['_getAutomaticUnsandboxRetryTitle'](shellType, blockedDomains);
+	}
+
+	function setActiveExecution(termId: string, execution: ITestActiveExecution): void {
+		const activeExecutions = (runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, ITestActiveExecution> })._activeExecutions;
+		activeExecutions.set(termId, execution);
+		store.add(toDisposable(() => activeExecutions.delete(termId)));
+	}
+
+	function createPendingActiveExecution(getOutput: () => string): ITestActiveExecution {
+		return {
+			completionPromise: new Promise(() => { }),
+			getOutput,
+			dispose: () => { },
+		};
 	}
 
 	suite('sandbox invocation messaging', () => {
@@ -1965,9 +1998,7 @@ suite('RunInTerminalTool', () => {
 			dispose: () => { },
 		} as unknown as { onDidDetectInputNeeded: Event<void>; continueMonitoringAsync: () => void; dispose: () => void };
 
-		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string }> })._activeExecutions.set(termId, {
-			getOutput: () => output,
-		});
+		setActiveExecution(termId, createPendingActiveExecution(() => output));
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: { onDidDetectInputNeeded: Event<void>; continueMonitoringAsync: () => void; dispose: () => void }) => void })
@@ -2012,9 +2043,7 @@ suite('RunInTerminalTool', () => {
 			isBackground: false,
 		});
 
-		(runInTerminalTool.constructor as unknown as { _activeExecutions: Map<string, { getOutput(): string }> })._activeExecutions.set(termId, {
-			getOutput: () => 'Password:',
-		});
+		setActiveExecution(termId, createPendingActiveExecution(() => 'Password:'));
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string, outputMonitor: { onDidDetectInputNeeded: Event<void>; continueMonitoringAsync: () => void; dispose: () => void }) => void })
@@ -2032,6 +2061,45 @@ suite('RunInTerminalTool', () => {
 		commandFinishedEmitter.fire({ exitCode: 0 });
 		ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Session terminal association should still be preserved after command finishes');
 		strictEqual(runInTerminalTool.sessionTerminalAssociations.get(sessionResource)!.isBackground, false, 'Terminal should still be foreground after command finishes');
+	});
+
+	test('should release completion notification session ref when execution completed before listener observes finish', async () => {
+		const termId = 'test-completed-before-notification-term';
+		const sessionResource = LocalChatSessionUri.forSession('test-completed-before-notification-session');
+
+		const commandFinishedEmitter = new Emitter<{ exitCode: number | undefined }>();
+		const terminalDisposedEmitter = new Emitter<void>();
+		const inputDataEmitter = new Emitter<string>();
+
+		const terminalInstance = {
+			capabilities: {
+				get: (cap: TerminalCapability) => cap === TerminalCapability.CommandDetection ? { onCommandFinished: commandFinishedEmitter.event } : undefined,
+			},
+			onDisposed: terminalDisposedEmitter.event,
+			onDidInputData: inputDataEmitter.event,
+		} as unknown as ITerminalInstance;
+
+		setActiveExecution(termId, {
+			completionPromise: Promise.resolve({ exitCode: 0 }),
+			getOutput: () => 'done',
+			dispose: () => { },
+		});
+
+		const acquiredBefore = acquiredSessionReferenceCount;
+		const disposedBefore = disposedSessionReferenceCount;
+
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		(runInTerminalTool as unknown as { _registerCompletionNotification: (terminal: ITerminalInstance, termId: string, session: URI, commandName: string) => void })
+			._registerCompletionNotification(terminalInstance, termId, sessionResource, 'echo done');
+
+		strictEqual(acquiredSessionReferenceCount, acquiredBefore + 1, 'Expected completion notification to acquire a session reference');
+		strictEqual(disposedSessionReferenceCount, disposedBefore, 'Reference should stay alive until completion cleanup runs');
+
+		await Promise.resolve();
+
+		strictEqual(disposedSessionReferenceCount, disposedBefore + 1, 'Expected completion promise cleanup to release the session reference');
+		strictEqual(capturedSteeringRequests.length, 1, 'Expected completion promise cleanup to send the missed completion notification');
+		ok(capturedSteeringRequests[0].message.includes('command completed with exit code 0'), 'Expected completion notification to include the exit code');
 	});
 
 	suite('auto approve warning acceptance mechanism', () => {


### PR DESCRIPTION
This fixes a chat model reference leak in the terminal tool background completion notification path.

The leak happens when `_registerCompletionNotification` acquires a chat session reference to keep the model alive until a background terminal command completes, but the command has already completed before the `onCommandFinished` listener is registered. Since `onCommandFinished` is not replayed, no later event releases the notification store, leaving the `RunInTerminalTool#completionNotification` reference visible in chat model reference inspection even though there is no outstanding background terminal task.

The fix wires completion cleanup to the active execution's `completionPromise` as well as command detection. Completion handling is guarded so only one completion notification is sent, while disposal can run freely from any lifecycle path.

Tests add a regression case where the execution completion promise has already resolved and no command-finished event is fired, verifying that the session reference is released and the completion steering notification is still sent.

Validation:
- `runInTerminalTool.test.ts`: 93 passed, 0 failed
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts`

(Written by Copilot)