### PR TITLE
Add cache-stable mode for vscode_renameSymbol and vscode_listCodeUsages (experimental)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -386,6 +386,15 @@ configurationRegistry.registerConfiguration({
 			default: 'word',
 			tags: ['experimental'],
 		},
+		[ChatConfiguration.SymbolToolsCacheStable]: {
+			type: 'boolean',
+			description: nls.localize('chat.experimental.symbolTools.cacheStable', "When enabled, the rename and list-code-usages tools are always registered with a static description (no per-language list). Stabilizes the tools-array bytes across requests so prompt caches survive language-extension activations mid-turn. Tool behavior is unchanged: unsupported languages still produce an error at invocation time."),
+			default: false,
+			tags: ['experimental'],
+			experiment: {
+				mode: 'startup'
+			}
+		},
 		'chat.detectParticipant.enabled': {
 			type: 'boolean',
 			description: nls.localize('chat.detectParticipant.enabled', "Enables chat participant autodetection for panel chat."),

--- a/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/renameTool.ts
@@ -18,11 +18,13 @@ import { ITextModelService } from '../../../../../editor/common/services/resolve
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { rename } from '../../../../../editor/contrib/rename/browser/rename.js';
 import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { IChatService } from '../../common/chatService/chatService.js';
+import { ChatConfiguration } from '../../common/constants.js';
 import { ChatModel } from '../../common/model/chatModel.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
@@ -47,6 +49,17 @@ IMPORTANT: The file and line do NOT need to be the definition of the symbol. Any
 
 If the tool returns an error, retry with corrected input - ensure the file path is correct, the line content matches the actual file content, and the symbol name appears in that line.`;
 
+/**
+ * Static description used when the {@link ChatConfiguration.SymbolToolsCacheStable}
+ * experiment is enabled. Identical to {@link BaseModelDescription} plus a single
+ * sentence describing the unsupported-language behavior. Crucially, this string
+ * does NOT depend on the set of registered rename providers, so it stays
+ * byte-stable across requests as language extensions activate during a turn.
+ */
+const StaticModelDescription = BaseModelDescription + `
+
+If the file's language has no rename provider registered, the tool returns an error.`;
+
 export class RenameTool extends Disposable implements IToolImpl {
 
 	private readonly _onDidUpdateToolData = this._store.add(new Emitter<void>());
@@ -59,17 +72,32 @@ export class RenameTool extends Disposable implements IToolImpl {
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IChatService private readonly _chatService: IChatService,
 		@IBulkEditService private readonly _bulkEditService: IBulkEditService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 
-		this._store.add(Event.debounce(
-			this._languageFeaturesService.renameProvider.onDidChange,
-			() => { },
-			2000
-		)((() => this._onDidUpdateToolData.fire())));
+		// In cache-stable mode the tool's wire bytes don't depend on the set
+		// of registered rename providers, so we don't need to re-fire the
+		// update event on provider changes. Skipping this subscription
+		// avoids unnecessary tool re-registration churn as well.
+		if (!this._isCacheStable()) {
+			this._store.add(Event.debounce(
+				this._languageFeaturesService.renameProvider.onDidChange,
+				() => { },
+				2000
+			)((() => this._onDidUpdateToolData.fire())));
+		}
+	}
+
+	private _isCacheStable(): boolean {
+		return this._configurationService.getValue<boolean>(ChatConfiguration.SymbolToolsCacheStable) === true;
 	}
 
 	getToolData(): IToolData | undefined {
+		if (this._isCacheStable()) {
+			return this._getStaticToolData();
+		}
+
 		const languageIds = this._languageFeaturesService.renameProvider.registeredLanguageIds;
 
 		if (languageIds.size === 0) {
@@ -87,6 +115,17 @@ export class RenameTool extends Disposable implements IToolImpl {
 			const niceNames = sorted.map(id => this._languageService.getLanguageName(id) ?? id);
 			userDescription = localize('tool.rename.userDescriptionWithLanguages', 'Rename a symbol across the workspace ({0})', niceNames.join(', '));
 		}
+		return this._buildToolData(modelDescription, userDescription);
+	}
+
+	private _getStaticToolData(): IToolData {
+		return this._buildToolData(
+			StaticModelDescription,
+			localize('tool.rename.userDescription', 'Rename a symbol across the workspace'),
+		);
+	}
+
+	private _buildToolData(modelDescription: string, userDescription: string): IToolData {
 		return {
 			id: RenameToolId,
 			toolReferenceName: 'rename',

--- a/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts
@@ -21,11 +21,13 @@ import { ITextModelService } from '../../../../../editor/common/services/resolve
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { getDefinitionsAtPosition, getImplementationsAtPosition, getReferencesAtPosition } from '../../../../../editor/contrib/gotoSymbol/browser/goToSymbol.js';
 import { localize } from '../../../../../nls.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ISearchService, QueryType, resultIsMatch } from '../../../../services/search/common/search.js';
+import { ChatConfiguration } from '../../common/constants.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress, } from '../../common/tools/languageModelToolsService.js';
 import { createToolSimpleTextResult } from '../../common/tools/builtinTools/toolHelpers.js';
 import { errorResult, findLineNumber, findSymbolColumn, ISymbolToolInput, resolveToolUri } from './toolHelpers.js';
@@ -44,6 +46,17 @@ IMPORTANT: The file and line do NOT need to be the definition of the symbol. Any
 
 If the tool returns an error, retry with corrected input - ensure the file path is correct, the line content matches the actual file content, and the symbol name appears in that line.`;
 
+/**
+ * Static description used when the {@link ChatConfiguration.SymbolToolsCacheStable}
+ * experiment is enabled. Identical to {@link BaseModelDescription} plus a single
+ * sentence describing the unsupported-language behavior. Crucially, this string
+ * does NOT depend on the set of registered reference providers, so it stays
+ * byte-stable across requests as language extensions activate during a turn.
+ */
+const StaticModelDescription = BaseModelDescription + `
+
+If the file's language has no reference provider registered, the tool returns an error.`;
+
 export class UsagesTool extends Disposable implements IToolImpl {
 
 	private readonly _onDidUpdateToolData = this._store.add(new Emitter<void>());
@@ -56,17 +69,32 @@ export class UsagesTool extends Disposable implements IToolImpl {
 		@ISearchService private readonly _searchService: ISearchService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 
-		this._store.add(Event.debounce(
-			this._languageFeaturesService.referenceProvider.onDidChange,
-			() => { },
-			2000
-		)((() => this._onDidUpdateToolData.fire())));
+		// In cache-stable mode the tool's wire bytes don't depend on the set
+		// of registered reference providers, so we don't re-fire the update
+		// event on provider changes. Skipping this subscription also avoids
+		// unnecessary tool re-registration churn.
+		if (!this._isCacheStable()) {
+			this._store.add(Event.debounce(
+				this._languageFeaturesService.referenceProvider.onDidChange,
+				() => { },
+				2000
+			)((() => this._onDidUpdateToolData.fire())));
+		}
+	}
+
+	private _isCacheStable(): boolean {
+		return this._configurationService.getValue<boolean>(ChatConfiguration.SymbolToolsCacheStable) === true;
 	}
 
 	getToolData(): IToolData | undefined {
+		if (this._isCacheStable()) {
+			return this._getStaticToolData();
+		}
+
 		const languageIds = this._languageFeaturesService.referenceProvider.registeredLanguageIds;
 
 		if (languageIds.size === 0) {
@@ -85,6 +113,17 @@ export class UsagesTool extends Disposable implements IToolImpl {
 			userDescription = localize('tool.usages.userDescriptionWithLanguages', 'Find references, definitions, and implementations of a symbol ({0})', niceNames.join(', '));
 		}
 
+		return this._buildToolData(modelDescription, userDescription);
+	}
+
+	private _getStaticToolData(): IToolData {
+		return this._buildToolData(
+			StaticModelDescription,
+			localize('tool.usages.userDescription', 'Find references, definitions, and implementations of a symbol'),
+		);
+	}
+
+	private _buildToolData(modelDescription: string, userDescription: string): IToolData {
 		return {
 			id: UsagesToolId,
 			toolReferenceName: 'usages',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -78,6 +78,17 @@ export enum ChatConfiguration {
 	IncrementalRendering = 'chat.experimental.incrementalRendering.enabled',
 	IncrementalRenderingStyle = 'chat.experimental.incrementalRendering.animationStyle',
 	IncrementalRenderingBuffering = 'chat.experimental.incrementalRendering.buffering',
+
+	/**
+	 * When enabled, `vscode_renameSymbol` and `vscode_listCodeUsages` are always
+	 * registered with a static, language-list-free description. This makes the
+	 * tools array byte-stable across rounds even as language extensions activate
+	 * mid-turn, which significantly improves prompt-cache hit rates on agent
+	 * conversations. Behavior is unchanged: the tools still error on
+	 * unsupported languages at invocation time. Behind an A/B flag for
+	 * controlled rollout.
+	 */
+	SymbolToolsCacheStable = 'chat.experimental.symbolTools.cacheStable',
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
@@ -18,6 +18,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../pl
 import { IBulkEditService, IBulkEditResult } from '../../../../../../editor/browser/services/bulkEditService.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { RenameTool } from '../../../browser/tools/renameTool.js';
+import { ChatConfiguration } from '../../../common/constants.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -106,7 +107,7 @@ suite('RenameTool', () => {
 		return { getLanguageName: (id: string) => id } as unknown as ILanguageService;
 	}
 
-	function createTool(textModelService: ITextModelService, options?: { bulkEditService?: IBulkEditService }): RenameTool {
+	function createTool(textModelService: ITextModelService, options?: { bulkEditService?: IBulkEditService; configurationService?: TestConfigurationService }): RenameTool {
 		return new RenameTool(
 			langFeatures,
 			createMockLanguageService(),
@@ -114,7 +115,7 @@ suite('RenameTool', () => {
 			createMockWorkspaceService(),
 			createMockChatService(),
 			options?.bulkEditService ?? createMockBulkEditService(),
-			new TestConfigurationService(),
+			options?.configurationService ?? new TestConfigurationService(),
 		);
 	}
 
@@ -152,6 +153,55 @@ suite('RenameTool', () => {
 			}));
 			const data = tool.getToolData();
 			assert.ok(data?.modelDescription.includes('all languages'));
+		});
+
+		suite('cache-stable mode', () => {
+			function createCacheStableTool(textModelService: ITextModelService) {
+				const configurationService = new TestConfigurationService();
+				configurationService.setUserConfiguration(ChatConfiguration.SymbolToolsCacheStable, true);
+				return disposables.add(createTool(textModelService, { configurationService }));
+			}
+
+			test('returns tool data even when no providers are registered', () => {
+				const tool = createCacheStableTool(createMockTextModelService(null!));
+				const data = tool.getToolData();
+				assert.ok(data, 'expected getToolData() to return data with no providers registered');
+			});
+
+			test('description does not include a per-language list', () => {
+				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+				const tool = createCacheStableTool(createMockTextModelService(model));
+				disposables.add(langFeatures.renameProvider.register('typescript', {
+					provideRenameEdits: () => ({ edits: [] }),
+				}));
+				const data = tool.getToolData();
+				assert.ok(data, 'expected getToolData() to return data');
+				assert.ok(!data!.modelDescription.includes('Currently supported for'),
+					`expected modelDescription to not list languages, got: ${data!.modelDescription}`);
+				assert.ok(!data!.modelDescription.includes('typescript'),
+					'expected modelDescription to not include any specific language id');
+				assert.ok(!data!.modelDescription.includes('all languages'),
+					'expected modelDescription to not mention "all languages"');
+			});
+
+			test('description is identical regardless of which providers are registered', () => {
+				const tool1 = createCacheStableTool(createMockTextModelService(null!));
+				const data1 = tool1.getToolData();
+
+				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+				const tool2 = createCacheStableTool(createMockTextModelService(model));
+				disposables.add(langFeatures.renameProvider.register('typescript', {
+					provideRenameEdits: () => ({ edits: [] }),
+				}));
+				disposables.add(langFeatures.renameProvider.register('python', {
+					provideRenameEdits: () => ({ edits: [] }),
+				}));
+				const data2 = tool2.getToolData();
+
+				assert.ok(data1 && data2);
+				assert.strictEqual(data1!.modelDescription, data2!.modelDescription,
+					'expected modelDescription to be byte-stable across provider registrations');
+			});
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/renameTool.test.ts
@@ -16,6 +16,7 @@ import { ILanguageService } from '../../../../../../editor/common/languages/lang
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IBulkEditService, IBulkEditResult } from '../../../../../../editor/browser/services/bulkEditService.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { RenameTool } from '../../../browser/tools/renameTool.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
@@ -113,6 +114,7 @@ suite('RenameTool', () => {
 			createMockWorkspaceService(),
 			createMockChatService(),
 			options?.bulkEditService ?? createMockBulkEditService(),
+			new TestConfigurationService(),
 		);
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
@@ -17,6 +17,7 @@ import { ILanguageService } from '../../../../../../editor/common/languages/lang
 import { createTextModel } from '../../../../../../editor/test/common/testTextModel.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { FileMatch, ISearchComplete, ISearchService, ITextQuery, OneLineRange, TextSearchMatch } from '../../../../../services/search/common/search.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { UsagesTool } from '../../../browser/tools/usagesTool.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -97,7 +98,7 @@ suite('UsagesTool', () => {
 	}
 
 	function createTool(textModelService: ITextModelService, workspaceService: IWorkspaceContextService, options?: { modelService?: IModelService; searchService?: ISearchService }): UsagesTool {
-		return new UsagesTool(langFeatures, createMockLanguageService(), options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService);
+		return new UsagesTool(langFeatures, createMockLanguageService(), options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService, new TestConfigurationService());
 	}
 
 	setup(() => {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/usagesTool.test.ts
@@ -19,6 +19,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../pl
 import { FileMatch, ISearchComplete, ISearchService, ITextQuery, OneLineRange, TextSearchMatch } from '../../../../../services/search/common/search.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { UsagesTool } from '../../../browser/tools/usagesTool.js';
+import { ChatConfiguration } from '../../../common/constants.js';
 import { IToolInvocation, IToolResult, IToolResultTextPart, ToolProgress } from '../../../common/tools/languageModelToolsService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 
@@ -97,8 +98,8 @@ suite('UsagesTool', () => {
 		return { getLanguageName: (id: string) => id } as unknown as ILanguageService;
 	}
 
-	function createTool(textModelService: ITextModelService, workspaceService: IWorkspaceContextService, options?: { modelService?: IModelService; searchService?: ISearchService }): UsagesTool {
-		return new UsagesTool(langFeatures, createMockLanguageService(), options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService, new TestConfigurationService());
+	function createTool(textModelService: ITextModelService, workspaceService: IWorkspaceContextService, options?: { modelService?: IModelService; searchService?: ISearchService; configurationService?: TestConfigurationService }): UsagesTool {
+		return new UsagesTool(langFeatures, createMockLanguageService(), options?.modelService ?? createMockModelService(), options?.searchService ?? createMockSearchService(), textModelService, workspaceService, options?.configurationService ?? new TestConfigurationService());
 	}
 
 	setup(() => {
@@ -131,6 +132,49 @@ suite('UsagesTool', () => {
 			disposables.add(langFeatures.referenceProvider.register('*', { provideReferences: () => [] }));
 			const data = tool.getToolData();
 			assert.ok(data?.modelDescription.includes('all languages'));
+		});
+
+		suite('cache-stable mode', () => {
+			function createCacheStableTool(textModelService: ITextModelService) {
+				const configurationService = new TestConfigurationService();
+				configurationService.setUserConfiguration(ChatConfiguration.SymbolToolsCacheStable, true);
+				return disposables.add(createTool(textModelService, createMockWorkspaceService(), { configurationService }));
+			}
+
+			test('returns tool data even when no providers are registered', () => {
+				const tool = createCacheStableTool(createMockTextModelService(null!));
+				const data = tool.getToolData();
+				assert.ok(data, 'expected getToolData() to return data with no providers registered');
+			});
+
+			test('description does not include a per-language list', () => {
+				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+				const tool = createCacheStableTool(createMockTextModelService(model));
+				disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
+				const data = tool.getToolData();
+				assert.ok(data, 'expected getToolData() to return data');
+				assert.ok(!data!.modelDescription.includes('Currently supported for'),
+					`expected modelDescription to not list languages, got: ${data!.modelDescription}`);
+				assert.ok(!data!.modelDescription.includes('typescript'),
+					'expected modelDescription to not include any specific language id');
+				assert.ok(!data!.modelDescription.includes('all languages'),
+					'expected modelDescription to not mention "all languages"');
+			});
+
+			test('description is identical regardless of which providers are registered', () => {
+				const tool1 = createCacheStableTool(createMockTextModelService(null!));
+				const data1 = tool1.getToolData();
+
+				const model = disposables.add(createTextModel('', 'typescript', undefined, testUri));
+				const tool2 = createCacheStableTool(createMockTextModelService(model));
+				disposables.add(langFeatures.referenceProvider.register('typescript', { provideReferences: () => [] }));
+				disposables.add(langFeatures.referenceProvider.register('python', { provideReferences: () => [] }));
+				const data2 = tool2.getToolData();
+
+				assert.ok(data1 && data2);
+				assert.strictEqual(data1!.modelDescription, data2!.modelDescription,
+					'expected modelDescription to be byte-stable across provider registrations');
+			});
 		});
 	});
 


### PR DESCRIPTION
## Why

`vscode_renameSymbol` and `vscode_listCodeUsages` currently emit a tool description that embeds the live set of registered language IDs (e.g. `Currently supported for: python, r, rmd.`) and return `undefined` from `getToolData()` when the corresponding provider has no registered languages.

Both behaviors poison the provider-side prompt cache during an agent turn:

1. **Description churn.** Every time a language extension activates (because the model touched a file in a previously-unloaded language), the sorted language list grows and the tool description bytes change. Anthropic and OpenAI prompt caches hash the full prefix, so any byte change inside the `tools[]` array invalidates everything from that tool onward.
2. **Presence churn.** When a provider's `registeredLanguageIds` goes empty, the whole tool disappears from the array, shifting every subsequent tool's index by one — a much larger byte delta than a description change. The two tools are wired to *independent* events (`renameProvider.onDidChange` vs `referenceProvider.onDidChange`), so they can flap in and out of the array out of step.

Both effects fire mid-turn, on perfectly normal use (e.g. the model reading one file in a new language), and produce 0% cache-hit requests in the middle of otherwise high-hit turns.

## What this PR does

Adds an experimental setting:

- **Key:** `chat.experimental.symbolTools.cacheStable`
- **Default:** `false`
- **Tags:** `experimental`, `experiment: { mode: 'startup' }` (eligible for ExP A/B treatment)

When enabled, both `RenameTool` and `UsagesTool`:

- Always register, regardless of whether any provider is currently registered.
- Use a static `modelDescription` that omits the per-language list. A single sentence is appended explaining that the tool returns an error if the file's language has no provider — which is already the runtime behavior in `invoke()`.
- Skip the debounced subscription to `*Provider.onDidChange`, so `onDidUpdateToolData` is never re-fired and the tool registration doesn't churn.

`prepareToolInvocation` and `invoke` are untouched; the tools still error out cleanly when a file's language has no provider registered.

When the setting is `false` (default) the existing behavior is preserved exactly.

## Why this is safe

- Default `false` — opt-in only.
- No change to `invoke()`, `prepareToolInvocation()`, or the input schemas.
- The model already needs to handle the "no provider" error path (it can hit it any time a user opens a file before the language extension finishes activating). Removing the language-list hint just leans more on that existing path.
- The static description still communicates capabilities — only the dynamically-changing list of supported languages is removed. The model can attempt the call; if a provider isn't there, it gets a clear error and adapts.

## Expected impact

Independent of this PR, request bodies captured locally show 0% cache-hit rounds occurring at the exact moments when the language list inside these two tools changes (or the tools flap in/out of the array). With the flag enabled, those events should no longer cause cache-prefix invalidation, leading to materially higher cache-hit percentages in long agent turns that touch multiple languages.

We will validate the impact via an A/B experiment by comparing prompt cache hit rates and uncached input tokens between treatment and control populations.

## Trying it out

Set in user settings:

```json
{
  "chat.experimental.symbolTools.cacheStable": true
}
```

Restart the window so the constructor's startup-time branch picks up the new value. (The setting is `experiment: { mode: 'startup' }` — runtime toggling is not supported.)

## Files changed

- `src/vs/workbench/contrib/chat/common/constants.ts` — new `ChatConfiguration.SymbolToolsCacheStable` enum entry.
- `src/vs/workbench/contrib/chat/browser/chat.contribution.ts` — registers the configuration with experimental tag and `experiment: { mode: 'startup' }`.
- `src/vs/workbench/contrib/chat/browser/tools/renameTool.ts` — gated branch in `getToolData()` returning a static `IToolData`; `IConfigurationService` injected.
- `src/vs/workbench/contrib/chat/browser/tools/usagesTool.ts` — same pattern.
