### PR TITLE
Addressing false positives for ai co author

### DIFF
--- a/src/vs/workbench/contrib/editTelemetry/browser/helpers/documentWithAnnotatedEdits.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/helpers/documentWithAnnotatedEdits.ts
@@ -102,11 +102,21 @@ export abstract class EditSourceBase {
 				return this._cache.get(new ExternalEditSource());
 			case 'inlineCompletionPartialAccept':
 			case 'inlineCompletionAccept': {
+				// Only classify as AI when an extension actually provided the
+				// completion. Built-in providers such as SuggestInlineCompletions
+				// have no $extensionId and should not trigger AI
+				// attribution (e.g. the Co-authored-by trailer). Empty or
+				// whitespace-only $extensionId values are also treated as absent.
+				const rawExtensionId = '$extensionId' in data ? data.$extensionId : undefined;
+				const extensionId = typeof rawExtensionId === 'string' ? rawExtensionId.trim() : undefined;
+				if (!extensionId) {
+					return this._cache.get(new IdeEditSource('suggest'));
+				}
 				const type = 'type' in data ? data.type : undefined;
 				if ('$nes' in data && data.$nes) {
-					return this._cache.get(new InlineSuggestEditSource('nes', data.$extensionId ?? '', data.$providerId ?? '', type));
+					return this._cache.get(new InlineSuggestEditSource('nes', extensionId, data.$providerId ?? '', type));
 				}
-				return this._cache.get(new InlineSuggestEditSource('completion', data.$extensionId ?? '', data.$providerId ?? '', type));
+				return this._cache.get(new InlineSuggestEditSource('completion', extensionId, data.$providerId ?? '', type));
 			}
 			case 'snippet':
 				return this._cache.get(new IdeEditSource('suggest'));

--- a/src/vs/workbench/contrib/editTelemetry/test/browser/aiContributionFeature.test.ts
+++ b/src/vs/workbench/contrib/editTelemetry/test/browser/aiContributionFeature.test.ts
@@ -12,6 +12,7 @@ import { AnnotatedDocuments, UriVisibilityProvider } from '../../browser/helpers
 import { StringEditWithReason } from '../../browser/helpers/observableWorkspace.js';
 import { AiContributionFeature } from '../../browser/aiContributionFeature.js';
 import { EditSources } from '../../../../../editor/common/textModelEditSource.js';
+import { ProviderId } from '../../../../../editor/common/languages.js';
 import { DiffService } from '../../browser/helpers/documentWithAnnotatedEdits.js';
 import { computeStringDiff } from '../../../../../editor/common/services/editorWebWorker.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -42,10 +43,18 @@ suite('AiContributionFeature', () => {
 
 	const userEdit = EditSources.cursor({ kind: 'type' });
 
-	const inlineCompletionEdit = EditSources.inlineCompletionAccept({
+	const builtinInlineCompletionEdit = EditSources.inlineCompletionAccept({
 		nes: false,
 		requestUuid: 'test-uuid',
 		languageId: 'plaintext',
+		correlationId: undefined,
+	});
+
+	const aiInlineCompletionEdit = EditSources.inlineCompletionAccept({
+		nes: false,
+		requestUuid: 'test-uuid',
+		languageId: 'plaintext',
+		providerId: ProviderId.fromExtensionId('github.copilot'),
 		correlationId: undefined,
 	});
 
@@ -95,15 +104,28 @@ suite('AiContributionFeature', () => {
 		disposables.dispose();
 	}));
 
-	test('detects inline completion AI edits at all level only', () => runWithFakedTimers({}, async () => {
+	test('detects extension-backed inline completion AI edits at all level only', () => runWithFakedTimers({}, async () => {
 		setup();
 		const d = disposables.add(workspace.createDocument({ uri: fileA, initialValue: 'hello' }, undefined));
 		await timeout(1500);
 
-		d.applyEdit(StringEditWithReason.replace(d.findRange('hello'), 'world', inlineCompletionEdit));
+		d.applyEdit(StringEditWithReason.replace(d.findRange('hello'), 'world', aiInlineCompletionEdit));
 		await timeout(1500);
 
 		assert.strictEqual(hasAiContributions([d.uri], 'all'), true);
+		assert.strictEqual(hasAiContributions([d.uri], 'chatAndAgent'), false);
+		disposables.dispose();
+	}));
+
+	test('does not detect built-in inline completions (no extensionId) as AI', () => runWithFakedTimers({}, async () => {
+		setup();
+		const d = disposables.add(workspace.createDocument({ uri: fileA, initialValue: 'hello' }, undefined));
+		await timeout(1500);
+
+		d.applyEdit(StringEditWithReason.replace(d.findRange('hello'), 'world', builtinInlineCompletionEdit));
+		await timeout(1500);
+
+		assert.strictEqual(hasAiContributions([d.uri], 'all'), false);
 		assert.strictEqual(hasAiContributions([d.uri], 'chatAndAgent'), false);
 		disposables.dispose();
 	}));


### PR DESCRIPTION
**AI Attribution Logic Improvements:**

* Updated `EditSourceBase` to check for a non-empty, non-whitespace `extensionId` before classifying an inline completion as AI-generated. Built-in providers without an `extensionId` are now correctly attributed as non-AI edits.

**Test Enhancements:**

* Added a test to ensure that only extension-backed inline completions (with a valid `extensionId`) are detected as AI contributions.
* Added a test to confirm that built-in inline completions (with no `extensionId`) are not detected as AI contributions.
* Refactored test variables to distinguish between built-in and extension-backed inline completions for clarity.
* Imported `ProviderId` for use in test setup, supporting the new test cases.<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
