### PR TITLE
Restore empty link text for non-skill agent-host links

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -411,13 +411,15 @@ export function rewriteMarkdownLinks(markdown: string, connectionAuthority: stri
  * or returns `undefined` if the token should be left alone (external
  * scheme or unparseable URI).
  *
- * The output is the canonical inline form `[text](newHref)` (or
- * `![text](newHref)` for images). When the original link has no display
- * text the chat renderer falls back to its file-widget rendering, but a
- * non-empty label (e.g. a skill name) is preserved so the renderer shows
- * it instead of the URI's basename. This also means autolinks (`<url>`)
- * and reference-style links (`[text][ref]`) are normalized into the
- * inline form.
+ * The output collapses to the canonical inline form `[](newHref)` (or
+ * `![](newHref)` for images) — the chat renderer has richer handling for
+ * empty-text agent-host links (rendering them as a file widget), so
+ * preserving the original label isn't useful for most links. The one
+ * exception is skill links (URIs whose basename is `SKILL.md`), where the
+ * skill name is preserved as the label so the skill pill renderer can
+ * display it instead of the always-identical `SKILL.md` basename. This
+ * also means autolinks (`<url>`) and reference-style links
+ * (`[text][ref]`) are normalized into the inline form.
  */
 function rewriteLinkTokenRaw(token: Tokens.Link | Tokens.Image, connectionAuthority: string): string | undefined {
 	let parsed: URI;
@@ -431,22 +433,26 @@ function rewriteLinkTokenRaw(token: Tokens.Link | Tokens.Image, connectionAuthor
 		return undefined;
 	}
 	let agentHostUri = toAgentHostUri(parsed, connectionAuthority);
+	const isSkill = isSkillFileUri(parsed);
 	// VS-Code-specific: links pointing at a `SKILL.md` file are rendered as a
 	// rich skill pill rather than a plain markdown link. The chat renderer's
 	// inline anchor widget keys off the `vscodeLinkType` query parameter (see
 	// `chatInlineAnchorWidget.ts`), so we tag the URI here on the client side
 	// rather than at the agent host. We do this whether or not the link came
 	// in pre-tagged so older sessions and other agent providers also benefit.
-	if (isSkillFileUri(parsed) && !agentHostUri.query.includes('vscodeLinkType=')) {
+	if (isSkill && !agentHostUri.query.includes('vscodeLinkType=')) {
 		const existing = agentHostUri.query;
 		agentHostUri = agentHostUri.with({ query: existing ? `${existing}&vscodeLinkType=skill` : 'vscodeLinkType=skill' });
 	}
 	const prefix = token.type === 'image' ? '![' : '[';
+	// Only preserve the link text for skill links — the skill pill renderer
+	// extracts the label from the markdown to display the skill name. For all
+	// other agent-host links, leave the text empty so the chat renderer's
+	// inline anchor widget takes over with its rich file-widget rendering.
 	// Escape only the characters that would break out of markdown link text
-	// syntax (`\` and `]`). A full markdown escape would leave visible
-	// backslashes in renderers (like the skill pill) that extract link text
-	// without re-parsing markdown.
-	const text = escapeMarkdownLinkLabel(token.text ?? '');
+	// syntax (`\` and `]`); a full markdown escape would leave visible
+	// backslashes in the skill pill which extracts text without re-parsing.
+	const text = isSkill ? escapeMarkdownLinkLabel(token.text ?? '') : '';
 	return `${prefix}${text}](${agentHostUri.toString()})`;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter.ts
@@ -445,14 +445,15 @@ function rewriteLinkTokenRaw(token: Tokens.Link | Tokens.Image, connectionAuthor
 		agentHostUri = agentHostUri.with({ query: existing ? `${existing}&vscodeLinkType=skill` : 'vscodeLinkType=skill' });
 	}
 	const prefix = token.type === 'image' ? '![' : '[';
-	// Only preserve the link text for skill links — the skill pill renderer
-	// extracts the label from the markdown to display the skill name. For all
-	// other agent-host links, leave the text empty so the chat renderer's
-	// inline anchor widget takes over with its rich file-widget rendering.
+	// Preserve the label for skill links (so the skill pill renderer can show
+	// the skill name) and for image alt text (accessibility — the inline
+	// anchor widget only applies to links, not images). For all other
+	// agent-host links, leave the text empty so the chat renderer's inline
+	// anchor widget takes over with its rich file-widget rendering.
 	// Escape only the characters that would break out of markdown link text
 	// syntax (`\` and `]`); a full markdown escape would leave visible
 	// backslashes in the skill pill which extracts text without re-parsing.
-	const text = isSkill ? escapeMarkdownLinkLabel(token.text ?? '') : '';
+	const text = isSkill || token.type === 'image' ? escapeMarkdownLinkLabel(token.text ?? '') : '';
 	return `${prefix}${text}](${agentHostUri.toString()})`;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -293,6 +293,43 @@ suite('stateToProgressAdapter', () => {
 			);
 		});
 
+		test('preserves label and tags vscodeLinkType=skill for SKILL.md links', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.Markdown,
+					id: 'md-skill',
+					content: 'Loaded [plan](file:///abs/repo/skills/plan/SKILL.md) and [other](file:///abs/repo/foo.ts).',
+				}],
+			});
+
+			const history = rawTurnsToHistory(URI.file('/'), [turn], 'p', 'my-host');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const value = (response.parts[0] as IChatMarkdownContent).content.value;
+			assert.strictEqual(value,
+				'Loaded [plan](vscode-agent-host://my-host/file/-/abs/repo/skills/plan/SKILL.md?vscodeLinkType%3Dskill) ' +
+				'and [](vscode-agent-host://my-host/file/-/abs/repo/foo.ts).'
+			);
+		});
+
+		test('preserves alt text for image tokens', () => {
+			const turn = createTurn({
+				responseParts: [{
+					kind: ResponsePartKind.Markdown,
+					id: 'md-image',
+					content: 'See ![diagram](file:///a/b.png).',
+				}],
+			});
+
+			const history = rawTurnsToHistory(URI.file('/'), [turn], 'p', 'my-host');
+			const response = history[1];
+			assert.strictEqual(response.type, 'response');
+			if (response.type !== 'response') { return; }
+			const value = (response.parts[0] as IChatMarkdownContent).content.value;
+			assert.strictEqual(value, 'See ![diagram](vscode-agent-host://my-host/file/-/a/b.png).');
+		});
+
 		test('error turn produces error message in history', () => {
 			const turn = createTurn({
 				state: TurnState.Error,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/stateToProgressAdapter.test.ts
@@ -244,8 +244,8 @@ suite('stateToProgressAdapter', () => {
 			if (response.type !== 'response') { return; }
 			const part = response.parts[0] as IChatMarkdownContent;
 			assert.deepStrictEqual(part.content.value,
-				'See [local](vscode-agent-host://my-host/file/-/a/b.ts), ' +
-				'[content](vscode-agent-host://my-host/agenthost-content/-/s/x), ' +
+				'See [](vscode-agent-host://my-host/file/-/a/b.ts), ' +
+				'[](vscode-agent-host://my-host/agenthost-content/-/s/x), ' +
 				'[external](https://example.com) and ' +
 				'[rel](./foo.md).'
 			);
@@ -270,8 +270,8 @@ suite('stateToProgressAdapter', () => {
 			assert.strictEqual(response.type, 'response');
 			if (response.type !== 'response') { return; }
 			const value = (response.parts[0] as IChatMarkdownContent).content.value;
-			assert.ok(value.includes('[real](vscode-agent-host://my-host/file/-/a.ts)'));
-			assert.ok(value.includes('[another](vscode-agent-host://my-host/file/-/c.ts)'));
+			assert.ok(value.includes('[](vscode-agent-host://my-host/file/-/a.ts)'));
+			assert.ok(value.includes('[](vscode-agent-host://my-host/file/-/c.ts)'));
 			// The link inside the fenced code block must NOT be rewritten.
 			assert.ok(value.includes('[fake](file:///b.ts)'));
 			assert.ok(!value.includes('[fake](vscode-agent-host'));
@@ -289,7 +289,7 @@ suite('stateToProgressAdapter', () => {
 			if (response.type !== 'response') { return; }
 			const value = (response.parts[0] as IChatMarkdownContent).content.value;
 			assert.strictEqual(value,
-				'Real [one](vscode-agent-host://my-host/file/-/a.ts) and literal `[two](file:///b.ts)` here.'
+				'Real [](vscode-agent-host://my-host/file/-/a.ts) and literal `[two](file:///b.ts)` here.'
 			);
 		});
 
@@ -415,7 +415,7 @@ suite('stateToProgressAdapter', () => {
 			assert.ok(invocation.pastTenseMessage);
 			assert.strictEqual(typeof invocation.pastTenseMessage, 'object');
 			const value = (invocation.pastTenseMessage as { value: string }).value;
-			assert.strictEqual(value, 'Read [foo.ts](vscode-agent-host://ssh__macbook-air/file/-/path/to/foo.ts)');
+			assert.strictEqual(value, 'Read [](vscode-agent-host://ssh__macbook-air/file/-/path/to/foo.ts)');
 		});
 
 		test('finalizes terminal tool with output and exit code', () => {


### PR DESCRIPTION
[#312557](https://github.com/microsoft/vscode/pull/312557) changed agent-host link rewriting to preserve the original markdown label for all links, which made every read-tool link render as a plain blue markdown link instead of the rich inline anchor / file widget.

Only skill links (URIs whose basename is `SKILL.md`) need a non-empty label, so the skill pill can display the skill name instead of the always-identical `SKILL.md` basename. Restore the empty-label behavior for everything else so the chat renderer's inline anchor widget takes over again.

(Written by Copilot)