### PR TITLE
feat(chat): add isExpectedError flag to suppress expected agent errors from telemetry

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -357,9 +357,16 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 						chatSessionContext,
 					}, token);
 
-					// Suppress expected operational errors (rate limiting, quota exceeded) from error telemetry
-					// to avoid noise in error reporting. See https://github.com/microsoft/vscode/issues/311582
-					if (rpcResult?.errorCallstack && !rpcResult.errorDetails?.isRateLimited && !rpcResult.errorDetails?.isQuotaExceeded) {
+					// Suppress expected operational errors (rate limiting, quota exceeded, and other
+					// user-actionable conditions flagged via `isExpectedError`) from error telemetry
+					// to avoid noise in error reporting.
+					// See https://github.com/microsoft/vscode/issues/311582 (rate-limited precedent),
+					// https://github.com/microsoft/vscode/issues/311583 (spawn git ENOENT),
+					// https://github.com/microsoft/vscode/issues/311584 (network connectivity),
+					// https://github.com/microsoft/vscode/issues/311585 (EPERM/permission errors),
+					// https://github.com/microsoft/vscode/issues/311586 (UNC host access),
+					// https://github.com/microsoft/vscode/issues/311587 (cloud agent not enabled).
+					if (rpcResult?.errorCallstack && !rpcResult.errorDetails?.isRateLimited && !rpcResult.errorDetails?.isQuotaExceeded && !rpcResult.errorDetails?.isExpectedError) {
 						type ChatAgentErrorEvent = { callstack: string; msg: string; errorName: string; agent: string; agentExtensionId: string };
 						type ChatAgentErrorClassification = {
 							owner: 'bryanchen-d';

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -1027,9 +1027,10 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 
 			const isQuotaExceeded = e instanceof Error && e.name === 'ChatQuotaExceeded';
 			const isRateLimited = e instanceof Error && e.name === 'ChatRateLimited';
+			const isExpectedError = e instanceof Error && e.name === 'ChatExpectedError';
 			const { callstack: errorCallstack } = packErrorForTelemetry(e);
 			const errorName = e instanceof Error ? e.name : undefined;
-			return { errorDetails: { message: toErrorMessage(e), responseIsIncomplete: true, isQuotaExceeded, isRateLimited }, errorCallstack, errorName };
+			return { errorDetails: { message: toErrorMessage(e), responseIsIncomplete: true, isQuotaExceeded, isRateLimited, isExpectedError }, errorCallstack, errorName };
 
 		} finally {
 			if (inFlightRequest) {

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -1012,7 +1012,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 						responseIsIncomplete: true
 					};
 				}
-				if (errorDetails?.responseIsRedacted || errorDetails?.isQuotaExceeded || errorDetails?.isRateLimited || errorDetails?.confirmationButtons || errorDetails?.code) {
+				if (errorDetails?.responseIsRedacted || errorDetails?.isQuotaExceeded || errorDetails?.isRateLimited || errorDetails?.isExpectedError || errorDetails?.confirmationButtons || errorDetails?.code) {
 					checkProposedApiEnabled(agent.extension, 'chatParticipantPrivate');
 				}
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -59,6 +59,12 @@ export interface IChatResponseErrorDetails {
 	responseIsRedacted?: boolean;
 	isQuotaExceeded?: boolean;
 	isRateLimited?: boolean;
+	/**
+	 * If true, the error is an expected operational condition (e.g. user-actionable
+	 * configuration, network connectivity, missing dependency) and should not be
+	 * logged as a `chatAgentError` telemetry event.
+	 */
+	isExpectedError?: boolean;
 	level?: ChatErrorLevel;
 	confirmationButtons?: IChatResponseErrorDetailsConfirmationButton[];
 	code?: string;

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -256,6 +256,15 @@ declare module 'vscode' {
 
 		isRateLimited?: boolean;
 
+		/**
+		 * If true, the error is an expected operational condition (e.g. user-actionable
+		 * configuration, network connectivity, missing dependency) and should not be
+		 * logged as a `chatAgentError` telemetry event. The error is still surfaced to
+		 * the user. Throwing an `Error` whose `name` is `'ChatExpectedError'` from a
+		 * chat participant handler will set this flag automatically.
+		 */
+		isExpectedError?: boolean;
+
 		level?: ChatErrorLevel;
 
 		code?: string;


### PR DESCRIPTION
## Summary

Generalizes the existing `isRateLimited` / `isQuotaExceeded` telemetry-suppression pattern (introduced in #311582) so that any user-actionable / expected operational condition thrown from a chat participant can opt out of the `chatAgentError` telemetry event — without needing a separate named-error sentinel for each case.

## Motivation

Five sibling error-telemetry issues were filed the same day for `chatagenterror` buckets that are not bugs but legitimate user-facing conditions surfaced through `throw`:

| Issue | Condition |
|---|---|
| #311583 | `spawn git ENOENT` (git binary missing) |
| #311584 | "It appears you're not connected to the internet" |
| #311585 | `EPERM: operation not permitted, mkdir` (`NoPermissions FileSystemError`) |
| #311586 | "UNC host '…' access is not allowed" (`security.allowedUNCHosts`) |
| #311587 | "Cloud agent is not enabled for this repository" |

All five have the same shape as the already-suppressed `ChatRateLimited` / `ChatQuotaExceeded` cases: the message is meant to prompt the user to take action, not to crash-report a bug. They currently produce daily error-telemetry buckets and noise in the triage pipeline.

Rather than adding five new named-error sentinels, this PR adds a single opt-in flag that any participant call site can set.

## Changes

- `vscode.proposed.chatParticipantPrivate.d.ts` — add `ChatErrorDetails.isExpectedError?: boolean`.
- `chatService.ts` — add same field to the internal `IChatResponseErrorDetails`.
- `extHostChatAgents2.ts` — set `isExpectedError = true` when the thrown `Error` has `name === 'ChatExpectedError'` (mirrors the `ChatRateLimited` / `ChatQuotaExceeded` pattern).
- `mainThreadChatAgents2.ts` — extend the existing telemetry-suppression guard to also skip when `isExpectedError` is set.

```ts
// extHostChatAgents2.ts (catch path)
const isExpectedError = e instanceof Error && e.name === 'ChatExpectedError';
return { errorDetails: { …, isQuotaExceeded, isRateLimited, isExpectedError }, errorCallstack, errorName };

// mainThreadChatAgents2.ts (telemetry guard)
if (rpcResult?.errorCallstack
    && !rpcResult.errorDetails?.isRateLimited
    && !rpcResult.errorDetails?.isQuotaExceeded
    && !rpcResult.errorDetails?.isExpectedError) {
  this._telemetryService.publicLogError2('chatAgentError', …);
}
```

## Adoption (follow-up in copilot-chat)

Once this lands, each call site in copilot-chat can opt in by throwing:

```ts
throw Object.assign(new Error('Cloud agent is not enabled for this repository…'), {
  name: 'ChatExpectedError',
});
```

(Or by catching the underlying `ENOENT` / `EPERM` / `FileSystemError` / fetch failure and rethrowing as `ChatExpectedError`.) The user still sees the same message; only the `chatagenterror` telemetry stops firing.

## Test Plan

- TypeScript compiles cleanly across the four touched files.
- Existing rate-limit / quota-exceeded behavior is unchanged (same guard, just one more clause).
- The flag is opt-in: no existing thrown error is renamed, so no behavior changes until a participant adopts `ChatExpectedError`.

## Refs

Closes-via-adoption: #311583, #311584, #311585, #311586, #311587
Precedent: #311582
