### PR TITLE
docs: clarify TabInputWebview.viewType prefix in vscode.d.ts

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -19216,12 +19216,15 @@ declare module 'vscode' {
 	 */
 	export class TabInputWebview {
 		/**
-		 * The type of webview. Maps to {@linkcode WebviewPanel.viewType WebviewPanel's viewType}
+		 * The type of webview. Corresponds to {@linkcode WebviewPanel.viewType WebviewPanel's viewType},
+		 * but prefixed with `mainThreadWebview-`. For example, a `WebviewPanel` created with
+		 * viewType `markdown.preview` is exposed here as `mainThreadWebview-markdown.preview`.
 		 */
 		readonly viewType: string;
 		/**
 		 * Constructs a webview tab input with the given view type.
-		 * @param viewType The type of webview. Maps to {@linkcode WebviewPanel.viewType WebviewPanel's viewType}
+		 * @param viewType The type of webview, including the `mainThreadWebview-` prefix
+		 * (see {@linkcode TabInputWebview.viewType}).
 		 */
 		constructor(viewType: string);
 	}


### PR DESCRIPTION
## Why

Issue #201884 reports that the JSDoc for `TabInputWebview.viewType` claims it "Maps to `WebviewPanel.viewType`", but the value exposed on `TabInputWebview` is actually the panel viewType prefixed with `mainThreadWebview-` (e.g. `markdown.preview` → `mainThreadWebview-markdown.preview`). Extension authors comparing the two values get unexpected mismatches.

Either the prefix should be stripped in the runtime, or the docs should be updated. Updating the docs is the safe, non-breaking option — stripping the prefix could break extensions that already filter on the prefixed form.

## What

Update the JSDoc on `TabInputWebview.viewType` (and its constructor parameter) in `src/vscode-dts/vscode.d.ts` to:

- Mention the `mainThreadWebview-` prefix.
- Give a concrete example so the relationship to `WebviewPanel.viewType` is unambiguous.

Documentation-only change. No runtime behavior change.

Fixes #201884