### PR TITLE
Reduce margin between session action group and right layout actions

### DIFF
--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -65,7 +65,7 @@
 
 /* Add spacing between the session action group and the right layout actions. */
 .monaco-workbench .part.titlebar > .sessions-titlebar-container > .titlebar-right > .titlebar-session-actions-container:not(.has-no-actions) + .titlebar-right-layout-container:not(.has-no-actions) {
-	margin-left: 8px;
+	margin-left: 4px;
 }
 
 /* Toggled action buttons in session actions toolbar */


### PR DESCRIPTION
Adjust the margin between the session action group and the right layout actions for improved visual alignment. Test by checking the spacing in the title bar after applying the changes.

