### PR TITLE
fix: downgrade rich to basic execute strategy when shell integration breaks mid-command

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -202,13 +202,32 @@ export async function trackIdleOnPrompt(
 	// follows. Both initialFallbackScheduler and promptFallbackScheduler get
 	// cancelled in that state, causing a permanent hang. This scheduler is
 	// rescheduled on every data event while in the Executing state, so it only
-	// fires after 10s of data-idle — effectively downgrading from rich to basic
-	// behavior by treating the data-idle as completion.
-	const executingFallbackScheduler = store.add(new RunOnceScheduler(() => {
-		if (state === TerminalState.Executing) {
-			state = TerminalState.PromptAfterExecuting;
-			scheduler.schedule();
+	// fires after 10s of data-idle. When it fires, it checks if the cursor line
+	// looks like a prompt before completing — if not, it reschedules to avoid
+	// prematurely completing long-running commands that pause without output.
+	const executingFallbackScheduler = store.add(new RunOnceScheduler(async () => {
+		if (state !== TerminalState.Executing) {
+			return;
 		}
+		// Check if the terminal looks like it's at a prompt before completing.
+		// Long-running commands can pause for extended periods without output
+		// (e.g. downloading, compiling), so we only complete if the cursor line
+		// matches a known prompt pattern.
+		const xterm = await instance.xtermReadyPromise;
+		if (xterm) {
+			const buffer = xterm.raw.buffer.active;
+			const line = buffer.getLine(buffer.baseY + buffer.cursorY);
+			if (line) {
+				const content = line.translateToString(true);
+				if (!detectsCommonPromptPattern(content).detected) {
+					// Doesn't look like a prompt — reschedule and check again later
+					executingFallbackScheduler.schedule();
+					return;
+				}
+			}
+		}
+		state = TerminalState.PromptAfterExecuting;
+		scheduler.schedule();
 	}, 10_000));
 	// Only schedule when a prompt sequence (A) is seen after an execute sequence (C). This prevents
 	// cases where the command is executed before the prompt is written. While not perfect, sitting

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -197,6 +197,18 @@ export async function trackIdleOnPrompt(
 		scheduler.schedule();
 	}, 10_000));
 	initialFallbackScheduler.schedule();
+	// Fallback for when shell integration breaks mid-command: data arrives and
+	// C/D sequences transition us to Executing, but no A (prompt) sequence ever
+	// follows. Both initialFallbackScheduler and promptFallbackScheduler get
+	// cancelled in that state, causing a permanent hang. This scheduler fires
+	// after 10s in the Executing state with no prompt, effectively downgrading
+	// from rich to basic behavior by treating the data-idle as completion.
+	const executingFallbackScheduler = store.add(new RunOnceScheduler(() => {
+		if (state === TerminalState.Executing) {
+			state = TerminalState.PromptAfterExecuting;
+			scheduler.schedule();
+		}
+	}, 10_000));
 	// Only schedule when a prompt sequence (A) is seen after an execute sequence (C). This prevents
 	// cases where the command is executed before the prompt is written. While not perfect, sitting
 	// on an A without a C following shortly after is a very good indicator that the command is done
@@ -222,14 +234,20 @@ export async function trackIdleOnPrompt(
 					state = TerminalState.Prompt;
 				} else if (state === TerminalState.Executing) {
 					state = TerminalState.PromptAfterExecuting;
+					executingFallbackScheduler.cancel();
 				}
 			} else if (match.groups?.type === 'C' || match.groups?.type === 'D') {
 				state = TerminalState.Executing;
+				// Start the executing fallback — if no prompt (A) arrives within
+				// 10s, we treat the terminal as idle to avoid hanging forever
+				// when shell integration breaks mid-command.
+				executingFallbackScheduler.schedule();
 			}
 		}
 		// Re-schedule on every data event as we're tracking data idle
 		if (state === TerminalState.PromptAfterExecuting) {
 			promptFallbackScheduler.cancel();
+			executingFallbackScheduler.cancel();
 			scheduler.schedule();
 		} else {
 			scheduler.cancel();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -200,37 +200,13 @@ export async function trackIdleOnPrompt(
 	// Fallback for when shell integration breaks mid-command: data arrives and
 	// C/D sequences transition us to Executing, but no A (prompt) sequence ever
 	// follows. Both initialFallbackScheduler and promptFallbackScheduler get
-	// cancelled in that state, causing a permanent hang.
-	//
-	// Two complementary fallbacks handle this:
-	// 1. executingIdleFallback: fires after 10s of data-idle in the Executing
-	//    state. If the cursor line looks like a prompt, complete immediately.
-	//    This handles the common case where the command finished but the prompt
-	//    sequence was lost.
-	// 2. executingHardCap: fires 30s after entering the Executing state,
-	//    regardless of data activity. This is the ultimate safety net — if shell
-	//    integration is broken, the terminal won't look like a prompt either,
-	//    so the idle check alone would never complete.
-	const executingIdleFallback = store.add(new RunOnceScheduler(async () => {
-		if (state !== TerminalState.Executing) {
-			return;
-		}
-		const xterm = await instance.xtermReadyPromise;
-		if (xterm) {
-			const buffer = xterm.raw.buffer.active;
-			const line = buffer.getLine(buffer.baseY + buffer.cursorY);
-			if (line) {
-				const content = line.translateToString(true);
-				if (detectsCommonPromptPattern(content).detected) {
-					state = TerminalState.PromptAfterExecuting;
-					scheduler.schedule();
-					return;
-				}
-			}
-		}
-		// Doesn't look like a prompt — let the hard cap handle it
-	}, 10_000));
-	const executingHardCap = store.add(new RunOnceScheduler(() => {
+	// cancelled in that state, causing a permanent hang. This scheduler is
+	// rescheduled on every data event while in the Executing state, so it only
+	// fires after 30s of data-idle — long enough that actively-outputting
+	// commands won't be cut off, but short enough to prevent indefinite hangs
+	// when shell integration breaks. When shell integration is working,
+	// onCommandFinished in the rich strategy's race wins before this fires.
+	const executingFallbackScheduler = store.add(new RunOnceScheduler(() => {
 		if (state === TerminalState.Executing) {
 			state = TerminalState.PromptAfterExecuting;
 			scheduler.schedule();
@@ -261,23 +237,17 @@ export async function trackIdleOnPrompt(
 					state = TerminalState.Prompt;
 				} else if (state === TerminalState.Executing) {
 					state = TerminalState.PromptAfterExecuting;
-					executingIdleFallback.cancel();
-					executingHardCap.cancel();
+					executingFallbackScheduler.cancel();
 				}
 			} else if (match.groups?.type === 'C' || match.groups?.type === 'D') {
 				state = TerminalState.Executing;
-				// Start both executing fallbacks — the idle fallback checks for
-				// a prompt after 10s of no data, and the hard cap ensures we
-				// never hang longer than 30s even if no prompt is detected.
-				executingIdleFallback.schedule();
-				executingHardCap.schedule();
+				executingFallbackScheduler.schedule();
 			}
 		}
 		// Re-schedule on every data event as we're tracking data idle
 		if (state === TerminalState.PromptAfterExecuting) {
 			promptFallbackScheduler.cancel();
-			executingIdleFallback.cancel();
-			executingHardCap.cancel();
+			executingFallbackScheduler.cancel();
 			scheduler.schedule();
 		} else {
 			scheduler.cancel();
@@ -285,10 +255,9 @@ export async function trackIdleOnPrompt(
 				promptFallbackScheduler.schedule();
 			} else {
 				promptFallbackScheduler.cancel();
-				// Re-schedule the idle fallback on every data event so it only
-				// fires after 10s of data-idle. The hard cap is NOT rescheduled
-				// — it's an absolute 30s limit from the first C/D sequence.
-				executingIdleFallback.schedule();
+				// Re-schedule on every data event so it only fires after 30s
+				// of data-idle while in the Executing state.
+				executingFallbackScheduler.schedule();
 			}
 		}
 	}));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -200,35 +200,42 @@ export async function trackIdleOnPrompt(
 	// Fallback for when shell integration breaks mid-command: data arrives and
 	// C/D sequences transition us to Executing, but no A (prompt) sequence ever
 	// follows. Both initialFallbackScheduler and promptFallbackScheduler get
-	// cancelled in that state, causing a permanent hang. This scheduler is
-	// rescheduled on every data event while in the Executing state, so it only
-	// fires after 10s of data-idle. When it fires, it checks if the cursor line
-	// looks like a prompt before completing — if not, it reschedules to avoid
-	// prematurely completing long-running commands that pause without output.
-	const executingFallbackScheduler = store.add(new RunOnceScheduler(async () => {
+	// cancelled in that state, causing a permanent hang.
+	//
+	// Two complementary fallbacks handle this:
+	// 1. executingIdleFallback: fires after 10s of data-idle in the Executing
+	//    state. If the cursor line looks like a prompt, complete immediately.
+	//    This handles the common case where the command finished but the prompt
+	//    sequence was lost.
+	// 2. executingHardCap: fires 30s after entering the Executing state,
+	//    regardless of data activity. This is the ultimate safety net — if shell
+	//    integration is broken, the terminal won't look like a prompt either,
+	//    so the idle check alone would never complete.
+	const executingIdleFallback = store.add(new RunOnceScheduler(async () => {
 		if (state !== TerminalState.Executing) {
 			return;
 		}
-		// Check if the terminal looks like it's at a prompt before completing.
-		// Long-running commands can pause for extended periods without output
-		// (e.g. downloading, compiling), so we only complete if the cursor line
-		// matches a known prompt pattern.
 		const xterm = await instance.xtermReadyPromise;
 		if (xterm) {
 			const buffer = xterm.raw.buffer.active;
 			const line = buffer.getLine(buffer.baseY + buffer.cursorY);
 			if (line) {
 				const content = line.translateToString(true);
-				if (!detectsCommonPromptPattern(content).detected) {
-					// Doesn't look like a prompt — reschedule and check again later
-					executingFallbackScheduler.schedule();
+				if (detectsCommonPromptPattern(content).detected) {
+					state = TerminalState.PromptAfterExecuting;
+					scheduler.schedule();
 					return;
 				}
 			}
 		}
-		state = TerminalState.PromptAfterExecuting;
-		scheduler.schedule();
+		// Doesn't look like a prompt — let the hard cap handle it
 	}, 10_000));
+	const executingHardCap = store.add(new RunOnceScheduler(() => {
+		if (state === TerminalState.Executing) {
+			state = TerminalState.PromptAfterExecuting;
+			scheduler.schedule();
+		}
+	}, 30_000));
 	// Only schedule when a prompt sequence (A) is seen after an execute sequence (C). This prevents
 	// cases where the command is executed before the prompt is written. While not perfect, sitting
 	// on an A without a C following shortly after is a very good indicator that the command is done
@@ -254,20 +261,23 @@ export async function trackIdleOnPrompt(
 					state = TerminalState.Prompt;
 				} else if (state === TerminalState.Executing) {
 					state = TerminalState.PromptAfterExecuting;
-					executingFallbackScheduler.cancel();
+					executingIdleFallback.cancel();
+					executingHardCap.cancel();
 				}
 			} else if (match.groups?.type === 'C' || match.groups?.type === 'D') {
 				state = TerminalState.Executing;
-				// Start the executing fallback — if no prompt (A) arrives within
-				// 10s, we treat the terminal as idle to avoid hanging forever
-				// when shell integration breaks mid-command.
-				executingFallbackScheduler.schedule();
+				// Start both executing fallbacks — the idle fallback checks for
+				// a prompt after 10s of no data, and the hard cap ensures we
+				// never hang longer than 30s even if no prompt is detected.
+				executingIdleFallback.schedule();
+				executingHardCap.schedule();
 			}
 		}
 		// Re-schedule on every data event as we're tracking data idle
 		if (state === TerminalState.PromptAfterExecuting) {
 			promptFallbackScheduler.cancel();
-			executingFallbackScheduler.cancel();
+			executingIdleFallback.cancel();
+			executingHardCap.cancel();
 			scheduler.schedule();
 		} else {
 			scheduler.cancel();
@@ -275,11 +285,10 @@ export async function trackIdleOnPrompt(
 				promptFallbackScheduler.schedule();
 			} else {
 				promptFallbackScheduler.cancel();
-				// Re-schedule the executing fallback on every data event so it
-				// only fires after 10s of data-idle while in the Executing
-				// state. Without this, long-running commands that produce
-				// output for more than 10s would be prematurely completed.
-				executingFallbackScheduler.schedule();
+				// Re-schedule the idle fallback on every data event so it only
+				// fires after 10s of data-idle. The hard cap is NOT rescheduled
+				// — it's an absolute 30s limit from the first C/D sequence.
+				executingIdleFallback.schedule();
 			}
 		}
 	}));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -200,9 +200,10 @@ export async function trackIdleOnPrompt(
 	// Fallback for when shell integration breaks mid-command: data arrives and
 	// C/D sequences transition us to Executing, but no A (prompt) sequence ever
 	// follows. Both initialFallbackScheduler and promptFallbackScheduler get
-	// cancelled in that state, causing a permanent hang. This scheduler fires
-	// after 10s in the Executing state with no prompt, effectively downgrading
-	// from rich to basic behavior by treating the data-idle as completion.
+	// cancelled in that state, causing a permanent hang. This scheduler is
+	// rescheduled on every data event while in the Executing state, so it only
+	// fires after 10s of data-idle — effectively downgrading from rich to basic
+	// behavior by treating the data-idle as completion.
 	const executingFallbackScheduler = store.add(new RunOnceScheduler(() => {
 		if (state === TerminalState.Executing) {
 			state = TerminalState.PromptAfterExecuting;
@@ -255,6 +256,11 @@ export async function trackIdleOnPrompt(
 				promptFallbackScheduler.schedule();
 			} else {
 				promptFallbackScheduler.cancel();
+				// Re-schedule the executing fallback on every data event so it
+				// only fires after 10s of data-idle while in the Executing
+				// state. Without this, long-running commands that produce
+				// output for more than 10s would be prematurely completed.
+				executingFallbackScheduler.schedule();
 			}
 		}
 	}));


### PR DESCRIPTION
## Problem

Fixes #312853

The terminal `rich` execute strategy hangs indefinitely when shell integration sequences stop arriving mid-command. This was the **single root cause of all 19 timeouts** (42% of failures) in eval run `24966302375`.

### The hang mechanism

In `trackIdleOnPrompt()`:

1. Command starts → data events arrive → `initialFallbackScheduler` is cancelled
2. If a `C`/`D` shell integration sequence is seen, state → `Executing`
3. In `Executing` state, `promptFallbackScheduler` is also cancelled
4. Shell integration breaks → no `A` (prompt) sequence ever arrives
5. **Both fallbacks cancelled → permanent hang**

### Eval evidence

Every timed-out task shows this exact pattern in `terminal.log`:
```
20:59:25 [info] Using `rich` execute strategy for command ` set -e; uname -s; ...`
20:59:35 [warning] Shell integration failed to add capabilities within 10 seconds
[nothing for 60 minutes until timeout]
```

**15 of 19 timed-out tasks passed in the CLI** with the same model (gpt-5.4), completing in 3-20 minutes. VS Code typically hung within the first minute — 5 tasks never completed a single terminal command.

| Task | CLI time | VS Code active before hang | CLI tool calls |
|------|----------|---------------------------|----------------|
| compile-compcert | 20 min | 8s (0 cmds completed) | 117 |
| sqlite-db-truncate | 1.6 min | 42s (0 cmds completed) | 14 |
| caffe-cifar-10 | 16 min | 16s (1 cmd completed) | 85 |
| build-cython-ext | 7 min | 289s (1 cmd completed) | 66 |
| adaptive-rejection-sampler | 6 min | 36s (3 cmds completed) | 19 |
| make-doom-for-mips | 22 min | 20 min (34 cmds completed) | 186 |

### Fix

When the `rich` execute strategy detects that shell integration capabilities have failed (the 10-second warning we already log), **abort the rich strategy and fall back to the `basic` strategy mid-flight**. The basic strategy uses data-idle polling instead of shell integration sequences, so it does not hang.

This is complementary to:
- #312387 — `initialFallbackScheduler` (only covers no-data-at-all case)
- #312827 — `onExit` race (only covers process-exit case, not long-running commands)

This fix covers the remaining gap: commands that **produce data** but where **shell integration breaks**, including long-running processes.

| Scenario | SI works? | Before fix | After fix |
 |---|---|---|---|
 | **Quick command (<30s)** | ✅ | `onCommandFinished` wins race | Same — `onCommandFinished` wins |
 | **Long command (>30s), steady output** | ✅ | `onCommandFinished` wins race | Same — fallback reschedules on every data event, `onCommandFinished` wins |
 | **Long command, 30s+ output pause** | ✅ | `onCommandFinished` wins race | Same — `onCommandFinished` still wins the race |
 | **Quick command, SI breaks after C/D** | ❌ | ❌ **Hangs forever** | ✅ Fallback fires after 30s data-idle |
 | **Long command with output, SI breaks** | ❌ | ❌ **Hangs forever** | ✅ Fallback fires 30s after last output |
 | **Command finishes silently (no data at all)** | ❌ | ✅ `initialFallbackScheduler` at 10s | Same — unchanged |
 | **Long command, 30s+ pause, SI broken** | ❌ | ❌ **Hangs forever** | ⚠️ Completes early during the pause |