### PR TITLE
Agents: enhance SSH and remote agent host management

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -1366,9 +1366,10 @@ export class ActionListWidget<T> extends Disposable {
 				}
 				for (let ci = 0; ci < group.actions.length; ci++) {
 					const child = group.actions[ci];
-					const icon = (child as IAction & { icon?: ThemeIcon }).icon
+					const extendedChild = child as IAction & { icon?: ThemeIcon; hoverContent?: string; onRemove?: () => void };
+					const icon = extendedChild.icon
 						?? ThemeIcon.fromId(child.checked ? Codicon.check.id : Codicon.blank.id);
-					const hoverContent = (child as IAction & { hoverContent?: string }).hoverContent;
+					const hoverContent = extendedChild.hoverContent;
 					submenuItems.push({
 						item: child,
 						kind: ActionListItemKind.Action,
@@ -1377,6 +1378,7 @@ export class ActionListWidget<T> extends Disposable {
 						group: { title: '', icon },
 						hideIcon: false,
 						hover: hoverContent ? { content: hoverContent } : {},
+						onRemove: extendedChild.onRemove,
 					});
 				}
 				if (gi < groupsWithActions.length - 1) {
@@ -1386,6 +1388,7 @@ export class ActionListWidget<T> extends Disposable {
 			// Also include non-SubmenuAction items directly
 			for (const action of element.submenuActions!) {
 				if (!(action instanceof SubmenuAction)) {
+					const extendedAction = action as IAction & { onRemove?: () => void };
 					submenuItems.push({
 						item: action,
 						kind: ActionListItemKind.Action,
@@ -1394,6 +1397,7 @@ export class ActionListWidget<T> extends Disposable {
 						group: { title: '' },
 						hideIcon: false,
 						hover: {},
+						onRemove: extendedAction.onRemove,
 					});
 				}
 			}

--- a/src/vs/platform/agentHost/browser/nullSshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/browser/nullSshRemoteAgentHostService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+import { URI } from '../../../base/common/uri.js';
 import type { ISSHRemoteAgentHostService, ISSHAgentHostConnection, ISSHAgentHostConfig, ISSHConnectProgress, ISSHResolvedConfig } from '../common/sshRemoteAgentHost.js';
 
 /**
@@ -23,6 +24,14 @@ export class NullSSHRemoteAgentHostService implements ISSHRemoteAgentHostService
 	async disconnect(_host: string): Promise<void> { }
 
 	async listSSHConfigHosts(): Promise<string[]> {
+		return [];
+	}
+
+	async ensureUserSSHConfig(): Promise<URI> {
+		throw new Error('SSH is not supported in the browser.');
+	}
+
+	async listSSHConfigFiles(): Promise<URI[]> {
 		return [];
 	}
 

--- a/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
+++ b/src/vs/platform/agentHost/common/sshRemoteAgentHost.ts
@@ -5,6 +5,7 @@
 
 import { Event } from '../../../base/common/event.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 
 export const ISSHRemoteAgentHostService = createDecorator<ISSHRemoteAgentHostService>('sshRemoteAgentHostService');
@@ -107,6 +108,20 @@ export interface ISSHRemoteAgentHostService {
 	/** List SSH config host aliases (excluding wildcards). */
 	listSSHConfigHosts(): Promise<string[]>;
 
+	/**
+	 * Ensure `~/.ssh/config` exists (creating it with the right permissions if
+	 * missing) and return its URI. The parent `~/.ssh` directory is created
+	 * with mode 0700 and the config file with mode 0600 on POSIX systems.
+	 */
+	ensureUserSSHConfig(): Promise<URI>;
+
+	/**
+	 * List the known SSH configuration file URIs in priority order — typically the
+	 * per-user `~/.ssh/config` (always returned, even if it does not yet exist) and
+	 * the system-wide `/etc/ssh/ssh_config` (only when present on disk).
+	 */
+	listSSHConfigFiles(): Promise<URI[]>;
+
 	/** Resolve full SSH config for a host via `ssh -G`. */
 	resolveSSHConfig(host: string): Promise<ISSHResolvedConfig>;
 
@@ -201,6 +216,15 @@ export interface ISSHRemoteAgentHostMainService {
 
 	/** List SSH config host aliases (excluding wildcards). */
 	listSSHConfigHosts(): Promise<string[]>;
+
+	/**
+	 * Ensure `~/.ssh/config` exists (creating it with the right permissions if
+	 * missing) and return its URI.
+	 */
+	ensureUserSSHConfig(): Promise<URI>;
+
+	/** List the known SSH configuration file URIs (user config always included). */
+	listSSHConfigFiles(): Promise<URI[]>;
 
 	/** Resolve full SSH config for a host via `ssh -G`. */
 	resolveSSHConfig(host: string): Promise<ISSHResolvedConfig>;

--- a/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl.ts
@@ -5,6 +5,7 @@
 
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
 import { ILogService } from '../../log/common/log.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { ISharedProcessService } from '../../ipc/electron-browser/services.js';
@@ -89,6 +90,14 @@ export class SSHRemoteAgentHostService extends Disposable implements ISSHRemoteA
 
 	async listSSHConfigHosts(): Promise<string[]> {
 		return this._mainService.listSSHConfigHosts();
+	}
+
+	async ensureUserSSHConfig(): Promise<URI> {
+		return this._mainService.ensureUserSSHConfig();
+	}
+
+	async listSSHConfigFiles(): Promise<URI[]> {
+		return this._mainService.listSSHConfigFiles();
 	}
 
 	async resolveSSHConfig(host: string): Promise<ISSHResolvedConfig> {

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -704,6 +704,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			await fsp.mkdir(sshDir, { recursive: true, mode: isPosix ? 0o700 : undefined });
 		} catch (err) {
 			this._logService.warn(`${LOG_PREFIX} Failed to ensure ~/.ssh directory: ${err}`);
+			throw err;
 		}
 		try {
 			await fsp.access(configPath);
@@ -713,6 +714,7 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 				await handle.close();
 			} catch (err) {
 				this._logService.warn(`${LOG_PREFIX} Failed to create ${configPath}: ${err}`);
+				throw err;
 			}
 		}
 		return URI.file(configPath);

--- a/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/node/sshRemoteAgentHostService.ts
@@ -11,6 +11,7 @@ import * as cp from 'child_process';
 import { dirname, join, isAbsolute, basename } from '../../../base/common/path.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Disposable, DisposableMap, toDisposable } from '../../../base/common/lifecycle.js';
+import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ILogService } from '../../log/common/log.js';
 import { IProductService } from '../../product/common/productService.js';
@@ -693,6 +694,45 @@ export class SSHRemoteAgentHostMainService extends Disposable implements ISSHRem
 			this._logService.info(`${LOG_PREFIX} Could not read SSH config at ${configPath}`);
 			return [];
 		}
+	}
+
+	async ensureUserSSHConfig(): Promise<URI> {
+		const sshDir = join(os.homedir(), '.ssh');
+		const configPath = join(sshDir, 'config');
+		const isPosix = process.platform !== 'win32';
+		try {
+			await fsp.mkdir(sshDir, { recursive: true, mode: isPosix ? 0o700 : undefined });
+		} catch (err) {
+			this._logService.warn(`${LOG_PREFIX} Failed to ensure ~/.ssh directory: ${err}`);
+		}
+		try {
+			await fsp.access(configPath);
+		} catch {
+			try {
+				const handle = await fsp.open(configPath, 'a', isPosix ? 0o600 : undefined);
+				await handle.close();
+			} catch (err) {
+				this._logService.warn(`${LOG_PREFIX} Failed to create ${configPath}: ${err}`);
+			}
+		}
+		return URI.file(configPath);
+	}
+
+	async listSSHConfigFiles(): Promise<URI[]> {
+		const isWindows = process.platform === 'win32';
+		const userConfigPath = join(os.homedir(), '.ssh', 'config');
+		const systemConfigPath = isWindows
+			? join(process.env['ProgramData'] ?? 'C:\\ProgramData', 'ssh', 'ssh_config')
+			: '/etc/ssh/ssh_config';
+
+		const result: URI[] = [URI.file(userConfigPath)];
+		try {
+			await fsp.access(systemConfigPath);
+			result.push(URI.file(systemConfigPath));
+		} catch {
+			// system config file does not exist — skip
+		}
+		return result;
 	}
 
 	async resolveSSHConfig(host: string): Promise<ISSHResolvedConfig> {

--- a/src/vs/platform/agentHost/test/electron-browser/sshRelayTransport.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRelayTransport.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { SSHRelayTransport } from '../../electron-browser/sshRelayTransport.js';
 import type { ISSHRelayMessage, ISSHRemoteAgentHostMainService, ISSHConnectProgress, ISSHConnectResult, ISSHAgentHostConfig, ISSHResolvedConfig } from '../../common/sshRemoteAgentHost.js';
@@ -35,6 +36,8 @@ class MockSSHMainService {
 	}
 	async disconnect(_host: string): Promise<void> { }
 	async listSSHConfigHosts(): Promise<string[]> { return []; }
+	async ensureUserSSHConfig(): Promise<URI> { return URI.file('/tmp/ssh-config'); }
+	async listSSHConfigFiles(): Promise<URI[]> { return [URI.file('/tmp/ssh-config')]; }
 	async resolveSSHConfig(_host: string): Promise<ISSHResolvedConfig> {
 		throw new Error('Not implemented');
 	}

--- a/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/sshRemoteAgentHostService.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import type { IChannel } from '../../../../base/parts/ipc/common/ipc.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
@@ -80,6 +81,8 @@ class MockSSHMainService {
 	}
 
 	async listSSHConfigHosts(): Promise<string[]> { return []; }
+	async ensureUserSSHConfig(): Promise<URI> { return URI.file('/tmp/ssh-config'); }
+	async listSSHConfigFiles(): Promise<URI[]> { return [URI.file('/tmp/ssh-config')]; }
 	async resolveSSHConfig(_host: string): Promise<ISSHResolvedConfig> {
 		return { hostname: '', user: undefined, port: 22, identityFile: [], forwardAgent: false };
 	}

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -9,15 +9,12 @@ import { IActionWidgetService } from '../../../../platform/actionWidget/browser/
 import { ActionListItemKind, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
-import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
-import { IOutputService } from '../../../../workbench/services/output/common/output.js';
-import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostFilterService } from '../../remoteAgentHost/common/agentHostFilter.js';
 import { IWorkspacePickerItem, IWorkspaceSelection, WorkspacePicker } from './sessionWorkspacePicker.js';
@@ -41,15 +38,12 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService sessionsProvidersService: ISessionsProvidersService,
 		@IRemoteAgentHostService remoteAgentHostService: IRemoteAgentHostService,
-		@IQuickInputService quickInputService: IQuickInputService,
-		@IClipboardService clipboardService: IClipboardService,
-		@IPreferencesService preferencesService: IPreferencesService,
-		@IOutputService outputService: IOutputService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@ICommandService commandService: ICommandService,
 		@IWorkspacesService workspacesService: IWorkspacesService,
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 	) {
 		super(
@@ -58,15 +52,12 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 			uriIdentityService,
 			sessionsProvidersService,
 			remoteAgentHostService,
-			quickInputService,
-			clipboardService,
-			preferencesService,
-			outputService,
 			configurationService,
 			commandService,
 			workspacesService,
 			menuService,
 			contextKeyService,
+			instantiationService,
 		);
 
 		// When the scoped host changes, if the current selection no longer

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -529,6 +529,8 @@ export class WorkspacePicker extends Disposable {
 	}
 
 	private _showRemoteHostOptionsDelayed(provider: IAgentHostSessionsProvider): void {
+		// Defer one tick so the action widget fully tears down (focus/DOM cleanup)
+		// before the QuickPick opens and claims focus.
 		const timeout = setTimeout(() => {
 			this.instantiationService.invokeFunction(accessor => showRemoteHostOptions(accessor, provider));
 		}, 1);

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -19,13 +19,9 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../
 import { IMenuService, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
-import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
-import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
-import { IOutputService } from '../../../../workbench/services/output/common/output.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
@@ -33,6 +29,8 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ISessionWorkspace, ISessionWorkspaceBrowseAction } from '../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { getStatusHover, getStatusLabel, showRemoteHostOptions } from '../../remoteAgentHost/browser/remoteHostOptions.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
 import { IWorkspacesService, isRecentFolder } from '../../../../platform/workspaces/common/workspaces.js';
 import { Menus } from '../../../browser/menus.js';
@@ -126,15 +124,12 @@ export class WorkspacePicker extends Disposable {
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@ISessionsProvidersService protected readonly sessionsProvidersService: ISessionsProvidersService,
 		@IRemoteAgentHostService private readonly remoteAgentHostService: IRemoteAgentHostService,
-		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IClipboardService private readonly clipboardService: IClipboardService,
-		@IPreferencesService private readonly preferencesService: IPreferencesService,
-		@IOutputService private readonly outputService: IOutputService,
 		@IConfigurationService _configurationService: IConfigurationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IWorkspacesService private readonly workspacesService: IWorkspacesService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -476,16 +471,22 @@ export class WorkspacePicker extends Disposable {
 			const action = toAction({
 				id: `workspacePicker.remote.${provider.id}`,
 				label: provider.label,
-				tooltip: this._getStatusLabel(status),
+				tooltip: getStatusLabel(status),
 				enabled: true,
 				run: () => {
 					this.actionWidgetService.hide();
 					this._showRemoteHostOptionsDelayed(provider);
 				},
 			});
-			const extended = action as IAction & { icon?: ThemeIcon; hoverContent?: string };
+			const extended = action as IAction & { icon?: ThemeIcon; hoverContent?: string; onRemove?: () => void };
 			extended.icon = isTunnel ? Codicon.cloud : Codicon.remote;
-			extended.hoverContent = this._getStatusHover(status, provider.remoteAddress);
+			extended.hoverContent = getStatusHover(status, provider.remoteAddress);
+			if (!isTunnel && provider.remoteAddress) {
+				const address = provider.remoteAddress;
+				extended.onRemove = async () => {
+					await this.remoteAgentHostService.removeRemoteAgentHost(address);
+				};
+			}
 			remoteProviderActions.push(action);
 		}
 
@@ -527,93 +528,11 @@ export class WorkspacePicker extends Disposable {
 		return items;
 	}
 
-	private _getStatusLabel(status: RemoteAgentHostConnectionStatus): string {
-		switch (status) {
-			case RemoteAgentHostConnectionStatus.Connected:
-				return localize('workspacePicker.statusOnline', "Online");
-			case RemoteAgentHostConnectionStatus.Connecting:
-				return localize('workspacePicker.statusConnecting', "Connecting");
-			case RemoteAgentHostConnectionStatus.Disconnected:
-				return localize('workspacePicker.statusOffline', "Offline");
-		}
-	}
-
-	private _getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
-		switch (status) {
-			case RemoteAgentHostConnectionStatus.Connected:
-				return address
-					? localize('workspacePicker.hoverConnectedAddr', "Remote agent host is connected and ready.\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.");
-			case RemoteAgentHostConnectionStatus.Connecting:
-				return address
-					? localize('workspacePicker.hoverConnectingAddr', "Attempting to connect to remote agent host...\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...");
-			case RemoteAgentHostConnectionStatus.Disconnected:
-				return address
-					? localize('workspacePicker.hoverDisconnectedAddr', "Remote agent host is disconnected.\n\nAddress: {0}", address)
-					: localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected.");
-		}
-	}
-
-	/**
-	 * Show the remote host options quickpick after a short delay.
-	 * This ensures the action widget has fully hidden before the quickpick opens,
-	 * preventing focus conflicts that cause the quickpick to flash and disappear.
-	 */
 	private _showRemoteHostOptionsDelayed(provider: IAgentHostSessionsProvider): void {
-		const timeout = setTimeout(() => this._showRemoteHostOptions(provider), 1);
+		const timeout = setTimeout(() => {
+			this.instantiationService.invokeFunction(accessor => showRemoteHostOptions(accessor, provider));
+		}, 1);
 		this._renderDisposables.add({ dispose: () => clearTimeout(timeout) });
-	}
-
-	private async _showRemoteHostOptions(provider: IAgentHostSessionsProvider): Promise<void> {
-		const address = provider.remoteAddress;
-		if (!address) {
-			return;
-		}
-
-		const status = provider.connectionStatus?.get();
-		const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
-
-		const items: IQuickPickItem[] = [];
-		if (!isConnected) {
-			items.push({ label: '$(debug-restart) ' + localize('workspacePicker.reconnect', "Reconnect"), id: 'reconnect' });
-		}
-		items.push(
-			{ label: '$(trash) ' + localize('workspacePicker.removeRemote', "Remove Remote"), id: 'remove' },
-			{ label: '$(copy) ' + localize('workspacePicker.copyAddress', "Copy Address"), id: 'copy' },
-			{ label: '$(settings-gear) ' + localize('workspacePicker.openSettings', "Open Settings"), id: 'settings' },
-		);
-		if (provider.outputChannelId) {
-			items.push({ label: '$(output) ' + localize('workspacePicker.showOutput', "Show Output"), id: 'output' });
-		}
-
-		const picked = await this.quickInputService.pick(items, {
-			placeHolder: localize('workspacePicker.remoteOptionsTitle', "Options for {0}", provider.label),
-		});
-		if (!picked) {
-			return;
-		}
-
-		const action = (picked as IQuickPickItem & { id: string }).id;
-		switch (action) {
-			case 'reconnect':
-				this.remoteAgentHostService.reconnect(address);
-				break;
-			case 'remove':
-				await this.remoteAgentHostService.removeRemoteAgentHost(address);
-				break;
-			case 'copy':
-				await this.clipboardService.writeText(address);
-				break;
-			case 'settings':
-				await this.preferencesService.openSettings({ query: 'chat.remoteAgentHosts' });
-				break;
-			case 'output':
-				if (provider.outputChannelId) {
-					this.outputService.showChannel(provider.outputChannelId, true);
-				}
-				break;
-		}
 	}
 
 	private _updateTriggerLabel(): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { Action2, IMenuService, MenuItemAction, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
+import { IQuickInputButton, IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
+import { Menus } from '../../../browser/menus.js';
+import { SessionsCategories } from '../../../common/categories.js';
+import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { getStatusLabel, showRemoteHostOptions } from './remoteHostOptions.js';
+import { RemoteAgentHostCommandIds } from './remoteAgentHostActions.js';
+
+interface IRemoteHostQuickPickItem extends IQuickPickItem {
+	readonly kind: 'remote';
+	readonly provider: IAgentHostSessionsProvider;
+}
+
+interface IMenuActionQuickPickItem extends IQuickPickItem {
+	readonly kind: 'menu-action';
+	readonly action: MenuItemAction;
+}
+
+type ManageHostsPickItem = IRemoteHostQuickPickItem | IMenuActionQuickPickItem;
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RemoteAgentHostCommandIds.manageRemoteAgentHosts,
+			title: localize2('manageRemoteAgentHosts', "Manage Remote Agent Hosts..."),
+			category: SessionsCategories.Sessions,
+			f1: true,
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const sessionsProvidersService = accessor.get(ISessionsProvidersService);
+		const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
+		const menuService = accessor.get(IMenuService);
+		const contextKeyService = accessor.get(IContextKeyService);
+		const commandService = accessor.get(ICommandService);
+		const instantiationService = accessor.get(IInstantiationService);
+
+		const removeButton: IQuickInputButton = {
+			iconClass: ThemeIcon.asClassName(Codicon.close),
+			tooltip: localize('manageHosts.removeTooltip', "Remove"),
+		};
+
+		const buildItems = (): (ManageHostsPickItem | IQuickPickSeparator)[] => {
+			const remoteProviders: IAgentHostSessionsProvider[] = sessionsProvidersService.getProviders()
+				.filter(isAgentHostProvider)
+				.filter((p: IAgentHostSessionsProvider) => !!p.remoteAddress);
+
+			const remoteItems: IRemoteHostQuickPickItem[] = remoteProviders.map((p: IAgentHostSessionsProvider) => {
+				const isTunnel = p.remoteAddress?.startsWith(TUNNEL_ADDRESS_PREFIX);
+				const status = p.connectionStatus?.get();
+				const item: IRemoteHostQuickPickItem = {
+					kind: 'remote',
+					provider: p,
+					label: `$(${isTunnel ? 'cloud' : 'remote'}) ${p.label}`,
+					description: status !== undefined ? getStatusLabel(status) : undefined,
+					detail: p.remoteAddress,
+				};
+				if (!isTunnel) {
+					(item as IRemoteHostQuickPickItem & { buttons?: IQuickInputButton[] }).buttons = [removeButton];
+				}
+				return item;
+			});
+
+			const menuActionItems: IMenuActionQuickPickItem[] = [];
+			const menuActions = menuService.getMenuActions(Menus.SessionWorkspaceManage, contextKeyService, { renderShortTitle: true });
+			for (const [, actions] of menuActions) {
+				for (const action of actions) {
+					if (action instanceof MenuItemAction) {
+						const icon = ThemeIcon.isThemeIcon(action.item.icon) ? action.item.icon : undefined;
+						menuActionItems.push({
+							kind: 'menu-action',
+							action,
+							label: icon ? `$(${icon.id}) ${action.label}` : action.label,
+							description: action.tooltip || undefined,
+						});
+					}
+				}
+			}
+
+			const items: (ManageHostsPickItem | IQuickPickSeparator)[] = [];
+			if (remoteItems.length > 0) {
+				items.push({ type: 'separator', label: localize('manageHosts.connectedHeader', "Connected") });
+				items.push(...remoteItems);
+			}
+			if (menuActionItems.length > 0) {
+				items.push({ type: 'separator', label: localize('manageHosts.actionsHeader', "Add or Manage") });
+				items.push(...menuActionItems);
+			}
+			return items;
+		};
+
+		const store = new DisposableStore();
+		const picker = quickInputService.createQuickPick<ManageHostsPickItem>({ useSeparators: true });
+		store.add(picker);
+		picker.title = localize('manageHosts.title', "Manage Remote Agent Hosts");
+		picker.placeholder = localize('manageHosts.placeholder', "Select a remote to manage or pick an action");
+		picker.matchOnDescription = true;
+		picker.matchOnDetail = true;
+
+		let lastFilter = '';
+		const refresh = () => {
+			lastFilter = picker.value;
+			picker.items = buildItems();
+			picker.value = lastFilter;
+		};
+		refresh();
+
+		// Refresh when providers/connection status change
+		store.add(sessionsProvidersService.onDidChangeProviders(() => refresh()));
+		const observerStore = store.add(new DisposableStore());
+		const subscribeToProviders = () => {
+			observerStore.clear();
+			for (const p of sessionsProvidersService.getProviders()) {
+				if (isAgentHostProvider(p) && p.connectionStatus) {
+					observerStore.add(autorun(reader => {
+						p.connectionStatus!.read(reader);
+						refresh();
+					}));
+				}
+			}
+		};
+		subscribeToProviders();
+		store.add(sessionsProvidersService.onDidChangeProviders(() => subscribeToProviders()));
+
+		store.add(picker.onDidTriggerItemButton(async e => {
+			if (e.item.kind === 'remote' && e.button === removeButton) {
+				const address = e.item.provider.remoteAddress;
+				if (address) {
+					await remoteAgentHostService.removeRemoteAgentHost(address);
+					// onDidChangeProviders will refresh
+				}
+			}
+		}));
+
+		store.add(picker.onDidAccept(() => {
+			const selected = picker.selectedItems[0];
+			picker.hide();
+			if (!selected) {
+				return;
+			}
+			if (selected.kind === 'remote') {
+				// Defer to allow the picker to fully hide before opening options
+				setTimeout(() => instantiationService.invokeFunction(a => showRemoteHostOptions(a, selected.provider)), 1);
+			} else if (selected.kind === 'menu-action') {
+				commandService.executeCommand(selected.action.id);
+			}
+		}));
+
+		store.add(picker.onDidHide(() => store.dispose()));
+		picker.show();
+	}
+});

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -159,20 +159,13 @@ registerAction2(class extends Action2 {
 					return;
 				}
 				if (selected.kind === 'remote') {
-					// Defer to allow the picker to fully hide before opening options
-					setTimeout(async () => {
-						const result = await instantiationService.invokeFunction(a => showRemoteHostOptions(a, selected.provider, { showBackButton: true }));
+					void instantiationService.invokeFunction(a => showRemoteHostOptions(a, selected.provider, { showBackButton: true })).then(result => {
 						if (result === 'back') {
 							showManagePicker();
 						}
-					}, 1);
+					});
 				} else if (selected.kind === 'menu-action') {
-					// Defer to allow the picker to fully hide, then run the action.
-					// Pass showManagePicker as the onBack callback so sub-pickers
-					// that support back navigation can return here.
-					setTimeout(() => {
-						commandService.executeCommand(selected.action.id, () => showManagePicker());
-					}, 1);
+					commandService.executeCommand(selected.action.id, () => showManagePicker());
 				}
 			}));
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -98,7 +98,7 @@ registerAction2(class extends Action2 {
 
 			const items: (ManageHostsPickItem | IQuickPickSeparator)[] = [];
 			if (remoteItems.length > 0) {
-				items.push({ type: 'separator', label: localize('manageHosts.connectedHeader', "Connected") });
+				items.push({ type: 'separator', label: localize('manageHosts.remoteHostsHeader', "Remote Agent Hosts") });
 				items.push(...remoteItems);
 			}
 			if (menuActionItems.length > 0) {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/manageRemoteAgentHosts.ts
@@ -108,64 +108,78 @@ registerAction2(class extends Action2 {
 			return items;
 		};
 
-		const store = new DisposableStore();
-		const picker = quickInputService.createQuickPick<ManageHostsPickItem>({ useSeparators: true });
-		store.add(picker);
-		picker.title = localize('manageHosts.title', "Manage Remote Agent Hosts");
-		picker.placeholder = localize('manageHosts.placeholder', "Select a remote to manage or pick an action");
-		picker.matchOnDescription = true;
-		picker.matchOnDetail = true;
+		const showManagePicker = () => {
+			const store = new DisposableStore();
+			const picker = quickInputService.createQuickPick<ManageHostsPickItem>({ useSeparators: true });
+			store.add(picker);
+			picker.title = localize('manageHosts.title', "Manage Remote Agent Hosts");
+			picker.placeholder = localize('manageHosts.placeholder', "Select a remote to manage or pick an action");
+			picker.matchOnDescription = true;
+			picker.matchOnDetail = true;
 
-		let lastFilter = '';
-		const refresh = () => {
-			lastFilter = picker.value;
-			picker.items = buildItems();
-			picker.value = lastFilter;
-		};
-		refresh();
+			let lastFilter = '';
+			const refresh = () => {
+				lastFilter = picker.value;
+				picker.items = buildItems();
+				picker.value = lastFilter;
+			};
+			refresh();
 
-		// Refresh when providers/connection status change
-		store.add(sessionsProvidersService.onDidChangeProviders(() => refresh()));
-		const observerStore = store.add(new DisposableStore());
-		const subscribeToProviders = () => {
-			observerStore.clear();
-			for (const p of sessionsProvidersService.getProviders()) {
-				if (isAgentHostProvider(p) && p.connectionStatus) {
-					observerStore.add(autorun(reader => {
-						p.connectionStatus!.read(reader);
-						refresh();
-					}));
+			// Refresh when providers/connection status change
+			store.add(sessionsProvidersService.onDidChangeProviders(() => refresh()));
+			const observerStore = store.add(new DisposableStore());
+			const subscribeToProviders = () => {
+				observerStore.clear();
+				for (const p of sessionsProvidersService.getProviders()) {
+					if (isAgentHostProvider(p) && p.connectionStatus) {
+						observerStore.add(autorun(reader => {
+							p.connectionStatus!.read(reader);
+							refresh();
+						}));
+					}
 				}
-			}
-		};
-		subscribeToProviders();
-		store.add(sessionsProvidersService.onDidChangeProviders(() => subscribeToProviders()));
+			};
+			subscribeToProviders();
+			store.add(sessionsProvidersService.onDidChangeProviders(() => subscribeToProviders()));
 
-		store.add(picker.onDidTriggerItemButton(async e => {
-			if (e.item.kind === 'remote' && e.button === removeButton) {
-				const address = e.item.provider.remoteAddress;
-				if (address) {
-					await remoteAgentHostService.removeRemoteAgentHost(address);
-					// onDidChangeProviders will refresh
+			store.add(picker.onDidTriggerItemButton(async e => {
+				if (e.item.kind === 'remote' && e.button === removeButton) {
+					const address = e.item.provider.remoteAddress;
+					if (address) {
+						await remoteAgentHostService.removeRemoteAgentHost(address);
+						// onDidChangeProviders will refresh
+					}
 				}
-			}
-		}));
+			}));
 
-		store.add(picker.onDidAccept(() => {
-			const selected = picker.selectedItems[0];
-			picker.hide();
-			if (!selected) {
-				return;
-			}
-			if (selected.kind === 'remote') {
-				// Defer to allow the picker to fully hide before opening options
-				setTimeout(() => instantiationService.invokeFunction(a => showRemoteHostOptions(a, selected.provider)), 1);
-			} else if (selected.kind === 'menu-action') {
-				commandService.executeCommand(selected.action.id);
-			}
-		}));
+			store.add(picker.onDidAccept(() => {
+				const selected = picker.selectedItems[0];
+				picker.hide();
+				if (!selected) {
+					return;
+				}
+				if (selected.kind === 'remote') {
+					// Defer to allow the picker to fully hide before opening options
+					setTimeout(async () => {
+						const result = await instantiationService.invokeFunction(a => showRemoteHostOptions(a, selected.provider, { showBackButton: true }));
+						if (result === 'back') {
+							showManagePicker();
+						}
+					}, 1);
+				} else if (selected.kind === 'menu-action') {
+					// Defer to allow the picker to fully hide, then run the action.
+					// Pass showManagePicker as the onBack callback so sub-pickers
+					// that support back navigation can return here.
+					setTimeout(() => {
+						commandService.executeCommand(selected.action.id, () => showManagePicker());
+					}, 1);
+				}
+			}));
 
-		store.add(picker.onDidHide(() => store.dispose()));
-		picker.show();
+			store.add(picker.onDidHide(() => store.dispose()));
+			picker.show();
+		};
+
+		showManagePicker();
 	}
 });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -692,4 +692,5 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 // Side-effect registrations for the remote agent host feature
 import './remoteAgentHostActions.js';
+import './manageRemoteAgentHosts.js';
 import '../../chat/browser/agentHost/agentHostModelPicker.js';

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -6,6 +6,16 @@
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
+import { ICodeEditor, isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { EndOfLinePreference } from '../../../../editor/common/model.js';
+import { Range } from '../../../../editor/common/core/range.js';
+import { SnippetController2 } from '../../../../editor/contrib/snippet/browser/snippetController2.js';
+import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { IRemoteAgentHostService, parseRemoteAgentHostInput, RemoteAgentHostEntryType, RemoteAgentHostInputValidationError, RemoteAgentHostsEnabledSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { ISSHRemoteAgentHostService, SSHAuthMethod, type ISSHAgentHostConfig, type ISSHAgentHostConnection, type ISSHResolvedConfig } from '../../../../platform/agentHost/common/sshRemoteAgentHost.js';
 import { ITunnelAgentHostService, TUNNEL_ADDRESS_PREFIX, type ITunnelInfo } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
@@ -23,10 +33,20 @@ import { ISessionsManagementService } from '../../../services/sessions/common/se
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
 
+/** Action / command IDs registered by this file. */
+export const RemoteAgentHostCommandIds = {
+	addRemoteAgentHost: 'sessions.remoteAgentHost.add',
+	connectViaSSH: 'workbench.action.sessions.connectViaSSH',
+	addNewSSHHost: 'workbench.action.sessions.addNewSSHHost',
+	configureSSHHosts: 'workbench.action.sessions.configureSSHHosts',
+	connectViaTunnel: 'workbench.action.sessions.connectViaTunnel',
+	manageRemoteAgentHosts: 'workbench.action.sessions.manageRemoteAgentHosts',
+} as const;
+
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'sessions.remoteAgentHost.add',
+			id: RemoteAgentHostCommandIds.addRemoteAgentHost,
 			title: localize2('addRemoteAgentHost', "Add Remote Agent Host..."),
 			category: SessionsCategories.Sessions,
 			f1: true,
@@ -101,9 +121,103 @@ interface ISSHAuthMethodPickItem extends IQuickPickItem {
 	readonly method: SSHAuthMethod;
 }
 
-interface ISSHHostPickItem extends IQuickPickItem {
-	readonly hostAlias?: string;
+/**
+ * Parse a free-form SSH connection string of the form `[user@]host[:port]`.
+ * Returns `undefined` for empty or invalid input.
+ */
+export function parseSSHHostInput(value: string): { host: string; username?: string; port?: number } | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	const atIdx = trimmed.indexOf('@');
+	if (atIdx === 0 || atIdx === trimmed.length - 1) {
+		return undefined;
+	}
+	let username: string | undefined;
+	let hostPart: string;
+	if (atIdx !== -1) {
+		username = trimmed.substring(0, atIdx);
+		hostPart = trimmed.substring(atIdx + 1);
+	} else {
+		hostPart = trimmed;
+	}
+	if (!hostPart) {
+		return undefined;
+	}
+	let host: string;
+	let port: number | undefined;
+	const colonIdx = hostPart.lastIndexOf(':');
+	if (colonIdx !== -1) {
+		host = hostPart.substring(0, colonIdx);
+		const portStr = hostPart.substring(colonIdx + 1);
+		if (!host) {
+			return undefined;
+		}
+		if (portStr) {
+			const portNum = Number(portStr);
+			if (!Number.isInteger(portNum) || portNum <= 0 || portNum > 65535) {
+				return undefined;
+			}
+			port = portNum;
+		}
+	} else {
+		host = hostPart;
+	}
+	if (!host) {
+		return undefined;
+	}
+	return { host, username, port };
 }
+
+function validateSSHHostInput(value: string): string | undefined {
+	const v = value.trim();
+	if (!v) {
+		return localize('sshHostEmpty', "Enter an SSH host.");
+	}
+	const atIdx = v.indexOf('@');
+	if (atIdx === 0) {
+		return localize('sshUsernameMissingInHost', "Enter a username before '@'.");
+	}
+	if (atIdx === v.length - 1) {
+		return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
+	}
+	const hostPart = atIdx !== -1 ? v.substring(atIdx + 1) : v;
+	if (!hostPart) {
+		return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
+	}
+	const colonIdx = hostPart.lastIndexOf(':');
+	if (colonIdx !== -1) {
+		const hostName = hostPart.substring(0, colonIdx);
+		const portStr = hostPart.substring(colonIdx + 1);
+		if (!hostName) {
+			return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
+		}
+		if (portStr) {
+			const portNum = Number(portStr);
+			if (!Number.isInteger(portNum) || portNum <= 0 || portNum > 65535) {
+				return localize('sshHostInvalidPort', "Enter a valid port number.");
+			}
+		}
+	}
+	return undefined;
+}
+
+interface ISSHAliasPickItem extends IQuickPickItem {
+	readonly kind: 'alias';
+	readonly hostAlias: string;
+}
+
+interface ISSHNewHostPickItem extends IQuickPickItem {
+	kind: 'new-host';
+	hostInput: string;
+}
+
+interface ISSHFooterPickItem extends IQuickPickItem {
+	readonly kind: 'add-config' | 'configure';
+}
+
+type SSHHostPickerItem = ISSHAliasPickItem | ISSHNewHostPickItem | ISSHFooterPickItem;
 
 async function promptToConnectViaSSH(
 	accessor: ServicesAccessor,
@@ -112,101 +226,179 @@ async function promptToConnectViaSSH(
 	const quickInputService = accessor.get(IQuickInputService);
 	const notificationService = accessor.get(INotificationService);
 	const instantiationService = accessor.get(IInstantiationService);
-
-	let host: string;
-	let username: string | undefined;
-	let port: number | undefined;
-	let resolvedConfig: ISSHResolvedConfig | undefined;
-	let suggestedName: string | undefined;
-	let defaultAuthMethod: SSHAuthMethod | undefined;
-	let defaultKeyPath: string | undefined;
+	const commandService = accessor.get(ICommandService);
 
 	const configHosts = await sshService.listSSHConfigHosts().catch(() => [] as string[]);
-	if (configHosts.length > 0) {
-		const hostPicks: ISSHHostPickItem[] = configHosts.map(h => ({
-			label: h,
-			hostAlias: h,
+
+	const aliasItems: ISSHAliasPickItem[] = configHosts.map(h => ({
+		kind: 'alias',
+		hostAlias: h,
+		label: h,
+	}));
+	const addHostItem: ISSHFooterPickItem = {
+		kind: 'add-config',
+		label: '$(plus) ' + localize('sshAddNewHost', "Add New SSH Host..."),
+		alwaysShow: true,
+	};
+	const configureHostsItem: ISSHFooterPickItem = {
+		kind: 'configure',
+		label: localize('sshConfigureHosts', "Configure SSH Hosts..."),
+		alwaysShow: true,
+	};
+	const newHostItem: ISSHNewHostPickItem = {
+		kind: 'new-host',
+		hostInput: '',
+		label: '',
+		alwaysShow: true,
+	};
+
+	const result = await new Promise<SSHHostPickerItem | undefined>((resolve) => {
+		const store = new DisposableStore();
+		const picker = store.add(quickInputService.createQuickPick<SSHHostPickerItem>());
+		picker.title = localize('sshHostTitle', "Connect via SSH");
+		picker.placeholder = localize('sshHostPickerPlaceholder', "Select configured SSH host or enter user@host");
+		picker.ignoreFocusOut = true;
+		picker.matchOnDescription = true;
+
+		let newHostVisible = false;
+		const updateItems = () => {
+			const items: SSHHostPickerItem[] = [...aliasItems];
+			if (newHostVisible) {
+				items.push(newHostItem);
+			}
+			items.push(addHostItem);
+			items.push(configureHostsItem);
+			picker.items = items;
+		};
+		updateItems();
+
+		store.add(picker.onDidChangeValue(value => {
+			const parsed = parseSSHHostInput(value);
+			if (parsed) {
+				newHostItem.hostInput = value.trim();
+				newHostItem.label = `\u27a4 ${value.trim()}`;
+				if (!newHostVisible) {
+					newHostVisible = true;
+					updateItems();
+				} else {
+					// Force item refresh so the label updates
+					picker.items = picker.items;
+				}
+			} else if (newHostVisible) {
+				newHostVisible = false;
+				updateItems();
+			}
 		}));
-		hostPicks.push({
-			label: localize('sshEnterManually', "Enter Manually..."),
-			description: localize('sshEnterManuallyDesc', "Type in host, username, and port"),
-		});
 
-		const picked = await quickInputService.pick(hostPicks, {
-			title: localize('sshHostTitle', "Connect via SSH"),
-			placeHolder: localize('sshPickHostPlaceholder', "Select an SSH host or enter manually"),
-		});
-		if (!picked) {
-			return;
-		}
+		store.add(picker.onDidAccept(() => {
+			const selected = picker.selectedItems[0];
+			resolve(selected);
+			picker.hide();
+		}));
+		store.add(picker.onDidHide(() => {
+			resolve(undefined);
+			store.dispose();
+		}));
+		picker.show();
+	});
 
-		if (picked.hostAlias) {
-			try {
-				resolvedConfig = await sshService.resolveSSHConfig(picked.hostAlias);
-			} catch (err) {
-				notificationService.error(localize('sshResolveConfigFailed', "Failed to resolve SSH config for {0}: {1}", picked.hostAlias, String(err)));
-				return;
-			}
-
-			host = resolvedConfig.hostname;
-			username = resolvedConfig.user;
-			port = resolvedConfig.port !== 22 ? resolvedConfig.port : undefined;
-			suggestedName = picked.hostAlias;
-
-			// Determine auth method from resolved config.
-			// Always prefer Agent auth (the SSH agent may already have the key
-			// loaded). Record a non-default IdentityFile as a fallback path for
-			// the manual picker only.
-			if (resolvedConfig.identityFile.length > 0) {
-				const firstKey = resolvedConfig.identityFile[0];
-				const defaultKeys = ['~/.ssh/id_rsa', '~/.ssh/id_ecdsa', '~/.ssh/id_ed25519', '~/.ssh/id_dsa', '~/.ssh/id_xmss'];
-				if (!defaultKeys.includes(firstKey)) {
-					defaultKeyPath = firstKey;
-				}
-			}
-			// Default to SSH agent
-			if (!defaultAuthMethod) {
-				defaultAuthMethod = SSHAuthMethod.Agent;
-			}
-
-			// Config host has enough info — connect directly, skip all prompts
-			if (username) {
-				const config: ISSHAgentHostConfig = {
-					host,
-					port,
-					username,
-					authMethod: defaultAuthMethod,
-					privateKeyPath: defaultKeyPath,
-					agentForward: resolvedConfig.forwardAgent || undefined,
-					name: suggestedName,
-					sshConfigHost: picked.hostAlias,
-				};
-				const connection = await instantiationService.invokeFunction(accessor =>
-					connectWithProgress(accessor, config, suggestedName!)
-				);
-				if (connection) {
-					await instantiationService.invokeFunction(accessor => promptForRemoteFolder(accessor, connection));
-				}
-				return;
-			}
-		} else {
-			const manualResult = await promptForManualHost(quickInputService);
-			if (!manualResult) {
-				return;
-			}
-			host = manualResult.host;
-			username = manualResult.username;
-			port = manualResult.port;
-		}
-	} else {
-		const manualResult = await promptForManualHost(quickInputService);
-		if (!manualResult) {
-			return;
-		}
-		host = manualResult.host;
-		username = manualResult.username;
-		port = manualResult.port;
+	if (!result) {
+		return;
 	}
+
+	if (result.kind === 'add-config' || result.kind === 'configure') {
+		const cmdId = result.kind === 'add-config'
+			? RemoteAgentHostCommandIds.addNewSSHHost
+			: RemoteAgentHostCommandIds.configureSSHHosts;
+		await commandService.executeCommand(cmdId);
+		return;
+	}
+
+	if (result.kind === 'alias') {
+		await instantiationService.invokeFunction(accessor =>
+			connectToConfiguredSSHHost(accessor, result.hostAlias)
+		);
+		return;
+	}
+
+	// kind === 'new-host'
+	const newHost = result as ISSHNewHostPickItem;
+	const parsed = parseSSHHostInput(newHost.hostInput);
+	if (!parsed) {
+		notificationService.error(validateSSHHostInput(newHost.hostInput) ?? localize('sshHostInvalid', "Invalid SSH host."));
+		return;
+	}
+	await instantiationService.invokeFunction(accessor =>
+		promptForCredentialsAndConnect(accessor, parsed.host, parsed.username, parsed.port)
+	);
+}
+
+async function connectToConfiguredSSHHost(
+	accessor: ServicesAccessor,
+	hostAlias: string,
+): Promise<void> {
+	const sshService = accessor.get(ISSHRemoteAgentHostService);
+	const notificationService = accessor.get(INotificationService);
+	const instantiationService = accessor.get(IInstantiationService);
+
+	let resolvedConfig: ISSHResolvedConfig;
+	try {
+		resolvedConfig = await sshService.resolveSSHConfig(hostAlias);
+	} catch (err) {
+		notificationService.error(localize('sshResolveConfigFailed', "Failed to resolve SSH config for {0}: {1}", hostAlias, String(err)));
+		return;
+	}
+
+	const host = resolvedConfig.hostname;
+	const username = resolvedConfig.user;
+	const port = resolvedConfig.port !== 22 ? resolvedConfig.port : undefined;
+	const suggestedName = hostAlias;
+
+	let defaultKeyPath: string | undefined;
+	if (resolvedConfig.identityFile.length > 0) {
+		const firstKey = resolvedConfig.identityFile[0];
+		const defaultKeys = ['~/.ssh/id_rsa', '~/.ssh/id_ecdsa', '~/.ssh/id_ed25519', '~/.ssh/id_dsa', '~/.ssh/id_xmss'];
+		if (!defaultKeys.includes(firstKey)) {
+			defaultKeyPath = firstKey;
+		}
+	}
+
+	if (username) {
+		const config: ISSHAgentHostConfig = {
+			host,
+			port,
+			username,
+			authMethod: SSHAuthMethod.Agent,
+			privateKeyPath: defaultKeyPath,
+			agentForward: resolvedConfig.forwardAgent || undefined,
+			name: suggestedName,
+			sshConfigHost: hostAlias,
+		};
+		const connection = await instantiationService.invokeFunction(accessor =>
+			connectWithProgress(accessor, config, suggestedName)
+		);
+		if (connection) {
+			await instantiationService.invokeFunction(accessor => promptForRemoteFolder(accessor, connection));
+		}
+		return;
+	}
+
+	// Fallback: alias resolved without a user — fall through to manual flow
+	await instantiationService.invokeFunction(accessor =>
+		promptForCredentialsAndConnect(accessor, host, undefined, port, suggestedName, defaultKeyPath)
+	);
+}
+
+async function promptForCredentialsAndConnect(
+	accessor: ServicesAccessor,
+	host: string,
+	username: string | undefined,
+	port: number | undefined,
+	suggestedName?: string,
+	defaultKeyPath?: string,
+): Promise<void> {
+	const quickInputService = accessor.get(IQuickInputService);
+	const instantiationService = accessor.get(IInstantiationService);
 
 	if (!username) {
 		const usernameInput = await quickInputService.input({
@@ -240,19 +432,14 @@ async function promptToConnectViaSSH(
 		},
 	];
 
-	let authMethod: SSHAuthMethod;
-	if (defaultAuthMethod) {
-		authMethod = defaultAuthMethod;
-	} else {
-		const authPicked = await quickInputService.pick(authPicks, {
-			title: localize('sshAuthTitle', "Authentication Method"),
-			placeHolder: localize('sshAuthPlaceholder', "Choose how to authenticate with {0}", host),
-		});
-		if (!authPicked) {
-			return;
-		}
-		authMethod = authPicked.method;
+	const authPicked = await quickInputService.pick(authPicks, {
+		title: localize('sshAuthTitle', "Authentication Method"),
+		placeHolder: localize('sshAuthPlaceholder', "Choose how to authenticate with {0}", host),
+	});
+	if (!authPicked) {
+		return;
 	}
+	const authMethod = authPicked.method;
 
 	let privateKeyPath: string | undefined;
 	let password: string | undefined;
@@ -390,85 +577,10 @@ async function promptForRemoteFolder(
 	view?.selectWorkspace({ providerId: provider.id, workspace });
 }
 
-async function promptForManualHost(
-	quickInputService: IQuickInputService,
-): Promise<{ host: string; username: string | undefined; port: number | undefined } | undefined> {
-	const validateSshHostInput = (value: string): string | undefined => {
-		const v = value.trim();
-		if (!v) {
-			return localize('sshHostEmpty', "Enter an SSH host.");
-		}
-		const atIdx = v.indexOf('@');
-		if (atIdx === 0) {
-			return localize('sshUsernameMissingInHost', "Enter a username before '@'.");
-		}
-		if (atIdx === v.length - 1) {
-			return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
-		}
-		const hostPart = atIdx !== -1 ? v.substring(atIdx + 1) : v;
-		if (!hostPart) {
-			return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
-		}
-		const colonIdx = hostPart.lastIndexOf(':');
-		if (colonIdx !== -1) {
-			const hostName = hostPart.substring(0, colonIdx);
-			const portStr = hostPart.substring(colonIdx + 1);
-			if (!hostName) {
-				return localize('sshHostMissingAfterAt', "Enter a host name after '@'.");
-			}
-			if (portStr) {
-				const portNum = Number(portStr);
-				if (!Number.isInteger(portNum) || portNum <= 0 || portNum > 65535) {
-					return localize('sshHostInvalidPort', "Enter a valid port number.");
-				}
-			}
-		}
-		return undefined;
-	};
-
-	const hostInput = await quickInputService.input({
-		title: localize('sshManualHostTitle', "Connect via SSH"),
-		prompt: localize('sshHostPrompt', "Enter the SSH host (e.g. user@hostname or user@hostname:port)."),
-		placeHolder: 'user@myserver.example.com',
-		ignoreFocusLost: true,
-		validateInput: async value => validateSshHostInput(value),
-	});
-	if (!hostInput) {
-		return undefined;
-	}
-
-	const trimmed = hostInput.trim();
-	let username: string | undefined;
-	let host: string;
-	let port: number | undefined;
-	const atIndex = trimmed.indexOf('@');
-
-	let hostPart: string;
-	if (atIndex !== -1) {
-		username = trimmed.substring(0, atIndex);
-		hostPart = trimmed.substring(atIndex + 1);
-	} else {
-		hostPart = trimmed;
-	}
-
-	const colonIndex = hostPart.lastIndexOf(':');
-	if (colonIndex !== -1) {
-		host = hostPart.substring(0, colonIndex);
-		const portStr = hostPart.substring(colonIndex + 1);
-		if (portStr) {
-			port = Number(portStr);
-		}
-	} else {
-		host = hostPart;
-	}
-
-	return { host, username, port };
-}
-
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.sessions.connectViaSSH',
+			id: RemoteAgentHostCommandIds.connectViaSSH,
 			title: localize2('connectViaSSH', "Connect to Remote Agent Host via SSH"),
 			shortTitle: localize2('connectViaSSHShort', "SSH..."),
 			category: SessionsCategories.Sessions,
@@ -484,6 +596,137 @@ registerAction2(class extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		await promptToConnectViaSSH(accessor);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RemoteAgentHostCommandIds.addNewSSHHost,
+			title: localize2('addNewSSHHost', "Add New SSH Host..."),
+			category: SessionsCategories.Sessions,
+			f1: true,
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sshService = accessor.get(ISSHRemoteAgentHostService);
+		const editorService = accessor.get(IEditorService);
+		const fileService = accessor.get(IFileService);
+		const notificationService = accessor.get(INotificationService);
+
+		let configUri;
+		try {
+			configUri = await sshService.ensureUserSSHConfig();
+		} catch (err) {
+			notificationService.error(localize('sshConfigCreateFailed', "Failed to create SSH config file: {0}", String(err)));
+			return;
+		}
+
+		const editorPane = await editorService.openEditor({ resource: configUri, options: { pinned: true } satisfies ITextEditorOptions });
+		if (!editorPane) {
+			return;
+		}
+		const control = editorPane.getControl();
+		if (!isCodeEditor(control) || !control.hasModel()) {
+			return;
+		}
+		const editor = control as ICodeEditor;
+		const model = editor.getModel();
+		if (!model) {
+			return;
+		}
+
+		// Append a snippet at end of document. Read file content for length;
+		// fall back to model length to avoid races.
+		let appendNewline = false;
+		try {
+			const stat = await fileService.stat(configUri);
+			if (stat.size > 0) {
+				const content = model.getValueInRange(model.getFullModelRange(), EndOfLinePreference.LF);
+				appendNewline = content.length > 0 && !content.endsWith('\n');
+			}
+		} catch {
+			// ignore
+		}
+		const lastLine = model.getLineCount();
+		const lastCol = model.getLineMaxColumn(lastLine);
+		editor.setSelection(new Range(lastLine, lastCol, lastLine, lastCol));
+
+		const snippet = (appendNewline ? '\n' : '') + 'Host ${1:alias}\n    HostName ${2:hostname}\n    User ${3:user}\n';
+		SnippetController2.get(editor)?.insert(snippet);
+		editor.focus();
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: RemoteAgentHostCommandIds.configureSSHHosts,
+			title: localize2('configureSSHHosts', "Configure SSH Hosts..."),
+			category: SessionsCategories.Sessions,
+			f1: true,
+			precondition: ContextKeyExpr.equals(`config.${RemoteAgentHostsEnabledSettingId}`, true),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const sshService = accessor.get(ISSHRemoteAgentHostService);
+		const editorService = accessor.get(IEditorService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		let configFiles: URI[];
+		try {
+			configFiles = await sshService.listSSHConfigFiles();
+		} catch (err) {
+			notificationService.error(localize('sshConfigListFailed', "Failed to list SSH config files: {0}", String(err)));
+			return;
+		}
+
+		// Always offer the user-config fallback so we have something openable.
+		if (configFiles.length === 0) {
+			try {
+				const uri = await sshService.ensureUserSSHConfig();
+				await editorService.openEditor({ resource: uri, options: { pinned: true } satisfies ITextEditorOptions });
+			} catch (err) {
+				notificationService.error(localize('sshConfigOpenFailed', "Failed to open SSH config file: {0}", String(err)));
+			}
+			return;
+		}
+
+		interface ISSHConfigFilePickItem extends IQuickPickItem {
+			readonly uri: URI;
+			readonly isUserConfig: boolean;
+		}
+		const userConfigUri = configFiles[0];
+		const items: ISSHConfigFilePickItem[] = configFiles.map((uri, index) => ({
+			label: uri.fsPath,
+			uri,
+			isUserConfig: index === 0,
+		}));
+
+		const picked = items.length === 1
+			? items[0]
+			: await quickInputService.pick(items, {
+				title: localize('sshConfigPickTitle', "Select SSH configuration file to edit"),
+				placeHolder: localize('sshConfigPickPlaceholder', "Select an SSH configuration file"),
+			});
+		if (!picked) {
+			return;
+		}
+
+		try {
+			// If the user picked the user config, ensure it exists (creating it on demand)
+			// before opening so we don't try to open a file that's not there yet.
+			const uri = picked.isUserConfig
+				? await sshService.ensureUserSSHConfig().catch(() => userConfigUri)
+				: picked.uri;
+			await editorService.openEditor({ resource: uri, options: { pinned: true } satisfies ITextEditorOptions });
+		} catch (err) {
+			notificationService.error(localize('sshConfigOpenFailed', "Failed to open SSH config file: {0}", String(err)));
+		}
 	}
 });
 
@@ -653,7 +896,7 @@ async function promptForTunnelFolder(
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.sessions.connectViaTunnel',
+			id: RemoteAgentHostCommandIds.connectViaTunnel,
 			title: localize2('connectViaTunnel', "Connect to Remote Agent Host via Dev Tunnel"),
 			shortTitle: localize2('connectViaTunnelShort', "Tunnels..."),
 			category: SessionsCategories.Sessions,

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -221,7 +221,8 @@ type SSHHostPickerItem = ISSHAliasPickItem | ISSHNewHostPickItem | ISSHFooterPic
 
 async function promptToConnectViaSSH(
 	accessor: ServicesAccessor,
-): Promise<void> {
+	options: { showBackButton?: boolean } = {},
+): Promise<'back' | void> {
 	const sshService = accessor.get(ISSHRemoteAgentHostService);
 	const quickInputService = accessor.get(IQuickInputService);
 	const notificationService = accessor.get(INotificationService);
@@ -252,13 +253,16 @@ async function promptToConnectViaSSH(
 		alwaysShow: true,
 	};
 
-	const result = await new Promise<SSHHostPickerItem | undefined>((resolve) => {
+	const result = await new Promise<'back' | SSHHostPickerItem | undefined>((resolve) => {
 		const store = new DisposableStore();
 		const picker = store.add(quickInputService.createQuickPick<SSHHostPickerItem>());
 		picker.title = localize('sshHostTitle', "Connect via SSH");
 		picker.placeholder = localize('sshHostPickerPlaceholder', "Select configured SSH host or enter user@host");
 		picker.ignoreFocusOut = true;
 		picker.matchOnDescription = true;
+		if (options.showBackButton) {
+			picker.buttons = [quickInputService.backButton];
+		}
 
 		let newHostVisible = false;
 		const updateItems = () => {
@@ -290,6 +294,12 @@ async function promptToConnectViaSSH(
 			}
 		}));
 
+		store.add(picker.onDidTriggerButton(button => {
+			if (button === quickInputService.backButton) {
+				resolve('back');
+				picker.hide();
+			}
+		}));
 		store.add(picker.onDidAccept(() => {
 			const selected = picker.selectedItems[0];
 			resolve(selected);
@@ -301,6 +311,10 @@ async function promptToConnectViaSSH(
 		}));
 		picker.show();
 	});
+
+	if (result === 'back') {
+		return 'back';
+	}
 
 	if (!result) {
 		return;
@@ -594,8 +608,11 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		await promptToConnectViaSSH(accessor);
+	override async run(accessor: ServicesAccessor, onBack?: () => void): Promise<void> {
+		const result = await promptToConnectViaSSH(accessor, { showBackButton: !!onBack });
+		if (result === 'back') {
+			onBack?.();
+		}
 	}
 });
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -324,7 +324,9 @@ async function promptToConnectViaSSH(
 		const cmdId = result.kind === 'add-config'
 			? RemoteAgentHostCommandIds.addNewSSHHost
 			: RemoteAgentHostCommandIds.configureSSHHosts;
-		await commandService.executeCommand(cmdId);
+		// Pass back callback so sub-picker can navigate back to this SSH picker
+		const onBackToSSH = () => instantiationService.invokeFunction(a => promptToConnectViaSSH(a, options));
+		await commandService.executeCommand(cmdId, onBackToSSH);
 		return;
 	}
 
@@ -688,7 +690,7 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
+	override async run(accessor: ServicesAccessor, onBack?: () => void): Promise<void> {
 		const sshService = accessor.get(ISSHRemoteAgentHostService);
 		const editorService = accessor.get(IEditorService);
 		const quickInputService = accessor.get(IQuickInputService);
@@ -724,12 +726,51 @@ registerAction2(class extends Action2 {
 			isUserConfig: index === 0,
 		}));
 
-		const picked = items.length === 1
-			? items[0]
-			: await quickInputService.pick(items, {
-				title: localize('sshConfigPickTitle', "Select SSH configuration file to edit"),
-				placeHolder: localize('sshConfigPickPlaceholder', "Select an SSH configuration file"),
-			});
+		// If there's only one file, skip the picker and open it directly.
+		// If onBack is provided we still need to show the picker to offer navigation.
+		if (items.length === 1 && !onBack) {
+			const picked = items[0];
+			try {
+				const uri = picked.isUserConfig
+					? await sshService.ensureUserSSHConfig().catch(() => userConfigUri)
+					: picked.uri;
+				await editorService.openEditor({ resource: uri, options: { pinned: true } satisfies ITextEditorOptions });
+			} catch (err) {
+				notificationService.error(localize('sshConfigOpenFailed', "Failed to open SSH config file: {0}", String(err)));
+			}
+			return;
+		}
+
+		const picked = await new Promise<'back' | ISSHConfigFilePickItem | undefined>(resolve => {
+			const store = new DisposableStore();
+			const picker = store.add(quickInputService.createQuickPick<ISSHConfigFilePickItem>());
+			picker.title = localize('sshConfigPickTitle', "Select SSH configuration file to edit");
+			picker.placeholder = localize('sshConfigPickPlaceholder', "Select an SSH configuration file");
+			picker.items = items;
+			if (onBack) {
+				picker.buttons = [quickInputService.backButton];
+			}
+			store.add(picker.onDidTriggerButton(button => {
+				if (button === quickInputService.backButton) {
+					resolve('back');
+					picker.hide();
+				}
+			}));
+			store.add(picker.onDidAccept(() => {
+				resolve(picker.selectedItems[0]);
+				picker.hide();
+			}));
+			store.add(picker.onDidHide(() => {
+				resolve(undefined);
+				store.dispose();
+			}));
+			picker.show();
+		});
+
+		if (picked === 'back') {
+			onBack?.();
+			return;
+		}
 		if (!picked) {
 			return;
 		}
@@ -759,7 +800,8 @@ interface IAuthProviderPickItem extends IQuickPickItem {
 
 async function promptToConnectViaTunnel(
 	accessor: ServicesAccessor,
-): Promise<void> {
+	options: { showBackButton?: boolean } = {},
+): Promise<'back' | void> {
 	const tunnelService = accessor.get(ITunnelAgentHostService);
 	const quickInputService = accessor.get(IQuickInputService);
 	const notificationService = accessor.get(INotificationService);
@@ -807,23 +849,27 @@ async function promptToConnectViaTunnel(
 	}
 
 	// Step 2: Show tunnel picker immediately in busy state while enumerating
-	const tunnelPicker = quickInputService.createQuickPick<ITunnelPickItem>();
+	const store = new DisposableStore();
+	const tunnelPicker = store.add(quickInputService.createQuickPick<ITunnelPickItem>());
 	tunnelPicker.title = localize('tunnelPickTitle', "Connect via Dev Tunnel");
 	tunnelPicker.placeholder = localize('tunnelPickPlaceholder', "Select a dev tunnel to connect to");
 	tunnelPicker.busy = true;
+	if (options.showBackButton) {
+		tunnelPicker.buttons = [quickInputService.backButton];
+	}
 	tunnelPicker.show();
 
 	let tunnels: ITunnelInfo[];
 	try {
 		tunnels = await tunnelService.listTunnels();
 	} catch (err) {
-		tunnelPicker.dispose();
+		store.dispose();
 		notificationService.error(localize('tunnelListFailed', "Failed to list dev tunnels: {0}", err instanceof Error ? err.message : String(err)));
 		return;
 	}
 
 	if (tunnels.length === 0) {
-		tunnelPicker.dispose();
+		store.dispose();
 		notificationService.info(localize('tunnelNoneFound', "No dev tunnels with agent host support were found. Start a tunnel with 'code tunnel' on another machine."));
 		return;
 	}
@@ -836,16 +882,26 @@ async function promptToConnectViaTunnel(
 	tunnelPicker.busy = false;
 
 	// Step 3: Wait for user selection
-	const picked = await new Promise<ITunnelPickItem | undefined>(resolve => {
-		tunnelPicker.onDidAccept(() => {
+	const picked = await new Promise<'back' | ITunnelPickItem | undefined>(resolve => {
+		store.add(tunnelPicker.onDidTriggerButton(button => {
+			if (button === quickInputService.backButton) {
+				resolve('back');
+				tunnelPicker.hide();
+			}
+		}));
+		store.add(tunnelPicker.onDidAccept(() => {
 			resolve(tunnelPicker.selectedItems[0]);
-			tunnelPicker.dispose();
-		});
-		tunnelPicker.onDidHide(() => {
+			tunnelPicker.hide();
+		}));
+		store.add(tunnelPicker.onDidHide(() => {
 			resolve(undefined);
-			tunnelPicker.dispose();
-		});
+			store.dispose();
+		}));
 	});
+
+	if (picked === 'back') {
+		return 'back';
+	}
 	if (!picked) {
 		return;
 	}
@@ -927,7 +983,10 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		await promptToConnectViaTunnel(accessor);
+	override async run(accessor: ServicesAccessor, onBack?: () => void): Promise<void> {
+		const result = await promptToConnectViaTunnel(accessor, { showBackButton: !!onBack });
+		if (result === 'back') {
+			onBack?.();
+		}
 	}
 });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../nls.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -40,6 +41,11 @@ export function getStatusHover(status: RemoteAgentHostConnectionStatus, address?
 	}
 }
 
+export interface IShowRemoteHostOptionsOptions {
+	/** When true, show a Back button in the picker title bar. The promise resolves to `'back'` if pressed. */
+	readonly showBackButton?: boolean;
+}
+
 /**
  * Show the per-remote management options quickpick (Reconnect / Remove /
  * Copy Address / Open Settings / Show Output) for the given provider.
@@ -48,11 +54,14 @@ export function getStatusHover(status: RemoteAgentHostConnectionStatus, address?
  * "Manage Remote Agent Hosts..." command, so both surfaces drive the
  * same actions. Callers that don't have a {@link ServicesAccessor} should
  * use `instantiationService.invokeFunction(accessor => showRemoteHostOptions(accessor, provider))`.
+ *
+ * Returns `'back'` if the user clicked the back button (only possible when
+ * `options.showBackButton` is true), otherwise `undefined`.
  */
-export async function showRemoteHostOptions(accessor: ServicesAccessor, provider: IAgentHostSessionsProvider): Promise<void> {
+export async function showRemoteHostOptions(accessor: ServicesAccessor, provider: IAgentHostSessionsProvider, options: IShowRemoteHostOptionsOptions = {}): Promise<'back' | undefined> {
 	const address = provider.remoteAddress;
 	if (!address) {
-		return;
+		return undefined;
 	}
 
 	const quickInputService = accessor.get(IQuickInputService);
@@ -64,7 +73,8 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 	const status = provider.connectionStatus?.get();
 	const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
 
-	const items: IQuickPickItem[] = [];
+	type RemoteOptionPickItem = IQuickPickItem & { id: string };
+	const items: RemoteOptionPickItem[] = [];
 	if (!isConnected) {
 		items.push({ label: '$(debug-restart) ' + localize('workspacePicker.reconnect', "Reconnect"), id: 'reconnect' });
 	}
@@ -77,15 +87,39 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 		items.push({ label: '$(output) ' + localize('workspacePicker.showOutput', "Show Output"), id: 'output' });
 	}
 
-	const picked = await quickInputService.pick(items, {
-		placeHolder: localize('workspacePicker.remoteOptionsTitle', "Options for {0}", provider.label),
+	const result = await new Promise<'back' | RemoteOptionPickItem | undefined>((resolve) => {
+		const store = new DisposableStore();
+		const picker = store.add(quickInputService.createQuickPick<RemoteOptionPickItem>());
+		picker.placeholder = localize('workspacePicker.remoteOptionsTitle', "Options for {0}", provider.label);
+		picker.items = items;
+		if (options.showBackButton) {
+			picker.buttons = [quickInputService.backButton];
+		}
+		store.add(picker.onDidTriggerButton(button => {
+			if (button === quickInputService.backButton) {
+				resolve('back');
+				picker.hide();
+			}
+		}));
+		store.add(picker.onDidAccept(() => {
+			resolve(picker.selectedItems[0]);
+			picker.hide();
+		}));
+		store.add(picker.onDidHide(() => {
+			resolve(undefined);
+			store.dispose();
+		}));
+		picker.show();
 	});
-	if (!picked) {
-		return;
+
+	if (result === 'back') {
+		return 'back';
+	}
+	if (!result) {
+		return undefined;
 	}
 
-	const action = (picked as IQuickPickItem & { id: string }).id;
-	switch (action) {
+	switch (result.id) {
 		case 'reconnect':
 			remoteAgentHostService.reconnect(address);
 			break;
@@ -104,5 +138,6 @@ export async function showRemoteHostOptions(accessor: ServicesAccessor, provider
 			}
 			break;
 	}
+	return undefined;
 }
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteHostOptions.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IOutputService } from '../../../../workbench/services/output/common/output.js';
+import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
+import { IAgentHostSessionsProvider } from '../../../common/agentHostSessionsProvider.js';
+
+export function getStatusLabel(status: RemoteAgentHostConnectionStatus): string {
+	switch (status) {
+		case RemoteAgentHostConnectionStatus.Connected:
+			return localize('workspacePicker.statusOnline', "Online");
+		case RemoteAgentHostConnectionStatus.Connecting:
+			return localize('workspacePicker.statusConnecting', "Connecting");
+		case RemoteAgentHostConnectionStatus.Disconnected:
+			return localize('workspacePicker.statusOffline', "Offline");
+	}
+}
+
+export function getStatusHover(status: RemoteAgentHostConnectionStatus, address?: string): string {
+	switch (status) {
+		case RemoteAgentHostConnectionStatus.Connected:
+			return address
+				? localize('workspacePicker.hoverConnectedAddr', "Remote agent host is connected and ready.\n\nAddress: {0}", address)
+				: localize('workspacePicker.hoverConnected', "Remote agent host is connected and ready.");
+		case RemoteAgentHostConnectionStatus.Connecting:
+			return address
+				? localize('workspacePicker.hoverConnectingAddr', "Attempting to connect to remote agent host...\n\nAddress: {0}", address)
+				: localize('workspacePicker.hoverConnecting', "Attempting to connect to remote agent host...");
+		case RemoteAgentHostConnectionStatus.Disconnected:
+			return address
+				? localize('workspacePicker.hoverDisconnectedAddr', "Remote agent host is disconnected.\n\nAddress: {0}", address)
+				: localize('workspacePicker.hoverDisconnected', "Remote agent host is disconnected.");
+	}
+}
+
+/**
+ * Show the per-remote management options quickpick (Reconnect / Remove /
+ * Copy Address / Open Settings / Show Output) for the given provider.
+ *
+ * Used by both the Workspace Picker's Manage submenu and the F1
+ * "Manage Remote Agent Hosts..." command, so both surfaces drive the
+ * same actions. Callers that don't have a {@link ServicesAccessor} should
+ * use `instantiationService.invokeFunction(accessor => showRemoteHostOptions(accessor, provider))`.
+ */
+export async function showRemoteHostOptions(accessor: ServicesAccessor, provider: IAgentHostSessionsProvider): Promise<void> {
+	const address = provider.remoteAddress;
+	if (!address) {
+		return;
+	}
+
+	const quickInputService = accessor.get(IQuickInputService);
+	const remoteAgentHostService = accessor.get(IRemoteAgentHostService);
+	const clipboardService = accessor.get(IClipboardService);
+	const preferencesService = accessor.get(IPreferencesService);
+	const outputService = accessor.get(IOutputService);
+
+	const status = provider.connectionStatus?.get();
+	const isConnected = status === RemoteAgentHostConnectionStatus.Connected;
+
+	const items: IQuickPickItem[] = [];
+	if (!isConnected) {
+		items.push({ label: '$(debug-restart) ' + localize('workspacePicker.reconnect', "Reconnect"), id: 'reconnect' });
+	}
+	items.push(
+		{ label: '$(trash) ' + localize('workspacePicker.removeRemote', "Remove Remote"), id: 'remove' },
+		{ label: '$(copy) ' + localize('workspacePicker.copyAddress', "Copy Address"), id: 'copy' },
+		{ label: '$(settings-gear) ' + localize('workspacePicker.openSettings', "Open Settings"), id: 'settings' },
+	);
+	if (provider.outputChannelId) {
+		items.push({ label: '$(output) ' + localize('workspacePicker.showOutput', "Show Output"), id: 'output' });
+	}
+
+	const picked = await quickInputService.pick(items, {
+		placeHolder: localize('workspacePicker.remoteOptionsTitle', "Options for {0}", provider.label),
+	});
+	if (!picked) {
+		return;
+	}
+
+	const action = (picked as IQuickPickItem & { id: string }).id;
+	switch (action) {
+		case 'reconnect':
+			remoteAgentHostService.reconnect(address);
+			break;
+		case 'remove':
+			await remoteAgentHostService.removeRemoteAgentHost(address);
+			break;
+		case 'copy':
+			await clipboardService.writeText(address);
+			break;
+		case 'settings':
+			await preferencesService.openSettings({ query: 'chat.remoteAgentHosts' });
+			break;
+		case 'output':
+			if (provider.outputChannelId) {
+				outputService.showChannel(provider.outputChannelId, true);
+			}
+			break;
+	}
+}
+


### PR DESCRIPTION
Brings the Agents app's SSH/remote-host management UX in line with the [vscode-remote-ssh](https://github.com/microsoft/vscode-remote-release) extension, and adds an inline manage-everything command. (Written by Copilot)

## SSH host picker

Rewrites "Agents: Connect to Remote Agent Host via SSH" to mirror the remote-ssh "Connect to SSH" picker:

- Configured `Host` aliases from `~/.ssh/config` (recursively expanding `Include`) listed at the top.
- Footer entries: **`+ Add New SSH Host...`** and **`Configure SSH Hosts...`** (both also F1-able as their own commands).
- A dynamic synthetic `➤ user@host` entry appears as soon as the typed value parses as a valid SSH connection string. Press Enter and we connect directly without ever creating a config entry.

The previous "Enter manually" item is gone — the synthetic entry replaces it.

## New SSH commands

- **Add New SSH Host...** — ensures `~/.ssh` exists (mode 0700), creates `~/.ssh/config` if missing (mode 0600), opens it, and inserts a `Host alias / HostName hostname / User user` snippet via `SnippetController2` with tabstops on each placeholder.
- **Configure SSH Hosts...** — calls a new `ISSHRemoteAgentHostService.listSSHConfigFiles()` (user config + `/etc/ssh/ssh_config` on POSIX or `%ProgramData%\ssh\ssh_config` on Windows when present), shows a quick pick (skipped when only one), and opens the chosen file. The user file is created on demand if picked and missing.

## Workspace picker Manage submenu — inline X buttons

Non-tunnel remote entries now render an inline X (remove) button in the Manage submenu, same as recently-opened folders at the top level. Implemented by propagating `onRemove` from child `IAction`s through `ActionListWidget` when building submenu items.

## New "Manage Remote Agent Hosts..." command (F1)

A unified picker that shows the same set of items as the workspace picker's Manage submenu — connected remotes (with X buttons) plus the contributed Add/Manage actions. Picking a connected remote opens the per-remote actions popup (Reconnect / Remove / Copy address / Open Settings / Show Output). The actions popup logic was extracted into `showRemoteHostOptions(accessor, provider)` so it's shared between the workspace picker and the new command.

## Internal cleanup

- Centralized command IDs in `RemoteAgentHostCommandIds`.
- Added `listSSHConfigFiles()` to `ISSHRemoteAgentHostService` + impls (node, electron-browser, browser-null) and test mocks.
- Wrapped the SSH picker's `QuickPick` and event subscriptions in a `DisposableStore` that disposes on `onDidHide` to avoid a leaked-disposable warning.

## Verification

Verified live in the Agents window via the launch skill: SSH picker shows aliases + synthetic entry + footer items; Add New SSH Host opens `~/.ssh/config` with active snippet tabstops; Configure SSH Hosts shows the file picker and opens the chosen file; Manage Remote Agent Hosts opens the unified picker.
