### PR TITLE
docs: clarify when WorkspaceEditEntryMetadata.label is shown

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -3935,12 +3935,17 @@ declare module 'vscode' {
 		needsConfirmation: boolean;
 
 		/**
-		 * A human-readable string which is rendered prominent.
+		 * A human-readable string which is rendered prominently when entries are
+		 * grouped (see {@link WorkspaceEditEntryMetadata}). In the refactor preview,
+		 * this label appears as the group's tree node header — entries sharing a
+		 * label are collected under that node. Note that the preview lists entries
+		 * flat by default; users see the label after enabling "Group change by type".
 		 */
 		label: string;
 
 		/**
-		 * A human-readable string which is rendered less prominent on the same line.
+		 * A human-readable string which is rendered less prominent on the same line
+		 * as {@link label} when entries are grouped.
 		 */
 		description?: string;
 


### PR DESCRIPTION
## Why

Issue #176984 reports that the JSDoc on `WorkspaceEditEntryMetadata.label` calls the string "rendered prominent", but in the refactor preview the label only appears when entries are grouped — and grouping is off by default. Extension authors set a label, expect it to show, and instead see a flat list of edits where their label is nowhere visible.

The interface comment already mentions that the editor "groups edits with equal labels into tree nodes", but the per-property JSDoc on `label` doesn't make the conditional rendering clear.

## What

In `src/vscode-dts/vscode.d.ts`:

- Expand the `label` JSDoc to spell out that it is the group's tree-node header.
- Note that the preview lists entries flat by default and the user has to enable "Group change by type" to see the labels.
- Tweak `description` to mention the relationship to `label`.

Documentation-only change. No runtime behavior change.

Fixes #176984