### PR TITLE
Fix terminal hang when process exits without shell integration sequences

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -90,6 +90,10 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 					this._log('onDone via terminal disposal');
 					return { type: 'disposal' } as const;
 				}),
+				Event.toPromise(this._instance.onExit, store).then((exitCodeOrError) => {
+					this._log(`onDone via process exit (code=${exitCodeOrError})`);
+					return { type: 'processExit', exitCodeOrError } as const;
+				}),
 				// A longer idle prompt event is used here as a catch all for unexpected cases where
 				// the end event doesn't fire for some reason.
 				trackIdleOnPrompt(this._instance, idlePollInterval * 3, store, idlePollInterval).then(() => {
@@ -160,9 +164,12 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 				this._log(`No finished command surfaced for requested=${commandId}`);
 			}
 
-			// Wait for the terminal to idle
-			this._log('Waiting for idle');
-			await waitForIdle(this._instance.onData, idlePollInterval);
+			// Wait for the terminal to idle, but skip if the process already exited
+			// since no more data will arrive.
+			if (!(onDoneResult && onDoneResult.type === 'processExit')) {
+				this._log('Waiting for idle');
+				await waitForIdle(this._instance.onData, idlePollInterval);
+			}
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
 			}
@@ -198,7 +205,11 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 				additionalInformationLines.push('Command produced no output');
 			}
 
-			const exitCode = finishedCommand?.exitCode;
+			// Determine exit code from shell integration or from the process exit event
+			let exitCode = finishedCommand?.exitCode;
+			if (exitCode === undefined && onDoneResult && onDoneResult.type === 'processExit') {
+				exitCode = isNumber(onDoneResult.exitCodeOrError) ? onDoneResult.exitCodeOrError : undefined;
+			}
 			if (isNumber(exitCode) && exitCode > 0) {
 				additionalInformationLines.push(`Command exited with code ${exitCode}`);
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -10,7 +10,7 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../../.
 import { isNumber } from '../../../../../../base/common/types.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
-import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
+import { ITerminalLogService, type ITerminalLaunchError } from '../../../../../../platform/terminal/common/terminal.js';
 import { trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
@@ -18,6 +18,27 @@ import { createAltBufferPromise, setupRecreatingStartMarker, stripCommandEchoAnd
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { isMacintosh } from '../../../../../../base/common/platform.js';
 import { isMultilineCommand } from '../runInTerminalHelpers.js';
+
+function isTerminalLaunchError(value: unknown): value is ITerminalLaunchError {
+	return typeof value === 'object' && value !== null && 'message' in value;
+}
+
+function formatExitCodeOrError(exitCodeOrError: number | ITerminalLaunchError | undefined): string {
+	if (isTerminalLaunchError(exitCodeOrError)) {
+		return `launch error: ${exitCodeOrError.message}${exitCodeOrError.code !== undefined ? `, code=${exitCodeOrError.code}` : ''}`;
+	}
+	return `code=${exitCodeOrError}`;
+}
+
+function extractExitCode(exitCodeOrError: number | ITerminalLaunchError | undefined): number | undefined {
+	if (isNumber(exitCodeOrError)) {
+		return exitCodeOrError;
+	}
+	if (isTerminalLaunchError(exitCodeOrError)) {
+		return exitCodeOrError.code;
+	}
+	return undefined;
+}
 
 /**
  * This strategy is used when shell integration is enabled, but rich command detection was not
@@ -91,7 +112,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 					return { type: 'disposal' } as const;
 				}),
 				Event.toPromise(this._instance.onExit, store).then((exitCodeOrError) => {
-					this._log(`onDone via process exit (code=${exitCodeOrError})`);
+					this._log(`onDone via process exit (${formatExitCodeOrError(exitCodeOrError)})`);
 					return { type: 'processExit', exitCodeOrError } as const;
 				}),
 				// A longer idle prompt event is used here as a catch all for unexpected cases where
@@ -208,7 +229,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			// Determine exit code from shell integration or from the process exit event
 			let exitCode = finishedCommand?.exitCode;
 			if (exitCode === undefined && onDoneResult && onDoneResult.type === 'processExit') {
-				exitCode = isNumber(onDoneResult.exitCodeOrError) ? onDoneResult.exitCodeOrError : undefined;
+				exitCode = extractExitCode(onDoneResult.exitCodeOrError);
 			}
 			if (isNumber(exitCode) && exitCode > 0) {
 				additionalInformationLines.push(`Command exited with code ${exitCode}`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -75,6 +75,10 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 					this._log('onDone via terminal disposal');
 					return { type: 'disposal' } as const;
 				}),
+				Event.toPromise(this._instance.onExit, store).then((exitCodeOrError) => {
+					this._log(`onDone via process exit (code=${exitCodeOrError})`);
+					return { type: 'processExit', exitCodeOrError } as const;
+				}),
 				trackIdleOnPrompt(this._instance, idlePollInterval, store, idlePollInterval).then(() => {
 					this._log('onDone via idle prompt');
 				}),
@@ -150,7 +154,11 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 				additionalInformationLines.push('Command produced no output');
 			}
 
-			const exitCode = finishedCommand?.exitCode;
+			// Determine exit code from shell integration or from the process exit event
+			let exitCode = finishedCommand?.exitCode;
+			if (exitCode === undefined && onDoneResult && onDoneResult.type === 'processExit') {
+				exitCode = isNumber(onDoneResult.exitCodeOrError) ? onDoneResult.exitCodeOrError : undefined;
+			}
 			if (isNumber(exitCode) && exitCode > 0) {
 				additionalInformationLines.push(`Command exited with code ${exitCode}`);
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -11,13 +11,34 @@ import { isNumber } from '../../../../../../base/common/types.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { isCI, isMacintosh } from '../../../../../../base/common/platform.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
-import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
+import { ITerminalLogService, type ITerminalLaunchError } from '../../../../../../platform/terminal/common/terminal.js';
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { createAltBufferPromise, setupRecreatingStartMarker, stripCommandEchoAndPrompt } from './strategyHelpers.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
 import { isMultilineCommand } from '../runInTerminalHelpers.js';
+
+function isTerminalLaunchError(value: unknown): value is ITerminalLaunchError {
+	return typeof value === 'object' && value !== null && 'message' in value;
+}
+
+function formatExitCodeOrError(exitCodeOrError: number | ITerminalLaunchError | undefined): string {
+	if (isTerminalLaunchError(exitCodeOrError)) {
+		return `launch error: ${exitCodeOrError.message}${exitCodeOrError.code !== undefined ? `, code=${exitCodeOrError.code}` : ''}`;
+	}
+	return `code=${exitCodeOrError}`;
+}
+
+function extractExitCode(exitCodeOrError: number | ITerminalLaunchError | undefined): number | undefined {
+	if (isNumber(exitCodeOrError)) {
+		return exitCodeOrError;
+	}
+	if (isTerminalLaunchError(exitCodeOrError)) {
+		return exitCodeOrError.code;
+	}
+	return undefined;
+}
 
 /**
  * This strategy is used when the terminal has rich shell integration/command detection is
@@ -76,7 +97,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 					return { type: 'disposal' } as const;
 				}),
 				Event.toPromise(this._instance.onExit, store).then((exitCodeOrError) => {
-					this._log(`onDone via process exit (code=${exitCodeOrError})`);
+					this._log(`onDone via process exit (${formatExitCodeOrError(exitCodeOrError)})`);
 					return { type: 'processExit', exitCodeOrError } as const;
 				}),
 				trackIdleOnPrompt(this._instance, idlePollInterval, store, idlePollInterval).then(() => {
@@ -157,7 +178,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			// Determine exit code from shell integration or from the process exit event
 			let exitCode = finishedCommand?.exitCode;
 			if (exitCode === undefined && onDoneResult && onDoneResult.type === 'processExit') {
-				exitCode = isNumber(onDoneResult.exitCodeOrError) ? onDoneResult.exitCodeOrError : undefined;
+				exitCode = extractExitCode(onDoneResult.exitCodeOrError);
 			}
 			if (isNumber(exitCode) && exitCode > 0) {
 				additionalInformationLines.push(`Command exited with code ${exitCode}`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/basicExecuteStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/basicExecuteStrategy.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import type { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
+import { BasicExecuteStrategy } from '../../browser/executeStrategy/basicExecuteStrategy.js';
+import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
+
+function createLogService(): ITerminalLogService {
+	return new class extends NullLogService { readonly _logBrand = undefined; };
+}
+
+suite('BasicExecuteStrategy', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('completes when terminal process exits without shell integration sequences', async () => {
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const onExitEmitter = new Emitter<number | undefined>();
+
+		const marker = {
+			line: 0,
+			dispose: () => { },
+			onDispose: Event.None,
+		};
+		const xterm = {
+			raw: {
+				registerMarker: () => marker,
+				buffer: {
+					active: {},
+					alternate: {},
+					onBufferChange: () => toDisposable(() => { }),
+				},
+				getContentsAsText: () => 'some output',
+			}
+		};
+		const instance = {
+			xtermReadyPromise: Promise.resolve(xterm),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: onExitEmitter.event,
+			sendText: () => {
+				// Simulate process exiting without firing onCommandFinished
+				queueMicrotask(() => onExitEmitter.fire(1));
+			},
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new BasicExecuteStrategy(
+			instance,
+			() => false,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		const result = await strategy.execute('exit 1', CancellationToken.None);
+
+		strictEqual(result.exitCode, 1);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
@@ -48,6 +48,7 @@ suite('RichExecuteStrategy', () => {
 			xtermReadyPromise: Promise.resolve(xterm),
 			onData: Event.None,
 			onDisposed: Event.None,
+			onExit: Event.None,
 			runCommand: (commandLine: string, _shouldExecute: boolean, commandId?: string, _forceBracketedPasteMode?: boolean, commandLineForMetadata?: string) => {
 				actualCommandLine = commandLine;
 				actualCommandId = commandId;
@@ -70,5 +71,50 @@ suite('RichExecuteStrategy', () => {
 		strictEqual(actualCommandLine, 'sandbox:echo hello');
 		strictEqual(actualCommandId, 'tool-command-id');
 		strictEqual(actualCommandLineForMetadata, 'echo hello');
+	});
+
+	test('completes when terminal process exits without shell integration sequences', async () => {
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const onExitEmitter = new Emitter<number | undefined>();
+
+		const marker = {
+			line: 0,
+			dispose: () => { },
+			onDispose: Event.None,
+		};
+		const xterm = {
+			raw: {
+				registerMarker: () => marker,
+				buffer: {
+					active: {},
+					alternate: {},
+					onBufferChange: () => toDisposable(() => { }),
+				},
+				getContentsAsText: () => 'some output',
+			}
+		};
+		const instance = {
+			xtermReadyPromise: Promise.resolve(xterm),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: onExitEmitter.event,
+			runCommand: () => {
+				// Simulate process exiting without firing onCommandFinished
+				queueMicrotask(() => onExitEmitter.fire(1));
+			},
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new RichExecuteStrategy(
+			instance,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		const result = await strategy.execute('exit 1', CancellationToken.None);
+
+		strictEqual(result.exitCode, 1);
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
@@ -117,4 +117,48 @@ suite('RichExecuteStrategy', () => {
 
 		strictEqual(result.exitCode, 1);
 	});
+
+	test('handles ITerminalLaunchError on process exit', async () => {
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const onExitEmitter = new Emitter<number | { message: string; code?: number } | undefined>();
+
+		const marker = {
+			line: 0,
+			dispose: () => { },
+			onDispose: Event.None,
+		};
+		const xterm = {
+			raw: {
+				registerMarker: () => marker,
+				buffer: {
+					active: {},
+					alternate: {},
+					onBufferChange: () => toDisposable(() => { }),
+				},
+				getContentsAsText: () => '',
+			}
+		};
+		const instance = {
+			xtermReadyPromise: Promise.resolve(xterm),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: onExitEmitter.event,
+			runCommand: () => {
+				queueMicrotask(() => onExitEmitter.fire({ message: 'Failed to launch', code: 127 }));
+			},
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new RichExecuteStrategy(
+			instance,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		const result = await strategy.execute('bad-command', CancellationToken.None);
+
+		strictEqual(result.exitCode, 127);
+	});
 });


### PR DESCRIPTION
## Problem

When a terminal process exits without emitting shell integration prompt sequences, `trackIdleOnPrompt` blocks forever because the `Executing` state cancels both schedulers and no more data arrives to reschedule them. This causes `run_in_terminal` to never complete, eventually timing out after 1 hour.

### Evidence from eval run `24890545491` (VS Code, terminalbench, gpt-5.4)

Analysis of the VS Code logs (`vsc-output/productLogs/terminal.log`) found **21 tasks with terminal hangs** — commands that started with the `rich` execute strategy but never completed (no corresponding `Finished` log line). Of these, **7 timed out entirely** (`X_AGENT_STILL_RESPONDING`), and 14 others lost significant time before recovering or failing for other reasons.

Tasks with terminal hangs that timed out:

| Task | Rich cmds | Finished | Hung | Shell integration failed |
|------|-----------|----------|------|--------------------------|
| cobol-modernization | 13 | 12 | 1 | yes |
| crack-7z-hash | 42 | 41 | 1 | yes |
| csv-to-parquet | 1 | 0 | 1 | yes |
| make-doom-for-mips | 2 | 1 | 1 | yes |
| neuron-to-jaxley-conversion | 6 | 5 | 1 | yes |
| reshard-c4-data | 3 | 2 | 1 | yes |
| build-initramfs-qemu | 3 | 2 | 1 | yes |

Tasks with terminal hangs that partially recovered:

| Task | Rich cmds | Finished | Hung | Shell integration failed |
|------|-----------|----------|------|--------------------------|
| git-multibranch | 19 | 15 | 4 | yes |
| make-mips-interpreter | 40 | 35 | 5 | yes |
| play-zork | 63 | 61 | 2 | yes |
| polyglot-rust-c | 27 | 24 | 3 | yes |
| solana-data | 21 | 19 | 2 | yes |
| build-tcc-qemu | 37 | 34 | 3 | yes |
| qemu-alpine-ssh | 12 | 10 | 2 | yes |
| hf-model-inference | 5 | 3 | 2 | yes |
| blind-maze-explorer-5x5 | 1 | 0 | 1 | yes |
| intrusion-detection | 10 | 9 | 1 | no |
| kv-store-grpc | 4 | 3 | 1 | no |
| mlflow-register | 9 | 8 | 1 | yes |
| run-pdp11-code | 20 | 19 | 1 | no |
| stable-parallel-kmeans | 6 | 5 | 1 | yes |

All show the same pattern: `Using 'rich' execute strategy` logged with **no subsequent `Finished` line** for the hung command.

### Also confirmed in eval run `24966302375` (terminalbench2)

A newer eval run showed all **19 out of 19 timeouts** caused by the same terminal hang pattern. **15 of those 19 tasks passed in the CLI** (run `22941092844`) with the same model. See #312853 for details.

## Fix

Add `onExit` to the `Promise.race` in both `richExecuteStrategy` and `basicExecuteStrategy`. When the process exits, the strategy resolves immediately with the available output and exit code instead of hanging indefinitely.

Also:
- Skip the post-race `waitForIdle` in basic strategy when the process already exited
- Fall back to the process exit code when shell integration did not provide one
- Handle `ITerminalLaunchError` properly in exit code extraction and logging

## Test

Added tests for both strategies:
- `completes when terminal process exits without shell integration sequences` — simulates process exit without `onCommandFinished`, verifying the strategy completes with the correct exit code
- `handles ITerminalLaunchError on process exit` — verifies `ITerminalLaunchError` objects are properly handled

## Limitations

This fix handles the **process exit** case. For long-running commands where the process stays alive but shell integration breaks, `onExit` won't fire until the process finishes. A complementary fix to downgrade from `rich` to `basic` strategy mid-flight is tracked in #312853.