### PR TITLE
Enable thinking and thinking effort picker for OpenRouter models

### DIFF
--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -108,7 +108,8 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 				tool_calls: !!knownModelInfo?.toolCalling,
 				vision: !!knownModelInfo?.vision,
 				thinking: !!knownModelInfo?.thinking,
-				adaptive_thinking: !!knownModelInfo?.adaptiveThinking
+				adaptive_thinking: !!knownModelInfo?.adaptiveThinking,
+				reasoning_effort: knownModelInfo?.supportsReasoningEffort
 			},
 			tokenizer: TokenizerType.O200K,
 			limits: {

--- a/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
@@ -12,7 +12,7 @@ import { IExperimentationService } from '../../../platform/telemetry/common/null
 import { IStringDictionary } from '../../../util/vs/base/common/collections';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { CopilotLanguageModelWrapper } from '../../conversation/vscode-node/languageModelAccess';
-import { BYOKAuthType, BYOKKnownModels, byokKnownModelsToAPIInfo, BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
+import { BYOKAuthType, BYOKKnownModels, BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { IBYOKStorageService } from './byokStorageService';
 import { byokKnownModelsToAPIInfoWithEffort } from './byokModelInfo';

--- a/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/abstractLanguageModelChatProvider.ts
@@ -15,6 +15,7 @@ import { CopilotLanguageModelWrapper } from '../../conversation/vscode-node/lang
 import { BYOKAuthType, BYOKKnownModels, byokKnownModelsToAPIInfo, BYOKModelCapabilities, resolveModelInfo } from '../common/byokProvider';
 import { OpenAIEndpoint } from '../node/openAIEndpoint';
 import { IBYOKStorageService } from './byokStorageService';
+import { byokKnownModelsToAPIInfoWithEffort } from './byokModelInfo';
 
 export interface LanguageModelChatConfiguration {
 	readonly apiKey?: string;
@@ -105,7 +106,7 @@ export abstract class AbstractOpenAICompatibleLMProvider<T extends LanguageModel
 		const modelsUrl = this.getModelsBaseUrl(configuration);
 		if (modelsUrl) {
 			const models = await this.getModelsFromEndpoint(modelsUrl, silent, apiKey);
-			return byokKnownModelsToAPIInfo(this._name, models).map(model => ({
+			return byokKnownModelsToAPIInfoWithEffort(this._name, models).map(model => ({
 				...model,
 				url: modelsUrl
 			}));

--- a/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/openRouterProvider.ts
@@ -61,7 +61,10 @@ export class OpenRouterLMProvider extends AbstractOpenAICompatibleLMProvider {
 			toolCalling: openRouterModelData.supported_parameters?.includes('tools') ?? false,
 			vision: openRouterModelData.architecture?.input_modalities?.includes('image') ?? false,
 			maxInputTokens: openRouterModelData.top_provider.context_length - 16000,
-			maxOutputTokens: 16000
+			maxOutputTokens: 16000,
+			thinking: (openRouterModelData.supported_parameters?.includes('reasoning') || openRouterModelData.supported_parameters?.includes('reasoning_effort')) ?? false,
+			adaptiveThinking: openRouterModelData.supported_parameters?.includes('reasoning_effort') ?? false,
+			supportsReasoningEffort: openRouterModelData.supported_parameters?.includes('reasoning_effort') ? ['none', 'low', 'medium', 'high'] : undefined
 		};
 	}
 


### PR DESCRIPTION
More specifically, it enable thinking for models that support toggling it or setting the effort, and enables the effort picker for models that actually support the effort parameter.

For example, MiniMax M2.7 can use reasoning (although it is not shown; a problem which is out of scope) but doesn't offer the picker (reasoning effort not in supported params list), while MoonshotAI's Kimi K2.6 shows None, Low, Medium, and High. Do note that Minimal and Xhigh has been excluded because it would require more advanced schema configurations to properly show the descriptions.