### PR TITLE
Enable inline history summarization and GPT-5.5 tool search

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4507,7 +4507,7 @@
 					},
 					"github.copilot.chat.agentHistorySummarizationInline": {
 						"type": "boolean",
-						"default": false,
+						"default": true,
 						"markdownDescription": "%github.copilot.config.agentHistorySummarizationInline%",
 						"tags": [
 							"advanced",

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -647,7 +647,7 @@ export namespace ConfigKey {
 
 		export const InstantApplyShortModelName = defineAndMigrateExpSetting<string>('chat.advanced.instantApply.shortContextModelName', 'chat.instantApply.shortContextModelName', CHAT_MODEL.SHORT_INSTANT_APPLY);
 		export const InstantApplyShortContextLimit = defineAndMigrateExpSetting<number>('chat.advanced.instantApply.shortContextLimit', 'chat.instantApply.shortContextLimit', 8000);
-		export const AgentHistorySummarizationInline = defineAndMigrateExpSetting<boolean>('chat.advanced.agentHistorySummarizationInline', 'chat.agentHistorySummarizationInline', false);
+		export const AgentHistorySummarizationInline = defineAndMigrateExpSetting<boolean>('chat.advanced.agentHistorySummarizationInline', 'chat.agentHistorySummarizationInline', true);
 		export const PromptFileContext = defineAndMigrateExpSetting<boolean>('chat.advanced.promptFileContextProvider.enabled', 'chat.promptFileContextProvider.enabled', true);
 		export const DefaultToolsGrouped = defineAndMigrateExpSetting<boolean>('chat.advanced.tools.defaultToolsGrouped', 'chat.tools.defaultToolsGrouped', false);
 		export const Gpt5AlternativePatch = defineAndMigrateExpSetting<boolean>('chat.advanced.gpt5AlternativePatch', 'chat.gpt5AlternativePatch', false);

--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -397,15 +397,14 @@ export function getVerbosityForModelSync(model: IChatEndpoint): 'low' | 'medium'
  * - Claude Opus 4.5 (claude-opus-4-5-* or claude-opus-4.5-*)
  * - Claude Opus 4.6 (claude-opus-4-6-* or claude-opus-4.6-*)
  * - Claude Opus 4.7 (claude-opus-4-7-* or claude-opus-4.7-*)
- * - OpenAI gpt-5.4 (gpt-5.4-*), but only when the `ResponsesApiToolSearchEnabled` setting is enabled
+ * - OpenAI gpt-5.4/gpt-5.5, but only when the `ResponsesApiToolSearchEnabled` setting is enabled
  */
 export function modelSupportsToolSearch(modelId: string, configurationService?: IConfigurationService, experimentationService?: IExperimentationService): boolean {
-	const lower = modelId.toLowerCase();
-	if (isGpt54(lower)) {
+	const normalized = modelId.toLowerCase().replace(/\./g, '-');
+	if (isResponsesApiToolSearchModelId(normalized)) {
 		return !!configurationService && !!experimentationService && isResponsesApiToolSearchEnabled(modelId, configurationService, experimentationService);
 	}
 
-	const normalized = lower.replace(/\./g, '-');
 	return normalized.startsWith('claude-sonnet-4-5') ||
 		normalized.startsWith('claude-sonnet-4-6') ||
 		normalized.startsWith('claude-opus-4-5') ||
@@ -414,12 +413,18 @@ export function modelSupportsToolSearch(modelId: string, configurationService?: 
 		isHiddenModelG(modelId);
 }
 
+function isResponsesApiToolSearchModelId(normalizedModelId: string): boolean {
+	return normalizedModelId.startsWith('gpt-5-4') || normalizedModelId.startsWith('gpt-5-5') || normalizedModelId.startsWith('gpt5-5');
+}
+
 export function isResponsesApiToolSearchEnabled(
 	endpoint: IChatEndpoint | string,
 	configurationService: IConfigurationService,
 	experimentationService: IExperimentationService,
 ): boolean {
-	return isGpt54(endpoint) && configurationService.getExperimentBasedConfig(ConfigKey.ResponsesApiToolSearchEnabled, experimentationService);
+	const modelId = typeof endpoint === 'string' ? endpoint : endpoint.model;
+	const normalized = modelId.toLowerCase().replace(/\./g, '-');
+	return isResponsesApiToolSearchModelId(normalized) && configurationService.getExperimentBasedConfig(ConfigKey.ResponsesApiToolSearchEnabled, experimentationService);
 }
 
 /**

--- a/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
@@ -66,7 +66,7 @@ describe('modelSupportsToolSearch', () => {
 		expect(modelSupportsToolSearch('claude-3-opus')).toBe(false);
 	});
 
-	test('supports OpenAI gpt-5.4 models when the setting is enabled', () => {
+	test('supports OpenAI gpt-5.4 and gpt-5.5 models when the setting is enabled', () => {
 		const configurationService = {
 			getExperimentBasedConfig: (key: unknown) => key === ConfigKey.ResponsesApiToolSearchEnabled,
 		} as unknown as IConfigurationService;
@@ -74,7 +74,11 @@ describe('modelSupportsToolSearch', () => {
 
 		expect(modelSupportsToolSearch('gpt-5.4', configurationService, experimentationService)).toBe(true);
 		expect(modelSupportsToolSearch('gpt-5.4-preview', configurationService, experimentationService)).toBe(true);
+		expect(modelSupportsToolSearch('gpt-5.5', configurationService, experimentationService)).toBe(true);
+		expect(modelSupportsToolSearch('gpt-5.5-preview', configurationService, experimentationService)).toBe(true);
+		expect(modelSupportsToolSearch('gpt5.5-preview', configurationService, experimentationService)).toBe(true);
 		expect(modelSupportsToolSearch('gpt-5.4')).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.5')).toBe(false);
 	});
 
 	test('rejects other non-Claude models', () => {


### PR DESCRIPTION
Summary:
- Enable inline agent history summarization by default in Copilot configuration.
- Add GPT-5.5 model IDs to the Responses API tool search gate while keeping the existing experiment setting check.