### PR TITLE
Persist terminal color changes (via escape sequences) correctly

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
@@ -7,6 +7,12 @@ import { IBufferCell } from '@xterm/xterm';
 
 export type XtermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCode'> & { clone?(): XtermAttributes };
 
+export interface IXtermThemeColors {
+	background: { css: string; rgba: number };
+	foreground: { css: string; rgba: number };
+	cursor: { css: string; rgba: number };
+}
+
 export interface IXtermCore {
 	viewport?: {
 		readonly scrollBarWidth: number;
@@ -29,6 +35,13 @@ export interface IXtermCore {
 		_renderer: {
 			value?: unknown;
 		};
+	};
+
+	_themeService: {
+		readonly colors: IXtermThemeColors;
+		readonly _restoreColors: IXtermThemeColors;
+		modifyColors(callback: (colors: IXtermThemeColors) => void): void;
+		restoreColor(slot?: number): void;
 	};
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -12,7 +12,7 @@ import type { SerializeAddon as SerializeAddonType } from '@xterm/addon-serializ
 import type { ImageAddon as ImageAddonType } from '@xterm/addon-image';
 import type { ClipboardAddon as ClipboardAddonType, ClipboardSelectionType } from '@xterm/addon-clipboard';
 import * as dom from '../../../../../base/browser/dom.js';
-import { IXtermCore } from '../xterm-private.js';
+import { IXtermCore, IXtermThemeColors } from '../xterm-private.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
@@ -1050,7 +1050,49 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	private _updateTheme(theme?: IColorTheme): void {
-		this.raw.options.theme = this.getXtermTheme(theme);
+		const newTheme = this.getXtermTheme(theme);
+		const themeService = this._core._themeService;
+
+		if (themeService) {
+			// Save color objects before _setTheme() mutates them, since
+			// themeService.colors returns the same mutable reference.
+			const currentBackground = themeService.colors.background;
+			const currentForeground = themeService.colors.foreground;
+			const currentCursor = themeService.colors.cursor;
+			const restoreBackground = themeService._restoreColors.background.css;
+			const restoreForeground = themeService._restoreColors.foreground.css;
+			const restoreCursor = themeService._restoreColors.cursor.css;
+
+			const preservedColors: { background?: typeof currentBackground; foreground?: typeof currentForeground; cursor?: typeof currentCursor } = {};
+
+			if (currentBackground.css !== restoreBackground) {
+				preservedColors.background = currentBackground;
+			}
+			if (currentForeground.css !== restoreForeground) {
+				preservedColors.foreground = currentForeground;
+			}
+			if (currentCursor.css !== restoreCursor) {
+				preservedColors.cursor = currentCursor;
+			}
+
+			this.raw.options.theme = newTheme;
+
+			if (preservedColors.background || preservedColors.foreground || preservedColors.cursor) {
+				themeService.modifyColors((colors: IXtermThemeColors) => {
+					if (preservedColors.background) {
+						colors.background = preservedColors.background;
+					}
+					if (preservedColors.foreground) {
+						colors.foreground = preservedColors.foreground;
+					}
+					if (preservedColors.cursor) {
+						colors.cursor = preservedColors.cursor;
+					}
+				});
+			}
+		} else {
+			this.raw.options.theme = newTheme;
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -12,8 +12,8 @@ import type { SerializeAddon as SerializeAddonType } from '@xterm/addon-serializ
 import type { ImageAddon as ImageAddonType } from '@xterm/addon-image';
 import type { ClipboardAddon as ClipboardAddonType, ClipboardSelectionType } from '@xterm/addon-clipboard';
 import * as dom from '../../../../../base/browser/dom.js';
-import { IXtermCore, IXtermThemeColors } from '../xterm-private.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import type { IXtermCore, IXtermThemeColors } from '../xterm-private.js';
+import type { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 import { IShellIntegration, ITerminalLogService, TerminalSettingId, type IDecorationAddon } from '../../../../../platform/terminal/common/terminal.js';

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -22,7 +22,7 @@ import { ITerminalConfiguration, TERMINAL_VIEW_ID } from '../../../common/termin
 import { registerColors, TERMINAL_BACKGROUND_COLOR, TERMINAL_CURSOR_BACKGROUND_COLOR, TERMINAL_CURSOR_FOREGROUND_COLOR, TERMINAL_FOREGROUND_COLOR, TERMINAL_INACTIVE_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_FOREGROUND_COLOR } from '../../../common/terminalColorRegistry.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { TestWebglAddon, TestXtermAddonImporter } from './xtermTestUtils.js';
-import { IXtermCore } from '../../../browser/xterm-private.js';
+import type { IXtermCore } from '../../../browser/xterm-private.js';
 
 registerColors();
 

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -448,8 +448,11 @@ suite('XtermTerminal', () => {
 				colors.background = { css: '#ff0000', rgba: 0xFF0000FF };
 			});
 
+			// xterm SpecialColorIndex.BACKGROUND, kept local to avoid an unexplained magic number.
+			const backgroundSpecialColorIndex = 257;
+
 			// Restore color (simulates OSC 111)
-			core._themeService.restoreColor(257); // SpecialColorIndex.BACKGROUND
+			core._themeService.restoreColor(backgroundSpecialColorIndex);
 
 			// Trigger theme update
 			xterm.refresh();

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -22,6 +22,7 @@ import { ITerminalConfiguration, TERMINAL_VIEW_ID } from '../../../common/termin
 import { registerColors, TERMINAL_BACKGROUND_COLOR, TERMINAL_CURSOR_BACKGROUND_COLOR, TERMINAL_CURSOR_FOREGROUND_COLOR, TERMINAL_FOREGROUND_COLOR, TERMINAL_INACTIVE_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_FOREGROUND_COLOR } from '../../../common/terminalColorRegistry.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { TestWebglAddon, TestXtermAddonImporter } from './xtermTestUtils.js';
+import { IXtermCore } from '../../../browser/xterm-private.js';
 
 registerColors();
 
@@ -376,6 +377,85 @@ suite('XtermTerminal', () => {
 				brightCyan: '#15000f',
 				brightWhite: '#16000f',
 			});
+		});
+		test('should preserve OSC 10/11/12 colors on theme update', () => {
+			themeService.setTheme(new TestColorTheme({
+				[TERMINAL_BACKGROUND_COLOR]: '#000100',
+				[TERMINAL_FOREGROUND_COLOR]: '#000200',
+				[TERMINAL_CURSOR_FOREGROUND_COLOR]: '#000300',
+				[TERMINAL_CURSOR_BACKGROUND_COLOR]: '#000400',
+			}));
+			xterm = store.add(instantiationService.createInstance(XtermTerminal, undefined, XTermBaseCtor, {
+				cols: 80,
+				rows: 30,
+				xtermAddonImporter: new TestXtermAddonImporter(),
+				xtermColorProvider: { getBackgroundColor: () => new Color(new RGBA(0, 1, 0)) },
+				capabilities: store.add(new TerminalCapabilityStore()),
+				disableShellIntegrationReporting: true,
+				disableOverviewRuler: true
+			}, undefined));
+
+			// _themeService is only created after open()
+			xterm.raw.open(document.createElement('div'));
+
+			const core = (xterm as unknown as { _core: IXtermCore })._core;
+			strictEqual(core._themeService.colors.background.css, '#000100');
+			strictEqual(core._themeService.colors.foreground.css, '#000200');
+			strictEqual(core._themeService.colors.cursor.css, '#000300');
+
+			// Simulate OSC 10, OSC 11, and OSC 12
+			core._themeService.modifyColors((colors) => {
+				colors.background = { css: '#ff0000', rgba: 0xFF0000FF };
+				colors.foreground = { css: '#00ff00', rgba: 0x00FF00FF };
+				colors.cursor = { css: '#0000ff', rgba: 0x0000FFFF };
+			});
+			strictEqual(core._themeService.colors.background.css, '#ff0000');
+			strictEqual(core._themeService.colors.foreground.css, '#00ff00');
+			strictEqual(core._themeService.colors.cursor.css, '#0000ff');
+
+			// Trigger theme update (simulates tab switch or theme change)
+			xterm.refresh();
+
+			// The OSC colors should be preserved
+			strictEqual(core._themeService.colors.background.css, '#ff0000');
+			strictEqual(core._themeService.colors.foreground.css, '#00ff00');
+			strictEqual(core._themeService.colors.cursor.css, '#0000ff');
+		});
+		test('should reset to theme color when OSC color is restored', () => {
+			themeService.setTheme(new TestColorTheme({
+				[TERMINAL_BACKGROUND_COLOR]: '#000100',
+				[TERMINAL_FOREGROUND_COLOR]: '#000200',
+				[TERMINAL_CURSOR_FOREGROUND_COLOR]: '#000300',
+				[TERMINAL_CURSOR_BACKGROUND_COLOR]: '#000400',
+			}));
+			xterm = store.add(instantiationService.createInstance(XtermTerminal, undefined, XTermBaseCtor, {
+				cols: 80,
+				rows: 30,
+				xtermAddonImporter: new TestXtermAddonImporter(),
+				xtermColorProvider: { getBackgroundColor: () => new Color(new RGBA(0, 1, 0)) },
+				capabilities: store.add(new TerminalCapabilityStore()),
+				disableShellIntegrationReporting: true,
+				disableOverviewRuler: true
+			}, undefined));
+
+			// _themeService is only created after open()
+			xterm.raw.open(document.createElement('div'));
+
+			const core = (xterm as unknown as { _core: IXtermCore })._core;
+
+			// Simulate OSC 11
+			core._themeService.modifyColors((colors) => {
+				colors.background = { css: '#ff0000', rgba: 0xFF0000FF };
+			});
+
+			// Restore color (simulates OSC 111)
+			core._themeService.restoreColor(257); // SpecialColorIndex.BACKGROUND
+
+			// Trigger theme update
+			xterm.refresh();
+
+			// Should use the theme color, not the OSC color
+			strictEqual(core._themeService.colors.background.css, '#000100');
 		});
 	});
 });


### PR DESCRIPTION
Fixes #312815

Previously, `XtermTerminal._updateTheme()` sets `this.raw.options.theme = newTheme`, which triggers xterm.js's `ThemeService._setTheme()`. This completely overwrites all current colors, including any OSC10/11/12-modified background, foreground, or cursor colors, because it updates both the active colors and the restore colors simultaneously. Refreshing the terminal, changing the theme color or switching the tab while the terminal is open in the editor area results in all the OSC set colors being changed to the current theme color.

With this PR, `_updateTheme()` preserves OSC-modified colors by comparing the current colors against their original restore values before applying the new theme, and re-applies any that differ using `modifyColors()`. This ensures OSC 10/11/12 colors survive theme refreshes caused by tab switches or VS Code theme changes.

However there is a quite rare edge case i have decided not to handle:
For example, if OSC 11 sets the background to a specific color, and the theme background also happens to be exactly that specific color, then in this case, this color would not be persisted. If the theme later changes to a different color, the background would follow the new theme instead of staying at that specific color.

To fix this edge case vscode would need to track terminal color modifications independently of xterm.js. This has to be extremely rare in practice, and i doubt anyone would notice it.