### PR TITLE
editor: keep linked-editing session alive when tag name is fully deleted

### DIFF
--- a/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
+++ b/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
@@ -310,6 +310,22 @@ export class LinkedEditingContribution extends Disposable implements IEditorCont
 			}
 		}
 
+		// When the reference range has been collapsed to an empty range (e.g. the
+		// user deleted the entire tag name) and the cursor is still at that
+		// position, keep the existing decorations alive instead of asking the
+		// provider for new ranges. Most providers do not return ranges for an
+		// empty tag name, which would otherwise tear down the linked editing
+		// session and prevent the new name from being synced to the closing tag.
+		// See https://github.com/microsoft/vscode/issues/239351.
+		if (this._currentDecorations.length > 0) {
+			const referenceRange = this._currentDecorations.getRange(0);
+			if (referenceRange && referenceRange.isEmpty() && referenceRange.containsPosition(position)) {
+				this._currentRequestPosition = position;
+				this._currentRequestModelVersion = modelVersionId;
+				return;
+			}
+		}
+
 		this._currentRequestPosition = position;
 		this._currentRequestModelVersion = modelVersionId;
 

--- a/src/vs/editor/contrib/linkedEditing/test/browser/linkedEditing.test.ts
+++ b/src/vs/editor/contrib/linkedEditing/test/browser/linkedEditing.test.ts
@@ -398,6 +398,26 @@ suite('linked editing', () => {
 	}, '<ooo></ooo>');
 
 	/**
+	 * Regression test for https://github.com/microsoft/vscode/issues/239351:
+	 * deleting the entire tag name and then typing a new one should keep the
+	 * linked editing session alive so the closing tag is updated as well,
+	 * even when `updateRanges` runs while the reference range is empty (which
+	 * happens once the cursor settles between the delete and the next type).
+	 */
+	testCase('Delete - left word then type - linked session survives empty tag name', state, async (editor) => {
+		const pos = new Position(1, 5);
+		await editor.setPosition(pos);
+		await editor.trigger('keyboard', 'deleteWordLeft', {});
+		// Force `updateRanges` to run while the reference range is collapsed.
+		// Without the fix, the language provider returns no ranges for an empty
+		// tag name and the linked editing session is torn down here.
+		await editor.setPosition(new Position(1, 2));
+		await editor.trigger('keyboard', Handler.Type, { text: 'b' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'o' });
+		await editor.trigger('keyboard', Handler.Type, { text: 'x' });
+	}, '<box></box>');
+
+	/**
 	 * Todo: Fix test
 	 */
 	// testCase('Delete - left all', state, async (editor) => {


### PR DESCRIPTION
## Summary

Fixes #239351

When linked editing is active on a paired HTML/JSX tag and the user clears the tag's name completely (e.g. `<ooo>` becomes `<>`), the closing tag stops mirroring further edits. Typing a new name afterwards only updates the opening tag, leaving the markup mismatched.

The root cause is in `LinkedEditingContribution.updateRanges`: after each edit, the code re-queries the language provider using the cursor position. When the reference range has just collapsed to empty at that cursor, the provider has nothing to anchor on and returns no ranges, so the existing decorations are torn down and the linked-editing session ends silently.

## Fix

Before re-querying the provider in `updateRanges`, detect the case where the current reference decoration range is empty and the primary cursor is still inside it. In that situation we keep the existing decorations alive and skip the provider call, so the next non-empty edit continues to mirror across both tags.

A regression test (`Delete - left word then type - linked session survives empty tag name`) was added to `linkedEditing.test.ts` that deletes the entire tag name, types a replacement, and asserts the closing tag is updated in lockstep with the opening tag.

## How to test

1. Open an HTML or JSX file in VS Code.
2. Type `<ooo></ooo>`.
3. Place the cursor inside the opening `<ooo>` tag, select the entire tag name, and delete it so the buffer reads `<></>`.
4. Type a new name, e.g. `div`.
5. Confirm that BOTH the opening and closing tags update together to `<div></div>`.

Before this change, only the opening tag updates and the closing tag stays empty.

## Files changed

- `src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts` - early-return guard in `updateRanges` for the collapsed-reference-with-cursor case.
- `src/vs/editor/contrib/linkedEditing/test/browser/linkedEditing.test.ts` - regression test covering the delete-then-retype flow.