### PR TITLE
docs: clarify unicodeHighlight settings serve a security purpose

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4342,19 +4342,19 @@ class UnicodeHighlight extends BaseEditorOption<EditorOption.unicodeHighlighting
 					type: ['boolean', 'string'],
 					enum: [true, false, inUntrustedWorkspace],
 					default: defaults.nonBasicASCII,
-					description: nls.localize('unicodeHighlight.nonBasicASCII', "Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII.")
+					description: nls.localize('unicodeHighlight.nonBasicASCII', "Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII. Surfacing these characters helps reviewers notice uncommon code points that could be used to obscure intent (a security concern, especially in untrusted code). Zero-width and other invisible characters are covered separately by `#editor.unicodeHighlight.invisibleCharacters#`.")
 				},
 				[unicodeHighlightConfigKeys.invisibleCharacters]: {
 					restricted: true,
 					type: 'boolean',
 					default: defaults.invisibleCharacters,
-					description: nls.localize('unicodeHighlight.invisibleCharacters', "Controls whether characters that just reserve space or have no width at all are highlighted.")
+					description: nls.localize('unicodeHighlight.invisibleCharacters', "Controls whether characters that just reserve space or have no width at all are highlighted. Invisible characters can hide code from review and are flagged for security reasons.")
 				},
 				[unicodeHighlightConfigKeys.ambiguousCharacters]: {
 					restricted: true,
 					type: 'boolean',
 					default: defaults.ambiguousCharacters,
-					description: nls.localize('unicodeHighlight.ambiguousCharacters', "Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale.")
+					description: nls.localize('unicodeHighlight.ambiguousCharacters', "Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale. Confusable characters (homoglyphs) are flagged for security reasons because they can be used to make malicious code look benign.")
 				},
 				[unicodeHighlightConfigKeys.includeComments]: {
 					restricted: true,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4341,19 +4341,19 @@ class UnicodeHighlight extends BaseEditorOption<EditorOption.unicodeHighlighting
 					type: ['boolean', 'string'],
 					enum: [true, false, inUntrustedWorkspace],
 					default: defaults.nonBasicASCII,
-					description: nls.localize('unicodeHighlight.nonBasicASCII', "Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII.")
+					description: nls.localize('unicodeHighlight.nonBasicASCII', "Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII. Highlighting these characters helps reveal hidden Unicode that could disguise the meaning of code (a security concern, especially in untrusted code).")
 				},
 				[unicodeHighlightConfigKeys.invisibleCharacters]: {
 					restricted: true,
 					type: 'boolean',
 					default: defaults.invisibleCharacters,
-					description: nls.localize('unicodeHighlight.invisibleCharacters', "Controls whether characters that just reserve space or have no width at all are highlighted.")
+					description: nls.localize('unicodeHighlight.invisibleCharacters', "Controls whether characters that just reserve space or have no width at all are highlighted. Invisible characters can hide code from review and are flagged for security reasons.")
 				},
 				[unicodeHighlightConfigKeys.ambiguousCharacters]: {
 					restricted: true,
 					type: 'boolean',
 					default: defaults.ambiguousCharacters,
-					description: nls.localize('unicodeHighlight.ambiguousCharacters', "Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale.")
+					description: nls.localize('unicodeHighlight.ambiguousCharacters', "Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale. Confusable characters (homoglyphs) are flagged for security reasons because they can be used to make malicious code look benign.")
 				},
 				[unicodeHighlightConfigKeys.includeComments]: {
 					restricted: true,


### PR DESCRIPTION
## Why

Issue #212812 reports that the descriptions for the `editor.unicodeHighlight.*` settings (`nonBasicASCII`, `invisibleCharacters`, `ambiguousCharacters`) describe **what** is highlighted but not **why**. Users have read these as cosmetic annoyances rather than mitigations against:

- Homoglyph attacks (confusable characters that make malicious code look benign).
- Invisible Unicode that hides code from review.
- Hidden Unicode that disguises the meaning of source code.

This led at least one user to spend time arguing in another issue about whether these characters are a real concern, when the editor's own setting docs could just have said so.

## What

In `src/vs/editor/common/config/editorOptions.ts`, append a short security rationale to each of the three relevant descriptions:

- `nonBasicASCII`: note that highlighting helps reveal hidden Unicode in untrusted code.
- `invisibleCharacters`: note that invisible characters can hide code from review and are flagged for security reasons.
- `ambiguousCharacters`: note that homoglyphs can make malicious code look benign and are flagged for security reasons.

No behavior change. Description-text only.

Fixes #212812