### PR TITLE
Cache listSessions result in AgentHostSessionListController

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -55,6 +55,8 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 	private readonly _agentRegistrations = this._register(new DisposableMap<AgentProvider, DisposableStore>());
 	/** Model providers keyed by agent provider, for pushing model updates. */
 	private readonly _modelProviders = new Map<AgentProvider, AgentHostLanguageModelProvider>();
+	/** List controllers keyed by agent provider, for cache resets on reconnect. */
+	private readonly _listControllers = new Map<AgentProvider, AgentHostSessionListController>();
 
 	/** Dedupes redundant `authenticate` RPCs when the resolved token hasn't changed. */
 	private readonly _authTokenCache = new AgentHostAuthTokenCache();
@@ -100,8 +102,13 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 		// Clear the auth cache whenever the local agent host (re)starts so the
 		// first post-restart authenticate RPC is never skipped as "unchanged".
+		// Also reset each list controller's session cache so the next refresh
+		// re-fetches via listSessions() rather than serving a stale in-memory list.
 		this._register(this._agentHostService.onAgentHostStart(() => {
 			this._authTokenCache.clear();
+			for (const controller of this._listControllers.values()) {
+				controller.resetCache();
+			}
 		}));
 
 		// Process initial root state if already available
@@ -164,6 +171,8 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 
 		// Session list controller
 		const listController = store.add(this._instantiationService.createInstance(AgentHostSessionListController, sessionType, agent.provider, this._loggedConnection!, undefined, 'local'));
+		this._listControllers.set(agent.provider, listController);
+		store.add({ dispose: () => this._listControllers.delete(agent.provider) });
 		store.add(this._chatSessionsService.registerChatSessionItemController(sessionType, listController));
 
 		// Customization sync provider + bundler + observable

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -143,6 +143,11 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		}));
 	}
 
+	/** Reset the list-sessions cache so the next {@link refresh} re-fetches from the agent host. */
+	resetCache(): void {
+		this._cacheValid = false;
+	}
+
 	get items(): readonly IChatSessionItem[] {
 		return this._items;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -76,6 +76,17 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 	private _items: IChatSessionItem[] = [];
 	/** Cached full summaries per session so partial updates can be applied. */
 	private readonly _cachedSummaries = new Map<string, SessionSummary>();
+	/**
+	 * Once `listSessions()` has succeeded, the in-memory list is kept in
+	 * sync by `notify/sessionAdded`, `notify/sessionRemoved`, and
+	 * `notify/sessionSummaryChanged`. Subsequent `refresh()` calls then
+	 * just re-emit the cached items instead of re-issuing the RPC.
+	 *
+	 * Lifetime: the controller is created per agent registration and
+	 * disposed when the registration is torn down (e.g. on connection
+	 * replacement), so this flag naturally resets on reconnect.
+	 */
+	private _cacheValid = false;
 
 	constructor(
 		private readonly _sessionType: string,
@@ -137,6 +148,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 	}
 
 	async refresh(_token: CancellationToken): Promise<void> {
+		if (this._cacheValid) {
+			// Cache is kept in sync by notify/sessionAdded,
+			// notify/sessionRemoved, and notify/sessionSummaryChanged. No
+			// need to round-trip through the agent host on every refresh.
+			this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
+			return;
+		}
 		try {
 			const sessions = await this._connection.listSessions();
 			const filtered = sessions.filter(s => AgentSession.provider(s.session) === this._provider);
@@ -168,6 +186,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 					diffs: s.diffs,
 				});
 			});
+			this._cacheValid = true;
 		} catch {
 			this._cachedSummaries.clear();
 			this._items = [];

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -667,6 +667,52 @@ suite('AgentHostChatContribution', () => {
 			assert.strictEqual(listController.items.length, 1);
 			assert.strictEqual(listController.items[0].archived, true);
 		});
+
+		test('refresh skips listSessions RPC after first successful call', async () => {
+			const { listController, agentHostService } = createContribution(disposables);
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'aaa'), startTime: 1000, modifiedTime: 2000, summary: 'My session' });
+
+			let listCalls = 0;
+			const originalListSessions = agentHostService.listSessions.bind(agentHostService);
+			agentHostService.listSessions = async () => { listCalls++; return originalListSessions(); };
+
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 1);
+			assert.strictEqual(listController.items.length, 1);
+
+			// Subsequent refresh should not re-fetch — the cache is kept in
+			// sync via notify/sessionAdded etc.
+			await listController.refresh(CancellationToken.None);
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 1);
+			assert.strictEqual(listController.items.length, 1);
+		});
+
+		test('refresh retries listSessions if the first call failed', async () => {
+			const { listController, agentHostService } = createContribution(disposables);
+
+			let listCalls = 0;
+			const originalListSessions = agentHostService.listSessions.bind(agentHostService);
+			agentHostService.listSessions = async () => {
+				listCalls++;
+				if (listCalls === 1) {
+					throw new Error('fail');
+				}
+				return originalListSessions();
+			};
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'aaa'), startTime: 1000, modifiedTime: 2000, summary: 'My session' });
+
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 1);
+			assert.strictEqual(listController.items.length, 0);
+
+			// Failure must not mark the cache valid; the next refresh retries.
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 2);
+			assert.strictEqual(listController.items.length, 1);
+		});
 	});
 
 	// ---- Session ID resolution in _invokeAgent --------------------------

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -62,7 +62,12 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	private readonly _onDidNotification = new Emitter<INotification>();
 	override readonly onDidNotification = this._onDidNotification.event;
 	override readonly onAgentHostExit = Event.None;
-	override readonly onAgentHostStart = Event.None;
+	private readonly _onAgentHostStart = new Emitter<void>();
+	override readonly onAgentHostStart = this._onAgentHostStart.event;
+
+	fireAgentHostStart(): void {
+		this._onAgentHostStart.fire();
+	}
 
 	private readonly _authenticationPending: ISettableObservable<boolean> = observableValue('authenticationPending', false);
 	override readonly authenticationPending: IObservable<boolean> = this._authenticationPending;
@@ -712,6 +717,30 @@ suite('AgentHostChatContribution', () => {
 			await listController.refresh(CancellationToken.None);
 			assert.strictEqual(listCalls, 2);
 			assert.strictEqual(listController.items.length, 1);
+		});
+
+		test('agent host restart invalidates cache so next refresh re-fetches', async () => {
+			const { listController, agentHostService } = createContribution(disposables);
+
+			agentHostService.addSession({ session: AgentSession.uri('copilot', 'aaa'), startTime: 1000, modifiedTime: 2000, summary: 'Before restart' });
+
+			let listCalls = 0;
+			const originalListSessions = agentHostService.listSessions.bind(agentHostService);
+			agentHostService.listSessions = async () => { listCalls++; return originalListSessions(); };
+
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 1);
+
+			// Subsequent refresh uses cache — no new RPC.
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 1);
+
+			// Directly resetting the cache (as onAgentHostStart does) must cause
+			// the next refresh to re-fetch.
+			listController.resetCache();
+
+			await listController.refresh(CancellationToken.None);
+			assert.strictEqual(listCalls, 2);
 		});
 	});
 


### PR DESCRIPTION
The workbench-side `AgentHostSessionListController` previously called `connection.listSessions()` on every `refresh()`, even though it already maintains an in-memory cache that's kept in sync via `notify/sessionAdded`, `notify/sessionRemoved`, and `notify/sessionSummaryChanged`. `refresh()` is fired on workspace folder change, trust change, availability change, items-provider change, and explicit user refreshes — i.e. far more often than the underlying session list actually changes.

This change adds a `_cacheValid` flag, set on the first successful `listSessions()`. After that, `refresh()` skips the RPC and just re-emits the cached items. Failures leave the cache invalid so the next `refresh()` retries.

Cache lifetime is tied to the controller instance, which is created per agent registration and disposed when the registration store tears down (e.g. on connection replacement), so reconnect implicitly drops the cache. This matches the AHP rule that notifications are not replayed on reconnect, and brings the workbench controller in line with the analogous one-shot caching that `BaseAgentHostSessionsProvider` already does on the sessions-app side.

Two new unit tests cover the cache hit and the failure-retry path.

(Written by Copilot)