### PR TITLE
docs: clarify useIgnoreFiles parent/global JSDoc requires local

### DIFF
--- a/src/vscode-dts/vscode.proposed.fileSearchProvider2.d.ts
+++ b/src/vscode-dts/vscode.proposed.fileSearchProvider2.d.ts
@@ -42,11 +42,11 @@ declare module 'vscode' {
 				 */
 				local: boolean;
 				/**
-				 * Use ignore files at the parent directory. If set, `local` in {@link FileSearchProviderOptions.useIgnoreFiles} should also be `true`.
+				 * Use ignore files at the parent directory. If set, `local` in {@link FileSearchProviderOptions.useIgnoreFiles} is also `true`.
 				 */
 				parent: boolean;
 				/**
-				 * Use global ignore files. If set, `local` in {@link FileSearchProviderOptions.useIgnoreFiles} should also be `true`.
+				 * Use global ignore files. If set, `local` in {@link FileSearchProviderOptions.useIgnoreFiles} is also `true`.
 				 */
 				global: boolean;
 			};

--- a/src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts
@@ -89,11 +89,11 @@ declare module 'vscode' {
 				 */
 				local: boolean;
 				/**
-				* Use ignore files at the parent directory. If set, `local` in {@link TextSearchProviderFolderOptions.useIgnoreFiles} should also be `true`.
+				* Use ignore files at the parent directory. If set, `local` in {@link TextSearchProviderFolderOptions.useIgnoreFiles} is also `true`.
 				*/
 				parent: boolean;
 				/**
-				 * Use global ignore files. If set, `local` in {@link TextSearchProviderFolderOptions.useIgnoreFiles} should also be `true`.
+				 * Use global ignore files. If set, `local` in {@link TextSearchProviderFolderOptions.useIgnoreFiles} is also `true`.
 				 */
 				global: boolean;
 			};


### PR DESCRIPTION
## Why

Issue #226736 reports that the JSDoc for `FileSearchProviderOptions.folderOptions.useIgnoreFiles` reads as if `local` *might* not be `true` even when `parent` or `global` are set:

> "If set, `local` in {@link FileSearchProviderOptions.useIgnoreFiles} should also be `true`."

Since the editor controls the data passed to file/text search providers, the relationship is enforced, not advisory. The wording "should also be" misleads provider authors into adding defensive checks that aren't necessary.

## What

Replace "should also be \`true\`" with "is also \`true\`" in the JSDoc for both `parent` and `global` properties of `useIgnoreFiles` in:

- `src/vscode-dts/vscode.proposed.fileSearchProvider2.d.ts`
- `src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts` (parallel `TextSearchProviderFolderOptions.useIgnoreFiles`, identical wording bug)

Documentation-only change, no behavior change.

Fixes #226736