### PR TITLE
Allow write to /tmp when allow all commands in session

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
@@ -46,6 +46,8 @@ export interface ICommandLineAnalyzerOptions {
 	terminalToolSessionId: string;
 	chatSessionResource: URI | undefined;
 	requiresUnsandboxConfirmation?: boolean;
+	// User has opted into "Allow All Commands in this Session"
+	hasSessionAutoApproval?: boolean;
 }
 
 export interface ICommandLineAnalyzerResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -157,6 +157,11 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								(fileUri.path.startsWith(folder.uri.path + '/') || fileUri.path === folder.uri.path)
 							);
 							if (!isInsideWorkspace) {
+								// Allow /tmp/ writes when the user has opted into "Allow All
+								// Commands in this Session" via the confirmation.
+								if (options.hasSessionAutoApproval && fileUri.path.startsWith('/tmp/')) {
+									continue;
+								}
 								isAutoApproveAllowed = false;
 								this._log('File write blocked outside workspace', fileUri.toString());
 								break;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -201,14 +201,17 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 
 	/**
 	 * Returns true if the given URI path points inside an OS temporary directory.
-	 * On posix systems this matches `/tmp/`. On Windows this matches the typical
+	 * On posix systems this matches `/tmp/`. On Windows this matches any `temp`
+	 * or `tmp` directory segment (case-insensitive), which covers the canonical
 	 * user temp (`...\AppData\Local\Temp\`), system temp (`C:\Windows\Temp\`),
-	 * and a top-level `\tmp\`
+	 * and common dev conventions like `C:\Temp\` and `C:\tmp\`.
 	 */
 	private _isInTempDirectory(uriPath: string, os: OperatingSystem | undefined): boolean {
 		if (os === OperatingSystem.Windows) {
-			// URI.file('C:\\Users\\foo\\AppData\\Local\\Temp\\x') -> path '/C:/Users/foo/AppData/Local/Temp/x'
-			return /(?:^|\/)(?:AppData\/Local\/Temp|Windows\/Temp|tmp)\//i.test(uriPath);
+			// Windows paths from URI.with({path}) keep their original backslashes,
+			// so accept either separator. Require content after the segment so the
+			// directory itself is not matched.
+			return /[\\/]te?mp[\\/].+/i.test(uriPath);
 		}
 		return uriPath.startsWith('/tmp/');
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -157,9 +157,9 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								(fileUri.path.startsWith(folder.uri.path + '/') || fileUri.path === folder.uri.path)
 							);
 							if (!isInsideWorkspace) {
-								// Allow /tmp/ writes when the user has opted into "Allow All
-								// Commands in this Session" via the confirmation.
-								if (options.hasSessionAutoApproval && fileUri.path.startsWith('/tmp/')) {
+								// Allow writes to OS temp locations when the user has opted into
+								// "Allow All Commands in this Session" via the confirmation.
+								if (options.hasSessionAutoApproval && this._isInTempDirectory(fileUri.path, options.os)) {
 									continue;
 								}
 								isAutoApproveAllowed = false;
@@ -197,5 +197,19 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 			isAutoApproveAllowed,
 			disclaimers,
 		};
+	}
+
+	/**
+	 * Returns true if the given URI path points inside an OS temporary directory.
+	 * On posix systems this matches `/tmp/`. On Windows this matches the typical
+	 * user temp (`...\AppData\Local\Temp\`), system temp (`C:\Windows\Temp\`),
+	 * and a top-level `\tmp\`
+	 */
+	private _isInTempDirectory(uriPath: string, os: OperatingSystem | undefined): boolean {
+		if (os === OperatingSystem.Windows) {
+			// URI.file('C:\\Users\\foo\\AppData\\Local\\Temp\\x') -> path '/C:/Users/foo/AppData/Local/Temp/x'
+			return /(?:^|\/)(?:AppData\/Local\/Temp|Windows\/Temp|tmp)\//i.test(uriPath);
+		}
+		return uriPath.startsWith('/tmp/');
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -753,6 +753,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			terminalToolSessionId,
 			chatSessionResource,
 			requiresUnsandboxConfirmation,
+			hasSessionAutoApproval: !!chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(chatSessionResource),
 		};
 
 		// In Autopilot/Bypass Approvals modes, do not interact with terminal auto-approve rules.

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -373,6 +373,9 @@ suite('CommandLineFileWriteAnalyzer', () => {
 				test('\\tmp - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\tmp\\file.txt', 'outsideWorkspace', true, true));
 				test('\\tmp - block when auto-approval disabled', () => tWithAutoApproval('Write-Host "hello" > C:\\tmp\\file.txt', 'outsideWorkspace', false, false));
 
+				// Top-level \Temp\ (common dev convention) - allow only when auto-approval is enabled
+				test('\\Temp - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Temp\\file.txt', 'outsideWorkspace', true, true));
+
 				// Case-insensitive matching (Windows paths are case-insensitive)
 				test('user TEMP lowercase - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\users\\foo\\appdata\\local\\temp\\file.txt', 'outsideWorkspace', true, true));
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -335,6 +335,61 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('single-quoted absolute path outside workspace - block', () => t('Write-Host \'hello\' > \'C:\\temp\\file.txt\'', 'outsideWorkspace', false, 1));
 			test('single-quoted absolute path to different drive - block', () => t('Write-Host \'hello\' > \'D:\\data\\file.txt\'', 'outsideWorkspace', false, 1));
 		});
+
+		suite('hasSessionAutoApproval', () => {
+			async function tWithAutoApproval(commandLine: string, blockDetectedFileWrites: 'never' | 'outsideWorkspace' | 'all', hasSessionAutoApproval: boolean, expectedAutoApprove: boolean, expectedDisclaimers: number = 1) {
+				configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.BlockDetectedFileWrites, blockDetectedFileWrites);
+
+				const workspace = new Workspace('test', [toWorkspaceFolder(cwd)]);
+				workspaceContextService.setWorkspace(workspace);
+
+				const options: ICommandLineAnalyzerOptions = {
+					commandLine,
+					cwd,
+					shell: 'pwsh',
+					os: OperatingSystem.Windows,
+					treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+					terminalToolSessionId: 'test',
+					chatSessionResource: undefined,
+					hasSessionAutoApproval,
+				};
+
+				const result = await analyzer.analyze(options);
+				strictEqual(result.isAutoApproveAllowed, expectedAutoApprove, `Expected auto approve to be ${expectedAutoApprove} for: ${commandLine}`);
+				strictEqual((result.disclaimers || []).length, expectedDisclaimers, `Expected ${expectedDisclaimers} disclaimers for: ${commandLine}`);
+			}
+
+			suite('blockDetectedFileWrites: outsideWorkspace', () => {
+				// User TEMP (AppData\Local\Temp) - allow only when auto-approval is enabled
+				test('user TEMP - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Users\\foo\\AppData\\Local\\Temp\\file.txt', 'outsideWorkspace', true, true));
+				test('user TEMP subdirectory - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Users\\foo\\AppData\\Local\\Temp\\sub\\file.txt', 'outsideWorkspace', true, true));
+				test('user TEMP - block when auto-approval disabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Users\\foo\\AppData\\Local\\Temp\\file.txt', 'outsideWorkspace', false, false));
+
+				// System Windows\Temp - allow only when auto-approval is enabled
+				test('Windows\\Temp - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Windows\\Temp\\file.txt', 'outsideWorkspace', true, true));
+				test('Windows\\Temp - block when auto-approval disabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Windows\\Temp\\file.txt', 'outsideWorkspace', false, false));
+
+				// Top-level \tmp\ - allow only when auto-approval is enabled
+				test('\\tmp - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\tmp\\file.txt', 'outsideWorkspace', true, true));
+				test('\\tmp - block when auto-approval disabled', () => tWithAutoApproval('Write-Host "hello" > C:\\tmp\\file.txt', 'outsideWorkspace', false, false));
+
+				// Case-insensitive matching (Windows paths are case-insensitive)
+				test('user TEMP lowercase - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\users\\foo\\appdata\\local\\temp\\file.txt', 'outsideWorkspace', true, true));
+
+				// Other outside-workspace paths remain blocked even with auto-approval enabled
+				test('C:\\Windows\\System32 - block even when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Windows\\System32\\config.txt', 'outsideWorkspace', true, false));
+				test('different drive - block even when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > D:\\data\\file.txt', 'outsideWorkspace', true, false));
+
+				// Mixed writes: TEMP allowed, but other outside paths still block
+				test('mixed TEMP and System32 - block even when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Users\\foo\\AppData\\Local\\Temp\\a.txt ; Write-Host "world" > C:\\Windows\\System32\\b.txt', 'outsideWorkspace', true, false));
+				test('mixed inside-workspace and TEMP - allow when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > file.txt ; Write-Host "world" > C:\\Users\\foo\\AppData\\Local\\Temp\\b.txt', 'outsideWorkspace', true, true));
+			});
+
+			suite('blockDetectedFileWrites: all', () => {
+				// `all` setting still blocks TEMP writes regardless of session auto-approval
+				test('user TEMP - block when auto-approval enabled', () => tWithAutoApproval('Write-Host "hello" > C:\\Users\\foo\\AppData\\Local\\Temp\\file.txt', 'all', true, false));
+			});
+		});
 	});
 
 	suite('disclaimer messages', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -127,6 +127,51 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('multiple inside workspace - block', () => t('echo hello > file1.txt && echo world > file2.txt', 'all', false, 1));
 		});
 
+		suite('hasSessionAutoApproval', () => {
+			async function tWithAutoApproval(commandLine: string, blockDetectedFileWrites: 'never' | 'outsideWorkspace' | 'all', hasSessionAutoApproval: boolean, expectedAutoApprove: boolean, expectedDisclaimers: number = 1) {
+				configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.BlockDetectedFileWrites, blockDetectedFileWrites);
+
+				const workspace = new Workspace('test', [toWorkspaceFolder(cwd)]);
+				workspaceContextService.setWorkspace(workspace);
+
+				const options: ICommandLineAnalyzerOptions = {
+					commandLine,
+					cwd,
+					shell: 'bash',
+					os: OperatingSystem.Linux,
+					treeSitterLanguage: TreeSitterCommandParserLanguage.Bash,
+					terminalToolSessionId: 'test',
+					chatSessionResource: undefined,
+					hasSessionAutoApproval,
+				};
+
+				const result = await analyzer.analyze(options);
+				strictEqual(result.isAutoApproveAllowed, expectedAutoApprove, `Expected auto approve to be ${expectedAutoApprove} for: ${commandLine}`);
+				strictEqual((result.disclaimers || []).length, expectedDisclaimers, `Expected ${expectedDisclaimers} disclaimers for: ${commandLine}`);
+			}
+
+			suite('blockDetectedFileWrites: outsideWorkspace', () => {
+				// /tmp writes are allowed only when session auto-approval is enabled
+				test('/tmp - allow when auto-approval enabled', () => tWithAutoApproval('echo hello > /tmp/file.txt', 'outsideWorkspace', true, true));
+				test('/tmp subdirectory - allow when auto-approval enabled', () => tWithAutoApproval('echo hello > /tmp/sub/file.txt', 'outsideWorkspace', true, true));
+				test('/tmp - block when auto-approval disabled', () => tWithAutoApproval('echo hello > /tmp/file.txt', 'outsideWorkspace', false, false));
+
+				// Other outside-workspace paths remain blocked even with auto-approval enabled
+				test('/etc - block even when auto-approval enabled', () => tWithAutoApproval('echo hello > /etc/config.txt', 'outsideWorkspace', true, false));
+				test('/home - block even when auto-approval enabled', () => tWithAutoApproval('echo hello > /home/user/file.txt', 'outsideWorkspace', true, false));
+				test('root - block even when auto-approval enabled', () => tWithAutoApproval('echo hello > /file.txt', 'outsideWorkspace', true, false));
+
+				// Mixed writes: /tmp allowed, but other outside paths still block
+				test('mixed /tmp and /etc - block even when auto-approval enabled', () => tWithAutoApproval('echo hello > /tmp/a.txt && echo world > /etc/b.txt', 'outsideWorkspace', true, false));
+				test('mixed inside-workspace and /tmp - allow when auto-approval enabled', () => tWithAutoApproval('echo hello > file.txt && echo world > /tmp/b.txt', 'outsideWorkspace', true, true));
+			});
+
+			suite('blockDetectedFileWrites: all', () => {
+				// `all` setting still blocks /tmp writes regardless of session auto-approval
+				test('/tmp - block when auto-approval enabled', () => tWithAutoApproval('echo hello > /tmp/file.txt', 'all', true, false));
+			});
+		});
+
 		suite('complex scenarios', () => {
 			test('pipeline with redirection inside workspace', () => t('cat file.txt | grep "test" > output.txt', 'outsideWorkspace', true, 1));
 			test('multiple redirections mixed inside/outside', () => t('echo hello > file.txt && echo world > /tmp/file.txt', 'outsideWorkspace', false, 1));


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/312671
I think these CLIs write to unix-first workflows, so this should be sufficient for windows as well.


after(approving write to /tmp once user clicks 'allow all commands for this session) :
Mac:
https://github.com/user-attachments/assets/6713794a-c3f7-4a88-acf2-68c2d1693ffb


windows: 

<img width="370" height="550" alt="allowTempForWindows" src="https://github.com/user-attachments/assets/8c6b889e-ddb5-4a56-8297-d4a0be36ccee" />



/cc @meganrogge 