### PR TITLE
fix: enable scrolling in workbench hover widget when content overflows

### DIFF
--- a/src/vs/platform/hover/browser/hoverWidget.ts
+++ b/src/vs/platform/hover/browser/hoverWidget.ts
@@ -49,6 +49,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 	private readonly _hoverContainer: HTMLElement;
 	private readonly _target: IHoverTarget;
 	private readonly _linkHandler: ((url: string) => void) | undefined;
+	private readonly _statusBarElement: HTMLElement[] = [];
 
 	private _isDisposed: boolean = false;
 	private _hoverPosition: HoverPosition;
@@ -222,6 +223,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 			});
 			statusBarElement.appendChild(actionsElement);
 			this._hover.containerDomNode.appendChild(statusBarElement);
+			this._statusBarElement.push(statusBarElement);
 		}
 
 		this._hoverContainer = $('div.workbench-hover-container');
@@ -254,6 +256,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 			infoElement.textContent = localize('hoverhint', 'Hold {0} key to mouse over', isMacintosh ? 'Option' : 'Alt');
 			statusBarElement.appendChild(infoElement);
 			this._hover.containerDomNode.appendChild(statusBarElement);
+			this._statusBarElement.push(statusBarElement);
 		}
 
 		const mouseTrackerTargets = [...this._target.targetElements];
@@ -342,6 +345,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 	public layout() {
 		this._hover.containerDomNode.classList.remove('right-aligned');
 		this._hover.contentsDomNode.style.maxHeight = '';
+		this._hover.scrollbar.getDomNode().style.maxHeight = '';
 
 		const getZoomAccountedBoundingClientRect = (e: HTMLElement) => {
 			const zoom = dom.getDomNodeZoomLevel(e);
@@ -585,6 +589,10 @@ export class HoverWidget extends Widget implements IHoverWidget {
 		}
 
 		this._hover.containerDomNode.style.maxHeight = `${maxHeight}px`;
+		const statusBarHeight = this._statusBarElement.reduce((total, el) => total + el.offsetHeight, 0);
+		const scrollableMaxHeight = Math.max(0, maxHeight - statusBarHeight);
+		this._hover.scrollbar.getDomNode().style.maxHeight = `${scrollableMaxHeight}px`;
+		this._hover.contentsDomNode.style.maxHeight = `${scrollableMaxHeight}px`;
 		if (this._hover.contentsDomNode.clientHeight < this._hover.contentsDomNode.scrollHeight) {
 			// Add padding for a vertical scrollbar
 			const extraRightPadding = `${this._hover.scrollbar.options.verticalScrollbarSize}px`;

--- a/src/vs/platform/hover/test/browser/hoverService.test.ts
+++ b/src/vs/platform/hover/test/browser/hoverService.test.ts
@@ -49,6 +49,7 @@ suite('HoverService', () => {
 		instantiationService.stub(IKeybindingService, {
 			mightProducePrintableCharacter() { return false; },
 			softDispatch() { return NoMatchingKb; },
+			lookupKeybinding() { return undefined; },
 			resolveKeyboardEvent() {
 				return {
 					getLabel() { return ''; },
@@ -241,6 +242,25 @@ suite('HoverService', () => {
 
 			hover.dispose();
 			assertNotInDOM(hover, 'Hover should be removed from DOM after dispose');
+		});
+
+		test('should constrain scrollable content height during layout', () => {
+			const target = createTarget();
+
+			const hover = hoverService.showInstantHover({
+				content: 'Test content',
+				target,
+				actions: [{ label: 'Test Action', commandId: 'test.action', run: () => { } }]
+			});
+
+			assert.ok(hover, 'Hover should be created');
+			assertInDOM(hover, 'Hover should be in DOM');
+
+			const contentsNode = asHoverWidget(hover).domNode.querySelector<HTMLElement>('.monaco-hover-content');
+			assert.ok(contentsNode, 'Contents node should exist');
+			assert.notStrictEqual(contentsNode.style.maxHeight, '', 'Contents node should have maxHeight set after layout so DomScrollableElement can detect overflow');
+
+			hover.dispose();
 		});
 	});
 


### PR DESCRIPTION
Fixes #215972

## Problem
The hover widget sets `maxHeight` on `containerDomNode` (which has `overflow: hidden` in CSS), but never constrains the `DomScrollableElement` wrapper inside it. Without a height constraint on the scrollable element, `scrollHeight` always equals `clientHeight` - the scrollbar never activates. The outer container's `overflow: hidden` simply clips the content invisibly.

## Fix
- Store a reference to the status bar element (`_statusBarElement`) when actions are rendered in the constructor
- In `adjustHoverMaxHeight`, set `maxHeight` on `scrollbar.getDomNode()` equal to `maxHeight - statusBarHeight`, so `DomScrollableElement` detects the overflow and activates the scrollbar
- Reset `scrollbar.getDomNode().style.maxHeight` at the start of each `layout()` call

## Testing
Hover over a terminal tab that has multiple extensions contributing to its environment (e.g. GitLens, GitHub Copilot) - enough to overflow the tooltip. The tooltip should now be scrollable with the mouse wheel instead of clipping the content.