### PR TITLE
fix chat: skip fragment-only markdown links to avoid false 'File not found' warnings

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
@@ -487,9 +487,9 @@ export class PromptBody {
 					const linkTarget = match[2];
 					const fragmentIndex = linkTarget.lastIndexOf('#');
 					const beforeFragment = fragmentIndex >= 0 ? linkTarget.substring(0, fragmentIndex) : linkTarget;
+					markdownLinkRanges.push(new Range(i + 1, match.index + 1, i + 1, match.index + match[0].length + 1));
 					if (beforeFragment.length > 0) {
 						fileReferences.push({ content: linkTarget, range, isMarkdownLink: true });
-						markdownLinkRanges.push(new Range(i + 1, match.index + 1, i + 1, match.index + match[0].length + 1));
 					}
 				}
 				// Match #file:<filePath> and #tool:<toolName>

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
@@ -483,8 +483,14 @@ export class PromptBody {
 					const linkEndOffset = match.index + match[0].length - 1; // before the parenthesis
 					const linkStartOffset = match.index + match[0].length - match[2].length - 1;
 					const range = new Range(i + 1, linkStartOffset + 1, i + 1, linkEndOffset + 1);
-					fileReferences.push({ content: match[2], range, isMarkdownLink: true });
-					markdownLinkRanges.push(new Range(i + 1, match.index + 1, i + 1, match.index + match[0].length + 1));
+					// Skip fragment-only links (e.g. [text](#anchor)) - these are intra-document anchors, not file references
+					const linkTarget = match[2];
+					const fragmentIndex = linkTarget.lastIndexOf('#');
+					const beforeFragment = fragmentIndex >= 0 ? linkTarget.substring(0, fragmentIndex) : linkTarget;
+					if (beforeFragment.length > 0) {
+						fileReferences.push({ content: linkTarget, range, isMarkdownLink: true });
+						markdownLinkRanges.push(new Range(i + 1, match.index + 1, i + 1, match.index + match[0].length + 1));
+					}
 				}
 				// Match #file:<filePath> and #tool:<toolName>
 				// Regarding the <toolName> pattern below, see also the variableReg regex in chatRequestParser.ts.

--- a/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
@@ -2015,6 +2015,35 @@ suite('PromptValidator', () => {
 			assert.deepStrictEqual(markers, [], 'Expected no validation issues');
 		});
 
+		test('body with fragment-only anchor link', async () => {
+			const content = [
+				'---',
+				'description: "Fragment-Only Links"',
+				'---',
+				'See [Details](#details) for more info.',
+				'See [Section](#section-name) and [Another](#another).',
+			].join('\n');
+			const markers = await validate(content, PromptsType.prompt);
+			assert.deepStrictEqual(markers, [], 'Expected no validation issues for fragment-only anchor links');
+		});
+
+		test('body with mixed link types', async () => {
+			const nonExistingRef = existingRef1.with({ path: '/nonexisting' });
+			const content = [
+				'---',
+				'description: "Mixed Links"',
+				'---',
+				`Here is a [url link](${existingRef1.toString()}).`,
+				'See [Details](#details) for more info.',
+				`Here is a [url link](${nonExistingRef.toString()}).`
+			].join('\n');
+			const markers = await validate(content, PromptsType.prompt);
+			const messages = markers.map(m => m.message).sort();
+			assert.deepStrictEqual(messages, [
+				`File 'myFs://test/nonexisting' not found at '/nonexisting'.`,
+			]);
+		});
+
 		test('body with url link', async () => {
 			const nonExistingRef = existingRef1.with({ path: '/nonexisting' });
 			const content = [

--- a/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
@@ -2027,6 +2027,20 @@ suite('PromptValidator', () => {
 			assert.deepStrictEqual(markers, [], 'Expected no validation issues for fragment-only anchor links');
 		});
 
+		test('body with fragment-only link containing #tool:', async () => {
+			const content = [
+				'---',
+				'description: "Fragment-Only Tool Links"',
+				'---',
+				'Use [tool](#tool:myTool) to do something.',
+				'See [file](#file:somefile) for actual file.',
+			].join('\n');
+			const markers = await validate(content, PromptsType.prompt);
+			// fragment-only #tool: links should not be treated as variable references
+			// fragment-only #file: links should not be treated as file references
+			assert.deepStrictEqual(markers, [], 'Expected no validation issues for fragment-only tool/file links');
+		});
+
 		test('body with mixed link types', async () => {
 			const nonExistingRef = existingRef1.with({ path: '/nonexisting' });
 			const content = [


### PR DESCRIPTION
Fixes microsoft/vscode#312673

In chatagent language mode files (*.agent.md), the prompt validator was treating [text](#anchor) links as file references, causing false-positive 'File not found at #anchor' warnings in the Problems panel.

These are GitHub-style intra-document anchor links, not file paths. The fix checks if the link target has no path component before the fragment (e.g. ''.substring(0, 0) = '' before '#details') and skips validation for such fragment-only links.

Steps to test:
1. Create .github/agents/test.agent.md with content containing `[Details](#details)`
2. Open Problems panel
3. Before fix: shows 'File #details not found'
4. After fix: no warning