### PR TITLE
Fix MCP install manifest dialog showing literal '&&Install' label (#312751)

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommandsAddConfiguration.ts
@@ -7,6 +7,7 @@ import { mapFindFirst } from '../../../../base/common/arraysFind.js';
 import { assertNever } from '../../../../base/common/assert.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
 import { parse as parseJsonc } from '../../../../base/common/jsonc.js';
+import { mnemonicButtonLabel } from '../../../../base/common/labels.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { autorun } from '../../../../base/common/observable.js';
@@ -616,7 +617,7 @@ export class McpInstallFromManifestCommand {
 			filters: [{ name: localize('mcp.installFromManifest.filter', "MCP Manifest"), extensions: ['json'] }],
 			canSelectFiles: true,
 			canSelectMany: false,
-			openLabel: localize({ key: 'mcp.installFromManifest.openLabel', comment: ['&& denotes a mnemonic'] }, "&&Install")
+			openLabel: mnemonicButtonLabel(localize({ key: 'mcp.installFromManifest.openLabel', comment: ['&& denotes a mnemonic'] }, "&&Install"))
 		});
 
 		if (!result?.[0]) {


### PR DESCRIPTION
The openLabel for IFileDialogService.showOpenDialog accepts { withMnemonic, withoutMnemonic } | string. Passing the raw '&&Install' string skipped mnemonic processing, so the literal '&&' leaked into the rendered button label.

Wrap the localized string with mnemonicButtonLabel() to match the convention used elsewhere (extensions install, update, add folder).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
