### PR TITLE
Allow string value in comments.lineComment JSON schema

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
+++ b/src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts
@@ -547,21 +547,30 @@ const schema: IJSONSchema = {
 					}]
 				},
 				lineComment: {
-					type: 'object',
-					description: nls.localize('schema.lineComment.object', 'Configuration for line comments.'),
-					properties: {
-						comment: {
+					description: nls.localize('schema.lineComment', 'Defines how line comments are marked. Either the comment string itself, or an object that also configures indentation behavior.'),
+					oneOf: [
+						{
 							type: 'string',
-							description: nls.localize('schema.lineComment.comment', 'The character sequence that starts a line comment.')
+							description: nls.localize('schema.lineComment.string', 'The character sequence that starts a line comment.')
 						},
-						noIndent: {
-							type: 'boolean',
-							description: nls.localize('schema.lineComment.noIndent', 'Whether the comment token should not be indented and placed at the first column. Defaults to false.'),
-							default: false
+						{
+							type: 'object',
+							description: nls.localize('schema.lineComment.object', 'Configuration for line comments.'),
+							properties: {
+								comment: {
+									type: 'string',
+									description: nls.localize('schema.lineComment.comment', 'The character sequence that starts a line comment.')
+								},
+								noIndent: {
+									type: 'boolean',
+									description: nls.localize('schema.lineComment.noIndent', 'Whether the comment token should not be indented and placed at the first column. Defaults to false.'),
+									default: false
+								}
+							},
+							required: ['comment'],
+							additionalProperties: false
 						}
-					},
-					required: ['comment'],
-					additionalProperties: false
+					]
 				}
 			}
 		},

--- a/src/vs/workbench/contrib/codeEditor/test/common/languageConfigurationExtensionPoint.test.ts
+++ b/src/vs/workbench/contrib/codeEditor/test/common/languageConfigurationExtensionPoint.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IJSONSchema } from '../../../../../base/common/jsonSchema.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Extensions, IJSONContributionRegistry } from '../../../../../platform/jsonschemas/common/jsonContributionRegistry.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+// Importing the contribution registers the `language-configuration` JSON schema as a side effect.
+import '../../common/languageConfigurationExtensionPoint.js';
+
+const LANGUAGE_CONFIGURATION_SCHEMA_ID = 'vscode://schemas/language-configuration';
+
+suite('LanguageConfigurationExtensionPoint schema', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function getLineCommentSchema(): IJSONSchema {
+		const schemas = Registry.as<IJSONContributionRegistry>(Extensions.JSONContribution).getSchemaContributions().schemas;
+		const schema = schemas[LANGUAGE_CONFIGURATION_SCHEMA_ID];
+		assert.ok(schema, 'the `language-configuration` JSON schema should be registered');
+		const lineComment = schema.properties?.comments?.properties?.lineComment;
+		assert.ok(lineComment, '`comments.lineComment` schema should be defined');
+		return lineComment;
+	}
+
+	// https://github.com/microsoft/vscode/issues/285594
+	// The language configuration API accepts both a string and an object for `lineComment`,
+	// so the contributed JSON schema must accept both. Otherwise a plain string value is
+	// incorrectly flagged with a validation warning in `language-configuration.json`.
+	test('comments.lineComment accepts both a string and an object', () => {
+		const lineComment = getLineCommentSchema();
+
+		assert.ok(Array.isArray(lineComment.oneOf), '`lineComment` should be described with `oneOf`');
+
+		const acceptsString = lineComment.oneOf!.some(s => s.type === 'string');
+		const acceptsObject = lineComment.oneOf!.some(s => s.type === 'object');
+
+		assert.strictEqual(acceptsString, true, '`lineComment` should accept a string value');
+		assert.strictEqual(acceptsObject, true, '`lineComment` should accept an object value');
+	});
+
+	test('the lineComment object form still requires a `comment` string property', () => {
+		const lineComment = getLineCommentSchema();
+		const objectSchema = lineComment.oneOf!.find(s => s.type === 'object');
+
+		assert.ok(objectSchema, '`lineComment` should still offer an object form');
+		assert.deepStrictEqual(objectSchema!.required, ['comment'], 'the object form should require `comment`');
+		assert.strictEqual(objectSchema!.properties?.comment?.type, 'string', '`comment` should be a string');
+	});
+});


### PR DESCRIPTION
## Why

Issue #285594 reports that authoring `language-configuration.json` with a plain string `lineComment` (e.g. `"lineComment": "//"`) triggers an editor warning that the value should be an object — even though the parser already accepts both forms.

The `LanguageConfiguration.lineComment` type is declared as `string | LineCommentConfig | null` in `src/vs/editor/common/languages/languageConfiguration.ts`, and the parser at `src/vs/workbench/contrib/codeEditor/common/languageConfigurationExtensionPoint.ts:163-179` explicitly handles both branches.

## What

Wrap the `lineComment` JSON schema entry in `oneOf` so it accepts:

- A `string` shorthand (the comment marker itself).
- The existing object form with `comment` + `noIndent`.

Matches the parser behavior and removes the spurious warning. No runtime behavior change.

## Test coverage

Added `src/vs/workbench/contrib/codeEditor/test/common/languageConfigurationExtensionPoint.test.ts`. It reads the contributed `vscode://schemas/language-configuration` schema back from the JSON contribution registry and asserts that `comments.lineComment` accepts **both** a string and an object (and that the object form still requires a `comment` string). This locks issue #285594's requirement as an executable contract.

## Test verification (RED → GREEN)

The test asserts `comments.lineComment` is described with `oneOf`. Before this PR the schema was `type: 'object'` (no `oneOf`), so the assertion fails; with the `oneOf` form it passes. Verified by running the test's assertion body against both schema variants:

```
patch REVERTED (type:object): RED (test fails) -> `lineComment` should be described with `oneOf`
patch APPLIED   (oneOf)     : GREEN (test passes)
```

> Note: the full `./scripts/test.sh` suite was not run on my local machine (unbuilt, disk-constrained checkout); CI exercises the GREEN (with-fix) side, and the RED side is demonstrated above by reverting the schema change.

Fixes #285594
