### PR TITLE
Fix awkward 'additional and new content' wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are many ways in which you can participate in this project, for example:
 
 * [Submit bugs and feature requests](https://github.com/microsoft/vscode/issues), and help us verify as they are checked in
 * Review [source code changes](https://github.com/microsoft/vscode/pulls)
-* Review the [documentation](https://github.com/microsoft/vscode-docs) and make pull requests for anything from typos to additional and new content
+* Review the [documentation](https://github.com/microsoft/vscode-docs) and make pull requests for anything from typos to new content
 
 If you are interested in fixing issues and contributing directly to the code base,
 please see the document [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-Contribute), which covers the following:


### PR DESCRIPTION
## Why

Fixes #312439

The README's Contributing section contains a small redundancy:

> Review the documentation and make pull requests for anything from typos to additional and new content

The phrase "additional and new" is redundant — both words convey the same meaning in this context. The issue author suggested either "additional content" or "new content".

## What

Replaced "additional and new content" with "new content" for clearer, tighter prose. "New" reads more naturally for documentation contributions of any size (small additions or fresh pages alike).

## Verification

- [x] Single-line README change, no code or build impact
- [x] No tests required (documentation fix)
- [x] Links to issue via `Fixes #312439`