### PR TITLE
sessions: add customizations overview header action

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -54,7 +54,7 @@ src/vs/sessions/contrib/chat/browser/
 ├── customizationHarnessService.ts              # Sessions harness service (accepts any content-provider-backed session type)
 └── promptsService.ts                           # AgenticPromptsService (CLI user roots)
 src/vs/sessions/contrib/sessions/browser/
-├── aiCustomizationShortcutsWidget.ts           # Shortcuts widget
+├── aiCustomizationShortcutsWidget.ts           # Sidebar shortcuts widget with header overview action
 └── customizationsToolbar.contribution.ts       # Sidebar customization links
 ```
 
@@ -220,6 +220,10 @@ Skills that are directly invoked by UI elements (toolbar buttons, menu items) ar
 ### Count Consistency
 
 Counts shown in the sidebar (per-link badges and the header total in `AICustomizationShortcutsWidget`) are driven by the same `IAICustomizationItemsModel` singleton (`workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts`) that feeds the customizations editor's list widget. The model owns the per-active-harness `ProviderCustomizationItemSource` cache and exposes per-section `IObservable<readonly IAICustomizationListItem[]>`; sidebar consumers `read` `.length` from those observables. There is exactly one discovery path, so editor and sidebar counts cannot diverge. McpServers and Plugins use their own service observables (`IMcpService.servers`, `IAgentPluginService.plugins`) directly.
+
+### Sidebar Overview Entrypoint
+
+The Agents sidebar `AICustomizationShortcutsWidget` exposes a home action in the Customizations header. The header label remains the collapse toggle, while the separate icon-only action opens the AI Customization management editor and calls `showWelcomePage()` so users can return to the overview/welcome page from any customization section. The action lives in the header, rather than inside the collapsible list content, so it remains visible and is not clipped by the sidebar's scrollable layout.
 
 ### Item Badges
 

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -6,7 +6,6 @@
 import '../../../browser/media/sidebarActionButton.css';
 import './media/customizationsToolbar.css';
 import * as DOM from '../../../../base/browser/dom.js';
-import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
@@ -23,13 +22,16 @@ import { CUSTOMIZATION_ITEMS } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
 import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 
 const $ = DOM.$;
 
 const CUSTOMIZATIONS_COLLAPSED_KEY = 'agentSessions.customizationsCollapsed';
+
+function isWelcomePageEditor(editor: unknown): editor is { showWelcomePage(): void } {
+	return typeof (editor as { showWelcomePage?: unknown })?.showWelcomePage === 'function';
+}
 
 export interface IAICustomizationShortcutsWidgetOptions {
 	readonly onDidChangeLayout?: () => void;
@@ -48,7 +50,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IAICustomizationItemsModel private readonly itemsModel: IAICustomizationItemsModel,
 		@IEditorService private readonly editorService: IEditorService,
-		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 
@@ -88,6 +89,26 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		const chevron = DOM.append(chevronContainer, $('.ai-customization-chevron'));
 		const headerTotalCount = DOM.append(chevronContainer, $('span.ai-customization-header-total.hidden'));
 		chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
+
+		const headerActions = DOM.append(header, $('.ai-customization-header-actions'));
+		const openOverviewLabel = localize('openCustomizationsOverview', "Open Customizations Overview");
+		const openOverviewButton = this._register(new Button(headerActions, {
+			...defaultButtonStyles,
+			secondary: true,
+			title: openOverviewLabel,
+			ariaLabel: openOverviewLabel,
+			supportIcons: true,
+			buttonSecondaryBackground: 'transparent',
+			buttonSecondaryHoverBackground: undefined,
+			buttonSecondaryForeground: undefined,
+			buttonSecondaryBorder: undefined,
+		}));
+		openOverviewButton.element.classList.add('ai-customization-overview-button');
+		openOverviewButton.label = `$(${Codicon.home.id})`;
+		this._register(openOverviewButton.onDidClick(e => {
+			e?.preventDefault();
+			this._openWelcomePage();
+		}));
 
 		// Toolbar container
 		const toolbarContainer = DOM.append(container, $('.ai-customization-toolbar-content.sidebar-action-list'));
@@ -145,43 +166,13 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
-
-		// Footer link — appended inside the collapsible content so it
-		// collapses/expands together with the section list. Provides a
-		// dedicated entrypoint to the Customizations welcome page.
-		const footer = DOM.append(toolbarContainer, $('.ai-customization-footer'));
-		const footerLink = DOM.append(footer, $('a.ai-customization-footer-link'));
-		footerLink.setAttribute('role', 'button');
-		footerLink.setAttribute('tabindex', '0');
-		footerLink.setAttribute('href', '#');
-		footerLink.textContent = localize('manageCustomizations', "Manage customizations");
-		const footerArrow = DOM.append(footerLink, $('span.ai-customization-footer-arrow'));
-		footerArrow.classList.add(...ThemeIcon.asClassNameArray(Codicon.arrowRight));
-		this._register(Gesture.addTarget(footerLink));
-		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
-			this._register(DOM.addDisposableListener(footerLink, eventType, (e: Event) => {
-				e.preventDefault();
-				this._openWelcomePage();
-			}));
-		}
-		this._register(DOM.addDisposableListener(footerLink, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				this._openWelcomePage();
-			}
-		}));
-		this._register(this.hoverService.setupDelayedHoverAtMouse(footerLink, () => ({
-			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
-			appearance: { compact: true, skipFadeInAnimation: true },
-		})));
 	}
 
 	private async _openWelcomePage(): Promise<void> {
 		const input = AICustomizationManagementEditorInput.getOrCreate();
 		const editor = await this.editorService.openEditor(input, { pinned: true });
-		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID) {
-			const editorWithWelcome = editor as { showWelcomePage?(): void };
-			editorWithWelcome.showWelcomePage?.();
+		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID && isWelcomePageEditor(editor)) {
+			editor.showWelcomePage();
 		}
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -68,31 +68,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		const header = DOM.append(container, $('.ai-customization-header'));
 		header.classList.toggle('collapsed', isCollapsed);
 
-		// Home button — opens the customizations management welcome page.
-		// Placed at the start of the header (before the toggle pill) so it
-		// reads as a clear, discoverable entrypoint.
-		const homeButton = DOM.append(header, $('.ai-customization-home-btn'));
-		homeButton.classList.add(...ThemeIcon.asClassNameArray(Codicon.home));
-		homeButton.setAttribute('role', 'button');
-		homeButton.setAttribute('tabindex', '0');
-		homeButton.setAttribute('aria-label', localize('openCustomizationsWelcomePage', "Open Customizations Overview"));
-		this._register(Gesture.addTarget(homeButton));
-		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
-			this._register(DOM.addDisposableListener(homeButton, eventType, () => {
-				this._openWelcomePage();
-			}));
-		}
-		this._register(DOM.addDisposableListener(homeButton, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				this._openWelcomePage();
-			}
-		}));
-		this._register(this.hoverService.setupDelayedHoverAtMouse(homeButton, () => ({
-			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
-			appearance: { compact: true, skipFadeInAnimation: true },
-		})));
-
 		const headerButtonContainer = DOM.append(header, $('.customization-link-button-container'));
 		const headerButton = this._register(new Button(headerButtonContainer, {
 			...defaultButtonStyles,
@@ -170,6 +145,35 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
+
+		// Footer link — appended inside the collapsible content so it
+		// collapses/expands together with the section list. Provides a
+		// dedicated entrypoint to the Customizations welcome page.
+		const footer = DOM.append(toolbarContainer, $('.ai-customization-footer'));
+		const footerLink = DOM.append(footer, $('a.ai-customization-footer-link'));
+		footerLink.setAttribute('role', 'button');
+		footerLink.setAttribute('tabindex', '0');
+		footerLink.setAttribute('href', '#');
+		footerLink.textContent = localize('manageCustomizations', "Manage customizations");
+		const footerArrow = DOM.append(footerLink, $('span.ai-customization-footer-arrow'));
+		footerArrow.classList.add(...ThemeIcon.asClassNameArray(Codicon.arrowRight));
+		this._register(Gesture.addTarget(footerLink));
+		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
+			this._register(DOM.addDisposableListener(footerLink, eventType, (e: Event) => {
+				e.preventDefault();
+				this._openWelcomePage();
+			}));
+		}
+		this._register(DOM.addDisposableListener(footerLink, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this._openWelcomePage();
+			}
+		}));
+		this._register(this.hoverService.setupDelayedHoverAtMouse(footerLink, () => ({
+			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
+			appearance: { compact: true, skipFadeInAnimation: true },
+		})));
 	}
 
 	private async _openWelcomePage(): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -68,6 +68,31 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		const header = DOM.append(container, $('.ai-customization-header'));
 		header.classList.toggle('collapsed', isCollapsed);
 
+		// Home button — opens the customizations management welcome page.
+		// Placed at the start of the header (before the toggle pill) so it
+		// reads as a clear, discoverable entrypoint.
+		const homeButton = DOM.append(header, $('.ai-customization-home-btn'));
+		homeButton.classList.add(...ThemeIcon.asClassNameArray(Codicon.home));
+		homeButton.setAttribute('role', 'button');
+		homeButton.setAttribute('tabindex', '0');
+		homeButton.setAttribute('aria-label', localize('openCustomizationsWelcomePage', "Open Customizations Overview"));
+		this._register(Gesture.addTarget(homeButton));
+		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
+			this._register(DOM.addDisposableListener(homeButton, eventType, () => {
+				this._openWelcomePage();
+			}));
+		}
+		this._register(DOM.addDisposableListener(homeButton, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this._openWelcomePage();
+			}
+		}));
+		this._register(this.hoverService.setupDelayedHoverAtMouse(homeButton, () => ({
+			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
+			appearance: { compact: true, skipFadeInAnimation: true },
+		})));
+
 		const headerButtonContainer = DOM.append(header, $('.customization-link-button-container'));
 		const headerButton = this._register(new Button(headerButtonContainer, {
 			...defaultButtonStyles,
@@ -145,29 +170,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
-
-		// Home button — opens the customizations management welcome page
-		const homeButton = DOM.append(header, $('.ai-customization-home-btn'));
-		homeButton.classList.add(...ThemeIcon.asClassNameArray(Codicon.home));
-		homeButton.setAttribute('role', 'button');
-		homeButton.setAttribute('tabindex', '0');
-		homeButton.setAttribute('aria-label', localize('openCustomizationsWelcomePage', "Open Customizations Overview"));
-		this._register(Gesture.addTarget(homeButton));
-		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
-			this._register(DOM.addDisposableListener(homeButton, eventType, () => {
-				this._openWelcomePage();
-			}));
-		}
-		this._register(DOM.addDisposableListener(homeButton, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				this._openWelcomePage();
-			}
-		}));
-		this._register(this.hoverService.setupDelayedHoverAtMouse(homeButton, () => ({
-			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
-			appearance: { compact: true, skipFadeInAnimation: true },
-		})));
 	}
 
 	private async _openWelcomePage(): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -22,16 +22,12 @@ import { CUSTOMIZATION_ITEMS } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
 import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 
 const $ = DOM.$;
 
 const CUSTOMIZATIONS_COLLAPSED_KEY = 'agentSessions.customizationsCollapsed';
-
-function isWelcomePageEditor(editor: unknown): editor is { showWelcomePage(): void } {
-	return typeof (editor as { showWelcomePage?: unknown })?.showWelcomePage === 'function';
-}
 
 export interface IAICustomizationShortcutsWidgetOptions {
 	readonly onDidChangeLayout?: () => void;
@@ -171,7 +167,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	private async _openWelcomePage(): Promise<void> {
 		const input = AICustomizationManagementEditorInput.getOrCreate();
 		const editor = await this.editorService.openEditor(input, { pinned: true });
-		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID && isWelcomePageEditor(editor)) {
+		if (editor instanceof AICustomizationManagementEditor) {
 			editor.showWelcomePage();
 		}
 	}

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -6,6 +6,7 @@
 import '../../../browser/media/sidebarActionButton.css';
 import './media/customizationsToolbar.css';
 import * as DOM from '../../../../base/browser/dom.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
@@ -21,6 +22,10 @@ import { IAICustomizationItemsModel } from '../../../../workbench/contrib/chat/b
 import { CUSTOMIZATION_ITEMS } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
 import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
+import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 
 const $ = DOM.$;
 
@@ -42,6 +47,8 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		@IMcpService private readonly mcpService: IMcpService,
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IAICustomizationItemsModel private readonly itemsModel: IAICustomizationItemsModel,
+		@IEditorService private readonly editorService: IEditorService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 
@@ -138,6 +145,38 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
+
+		// Home button — opens the customizations management welcome page
+		const homeButton = DOM.append(header, $('.ai-customization-home-btn'));
+		homeButton.classList.add(...ThemeIcon.asClassNameArray(Codicon.home));
+		homeButton.setAttribute('role', 'button');
+		homeButton.setAttribute('tabindex', '0');
+		homeButton.setAttribute('aria-label', localize('openCustomizationsWelcomePage', "Open Customizations Overview"));
+		this._register(Gesture.addTarget(homeButton));
+		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap] as const) {
+			this._register(DOM.addDisposableListener(homeButton, eventType, () => {
+				this._openWelcomePage();
+			}));
+		}
+		this._register(DOM.addDisposableListener(homeButton, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				this._openWelcomePage();
+			}
+		}));
+		this._register(this.hoverService.setupDelayedHoverAtMouse(homeButton, () => ({
+			content: localize('openCustomizationsWelcomePage', "Open Customizations Overview"),
+			appearance: { compact: true, skipFadeInAnimation: true },
+		})));
+	}
+
+	private async _openWelcomePage(): Promise<void> {
+		const input = AICustomizationManagementEditorInput.getOrCreate();
+		const editor = await this.editorService.openEditor(input, { pinned: true });
+		if (editor?.getId() === AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID) {
+			const editorWithWelcome = editor as { showWelcomePage?(): void };
+			editorWithWelcome.showWelcomePage?.();
+		}
 	}
 
 	focus(): void {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -168,6 +168,9 @@
 
 .ai-customization-toolbar .ai-customization-home-btn .codicon {
 	margin: 0;
+	/* Codicons are a single-weight font; bump the size so the home icon
+	 * visually matches the weight of the bold "Customizations" label. */
+	font-size: 18px;
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:hover {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -86,9 +86,22 @@
 	position: relative;
 }
 
-/* Customizations header label uses heavier weight */
+/* Customizations header label uses heavier weight and the strong
+ * foreground color, so the entire `<home> Customizations` row reads as
+ * the section title. */
 .ai-customization-toolbar .ai-customization-header .customization-link-button {
 	font-weight: 500;
+	/* Drop the leading padding so "Customizations" sits exactly 10px
+	 * after the home icon — matching the icon→label distance of the
+	 * section rows below. */
+	padding-left: 0;
+	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
+}
+
+/* Section rows below the header use a lighter foreground so the header
+ * remains the most prominent element in the section. */
+.ai-customization-toolbar .ai-customization-toolbar-content .customization-link-button {
+	color: var(--vscode-descriptionForeground);
 }
 
 /* Counts - floating right inside the button */
@@ -137,18 +150,18 @@
 }
 
 /* Home button — leading entrypoint to the customizations welcome page.
- * Matches `.sidebar-action-button` layout (padding + gap) so the home
- * icon aligns vertically with the section icons rendered below. */
+ * Mirrors `.sidebar-action-button` padding so the home icon's left edge
+ * lands at the same x as the Agents/Skills icons. The right padding is
+ * 10px because the adjacent header button drops its own left padding,
+ * yielding exactly the same icon→label gap as the section rows. */
 .ai-customization-toolbar .ai-customization-home-btn {
 	flex-shrink: 0;
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
-	padding: 4px 8px;
-	gap: 10px;
+	padding: 4px 10px 4px 8px;
 	border-radius: 4px;
 	cursor: pointer;
-	opacity: 0.8;
 	touch-action: manipulation;
 	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
 }
@@ -158,12 +171,10 @@
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:hover {
-	opacity: 1;
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:focus {
-	opacity: 1;
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -137,22 +137,24 @@
 }
 
 /* Home button — leading entrypoint to the customizations welcome page.
- * Uses the same horizontal padding as `.sidebar-action-button` so the
- * home icon vertically aligns with the section icons below it. */
+ * Matches `.sidebar-action-button` layout (padding + gap) so the home
+ * icon aligns vertically with the section icons rendered below. */
 .ai-customization-toolbar .ai-customization-home-btn {
 	flex-shrink: 0;
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
-	justify-content: center;
 	padding: 4px 8px;
-	height: 22px;
+	gap: 10px;
 	border-radius: 4px;
 	cursor: pointer;
 	opacity: 0.8;
 	touch-action: manipulation;
-	font-size: 16px;
 	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
+}
+
+.ai-customization-toolbar .ai-customization-home-btn .codicon {
+	margin: 0;
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:hover {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -168,9 +168,6 @@
 
 .ai-customization-toolbar .ai-customization-home-btn .codicon {
 	margin: 0;
-	/* Codicons are a single-weight font; bump the size so the home icon
-	 * visually matches the weight of the bold "Customizations" label. */
-	font-size: 18px;
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:hover {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -39,6 +39,7 @@
 	align-items: center;
 	-webkit-user-select: none;
 	user-select: none;
+	gap: 4px;
 }
 
 .ai-customization-toolbar .ai-customization-header:not(.collapsed) {
@@ -79,6 +80,39 @@
 	overflow: hidden;
 	min-width: 0;
 	flex: 1;
+}
+
+.ai-customization-toolbar .ai-customization-header-actions {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+}
+
+.ai-customization-toolbar .ai-customization-overview-button.monaco-button {
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	margin: 0;
+	border: none;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--vscode-descriptionForeground);
+	background: transparent;
+	opacity: 0.85;
+}
+
+.ai-customization-toolbar .ai-customization-overview-button.monaco-button:hover,
+.ai-customization-toolbar .ai-customization-overview-button.monaco-button:focus {
+	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
+	background-color: var(--vscode-toolbar-hoverBackground);
+	opacity: 1;
+}
+
+.ai-customization-toolbar .ai-customization-overview-button.monaco-button .codicon {
+	margin: 0;
+	font-size: 16px;
 }
 
 /* Button needs relative positioning for counts overlay */
@@ -134,48 +168,4 @@
 .ai-customization-toolbar.collapsed .ai-customization-toolbar-content {
 	max-height: 0;
 	padding-bottom: 0;
-}
-
-/* Footer link — "Manage customizations →" entrypoint to the welcome page.
- * Sits below the section list, separated by a subtle top border. */
-.ai-customization-toolbar .ai-customization-footer {
-	margin-top: 6px;
-	padding-top: 6px;
-	border-top: 1px solid var(--vscode-agentsPanel-border, transparent);
-}
-
-.ai-customization-toolbar .ai-customization-footer-link {
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	padding: 4px 8px;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
-	text-decoration: none;
-	touch-action: manipulation;
-}
-
-.ai-customization-toolbar .ai-customization-footer-link:hover {
-	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
-	background-color: var(--vscode-toolbar-hoverBackground);
-	text-decoration: none;
-}
-
-.ai-customization-toolbar .ai-customization-footer-link:focus {
-	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: -1px;
-	text-decoration: none;
-}
-
-.ai-customization-toolbar .ai-customization-footer-arrow {
-	font-size: 12px;
-	opacity: 0.7;
-	transition: transform 0.15s ease-out;
-}
-
-.ai-customization-toolbar .ai-customization-footer-link:hover .ai-customization-footer-arrow {
-	transform: translateX(2px);
-	opacity: 1;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -86,6 +86,7 @@
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
+	margin-right: 4px;
 }
 
 .ai-customization-toolbar .ai-customization-overview-button.monaco-button {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -135,3 +135,35 @@
 	max-height: 0;
 	padding-bottom: 0;
 }
+
+/* Home button — reveals on hover to navigate to the customizations welcome page */
+.ai-customization-toolbar .ai-customization-home-btn {
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 4px;
+	cursor: pointer;
+	opacity: 0;
+	touch-action: manipulation;
+	font-size: 14px;
+	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
+}
+
+.ai-customization-toolbar .ai-customization-header:hover .ai-customization-home-btn,
+.ai-customization-toolbar .ai-customization-header:focus-within .ai-customization-home-btn {
+	opacity: 0.7;
+}
+
+.ai-customization-toolbar .ai-customization-home-btn:hover {
+	opacity: 1 !important;
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.ai-customization-toolbar .ai-customization-home-btn:focus {
+	opacity: 1 !important;
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -136,34 +136,30 @@
 	padding-bottom: 0;
 }
 
-/* Home button — reveals on hover to navigate to the customizations welcome page */
+/* Home button — leading entrypoint to the customizations welcome page */
 .ai-customization-toolbar .ai-customization-home-btn {
 	flex-shrink: 0;
-	width: 20px;
-	height: 20px;
+	width: 22px;
+	height: 22px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	border-radius: 4px;
 	cursor: pointer;
-	opacity: 0;
+	opacity: 0.8;
 	touch-action: manipulation;
 	font-size: 14px;
+	margin-right: 4px;
 	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
 }
 
-.ai-customization-toolbar .ai-customization-header:hover .ai-customization-home-btn,
-.ai-customization-toolbar .ai-customization-header:focus-within .ai-customization-home-btn {
-	opacity: 0.7;
-}
-
 .ai-customization-toolbar .ai-customization-home-btn:hover {
-	opacity: 1 !important;
+	opacity: 1;
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .ai-customization-toolbar .ai-customization-home-btn:focus {
-	opacity: 1 !important;
+	opacity: 1;
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -86,22 +86,9 @@
 	position: relative;
 }
 
-/* Customizations header label uses heavier weight and the strong
- * foreground color, so the entire `<home> Customizations` row reads as
- * the section title. */
+/* Customizations header label uses heavier weight */
 .ai-customization-toolbar .ai-customization-header .customization-link-button {
 	font-weight: 500;
-	/* Drop the leading padding so "Customizations" sits exactly 10px
-	 * after the home icon — matching the icon→label distance of the
-	 * section rows below. */
-	padding-left: 0;
-	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
-}
-
-/* Section rows below the header use a lighter foreground so the header
- * remains the most prominent element in the section. */
-.ai-customization-toolbar .ai-customization-toolbar-content .customization-link-button {
-	color: var(--vscode-descriptionForeground);
 }
 
 /* Counts - floating right inside the button */
@@ -149,32 +136,46 @@
 	padding-bottom: 0;
 }
 
-/* Home button — leading entrypoint to the customizations welcome page.
- * Mirrors `.sidebar-action-button` padding so the home icon's left edge
- * lands at the same x as the Agents/Skills icons. The right padding is
- * 10px because the adjacent header button drops its own left padding,
- * yielding exactly the same icon→label gap as the section rows. */
-.ai-customization-toolbar .ai-customization-home-btn {
-	flex-shrink: 0;
-	box-sizing: border-box;
+/* Footer link — "Manage customizations →" entrypoint to the welcome page.
+ * Sits below the section list, separated by a subtle top border. */
+.ai-customization-toolbar .ai-customization-footer {
+	margin-top: 6px;
+	padding-top: 6px;
+	border-top: 1px solid var(--vscode-agentsPanel-border, transparent);
+}
+
+.ai-customization-toolbar .ai-customization-footer-link {
 	display: flex;
 	align-items: center;
-	padding: 4px 10px 4px 8px;
+	gap: 4px;
+	padding: 4px 8px;
 	border-radius: 4px;
 	cursor: pointer;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	text-decoration: none;
 	touch-action: manipulation;
+}
+
+.ai-customization-toolbar .ai-customization-footer-link:hover {
 	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
-}
-
-.ai-customization-toolbar .ai-customization-home-btn .codicon {
-	margin: 0;
-}
-
-.ai-customization-toolbar .ai-customization-home-btn:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
+	text-decoration: none;
 }
 
-.ai-customization-toolbar .ai-customization-home-btn:focus {
+.ai-customization-toolbar .ai-customization-footer-link:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
+	text-decoration: none;
+}
+
+.ai-customization-toolbar .ai-customization-footer-arrow {
+	font-size: 12px;
+	opacity: 0.7;
+	transition: transform 0.15s ease-out;
+}
+
+.ai-customization-toolbar .ai-customization-footer-link:hover .ai-customization-footer-arrow {
+	transform: translateX(2px);
+	opacity: 1;
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -136,20 +136,22 @@
 	padding-bottom: 0;
 }
 
-/* Home button — leading entrypoint to the customizations welcome page */
+/* Home button — leading entrypoint to the customizations welcome page.
+ * Uses the same horizontal padding as `.sidebar-action-button` so the
+ * home icon vertically aligns with the section icons below it. */
 .ai-customization-toolbar .ai-customization-home-btn {
 	flex-shrink: 0;
-	width: 22px;
-	height: 22px;
+	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 4px 8px;
+	height: 22px;
 	border-radius: 4px;
 	cursor: pointer;
 	opacity: 0.8;
 	touch-action: manipulation;
-	font-size: 14px;
-	margin-right: 4px;
+	font-size: 16px;
 	color: var(--vscode-agentsPanel-foreground, var(--vscode-foreground));
 }
 

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -20,6 +20,7 @@ import { ComponentFixtureContext, createEditorServices, defineComponentFixture, 
 import { AICustomizationShortcutsWidget } from '../../browser/aiCustomizationShortcutsWidget.js';
 import { CUSTOMIZATION_ITEMS, CustomizationLinkViewItem } from '../../browser/customizationsToolbar.contribution.js';
 import { Menus } from '../../../../browser/menus.js';
+import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 
 // Ensure color registrations are loaded
 import '../../../../common/theme.js';
@@ -157,6 +158,12 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 			reg.defineInstance(IMcpService, createMockMcpService(options?.mcpServerCount ?? 0));
 			reg.defineInstance(IAgentPluginService, new class extends mock<IAgentPluginService>() {
 				override readonly plugins = observableValue<readonly never[]>('mockPlugins', []);
+			}());
+			reg.defineInstance(IEditorService, new class extends mock<IEditorService>() {
+				override readonly onDidActiveEditorChange = Event.None;
+				override readonly onDidVisibleEditorsChange = Event.None;
+				override readonly onDidEditorsChange = Event.None;
+				override async openEditor() { return undefined; }
 			}());
 		},
 	});

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
@@ -21,8 +21,8 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AICustomizationManagementEditor } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { AICustomizationManagementEditorInput } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
-import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { IAICustomizationItemsModel, ItemsModelSection } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.js';
 import { IAICustomizationListItem } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.js';
 import { IAgentPluginService } from '../../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
@@ -63,29 +63,15 @@ class TestMenuService implements IMenuService {
 	resetHiddenStates() { }
 }
 
-class TestWelcomeEditor extends mock<IEditorPane>() {
-	override readonly onDidFocus = Event.None;
-	override readonly onDidBlur = Event.None;
-	override readonly onDidChangeControl = Event.None;
-	showWelcomePageCallCount = 0;
+type TestWelcomeEditor = AICustomizationManagementEditor & { showWelcomePageCallCount: number };
 
-	override getId(): string {
-		return AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID;
-	}
-
-	override getTitle(): string | undefined {
-		return undefined;
-	}
-
-	override hasFocus(): boolean {
-		return false;
-	}
-
-	override focus(): void { }
-
-	showWelcomePage(): void {
-		this.showWelcomePageCallCount++;
-	}
+function createTestWelcomeEditor(): TestWelcomeEditor {
+	const editor = Object.create(AICustomizationManagementEditor.prototype) as TestWelcomeEditor;
+	editor.showWelcomePageCallCount = 0;
+	editor.showWelcomePage = () => {
+		editor.showWelcomePageCallCount++;
+	};
+	return editor;
 }
 
 class TestEditorService extends mock<IEditorService>() {
@@ -95,7 +81,7 @@ class TestEditorService extends mock<IEditorService>() {
 
 	openEditorCallCount = 0;
 	lastInput: EditorInput | IUntypedEditorInput | undefined;
-	readonly editor = new TestWelcomeEditor();
+	readonly editor = createTestWelcomeEditor();
 
 	override openEditor(editor: IResourceEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;
 	override openEditor(editor: ITextResourceEditorInput | IUntitledTextResourceEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestCommandService } from '../../../../../editor/test/browser/editorTestServices.js';
+import { IActionViewItemFactory, IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
+import { IMenu, IMenuActionOptions, IMenuService, MenuId } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { MockContextKeyService, MockKeybindingService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryServiceShape } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { AICustomizationManagementEditorInput } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
+import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { IAICustomizationItemsModel, ItemsModelSection } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.js';
+import { IAICustomizationListItem } from '../../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.js';
+import { IAgentPluginService } from '../../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
+import { IMcpServer, IMcpService } from '../../../../../workbench/contrib/mcp/common/mcpTypes.js';
+import { IEditorService, PreferredGroup } from '../../../../../workbench/services/editor/common/editorService.js';
+import { IEditorPane, IResourceDiffEditorInput, ITextDiffEditorPane, ITextResourceDiffEditorInput, IUntitledTextResourceEditorInput, IUntypedEditorInput } from '../../../../../workbench/common/editor.js';
+import { EditorInput } from '../../../../../workbench/common/editor/editorInput.js';
+import { IEditorOptions, IResourceEditorInput, ITextResourceEditorInput } from '../../../../../platform/editor/common/editor.js';
+import { AICustomizationShortcutsWidget } from '../../browser/aiCustomizationShortcutsWidget.js';
+
+class TestActionViewItemService implements IActionViewItemService {
+	declare _serviceBrand: undefined;
+
+	readonly onDidChange = Event.None;
+
+	register(_menu: MenuId, _commandId: string | MenuId, _provider: IActionViewItemFactory): { dispose(): void } {
+		return { dispose: () => { } };
+	}
+
+	lookUp(_menu: MenuId, _commandId: string | MenuId): IActionViewItemFactory | undefined {
+		return undefined;
+	}
+}
+
+class TestMenuService implements IMenuService {
+	declare readonly _serviceBrand: undefined;
+
+	createMenu(_id: MenuId): IMenu {
+		return {
+			onDidChange: Event.None,
+			dispose: () => { },
+			getActions: () => [],
+		};
+	}
+
+	getMenuActions(_id: MenuId, _contextKeyService: unknown, _options?: IMenuActionOptions) { return []; }
+	getMenuContexts() { return new Set<string>(); }
+	resetHiddenStates() { }
+}
+
+class TestWelcomeEditor extends mock<IEditorPane>() {
+	override readonly onDidFocus = Event.None;
+	override readonly onDidBlur = Event.None;
+	override readonly onDidChangeControl = Event.None;
+	showWelcomePageCallCount = 0;
+
+	override getId(): string {
+		return AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID;
+	}
+
+	override getTitle(): string | undefined {
+		return undefined;
+	}
+
+	override hasFocus(): boolean {
+		return false;
+	}
+
+	override focus(): void { }
+
+	showWelcomePage(): void {
+		this.showWelcomePageCallCount++;
+	}
+}
+
+class TestEditorService extends mock<IEditorService>() {
+	override readonly onDidActiveEditorChange = Event.None;
+	override readonly onDidVisibleEditorsChange = Event.None;
+	override readonly onDidEditorsChange = Event.None;
+
+	openEditorCallCount = 0;
+	lastInput: EditorInput | IUntypedEditorInput | undefined;
+	readonly editor = new TestWelcomeEditor();
+
+	override openEditor(editor: IResourceEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override openEditor(editor: ITextResourceEditorInput | IUntitledTextResourceEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override openEditor(editor: ITextResourceDiffEditorInput | IResourceDiffEditorInput, group?: PreferredGroup): Promise<ITextDiffEditorPane | undefined>;
+	override openEditor(editor: IUntypedEditorInput, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override openEditor(editor: EditorInput, options?: IEditorOptions, group?: PreferredGroup): Promise<IEditorPane | undefined>;
+	override async openEditor(editor: EditorInput | IUntypedEditorInput, _optionsOrGroup?: IEditorOptions | PreferredGroup, _group?: PreferredGroup): Promise<IEditorPane | ITextDiffEditorPane | undefined> {
+		this.openEditorCallCount++;
+		this.lastInput = editor;
+		return this.editor;
+	}
+}
+
+function createMockItemsModel(): IAICustomizationItemsModel {
+	const emptyItems = observableValue<readonly IAICustomizationListItem[]>('emptyCustomizationItems', []);
+	const zeroCount = observableValue('emptyCustomizationCount', 0);
+
+	return new class extends mock<IAICustomizationItemsModel>() {
+		override getItems(_section: ItemsModelSection): IObservable<readonly IAICustomizationListItem[]> {
+			return emptyItems;
+		}
+
+		override getCount(_section: ItemsModelSection): IObservable<number> {
+			return zeroCount;
+		}
+	}();
+}
+
+function createWidget(disposables: DisposableStore, storageService = disposables.add(new InMemoryStorageService())): { container: HTMLElement; editorService: TestEditorService; storageService: InMemoryStorageService } {
+	const container = document.createElement('div');
+	document.body.appendChild(container);
+	disposables.add({ dispose: () => container.remove() });
+
+	const editorService = new TestEditorService();
+	const instantiationService = createInstantiationService(disposables, storageService, editorService);
+
+	disposables.add(instantiationService.createInstance(AICustomizationShortcutsWidget, container, undefined));
+	return { container, editorService, storageService };
+}
+
+function createInstantiationService(disposables: DisposableStore, storageService: IStorageService, editorService: IEditorService): TestInstantiationService {
+	const instantiationService = disposables.add(new TestInstantiationService());
+	instantiationService.set(IMenuService, new TestMenuService());
+	instantiationService.set(IActionViewItemService, new TestActionViewItemService());
+	instantiationService.set(IContextKeyService, new MockContextKeyService());
+	instantiationService.set(IContextMenuService, {
+		_serviceBrand: undefined,
+		onDidShowContextMenu: Event.None,
+		onDidHideContextMenu: Event.None,
+		showContextMenu: () => { },
+	});
+	instantiationService.set(IKeybindingService, new MockKeybindingService());
+	instantiationService.set(ICommandService, new TestCommandService(instantiationService));
+	instantiationService.set(ITelemetryService, new NullTelemetryServiceShape());
+	instantiationService.set(IStorageService, storageService);
+	instantiationService.set(IEditorService, editorService);
+	instantiationService.set(IAICustomizationItemsModel, createMockItemsModel());
+	instantiationService.set(IMcpService, new class extends mock<IMcpService>() {
+		override readonly servers = observableValue<readonly IMcpServer[]>('emptyMcpServers', []);
+	}());
+	instantiationService.set(IAgentPluginService, new class extends mock<IAgentPluginService>() {
+		override readonly plugins = observableValue<readonly never[]>('emptyPlugins', []);
+	}());
+	return instantiationService;
+}
+
+suite('AICustomizationShortcutsWidget', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('overview button opens the welcome page without collapsing the section', async () => {
+		const testDisposables = disposables.add(new DisposableStore());
+		const { container, editorService, storageService } = createWidget(testDisposables);
+		const toolbar = container.querySelector<HTMLElement>('.ai-customization-toolbar');
+		const overviewButton = container.querySelector<HTMLElement>('.ai-customization-overview-button');
+
+		assert.ok(toolbar);
+		assert.ok(overviewButton);
+		assert.strictEqual(toolbar.classList.contains('collapsed'), false);
+		assert.strictEqual(storageService.getBoolean('agentSessions.customizationsCollapsed', StorageScope.PROFILE, false), false);
+
+		overviewButton.click();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		if (editorService.lastInput instanceof EditorInput) {
+			testDisposables.add(editorService.lastInput);
+		}
+
+		assert.deepStrictEqual({
+			openEditorCallCount: editorService.openEditorCallCount,
+			openedInputIsManagementEditor: editorService.lastInput instanceof AICustomizationManagementEditorInput,
+			showWelcomePageCallCount: editorService.editor.showWelcomePageCallCount,
+			collapsed: toolbar.classList.contains('collapsed'),
+			storedCollapsed: storageService.getBoolean('agentSessions.customizationsCollapsed', StorageScope.PROFILE, false),
+			ariaLabel: overviewButton.getAttribute('aria-label'),
+		}, {
+			openEditorCallCount: 1,
+			openedInputIsManagementEditor: true,
+			showWelcomePageCallCount: 1,
+			collapsed: false,
+			storedCollapsed: false,
+			ariaLabel: 'Open Customizations Overview',
+		});
+	});
+
+	test('overview button remains available when the section is collapsed', () => {
+		const testDisposables = disposables.add(new DisposableStore());
+		const storageService = testDisposables.add(new InMemoryStorageService());
+		storageService.store('agentSessions.customizationsCollapsed', true, StorageScope.PROFILE, StorageTarget.USER);
+		const { container } = createWidget(testDisposables, storageService);
+
+		assert.deepStrictEqual({
+			collapsed: container.querySelector<HTMLElement>('.ai-customization-toolbar')?.classList.contains('collapsed'),
+			overviewButtonVisible: !!container.querySelector<HTMLElement>('.ai-customization-overview-button'),
+		}, {
+			collapsed: true,
+			overviewButtonVisible: true,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a home icon action to the Agents sidebar **Customizations** header so users can return to the AI Customizations management editor welcome/overview page.

## UX

The action sits at the right edge of the Customizations header, separate from the header label/collapse toggle. This keeps the row alignment clean, avoids footer clipping in the sidebar layout, and keeps the overview entrypoint available in both expanded and collapsed states.

## Changes

- Adds a localized, accessible icon-only overview action in `AICustomizationShortcutsWidget`.
- Opens `AICustomizationManagementEditorInput` and calls `showWelcomePage()` only when the opened editor is the AI Customization management editor.
- Removes the previous footer-link approach.
- Adds focused browser unit coverage for opening the welcome page without collapsing the section and for collapsed-state availability.
- Updates the Sessions AI Customizations design doc.