### PR TITLE
Add `/requires-eval-assessment` comment command

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -670,5 +670,11 @@
 		"addLabel": "accessibility-sla",
 		"removeLabel": "~accessibility-sla",
 		"comment": "The Visual Studio and VS Code teams have an agreement with the Accessibility team that 3:1 contrast is enough for inside the editor."
+	},
+	{
+		"type": "comment",
+		"name": "requires-eval-assessment",
+		"action": "updateLabels",
+		"addLabel": "~requires-eval-assessment"
 	}
 ]


### PR DESCRIPTION
Adds a `/requires-eval-assessment` comment command to `commands.json` so that commenting `/requires-eval-assessment [benchmark]` on a PR automatically applies the `~requires-eval-assessment` label.

This triggers the eval-assessment pipeline (build → publish → evald benchmark) without needing to manually apply the label.

