### PR TITLE
Fix leaked disposable in OutputMonitor._setupIdleInputListener

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -473,6 +473,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	 * This ensures we catch any input that happens between idle detection and prompt creation.
 	 */
 	private _setupIdleInputListener(): void {
+		if (this._store.isDisposed) {
+			return;
+		}
 		this._userInputtedSinceIdleDetected = false;
 		this._logService.trace('OutputMonitor: Setting up idle input listener');
 


### PR DESCRIPTION
When OutputMonitor is disposed while _startMonitoring runs asynchronously, _setupIdleInputListener can execute after the MutableDisposable is already disposed. MutableDisposable.value silently drops new values when disposed, causing the onDidInputData subscription to leak.

Add an early return when the store is disposed to prevent creating the orphaned event subscription.

fixes #311722

No longer seeing this leak here https://github.com/microsoft/vscode/actions/runs/25018225646
