### PR TITLE
Be less aggressive about removing terminal in agents app

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -152,11 +152,28 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 			}
 		}));
 
-		// When a session is archived or removed, close all terminals for its cwd
+		// Close terminals for archived/removed sessions, but only when no other
+		// live session still owns that cwd. Terminals are reused across sessions
+		// at the same cwd, so a plain cwd match would kill a terminal still in use
+		// (e.g. the committed session from `onDidReplaceSession`).
+		// TODO: Consider removing the logic for trying to "delete/clean-up" terminal.
+		// Or consider tag terminals by sessionId + refcount instead of guarding here.
+
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
-			for (const session of [...e.removed, ...e.changed.filter(s => s.isArchived.get())]) {
+			const removedIds = new Set(e.removed.map(s => s.sessionId));
+			const liveCwdKeys = new Set<string>();
+			for (const session of this._sessionsManagementService.getSessions()) {
+				if (removedIds.has(session.sessionId) || session.isArchived.get()) {
+					continue;
+				}
 				const info = getSessionTerminalInfo(session);
 				if (info) {
+					liveCwdKeys.add(info.cwd.fsPath.toLowerCase());
+				}
+			}
+			for (const session of [...e.removed, ...e.changed.filter(s => s.isArchived.get())]) {
+				const info = getSessionTerminalInfo(session);
+				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
 					this._closeTerminalsForPath(info.cwd.fsPath);
 				}
 			}

--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -64,7 +64,9 @@ function getSessionTerminalInfo(session: ISession | undefined): ISessionTerminal
  * Manages terminal instances in the sessions window, ensuring:
  * - A terminal exists for the active session's worktree (or repository if no worktree).
  * - Terminals are shown/hidden based on their initial cwd matching the active path.
- * - All terminals for a worktree are closed when the session is archived.
+ * - Terminals for an archived/removed session are closed only when no other
+ *   live session still owns the same cwd (terminals are reused across sessions
+ *   at the same worktree).
  */
 export class SessionsTerminalContribution extends Disposable implements IWorkbenchContribution {
 
@@ -160,6 +162,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		// Or consider tag terminals by sessionId + refcount instead of guarding here.
 
 		this._register(this._sessionsManagementService.onDidChangeSessions(e => {
+			const archivedChanged = e.changed.filter(s => s.isArchived.get());
+			if (e.removed.length === 0 && archivedChanged.length === 0) {
+				return;
+			}
 			const removedIds = new Set(e.removed.map(s => s.sessionId));
 			const liveCwdKeys = new Set<string>();
 			for (const session of this._sessionsManagementService.getSessions()) {
@@ -171,7 +177,7 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 					liveCwdKeys.add(info.cwd.fsPath.toLowerCase());
 				}
 			}
-			for (const session of [...e.removed, ...e.changed.filter(s => s.isArchived.get())]) {
+			for (const session of [...e.removed, ...archivedChanged]) {
 				const info = getSessionTerminalInfo(session);
 				if (info && !liveCwdKeys.has(info.cwd.fsPath.toLowerCase())) {
 					this._closeTerminalsForPath(info.cwd.fsPath);

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -50,6 +50,7 @@ function makeAgentSession(opts: {
 	worktree?: URI;
 	providerType?: string;
 	isArchived?: boolean;
+	sessionId?: string;
 }): IActiveSession {
 	const repo = opts.repository || opts.worktree ? {
 		uri: opts.repository ?? opts.worktree!,
@@ -72,7 +73,7 @@ function makeAgentSession(opts: {
 		description: observableValue('test.description', undefined),
 	};
 	const session: IActiveSession = {
-		sessionId: 'test:session',
+		sessionId: opts.sessionId ?? 'test:session',
 		resource: chat.resource,
 		providerId: 'test',
 		sessionType: opts.providerType ?? AgentSessionProviders.Local,
@@ -198,6 +199,7 @@ suite('SessionsTerminalContribution', () => {
 	let showBackgroundCalls: number[];
 	let disposeOnCreatePaths: Set<string>;
 	let logService: TestLogService;
+	let allSessions: ISession[];
 
 	setup(() => {
 		createdTerminals = [];
@@ -211,6 +213,7 @@ suite('SessionsTerminalContribution', () => {
 		showBackgroundCalls = [];
 		disposeOnCreatePaths = new Set();
 		logService = new TestLogService();
+		allSessions = [];
 
 		const instantiationService = store.add(new TestInstantiationService());
 
@@ -223,6 +226,7 @@ suite('SessionsTerminalContribution', () => {
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override activeSession = activeSessionObs;
 			override readonly onDidChangeSessions = onDidChangeSessions.event;
+			override getSessions(): ISession[] { return [...allSessions]; }
 		});
 
 		instantiationService.stub(ITerminalService, new class extends mock<ITerminalService>() {
@@ -551,6 +555,50 @@ suite('SessionsTerminalContribution', () => {
 		await tick();
 
 		assert.strictEqual(disposedInstances.length, 1);
+	});
+
+	test('does not close terminal when another live session still owns the cwd (replace case)', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+
+		// Simulate the onDidReplaceSession flow: `from` (untitled) is reported as
+		// removed while `to` (committed) is still live at the same cwd.
+		const fromSession = makeAgentSession({ sessionId: 'test:untitled', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const toSession = makeAgentSession({ sessionId: 'test:committed', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		allSessions = [toSession];
+
+		onDidChangeSessions.fire({ added: [], removed: [fromSession], changed: [toSession] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'terminal should be kept alive for the surviving session');
+	});
+
+	test('does not close terminal when archiving one of two sessions sharing a cwd', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+
+		const liveSession = makeAgentSession({ sessionId: 'test:live', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		const archivedSession = makeAgentSession({ sessionId: 'test:archived', worktree: worktreeUri, providerType: AgentSessionProviders.Background, isArchived: true });
+		allSessions = [liveSession, archivedSession];
+
+		onDidChangeSessions.fire({ added: [], removed: [], changed: [archivedSession] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 0, 'terminal should be kept for the still-live session');
+	});
+
+	test('closes terminal when the only session at a cwd is removed even if other live sessions exist elsewhere', async () => {
+		const worktreeUri = URI.file('/worktree');
+		await contribution.ensureTerminal(worktreeUri, false);
+
+		const otherLive = makeAgentSession({ sessionId: 'test:other', worktree: URI.file('/other'), providerType: AgentSessionProviders.Background });
+		const removedSession = makeAgentSession({ sessionId: 'test:gone', worktree: worktreeUri, providerType: AgentSessionProviders.Background });
+		allSessions = [otherLive];
+
+		onDidChangeSessions.fire({ added: [], removed: [removedSession], changed: [] });
+		await tick();
+
+		assert.strictEqual(disposedInstances.length, 1, 'no live session owns this cwd, terminal should be closed');
 	});
 
 	// --- switching back to previously used path reuses terminal ---


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/312872 

https://github.com/user-attachments/assets/2f02dcec-89e6-445b-aa25-0c766d355fad


/cc @TylerLeonhardt 

Agents app code has this logic where terminals are forced to close in conditions like archiving/changing sessions based on cwd. Removal was based on cwd, but also cwd was used to share terminal for multiple session which doesn't make sense to me..

I think it's fair to not have such removal, or figure out better way to associate particular session with particular terminal? 

Even for associating particular session with particular terminal, user always has to freedom to cd in/out of particular directory so labeling a terminal to a particular session seems to aggressive.

