### PR TITLE
test: trivial README wording tweak to validate eval-assessment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository ("`Code - OSS`") is where we (Microsoft) develop the [Visual Stu
 
 [Visual Studio Code](https://code.visualstudio.com) is a distribution of the `Code - OSS` repository with Microsoft-specific customizations released under a traditional [Microsoft product license](https://code.visualstudio.com/License/).
 
-[Visual Studio Code](https://code.visualstudio.com) combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle. It provides comprehensive code editing, navigation, and understanding support along with lightweight debugging, a rich extensibility model, and lightweight integration with existing tools.
+[Visual Studio Code](https://code.visualstudio.com) combines the simplicity of a code editor with what developers need for their core edit, build, and debug cycle. It provides comprehensive code editing, navigation, and understanding support along with lightweight debugging, a rich extensibility model, and lightweight integration with existing tools.
 
 Visual Studio Code is updated monthly with new features and bug fixes. You can download it for Windows, macOS, and Linux on [Visual Studio Code's website](https://code.visualstudio.com/Download). To get the latest releases every day, install the [Insiders build](https://code.visualstudio.com/insiders).
 


### PR DESCRIPTION
Test PR for #312430 — validating the `~requires-eval-assessment` eval-assessment CI flow.

**Do not merge.**

Plan:
1. Verify happy path by applying `~requires-eval-assessment` to this PR and watching for the 5 progress comments.
2. Will use a separate PR for the failure-path test (step 13).
3. Will test benchmark override (`~requires-eval-assessment swebench`) on a follow-up.