### PR TITLE
Add /chronicle:reindex command to rebuild local session index from JS…

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -1571,6 +1571,11 @@
 						"when": "github.copilot.sessionSearch.enabled"
 					},
 					{
+						"name": "chronicle:reindex",
+						"description": "%copilot.chronicle.reindex.description%",
+						"when": "github.copilot.sessionSearch.enabled"
+					},
+					{
 						"name": "explain",
 						"description": "%copilot.workspace.explain.description%"
 					},

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -171,6 +171,7 @@
 	"copilot.chronicle.description": "Session history tools and insights",
 	"copilot.chronicle.standup.description": "Generate a standup report from recent chat sessions",
 	"copilot.chronicle.tips.description": "Get personalized tips based on your chat session usage patterns",
+	"copilot.chronicle.reindex.description": "Rebuild the local session index from stored session logs. Add 'force' to re-process already indexed sessions.",
 	"github.copilot.config.sessionSearch.enabled": "Enable session search and /chronicle commands. This is a team-internal setting.",
 	"github.copilot.config.sessionSearch.localIndex.enabled": "Enable local session tracking. When enabled, Copilot tracks session data locally for /chronicle commands.",
 	"github.copilot.config.localIndex.enabled": "Enable local session tracking. When enabled, session data is tracked locally for /chronicle commands.",

--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -23,14 +23,22 @@ export const MAX_ASSISTANT_RESPONSE_LENGTH = 1000;
 export const MAX_SUMMARY_LENGTH = 100;
 
 /**
- * Truncate a string to `maxLength`, appending '...' if it was truncated.
+ * Truncate a string to at most `maxLength` stored characters, appending '...' if truncated.
+ * The returned value, including the truncation suffix, never exceeds `maxLength`.
  * Returns `undefined` for falsy input.
  */
 export function truncateForStore(value: string | undefined, maxLength: number): string | undefined {
 	if (!value) {
 		return undefined;
 	}
-	return value.length > maxLength ? value.slice(0, maxLength).trim() + '...' : value;
+	if (value.length <= maxLength) {
+		return value;
+	}
+	const ellipsis = '...';
+	if (maxLength <= ellipsis.length) {
+		return ellipsis.slice(0, maxLength);
+	}
+	return value.slice(0, maxLength - ellipsis.length).trimEnd() + ellipsis;
 }
 
 /** Terminal/shell tool names that may produce refs. */

--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -4,8 +4,36 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Helpers for extracting file paths and refs from tool calls.
+ * Helpers for extracting file paths and refs from tool calls,
+ * plus shared constants for session store truncation limits.
  */
+
+// ── Truncation limits (shared by sessionStoreTracker and sessionReindexer) ──
+
+/** Maximum characters stored for user_message. */
+export const MAX_USER_MESSAGE_LENGTH = 100;
+
+/** Maximum characters stored for assistant_response. */
+export const MAX_ASSISTANT_RESPONSE_LENGTH = 1000;
+
+/** Maximum characters stored for session summary. */
+export const MAX_SUMMARY_LENGTH = 100;
+
+/**
+ * Truncate a string to `maxLength`, appending '...' if it was truncated.
+ * Returns `undefined` for falsy input.
+ */
+export function truncateForStore(value: string | undefined, maxLength: number): string | undefined {
+	if (!value) {
+		return undefined;
+	}
+	return value.length > maxLength ? value.slice(0, maxLength).trim() + '...' : value;
+}
+
+/** Terminal/shell tool names that may produce refs. */
+export function isTerminalTool(toolName: string): boolean {
+	return toolName === 'runInTerminal' || toolName === 'run_in_terminal';
+}
 
 /** Tools whose arguments contain a file path being modified or read. */
 const FILE_TRACKING_TOOLS = new Set([

--- a/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
+++ b/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
@@ -60,14 +60,6 @@ function tryParseArgs(raw: string | number | boolean | undefined): unknown {
 
 /**
  * Rebuild the local Chronicle session store by re-reading JSONL debug logs from disk.
- *
- * Design principles:
- * - **Streaming**: Uses `streamEntries()` callback — never loads an entire JSONL file into memory.
- * - **Sequential**: Processes one session at a time; per-session buffer is a local variable.
- * - **Bounded**: Strings are truncated to match sessionStoreTracker limits.
- * - **Non-blocking**: Yields to the event loop between sessions via `setTimeout(0)`.
- * - **Idempotent**: Uses UPSERT/INSERT OR IGNORE so re-running is safe.
- * - **Cancellable**: Checks `token.isCancellationRequested` between sessions.
  */
 export async function reindexSessions(
 	store: ISessionStore,
@@ -204,7 +196,6 @@ function processEntry(
 		case 'turn_start':
 			processUserMessage(entry, state);
 			break;
-		case 'llm_request':
 		case 'agent_response':
 			processAssistantResponse(entry, sessionId, buffer, state);
 			break;
@@ -251,9 +242,9 @@ function processAssistantResponse(
 	buffer: PerSessionWriteBuffer,
 	state: TurnPairingState,
 ): void {
-	// Extract assistant response from outputMessages attribute (same as sessionStoreTracker)
-	const outputMessagesRaw = entry.attrs.outputMessages as string | undefined;
-	const assistantResponse = extractAssistantResponse(outputMessagesRaw);
+	// Extract assistant response from the 'response' attribute (as written by chatDebugFileLoggerService)
+	const responseRaw = entry.attrs.response as string | undefined;
+	const assistantResponse = extractAssistantResponse(responseRaw);
 
 	// Only create a turn if we have at least a user message or assistant response
 	if (!state.pendingUserMessage && !assistantResponse) {

--- a/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
+++ b/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
@@ -1,0 +1,329 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as l10n from '@vscode/l10n';
+import type { IChatDebugFileLoggerService, IDebugLogEntry } from '../../../platform/chat/common/chatDebugFileLoggerService';
+import type { ISessionStore, SessionRow, TurnRow, FileRow, RefRow } from '../../../platform/chronicle/common/sessionStore';
+import type { CancellationToken } from '../../../util/vs/base/common/cancellation';
+import {
+	MAX_ASSISTANT_RESPONSE_LENGTH,
+	MAX_SUMMARY_LENGTH,
+	MAX_USER_MESSAGE_LENGTH,
+	extractAssistantResponse,
+	extractFilePath,
+	extractRefsFromMcpTool,
+	extractRefsFromTerminal,
+	extractRepoFromMcpTool,
+	isGitHubMcpTool,
+	isTerminalTool,
+	truncateForStore,
+} from '../common/sessionStoreTracking';
+
+/**
+ * Result of a reindex operation.
+ */
+export interface ReindexResult {
+	/** Number of sessions successfully processed. */
+	processed: number;
+	/** Number of sessions skipped (already indexed or errors). */
+	skipped: number;
+	/** Whether the operation was cancelled. */
+	cancelled: boolean;
+}
+
+/**
+ * Per-session write buffer. Allocated per-session, freed after the transaction commits.
+ * Bounded by the number of events in a single session.
+ */
+interface PerSessionWriteBuffer {
+	session: SessionRow | undefined;
+	turns: TurnRow[];
+	files: FileRow[];
+	refs: RefRow[];
+}
+
+/**
+ * Safely parse JSON from a string attribute. Returns undefined on failure.
+ */
+function tryParseArgs(raw: string | number | boolean | undefined): unknown {
+	if (typeof raw !== 'string') {
+		return undefined;
+	}
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Rebuild the local Chronicle session store by re-reading JSONL debug logs from disk.
+ *
+ * Design principles:
+ * - **Streaming**: Uses `streamEntries()` callback — never loads an entire JSONL file into memory.
+ * - **Sequential**: Processes one session at a time; per-session buffer is a local variable.
+ * - **Bounded**: Strings are truncated to match sessionStoreTracker limits.
+ * - **Non-blocking**: Yields to the event loop between sessions via `setTimeout(0)`.
+ * - **Idempotent**: Uses UPSERT/INSERT OR IGNORE so re-running is safe.
+ * - **Cancellable**: Checks `token.isCancellationRequested` between sessions.
+ */
+export async function reindexSessions(
+	store: ISessionStore,
+	debugLogService: IChatDebugFileLoggerService,
+	reportProgress: (message: string) => void,
+	token: CancellationToken,
+	force: boolean = false,
+): Promise<ReindexResult> {
+	const sessionIds = await debugLogService.listSessionIds();
+
+	let processed = 0;
+	let skipped = 0;
+
+	for (let i = 0; i < sessionIds.length; i++) {
+		if (token.isCancellationRequested) {
+			return { processed, skipped, cancelled: true };
+		}
+
+		const sessionId = sessionIds[i];
+
+		// Fast-path: skip sessions already in the store unless force mode
+		if (!force && store.getSession(sessionId)) {
+			skipped++;
+			continue;
+		}
+
+		reportProgress(l10n.t('Reindexing session {0} of {1}...', i + 1, sessionIds.length));
+
+		try {
+			await reindexOneSession(store, debugLogService, sessionId);
+			processed++;
+		} catch {
+			// Non-fatal — skip corrupt/unreadable sessions
+			skipped++;
+		}
+
+		// Yield to event loop between sessions to avoid blocking the extension host
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+	}
+
+	return { processed, skipped, cancelled: false };
+}
+
+/**
+ * Reindex a single session from its JSONL debug log.
+ * Streams events, builds a bounded per-session buffer, and flushes atomically.
+ */
+async function reindexOneSession(
+	store: ISessionStore,
+	debugLogService: IChatDebugFileLoggerService,
+	sessionId: string,
+): Promise<void> {
+	const buffer: PerSessionWriteBuffer = {
+		session: undefined,
+		turns: [],
+		files: [],
+		refs: [],
+	};
+
+	// State for turn pairing — tracks the pending user message to pair with next assistant response.
+	let pendingUserMessage: string | undefined;
+	let pendingUserTimestamp: string | undefined;
+	let turnIndex = 0;
+
+	await debugLogService.streamEntries(sessionId, (entry: IDebugLogEntry) => {
+		processEntry(entry, sessionId, buffer, {
+			get pendingUserMessage() { return pendingUserMessage; },
+			set pendingUserMessage(v) { pendingUserMessage = v; },
+			get pendingUserTimestamp() { return pendingUserTimestamp; },
+			set pendingUserTimestamp(v) { pendingUserTimestamp = v; },
+			get turnIndex() { return turnIndex; },
+			set turnIndex(v) { turnIndex = v; },
+		});
+	});
+
+	// If there's a trailing user message without a paired assistant response, flush it
+	if (pendingUserMessage) {
+		buffer.turns.push({
+			session_id: sessionId,
+			turn_index: turnIndex,
+			user_message: truncateForStore(pendingUserMessage, MAX_USER_MESSAGE_LENGTH),
+			timestamp: pendingUserTimestamp,
+		});
+	}
+
+	// Ensure we always have a session row (even if no session_start event was found)
+	if (!buffer.session) {
+		buffer.session = { id: sessionId, host_type: 'vscode' };
+	}
+
+	// Flush all buffered data in a single transaction
+	store.runInTransaction(() => {
+		store.upsertSession(buffer.session!);
+
+		for (const turn of buffer.turns) {
+			store.insertTurn(turn);
+		}
+		for (const file of buffer.files) {
+			store.insertFile(file);
+		}
+		for (const ref of buffer.refs) {
+			store.insertRef(ref);
+		}
+	});
+
+	// Help GC by clearing references — buffer is a local variable so this
+	// is defensive; it becomes unreachable when the function returns.
+	buffer.turns.length = 0;
+	buffer.files.length = 0;
+	buffer.refs.length = 0;
+}
+
+interface TurnPairingState {
+	pendingUserMessage: string | undefined;
+	pendingUserTimestamp: string | undefined;
+	turnIndex: number;
+}
+
+/**
+ * Process a single JSONL entry and update the per-session buffer.
+ * This is the streaming callback — called once per line, no accumulation.
+ */
+function processEntry(
+	entry: IDebugLogEntry,
+	sessionId: string,
+	buffer: PerSessionWriteBuffer,
+	state: TurnPairingState,
+): void {
+	switch (entry.type) {
+		case 'session_start':
+			processSessionStart(entry, sessionId, buffer);
+			break;
+		case 'user_message':
+		case 'turn_start':
+			processUserMessage(entry, state);
+			break;
+		case 'llm_request':
+		case 'agent_response':
+			processAssistantResponse(entry, sessionId, buffer, state);
+			break;
+		case 'tool_call':
+			processToolCall(entry, sessionId, buffer, state);
+			break;
+	}
+}
+
+function processSessionStart(
+	entry: IDebugLogEntry,
+	sessionId: string,
+	buffer: PerSessionWriteBuffer,
+): void {
+	const attrs = entry.attrs;
+	buffer.session = {
+		id: sessionId,
+		host_type: 'vscode',
+		cwd: typeof attrs.cwd === 'string' ? attrs.cwd : undefined,
+		repository: typeof attrs.repository === 'string' ? attrs.repository : undefined,
+		branch: typeof attrs.branch === 'string' ? attrs.branch : undefined,
+		created_at: new Date(entry.ts).toISOString(),
+	};
+}
+
+function processUserMessage(
+	entry: IDebugLogEntry,
+	state: TurnPairingState,
+): void {
+	const content = typeof entry.attrs.content === 'string'
+		? entry.attrs.content
+		: typeof entry.attrs.userRequest === 'string'
+			? entry.attrs.userRequest
+			: undefined;
+	if (content) {
+		state.pendingUserMessage = content;
+		state.pendingUserTimestamp = new Date(entry.ts).toISOString();
+	}
+}
+
+function processAssistantResponse(
+	entry: IDebugLogEntry,
+	sessionId: string,
+	buffer: PerSessionWriteBuffer,
+	state: TurnPairingState,
+): void {
+	// Extract assistant response from outputMessages attribute (same as sessionStoreTracker)
+	const outputMessagesRaw = entry.attrs.outputMessages as string | undefined;
+	const assistantResponse = extractAssistantResponse(outputMessagesRaw);
+
+	// Only create a turn if we have at least a user message or assistant response
+	if (!state.pendingUserMessage && !assistantResponse) {
+		return;
+	}
+
+	buffer.turns.push({
+		session_id: sessionId,
+		turn_index: state.turnIndex,
+		user_message: truncateForStore(state.pendingUserMessage, MAX_USER_MESSAGE_LENGTH),
+		assistant_response: truncateForStore(assistantResponse, MAX_ASSISTANT_RESPONSE_LENGTH),
+		timestamp: state.pendingUserTimestamp ?? new Date(entry.ts).toISOString(),
+	});
+
+	// Use first user message as summary if not yet set
+	if (!buffer.session?.summary && state.pendingUserMessage) {
+		const summary = truncateForStore(state.pendingUserMessage, MAX_SUMMARY_LENGTH);
+		if (!buffer.session) {
+			buffer.session = { id: sessionId, host_type: 'vscode' };
+		}
+		buffer.session.summary = summary;
+	}
+
+	state.turnIndex++;
+	state.pendingUserMessage = undefined;
+	state.pendingUserTimestamp = undefined;
+}
+
+function processToolCall(
+	entry: IDebugLogEntry,
+	sessionId: string,
+	buffer: PerSessionWriteBuffer,
+	state: TurnPairingState,
+): void {
+	const toolName = entry.name;
+	const toolArgs = tryParseArgs(entry.attrs.args);
+	const resultText = typeof entry.attrs.result === 'string' ? entry.attrs.result : undefined;
+
+	// Extract file path
+	const filePath = extractFilePath(toolName, toolArgs);
+	if (filePath) {
+		buffer.files.push({
+			session_id: sessionId,
+			file_path: filePath,
+			tool_name: toolName,
+			turn_index: state.turnIndex,
+		});
+	}
+
+	// Extract refs from GitHub MCP tools
+	if (isGitHubMcpTool(toolName)) {
+		const refs = extractRefsFromMcpTool(toolName, toolArgs);
+		for (const ref of refs) {
+			buffer.refs.push({ session_id: sessionId, ...ref, turn_index: state.turnIndex });
+		}
+
+		const repo = extractRepoFromMcpTool(toolArgs);
+		if (repo) {
+			if (!buffer.session) {
+				buffer.session = { id: sessionId, host_type: 'vscode' };
+			}
+			buffer.session.repository = repo;
+		}
+	}
+
+	// Extract refs from terminal/shell tools
+	if (isTerminalTool(toolName)) {
+		const refs = extractRefsFromTerminal(toolArgs, resultText);
+		for (const ref of refs) {
+			buffer.refs.push({ session_id: sessionId, ...ref, turn_index: state.turnIndex });
+		}
+	}
+}

--- a/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
@@ -105,9 +105,9 @@ describe('reindexSessions', () => {
 		entries.set('session-1', [
 			makeEntry({ type: 'session_start', name: 'session_start', sid: 'session-1', attrs: { cwd: '/workspace' } }),
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Fix the bug' } }),
-			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'I fixed the bug by changing X' }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'I fixed the bug by changing X' }] }]) } }),
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Now add tests' } }),
-			makeEntry({ type: 'llm_request', name: 'llm_request', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Added tests for X' }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Added tests for X' }] }]) } }),
 		]);
 
 		const debugLog = createMockDebugLogService(['session-1'], entries);
@@ -233,7 +233,7 @@ describe('reindexSessions', () => {
 		const entries = new Map<string, IDebugLogEntry[]>();
 		entries.set('session-good', [
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-good', attrs: { content: 'hello' } }),
-			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-good', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-good', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
 		]);
 
 		// Create a debug log service where session-bad throws
@@ -261,7 +261,7 @@ describe('reindexSessions', () => {
 		const entries = new Map<string, IDebugLogEntry[]>();
 		entries.set('session-1', [
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: longUserMsg } }),
-			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: longAssistantMsg }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: longAssistantMsg }] }]) } }),
 		]);
 
 		const debugLog = createMockDebugLogService(['session-1'], entries);
@@ -269,8 +269,8 @@ describe('reindexSessions', () => {
 
 		await reindexSessions(store, debugLog, vi.fn(), cts.token);
 
-		expect(store.insertedTurns[0].user_message!.length).toBeLessThanOrEqual(103); // 100 + '...'
-		expect(store.insertedTurns[0].assistant_response!.length).toBeLessThanOrEqual(1003); // 1000 + '...'
+		expect(store.insertedTurns[0].user_message!.length).toBeLessThanOrEqual(100);
+		expect(store.insertedTurns[0].assistant_response!.length).toBeLessThanOrEqual(1000);
 	});
 
 	it('handles sessions with no session_start event', async () => {
@@ -278,7 +278,7 @@ describe('reindexSessions', () => {
 		const entries = new Map<string, IDebugLogEntry[]>();
 		entries.set('session-1', [
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'hello' } }),
-			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
 		]);
 
 		const debugLog = createMockDebugLogService(['session-1'], entries);
@@ -328,7 +328,7 @@ describe('reindexSessions', () => {
 		const entries = new Map<string, IDebugLogEntry[]>();
 		entries.set('session-1', [
 			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Implement a login page' } }),
-			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Done' }] }]) } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { response: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Done' }] }]) } }),
 		]);
 
 		const debugLog = createMockDebugLogService(['session-1'], entries);

--- a/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/node/test/sessionReindexer.spec.ts
@@ -1,0 +1,351 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from 'vitest';
+import type { IChatDebugFileLoggerService, IDebugLogEntry } from '../../../../platform/chat/common/chatDebugFileLoggerService';
+import type { ISessionStore, SessionRow, TurnRow, FileRow, RefRow } from '../../../../platform/chronicle/common/sessionStore';
+import { CancellationTokenSource } from '../../../../util/vs/base/common/cancellation';
+import { reindexSessions } from '../sessionReindexer';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<IDebugLogEntry>): IDebugLogEntry {
+	return {
+		ts: Date.now(),
+		dur: 0,
+		sid: 'session-1',
+		type: 'generic',
+		name: '',
+		spanId: 'span-1',
+		status: 'ok',
+		attrs: {},
+		...overrides,
+	};
+}
+
+interface MockSessionStore extends ISessionStore {
+	upsertedSessions: SessionRow[];
+	insertedTurns: TurnRow[];
+	insertedFiles: FileRow[];
+	insertedRefs: RefRow[];
+	existingSessions: Set<string>;
+}
+
+function createMockStore(): MockSessionStore {
+	const mock: MockSessionStore = {
+		_serviceBrand: undefined as any,
+		upsertedSessions: [] as SessionRow[],
+		insertedTurns: [] as TurnRow[],
+		insertedFiles: [] as FileRow[],
+		insertedRefs: [] as RefRow[],
+		existingSessions: new Set<string>(),
+
+		getPath: () => '/tmp/test.db',
+		upsertSession: (s: SessionRow) => mock.upsertedSessions.push(s),
+		insertTurn: (t: TurnRow) => mock.insertedTurns.push(t),
+		insertCheckpoint: () => { },
+		insertFile: (f: FileRow) => mock.insertedFiles.push(f),
+		insertRef: (r: RefRow) => mock.insertedRefs.push(r),
+		indexWorkspaceArtifact: () => { },
+		search: () => [],
+		getSession: (id: string) => mock.existingSessions.has(id) ? { id } as SessionRow : undefined,
+		getTurns: () => [],
+		getFiles: () => [],
+		getRefs: () => [],
+		getMaxTurnIndex: () => -1,
+		getStats: () => ({ sessions: 0, turns: 0, checkpoints: 0, files: 0, refs: 0 }),
+		executeReadOnly: () => [],
+		executeReadOnlyFallback: () => [],
+		runInTransaction: (fn: () => void) => fn(),
+		close: () => { },
+	};
+	return mock;
+}
+
+function createMockDebugLogService(
+	sessionIds: string[],
+	entriesMap: Map<string, IDebugLogEntry[]>,
+): IChatDebugFileLoggerService {
+	return {
+		_serviceBrand: undefined as any,
+		listSessionIds: async () => sessionIds,
+		streamEntries: async (sessionId: string, onEntry: (entry: IDebugLogEntry) => void) => {
+			const entries = entriesMap.get(sessionId) ?? [];
+			for (const entry of entries) {
+				onEntry(entry);
+			}
+		},
+		// Stubs for unused methods
+		startSession: async () => { },
+		startChildSession: () => { },
+		registerSpanSession: () => { },
+		endSession: async () => { },
+		flush: async () => { },
+		getLogPath: () => undefined,
+		getSessionDir: () => undefined,
+		getActiveSessionIds: () => [],
+		isDebugLogUri: () => false,
+		getSessionDirForResource: () => undefined,
+		setModelSnapshot: () => { },
+		debugLogsDir: undefined,
+		onDidEmitEntry: undefined as any,
+		readEntries: async () => [],
+		readTailEntries: async () => [],
+	} as any;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('reindexSessions', () => {
+	it('processes a session with user + assistant turns', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'session_start', name: 'session_start', sid: 'session-1', attrs: { cwd: '/workspace' } }),
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Fix the bug' } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'I fixed the bug by changing X' }] }]) } }),
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Now add tests' } }),
+			makeEntry({ type: 'llm_request', name: 'llm_request', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Added tests for X' }] }]) } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+		const progress = vi.fn();
+
+		const result = await reindexSessions(store, debugLog, progress, cts.token);
+
+		expect(result).toEqual({ processed: 1, skipped: 0, cancelled: false });
+		expect(store.upsertedSessions).toHaveLength(1);
+		expect(store.upsertedSessions[0].cwd).toBe('/workspace');
+		expect(store.insertedTurns).toHaveLength(2);
+		expect(store.insertedTurns[0].user_message).toBe('Fix the bug');
+		expect(store.insertedTurns[0].assistant_response).toBe('I fixed the bug by changing X');
+		expect(store.insertedTurns[1].user_message).toBe('Now add tests');
+		expect(store.insertedTurns[1].assistant_response).toBe('Added tests for X');
+	});
+
+	it('extracts file paths from tool_call events', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'tool_call', name: 'read_file', sid: 'session-1', attrs: { args: JSON.stringify({ filePath: '/src/foo.ts', startLine: 1, endLine: 10 }) } }),
+			makeEntry({ type: 'tool_call', name: 'create_file', sid: 'session-1', attrs: { args: JSON.stringify({ filePath: '/src/bar.ts', content: '// new' }) } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.insertedFiles).toHaveLength(2);
+		expect(store.insertedFiles[0].file_path).toBe('/src/foo.ts');
+		expect(store.insertedFiles[1].file_path).toBe('/src/bar.ts');
+	});
+
+	it('extracts refs from GitHub MCP tool calls', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({
+				type: 'tool_call',
+				name: 'mcp_github_pull_request_read',
+				sid: 'session-1',
+				attrs: { args: JSON.stringify({ owner: 'microsoft', repo: 'vscode', pullNumber: 42 }) },
+			}),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.insertedRefs).toHaveLength(1);
+		expect(store.insertedRefs[0]).toEqual(expect.objectContaining({ ref_type: 'pr', ref_value: '42' }));
+		expect(store.upsertedSessions[0].repository).toBe('microsoft/vscode');
+	});
+
+	it('extracts refs from terminal tool calls', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({
+				type: 'tool_call',
+				name: 'run_in_terminal',
+				sid: 'session-1',
+				attrs: {
+					args: JSON.stringify({ command: 'gh pr create --title "Fix" --body "desc"' }),
+					result: 'https://github.com/microsoft/vscode/pull/123',
+				},
+			}),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.insertedRefs).toHaveLength(1);
+		expect(store.insertedRefs[0]).toEqual(expect.objectContaining({ ref_type: 'pr', ref_value: '123' }));
+	});
+
+	it('skips already-indexed sessions unless force=true', async () => {
+		const store = createMockStore();
+		store.existingSessions.add('session-1');
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'hello' } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		// Default: skip
+		const result = await reindexSessions(store, debugLog, vi.fn(), cts.token);
+		expect(result).toEqual({ processed: 0, skipped: 1, cancelled: false });
+		expect(store.insertedTurns).toHaveLength(0);
+
+		// Force: process
+		const result2 = await reindexSessions(store, debugLog, vi.fn(), cts.token, true);
+		expect(result2.processed).toBe(1);
+	});
+
+	it('respects cancellation token', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [makeEntry({ type: 'session_start', name: 'session_start', sid: 'session-1' })]);
+		entries.set('session-2', [makeEntry({ type: 'session_start', name: 'session_start', sid: 'session-2' })]);
+
+		const debugLog = createMockDebugLogService(['session-1', 'session-2'], entries);
+		const cts = new CancellationTokenSource();
+
+		// Cancel immediately
+		cts.cancel();
+
+		const result = await reindexSessions(store, debugLog, vi.fn(), cts.token);
+		expect(result.cancelled).toBe(true);
+		expect(result.processed).toBe(0);
+	});
+
+	it('skips corrupt sessions and continues', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-good', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-good', attrs: { content: 'hello' } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-good', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
+		]);
+
+		// Create a debug log service where session-bad throws
+		const debugLog = createMockDebugLogService(['session-bad', 'session-good'], entries);
+		const originalStream = debugLog.streamEntries.bind(debugLog);
+		(debugLog as any).streamEntries = async (sessionId: string, onEntry: any) => {
+			if (sessionId === 'session-bad') {
+				throw new Error('corrupt file');
+			}
+			return originalStream(sessionId, onEntry);
+		};
+
+		const cts = new CancellationTokenSource();
+		const result = await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(result.processed).toBe(1);
+		expect(result.skipped).toBe(1);
+		expect(store.insertedTurns).toHaveLength(1);
+	});
+
+	it('truncates long user messages and assistant responses', async () => {
+		const store = createMockStore();
+		const longUserMsg = 'a'.repeat(200);
+		const longAssistantMsg = 'b'.repeat(2000);
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: longUserMsg } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: longAssistantMsg }] }]) } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.insertedTurns[0].user_message!.length).toBeLessThanOrEqual(103); // 100 + '...'
+		expect(store.insertedTurns[0].assistant_response!.length).toBeLessThanOrEqual(1003); // 1000 + '...'
+	});
+
+	it('handles sessions with no session_start event', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'hello' } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }]) } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.upsertedSessions).toHaveLength(1);
+		expect(store.upsertedSessions[0].id).toBe('session-1');
+		expect(store.upsertedSessions[0].host_type).toBe('vscode');
+	});
+
+	it('handles trailing user message without assistant response', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'hello' } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.insertedTurns).toHaveLength(1);
+		expect(store.insertedTurns[0].user_message).toBe('hello');
+		expect(store.insertedTurns[0].assistant_response).toBeUndefined();
+	});
+
+	it('reports progress for each session', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('s1', [makeEntry({ type: 'session_start', name: 'session_start', sid: 's1' })]);
+		entries.set('s2', [makeEntry({ type: 'session_start', name: 'session_start', sid: 's2' })]);
+
+		const debugLog = createMockDebugLogService(['s1', 's2'], entries);
+		const cts = new CancellationTokenSource();
+		const progress = vi.fn();
+
+		await reindexSessions(store, debugLog, progress, cts.token);
+
+		expect(progress).toHaveBeenCalledTimes(2);
+	});
+
+	it('sets summary from first user message', async () => {
+		const store = createMockStore();
+		const entries = new Map<string, IDebugLogEntry[]>();
+		entries.set('session-1', [
+			makeEntry({ type: 'user_message', name: 'user_message', sid: 'session-1', attrs: { content: 'Implement a login page' } }),
+			makeEntry({ type: 'agent_response', name: 'agent_response', sid: 'session-1', attrs: { outputMessages: JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'Done' }] }]) } }),
+		]);
+
+		const debugLog = createMockDebugLogService(['session-1'], entries);
+		const cts = new CancellationTokenSource();
+
+		await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(store.upsertedSessions[0].summary).toBe('Implement a login page');
+	});
+
+	it('returns empty result for no sessions', async () => {
+		const store = createMockStore();
+		const debugLog = createMockDebugLogService([], new Map());
+		const cts = new CancellationTokenSource();
+
+		const result = await reindexSessions(store, debugLog, vi.fn(), cts.token);
+
+		expect(result).toEqual({ processed: 0, skipped: 0, cancelled: false });
+	});
+});

--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
@@ -15,12 +15,16 @@ import { autorun } from '../../../util/vs/base/common/observableInternal';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IExtensionContribution } from '../../common/contributions';
 import {
+	MAX_ASSISTANT_RESPONSE_LENGTH,
+	MAX_SUMMARY_LENGTH,
 	extractAssistantResponse,
 	extractFilePath,
 	extractRefsFromMcpTool,
 	extractRefsFromTerminal,
 	extractRepoFromMcpTool,
 	isGitHubMcpTool,
+	isTerminalTool,
+	truncateForStore,
 } from '../common/sessionStoreTracking';
 
 /** How often to flush buffered writes to SQLite (ms). */
@@ -209,9 +213,7 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 		const userRequest = span.attributes[CopilotChatAttr.USER_REQUEST] as string | undefined;
 
 		if (branch || remoteUrl || userRequest) {
-			const summary = userRequest
-				? (userRequest.length > 100 ? userRequest.slice(0, 100).trim() + '...' : userRequest)
-				: undefined;
+			const summary = truncateForStore(userRequest, MAX_SUMMARY_LENGTH);
 
 			this._bufferSessionUpsert({
 				id: sessionId,
@@ -256,7 +258,7 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 		}
 
 		// Track refs from terminal/shell tool
-		if (toolName === 'runInTerminal' || toolName === 'run_in_terminal') {
+		if (isTerminalTool(toolName)) {
 			const resultText = span.attributes['gen_ai.tool.result'] as string | undefined;
 			const refs = extractRefsFromTerminal(toolArgs, resultText);
 			for (const ref of refs) {
@@ -290,17 +292,15 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 		const existingSession = this._buffer.sessions.get(sessionId);
 		if (!existingSession?.summary) {
 			const firstMessage = userMessages[0]?.content ?? userRequest;
-			if (firstMessage) {
-				const summary = firstMessage.length > 100 ? firstMessage.slice(0, 100).trim() + '...' : firstMessage;
+			const summary = truncateForStore(firstMessage, MAX_SUMMARY_LENGTH);
+			if (summary) {
 				this._bufferSessionUpsert({ id: sessionId, summary });
 			}
 		}
 
 		// Extract assistant response from OUTPUT_MESSAGES attribute, truncated for storage
 		const fullResponse = extractAssistantResponse(span.attributes[GenAiAttr.OUTPUT_MESSAGES] as string | undefined);
-		const assistantResponse = fullResponse
-			? (fullResponse.length > 1000 ? fullResponse.slice(0, 1000).trim() + '...' : fullResponse)
-			: undefined;
+		const assistantResponse = truncateForStore(fullResponse, MAX_ASSISTANT_RESPONSE_LENGTH);
 
 		// Use in-memory turn counter to avoid collisions with buffered-but-unflushed turns.
 		// Initialize from DB on first use, then increment in memory.

--- a/extensions/copilot/src/extension/common/constants.ts
+++ b/extensions/copilot/src/extension/common/constants.ts
@@ -50,6 +50,7 @@ export const agentsToCommands: Partial<Record<Intent, Record<string, Intent>>> =
 		'chronicle': Intent.Chronicle,
 		'chronicle:standup': Intent.Chronicle,
 		'chronicle:tips': Intent.Chronicle,
+		'chronicle:reindex': Intent.Chronicle,
 	},
 	[Intent.VSCode]: {
 		'search': Intent.Search,

--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -9,6 +9,7 @@ import { IAuthenticationService } from '../../../platform/authentication/common/
 import { ICopilotTokenManager } from '../../../platform/authentication/common/copilotTokenManager';
 import { ChatLocation } from '../../../platform/chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { IChatDebugFileLoggerService } from '../../../platform/chat/common/chatDebugFileLoggerService';
 import { type SessionRow, type RefRow, ISessionStore } from '../../../platform/chronicle/common/sessionStore';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { IEndpointProvider } from '../../../platform/endpoint/common/endpointProvider';
@@ -32,6 +33,7 @@ import { DefaultIntentRequestHandler } from '../../prompt/node/defaultIntentRequ
 import { IIntent, IIntentInvocation, IIntentInvocationContext, IIntentSlashCommandInfo, IntentLinkificationOptions } from '../../prompt/node/intents';
 import { PromptRenderer, RendererIntentInvocation } from '../../prompts/node/base/promptRenderer';
 import { ChroniclePrompt } from '../../prompts/node/panel/chroniclePrompt';
+import { reindexSessions } from '../../chronicle/node/sessionReindexer';
 
 /** Cloud SQL dialect sessions query. */
 const SESSIONS_QUERY_CLOUD = `SELECT *
@@ -40,7 +42,7 @@ const SESSIONS_QUERY_CLOUD = `SELECT *
 	ORDER BY updated_at DESC
 	LIMIT 100`;
 
-const SUBCOMMANDS = ['standup', 'tips', 'improve'] as const;
+const SUBCOMMANDS = ['standup', 'tips', 'improve', 'reindex'] as const;
 type ChronicleSubcommand = typeof SUBCOMMANDS[number];
 
 export class ChronicleIntent implements IIntent {
@@ -67,6 +69,7 @@ export class ChronicleIntent implements IIntent {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IExperimentationService private readonly _expService: IExperimentationService,
 		@IFetcherService private readonly _fetcherService: IFetcherService,
+		@IChatDebugFileLoggerService private readonly _debugLogService: IChatDebugFileLoggerService,
 	) {
 		this._indexingPreference = new SessionIndexingPreference(this._configService);
 	}
@@ -99,6 +102,8 @@ export class ChronicleIntent implements IIntent {
 				return this._handleStandup(rest, stream, request, token);
 			case 'tips':
 				return this._handleTips(rest, stream, request, token, conversation, documentContext, location, chatTelemetry);
+			case 'reindex':
+				return this._handleReindex(rest, stream, token);
 			case 'improve':
 				stream.markdown(l10n.t('`/chronicle {0}` is not yet implemented. Try `/chronicle:standup` or `/chronicle:tips`.', subcommand));
 				return {};
@@ -136,6 +141,62 @@ export class ChronicleIntent implements IIntent {
 			subcommand: trimmed.slice(0, spaceIdx).toLowerCase(),
 			rest: trimmed.slice(spaceIdx + 1).trim() || undefined,
 		};
+	}
+
+	private async _handleReindex(
+		rest: string | undefined,
+		stream: vscode.ChatResponseStream,
+		token: CancellationToken,
+	): Promise<vscode.ChatResult> {
+		const force = rest?.toLowerCase().includes('force') ?? false;
+		const statsBefore = this._sessionStore.getStats();
+		const startTime = Date.now();
+
+		stream.progress(l10n.t('Discovering sessions...'));
+
+		const result = await reindexSessions(
+			this._sessionStore,
+			this._debugLogService,
+			(message: string) => stream.progress(message),
+			token,
+			force,
+		);
+
+		const statsAfter = this._sessionStore.getStats();
+
+		const lines: string[] = [];
+		if (result.cancelled) {
+			lines.push(l10n.t('Reindex cancelled.'));
+		} else {
+			lines.push(l10n.t('Reindex complete.'));
+		}
+
+		lines.push('');
+		lines.push(`| | ${l10n.t('Before')} | ${l10n.t('After')} | ${l10n.t('Delta')} |`);
+		lines.push('|---|---|---|---|');
+		lines.push(`| ${l10n.t('Sessions')} | ${statsBefore.sessions} | ${statsAfter.sessions} | +${statsAfter.sessions - statsBefore.sessions} |`);
+		lines.push(`| ${l10n.t('Turns')} | ${statsBefore.turns} | ${statsAfter.turns} | +${statsAfter.turns - statsBefore.turns} |`);
+		lines.push(`| ${l10n.t('Files')} | ${statsBefore.files} | ${statsAfter.files} | +${statsAfter.files - statsBefore.files} |`);
+		lines.push(`| ${l10n.t('Refs')} | ${statsBefore.refs} | ${statsAfter.refs} | +${statsAfter.refs - statsBefore.refs} |`);
+		lines.push('');
+		lines.push(l10n.t('{0} session(s) processed, {1} skipped.', result.processed, result.skipped));
+
+		stream.markdown(lines.join('\n'));
+
+		this._telemetryService.sendMSFTTelemetryEvent('chronicle', {
+			subcommand: 'reindex',
+			querySource: 'local',
+			force: String(force),
+			cancelled: String(result.cancelled),
+		}, {
+			localSessionCount: result.processed,
+			cloudSessionCount: 0,
+			totalSessionCount: result.processed + result.skipped,
+			skippedCount: result.skipped,
+			durationMs: Date.now() - startTime,
+		});
+
+		return {};
 	}
 
 	private async _handleStandup(
@@ -378,12 +439,16 @@ Use the session_store_sql tool to run queries. Start with a broad query, then dr
 "chronicle" : {
 "owner": "vijayu",
 "comment": "Tracks chronicle subcommand usage, data sources, and query failures",
-"subcommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chronicle subcommand: standup, tips, or freeform." },
+"subcommand": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chronicle subcommand: standup, tips, freeform, or reindex." },
 "querySource": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The data source used: local, cloud, both, or cloudRefs." },
 "error": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "comment": "Truncated error message." },
+"force": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether force mode was used (reindex only)." },
+"cancelled": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether the operation was cancelled (reindex only)." },
 "localSessionCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of local sessions used." },
 "cloudSessionCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of cloud sessions used." },
-"totalSessionCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Total sessions used." }
+"totalSessionCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Total sessions used." },
+"skippedCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Number of sessions skipped during reindex." },
+"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Duration of the reindex operation in milliseconds." }
 }
 */
 		this._telemetryService.sendMSFTTelemetryEvent('chronicle', {


### PR DESCRIPTION
Adds a /chronicle:reindex slash command that rebuilds the local Chronicle SQLite session store by re-reading JSONL debug logs from disk. This enables users to manually recover session data that the live tracker may have missed, or to populate the index after enabling the local indexing setting.