### PR TITLE
Fix harness dropdown picker theming in AI Customizations editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -215,7 +215,10 @@
 	background: transparent;
 	cursor: pointer;
 	font-size: 12px;
+	font-family: inherit;
 	text-align: left;
+	-webkit-appearance: none;
+	appearance: none;
 }
 
 .ai-customization-management-editor .harness-dropdown-button:hover {


### PR DESCRIPTION
The harness dropdown in the Agent Customizations sidebar was rendering with a light system "buttonface" background instead of being transparent (regression introduced when `background: transparent` was added in #312689 — the transparent background was being overridden by Chromium's native `<button>` rendering).

Setting `-webkit-appearance: none; appearance: none;` disables the native form control rendering so the CSS background takes effect. Matches the pattern already used by `.welcome-prompts-input` in this view.

Also added `font-family: inherit;` so the button uses the workbench font rather than the platform default.

Before: light pill background as shown in the regression screenshot.
After: transparent background that picks up dropdown styling on hover.