### PR TITLE
Remove anthropic.thinking.budgetTokens setting and hardcode budget to 16000

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3254,13 +3254,6 @@
 						"tags": [
 							"onExp"
 						]
-					},
-					"github.copilot.chat.anthropic.thinking.budgetTokens": {
-						"type": "number",
-						"markdownDescription": "%github.copilot.config.anthropic.thinking.budgetTokens%",
-						"minimum": 0,
-						"maximum": 32000,
-						"default": 16000
 					}
 				}
 			},

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -351,7 +351,6 @@
 	"github.copilot.config.updated53CodexPrompt.enabled": "Enables the updated prompt for gpt-5.3-codex model.",
 	"github.copilot.config.gpt54ConcisePrompt.enabled": "Enables the concise prompt experiment for gpt-5.4 model.",
 	"github.copilot.config.gpt54LargePrompt.enabled": "Enables the large prompt experiment for gpt-5.4 model.",
-	"github.copilot.config.anthropic.thinking.budgetTokens": "Maximum number of tokens to allocate for extended thinking in Anthropic models. Setting this value enables extended thinking. Valid range is `1,024` to `max_tokens-1`.",
 	"github.copilot.config.anthropic.tools.websearch.enabled": "Enable Anthropic's native web search tool for BYOK Claude models. When enabled, allows Claude to search the web for current information. \n\n**Note**: This is an experimental feature only available for BYOK Anthropic Claude models.",
 	"github.copilot.config.anthropic.tools.websearch.maxUses": "Maximum number of web searches allowed per request. Valid range is 1 to 20. Prevents excessive API calls within a single interaction. If Claude exceeds this limit, the response returns an error.",
 	"github.copilot.config.anthropic.tools.websearch.allowedDomains": "List of domains to restrict web search results to (e.g., `[\"example.com\", \"docs.example.com\"]`). Domains should not include the HTTP/HTTPS scheme. Subdomains are automatically included. Cannot be used together with blocked domains.",

--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -51,18 +51,12 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 	}
 
 	private _getThinkingBudget(modelId: string, maxOutputTokens: number): number | undefined {
-		const configuredBudget = this._configurationService.getConfig(ConfigKey.AnthropicThinkingBudget);
-		if (!configuredBudget || configuredBudget === 0) {
-			return undefined;
-		}
-
 		const modelCapabilities = this._knownModels?.[modelId];
 		const modelSupportsThinking = modelCapabilities?.thinking ?? false;
 		if (!modelSupportsThinking) {
 			return undefined;
 		}
-		const normalizedBudget = configuredBudget < 1024 ? 1024 : configuredBudget;
-		return Math.min(32000, maxOutputTokens - 1, normalizedBudget);
+		return Math.min(32000, maxOutputTokens - 1, 16000);
 	}
 
 	// Filters the byok known models based on what the anthropic API knows as well

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -929,8 +929,6 @@ export namespace ConfigKey {
 	/** Enable large prompt experiment for GPT-5.4 model */
 	export const EnableGpt54LargePromptExp = defineSetting<boolean>('chat.gpt54LargePrompt.enabled', ConfigType.ExperimentBased, false);
 	export const EnableChatImageUpload = defineSetting<boolean>('chat.imageUpload.enabled', ConfigType.ExperimentBased, true);
-	/** Thinking token budget for Anthropic extended thinking. If set, enables extended thinking. */
-	export const AnthropicThinkingBudget = defineSetting<number>('chat.anthropic.thinking.budgetTokens', ConfigType.Simple, 16000);
 	/** Enable Anthropic web search tool for BYOK Claude models */
 	export const AnthropicWebSearchToolEnabled = defineSetting<boolean>('chat.anthropic.tools.websearch.enabled', ConfigType.ExperimentBased, false);
 	/** Maximum number of web searches allowed per request */

--- a/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/messagesApi.ts
@@ -137,20 +137,15 @@ export function createMessagesRequestBody(accessor: ServicesAccessor, options: I
 	const reasoningEffort = options.modelCapabilities?.reasoningEffort;
 	let thinkingConfig: { type: 'enabled' | 'adaptive'; budget_tokens?: number; display?: 'summarized' } | undefined;
 	if (options.modelCapabilities?.enableThinking) {
-		const configuredBudget = configurationService.getConfig(ConfigKey.AnthropicThinkingBudget);
-		const thinkingExplicitlyDisabled = configuredBudget === 0;
-		if (endpoint.supportsAdaptiveThinking && !thinkingExplicitlyDisabled) {
+		const hardcodedBudget = 16000;
+		if (endpoint.supportsAdaptiveThinking) {
 			thinkingConfig = { type: 'adaptive', display: 'summarized' };
-		} else if (!thinkingExplicitlyDisabled && endpoint.maxThinkingBudget && endpoint.minThinkingBudget) {
+		} else if (endpoint.maxThinkingBudget && endpoint.minThinkingBudget) {
 			const maxTokens = options.postOptions.max_tokens ?? 1024;
 			const minBudget = endpoint.minThinkingBudget ?? 1024;
-			const normalizedBudget = (configuredBudget && configuredBudget > 0)
-				? (configuredBudget < minBudget ? minBudget : configuredBudget)
-				: undefined;
+			const normalizedBudget = hardcodedBudget < minBudget ? minBudget : hardcodedBudget;
 			const maxBudget = endpoint.maxThinkingBudget ?? 32000;
-			const thinkingBudget = normalizedBudget
-				? Math.min(maxBudget, maxTokens - 1, normalizedBudget)
-				: undefined;
+			const thinkingBudget = Math.min(maxBudget, maxTokens - 1, normalizedBudget);
 			if (thinkingBudget) {
 				thinkingConfig = { type: 'enabled', budget_tokens: thinkingBudget };
 			}

--- a/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/messagesApi.spec.ts
@@ -9,8 +9,6 @@ import { beforeEach, describe, expect, suite, test } from 'vitest';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatLocation } from '../../../chat/common/commonTypes';
-import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
-import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
 import { AnthropicMessagesTool, CUSTOM_TOOL_SEARCH_NAME } from '../../../networking/common/anthropic';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
@@ -995,7 +993,6 @@ suite('addLastTwoMessagesCacheControl', function () {
 describe('createMessagesRequestBody reasoning effort', () => {
 	let disposables: DisposableStore;
 	let instantiationService: IInstantiationService;
-	let mockConfig: InMemoryConfigurationService;
 
 	function createMockEndpoint(overrides: Partial<IChatEndpoint> = {}): IChatEndpoint {
 		return {
@@ -1050,7 +1047,6 @@ describe('createMessagesRequestBody reasoning effort', () => {
 		});
 		const accessor = services.createTestingAccessor();
 		instantiationService = accessor.get(IInstantiationService);
-		mockConfig = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 	});
 
 	test('includes effort in output_config when model supports reasoning effort and thinking is adaptive', () => {
@@ -1135,7 +1131,6 @@ describe('createMessagesRequestBody reasoning effort', () => {
 			minThinkingBudget: 1024,
 			supportsReasoningEffort: ['low', 'medium', 'high'],
 		});
-		mockConfig.setConfig(ConfigKey.AnthropicThinkingBudget, 10000);
 		const options = createMinimalOptions({
 			modelCapabilities: { enableThinking: true, reasoningEffort: 'low' },
 		});


### PR DESCRIPTION
## Summary

Remove the user-configurable setting `github.copilot.chat.anthropic.thinking.budgetTokens` and hardcode the thinking budget to `16000` (the previous default value).

## Changes

- **configurationService.ts** — removed `AnthropicThinkingBudget` setting definition
- **package.json** — removed the configuration property
- **package.nls.json** — removed the localization string
- **messagesApi.ts** — replaced config lookup with hardcoded `16000`, removed "explicitly disabled" code path
- **anthropicProvider.ts** — replaced config lookup with hardcoded `16000`, simplified `_getThinkingBudget()`
- **messagesApi.spec.ts** — removed `mockConfig.setConfig` call and cleaned up unused imports/variables