### PR TITLE
fix: prevent malformed chromium feature flags causing network process…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -320,25 +320,28 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	});
 
 	// Following features are enabled from the runtime:
-	// `NetAdapterMaxBufSizeFeature` - Specify the max buffer size for NetToMojoPendingBuffer, refs https://github.com/microsoft/vscode/issues/268800
+	// `NetAdapterMaxBufSize` - Specify the max buffer size for NetToMojoPendingBuffer, refs https://github.com/microsoft/vscode/issues/268800
 	// `DocumentPolicyIncludeJSCallStacksInCrashReports` - https://www.electronjs.org/docs/latest/api/web-frame-main#framecollectjavascriptcallstack-experimental
 	// `EarlyEstablishGpuChannel` - Refs https://issues.chromium.org/issues/40208065
 	// `EstablishGpuChannelAsync` - Refs https://issues.chromium.org/issues/40208065
+	const enableFeatures = app.commandLine.getSwitchValue('enable-features');
 	const featuresToEnable =
-		`NetAdapterMaxBufSizeFeature:NetAdapterMaxBufSize/8192,DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync,${app.commandLine.getSwitchValue('enable-features')}`;
+		`NetAdapterMaxBufSize:NetAdapterMaxBufSize/8192,DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync${enableFeatures ? `,${enableFeatures}` : ''}`;
 	app.commandLine.appendSwitch('enable-features', featuresToEnable);
 
 	// Following features are disabled from the runtime:
 	// `CalculateNativeWinOcclusion` - Disable native window occlusion tracker (https://groups.google.com/a/chromium.org/g/embedder-dev/c/ZF3uHHyWLKw/m/VDN2hDXMAAAJ)
+	const disableFeatures = app.commandLine.getSwitchValue('disable-features');
 	const featuresToDisable =
-		`CalculateNativeWinOcclusion,${app.commandLine.getSwitchValue('disable-features')}`;
+		`CalculateNativeWinOcclusion${disableFeatures ? `,${disableFeatures}` : ''}`;
 	app.commandLine.appendSwitch('disable-features', featuresToDisable);
 
 	// Blink features to configure.
-	// `FontMatchingCTMigration` - Siwtch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
+	// `FontMatchingCTMigration` - Switch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
 	// `StandardizedBrowserZoom` - Disable zoom adjustment for bounding box (https://github.com/microsoft/vscode/issues/232750#issuecomment-2459495394)
+	const disableBlinkFeatures = app.commandLine.getSwitchValue('disable-blink-features');
 	const blinkFeaturesToDisable =
-		`FontMatchingCTMigration,StandardizedBrowserZoom,${app.commandLine.getSwitchValue('disable-blink-features')}`;
+		`FontMatchingCTMigration,StandardizedBrowserZoom${disableBlinkFeatures ? `,${disableBlinkFeatures}` : ''}`;
 	app.commandLine.appendSwitch('disable-blink-features', blinkFeaturesToDisable);
 
 	// Support JS Flags
@@ -358,6 +361,7 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 
 	return argvConfig;
 }
+
 
 interface IArgvConfig {
 	[key: string]: string | string[] | boolean | undefined;


### PR DESCRIPTION
Fixes #312741

**Description**
This PR fixes a critical startup issue on macOS (particularly M4 Pro) where VS Code Insiders launches into a completely blank/dark window. The root cause was a network process crash (`exitCode: 9`) triggered by malformed Chromium feature flags.

**Changes made:**
- Changed the invalid feature name `NetAdapterMaxBufSizeFeature` to the correct Chromium feature `NetAdapterMaxBufSize`.
- Switched the interpolation of user flags (e.g. `--enable-features`) to use an inline ternary check. This prevents the injection of a fatal trailing comma (`...,EstablishGpuChannelAsync,`) when a user launches the app without custom features.
- Fixed a minor typo in a comment ("Siwtch" -> "Switch").

By ensuring the feature string is strictly formatted and the feature name is valid, the network process boots correctly and the UI renders as expected.

 How to test
1. Launch the built version of VS Code on macOS (preferably Apple Silicon/M4 if available) without any custom `--enable-features` flags.
2. Verify that the window opens and renders the UI normally, instead of getting stuck on a blank/dark screen.
3. Check the startup logs (`--verbose`) to ensure the `[network process]` does not crash or loop.