### PR TITLE
Agents: Remove product quality handling from OpenInAgentsTitleBarWidget

### DIFF
--- a/src/vs/workbench/electron-browser/actions/media/openInAgents.css
+++ b/src/vs/workbench/electron-browser/actions/media/openInAgents.css
@@ -66,22 +66,6 @@
 	outline: none;
 }
 
-/* Quality-tinted hover/focus background — blue (stable), green (insider), orange (exploration). */
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="stable"]:hover,
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="stable"]:focus-visible {
-	background-color: rgba(0, 122, 204, 0.18);
-}
-
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="insider"]:hover,
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="insider"]:focus-visible {
-	background-color: rgba(36, 187, 26, 0.20);
-}
-
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="exploration"]:hover,
-.monaco-workbench .open-in-agents-titlebar-widget[data-product-quality="exploration"]:focus-visible {
-	background-color: rgba(255, 140, 0, 0.22);
-}
-
 .monaco-workbench .open-in-agents-titlebar-widget:hover > .open-in-agents-titlebar-widget-label,
 .monaco-workbench .open-in-agents-titlebar-widget:focus-visible > .open-in-agents-titlebar-widget-label {
 	max-width: 200px;

--- a/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
+++ b/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
@@ -144,7 +144,6 @@ class OpenInAgentsTitleBarWidget extends BaseActionViewItem {
 	constructor(
 		action: IAction,
 		options: IBaseActionViewItemOptions | undefined,
-		@IProductService private readonly productService: IProductService,
 		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super(undefined, action, options);
@@ -155,7 +154,6 @@ class OpenInAgentsTitleBarWidget extends BaseActionViewItem {
 
 		container.classList.add('open-in-agents-titlebar-widget');
 		container.setAttribute('role', 'button');
-		container.setAttribute('data-product-quality', this.productService.quality ?? 'stable');
 
 		const label = this.action.label || localize('openInAgentsLabel', "Open in Agents");
 		container.setAttribute('aria-label', label);


### PR DESCRIPTION
Eliminate product quality handling from the OpenInAgentsTitleBarWidget to simplify the component. This change removes unnecessary complexity related to product quality attributes in both the CSS and TypeScript files.

