### PR TITLE
agent-host: report git-driven session file diffs

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -91,7 +91,7 @@ export abstract class AHPFileSystemProvider extends Disposable implements IFileS
 			return { type: FileType.Directory, mtime: 0, ctime: 0, size: 0, permissions: FilePermission.Readonly };
 		}
 		const decoded = this._decodeUri(resource);
-		if (decoded.scheme === 'session-db') {
+		if (decoded.scheme === 'session-db' || decoded.scheme === 'git-blob') {
 			return { type: FileType.File, mtime: 0, ctime: 0, size: 0, permissions: FilePermission.Readonly };
 		}
 

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -4,9 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
+import * as fs from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
+import { VSBuffer } from '../../../base/common/buffer.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
-import type { ISessionGitState } from '../common/state/sessionState.js';
+import { FileEditKind, type ISessionFileDiff, type ISessionGitState } from '../common/state/sessionState.js';
+import { buildGitBlobUri } from './gitDiffContent.js';
 
 export const IAgentHostGitService = createDecorator<IAgentHostGitService>('agentHostGitService');
 
@@ -27,6 +32,56 @@ export interface IAgentHostGitService {
 	 * so the UI always reflects current branch/remote/change state.
 	 */
 	getSessionGitState(workingDirectory: URI): Promise<ISessionGitState | undefined>;
+
+	/**
+	 * Computes per-file diffs for the session by shelling out to `git
+	 * diff --raw --numstat --diff-filter=ADMR -z` against the merge base of
+	 * the current branch and {@link IComputeSessionFileDiffsOptions.baseBranch}
+	 * (or `HEAD` if no base branch is available). When the working tree has
+	 * untracked files, the diff is computed via a temp index so the
+	 * untracked content is included.
+	 *
+	 * Returns `undefined` when {@link workingDirectory} is not a git work
+	 * tree, so callers can fall back to other diff sources.
+	 *
+	 * Each returned {@link ISessionFileDiff} has its `before.content` set to
+	 * a `git-blob:` URI ({@link buildGitBlobUri}); `after.content` is a
+	 * `file:` URI on the working-tree path. Adds and deletes drop the
+	 * missing side.
+	 */
+	computeSessionFileDiffs(workingDirectory: URI, options: IComputeSessionFileDiffsOptions): Promise<readonly ISessionFileDiff[] | undefined>;
+
+	/**
+	 * Reads a single git blob via `git show <sha>:<repoRelativePath>` from
+	 * the given working directory. Returns `undefined` when the blob does
+	 * not exist or the directory is not a git work tree.
+	 */
+	showBlob(workingDirectory: URI, sha: string, repoRelativePath: string): Promise<VSBuffer | undefined>;
+}
+
+/**
+ * Provider-agnostic session-database metadata key under which agents
+ * persist the branch they want git-driven diffs anchored to. Read by
+ * {@link AgentSideEffects} when computing per-session file diffs; absent
+ * value means the diff falls back to anchoring at HEAD.
+ */
+export const META_DIFF_BASE_BRANCH = 'agentHost.diffBaseBranch';
+
+/** Options for {@link IAgentHostGitService.computeSessionFileDiffs}. */
+export interface IComputeSessionFileDiffsOptions {
+	/**
+	 * The session URI, used as the authority of the produced
+	 * `git-blob:` URIs so the resolver can find the session's working
+	 * directory.
+	 */
+	readonly sessionUri: string;
+	/**
+	 * The branch to diff against. Typically the worktree's start-point
+	 * branch (for worktree sessions) or the repository's default branch.
+	 * When undefined or unresolvable, the diff is taken against `HEAD`,
+	 * which surfaces uncommitted work but no committed-on-branch work.
+	 */
+	readonly baseBranch?: string;
 }
 
 function getCommonBranchPriority(branch: string): number {
@@ -114,6 +169,104 @@ export class AgentHostGitService implements IAgentHostGitService {
 		await this._runGit(repositoryRoot, ['worktree', 'remove', '--force', worktree.fsPath], { timeout: 30_000, throwOnError: true });
 	}
 
+	async computeSessionFileDiffs(workingDirectory: URI, options: IComputeSessionFileDiffsOptions): Promise<readonly ISessionFileDiff[] | undefined> {
+		// Bail fast if not inside a git work tree so callers can fall back
+		// to other diff sources.
+		const inside = await this._runGit(workingDirectory, ['rev-parse', '--is-inside-work-tree']);
+		if (inside?.trim() !== 'true') {
+			return undefined;
+		}
+
+		// All git invocations run from the working tree's repository root so
+		// `--raw` paths are repo-relative — that's what `git show <sha>:<path>`
+		// expects when we resolve `git-blob:` URIs later.
+		const repositoryRootPath = (await this._runGit(workingDirectory, ['rev-parse', '--show-toplevel']))?.trim();
+		if (!repositoryRootPath) {
+			return undefined;
+		}
+		const repositoryRoot = URI.file(repositoryRootPath);
+
+		// Resolve the merge-base commit. With a base branch, this is
+		// `merge-base HEAD <base>` so the diff stays anchored even when the
+		// base branch advances. Without one, fall back to HEAD itself, which
+		// surfaces uncommitted work but no committed-on-branch work — the
+		// best we can do without context. For empty repos with no HEAD, fall
+		// back to the well-known empty-tree object.
+		let mergeBaseCommit: string | undefined;
+		if (options.baseBranch) {
+			mergeBaseCommit = (await this._runGit(repositoryRoot, ['merge-base', 'HEAD', options.baseBranch]))?.trim();
+		}
+		if (!mergeBaseCommit) {
+			mergeBaseCommit = (await this._runGit(repositoryRoot, ['rev-parse', 'HEAD']))?.trim();
+		}
+		if (!mergeBaseCommit) {
+			mergeBaseCommit = EMPTY_TREE_OBJECT;
+		}
+
+		// Detect whether the working tree has any untracked files. If so we
+		// have to use the temp-index trick so the untracked content is
+		// included in `--cached --raw` output; otherwise a plain `git diff`
+		// is sufficient and avoids the temp-dir overhead.
+		const statusOut = await this._runGit(repositoryRoot, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
+		const untracked = parseUntrackedPaths(statusOut);
+
+		let rawDiffOutput: string | undefined;
+		if (untracked.length === 0) {
+			rawDiffOutput = await this._runGit(repositoryRoot, ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--']);
+		} else {
+			rawDiffOutput = await this._runWithTempIndex(repositoryRoot, mergeBaseCommit);
+		}
+
+		if (rawDiffOutput === undefined) {
+			return undefined;
+		}
+
+		return parseGitDiffRawNumstat(rawDiffOutput, repositoryRoot, options.sessionUri, mergeBaseCommit);
+	}
+
+	private async _runWithTempIndex(repositoryRoot: URI, mergeBaseCommit: string): Promise<string | undefined> {
+		// Build a throwaway index so we can stage the entire working tree
+		// (including untracked files) without disturbing the user's real
+		// index. `read-tree HEAD` seeds it; in empty repos that fails so we
+		// fall back to the empty tree, leaving everything as "added".
+		const tempDir = await fs.mkdtemp(join(tmpdir(), 'agent-host-git-diff-'));
+		const indexFile = join(tempDir, 'index');
+		const env: Record<string, string> = { GIT_INDEX_FILE: indexFile };
+		try {
+			const seeded = await this._runGit(repositoryRoot, ['read-tree', 'HEAD'], { env });
+			if (seeded === undefined) {
+				// Empty repo (no HEAD yet) — `read-tree` of the empty tree always succeeds.
+				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
+			}
+			// Stage every change in the working tree (modified, deleted,
+			// untracked, renamed). `add -A` plus an explicit `:/` pathspec
+			// covers the entire repo from any cwd.
+			await this._runGit(repositoryRoot, ['add', '-A', '--', ':/'], { env });
+			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env });
+		} finally {
+			try { await fs.rm(tempDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+	}
+
+	async showBlob(workingDirectory: URI, sha: string, repoRelativePath: string): Promise<VSBuffer | undefined> {
+		const inside = await this._runGit(workingDirectory, ['rev-parse', '--is-inside-work-tree']);
+		if (inside?.trim() !== 'true') {
+			return undefined;
+		}
+		// `git show` exits non-zero when the path didn't exist at that
+		// commit; `_runGit` swallows that into `undefined` which is exactly
+		// the contract callers want.
+		return new Promise((resolve) => {
+			cp.execFile('git', ['show', `${sha}:${repoRelativePath}`], { cwd: workingDirectory.fsPath, timeout: 5000, encoding: 'buffer', maxBuffer: 32 * 1024 * 1024 }, (error, stdout) => {
+				if (error) {
+					resolve(undefined);
+					return;
+				}
+				resolve(VSBuffer.wrap(stdout as Buffer));
+			});
+		});
+	}
+
 	async getSessionGitState(workingDirectory: URI): Promise<ISessionGitState | undefined> {
 		return this._computeSessionGitState(workingDirectory);
 	}
@@ -171,9 +324,10 @@ export class AgentHostGitService implements IAgentHostGitService {
 		return stripUndefined(result);
 	}
 
-	private _runGit(workingDirectory: URI, args: readonly string[], options?: { readonly timeout?: number; readonly throwOnError?: boolean }): Promise<string | undefined> {
+	private _runGit(workingDirectory: URI, args: readonly string[], options?: { readonly timeout?: number; readonly throwOnError?: boolean; readonly env?: Record<string, string> }): Promise<string | undefined> {
 		return new Promise((resolve, reject) => {
-			cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, timeout: options?.timeout ?? 5000 }, (error, stdout, stderr) => {
+			const env = options?.env ? { ...process.env, ...options.env } : undefined;
+			cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, timeout: options?.timeout ?? 5000, env }, (error, stdout, stderr) => {
 				if (error) {
 					if (options?.throwOnError) {
 						reject(new Error(stderr || error.message));
@@ -186,6 +340,134 @@ export class AgentHostGitService implements IAgentHostGitService {
 			});
 		});
 	}
+}
+
+/**
+ * The well-known SHA-1 of git's empty tree, used as a fallback when a
+ * repository has no commits (no `HEAD` to read into the temp index).
+ */
+export const EMPTY_TREE_OBJECT = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+/**
+ * Parses NUL-separated `git status --porcelain=v1 -z --untracked-files=all`
+ * output and returns the repo-relative paths of untracked entries (status
+ * `??`). Other entries are ignored; we only need to know whether any
+ * untracked files exist to decide whether to use the temp-index path.
+ *
+ * Exported for tests.
+ */
+export function parseUntrackedPaths(output: string | undefined): string[] {
+	if (!output) {
+		return [];
+	}
+	const result: string[] = [];
+	const segments = output.split('\x00');
+	for (let i = 0; i < segments.length; i++) {
+		const seg = segments[i];
+		if (!seg) { continue; }
+		// Each entry is "XY <path>"; for renames v1 emits a second NUL-separated
+		// "from" path that we have to skip. We only care about untracked here.
+		const status = seg.substring(0, 2);
+		const path = seg.substring(3);
+		if (status === '??') {
+			result.push(path);
+		} else if (status[0] === 'R' || status[0] === 'C') {
+			// Skip the "from" path for renames/copies.
+			i++;
+		}
+	}
+	return result;
+}
+
+/**
+ * Parses combined `--raw --numstat -z` output produced by
+ * {@link IAgentHostGitService.computeSessionFileDiffs} and converts each
+ * change into an {@link ISessionFileDiff} ready for the protocol.
+ *
+ * The combined NUL-separated stream alternates between `--raw` segments
+ * (start with `:`) and `--numstat` segments. For renames the raw segment
+ * is followed by two extra path segments (old, new); the numstat segment
+ * has an empty path field followed by old/new path segments.
+ *
+ * Exported for tests.
+ */
+export function parseGitDiffRawNumstat(output: string, repositoryRoot: URI, sessionUri: string, mergeBaseCommit: string): ISessionFileDiff[] {
+	const segments = output.split('\x00');
+	const changes: { kind: FileEditKind; oldPath?: string; newPath?: string }[] = [];
+	const numStats = new Map<string, { added: number; removed: number }>();
+
+	let i = 0;
+	while (i < segments.length) {
+		const segment = segments[i++];
+		if (!segment) { continue; }
+
+		if (segment.startsWith(':')) {
+			// Raw line: ":<srcMode> <dstMode> <srcSha> <dstSha> <status>"
+			// followed by NUL-separated path(s).
+			const fields = segment.split(' ');
+			const status = fields[4] ?? '';
+			const path1 = segments[i++];
+			if (!path1) { continue; }
+
+			switch (status[0]) {
+				case 'A':
+					changes.push({ kind: FileEditKind.Create, newPath: path1 });
+					break;
+				case 'M':
+					changes.push({ kind: FileEditKind.Edit, oldPath: path1, newPath: path1 });
+					break;
+				case 'D':
+					changes.push({ kind: FileEditKind.Delete, oldPath: path1 });
+					break;
+				case 'R': {
+					const path2 = segments[i++];
+					if (!path2) { continue; }
+					changes.push({ kind: FileEditKind.Rename, oldPath: path1, newPath: path2 });
+					break;
+				}
+				default:
+					break;
+			}
+		} else {
+			// Numstat line: "<added>\t<removed>\t<path>" or, for renames,
+			// "<added>\t<removed>\t" followed by NUL-separated old/new paths.
+			const [addedStr, removedStr, filePath] = segment.split('\t');
+			let key: string;
+			if (filePath === '' || filePath === undefined) {
+				const oldPath = segments[i++];
+				const newPath = segments[i++];
+				key = newPath ?? oldPath ?? '';
+			} else {
+				key = filePath;
+			}
+			if (!key) { continue; }
+			numStats.set(key, {
+				added: addedStr === '-' ? 0 : Number(addedStr) || 0,
+				removed: removedStr === '-' ? 0 : Number(removedStr) || 0,
+			});
+		}
+	}
+
+	return changes.map(change => {
+		const stats = numStats.get(change.newPath ?? change.oldPath ?? '');
+		const hasBefore = change.kind !== FileEditKind.Create;
+		const hasAfter = change.kind !== FileEditKind.Delete;
+		return {
+			...(hasBefore && change.oldPath ? {
+				before: {
+					uri: URI.joinPath(repositoryRoot, change.oldPath).toString(),
+					content: { uri: buildGitBlobUri(sessionUri, mergeBaseCommit, change.oldPath) },
+				},
+			} : {}),
+			...(hasAfter && change.newPath ? {
+				after: {
+					uri: URI.joinPath(repositoryRoot, change.newPath).toString(),
+					content: { uri: URI.joinPath(repositoryRoot, change.newPath).toString() },
+				},
+			} : {}),
+			diff: { added: stats?.added ?? 0, removed: stats?.removed ?? 0 },
+		};
+	});
 }
 
 /**

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -249,6 +249,13 @@ export class AgentHostGitService implements IAgentHostGitService {
 	}
 
 	async showBlob(workingDirectory: URI, sha: string, repoRelativePath: string): Promise<VSBuffer | undefined> {
+		// Validate sha before passing it to git. `git show <sha>:<path>` parses
+		// its argument as a revision, so an attacker-controlled sha that starts
+		// with `-` could inject options, and a non-hex value could resolve to
+		// commit could resolve to surprising refs. Object names are 4-64 lowercase hex chars.
+		if (!/^[0-9a-f]{4,64}$/.test(sha)) {
+			return undefined;
+		}
 		const inside = await this._runGit(workingDirectory, ['rev-parse', '--is-inside-work-tree']);
 		if (inside?.trim() !== 'true') {
 			return undefined;
@@ -324,10 +331,13 @@ export class AgentHostGitService implements IAgentHostGitService {
 		return stripUndefined(result);
 	}
 
-	private _runGit(workingDirectory: URI, args: readonly string[], options?: { readonly timeout?: number; readonly throwOnError?: boolean; readonly env?: Record<string, string> }): Promise<string | undefined> {
+	private _runGit(workingDirectory: URI, args: readonly string[], options?: { readonly timeout?: number; readonly throwOnError?: boolean; readonly env?: Record<string, string>; readonly maxBuffer?: number }): Promise<string | undefined> {
 		return new Promise((resolve, reject) => {
 			const env = options?.env ? { ...process.env, ...options.env } : undefined;
-			cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, timeout: options?.timeout ?? 5000, env }, (error, stdout, stderr) => {
+			// Default maxBuffer is 32MB — Node's default is ~1MB, which is
+			// easy to exceed for diff output in large repos. Exceeding it
+			// causes execFile to error and we'd silently drop the diff.
+			cp.execFile('git', [...args], { cwd: workingDirectory.fsPath, timeout: options?.timeout ?? 5000, env, maxBuffer: options?.maxBuffer ?? 32 * 1024 * 1024 }, (error, stdout, stderr) => {
 				if (error) {
 					if (options?.throwOnError) {
 						reject(new Error(stderr || error.message));

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -240,6 +240,11 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// a real OS path string, not a URI.
 		const indexFile = URI.joinPath(tempDir, 'index').fsPath;
 		const env: Record<string, string> = { GIT_INDEX_FILE: indexFile };
+		// GVFS (Virtual File System) repos use a hook that acquires a lock around
+		// git commands. Setting COMMAND_HOOK_LOCK=1 prevents the temp-index
+		// operations from blocking the main working-tree lock. This mirrors what
+		// the extension's `buildTempIndexEnv` does for the same reason.
+		env.COMMAND_HOOK_LOCK = '1';
 		try {
 			const seeded = await this._runGit(repositoryRoot, ['read-tree', 'HEAD'], { env });
 			if (seeded === undefined) {

--- a/src/vs/platform/agentHost/node/agentHostGitService.ts
+++ b/src/vs/platform/agentHost/node/agentHostGitService.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
-import * as fs from 'fs/promises';
-import { tmpdir } from 'os';
-import { join } from '../../../base/common/path.js';
 import { URI } from '../../../base/common/uri.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
+import { generateUuid } from '../../../base/common/uuid.js';
+import { INativeEnvironmentService } from '../../environment/common/environment.js';
+import { IFileService } from '../../files/common/files.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { FileEditKind, type ISessionFileDiff, type ISessionGitState } from '../common/state/sessionState.js';
 import { buildGitBlobUri } from './gitDiffContent.js';
@@ -106,6 +106,11 @@ export function getBranchCompletions(branches: readonly string[], options?: { re
 
 export class AgentHostGitService implements IAgentHostGitService {
 	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IFileService private readonly _fileService: IFileService,
+		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
+	) { }
 
 	async isInsideWorkTree(workingDirectory: URI): Promise<boolean> {
 		return (await this._runGit(workingDirectory, ['rev-parse', '--is-inside-work-tree']))?.trim() === 'true';
@@ -229,13 +234,16 @@ export class AgentHostGitService implements IAgentHostGitService {
 		// (including untracked files) without disturbing the user's real
 		// index. `read-tree HEAD` seeds it; in empty repos that fails so we
 		// fall back to the empty tree, leaving everything as "added".
-		const tempDir = await fs.mkdtemp(join(tmpdir(), 'agent-host-git-diff-'));
-		const indexFile = join(tempDir, 'index');
+		const tempDir = URI.joinPath(this._environmentService.tmpDir, `agent-host-git-diff-${generateUuid()}`);
+		await this._fileService.createFolder(tempDir);
+		// `GIT_INDEX_FILE` is consumed by the `git` subprocess so it must be
+		// a real OS path string, not a URI.
+		const indexFile = URI.joinPath(tempDir, 'index').fsPath;
 		const env: Record<string, string> = { GIT_INDEX_FILE: indexFile };
 		try {
 			const seeded = await this._runGit(repositoryRoot, ['read-tree', 'HEAD'], { env });
 			if (seeded === undefined) {
-				// Empty repo (no HEAD yet) — `read-tree` of the empty tree always succeeds.
+				// Empty repo (no HEAD yet) - `read-tree` of the empty tree always succeeds.
 				await this._runGit(repositoryRoot, ['read-tree', EMPTY_TREE_OBJECT], { env });
 			}
 			// Stage every change in the working tree (modified, deleted,
@@ -244,7 +252,7 @@ export class AgentHostGitService implements IAgentHostGitService {
 			await this._runGit(repositoryRoot, ['add', '-A', '--', ':/'], { env });
 			return await this._runGit(repositoryRoot, ['diff', '--cached', '--raw', '--numstat', '--diff-filter=ADMR', '-z', mergeBaseCommit, '--'], { env });
 		} finally {
-			try { await fs.rm(tempDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+			try { await this._fileService.del(tempDir, { recursive: true, useTrash: false }); } catch { /* best-effort */ }
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -89,21 +89,23 @@ function startAgentHost(): void {
 	// Create the real service implementation that lives in this process
 	let agentService: AgentService;
 	try {
-		const gitService = new AgentHostGitService();
-		agentService = new AgentService(logService, fileService, sessionDataService, productService, gitService);
-		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
+		// Build the DI container early so the git service can be created via
+		// `createInstance` (it needs IFileService + INativeEnvironmentService).
 		const diServices = new ServiceCollection();
 		diServices.set(INativeEnvironmentService, environmentService);
 		diServices.set(ILogService, logService);
 		diServices.set(IFileService, fileService);
 		diServices.set(ISessionDataService, sessionDataService);
+		const instantiationService = new InstantiationService(diServices);
+		const gitService = instantiationService.createInstance(AgentHostGitService);
+		diServices.set(IAgentHostGitService, gitService);
+		agentService = new AgentService(logService, fileService, sessionDataService, productService, gitService);
+		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
 		diServices.set(IAgentPluginManager, pluginManager);
 		const diffComputeService = disposables.add(new NodeWorkerDiffComputeService(logService));
 		diServices.set(IDiffComputeService, diffComputeService);
 
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
-		const instantiationService = new InstantiationService(diServices);
-		diServices.set(IAgentHostGitService, gitService);
 		agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
 	} catch (err) {
 		logService.error('Failed to create AgentService', err);

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -162,8 +162,11 @@ async function main(): Promise<void> {
 	// Session data service
 	const sessionDataService = new SessionDataService(URI.file(environmentService.userDataPath), fileService, logService);
 
-	// Create the agent service (owns AgentHostStateManager + AgentSideEffects internally)
+	// Git service is shared by AgentService (for diff computation + showBlob)
+	// and the production agent registration path. Construct once.
 	const gitService = new AgentHostGitService();
+
+	// Create the agent service (owns AgentHostStateManager + AgentSideEffects internally)
 	const agentService = new AgentService(logService, fileService, sessionDataService, productService, gitService);
 	disposables.add(agentService);
 

--- a/src/vs/platform/agentHost/node/agentHostServerMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostServerMain.ts
@@ -162,9 +162,18 @@ async function main(): Promise<void> {
 	// Session data service
 	const sessionDataService = new SessionDataService(URI.file(environmentService.userDataPath), fileService, logService);
 
-	// Git service is shared by AgentService (for diff computation + showBlob)
-	// and the production agent registration path. Construct once.
-	const gitService = new AgentHostGitService();
+	// Build the DI container early so the git service can be created via
+	// `createInstance` (it needs IFileService + INativeEnvironmentService).
+	// The git service is shared by AgentService (for diff computation +
+	// showBlob) and the production agent registration path.
+	const diServices = new ServiceCollection();
+	diServices.set(IProductService, productService);
+	diServices.set(INativeEnvironmentService, environmentService);
+	diServices.set(ILogService, logService);
+	diServices.set(IFileService, fileService);
+	diServices.set(ISessionDataService, sessionDataService);
+	const instantiationService = new InstantiationService(diServices);
+	const gitService = instantiationService.createInstance(AgentHostGitService);
 
 	// Create the agent service (owns AgentHostStateManager + AgentSideEffects internally)
 	const agentService = new AgentService(logService, fileService, sessionDataService, productService, gitService);
@@ -173,18 +182,11 @@ async function main(): Promise<void> {
 	// Register agents
 	if (!options.quiet) {
 		// Production agents (require DI)
-		const diServices = new ServiceCollection();
 		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
-		diServices.set(IProductService, productService);
-		diServices.set(INativeEnvironmentService, environmentService);
-		diServices.set(ILogService, logService);
-		diServices.set(IFileService, fileService);
-		diServices.set(ISessionDataService, sessionDataService);
 		diServices.set(IAgentPluginManager, pluginManager);
 		diServices.set(IDiffComputeService, disposables.add(new NodeWorkerDiffComputeService(logService)));
 		diServices.set(IAgentHostTerminalManager, agentService.terminalManager);
 		diServices.set(IAgentHostGitService, gitService);
-		const instantiationService = new InstantiationService(diServices);
 		const copilotAgent = disposables.add(instantiationService.createInstance(CopilotAgent));
 		agentService.registerProvider(copilotAgent);
 		log('CopilotAgent registered');

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -26,6 +26,7 @@ import { AgentConfigurationService, IAgentConfigurationService } from './agentCo
 import { AgentSideEffects } from './agentSideEffects.js';
 import { AgentHostTerminalManager, type IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { ISessionDbUriFields, parseSessionDbUri } from './copilot/fileEditTracker.js';
+import { IGitBlobUriFields, parseGitBlobUri } from './gitDiffContent.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
 import { IAgentHostGitService } from './agentHostGitService.js';
 
@@ -112,6 +113,7 @@ export class AgentService extends Disposable implements IAgentService {
 			getAgent: session => this._findProviderForSession(session),
 			sessionDataService: this._sessionDataService,
 			agents: this._agents,
+			gitService: this._gitService,
 			onTurnComplete: session => {
 				const workingDirStr = this._stateManager.getSessionState(session)?.summary.workingDirectory;
 				this._attachGitState(URI.parse(session), workingDirStr ? URI.parse(workingDirStr) : undefined);
@@ -648,6 +650,15 @@ export class AgentService extends Disposable implements IAgentService {
 			return this._fetchSessionDbContent(dbFields);
 		}
 
+		// Handle git-blob: URIs that reference file content at a specific
+		// git commit (the merge-base used as diff baseline). The URI
+		// encodes the session it belongs to so we can find the right
+		// working directory to run `git show` from.
+		const blobFields = parseGitBlobUri(uri.toString());
+		if (blobFields) {
+			return this._fetchGitBlobContent(blobFields);
+		}
+
 		try {
 			const content = await this._fileService.readFile(uri);
 			return {
@@ -1029,6 +1040,25 @@ export class AgentService extends Disposable implements IAgentService {
 		} finally {
 			ref.dispose();
 		}
+	}
+
+	private async _fetchGitBlobContent(fields: IGitBlobUriFields): Promise<ResourceReadResult> {
+		if (!this._gitService) {
+			throw new ProtocolError(AhpErrorCodes.NotFound, `git service unavailable for: ${fields.repoRelativePath}`);
+		}
+		const workingDirectory = this._stateManager.getSessionState(fields.sessionUri)?.summary.workingDirectory;
+		if (!workingDirectory) {
+			throw new ProtocolError(AhpErrorCodes.NotFound, `Session has no working directory for git-blob URI: ${fields.sessionUri}`);
+		}
+		const blob = await this._gitService.showBlob(URI.parse(workingDirectory), fields.sha, fields.repoRelativePath);
+		if (!blob) {
+			throw new ProtocolError(AhpErrorCodes.NotFound, `git blob not found: ${fields.sha}:${fields.repoRelativePath}`);
+		}
+		return {
+			data: blob.toString(),
+			encoding: ContentEncoding.Utf8,
+			contentType: 'text/plain',
+		};
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -106,6 +106,7 @@ export class AgentService extends Disposable implements IAgentService {
 		const services = new ServiceCollection(
 			[ILogService, this._logService],
 			[IAgentConfigurationService, configurationService],
+			[IAgentHostGitService, this._gitService],
 		);
 		const instantiationService = this._register(new InstantiationService(services, /*strict*/ true));
 
@@ -113,7 +114,6 @@ export class AgentService extends Disposable implements IAgentService {
 			getAgent: session => this._findProviderForSession(session),
 			sessionDataService: this._sessionDataService,
 			agents: this._agents,
-			gitService: this._gitService,
 			onTurnComplete: session => {
 				const workingDirStr = this._stateManager.getSessionState(session)?.summary.workingDirectory;
 				this._attachGitState(URI.parse(session), workingDirStr ? URI.parse(workingDirStr) : undefined);

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -14,7 +14,7 @@ import { ILogService } from '../../log/common/log.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { IAgent, IAgentAttachment, IAgentProgressEvent, type IAgentToolCompleteEvent, type IAgentToolReadyEvent } from '../common/agentService.js';
 import { IDiffComputeService } from '../common/diffComputeService.js';
-import { ISessionDataService } from '../common/sessionDataService.js';
+import { ISessionDatabase, ISessionDataService } from '../common/sessionDataService.js';
 import type { AgentInfo } from '../common/state/protocol/state.js';
 import { ActionType, SessionAction } from '../common/state/sessionActions.js';
 import {
@@ -29,10 +29,12 @@ import {
 	type SessionCustomization,
 	type SessionState,
 	type ToolResultContent,
+	type ISessionFileDiff,
 	type URI as ProtocolURI,
 } from '../common/state/sessionState.js';
 import { AgentEventMapper } from './agentEventMapper.js';
 import { AgentHostStateManager } from './agentHostStateManager.js';
+import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from './agentHostGitService.js';
 import { NodeWorkerDiffComputeService } from './diffComputeService.js';
 import { computeSessionDiffs, type IIncrementalDiffOptions } from './sessionDiffAggregator.js';
 import { SessionPermissionManager } from './sessionPermissions.js';
@@ -53,6 +55,12 @@ export interface IAgentSideEffectsOptions {
 	 * excluded — only the parent session URI is passed.
 	 */
 	readonly onTurnComplete: (session: ProtocolURI) => void;
+	/**
+	 * Optional git service used for the git-driven diff path. When absent
+	 * (e.g. minimal test setups), diff computation falls back to the
+	 * edit-tracker aggregator.
+	 */
+	readonly gitService?: IAgentHostGitService;
 }
 
 /** A progress event that was deferred because its subagent session does not exist yet. */
@@ -931,20 +939,29 @@ export class AgentSideEffects extends Disposable {
 			return;
 		}
 		try {
-			// Build incremental options when a specific turn triggered the recomputation
-			let incremental: IIncrementalDiffOptions | undefined;
-			if (changedTurnId) {
-				const previousDiffs = this._stateManager.getSessionState(session)?.summary.diffs;
-				if (previousDiffs) {
-					incremental = { changedTurnId, previousDiffs };
+			// Prefer a git-driven diff so terminal-driven file changes show up
+			// alongside SDK-tracked tool edits. The git path is the source of
+			// truth whenever the working directory is a real work tree; we
+			// only fall back to the edit-tracker aggregator when it isn't
+			// (e.g. agents running in non-git scratch directories or under
+			// test harnesses without git).
+			let diffs = await this._tryComputeGitDiffs(session, ref.object);
+			if (!diffs) {
+				// Build incremental options when a specific turn triggered the recomputation
+				let incremental: IIncrementalDiffOptions | undefined;
+				if (changedTurnId) {
+					const previousDiffs = this._stateManager.getSessionState(session)?.summary.diffs;
+					if (previousDiffs) {
+						incremental = { changedTurnId, previousDiffs };
+					}
 				}
+				diffs = await computeSessionDiffs(session, ref.object, this._diffComputeService, incremental);
 			}
 
-			const diffs = await computeSessionDiffs(session, ref.object, this._diffComputeService, incremental);
 			this._stateManager.dispatchServerAction({
 				type: ActionType.SessionDiffsChanged,
 				session,
-				diffs,
+				diffs: [...diffs],
 			});
 			// Persist diffs to the session database so they survive restarts
 			ref.object.setMetadata('diffs', JSON.stringify(diffs)).catch(err => {
@@ -954,6 +971,39 @@ export class AgentSideEffects extends Disposable {
 			this._logService.warn('[AgentSideEffects] Failed to compute session diffs', err);
 		} finally {
 			ref.dispose();
+		}
+	}
+
+	/**
+	 * Computes session diffs by shelling out to git. Returns the diff list
+	 * when the session has a working directory and that directory is a git
+	 * work tree; returns `undefined` otherwise so the caller can fall back
+	 * to the edit-tracker aggregator. The base branch (anchor for the
+	 * `merge-base` baseline) is read from the provider-agnostic
+	 * {@link META_DIFF_BASE_BRANCH} metadata key — agents that create
+	 * worktrees write it at session-creation time.
+	 */
+	private async _tryComputeGitDiffs(session: ProtocolURI, db: ISessionDatabase): Promise<readonly ISessionFileDiff[] | undefined> {
+		const workingDirectory = this._stateManager.getSessionState(session)?.summary.workingDirectory;
+		if (!workingDirectory) {
+			return undefined;
+		}
+		let workingDirectoryUri: URI;
+		try {
+			workingDirectoryUri = URI.parse(workingDirectory);
+		} catch {
+			return undefined;
+		}
+		const baseBranch = (await db.getMetadata(META_DIFF_BASE_BRANCH)) ?? undefined;
+		const gitService = this._options.gitService;
+		if (!gitService) {
+			return undefined;
+		}
+		try {
+			return await gitService.computeSessionFileDiffs(workingDirectoryUri, { sessionUri: session, baseBranch });
+		} catch (err) {
+			this._logService.warn('[AgentSideEffects] git-driven diff computation failed; falling back to edit-tracker', err);
+			return undefined;
 		}
 	}
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -55,12 +55,6 @@ export interface IAgentSideEffectsOptions {
 	 * excluded — only the parent session URI is passed.
 	 */
 	readonly onTurnComplete: (session: ProtocolURI) => void;
-	/**
-	 * Optional git service used for the git-driven diff path. When absent
-	 * (e.g. minimal test setups), diff computation falls back to the
-	 * edit-tracker aggregator.
-	 */
-	readonly gitService?: IAgentHostGitService;
 }
 
 /** A progress event that was deferred because its subagent session does not exist yet. */
@@ -121,6 +115,7 @@ export class AgentSideEffects extends Disposable {
 		private readonly _options: IAgentSideEffectsOptions,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
+		@IAgentHostGitService private readonly _gitService: IAgentHostGitService,
 	) {
 		super();
 		this._diffComputeService = this._register(new NodeWorkerDiffComputeService(this._logService));
@@ -995,12 +990,8 @@ export class AgentSideEffects extends Disposable {
 			return undefined;
 		}
 		const baseBranch = (await db.getMetadata(META_DIFF_BASE_BRANCH)) ?? undefined;
-		const gitService = this._options.gitService;
-		if (!gitService) {
-			return undefined;
-		}
 		try {
-			return await gitService.computeSessionFileDiffs(workingDirectoryUri, { sessionUri: session, baseBranch });
+			return await this._gitService.computeSessionFileDiffs(workingDirectoryUri, { sessionUri: session, baseBranch });
 		} catch (err) {
 			this._logService.warn('[AgentSideEffects] git-driven diff computation failed; falling back to edit-tracker', err);
 			return undefined;

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -31,7 +31,7 @@ import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from 
 import { ProtectedResourceMetadata, type ConfigSchema, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { CustomizationStatus, CustomizationRef, SessionInputResponseKind, type PendingMessage, type SessionInputAnswer, type ToolCallResult, type PolicyState } from '../../common/state/sessionState.js';
-import { IAgentHostGitService } from '../agentHostGitService.js';
+import { IAgentHostGitService, META_DIFF_BASE_BRANCH } from '../agentHostGitService.js';
 import { IAgentHostTerminalManager } from '../agentHostTerminalManager.js';
 import { CopilotAgentSession, SessionWrapperFactory, type IActiveClientSnapshot } from './copilotAgentSession.js';
 import { ICopilotSessionContext, projectFromCopilotContext } from './copilotGitProject.js';
@@ -1024,7 +1024,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._pendingFirstTurnAnnouncements.set(sessionId, buildWorktreeAnnouncementText(branchName));
 		const sessionUri = AgentSession.uri(this.id, sessionId);
 		try {
-			await this._writeWorktreeBranchMetadata(sessionUri, branchName);
+			await this._writeWorktreeBranchMetadata(sessionUri, branchName, baseBranch);
 		} catch (error) {
 			this._logService.warn(`[Copilot:${sessionId}] Failed to persist worktree branch metadata: ${error instanceof Error ? error.message : String(error)}`);
 		}
@@ -1054,10 +1054,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private static readonly _META_PROJECT_DISPLAY_NAME = 'copilot.project.displayName';
 	private static readonly _META_WORKTREE_BRANCH = 'copilot.worktree.branchName';
 
-	private async _writeWorktreeBranchMetadata(session: URI, branchName: string): Promise<void> {
+	private async _writeWorktreeBranchMetadata(session: URI, branchName: string, baseBranch: string | undefined): Promise<void> {
 		const dbRef = this._sessionDataService.openDatabase(session);
 		try {
-			await dbRef.object.setMetadata(CopilotAgent._META_WORKTREE_BRANCH, branchName);
+			const work: Promise<void>[] = [dbRef.object.setMetadata(CopilotAgent._META_WORKTREE_BRANCH, branchName)];
+			if (baseBranch) {
+				work.push(dbRef.object.setMetadata(META_DIFF_BASE_BRANCH, baseBranch));
+			}
+			await Promise.all(work);
 		} finally {
 			dbRef.dispose();
 		}

--- a/src/vs/platform/agentHost/node/gitDiffContent.ts
+++ b/src/vs/platform/agentHost/node/gitDiffContent.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { decodeHex, encodeHex, VSBuffer } from '../../../base/common/buffer.js';
+import { basename } from '../../../base/common/path.js';
+import { URI } from '../../../base/common/uri.js';
+
+const GIT_BLOB_SCHEME = 'git-blob';
+
+/**
+ * Builds a `git-blob:` URI that references a file blob at a specific git
+ * commit, scoped to a given session. Resolved by reading the session's
+ * working directory and shelling out to `git show <sha>:<path>`.
+ *
+ * The session URI is preserved so the resolver can find the session's
+ * working directory; the SHA and repository-relative path identify the
+ * blob to fetch.
+ */
+export function buildGitBlobUri(sessionUri: string, sha: string, repoRelativePath: string): string {
+	return URI.from({
+		scheme: GIT_BLOB_SCHEME,
+		authority: encodeHex(VSBuffer.fromString(sessionUri)).toString(),
+		path: `/${encodeURIComponent(sha)}/${encodeHex(VSBuffer.fromString(repoRelativePath))}/${basename(repoRelativePath)}`,
+	}).toString();
+}
+
+/** Parsed fields from a `git-blob:` content URI. */
+export interface IGitBlobUriFields {
+	readonly sessionUri: string;
+	readonly sha: string;
+	readonly repoRelativePath: string;
+}
+
+/**
+ * Parses a `git-blob:` URI produced by {@link buildGitBlobUri}.
+ * Returns `undefined` if the URI is not a valid `git-blob:` URI.
+ */
+export function parseGitBlobUri(raw: string): IGitBlobUriFields | undefined {
+	let parsed: URI;
+	try {
+		parsed = URI.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (parsed.scheme !== GIT_BLOB_SCHEME) {
+		return undefined;
+	}
+	const [, sha, encodedPath] = parsed.path.split('/');
+	if (!sha || !encodedPath) {
+		return undefined;
+	}
+	try {
+		return {
+			sessionUri: decodeHex(parsed.authority).toString(),
+			sha: decodeURIComponent(sha),
+			repoRelativePath: decodeHex(encodedPath).toString(),
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -4,10 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { agentHostRemotePath, agentHostUri } from '../../common/agentHostFileSystemProvider.js';
+import { FileType } from '../../../files/common/files.js';
+import { AgentHostFileSystemProvider, agentHostRemotePath, agentHostUri, type IRemoteFilesystemConnection } from '../../common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../common/agentHostUri.js';
+import { ContentEncoding, type ResourceListResult, type ResourceReadResult } from '../../common/state/protocol/commands.js';
 
 suite('AgentHostFileSystemProvider - URI helpers', () => {
 
@@ -174,5 +177,113 @@ suite('AGENT_HOST_LABEL_FORMATTER', () => {
 
 		const stripped = stripPath(encodedUri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
 		assert.strictEqual(stripped, '/snap/before');
+	});
+});
+
+suite('AgentHostFileSystemProvider - synthetic content schemes', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Stub connection that records the URIs it's asked about and returns
+	 * canned data, so we can assert on the URIs the provider passes through.
+	 */
+	class StubConnection implements IRemoteFilesystemConnection {
+		readonly readCalls: URI[] = [];
+		readonly listCalls: URI[] = [];
+		readResult: ResourceReadResult = { data: 'stub-content', encoding: ContentEncoding.Utf8, contentType: 'text/plain' };
+
+		async resourceRead(uri: URI): Promise<ResourceReadResult> {
+			this.readCalls.push(uri);
+			return this.readResult;
+		}
+		async resourceList(uri: URI): Promise<ResourceListResult> {
+			this.listCalls.push(uri);
+			return { entries: [] };
+		}
+		async resourceWrite(): Promise<{}> { return {}; }
+		async resourceDelete(): Promise<{}> { return {}; }
+		async resourceMove(): Promise<{}> { return {}; }
+	}
+
+	function setup() {
+		const provider = disposables.add(new AgentHostFileSystemProvider());
+		const connection = new StubConnection();
+		disposables.add(provider.registerAuthority('local', connection));
+		return { provider, connection };
+	}
+
+	// Regression: AHPFileSystemProvider.stat() used to fall through to
+	// _listDirectory(parent) for any URI whose decoded scheme wasn't
+	// session-db, which fails with "Directory not found" for synthetic
+	// content URIs that have no real parent directory. The diff editor
+	// stats every URI before reading it, so this broke "open diff of a
+	// modified file" entirely. The fix is the scheme allowlist in stat().
+
+	test('stat returns File for git-blob: URIs without listing the parent', async () => {
+		const { provider, connection } = setup();
+		const inner = URI.from({ scheme: 'git-blob', authority: 'sess1', path: '/sha/encoded/file.ts' });
+		const wrapped = toAgentHostUri(inner, 'local');
+
+		const stat = await provider.stat(wrapped);
+
+		assert.strictEqual(stat.type, FileType.File);
+		assert.deepStrictEqual(connection.listCalls, [], 'stat must not list a synthetic parent directory');
+	});
+
+	test('stat returns File for session-db: URIs (parity with git-blob)', async () => {
+		const { provider, connection } = setup();
+		const inner = URI.from({ scheme: 'session-db', authority: 'sess1', path: '/snap/some-blob' });
+		const wrapped = toAgentHostUri(inner, 'local');
+
+		const stat = await provider.stat(wrapped);
+
+		assert.strictEqual(stat.type, FileType.File);
+		assert.deepStrictEqual(connection.listCalls, []);
+	});
+
+	test('stat still lists parent for ordinary file: URIs', async () => {
+		// Use a non-local authority so the URI actually goes through the
+		// agent-host wrapping (toAgentHostUri short-circuits 'local'
+		// + file:// to return the URI unchanged).
+		const provider = disposables.add(new AgentHostFileSystemProvider());
+		const connection = new StubConnection();
+		disposables.add(provider.registerAuthority('remote', connection));
+		const wrapped = agentHostUri('remote', '/some/file.ts');
+
+		try {
+			await provider.stat(wrapped);
+		} catch {
+			// Either FileNotFound or EntryNotFound is fine — we only
+			// care that the provider tried to list the parent (rather
+			// than treating this as a synthetic content URI).
+		}
+		assert.strictEqual(connection.listCalls.length, 1);
+	});
+
+	test('readFile passes the decoded synthetic URI through to the connection', async () => {
+		const { provider, connection } = setup();
+		const inner = URI.from({ scheme: 'git-blob', authority: 'sess1', path: '/sha/encoded/file.ts' });
+		const wrapped = toAgentHostUri(inner, 'local');
+
+		const bytes = await provider.readFile(wrapped);
+
+		assert.strictEqual(VSBuffer.wrap(bytes).toString(), 'stub-content');
+		assert.deepStrictEqual(connection.readCalls.map(u => u.toString()), [inner.toString()]);
+	});
+
+	test('full stat-then-read round-trip mirrors the diff editor flow', async () => {
+		// This is the exact sequence the workbench's TextFileEditorModel
+		// goes through when DiffEditorInput.createModel resolves: stat
+		// the URI, then read the file. Pre-fix this combo failed at the
+		// stat step before readFile was even called.
+		const { provider } = setup();
+		const inner = URI.from({ scheme: 'git-blob', authority: 'sess1', path: '/sha/encoded/file.ts' });
+		const wrapped = toAgentHostUri(inner, 'local');
+
+		const stat = await provider.stat(wrapped);
+		assert.strictEqual(stat.type, FileType.File);
+		const bytes = await provider.readFile(wrapped);
+		assert.strictEqual(VSBuffer.wrap(bytes).toString(), 'stub-content');
 	});
 });

--- a/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
+++ b/src/vs/platform/agentHost/test/common/sessionTestHelpers.ts
@@ -172,6 +172,8 @@ export function createNoopGitService(): import('../../node/agentHostGitService.j
 		addWorktree: async () => { },
 		removeWorktree: async () => { },
 		getSessionGitState: async () => undefined,
+		computeSessionFileDiffs: async () => undefined,
+		showBlob: async () => undefined,
 	};
 }
 

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -125,3 +125,133 @@ suite('AgentHostGitService - getSessionGitState (real git)', () => {
 		}
 	});
 });
+
+suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const hasGit = (() => {
+		try { cp.execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+	})();
+
+	let tmpRoot: string | undefined;
+	let svc: AgentHostGitService | undefined;
+
+	setup(() => {
+		tmpRoot = undefined;
+		svc = new AgentHostGitService();
+	});
+
+	teardown(() => {
+		if (tmpRoot) {
+			rmSync(tmpRoot, { recursive: true, force: true });
+		}
+	});
+
+	function initRepo(): { dir: string; run: (...args: string[]) => Buffer } {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'agent-host-diff-'));
+		const env = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
+		const run = (...args: string[]) => cp.execFileSync('git', args, { cwd: tmpRoot!, env, stdio: 'pipe' });
+		run('init', '-q', '-b', 'main');
+		return { dir: tmpRoot!, run };
+	}
+
+	(hasGit ? test : test.skip)('returns undefined for a non-git directory', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'agent-host-nongit-diff-'));
+		tmpRoot = dir;
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+		assert.strictEqual(result, undefined);
+	});
+
+	(hasGit ? test : test.skip)('reports modified, added (untracked) and deleted files against HEAD', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'kept.txt'), 'one\ntwo\nthree\n');
+		await fs.writeFile(join(dir, 'gone.txt'), 'bye\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+
+		// Modify, add (untracked), delete.
+		await fs.writeFile(join(dir, 'kept.txt'), 'one\ntwo\nthree\nfour\n');
+		await fs.writeFile(join(dir, 'fresh.txt'), 'hello\n');
+		await fs.unlink(join(dir, 'gone.txt'));
+
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+		assert.ok(result, 'expected diffs');
+		const byPath = new Map(result.map(d => [d.after?.uri ?? d.before?.uri, d]));
+
+		// Find by basename to be robust against path normalization differences (e.g. macOS /private prefix).
+		const findByBasename = (name: string) => result.find(d => {
+			const u = d.after?.uri ?? d.before?.uri;
+			return typeof u === 'string' && u.endsWith('/' + name);
+		});
+
+		const kept = findByBasename('kept.txt');
+		assert.ok(kept?.before && kept.after, `modified file should have before+after; result=${JSON.stringify(result.map(d => ({ a: d.after?.uri, b: d.before?.uri })))}`);
+		assert.deepStrictEqual(kept!.diff, { added: 1, removed: 0 });
+		assert.ok(kept!.before!.content.uri.startsWith('git-blob://'), 'before content should be a git-blob: URI');
+
+		const fresh = findByBasename('fresh.txt');
+		assert.ok(fresh?.after && !fresh.before, 'untracked file should have only after');
+
+		const gone = findByBasename('gone.txt');
+		assert.ok(gone?.before && !gone.after, 'deleted file should have only before');
+		void byPath;
+	});
+
+	(hasGit ? test : test.skip)('anchors against the merge-base of the requested base branch', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'a.txt'), 'a\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+		// Branch off, then advance main behind us so merge-base != HEAD.
+		run('checkout', '-q', '-b', 'feature');
+		await fs.writeFile(join(dir, 'b.txt'), 'b\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'add b on feature');
+
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s', baseBranch: 'main' });
+		assert.ok(result, 'expected diffs');
+		// `b.txt` was committed on `feature` after branching from `main`, so
+		// it must show up in the merge-base diff even though there are no
+		// uncommitted changes in the working tree.
+		const paths = result.map(d => (d.after?.uri ?? d.before?.uri));
+		assert.ok(paths.some(p => p?.endsWith('b.txt')), `expected b.txt in diff; got ${paths.join(', ')}`);
+	});
+
+	(hasGit ? test : test.skip)('returns no diffs for a clean repo', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'a.txt'), 'a\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+		assert.deepStrictEqual(result, []);
+	});
+
+	(hasGit ? test : test.skip)('handles an empty repo (no HEAD) by treating files as added', async () => {
+		const fs = await import('fs/promises');
+		const { dir } = initRepo();
+		await fs.writeFile(join(dir, 'first.txt'), 'hello\n');
+
+		const result = await svc!.computeSessionFileDiffs(URI.file(dir), { sessionUri: 'copilot:/s' });
+		assert.ok(result, 'expected diffs');
+		assert.strictEqual(result.length, 1);
+		assert.ok(result[0].after && !result[0].before, 'untracked file in empty repo should be an addition');
+	});
+
+	(hasGit ? test : test.skip)('showBlob retrieves committed content', async () => {
+		const fs = await import('fs/promises');
+		const { dir, run } = initRepo();
+		await fs.writeFile(join(dir, 'a.txt'), 'original\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+		const sha = cp.execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
+		await fs.writeFile(join(dir, 'a.txt'), 'changed\n');
+
+		const blob = await svc!.showBlob(URI.file(dir), sha, 'a.txt');
+		assert.ok(blob);
+		assert.strictEqual(blob.toString(), 'original\n');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.integrationTest.ts
@@ -17,13 +17,27 @@ import assert from 'assert';
 import * as cp from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
+import { NullLogService } from '../../../log/common/log.js';
 import { join } from '../../../../base/common/path.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { INativeEnvironmentService } from '../../../environment/common/environment.js';
+import { FileService } from '../../../files/common/fileService.js';
+import { Schemas } from '../../../../base/common/network.js';
+import { DiskFileSystemProvider } from '../../../files/node/diskFileSystemProvider.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { AgentHostGitService } from '../../node/agentHostGitService.js';
 
+function createGitService(disposables: Pick<DisposableStore, 'add'>): AgentHostGitService {
+	const logService = new NullLogService();
+	const fileService = disposables.add(new FileService(logService));
+	disposables.add(fileService.registerProvider(Schemas.file, disposables.add(new DiskFileSystemProvider(logService))));
+	const env: Partial<INativeEnvironmentService> = { tmpDir: URI.file(tmpdir()) };
+	return new AgentHostGitService(fileService, env as INativeEnvironmentService);
+}
+
 suite('AgentHostGitService - getSessionGitState (real git)', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	// Skip the on-disk git tests when `git` is not on PATH (e.g. minimal CI).
 	const hasGit = (() => {
@@ -35,7 +49,7 @@ suite('AgentHostGitService - getSessionGitState (real git)', () => {
 
 	setup(() => {
 		tmpRoot = undefined;
-		svc = new AgentHostGitService();
+		svc = createGitService(disposables);
 	});
 
 	teardown(() => {
@@ -127,7 +141,7 @@ suite('AgentHostGitService - getSessionGitState (real git)', () => {
 });
 
 suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const hasGit = (() => {
 		try { cp.execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
@@ -138,7 +152,7 @@ suite('AgentHostGitService - computeSessionFileDiffs (real git)', () => {
 
 	setup(() => {
 		tmpRoot = undefined;
-		svc = new AgentHostGitService();
+		svc = createGitService(disposables);
 	});
 
 	teardown(() => {

--- a/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostGitService.test.ts
@@ -5,7 +5,9 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { getBranchCompletions, parseDefaultBranchRef, parseGitStatusV2, parseHasGitHubRemote } from '../../node/agentHostGitService.js';
+import { EMPTY_TREE_OBJECT, getBranchCompletions, parseDefaultBranchRef, parseGitDiffRawNumstat, parseGitStatusV2, parseHasGitHubRemote, parseUntrackedPaths } from '../../node/agentHostGitService.js';
+import { buildGitBlobUri } from '../../node/gitDiffContent.js';
+import { URI } from '../../../../base/common/uri.js';
 
 suite('AgentHostGitService', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -115,6 +117,80 @@ suite('AgentHostGitService', () => {
 			assert.strictEqual(parseDefaultBranchRef(undefined), undefined);
 			assert.strictEqual(parseDefaultBranchRef('   '), undefined);
 		});
+	});
+
+	suite('parseUntrackedPaths', () => {
+		test('returns empty for empty/undefined output', () => {
+			assert.deepStrictEqual(parseUntrackedPaths(undefined), []);
+			assert.deepStrictEqual(parseUntrackedPaths(''), []);
+		});
+
+		test('extracts untracked entries and skips others', () => {
+			// `git status --porcelain=v1 -z` emits NUL-separated entries; the
+			// rename entry includes a second NUL-separated "from" path that
+			// must be skipped.
+			const out = '?? new.txt\x00 M edited.txt\x00R  to.txt\x00from.txt\x00?? other.txt\x00';
+			assert.deepStrictEqual(parseUntrackedPaths(out), ['new.txt', 'other.txt']);
+		});
+	});
+
+	suite('parseGitDiffRawNumstat', () => {
+		const root = URI.file('/repo');
+		const sessionUri = 'copilot:/abc';
+		const sha = 'cafe1234cafe1234cafe1234cafe1234cafe1234';
+
+		test('parses an add, modify, delete and rename in a single stream', () => {
+			// Format: alternating `--raw` and `--numstat` segments separated by
+			// NUL bytes. Renames have an extra path segment in both halves.
+			const segments: string[] = [
+				':100644 100644 0000000 1111111 M', 'modified.ts',
+				':000000 100644 0000000 2222222 A', 'added.ts',
+				':100644 000000 3333333 0000000 D', 'deleted.ts',
+				':100644 100644 4444444 5555555 R100', 'old/path.ts', 'new/path.ts',
+				'5\t2\tmodified.ts',
+				'10\t0\tadded.ts',
+				'0\t7\tdeleted.ts',
+				'3\t3\t', 'old/path.ts', 'new/path.ts',
+				'',
+			];
+			const out = segments.join('\x00');
+			const diffs = parseGitDiffRawNumstat(out, root, sessionUri, sha);
+			assert.deepStrictEqual(diffs, [
+				{
+					before: { uri: 'file:///repo/modified.ts', content: { uri: buildGitBlobUri(sessionUri, sha, 'modified.ts') } },
+					after: { uri: 'file:///repo/modified.ts', content: { uri: 'file:///repo/modified.ts' } },
+					diff: { added: 5, removed: 2 },
+				},
+				{
+					after: { uri: 'file:///repo/added.ts', content: { uri: 'file:///repo/added.ts' } },
+					diff: { added: 10, removed: 0 },
+				},
+				{
+					before: { uri: 'file:///repo/deleted.ts', content: { uri: buildGitBlobUri(sessionUri, sha, 'deleted.ts') } },
+					diff: { added: 0, removed: 7 },
+				},
+				{
+					before: { uri: 'file:///repo/old/path.ts', content: { uri: buildGitBlobUri(sessionUri, sha, 'old/path.ts') } },
+					after: { uri: 'file:///repo/new/path.ts', content: { uri: 'file:///repo/new/path.ts' } },
+					diff: { added: 3, removed: 3 },
+				},
+			]);
+		});
+
+		test('treats `-` numstat values (binary) as zero', () => {
+			const out = [':100644 100644 0 0 M', 'image.png', '-\t-\timage.png', ''].join('\x00');
+			const diffs = parseGitDiffRawNumstat(out, root, sessionUri, sha);
+			assert.strictEqual(diffs.length, 1);
+			assert.deepStrictEqual(diffs[0].diff, { added: 0, removed: 0 });
+		});
+
+		test('returns empty for empty input', () => {
+			assert.deepStrictEqual(parseGitDiffRawNumstat('', root, sessionUri, sha), []);
+		});
+	});
+
+	test('exports the well-known empty-tree object SHA', () => {
+		assert.strictEqual(EMPTY_TREE_OBJECT, '4b825dc642cb6eb9a060e54bf8d69288fbee4904');
 	});
 });
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -291,6 +291,8 @@ suite('AgentService (node dispatcher)', () => {
 				addWorktree: async () => { },
 				removeWorktree: async () => { },
 				getSessionGitState: async (uri: URI) => { calls.push(uri.fsPath); return gitState; },
+				computeSessionFileDiffs: async () => undefined,
+				showBlob: async () => undefined,
 			};
 			const localService = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
 			const agent = new MockAgent('copilot');
@@ -328,6 +330,8 @@ suite('AgentService (node dispatcher)', () => {
 				addWorktree: async () => { },
 				removeWorktree: async () => { },
 				getSessionGitState: async () => undefined,
+				computeSessionFileDiffs: async () => undefined,
+				showBlob: async () => undefined,
 			};
 			const localService = disposables.add(new AgentService(new NullLogService(), fileService, nullSessionDataService, { _serviceBrand: undefined } as IProductService, gitService));
 			const agent = new MockAgent('copilot');

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1953,7 +1953,14 @@ suite('AgentSideEffects', () => {
 			disposables.add(localSideEffects.registerProgressListener(localAgent));
 
 			const envelopes: ActionEnvelope[] = [];
-			disposables.add(localStateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+			let resolveDiffs: (() => void) | undefined;
+			const diffsEmitted = new Promise<void>(r => { resolveDiffs = r; });
+			disposables.add(localStateManager.onDidEmitEnvelope(e => {
+				envelopes.push(e);
+				if (e.action.type === ActionType.SessionDiffsChanged) {
+					resolveDiffs?.();
+				}
+			}));
 
 			// Trigger a turn-complete (which fires the immediate diff path).
 			localSideEffects.handleAction({
@@ -1964,8 +1971,9 @@ suite('AgentSideEffects', () => {
 			});
 			localAgent.fireProgress({ session: URI.parse(sessionUri.toString()), type: 'idle' });
 
-			// Wait for the sequenced async diff computation to settle.
-			await new Promise(r => setTimeout(r, 100));
+			// Wait deterministically for the SessionDiffsChanged envelope rather
+			// than sleeping a fixed amount.
+			await diffsEmitted;
 
 			assert.deepStrictEqual(computeCalls, [{ workingDirectory: 'file:///wd', sessionUri: sessionUri.toString(), baseBranch: 'main' }]);
 			const diffsAction = envelopes.map(e => e.action).find(a => a.type === ActionType.SessionDiffsChanged);
@@ -2005,7 +2013,14 @@ suite('AgentSideEffects', () => {
 			disposables.add(localSideEffects.registerProgressListener(localAgent));
 
 			const envelopes: ActionEnvelope[] = [];
-			disposables.add(localStateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+			let resolveDiffs: (() => void) | undefined;
+			const diffsEmitted = new Promise<void>(r => { resolveDiffs = r; });
+			disposables.add(localStateManager.onDidEmitEnvelope(e => {
+				envelopes.push(e);
+				if (e.action.type === ActionType.SessionDiffsChanged) {
+					resolveDiffs?.();
+				}
+			}));
 
 			localSideEffects.handleAction({
 				type: ActionType.SessionTurnStarted,
@@ -2015,7 +2030,7 @@ suite('AgentSideEffects', () => {
 			});
 			localAgent.fireProgress({ session: URI.parse(sessionUri.toString()), type: 'idle' });
 
-			await new Promise(r => setTimeout(r, 100));
+			await diffsEmitted;
 
 			// With no recorded edits, the edit-tracker aggregator returns an empty array — the
 			// important assertion is that we still produced a SessionDiffsChanged envelope, which

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1907,4 +1907,122 @@ suite('AgentSideEffects', () => {
 			]);
 		});
 	});
+
+	// ---- Session diff computation ----------------------------------------------
+
+	suite('session diff computation', () => {
+
+		test('git-driven path is preferred when a git service is provided and the working dir is a git work tree', async () => {
+			const sessionDb = new SessionDatabase(':memory:');
+			disposables.add(toDisposable(() => sessionDb.close()));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+			const localAgent = new MockAgent();
+			disposables.add(toDisposable(() => localAgent.dispose()));
+
+			const gitDiffs = [{
+				after: { uri: 'file:///wd/new.ts', content: { uri: 'file:///wd/new.ts' } },
+				diff: { added: 1, removed: 0 },
+			}];
+			const computeCalls: { workingDirectory: string; sessionUri: string; baseBranch: string | undefined }[] = [];
+			const stubGit = {
+				computeSessionFileDiffs: async (wd: URI, opts: { sessionUri: string; baseBranch?: string }) => {
+					computeCalls.push({ workingDirectory: wd.toString(), sessionUri: opts.sessionUri, baseBranch: opts.baseBranch });
+					return gitDiffs;
+				},
+			} as unknown as import('../../node/agentHostGitService.js').IAgentHostGitService;
+
+			const localSideEffects = createTestSideEffects(disposables, localStateManager, {
+				getAgent: () => localAgent,
+				agents: observableValue<readonly IAgent[]>('agents', [localAgent]),
+				sessionDataService,
+				gitService: stubGit,
+				onTurnComplete: () => { },
+			});
+
+			localStateManager.createSession({
+				resource: sessionUri.toString(),
+				provider: 'mock',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+				workingDirectory: 'file:///wd',
+			});
+			await sessionDb.setMetadata('agentHost.diffBaseBranch', 'main');
+			disposables.add(localSideEffects.registerProgressListener(localAgent));
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(localStateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			// Trigger a turn-complete (which fires the immediate diff path).
+			localSideEffects.handleAction({
+				type: ActionType.SessionTurnStarted,
+				session: sessionUri.toString(),
+				turnId: 'turn-1',
+				userMessage: { text: 'hi' },
+			});
+			localAgent.fireProgress({ session: URI.parse(sessionUri.toString()), type: 'idle' });
+
+			// Wait for the sequenced async diff computation to settle.
+			await new Promise(r => setTimeout(r, 100));
+
+			assert.deepStrictEqual(computeCalls, [{ workingDirectory: 'file:///wd', sessionUri: sessionUri.toString(), baseBranch: 'main' }]);
+			const diffsAction = envelopes.map(e => e.action).find(a => a.type === ActionType.SessionDiffsChanged);
+			assert.ok(diffsAction, 'expected a SessionDiffsChanged action');
+			assert.deepStrictEqual((diffsAction as { diffs: unknown }).diffs, gitDiffs);
+		});
+
+		test('falls back to the edit-tracker aggregator when the git service returns undefined', async () => {
+			const sessionDb = new SessionDatabase(':memory:');
+			disposables.add(toDisposable(() => sessionDb.close()));
+			const sessionDataService = createSessionDataService(sessionDb);
+			const localStateManager = disposables.add(new AgentHostStateManager(new NullLogService()));
+			const localAgent = new MockAgent();
+			disposables.add(toDisposable(() => localAgent.dispose()));
+
+			const stubGit = {
+				computeSessionFileDiffs: async () => undefined,
+			} as unknown as import('../../node/agentHostGitService.js').IAgentHostGitService;
+
+			const localSideEffects = createTestSideEffects(disposables, localStateManager, {
+				getAgent: () => localAgent,
+				agents: observableValue<readonly IAgent[]>('agents', [localAgent]),
+				sessionDataService,
+				gitService: stubGit,
+				onTurnComplete: () => { },
+			});
+
+			localStateManager.createSession({
+				resource: sessionUri.toString(),
+				provider: 'mock',
+				title: 'Test',
+				status: SessionStatus.Idle,
+				createdAt: Date.now(),
+				modifiedAt: Date.now(),
+				workingDirectory: 'file:///wd',
+			});
+			disposables.add(localSideEffects.registerProgressListener(localAgent));
+
+			const envelopes: ActionEnvelope[] = [];
+			disposables.add(localStateManager.onDidEmitEnvelope(e => envelopes.push(e)));
+
+			localSideEffects.handleAction({
+				type: ActionType.SessionTurnStarted,
+				session: sessionUri.toString(),
+				turnId: 'turn-1',
+				userMessage: { text: 'hi' },
+			});
+			localAgent.fireProgress({ session: URI.parse(sessionUri.toString()), type: 'idle' });
+
+			await new Promise(r => setTimeout(r, 100));
+
+			// With no recorded edits, the edit-tracker aggregator returns an empty array — the
+			// important assertion is that we still produced a SessionDiffsChanged envelope, which
+			// proves the fallback path executed without throwing.
+			const diffsAction = envelopes.map(e => e.action).find(a => a.type === ActionType.SessionDiffsChanged);
+			assert.ok(diffsAction, 'expected a SessionDiffsChanged action from the fallback path');
+			assert.deepStrictEqual((diffsAction as { diffs: unknown[] }).diffs, []);
+		});
+	});
 });

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -23,6 +23,7 @@ import { ActionType, ActionEnvelope, SessionAction } from '../../common/state/se
 import { AttachmentType, buildSubagentSessionUri, PendingMessageKind, ResponsePartKind, SessionStatus, ToolCallStatus, ToolResultContentType } from '../../common/state/sessionState.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentConfigurationService, IAgentConfigurationService } from '../../node/agentConfigurationService.js';
+import { IAgentHostGitService } from '../../node/agentHostGitService.js';
 import { AgentService } from '../../node/agentService.js';
 import { AgentSideEffects, IAgentSideEffectsOptions } from '../../node/agentSideEffects.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
@@ -35,14 +36,15 @@ import { MockAgent } from './mockAgent.js';
 /**
  * Constructs an {@link AgentSideEffects} with a minimal local instantiation
  * scope that satisfies its {@link IAgentConfigurationService} /
- * {@link ILogService} dependencies.
+ * {@link ILogService} / {@link IAgentHostGitService} dependencies.
  */
-function createTestSideEffects(disposables: DisposableStore, stateManager: AgentHostStateManager, options: IAgentSideEffectsOptions): AgentSideEffects {
+function createTestSideEffects(disposables: DisposableStore, stateManager: AgentHostStateManager, options: IAgentSideEffectsOptions, gitService?: IAgentHostGitService): AgentSideEffects {
 	const logService = new NullLogService();
 	const configService = disposables.add(new AgentConfigurationService(stateManager, logService));
 	const instantiationService = disposables.add(new InstantiationService(new ServiceCollection(
 		[ILogService, logService],
 		[IAgentConfigurationService, configService],
+		[IAgentHostGitService, gitService ?? createNoopGitService()],
 	), /*strict*/ true));
 	return disposables.add(instantiationService.createInstance(AgentSideEffects, stateManager, options));
 }
@@ -1936,9 +1938,8 @@ suite('AgentSideEffects', () => {
 				getAgent: () => localAgent,
 				agents: observableValue<readonly IAgent[]>('agents', [localAgent]),
 				sessionDataService,
-				gitService: stubGit,
 				onTurnComplete: () => { },
-			});
+			}, stubGit);
 
 			localStateManager.createSession({
 				resource: sessionUri.toString(),
@@ -1997,9 +1998,8 @@ suite('AgentSideEffects', () => {
 				getAgent: () => localAgent,
 				agents: observableValue<readonly IAgent[]>('agents', [localAgent]),
 				sessionDataService,
-				gitService: stubGit,
 				onTurnComplete: () => { },
-			});
+			}, stubGit);
 
 			localStateManager.createSession({
 				resource: sessionUri.toString(),

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -56,6 +56,8 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	}
 	async removeWorktree(): Promise<void> { }
 	async getSessionGitState(): Promise<undefined> { return undefined; }
+	async computeSessionFileDiffs(): Promise<undefined> { return undefined; }
+	async showBlob(): Promise<undefined> { return undefined; }
 }
 
 class TestAgentHostTerminalManager implements IAgentHostTerminalManager {

--- a/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotGitProject.test.ts
@@ -25,6 +25,8 @@ class TestAgentHostGitService implements IAgentHostGitService {
 	async addWorktree(): Promise<void> { }
 	async removeWorktree(): Promise<void> { }
 	async getSessionGitState(): Promise<undefined> { return undefined; }
+	async computeSessionFileDiffs(): Promise<undefined> { return undefined; }
+	async showBlob(): Promise<undefined> { return undefined; }
 }
 
 suite('Copilot Git Project', () => {

--- a/src/vs/platform/agentHost/test/node/gitDiffContent.test.ts
+++ b/src/vs/platform/agentHost/test/node/gitDiffContent.test.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { buildGitBlobUri, parseGitBlobUri } from '../../node/gitDiffContent.js';
+
+suite('gitDiffContent', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('round-trips simple inputs', () => {
+		const sessionUri = 'copilot:/abc-123';
+		const sha = 'deadbeef0123456789abcdef0123456789abcdef';
+		const path = 'src/foo/bar.ts';
+		const built = buildGitBlobUri(sessionUri, sha, path);
+		const parsed = parseGitBlobUri(built);
+		assert.deepStrictEqual(parsed, { sessionUri, sha, repoRelativePath: path });
+	});
+
+	test('round-trips paths with spaces, unicode and slashes', () => {
+		const sessionUri = 'copilot:/sess/with space?q=1';
+		const sha = '1234567890abcdef1234567890abcdef12345678';
+		const path = 'a folder/файл.txt';
+		const parsed = parseGitBlobUri(buildGitBlobUri(sessionUri, sha, path));
+		assert.deepStrictEqual(parsed, { sessionUri, sha, repoRelativePath: path });
+	});
+
+	test('returns undefined for non git-blob URIs', () => {
+		assert.strictEqual(parseGitBlobUri('file:///foo/bar.ts'), undefined);
+		assert.strictEqual(parseGitBlobUri('session-db://abc/def/before/x'), undefined);
+		assert.strictEqual(parseGitBlobUri('not a uri at all'), undefined);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -574,7 +574,7 @@ export class ScriptedMockAgent implements IAgent {
 					// without emitting any ToolResultFileEditContent. The test relies on the
 					// git-driven diff path to pick this up. Format: `terminal-edit:<absPath>`.
 					const filePath = prompt.slice('terminal-edit:'.length);
-					(async () => {
+					void (async () => {
 						this._onDidSessionProgress.fire({ type: 'tool_start', session, toolCallId: 'tc-term-edit-1', toolName: 'bash', displayName: 'Run Command', invocationMessage: 'Edit file via shell' });
 						const fs = await import('fs/promises');
 						await fs.writeFile(filePath, 'edited-from-terminal\n');
@@ -582,7 +582,14 @@ export class ScriptedMockAgent implements IAgent {
 							{ type: 'tool_complete', session, toolCallId: 'tc-term-edit-1', result: { pastTenseMessage: 'Edited file', content: [{ type: ToolResultContentType.Text, text: 'ok' }], success: true } },
 							{ type: 'idle', session },
 						]);
-					})();
+					})().catch(err => {
+						// Surface failures deterministically — an unhandled rejection
+						// would make the test suite flaky.
+						this._fireSequence(session, [
+							{ type: 'delta', session, messageId: 'msg-err', content: 'terminal-edit failed: ' + (err instanceof Error ? err.message : String(err)) },
+							{ type: 'idle', session },
+						]);
+					});
 					break;
 				}
 				this._fireSequence(session, [

--- a/src/vs/platform/agentHost/test/node/mockAgent.ts
+++ b/src/vs/platform/agentHost/test/node/mockAgent.ts
@@ -569,6 +569,22 @@ export class ScriptedMockAgent implements IAgent {
 			}
 
 			default:
+				if (prompt.startsWith('terminal-edit:')) {
+					// Test prompt: simulate a terminal command that edits a file on disk
+					// without emitting any ToolResultFileEditContent. The test relies on the
+					// git-driven diff path to pick this up. Format: `terminal-edit:<absPath>`.
+					const filePath = prompt.slice('terminal-edit:'.length);
+					(async () => {
+						this._onDidSessionProgress.fire({ type: 'tool_start', session, toolCallId: 'tc-term-edit-1', toolName: 'bash', displayName: 'Run Command', invocationMessage: 'Edit file via shell' });
+						const fs = await import('fs/promises');
+						await fs.writeFile(filePath, 'edited-from-terminal\n');
+						this._fireSequence(session, [
+							{ type: 'tool_complete', session, toolCallId: 'tc-term-edit-1', result: { pastTenseMessage: 'Edited file', content: [{ type: ToolResultContentType.Text, text: 'ok' }], success: true } },
+							{ type: 'idle', session },
+						]);
+					})();
+					break;
+				}
 				this._fireSequence(session, [
 					{ type: 'delta', session, messageId: 'msg-1', content: 'Unknown prompt: ' + prompt },
 					{ type: 'idle', session },

--- a/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionDiffs.integrationTest.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as cp from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from '../../../../../base/common/path.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { SubscribeResult } from '../../../common/state/protocol/commands.js';
+import type { SessionAddedNotification, SessionDiffsChangedAction } from '../../../common/state/sessionActions.js';
+import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
+import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
+import {
+	dispatchTurnStarted,
+	getActionEnvelope,
+	IServerHandle,
+	isActionNotification,
+	nextSessionUri,
+	startServer,
+	TestProtocolClient,
+} from './testHelpers.js';
+
+const hasGit = (() => {
+	try { cp.execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+})();
+
+(hasGit ? suite : suite.skip)('Protocol WebSocket — Git-driven session diffs', function () {
+
+	let server: IServerHandle;
+	let client: TestProtocolClient;
+	let tmpRoot: string;
+
+	suiteSetup(async function () {
+		this.timeout(15_000);
+		server = await startServer();
+	});
+
+	suiteTeardown(function () {
+		server.process.kill();
+	});
+
+	setup(async function () {
+		this.timeout(10_000);
+		// Initialize a tmp git repo as the session's working directory.
+		tmpRoot = mkdtempSync(join(tmpdir(), 'agent-host-proto-diff-'));
+		const env = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
+		const run = (...args: string[]) => cp.execFileSync('git', args, { cwd: tmpRoot, env, stdio: 'pipe' });
+		run('init', '-q', '-b', 'main');
+		writeFileSync(join(tmpRoot, 'seed.txt'), 'seed\n');
+		run('add', '.');
+		run('commit', '-q', '-m', 'init');
+
+		client = new TestProtocolClient(server.port);
+		await client.connect();
+	});
+
+	teardown(function () {
+		client.close();
+		if (tmpRoot) {
+			rmSync(tmpRoot, { recursive: true, force: true });
+		}
+	});
+
+	test('terminal-driven file edit (no ToolResultFileEditContent) is reported via summary.diffs', async function () {
+		this.timeout(15_000);
+
+		// Create a session whose working directory is the tmp git repo.
+		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'test-git-diffs' });
+
+		const workingDirectory = URI.file(tmpRoot).toString();
+		await client.call('createSession', { session: nextSessionUri(), provider: 'mock', workingDirectory });
+
+		const addedNotif = await client.waitForNotification(n =>
+			n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded'
+		);
+		const sessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as SessionAddedNotification).summary.resource;
+
+		await client.call<SubscribeResult>('subscribe', { resource: sessionUri });
+		client.clearReceived();
+
+		// Fire a turn that runs the `terminal-edit:<path>` mock prompt. The mock
+		// agent writes the file via fs.writeFile (no ToolResultFileEditContent),
+		// so the diff must come from the git-driven path.
+		const editedFile = join(tmpRoot, 'from-terminal.txt');
+		dispatchTurnStarted(client, sessionUri, 'turn-1', `terminal-edit:${editedFile}`, 1);
+
+		// Wait for the diff broadcast that comes after the idle event.
+		const diffNotif = await client.waitForNotification(n => isActionNotification(n, 'session/diffsChanged'), 10_000);
+		const action = getActionEnvelope(diffNotif).action as SessionDiffsChangedAction;
+
+		// On macOS, git's `--show-toplevel` resolves symlinks (/var → /private/var)
+		// so the diff URI may differ in prefix; match by basename instead.
+		const matching = action.diffs.find(d => {
+			const u = d.after?.uri ?? d.before?.uri;
+			return typeof u === 'string' && u.endsWith('/from-terminal.txt');
+		});
+		assert.ok(matching, `expected diff for from-terminal.txt; got ${JSON.stringify(action.diffs.map(d => d.after?.uri ?? d.before?.uri))}`);
+		assert.ok(matching!.after, 'expected after-side for newly added file');
+		assert.ok(!matching!.before, 'newly added file should have no before-side');
+	});
+});

--- a/src/vs/platform/agentHost/test/node/protocol/sessionDiffsRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionDiffsRealSdk.integrationTest.ts
@@ -150,7 +150,10 @@ function resolveGitHubToken(): string {
 		// (not a write_file tool) so the edit isn't reported via the SDK's
 		// file-edit content events — the diff has to come from git.
 		const targetFile = join(tempDir, 'from-bash.txt');
-		const prompt = `Use the bash shell tool to run exactly: echo hello > ${targetFile}\nDo not use any file-write tool. Use only bash.`;
+		// Quote/escape targetFile for the shell so paths containing spaces or
+		// shell metacharacters don't break the test.
+		const shellQuotedTargetFile = `'${targetFile.replace(/'/g, `'\\''`)}'`;
+		const prompt = `Use the bash shell tool to run exactly: echo hello > ${shellQuotedTargetFile}\nDo not use any file-write tool. Use only bash.`;
 		client.notify('dispatchAction', {
 			clientSeq: 1,
 			action: { type: 'session/turnStarted', session: realSessionUri, turnId: 'turn-diff', userMessage: { text: prompt } },

--- a/src/vs/platform/agentHost/test/node/protocol/sessionDiffsRealSdk.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionDiffsRealSdk.integrationTest.ts
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Real-SDK integration test for the git-driven session diff path.
+ *
+ * Disabled by default. Run with:
+ *
+ *   AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh \
+ *     --run src/vs/platform/agentHost/test/node/protocol/sessionDiffsRealSdk.integrationTest.ts
+ *
+ * Authentication: token from `gh auth token` (or `GITHUB_TOKEN`).
+ *
+ * SAFETY: Working directory is always a freshly-`git init`-ed temp folder
+ * scoped to a single test, removed in teardown.
+ */
+
+import assert from 'assert';
+import * as cp from 'child_process';
+import { execSync } from 'child_process';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from '../../../../../base/common/path.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { SubscribeResult } from '../../../common/state/protocol/commands.js';
+import { PROTOCOL_VERSION } from '../../../common/state/sessionCapabilities.js';
+import type { INotificationBroadcastParams } from '../../../common/state/sessionProtocol.js';
+import type { SessionState } from '../../../common/state/sessionState.js';
+import type { SessionAddedNotification, SessionDiffsChangedAction, SessionToolCallReadyAction } from '../../../common/state/sessionActions.js';
+import {
+	getActionEnvelope,
+	IServerHandle,
+	isActionNotification,
+	startRealServer,
+	TestProtocolClient,
+} from './testHelpers.js';
+
+const REAL_SDK_ENABLED = process.env['AGENT_HOST_REAL_SDK'] === '1';
+
+const hasGit = (() => {
+	try { cp.execFileSync('git', ['--version'], { stdio: 'ignore' }); return true; } catch { return false; }
+})();
+
+function resolveGitHubToken(): string {
+	const envToken = process.env['GITHUB_TOKEN'];
+	if (envToken) {
+		return envToken;
+	}
+	return execSync('gh auth token', { encoding: 'utf-8' }).trim();
+}
+
+(REAL_SDK_ENABLED && hasGit ? suite : suite.skip)('Protocol WebSocket — Real Copilot SDK git-driven diffs', function () {
+
+	let server: IServerHandle;
+	let client: TestProtocolClient;
+	const createdSessions: string[] = [];
+	const tempDirs: string[] = [];
+
+	suiteSetup(async function () {
+		this.timeout(60_000);
+		server = await startRealServer();
+	});
+
+	suiteTeardown(function () {
+		server?.process.kill();
+	});
+
+	setup(async function () {
+		this.timeout(30_000);
+		client = new TestProtocolClient(server.port);
+		await client.connect();
+	});
+
+	teardown(async function () {
+		for (const session of createdSessions) {
+			try { await client.call('disposeSession', { session }, 5000); } catch { /* best-effort */ }
+		}
+		createdSessions.length = 0;
+		client.close();
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs.length = 0;
+	});
+
+	test('terminal-driven file edit shows up in summary.diffs (no ToolResultFileEditContent emitted)', async function () {
+		this.timeout(180_000);
+
+		// Initialize a tmp git repo as the working directory.
+		const tempDir = mkdtempSync(`${tmpdir()}/ahp-real-diff-`);
+		tempDirs.push(tempDir);
+		const env = { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' };
+		const runGit = (...args: string[]) => execSync(`git ${args.join(' ')}`, { cwd: tempDir, env, stdio: 'pipe' });
+		runGit('init', '-q', '-b', 'main');
+		writeFileSync(join(tempDir, 'seed.txt'), 'seed\n');
+		runGit('add', '.');
+		runGit('commit', '-q', '-m', 'init');
+
+		const workingDirUri = URI.file(tempDir).toString();
+
+		await client.call('initialize', { protocolVersion: PROTOCOL_VERSION, clientId: 'real-sdk-git-diffs' }, 30_000);
+		await client.call('authenticate', { resource: 'https://api.github.com', token: resolveGitHubToken() }, 30_000);
+
+		const sessionUri = URI.from({ scheme: 'copilotcli', path: `/real-diff-${Date.now()}` }).toString();
+		await client.call('createSession', { session: sessionUri, provider: 'copilotcli', workingDirectory: workingDirUri }, 30_000);
+
+		const addedNotif = await client.waitForNotification(n =>
+			n.method === 'notification' && (n.params as INotificationBroadcastParams).notification.type === 'notify/sessionAdded',
+			15_000,
+		);
+		const realSessionUri = ((addedNotif.params as INotificationBroadcastParams).notification as SessionAddedNotification).summary.resource;
+		createdSessions.push(realSessionUri);
+
+		await client.call<SubscribeResult>('subscribe', { resource: realSessionUri });
+		client.clearReceived();
+
+		// Approve any tool call the agent issues. Restricted to `bash`-style
+		// shell tools so the model can't trick the test into running arbitrary
+		// other tools.
+		let approvalSeq = 1;
+		const approve = (action: SessionToolCallReadyAction & { session: string; turnId: string }) => {
+			client.notify('dispatchAction', {
+				clientSeq: ++approvalSeq,
+				action: {
+					type: 'session/toolCallConfirmed',
+					session: action.session,
+					turnId: action.turnId,
+					toolCallId: action.toolCallId,
+					approved: true,
+				},
+			});
+		};
+		const seenSeqs = new Set<number>();
+		let approverActive = true;
+		const approverLoop = (async () => {
+			while (approverActive) {
+				try {
+					const ready = await client.waitForNotification(n => isActionNotification(n, 'session/toolCallReady') && !seenSeqs.has(getActionEnvelope(n).serverSeq), 2_000);
+					const env = getActionEnvelope(ready);
+					seenSeqs.add(env.serverSeq);
+					approve(env.action as SessionToolCallReadyAction & { session: string; turnId: string });
+				} catch { /* timeout — keep polling */ }
+			}
+		})();
+
+		// Ask the agent to use bash to write a specific file. The exact filename
+		// is fixed so we can assert on it. The model is instructed to use bash
+		// (not a write_file tool) so the edit isn't reported via the SDK's
+		// file-edit content events — the diff has to come from git.
+		const targetFile = join(tempDir, 'from-bash.txt');
+		const prompt = `Use the bash shell tool to run exactly: echo hello > ${targetFile}\nDo not use any file-write tool. Use only bash.`;
+		client.notify('dispatchAction', {
+			clientSeq: 1,
+			action: { type: 'session/turnStarted', session: realSessionUri, turnId: 'turn-diff', userMessage: { text: prompt } },
+		});
+
+		await client.waitForNotification(n => isActionNotification(n, 'session/turnComplete'), 150_000);
+		approverActive = false;
+		await approverLoop;
+
+		// Sanity: file was actually written by the agent.
+		const files = readdirSync(tempDir);
+		assert.ok(files.includes('from-bash.txt'), `agent did not write the requested file. dir contents: ${files.join(', ')}`);
+
+		// The diff broadcast may have already arrived during the turn — accept
+		// any matching one received during the run, or look at the final state.
+		const targetUri = URI.file(targetFile).toString();
+		const diffNotifs = client.receivedNotifications(n => isActionNotification(n, 'session/diffsChanged'));
+		const sawInLive = diffNotifs.some(n => {
+			const a = getActionEnvelope(n).action as SessionDiffsChangedAction;
+			return a.diffs.some(d => d.after?.uri === targetUri || d.before?.uri === targetUri);
+		});
+
+		if (!sawInLive) {
+			// Fall back to the final snapshot.
+			const result = await client.call<SubscribeResult>('subscribe', { resource: realSessionUri });
+			const state = result.snapshot.state as SessionState;
+			const diffs = state.summary.diffs ?? [];
+			const matching = diffs.find(d => d.after?.uri === targetUri || d.before?.uri === targetUri);
+			assert.ok(matching, `expected git-driven diff for ${targetUri}; live notifications=${diffNotifs.length}; snapshot diffs=${JSON.stringify(diffs.map(d => d.after?.uri ?? d.before?.uri))}`);
+		}
+	});
+});

--- a/src/vs/sessions/contrib/agentHost/browser/agentHostDiffs.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentHostDiffs.ts
@@ -7,8 +7,8 @@ import { isDefined } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { SessionStatus as ProtocolSessionStatus } from '../../../../platform/agentHost/common/state/protocol/state.js';
 import { ISessionFileDiff } from '../../../../platform/agentHost/common/state/sessionState.js';
-import { IChatSessionFileChange } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { SessionStatus } from '../../../services/sessions/common/session.js';
+import { IChatSessionFileChange2, isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { ISessionFileChange, SessionStatus } from '../../../services/sessions/common/session.js';
 
 /**
  * Maps the protocol-layer session status bitset to the UI-layer
@@ -34,14 +34,21 @@ export function mapProtocolStatus(protocol: ProtocolSessionStatus): SessionStatu
  * @param mapUri Optional URI mapper applied after parsing. The remote agent
  *   host provider uses this to rewrite `file:` URIs into agent-host URIs.
  */
-export function diffsToChanges(diffs: readonly ISessionFileDiff[], mapUri?: (uri: URI) => URI): IChatSessionFileChange[] {
+export function diffsToChanges(diffs: readonly ISessionFileDiff[], mapUri?: (uri: URI) => URI): IChatSessionFileChange2[] {
 	return diffs.map(d => {
-		const uri = d.after?.uri || d.before?.uri;
-		if (!uri) {
+		const rawUri = d.after?.uri ?? d.before?.uri;
+		if (!rawUri) {
 			return undefined;
 		}
 
-		const modifiedUri = mapUri ? mapUri(URI.parse(uri)) : URI.parse(uri);
+		const uri = mapUri ? mapUri(URI.parse(rawUri)) : URI.parse(rawUri);
+
+		// For deletions (no `after`), `modifiedUri` is `undefined` so the
+		// renderer treats the entry as a deletion and doesn't try to open the
+		// (now-missing) file as the "modified" side of the diff editor.
+		const modifiedUri = d.after
+			? (mapUri ? mapUri(URI.parse(d.after.uri)) : URI.parse(d.after.uri))
+			: undefined;
 
 		// Use the before-content reference URI so the diff editor can
 		// fetch the snapshot of the file *before* the session's edits.
@@ -52,11 +59,12 @@ export function diffsToChanges(diffs: readonly ISessionFileDiff[], mapUri?: (uri
 		}
 
 		return {
+			uri,
 			modifiedUri,
 			originalUri,
 			insertions: d.diff?.added ?? 0,
 			deletions: d.diff?.removed ?? 0,
-		};
+		} satisfies IChatSessionFileChange2;
 	}).filter(isDefined);
 }
 
@@ -64,20 +72,21 @@ export function diffsToChanges(diffs: readonly ISessionFileDiff[], mapUri?: (uri
  * Returns `true` when the current file changes already
  * match the incoming diffs, avoiding unnecessary observable updates.
  */
-export function diffsEqual(current: readonly IChatSessionFileChange[], diffs: readonly ISessionFileDiff[], mapUri?: (uri: URI) => URI): boolean {
+export function diffsEqual(current: readonly ISessionFileChange[], diffs: readonly ISessionFileDiff[], mapUri?: (uri: URI) => URI): boolean {
 	if (current.length !== diffs.length) {
 		return false;
 	}
 	for (let i = 0; i < current.length; i++) {
 		const c = current[i];
 		const d = diffs[i];
-		const uri = d.after?.uri || d.before?.uri;
-		if (!uri) {
+		const rawUri = d.after?.uri ?? d.before?.uri;
+		if (!rawUri) {
 			continue;
 		}
-		const parsed = URI.parse(uri);
+		const parsed = URI.parse(rawUri);
 		const diffUri = mapUri ? mapUri(parsed) : parsed;
-		if (c.modifiedUri.toString() !== diffUri.toString() || c.insertions !== (d.diff?.added ?? 0) || c.deletions !== (d.diff?.removed ?? 0)) {
+		const cUri = isIChatSessionFileChange2(c) ? c.uri : c.modifiedUri;
+		if (cUri.toString() !== diffUri.toString() || c.insertions !== (d.diff?.added ?? 0) || c.deletions !== (d.diff?.removed ?? 0)) {
 			return false;
 		}
 

--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -22,7 +22,7 @@ import { ActionType, isSessionAction } from '../../../../platform/agentHost/comm
 import { readSessionGitState, StateComponents, type ISessionGitState } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSendRequestOptions, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
-import { IChatSessionFileChange, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChatSessionFileChange, IChatSessionFileChange2, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { diffsEqual, diffsToChanges, mapProtocolStatus } from './agentHostDiffs.js';
@@ -70,7 +70,7 @@ export class AgentHostSessionAdapter implements ISession {
 	readonly title: ISettableObservable<string>;
 	readonly updatedAt: ISettableObservable<Date>;
 	readonly status: ISettableObservable<SessionStatus>;
-	readonly changes = observableValue<readonly IChatSessionFileChange[]>('changes', []);
+	readonly changes = observableValue<readonly (IChatSessionFileChange | IChatSessionFileChange2)[]>('changes', []);
 	readonly modelId: ISettableObservable<string | undefined>;
 	modelSelection: ModelSelection | undefined;
 	readonly mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>('mode', undefined);
@@ -523,7 +523,7 @@ export abstract class BaseAgentHostSessionsProvider extends Disposable implement
 		const status = observableValue<SessionStatus>(this, SessionStatus.Untitled);
 		const title = observableValue(this, '');
 		const updatedAt = observableValue(this, new Date());
-		const changes = observableValue<readonly IChatSessionFileChange[]>(this, []);
+		const changes = observableValue<readonly (IChatSessionFileChange | IChatSessionFileChange2)[]>(this, []);
 		const modelId = observableValue<string | undefined>(this, undefined);
 		const mode = observableValue<{ readonly id: string; readonly kind: string } | undefined>(this, undefined);
 		const isArchived = observableValue(this, false);


### PR DESCRIPTION
Adds an alternative diff source for agent sessions that derives changes from working-tree git state instead of from edit-tool emissions, so edits made via terminal/shell commands also show up in the Changes view.

## Approach

- `IAgentHostGitService` gains `computeSessionFileDiffs()` and `showBlob()`. Diffs come from `git diff --raw --numstat` against the merge-base of HEAD and an optional base branch (`META_DIFF_BASE_BRANCH` in session metadata). Untracked files are included via a temp-index trick (`read-tree HEAD` + `add -A` in a throwaway `GIT_INDEX_FILE`).
- New `gitDiffContent.ts` encodes `git-blob:` content URIs that pin a blob to a session + sha + repo-relative path.
- `AgentService` routes `git-blob:` `resourceRead` requests to `gitService.showBlob()`. `AgentHostFileSystemProvider.stat()` short-circuits `git-blob:` URIs alongside `session-db:` so the diff editor's stat-then-read flow works end-to-end.
- `AgentSideEffects._tryComputeGitDiffs` runs after each turn (debounced with the existing diff scheduler) and overrides edit-tool diffs when git is available; falls back to the edit-tool path otherwise.

## Tests

- Unit: URI round-trip (`gitDiffContent.test.ts`), `parseGitDiffRawNumstat` add/modify/delete/rename + numstat pairing.
- Integration (real git repo): `agentHostGitService.integrationTest.ts` — `computeSessionFileDiffs` + `showBlob`.
- Side-effects: `agentSideEffects.test.ts` — verifies git-driven path overrides edit-tool diffs and falls back when git returns undefined.
- Protocol: `protocol/sessionDiffs.integrationTest.ts` — `session/diffsChanged` round-trip with mock git.
- Gated end-to-end with real Copilot CLI agent: `protocol/sessionDiffsRealSdk.integrationTest.ts` (skipped without env var).

(Written by Copilot)