### PR TITLE
Run Agents App in transient mode when VS Code is launched with --transient

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -250,13 +250,17 @@ export async function main(argv: string[]): Promise<void> {
 			const tempExtensionsDir = join(tempParentDir, 'extensions');
 			const tempSharedDataDir = join(tempParentDir, 'shared');
 			const tempAgentPluginsDir = join(tempParentDir, 'agent-plugins');
+			const tempAgentsUserDataDir = join(tempParentDir, 'agents-data');
+			const tempAgentsExtensionsDir = join(tempParentDir, 'agents-extensions');
 
 			addArg(argv, '--user-data-dir', tempUserDataDir);
 			addArg(argv, '--extensions-dir', tempExtensionsDir);
 			addArg(argv, '--shared-data-dir', tempSharedDataDir);
 			addArg(argv, '--agent-plugins-dir', tempAgentPluginsDir);
+			addArg(argv, '--agents-user-data-dir', tempAgentsUserDataDir);
+			addArg(argv, '--agents-extensions-dir', tempAgentsExtensionsDir);
 
-			console.log(`State is temporarily stored. Relaunch this state with: ${product.applicationName} --user-data-dir "${tempUserDataDir}" --extensions-dir "${tempExtensionsDir}" --shared-data-dir "${tempSharedDataDir}" --agent-plugins-dir "${tempAgentPluginsDir}"`);
+			console.log(`State is temporarily stored. Relaunch this state with: ${product.applicationName} --user-data-dir "${tempUserDataDir}" --extensions-dir "${tempExtensionsDir}" --shared-data-dir "${tempSharedDataDir}" --agent-plugins-dir "${tempAgentPluginsDir}" --agents-user-data-dir "${tempAgentsUserDataDir}" --agents-extensions-dir "${tempAgentsExtensionsDir}"`);
 		}
 
 		const hasReadStdinArg = args._.some(arg => arg === '-') || args.chat?._.some(arg => arg === '-');

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -77,6 +77,8 @@ export interface NativeParsedArgs {
 	'builtin-extensions-dir'?: string;
 	'shared-data-dir'?: string;
 	'agent-plugins-dir'?: string;
+	'agents-user-data-dir'?: string;
+	'agents-extensions-dir'?: string;
 	extensionDevelopmentPath?: string[]; // undefined or array of 1 or more local paths or URIs
 	extensionTestsPath?: string; // either a local path or a URI
 	extensionDevelopmentKind?: string[];

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -122,6 +122,8 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'shared-data-dir': { type: 'string' },
 	'list-extensions': { type: 'boolean', cat: 'e', description: localize('listExtensions', "List the installed extensions.") },
 	'agent-plugins-dir': { type: 'string' },
+	'agents-user-data-dir': { type: 'string' },
+	'agents-extensions-dir': { type: 'string' },
 	'show-versions': { type: 'boolean', cat: 'e', description: localize('showVersions', "Show versions of installed extensions, when using --list-extensions.") },
 	'category': { type: 'string', allowEmptyValue: true, cat: 'e', description: localize('category', "Filters installed extensions by provided category, when using --list-extensions."), args: 'category' },
 	'install-extension': { type: 'string[]', cat: 'e', args: 'ext-id | path', description: localize('installExtension', "Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.") },

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -315,7 +315,19 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	}
 
 	async launchSiblingApp(_windowId: number | undefined, args?: string[]): Promise<void> {
-		const result = launchSiblingApp(this.productService, args, err => {
+		const finalArgs = [...(args ?? [])];
+
+		// Forward transient agents dirs to the sibling app
+		const agentsUserDataDir = this.environmentMainService.args['agents-user-data-dir'];
+		if (agentsUserDataDir) {
+			finalArgs.push('--user-data-dir', agentsUserDataDir);
+		}
+		const agentsExtensionsDir = this.environmentMainService.args['agents-extensions-dir'];
+		if (agentsExtensionsDir) {
+			finalArgs.push('--extensions-dir', agentsExtensionsDir);
+		}
+
+		const result = launchSiblingApp(this.productService, finalArgs, err => {
 			this.logService.error('[launchSiblingApp] Failed to spawn sibling app:', err.message);
 		});
 		if (!result) {

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -317,7 +317,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	async launchSiblingApp(_windowId: number | undefined, args?: string[]): Promise<void> {
 		const finalArgs = [...(args ?? [])];
 
-		// Forward transient agents dirs to the sibling app
+		// Forward transient dirs to the sibling app so it runs fully isolated
 		const agentsUserDataDir = this.environmentMainService.args['agents-user-data-dir'];
 		if (agentsUserDataDir) {
 			finalArgs.push('--user-data-dir', agentsUserDataDir);
@@ -325,6 +325,14 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		const agentsExtensionsDir = this.environmentMainService.args['agents-extensions-dir'];
 		if (agentsExtensionsDir) {
 			finalArgs.push('--extensions-dir', agentsExtensionsDir);
+		}
+		const sharedDataDir = this.environmentMainService.args['shared-data-dir'];
+		if (sharedDataDir) {
+			finalArgs.push('--shared-data-dir', sharedDataDir);
+		}
+		const agentPluginsDir = this.environmentMainService.args['agent-plugins-dir'];
+		if (agentPluginsDir) {
+			finalArgs.push('--agent-plugins-dir', agentPluginsDir);
 		}
 
 		const result = launchSiblingApp(this.productService, finalArgs, err => {


### PR DESCRIPTION
## Summary

When VS Code is launched with `--transient`, the Agents App now also runs in transient mode with its own dedicated temporary user data and extensions directories, created under the same temp parent folder.

## Changes

- **`argv.ts` (common + node)**: Add `--agents-user-data-dir` and `--agents-extensions-dir` CLI args
- **`cli.ts`**: In the `--transient` block, create `agents-data/` and `agents-extensions/` subdirs alongside the existing temp dirs, pass them via the new args, and include them in the relaunch hint message
- **`nativeHostMainService.ts`**: When launching the sibling Agents app (`launchSiblingApp`), forward the transient dirs as `--user-data-dir` and `--extensions-dir` so the Agents process also runs fully isolated in transient mode
