### PR TITLE
Fix webview overlay clipping when maximizing editor groups

### DIFF
--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -183,7 +183,7 @@ export class WebviewEditor extends EditorPane {
 		// Check if this editor is inside a modal editor
 		const modalEditorContainer = this._editorGroupsService.activeModalEditorPart?.modalElement;
 		const isModal = isHTMLElement(modalEditorContainer) && this._element && modalEditorContainer.contains(this._element);
-		this._clippingContainer = isModal ? undefined : this._workbenchLayoutService.getContainer(this.window, Parts.EDITOR_PART);
+		this._clippingContainer = isModal ? undefined : this._element?.parentElement ?? undefined;
 
 		// When shown in a modal editor, the webview overlay must sit above the modal layer
 		input.webview.container.style.zIndex = isModal ? '2541' : ''; // One over the modal z-index


### PR DESCRIPTION
Fixes #312600

## Problem
When an editor group containing a webview-backed preview (for example Markdown Preview, PDF preview via extension, etc.) is maximized, a small orphaned preview surface can remain visible instead of being fully hidden with the non-maximized group.

In practice this shows up as a tiny, unmovable webview "sliver" near the top of the window after maximizing another editor group.

## Repro (from issue)
1. Open a file and open a webview-backed preview (for example: Markdown Preview to the Side).
2. Maximize the editor group containing the source editor.
3. Observe that the preview should be hidden, but a tiny preview surface can remain visible.

## Root Cause
`WebviewEditor` anchors/clips overlay webviews through `OverlayLayoutElement`.

Before this change, non-modal webviews were clipped against the full editor part container (`Parts.EDITOR_PART`) instead of the owning editor group container.

That means when group layout changes (for example maximize/restore), the clip region can still include space outside the actual group bounds for the webview owner, allowing a residual visible fragment.

## Fix
Use the owning editor group's container as the clipping container:

- before: clip to editor part container
- after: clip to the current editor group's DOM container (`this._element?.parentElement`)

Code change is localized to `WebviewEditor.claimWebview(...)` and keeps modal behavior unchanged.

## Why This Is Safe
- No behavior change for modal editors (`isModal` path still skips clipping as before).
- No lifecycle/ownership changes to webview claim/release.
- Only adjusts clipping scope from global editor part to per-group container.
- The change is minimal (single-line behavior change) and constrained to webview overlay placement.

## Validation
- TypeScript compile check:
  - `npm run compile-check-ts-native`
- Hygiene check:
  - `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts`

## Expected Outcome After Fix
When maximizing an editor group, webview-backed previews in non-maximized groups are fully clipped out and no tiny residual preview surface remains visible.
