### PR TITLE
git: clarify valid keys for git.diagnosticsCommitHook.sources

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -321,7 +321,7 @@
 	"config.blameIgnoreWhitespace": "Controls whether to ignore whitespace changes when computing blame information.",
 	"config.commitShortHashLength": "Controls the length of the commit short hash.",
 	"config.diagnosticsCommitHook.enabled": "Controls whether to check for unresolved diagnostics before committing.",
-	"config.diagnosticsCommitHook.sources": "Controls the list of sources (**Item**) and the minimum severity (**Value**) to be considered before committing. **Note:** To ignore diagnostics from a particular source, add the source to the list and set the minimum severity to `none`.",
+	"config.diagnosticsCommitHook.sources": "Controls the list of diagnostic sources (**Item**) and the minimum severity (**Value**) to be considered before committing. **Items** are diagnostic source identifiers as reported by extensions (for example `eslint`, `ts`, `pylint`), and `*` matches all sources. **Values** are one of `error`, `warning`, `information`, or `hint`; an explicit source identifier may also be set to `none` to ignore its diagnostics (the `*` wildcard does not support `none`). **Note:** To ignore diagnostics from a particular source, add the source to the list and set the minimum severity to `none`.",
 	"config.discardUntrackedChangesToTrash": "Controls whether discarding untracked changes moves the file(s) to the Recycle Bin (Windows), Trash (macOS, Linux) instead of deleting them permanently. **Note:** This setting has no effect when connected to a remote or when running in Linux as a snap package.",
 	"config.showReferenceDetails": "Controls whether to show the details of the last commit for Git refs in the checkout, branch, and tag pickers.",
 	"submenu.explorer": "Git",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -321,7 +321,7 @@
 	"config.blameIgnoreWhitespace": "Controls whether to ignore whitespace changes when computing blame information.",
 	"config.commitShortHashLength": "Controls the length of the commit short hash.",
 	"config.diagnosticsCommitHook.enabled": "Controls whether to check for unresolved diagnostics before committing.",
-	"config.diagnosticsCommitHook.sources": "Controls the list of sources (**Item**) and the minimum severity (**Value**) to be considered before committing. **Note:** To ignore diagnostics from a particular source, add the source to the list and set the minimum severity to `none`.",
+	"config.diagnosticsCommitHook.sources": "Controls the list of diagnostic sources (**Item**) and the minimum severity (**Value**) to be considered before committing. **Items** are diagnostic source identifiers as reported by extensions (for example `eslint`, `ts`, `pylint`), and `*` matches all sources. **Values** are one of `error`, `warning`, `information`, `hint`, or `none`. **Note:** To ignore diagnostics from a particular source, add the source to the list and set the minimum severity to `none`.",
 	"config.discardUntrackedChangesToTrash": "Controls whether discarding untracked changes moves the file(s) to the Recycle Bin (Windows), Trash (macOS, Linux) instead of deleting them permanently. **Note:** This setting has no effect when connected to a remote or when running in Linux as a snap package.",
 	"config.showReferenceDetails": "Controls whether to show the details of the last commit for Git refs in the checkout, branch, and tag pickers.",
 	"submenu.explorer": "Git",


### PR DESCRIPTION
## Why

Issue #241879 reports that the description of `git.diagnosticsCommitHook.sources` doesn't explain what counts as a valid key. Users assume the keys are glob patterns (e.g. `*.ts`) because the description just refers to them as "**Item**". In practice, the schema (`extensions/git/package.json`) accepts a map of diagnostic-source identifiers (as reported by extensions, e.g. `eslint`, `ts`, `pylint`) → severity, with `*` as a wildcard.

## What

Update the localized description string for `config.diagnosticsCommitHook.sources` in `extensions/git/package.nls.json` to:

- Call out that **items** are diagnostic source identifiers, with concrete examples (`eslint`, `ts`, `pylint`).
- Note that `*` matches all sources.
- List the allowed severity values inline (`error`, `warning`, `information`, `hint`, `none`) so users see the full contract in the setting description.

No code/schema change — description text only.

Fixes #241879