### PR TITLE
Fix chat model picker hiding models when `metadata.id` collides across vendors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -241,14 +241,13 @@ export function buildModelPickerItems(
 				modelsByMetadataId.set(model.metadata.id, model);
 			}
 
+			// Tracks model identifiers (e.g. `vendor/group/id`) and control-manifest
+			// entry IDs that have already been rendered in the Auto / Promoted section.
+			// Intentionally does NOT include bare `metadata.id` values, because two
+			// models from different vendors can legitimately share the same
+			// `metadata.id` (e.g. a BYOK provider exposing `claude-opus-4.7` alongside
+			// the built-in Copilot one) — see issue #312908.
 			const placed = new Set<string>();
-
-			const markPlaced = (identifierOrId: string, metadataId?: string) => {
-				placed.add(identifierOrId);
-				if (metadataId) {
-					placed.add(metadataId);
-				}
-			};
 
 			const resolveModel = (id: string) => allModelsMap.get(id) ?? modelsByMetadataId.get(id);
 
@@ -266,7 +265,7 @@ export function buildModelPickerItems(
 			// --- 1. Auto ---
 			const autoModel = models.find(m => isAutoModel(m));
 			if (autoModel) {
-				markPlaced(autoModel.identifier, autoModel.metadata.id);
+				placed.add(autoModel.identifier);
 				items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect, languageModelsService!), autoModel));
 			}
 
@@ -284,7 +283,7 @@ export function buildModelPickerItems(
 				}
 				const model = resolveModel(id);
 				if (model && !placed.has(model.identifier)) {
-					markPlaced(model.identifier, model.metadata.id);
+					placed.add(model.identifier);
 					const entry = controlModels[model.metadata.id];
 					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
 						promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
@@ -296,7 +295,7 @@ export function buildModelPickerItems(
 				if (!model) {
 					const entry = controlModels[id];
 					if (entry && !entry.exists) {
-						markPlaced(id);
+						placed.add(id);
 						promotedItems.push({ kind: 'unavailable', id, entry, reason: getUnavailableReason(entry) });
 						return true;
 					}
@@ -324,16 +323,16 @@ export function buildModelPickerItems(
 					if (model && !placed.has(model.identifier)) {
 						if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
 							if (showUnavailableFeatured) {
-								markPlaced(model.identifier, model.metadata.id);
+								placed.add(model.identifier);
 								promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
 							}
 						} else {
-							markPlaced(model.identifier, model.metadata.id);
+							placed.add(model.identifier);
 							promotedItems.push({ kind: 'available', model });
 						}
 					} else if (!model && !entry.exists) {
 						if (showUnavailableFeatured) {
-							markPlaced(entryId);
+							placed.add(entryId);
 							promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
 						}
 					}
@@ -363,8 +362,11 @@ export function buildModelPickerItems(
 			}
 
 			// --- 3. Other Models (collapsible) ---
+			// Filter strictly by `identifier`. Filtering by `metadata.id` would
+			// incorrectly drop models from other vendors that share an id with a
+			// promoted model (issue #312908).
 			otherModels = models
-				.filter(m => !placed.has(m.identifier) && !placed.has(m.metadata.id))
+				.filter(m => !placed.has(m.identifier))
 				.sort((a, b) => {
 					const aEntry = controlModels[a.metadata.id] ?? controlModels[a.identifier];
 					const bEntry = controlModels[b.metadata.id] ?? controlModels[b.identifier];

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -728,4 +728,38 @@ suite('buildModelPickerItems', () => {
 		const otherGpt = actions.find(a => a.label === 'GPT-4o' && a.section === 'other');
 		assert.ok(otherGpt, 'Version-gated featured model should appear in Other Models when showUnavailableFeatured=false');
 	});
+
+	test('models from different vendors sharing a metadata.id all appear (issue #312908)', () => {
+		// A BYOK model that shares its `metadata.id` with a built-in Copilot model
+		// must not be filtered out of the picker just because the Copilot model was
+		// promoted (selected / recently used / featured). Each model is uniquely
+		// identified by its `identifier`, not by its bare `metadata.id`.
+		const auto = createAutoModel();
+		const copilotClaude = createModel('claude-opus-4.7', 'Claude Opus 4.7', 'copilot');
+		const byokClaude = createModel('claude-opus-4.7', 'Claude Opus 4.7 (my-endpoint)', 'customoai');
+		const items = callBuild([auto, copilotClaude, byokClaude], {
+			selectedModelId: copilotClaude.identifier,
+		});
+		const labels = getActionLabels(items);
+		assert.ok(labels.includes('Claude Opus 4.7'), 'Promoted Copilot model should appear');
+		assert.ok(labels.includes('Claude Opus 4.7 (my-endpoint)'), 'BYOK model with colliding metadata.id should still appear in Other Models');
+	});
+
+	test('promoted model does not hide other models with same metadata.id from Other Models', () => {
+		// Recently-used and featured promotion paths must also not pollute the
+		// `placed` set with bare metadata IDs, otherwise unrelated models from
+		// other vendors that happen to share a metadata.id are silently dropped.
+		const auto = createAutoModel();
+		const ollamaGemma = createModel('gemma:7b', 'gemma:7b', 'ollama');
+		const byokGemma = createModel('gemma:7b', 'gemma:7b (my-endpoint)', 'customoai');
+		const items = callBuild([auto, ollamaGemma, byokGemma], {
+			recentModelIds: [ollamaGemma.identifier],
+			controlModels: {
+				'gemma:7b': { label: 'gemma:7b', featured: true, exists: true },
+			},
+		});
+		const labels = getActionLabels(items);
+		assert.ok(labels.includes('gemma:7b'), 'Featured/recent Ollama model should appear');
+		assert.ok(labels.includes('gemma:7b (my-endpoint)'), 'BYOK model with colliding metadata.id should still appear in Other Models');
+	});
 });


### PR DESCRIPTION
Fixes #312908

### Problem

In `buildModelPickerItems`, the `placed` set was keyed on **both** a model's full `identifier` (e.g. `customoai/<group>/<id>`) **and** its bare `metadata.id` (e.g. `claude-opus-4.7`). Once any one model was placed in the Auto / Promoted (selected / recently-used / featured) section, every other model from a different vendor that happened to share the same `metadata.id` was filtered out of the "Other Models" section — and was therefore unreachable from the chat model picker entirely (search included), even though it appeared correctly in the Language Models settings view.

### Fix

Track promoted models strictly by `identifier` in the `placed` set. The lookup paths that match by bare `metadata.id` (resolving featured / recent IDs from the control manifest to a concrete model via `modelsByMetadataId`) still resolve via that map, but only record the resulting **identifier** in `placed`.

Control-manifest entries that have no concrete matching model (`!entry.exists` placeholders) keep using their entry id — those IDs live in a separate id-namespace and don't collide with vendors' `metadata.id`s.

The "Other Models" filter is now `models.filter(m => !placed.has(m.identifier))`.

### Tests

Two new tests in `chatModelPicker.test.ts`:

- `models from different vendors sharing a metadata.id all appear (issue #312908)` — covers the selected-model promotion path.
- `promoted model does not hide other models with same metadata.id from Other Models` — covers the recently-used and featured promotion paths.

Both fail before the fix and pass after.

All 42 `buildModelPickerItems` tests pass; ran the broader chat picker / language models suite with no regressions.