### PR TITLE
comments: fix listener leak in mainThreadComments

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/browser/mainThreadComments.ts
@@ -573,6 +573,14 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 			this._activeEditingCommentThread = thread as MainThreadCommentThread<IRange | ICellRange>;
 			controller.activeEditingCommentThread = this._activeEditingCommentThread;
 		}));
+
+		this._register(this._commentService.onResourceHasCommentingRanges(() => {
+			this.registerView();
+		}));
+
+		this._register(this._commentService.onDidUpdateCommentThreads(() => {
+			this.registerView();
+		}));
 	}
 
 	$registerCommentController(handle: number, id: string, label: string, extensionId: string): void {
@@ -582,14 +590,6 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		const provider = new MainThreadCommentController(this._proxy, this._commentService, handle, providerId, id, label, {});
 		this._commentService.registerCommentController(providerId, provider);
 		this._commentControllers.set(handle, provider);
-
-		this._register(this._commentService.onResourceHasCommentingRanges(e => {
-			this.registerView();
-		}));
-
-		this._register(this._commentService.onDidUpdateCommentThreads(e => {
-			this.registerView();
-		}));
 
 		this._commentService.setWorkspaceComments(String(handle), []);
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/312612

## Problem

`onResourceHasCommentingRanges` and `onDidUpdateCommentThreads` were subscribed inside `$registerCommentController` using `this._register()`, which appends to the class-level `DisposableStore`. Each call to `$registerCommentController` — one per comment provider extension — permanently added a new pair of listeners, causing unbounded accumulation. With enough extensions (or extension host restarts), this hits the global leak warning threshold of 175.

## Root cause

The regression was introduced by f64aa5122e5 (#242550, "Comments panel appears without having GHPR installed"). That change correctly made view registration lazy (event-driven rather than eager), but accidentally placed the event subscriptions in `$registerCommentController` instead of the constructor.

The subsequent March 2025 fixes (#243846, #244017) fixed other leaks in `registerViewListeners` but missed this one.

## Fix

Move both listeners to the constructor, where they're registered exactly once. The lazy behavior from #242550 is fully preserved — `registerView()` is still only called when comments actually exist, and it contains its own idempotency guard (`getViewDescriptorById`).

(Written by Copilot)