### PR TITLE
docs: improve languageModelTools.canBeReferencedInPrompt description

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
@@ -97,7 +97,7 @@ const languageModelToolsExtensionPoint = extensionsRegistry.ExtensionsRegistry.r
 					$ref: toolsParametersSchemaSchemaId
 				},
 				canBeReferencedInPrompt: {
-					markdownDescription: localize('canBeReferencedInPrompt', "If true, this tool shows up as an attachment that the user can add manually to their request. Chat participants will receive the tool in {0}.", '`ChatRequest#toolReferences`'),
+					markdownDescription: localize('canBeReferencedInPrompt', "If true, this tool shows up as an attachment that the user can add manually to their request (using `#` followed by the tool's `toolReferenceName`), and the tool also becomes available for use in agent mode."),
 					type: 'boolean'
 				},
 				icon: {


### PR DESCRIPTION
## Why

Issue #245129 reports that the `canBeReferencedInPrompt` contribution-point description only mentions manual attachment by the user and "Chat participants will receive the tool in `ChatRequest#toolReferences`", but the same flag also gates whether the tool is exposed in agent mode. Extension authors who want agent-mode exposure don't realize they have to set this flag, and the chat-participant reference is now misleading because participants aren't the only consumer.

## What

In `src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts`, rewrite the `canBeReferencedInPrompt` schema description to:

- Mention agent-mode availability as a documented effect of setting the flag.
- Drop the chat-participant-specific reference.
- Spell out that the user-facing form is `#` followed by the tool's `toolReferenceName`.

Description-only change. No behavior change.

Fixes #245129