### PR TITLE
Fix MCP install manifest dialog showing literal '&&Install' label

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -7,6 +7,7 @@ import { mapFindFirst } from '../../../../base/common/arraysFind.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { parse as parseJsonc } from '../../../../base/common/jsonc.js';
+import { mnemonicButtonLabel } from '../../../../base/common/labels.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { autorun } from '../../../../base/common/observable.js';
@@ -616,7 +617,7 @@ export class McpInstallFromManifestCommand {
 			filters: [{ name: localize('mcp.installFromManifest.filter', "MCP Manifest"), extensions: ['json'] }],
 			canSelectFiles: true,
 			canSelectMany: false,
-			openLabel: localize({ key: 'mcp.installFromManifest.openLabel', comment: ['&& denotes a mnemonic'] }, "&&Install")
+			openLabel: mnemonicButtonLabel(localize({ key: 'mcp.installFromManifest.openLabel', comment: ['&& denotes a mnemonic'] }, "&&Install"))
 		});
 
 		if (!result?.[0]) {


### PR DESCRIPTION
### Bug

The "Install MCP server from manifest" file picker rendered its OK button as the literal text `&&Install` instead of `Install`:

<img src="https://raw.githubusercontent.com/ulugbekna/screenshots/main/mcp-install-bad-label.png" width="500" />

### Cause

`IFileDialogService.showOpenDialog`'s `openLabel` is typed as `{ withMnemonic, withoutMnemonic } | string`. When a raw string is passed, it's used  no mnemonic processing  so the `&&` mnemonic marker leaked into the rendered label.happens verbatim 

### Fix

Wrap the localized string with `mnemonicButtonLabel(...)` so each platform renders the mnemonic correctly (Alt-underlined on Windows/Linux, stripped on macOS/web). This matches the convention used by other call sites such as the extensions install dialog, the update prompt, and `workspaceCommands`.
