### PR TITLE
feat : auto-generate commit message if empty

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3513,6 +3513,15 @@
           "description": "%config.useEditorAsCommitInput%",
           "default": true
         },
+        "git.experimental.generateCommitMessageIfEmpty": {
+          "type": "boolean",
+          "scope": "resource",
+          "markdownDescription": "%config.experimental.generateCommitMessageIfEmpty%",
+          "default": false,
+          "tags": [
+            "experimental"
+          ]
+        },
         "git.verboseCommit": {
           "type": "boolean",
           "scope": "resource",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -204,6 +204,7 @@
 	"config.ignoreRebaseWarning": "Ignores the warning when it looks like the branch might have been rebased when pulling.",
 	"config.defaultCloneDirectory": "The default location to clone a Git repository.",
 	"config.useEditorAsCommitInput": "Controls whether a full text editor will be used to author commit messages, whenever no message is provided in the commit input box.",
+	"config.experimental.generateCommitMessageIfEmpty": "Controls whether to automatically generate a commit message using the configured commit message generation provider (e.g. GitHub Copilot) when committing with an empty message. Falls back to the default behavior if the provider is not available.",
 	"config.verboseCommit": "Enable verbose output when `#git.useEditorAsCommitInput#` is enabled.",
 	"config.enableSmartCommit": "Commit all changes when there are no staged changes.",
 	"config.smartCommitChanges": "Control which changes are automatically staged by Smart Commit.",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2573,6 +2573,10 @@ export class CommandCenter {
 		const getCommitMessage = async () => {
 			let _message: string | undefined = message;
 
+			if (!_message && !opts.amend && config.get<boolean>('experimental.generateCommitMessageIfEmpty')) {
+				_message = await this.tryGenerateCommitMessage(repository);
+			}
+
 			if (!_message && !config.get<boolean>('useEditorAsCommitInput')) {
 				const value: string | undefined = undefined;
 
@@ -2601,6 +2605,22 @@ export class CommandCenter {
 		};
 
 		await this.smartCommit(repository, getCommitMessage, opts);
+	}
+
+	private async tryGenerateCommitMessage(repository: Repository): Promise<string | undefined> {
+		try {
+			const generateCommand = 'github.copilot.git.generateCommitMessage';
+			const availableCommands = await commands.getCommands(true);
+
+			if (!availableCommands.includes(generateCommand)) {
+				return undefined;
+			}
+
+			await commands.executeCommand(generateCommand, Uri.file(repository.root));
+			return repository.inputBox.value || undefined;
+		} catch {
+			return undefined;
+		}
 	}
 
 	@command('git.commit', { repository: true })


### PR DESCRIPTION
Fixes #312643

## Context

I've been exploring the VS Code codebase for the past few days, and when this feature request landed I saw it was a clean, self-contained change so I went ahead and implemented it. I know @lszomoru is assigned to this, so happy to adjust the approach or close this if you'd prefer to handle it differently.

## What this PR does

Adds a new **opt-in** setting `git.experimental.generateCommitMessageIfEmpty` (default: `false`) that automatically generates a commit message using the configured provider (e.g. GitHub Copilot) when the user clicks **Commit** with an empty message field.

### Behavior

- **Setting OFF (default):** No change — existing behavior is preserved.
- **Setting ON + message field empty:**
  1. Checks if `github.copilot.git.generateCommitMessage` command is available
  2. If available, executes it to auto-generate the commit message
  3. If generation succeeds → commits with the generated message
  4. If generation fails or Copilot isn't installed → falls back to the existing flow (editor or input box prompt)
- **Setting ON + message field has content:** Uses the user-provided message as-is (no generation).
- **Amend commits:** Skipped — generation is not triggered for amend operations.

## Changes

| File | Change |
|------|--------|
| `extensions/git/package.json` | New `git.experimental.generateCommitMessageIfEmpty` setting |
| `extensions/git/package.nls.json` | Localized description for the setting |
| `extensions/git/src/commands.ts` | `commitWithAnyInput()` checks the setting and calls `tryGenerateCommitMessage()` |

## Testing

1. Enable the setting: `"git.experimental.generateCommitMessageIfEmpty": true`
2. Make some changes and stage them
3. Leave the commit message field empty and click **Commit**
4. Expected: Copilot generates and fills the commit message, then the commit proceeds
5. With Copilot disabled/uninstalled: Falls back to the editor or input box prompt
