### PR TITLE
fix html: set editor.wrappingIndent to 'indent' by default

### DIFF
--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -246,10 +246,12 @@
     },
     "configurationDefaults": {
       "[html]": {
-        "editor.suggest.insertMode": "replace"
+        "editor.suggest.insertMode": "replace",
+        "editor.wrappingIndent": "indent"
       },
       "[handlebars]": {
-        "editor.suggest.insertMode": "replace"
+        "editor.suggest.insertMode": "replace",
+        "editor.wrappingIndent": "indent"
       }
     },
     "jsonValidation": [


### PR DESCRIPTION
For issue #312719 - HTML/handlebars text is harder to read when wrapping uses 'same' indent, making wrapped lines invisible. Set default wrappingIndent to 'indent' so wrapped text lines are visually distinct.

Fixes microsoft/vscode#312719