### PR TITLE
feat : retain commit message after commit

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3557,6 +3557,15 @@
           "description": "%config.confirmEmptyCommits%",
           "default": true
         },
+        "git.experimental.retainCommitMessageAfterCommit": {
+          "type": "boolean",
+          "scope": "resource",
+          "markdownDescription": "%config.experimental.retainCommitMessageAfterCommit%",
+          "default": false,
+          "tags": [
+            "experimental"
+          ]
+        },
         "git.decorations.enabled": {
           "type": "boolean",
           "default": true,

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -264,6 +264,7 @@
 	"config.showProgress": "Controls whether Git actions should show progress.",
 	"config.rebaseWhenSync": "Force Git to use rebase when running the sync command.",
 	"config.confirmEmptyCommits": "Always confirm the creation of empty commits for the 'Git: Commit Empty' command.",
+	"config.experimental.retainCommitMessageAfterCommit": "Controls whether the commit message is retained in the input box after a successful commit, instead of clearing it.",
 	"config.fetchOnPull": "When enabled, fetch all branches when pulling. Otherwise, fetch just the current one.",
 	"config.pullBeforeCheckout": "Controls whether a branch that does not have outgoing commits is fast-forwarded before it is checked out.",
 	"config.pullTags": "Fetch all tags when pulling.",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1472,7 +1472,10 @@ export class Repository implements Disposable {
 
 	private async commitOperationCleanup(message: string | undefined, indexResources: string[], workingGroupResources: string[]) {
 		if (message) {
-			this.inputBox.value = await this.getInputTemplate();
+			const config = workspace.getConfiguration('git', Uri.file(this.repository.root));
+			if (!config.get<boolean>('experimental.retainCommitMessageAfterCommit')) {
+				this.inputBox.value = await this.getInputTemplate();
+			}
 		}
 		this.closeDiffEditors(indexResources, workingGroupResources);
 


### PR DESCRIPTION
Fixes #312658

## Context

I've been exploring the VS Code codebase for the past few days, and when this feature request landed I saw it was a clean, self-contained change so I went ahead and implemented it. I know @lszomoru is assigned to this, so happy to adjust the approach or close this if you'd prefer to handle it differently.

## What this PR does

Adds a new **opt-in** setting `git.experimental.retainCommitMessageAfterCommit` (default: `false`) that keeps the commit message in the input box after a successful commit, instead of clearing it.

### Behavior

- **Setting OFF (default):** No change input box is cleared after commit (existing behavior).
- **Setting ON:** The commit message stays in the input box after a successful commit, so users can reuse or modify it for subsequent commits.

## Changes

| File | Change |
|------|--------|
| `extensions/git/package.json` | New `git.experimental.retainCommitMessageAfterCommit` setting |
| `extensions/git/package.nls.json` | Localized description for the setting |
| `extensions/git/src/repository.ts` | `commitOperationCleanup()` skips resetting input box when setting is enabled |

## Testing

1. Enable: `"git.experimental.retainCommitMessageAfterCommit": true`
2. Stage changes, type a commit message, click **Commit**
3. Expected: The commit message remains in the input box
4. With setting OFF: Input box clears as usual
