### PR TITLE
agents: show disclaimer on signed-in welcome screen

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -239,7 +239,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 	private _renderWelcome(stepDisposables: DisposableStore, right: HTMLElement, productName: string): void {
 		this._isShowingWelcome = true;
-		this.disclaimerElement.classList.add('hidden');
+		this.disclaimerElement.classList.toggle('hidden', this.disclaimerLinks.length === 0);
 
 		append(right, $('h2', undefined, localize('walkthrough.welcome.title', "Welcome to {0}", productName)));
 		append(right, $('p', undefined, localize('walkthrough.welcome.subtitle', "Your AI-powered coding agent that builds, tests, and iterates for you.")));
@@ -253,7 +253,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 			this.complete();
 		}));
 
-		this.currentFocusableElements = [getStartedBtn];
+		this.currentFocusableElements = [getStartedBtn, ...this.disclaimerLinks];
 
 		disposableTimeout(() => {
 			if (this.overlay.isConnected) {


### PR DESCRIPTION
## Summary

The terms & conditions (disclaimer) was not shown on the signed-in first-launch welcome screen.

### Root cause

`_renderWelcome()` explicitly called `this.disclaimerElement.classList.add('hidden')`, which hid the disclaimer unconditionally — even when the product has valid terms/privacy URLs.

### Fix

- Use the same `classList.toggle('hidden', this.disclaimerLinks.length === 0)` logic that `_renderSignIn()` uses, so the disclaimer is shown whenever links are available.
- Also add the disclaimer links to `currentFocusableElements` so keyboard users can Tab to them from the "Get Started" button.