### PR TITLE
agents: enhance welcome screen for first-launch and signed-in users

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
+++ b/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
@@ -363,6 +363,43 @@
 	border-radius: 2px !important;
 }
 
+/* ---- Welcome screen (first launch + signed in) ---- */
+
+.sessions-walkthrough-welcome-actions {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
+	margin-top: 16px;
+}
+
+.sessions-walkthrough-get-started-btn {
+	padding: 8px 24px;
+	border-radius: 6px;
+	border: none;
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 100ms;
+}
+
+.sessions-walkthrough-get-started-btn:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.sessions-walkthrough-get-started-btn:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.sessions-walkthrough-tagline {
+	font-style: italic;
+	opacity: 0.85;
+	margin-top: 4px;
+}
+
 /* Reduced motion */
 
 .monaco-reduce-motion .sessions-walkthrough-overlay,

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -151,10 +151,11 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		const titleEl = this._isFirstLaunch
 			? append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)))
 			: append(right, $('h2', undefined, localize('walkthrough.signin.title', "Sign In")));
-		const subtitleEl = append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding agent that builds, tests, and iterates for you.")));
-		append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
-		if (!this._isFirstLaunch) {
-			append(right, $('p', undefined, localize('walkthrough.signin.subtitle', "Sign in to continue.")));
+		const subtitleEl = append(right, $('p', undefined, this._isFirstLaunch
+			? localize('walkthrough.welcome.subtitle', "Your AI-powered coding agent that builds, tests, and iterates for you.")
+			: localize('walkthrough.signin.subtitle', "Sign in to continue.")));
+		if (this._isFirstLaunch) {
+			append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
 		}
 
 		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl);

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -49,12 +49,22 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	private currentFocusableElements: readonly HTMLElement[] = [];
 	private _resolveOutcome!: (outcome: WalkthroughOutcome) => void;
 	private _outcomeResolved = false;
+	private _isShowingWelcome = false;
+
+	/**
+	 * Whether the overlay is currently displaying the signed-in welcome
+	 * greeting (as opposed to the sign-in provider buttons). When `true`,
+	 * external callers should **not** auto-dismiss the overlay — the user
+	 * is expected to click "Get Started" to proceed.
+	 */
+	get isShowingWelcome(): boolean { return this._isShowingWelcome; }
 
 	/** Resolves when the user completes or dismisses the walkthrough. */
 	readonly outcome: Promise<WalkthroughOutcome> = new Promise(resolve => { this._resolveOutcome = resolve; });
 
 	constructor(
 		container: HTMLElement,
+		private readonly _isFirstLaunch: boolean,
 		@IChatEntitlementService private readonly chatEntitlementService: ChatEntitlementService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -102,6 +112,12 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		this.disclaimerElement = disclaimer.element;
 		this.disclaimerLinks = disclaimer.links;
 
+		// Set synchronously so the autorun in the contribution doesn't
+		// auto-dismiss before the async _renderSignIn completes.
+		if (this._isFirstLaunch && this._isAlreadySetUp()) {
+			this._isShowingWelcome = true;
+		}
+
 		this._renderSignIn();
 	}
 
@@ -115,26 +131,41 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		this.footerContainer.textContent = '';
 		this.disclaimerElement.classList.toggle('hidden', this.disclaimerLinks.length === 0);
 
+		const productName = this.productService.nameLong;
+
 		// Horizontal layout: icon left, text + buttons right
 		const layout = append(this.contentContainer, $('.sessions-walkthrough-hero'));
 
 		append(layout, $('div.sessions-walkthrough-logo'));
 
 		const right = append(layout, $('.sessions-walkthrough-hero-text'));
-		const titleEl = append(right, $('h2', undefined, localize('walkthrough.step1.title', "Welcome to Agents")));
-		const subtitleEl = append(right, $('p', undefined, localize('walkthrough.step1.subtitle', "Sign in to continue with agent-powered development.")));
 
-		// If already signed in, finish immediately so the app can render.
-		if (this._isAlreadySetUp()) {
-			this.complete();
+		// First time + signed in → welcome greeting with "Get Started"
+		if (this._isFirstLaunch && this._isAlreadySetUp()) {
+			this._renderWelcome(stepDisposables, right, productName);
 			return;
 		}
 
+		// First time + not signed in → welcome content with sign-in buttons
+		// Returning + not signed in → plain sign-in screen
+		const titleEl = this._isFirstLaunch
+			? append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)))
+			: append(right, $('h2', undefined, localize('walkthrough.signin.title', "Sign In")));
+		const subtitleEl = append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding agent that builds, tests, and iterates for you.")));
+		append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
+		if (!this._isFirstLaunch) {
+			append(right, $('p', undefined, localize('walkthrough.signin.subtitle', "Sign in to continue.")));
+		}
+
+		this._renderSignInButtons(stepDisposables, right, titleEl, subtitleEl);
+	}
+
+	private _renderSignInButtons(stepDisposables: DisposableStore, right: HTMLElement, titleEl: HTMLElement, subtitleEl: HTMLElement): void {
 		const signInActions = append(right, $('.sessions-walkthrough-sign-in-actions'));
 		const providerRow = append(signInActions, $('.sessions-walkthrough-providers-row'));
 
 		const githubBtn = append(providerRow, $('button.sessions-walkthrough-provider-btn.sessions-walkthrough-provider-primary.provider-github')) as HTMLButtonElement;
-		append(githubBtn, $('span.sessions-walkthrough-provider-label', undefined, localize('walkthrough.signin.github', "Continue with GitHub")));
+		append(githubBtn, $('span.sessions-walkthrough-provider-label', undefined, localize('walkthrough.signin.github', "Sign in with GitHub")));
 
 		// Desktop-only provider buttons
 		let providerButtons: HTMLButtonElement[];
@@ -200,6 +231,34 @@ export class SessionsWalkthroughOverlay extends Disposable {
 				)));
 			}
 		}
+	}
+
+	// ------------------------------------------------------------------
+	// Welcome (first launch + signed in)
+
+	private _renderWelcome(stepDisposables: DisposableStore, right: HTMLElement, productName: string): void {
+		this._isShowingWelcome = true;
+		this.disclaimerElement.classList.add('hidden');
+
+		append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)));
+		append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding agent that builds, tests, and iterates for you.")));
+		append(right, $('p.sessions-walkthrough-tagline', undefined, localize('walkthrough.welcome.tagline', "Happy Agentic Coding!")));
+
+		const actions = append(right, $('.sessions-walkthrough-welcome-actions'));
+		const getStartedBtn = append(actions, $('button.sessions-walkthrough-get-started-btn')) as HTMLButtonElement;
+		getStartedBtn.textContent = localize('walkthrough.welcome.getStarted', "Get Started");
+		stepDisposables.add(addDisposableListener(getStartedBtn, EventType.CLICK, () => {
+			this._isShowingWelcome = false;
+			this.complete();
+		}));
+
+		this.currentFocusableElements = [getStartedBtn];
+
+		disposableTimeout(() => {
+			if (this.overlay.isConnected) {
+				getStartedBtn.focus();
+			}
+		}, 0, stepDisposables);
 	}
 
 	private _isAlreadySetUp(): boolean {

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -75,13 +75,14 @@ export function resetSessionsWelcome(
 	const walkthrough = store.add(instantiationService.createInstance(
 		SessionsWalkthroughOverlay,
 		layoutService.mainContainer,
+		true,
 	));
 
 	store.add(autorun(reader => {
 		chatEntitlementService.sentimentObs.read(reader);
 		chatEntitlementService.entitlementObs.read(reader);
 
-		if (!needsChatSetup(chatEntitlementService)) {
+		if (!walkthrough.isShowingWelcome && !needsChatSetup(chatEntitlementService)) {
 			storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 			walkthrough.complete();
 			store.dispose();
@@ -141,7 +142,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		}
 		const isFirstLaunch = !this.storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false);
 		if (isFirstLaunch) {
-			this.showWalkthrough();
+			this.showWalkthrough(true);
 		} else {
 			this.showWalkthroughIfNeeded();
 		}
@@ -163,7 +164,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		} catch {
 			// Provider not available yet — show walkthrough
 		}
-		this.showWalkthrough();
+		this.showWalkthrough(false);
 	}
 
 	/**
@@ -188,13 +189,13 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			}
 			this.logService.info('[sessions welcome] GitHub session removed on web, re-showing walkthrough');
 			this.storageService.remove(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION);
-			this.showWalkthrough();
+			this.showWalkthrough(false);
 		}));
 	}
 
 	private showWalkthroughIfNeeded(): void {
 		if (this._needsChatSetup()) {
-			this.showWalkthrough();
+			this.showWalkthrough(false);
 		} else {
 			this.watchEntitlementState();
 		}
@@ -220,7 +221,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			const includeUnknown = !this.storageService.getBoolean(WELCOME_COMPLETE_KEY, StorageScope.APPLICATION, false);
 			const needsSetup = this._needsChatSetup(includeUnknown);
 			if (setupComplete && needsSetup) {
-				this.showWalkthrough();
+				this.showWalkthrough(false);
 			}
 			setupComplete = !needsSetup;
 		});
@@ -230,7 +231,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		return needsChatSetup(this.chatEntitlementService, includeUnknown);
 	}
 
-	private showWalkthrough(): void {
+	private showWalkthrough(isFirstLaunch: boolean): void {
 		if (this.overlayRef.value) {
 			return;
 		}
@@ -247,6 +248,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 		const walkthrough = this.overlayRef.value.add(this.instantiationService.createInstance(
 			SessionsWalkthroughOverlay,
 			this.layoutService.mainContainer,
+			isFirstLaunch,
 		));
 
 		// When chat setup completes (observables flip), persist completion and
@@ -255,7 +257,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			this.chatEntitlementService.sentimentObs.read(reader);
 			this.chatEntitlementService.entitlementObs.read(reader);
 
-			if (!welcomeCompletionStored && !this._needsChatSetup()) {
+			if (!welcomeCompletionStored && !walkthrough.isShowingWelcome && !this._needsChatSetup()) {
 				welcomeCompletionStored = true;
 				this.storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 				walkthrough.complete();

--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -299,7 +299,7 @@ suite('SessionsWelcomeContribution', () => {
 		document.body.appendChild(container);
 
 		try {
-			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container));
+			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
 			const overlayElement = container.querySelector<HTMLElement>('.sessions-walkthrough-overlay');
 			assert.ok(overlayElement);
 
@@ -349,7 +349,7 @@ suite('SessionsWelcomeContribution', () => {
 					}
 				} as unknown as ICommandService);
 
-				const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container));
+				const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
 				const githubButton = container.querySelector<HTMLButtonElement>('.sessions-walkthrough-provider-btn.provider-github');
 				const googleButton = container.querySelector<HTMLButtonElement>('.sessions-walkthrough-provider-btn.provider-google');
 				const appleButton = container.querySelector<HTMLButtonElement>('.sessions-walkthrough-provider-btn.provider-apple');
@@ -406,7 +406,7 @@ suite('SessionsWelcomeContribution', () => {
 		document.body.appendChild(container);
 
 		try {
-			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container));
+			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
 			const enterpriseButton = container.querySelector<HTMLButtonElement>('.sessions-walkthrough-provider-btn.provider-enterprise');
 			assert.ok(enterpriseButton);
 
@@ -455,7 +455,7 @@ suite('SessionsWelcomeContribution', () => {
 		document.body.appendChild(container);
 
 		try {
-			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container));
+			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
 			const disclaimer = container.querySelector<HTMLElement>('.sessions-walkthrough-disclaimer');
 			assert.ok(disclaimer);
 			assert.strictEqual(disclaimer.classList.contains('hidden'), false);
@@ -499,7 +499,7 @@ suite('SessionsWelcomeContribution', () => {
 		document.body.appendChild(container);
 
 		try {
-			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container));
+			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
 			const disclaimer = container.querySelector<HTMLElement>('.sessions-walkthrough-disclaimer');
 			assert.ok(disclaimer);
 			assert.strictEqual(disclaimer.classList.contains('hidden'), false);

--- a/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
+++ b/src/vs/sessions/contrib/welcome/test/browser/welcome.contribution.test.ts
@@ -279,6 +279,50 @@ suite('SessionsWelcomeContribution', () => {
 		assert.strictEqual(isOverlayVisible(), false, 'should dismiss once setup completes');
 	});
 
+	(isWeb ? test.skip : test)('first-launch + already signed in shows welcome screen; Get Started completes it', async () => {
+		// Already set up: installed, not disabled, has entitlement
+		mockEntitlementService.entitlementObs.set(ChatEntitlement.Free, undefined);
+		mockEntitlementService.sentimentObs.set({ completed: true, installed: true } as IChatSentiment, undefined);
+
+		instantiationService.stub(IDefaultAccountService, {
+			getDefaultAccount: () => Promise.resolve(undefined)
+		} as unknown as IDefaultAccountService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ICommandService, {
+			executeCommand: () => Promise.resolve(false)
+		} as unknown as ICommandService);
+		instantiationService.stub(IExtensionService, {
+			stopExtensionHosts: () => Promise.resolve(false),
+			startExtensionHosts: () => Promise.resolve()
+		} as unknown as IExtensionService);
+
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		try {
+			const overlay = disposables.add(instantiationService.createInstance(SessionsWalkthroughOverlay, container, true));
+
+			assert.strictEqual(overlay.isShowingWelcome, true, 'should be in welcome mode');
+			assert.ok(container.querySelector('.sessions-walkthrough-get-started-btn'), 'should show Get Started button');
+			assert.strictEqual(container.querySelector('.sessions-walkthrough-provider-btn'), null, 'should not show sign-in buttons');
+
+			let outcomeResolved = false;
+			overlay.outcome.then(() => { outcomeResolved = true; });
+
+			const getStartedBtn = container.querySelector<HTMLButtonElement>('.sessions-walkthrough-get-started-btn');
+			assert.ok(getStartedBtn);
+			getStartedBtn.click();
+			await flushMicrotasks();
+
+			assert.strictEqual(overlay.isShowingWelcome, false, 'isShowingWelcome should be cleared after Get Started');
+			assert.strictEqual(outcomeResolved, true, 'outcome should resolve after Get Started click');
+
+			overlay.dispose();
+		} finally {
+			container.remove();
+		}
+	});
+
 	test('walkthrough cannot be dismissed by Escape or backdrop click', () => {
 		mockEntitlementService.entitlementObs.set(ChatEntitlement.Unknown, undefined);
 		mockEntitlementService.sentimentObs.set({ installed: false } as IChatSentiment, undefined);


### PR DESCRIPTION
## Summary

Enhances the Agents App welcome screen to provide a tailored experience based on whether the user is signed in and whether it's their first launch.

### Changes

**Three distinct welcome experiences:**
1. **First-launch + already signed in** → Welcome greeting screen with a "Get Started" button (no sign-in required)
2. **First-launch + not signed in** → Enhanced sign-in screen with welcome content
3. **Returning + not signed in** → Plain sign-in screen (unchanged behavior)

**Other improvements:**
- Updated sign-in button label to "Sign in with GitHub"
- Added "Happy Agentic Coding!" tagline to welcome screens
- Added `isFirstLaunch` parameter to `SessionsWalkthroughOverlay`
- Fixed race condition: `isShowingWelcome` is now set synchronously in the constructor so the autorun guard doesn't auto-dismiss the overlay before the welcome renders
- Fixed developer reset command (`workbench.action.resetSessionsWelcome`) to properly simulate a first-launch experience

### Files changed

- `sessionsWalkthrough.ts` — core overlay; added `_isFirstLaunch` param, `isShowingWelcome` getter, `_renderWelcome()` method
- `welcome.contribution.ts` — overlay lifecycle; added `isFirstLaunch` passing, autorun guard, reset command fix
- `sessionsWalkthrough.css` — welcome action/button/tagline styles
- `welcome.contribution.test.ts` — updated tests to pass `isFirstLaunch = true`