### PR TITLE
docs: simplify TextSearchQuery2 JSDoc per #226869

### DIFF
--- a/src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts
@@ -13,42 +13,34 @@ declare module 'vscode' {
 	export interface TextSearchQuery2 {
 		/**
 		 * The text pattern to search for.
-		 *
-		 * If pattern contains a newline character (`\n`), the default search behavior
-		 * will automatically enable {@link isMultiline}.
 		 */
 		pattern: string;
 
 		/**
 		 * Whether or not {@link pattern} should match multiple lines of text.
 		 *
-		 * If using the default search provider, this will be interpreted as `true` if
-		 * {@link pattern} contains a newline character (`\n`).
+		 * Providers that do not handle multiline patterns themselves can fall back
+		 * to single-line matching; the built-in provider treats {@link pattern} as
+		 * multiline whenever it contains a newline character (`\n`).
 		 */
 		isMultiline?: boolean;
 
 		/**
 		 * Whether or not `pattern` should be interpreted as a regular expression.
-		 *
-		 * If using the default search provider, this will be interpreted case-insensitively
-		 * if {@link isCaseSensitive} is `false` or not set.
 		 */
 		isRegExp?: boolean;
 
 		/**
 		 * Whether or not the search should be case-sensitive.
 		 *
-		 * If using the default search provider, this can be affected by the `search.smartCase` setting.
-		 * See the setting description for more information.
+		 * Note: when this is `false`, the built-in search provider may still apply
+		 * case-sensitive matching based on the user's `search.smartCase` setting.
 		 */
 		isCaseSensitive?: boolean;
 
 		/**
-		 * Whether or not to search for whole word matches only.
-		 *
-		 * If enabled, the default search provider will check for boundary characters
-		 * (regex pattern `\b`) surrounding the {@link pattern} to see whether something
-		 * is a word match.
+		 * Whether or not to search for whole word matches only — matches surrounded
+		 * by word-boundary characters (regex pattern `\b`).
 		 */
 		isWordMatch?: boolean;
 	}


### PR DESCRIPTION
## Why

Issue #226869 reports that the JSDoc on `TextSearchQuery2` repeatedly hedges with "If using the default search provider..." for things that are either:

- universal flag semantics (case-insensitivity when `isCaseSensitive` is false, word-boundary matching for `isWordMatch`), or
- not describing the property they are attached to — the case-insensitive note was hanging under `isRegExp`, but it's really about `isCaseSensitive`.

That framing made search-provider authors think the editor would auto-enable flags for them, when in reality the flags are inputs they themselves must honor.

## What

In `src/vscode-dts/vscode.proposed.textSearchProvider2.d.ts`:

- Drop "If using the default search provider..." qualifications from descriptions of universal flag semantics.
- Move the genuinely provider-specific note about `search.smartCase` onto `isCaseSensitive`, where it belongs, and label it as built-in provider behavior.
- For `isMultiline`, keep the built-in newline-detection shortcut but frame it as a fallback example, not as universal behavior.

Documentation-only change in a proposed API; no runtime change.

Fixes #226869