### PR TITLE
Fix agent host agents in vscode

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -145,6 +145,14 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		const agentId = sessionType;
 		const vendor = sessionType;
 
+		// In the Agents app, the agent-host displayName is unambiguous because
+		// only agent-host sessions exist there. In VS Code, the same picker
+		// also lists the extension-host harness with the same displayName
+		// (e.g. "Copilot CLI"), so suffix with "- Agent Host" to disambiguate.
+		const displayName = this._isSessionsWindow
+			? agent.displayName
+			: localize('agentHost.displayName', "{0} - Agent Host", agent.displayName);
+
 		// Chat session contribution.
 		// In the Agents app, hide the delegation picker for local agent host
 		// sessions (matches behavior of remote agent host sessions). In VS Code,
@@ -152,7 +160,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 		store.add(this._chatSessionsService.registerChatSessionContribution({
 			type: sessionType,
 			name: agentId,
-			displayName: agent.displayName,
+			displayName,
 			description: agent.description,
 			canDelegate: true,
 			requiresCustomModels: true,

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -810,10 +810,17 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		}
 
 		this._contributions.set(contribution.type, { contribution, extension: undefined });
+		// Programmatically-registered contributions are always considered
+		// available; mark them as such so the autorun in the constructor
+		// registers the in-place "New {0} Session" action for them. Without
+		// this, types like `agent-host-copilotcli` (registered by the local
+		// agent host) have no `openNewChatSessionInPlace.<type>` command.
+		this._contributionDisposables.set(contribution.type, new DisposableStore());
 		this._onDidChangeAvailability.fire();
 
 		return toDisposable(() => {
 			this._contributions.delete(contribution.type);
+			this._contributionDisposables.deleteAndDispose(contribution.type);
 			this._onDidChangeAvailability.fire();
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -816,11 +816,13 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		// this, types like `agent-host-copilotcli` (registered by the local
 		// agent host) have no `openNewChatSessionInPlace.<type>` command.
 		this._contributionDisposables.set(contribution.type, new DisposableStore());
+		this._updateHasCanDelegateProvidersContextKey();
 		this._onDidChangeAvailability.fire();
 
 		return toDisposable(() => {
 			this._contributions.delete(contribution.type);
 			this._contributionDisposables.deleteAndDispose(contribution.type);
+			this._updateHasCanDelegateProvidersContextKey();
 			this._onDidChangeAvailability.fire();
 		});
 	}


### PR DESCRIPTION
Fixes the "command 'workbench.action.chat.openNewChatSessionInPlace.agent-host-copilotcli' not found" error that fires when switching to the local Copilot CLI agent host from the session-type picker in VS Code.

## What

- In `ChatSessionsService.registerChatSessionContribution`, also populate `_contributionDisposables` so programmatic contributions participate in the autorun that registers `openNewChatSessionInPlace.<type>` actions.
- In `AgentHostContribution._registerAgent`, suffix the agent's `displayName` with `" - Agent Host"` when running in VS Code, to disambiguate from the extension-host Copilot CLI harness which uses the same label. The Agents window keeps the original `displayName`.

## Why

The autorun in `chatSessions.contribution.ts` iterates `_contributions` filtered by `_contributionDisposables.has(...)` to register the per-type "New {0} Session" action. Only extension-contributed providers were being added to that map (via `_evaluateAvailability`); programmatic registrations (used by both local and remote agent hosts) only populated `_contributions`, so the autorun filtered them out and no command was registered.

This affected both local agent host (`agent-host-copilotcli`) and remote agent host (`remote-*`) types.

## Notes for reviewers

- The label disambiguation only applies in VS Code (`!_isSessionsWindow`). The Agents window already shows only agent-host sessions, so no suffix is needed.
- No new tests; the fix is a one-line wiring change in a path exercised at runtime by `AgentHostContribution`.

(Written by Copilot)