### PR TITLE
agents: group worktree sessions by repository root

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -6,14 +6,33 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../../base/common/network.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
-import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_SCHEME, fromAgentHostUri, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ISessionFileDiff, SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { ChatSessionStatus, IChatNewSessionRequest, IChatSessionFileChange2, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta } from '../../../common/chatSessionsService.js';
 import { getAgentHostIcon } from '../agentSessions.js';
+
+/**
+ * Resolves a project URI from a value that may be a URI object or a serialized
+ * URI string (as received over the agent host protocol wire format).
+ */
+function resolveProjectUri(value: unknown): URI | undefined {
+	if (URI.isUri(value)) {
+		return value;
+	}
+	if (typeof value === 'string') {
+		try {
+			return URI.parse(value);
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
 
 function mapDiffsToChanges(diffs: readonly ISessionFileDiff[] | undefined, connectionAuthority: string): readonly IChatSessionFileChange2[] | undefined {
 	if (!diffs || diffs.length === 0) {
@@ -190,12 +209,14 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 					createdAt: s.startTime,
 					modifiedAt: s.modifiedTime,
 					workingDirectory: s.workingDirectory?.toString(),
+					...(s.project ? { project: { uri: s.project.uri.toString(), displayName: s.project.displayName } } : {}),
 				});
 				return this._makeItem(rawId, {
 					title: s.summary,
 					status,
 					activity: s.activity,
 					workingDirectory: s.workingDirectory,
+					project: s.project?.uri,
 					createdAt: s.startTime,
 					modifiedAt: s.modifiedTime,
 					diffs: s.diffs,
@@ -211,11 +232,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 
 	private _makeItemFromSummary(rawId: string, summary: SessionSummary, diffs: readonly ISessionFileDiff[] | undefined): IChatSessionItem {
 		const workingDir = typeof summary.workingDirectory === 'string' ? URI.parse(summary.workingDirectory) : summary.workingDirectory;
+		const projectUri = resolveProjectUri(summary.project?.uri);
 		return this._makeItem(rawId, {
 			title: summary.title,
 			status: summary.status,
 			activity: summary.activity,
 			workingDirectory: workingDir,
+			project: projectUri,
 			createdAt: summary.createdAt,
 			modifiedAt: summary.modifiedAt,
 			diffs,
@@ -227,6 +250,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		status?: SessionStatus;
 		activity?: string;
 		workingDirectory?: URI;
+		project?: URI;
 		createdAt: number;
 		modifiedAt: number;
 		diffs?: readonly ISessionFileDiff[];
@@ -240,7 +264,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 			iconPath: getAgentHostIcon(this._productService),
 			status: mapSessionStatus(opts.status),
 			archived: opts.status !== undefined && (opts.status & SessionStatus.IsArchived) === SessionStatus.IsArchived,
-			metadata: this._buildMetadata(opts.workingDirectory),
+			metadata: this._buildMetadata(opts.workingDirectory, opts.project),
 			timing: {
 				created: opts.createdAt,
 				lastRequestStarted: opts.modifiedAt,
@@ -250,13 +274,22 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		};
 	}
 
-	private _buildMetadata(workingDirectory: URI | undefined): { readonly [key: string]: unknown } | undefined {
-		if (!this._description && !workingDirectory) {
+	private _buildMetadata(workingDirectory: URI | undefined, projectUri?: URI): { readonly [key: string]: unknown } | undefined {
+		if (!this._description && !workingDirectory && !projectUri) {
 			return undefined;
 		}
 		const result: { [key: string]: unknown } = {};
 		if (this._description) {
 			result.remoteAgentHost = this._description;
+		}
+		if (projectUri?.scheme === Schemas.file) {
+			result.repositoryPath = projectUri.fsPath;
+		} else if (projectUri?.scheme === AGENT_HOST_SCHEME) {
+			// Remote session: unwrap the vscode-agent-host:// wrapper to get
+			// the original remote file path. Using the repo root (not the
+			// worktree-specific working directory) ensures all worktrees from
+			// the same remote repository collapse into a single group.
+			result.repositoryPath = fromAgentHostUri(projectUri).fsPath;
 		}
 		if (workingDirectory) {
 			result.workingDirectoryPath = workingDirectory.fsPath;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -6,9 +6,10 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../../base/common/network.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 import { URI } from '../../../../../../base/common/uri.js';
-import { toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
+import { AGENT_HOST_SCHEME, fromAgentHostUri, toAgentHostUri } from '../../../../../../platform/agentHost/common/agentHostUri.js';
 import { AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
 import { ISessionFileDiff, SessionStatus, type SessionSummary } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
@@ -16,6 +17,24 @@ import { ChatSessionStatus, IChatSessionFileChange2, IChatSessionItem, IChatSess
 import { getAgentHostIcon } from '../agentSessions.js';
 
 type ICompactSessionFileDiff = { readonly uri: string; readonly added?: number; readonly removed?: number };
+
+/**
+ * Resolves a project URI from a value that may be a URI object or a serialized
+ * URI string (as received over the agent host protocol wire format).
+ */
+function resolveProjectUri(value: unknown): URI | undefined {
+	if (URI.isUri(value)) {
+		return value;
+	}
+	if (typeof value === 'string') {
+		try {
+			return URI.parse(value);
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
 
 function mapDiffsToChanges(diffs: readonly ISessionFileDiff[] | readonly ICompactSessionFileDiff[] | undefined, connectionAuthority: string): readonly IChatSessionFileChange2[] | undefined {
 	if (!diffs || diffs.length === 0) {
@@ -104,10 +123,12 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				const rawId = AgentSession.id(n.summary.resource);
 				this._cachedSummaries.set(rawId, n.summary);
 				const workingDir = typeof n.summary.workingDirectory === 'string' ? URI.parse(n.summary.workingDirectory) : undefined;
+				const projectUri = resolveProjectUri(n.summary.project?.uri);
 				const item = this._makeItem(rawId, {
 					title: n.summary.title,
 					status: n.summary.status,
 					workingDirectory: workingDir,
+					project: projectUri,
 					createdAt: n.summary.createdAt,
 					modifiedAt: n.summary.modifiedAt,
 					diffs: n.summary.diffs,
@@ -181,11 +202,13 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 					createdAt: s.startTime,
 					modifiedAt: s.modifiedTime,
 					workingDirectory: s.workingDirectory?.toString(),
+					...(s.project ? { project: { uri: s.project.uri.toString(), displayName: s.project.displayName } } : {}),
 				});
 				return this._makeItem(rawId, {
 					title: s.summary,
 					status,
 					workingDirectory: s.workingDirectory,
+					project: s.project?.uri,
 					createdAt: s.startTime,
 					modifiedAt: s.modifiedTime,
 					diffs: s.diffs,
@@ -201,10 +224,12 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 
 	private _makeItemFromSummary(rawId: string, summary: SessionSummary, diffs: readonly ISessionFileDiff[] | undefined): IChatSessionItem {
 		const workingDir = typeof summary.workingDirectory === 'string' ? URI.parse(summary.workingDirectory) : summary.workingDirectory;
+		const projectUri = resolveProjectUri(summary.project?.uri);
 		return this._makeItem(rawId, {
 			title: summary.title,
 			status: summary.status,
 			workingDirectory: workingDir,
+			project: projectUri,
 			createdAt: summary.createdAt,
 			modifiedAt: summary.modifiedAt,
 			diffs,
@@ -215,6 +240,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		title?: string;
 		status?: SessionStatus;
 		workingDirectory?: URI;
+		project?: URI;
 		createdAt: number;
 		modifiedAt: number;
 		diffs?: readonly ISessionFileDiff[] | readonly ICompactSessionFileDiff[];
@@ -226,7 +252,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 			iconPath: getAgentHostIcon(this._productService),
 			status: mapSessionStatus(opts.status),
 			archived: opts.status !== undefined && (opts.status & SessionStatus.IsArchived) === SessionStatus.IsArchived,
-			metadata: this._buildMetadata(opts.workingDirectory),
+			metadata: this._buildMetadata(opts.workingDirectory, opts.project),
 			timing: {
 				created: opts.createdAt,
 				lastRequestStarted: opts.modifiedAt,
@@ -236,13 +262,22 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		};
 	}
 
-	private _buildMetadata(workingDirectory: URI | undefined): { readonly [key: string]: unknown } | undefined {
-		if (!this._description && !workingDirectory) {
+	private _buildMetadata(workingDirectory: URI | undefined, projectUri?: URI): { readonly [key: string]: unknown } | undefined {
+		if (!this._description && !workingDirectory && !projectUri) {
 			return undefined;
 		}
 		const result: { [key: string]: unknown } = {};
 		if (this._description) {
 			result.remoteAgentHost = this._description;
+		}
+		if (projectUri?.scheme === Schemas.file) {
+			result.repositoryPath = projectUri.fsPath;
+		} else if (projectUri?.scheme === AGENT_HOST_SCHEME) {
+			// Remote session: unwrap the vscode-agent-host:// wrapper to get
+			// the original remote file path. Using the repo root (not the
+			// worktree-specific working directory) ensures all worktrees from
+			// the same remote repository collapse into a single group.
+			result.repositoryPath = fromAgentHostUri(projectUri).fsPath;
 		}
 		if (workingDirectory) {
 			result.workingDirectoryPath = workingDirectory.fsPath;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -2810,6 +2810,61 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('list controller adds repositoryPath to metadata when project URI is provided', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const controller = disposables.add(instantiationService.createInstance(
+				AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			const repoRoot = URI.file('/home/user/my-repo');
+			const workingDirectory = URI.file('/home/user/my-repo-feature-branch');
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'sess-worktree'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Worktree session',
+				workingDirectory,
+				project: { uri: repoRoot, displayName: 'my-repo' },
+			});
+			await controller.refresh(CancellationToken.None);
+
+			assert.strictEqual(controller.items.length, 1);
+			assert.deepStrictEqual(controller.items[0].metadata, {
+				repositoryPath: repoRoot.fsPath,
+				workingDirectoryPath: workingDirectory.fsPath,
+			});
+		});
+
+		test('list controller adds repositoryPath from vscode-agent-host URI for remote sessions', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const server = 'my-remote-server';
+
+			const controller = disposables.add(instantiationService.createInstance(
+				AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, server));
+
+			// For remote sessions the project URI and working directory arrive already wrapped
+			// as vscode-agent-host:// URIs (done by remoteAgentHostProtocolClient._toLocalProjectUri).
+			const remoteRepoRoot = URI.from({ scheme: 'vscode-agent-host', authority: server, path: '/file/-/home/user/my-repo' });
+			const remoteWorkingDir = URI.from({ scheme: 'vscode-agent-host', authority: server, path: '/file/-/home/user/my-repo-feature-branch' });
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'sess-remote-worktree'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Remote worktree session',
+				workingDirectory: remoteWorkingDir,
+				project: { uri: remoteRepoRoot, displayName: 'my-repo' },
+			});
+			await controller.refresh(CancellationToken.None);
+
+			assert.strictEqual(controller.items.length, 1);
+			// repositoryPath should be the unwrapped remote path so that sessions
+			// from different worktrees of the same remote repo group together.
+			assert.deepStrictEqual(controller.items[0].metadata, {
+				repositoryPath: '/home/user/my-repo',
+				workingDirectoryPath: '/file/-/home/user/my-repo-feature-branch',
+			});
+		});
+
 		test('handler works with any IAgentConnection, not just IAgentHostService', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -2150,6 +2150,61 @@ suite('AgentHostChatContribution', () => {
 			});
 		});
 
+		test('list controller adds repositoryPath to metadata when project URI is provided', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+
+			const controller = disposables.add(instantiationService.createInstance(
+				AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
+
+			const repoRoot = URI.file('/home/user/my-repo');
+			const workingDirectory = URI.file('/home/user/my-repo-feature-branch');
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'sess-worktree'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Worktree session',
+				workingDirectory,
+				project: { uri: repoRoot, displayName: 'my-repo' },
+			});
+			await controller.refresh(CancellationToken.None);
+
+			assert.strictEqual(controller.items.length, 1);
+			assert.deepStrictEqual(controller.items[0].metadata, {
+				repositoryPath: repoRoot.fsPath,
+				workingDirectoryPath: workingDirectory.fsPath,
+			});
+		});
+
+		test('list controller adds repositoryPath from vscode-agent-host URI for remote sessions', async () => {
+			const { instantiationService, agentHostService } = createTestServices(disposables);
+			const server = 'my-remote-server';
+
+			const controller = disposables.add(instantiationService.createInstance(
+				AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, server));
+
+			// For remote sessions the project URI and working directory arrive already wrapped
+			// as vscode-agent-host:// URIs (done by remoteAgentHostProtocolClient._toLocalProjectUri).
+			const remoteRepoRoot = URI.from({ scheme: 'vscode-agent-host', authority: server, path: '/file/-/home/user/my-repo' });
+			const remoteWorkingDir = URI.from({ scheme: 'vscode-agent-host', authority: server, path: '/file/-/home/user/my-repo-feature-branch' });
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'sess-remote-worktree'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'Remote worktree session',
+				workingDirectory: remoteWorkingDir,
+				project: { uri: remoteRepoRoot, displayName: 'my-repo' },
+			});
+			await controller.refresh(CancellationToken.None);
+
+			assert.strictEqual(controller.items.length, 1);
+			// repositoryPath should be the unwrapped remote path so that sessions
+			// from different worktrees of the same remote repo group together.
+			assert.deepStrictEqual(controller.items[0].metadata, {
+				repositoryPath: '/home/user/my-repo',
+				workingDirectoryPath: '/file/-/home/user/my-repo-feature-branch',
+			});
+		});
+
 		test('handler works with any IAgentConnection, not just IAgentHostService', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { instantiationService, agentHostService, chatAgentService } = createTestServices(disposables);
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -826,6 +826,25 @@ suite('AgentSessionsDataSource', () => {
 			]);
 		});
 
+		test('groups sessions from user-created worktrees (arbitrary paths) using repositoryPath metadata', () => {
+			// Reproduces https://github.com/microsoft/vscode/issues/312729:
+			// Sessions from user-created worktrees at arbitrary paths should be grouped
+			// together when all their metadata includes the same repositoryPath.
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryPath: '/home/user/vscode', workingDirectoryPath: '/home/user/vscode' } }),
+				createMockSession({ id: '2', metadata: { repositoryPath: '/home/user/vscode', workingDirectoryPath: '/home/user/vscode-feature-1' } }),
+				createMockSession({ id: '3', metadata: { repositoryPath: '/home/user/vscode', workingDirectoryPath: '/home/user/vscode-feature-2' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(sortedGroups(result), [
+				{ label: 'vscode', count: 3 },
+			]);
+		});
+
 		test('groups sessions by badge with $(repo) prefix', () => {
 			const sessions = [
 				createMockSession({ id: '1', badge: '$(repo) vscode' }),


### PR DESCRIPTION
Fixes #312729

## Problem

Sessions from user-created git worktrees (at arbitrary paths) appeared as separate groups in the Agents Sessions list. Each worktree had a different `workingDirectoryPath` in session metadata, which the viewer used for grouping — so each worktree produced its own group even though they belong to the same repository.

## Fix

`_buildMetadata()` in `AgentHostSessionListController` now also emits `repositoryPath` from `project.uri` (the git repository root, resolved by the Copilot agent at session-creation time via `resolveGitProject()`).

The viewer's `getRepositoryName()` already checks `repositoryPath` before `workingDirectoryPath`, so sessions sharing the same repo root now collapse into a single group regardless of which worktree they ran in. No changes to the viewer were needed.

Both URI schemes are handled:
- **Local sessions**: `file://` project URI → `fsPath` used directly as `repositoryPath`
- **Remote sessions**: `vscode-agent-host://server/file/-/path` URI (as wrapped by `remoteAgentHostProtocolClient`) → unwrapped via `fromAgentHostUri()` to extract the remote path

## Tests

- `agentHostChatContribution.test.ts`: verifies `repositoryPath` is set from `project.uri` for local sessions, and that remote (`vscode-agent-host://`) project URIs are unwrapped correctly
- `agentSessionsDataSource.test.ts`: verifies that 3 sessions with the same `repositoryPath` but different `workingDirectoryPath` values are grouped into a single repository group