### PR TITLE
terminal: drop sandbox output retry heuristics

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -75,7 +75,7 @@ import { IChatWidgetService } from '../../../../chat/browser/chat.js';
 import { TerminalChatCommandId } from '../../../chat/browser/terminalChat.js';
 import { clamp } from '../../../../../../base/common/numbers.js';
 import { IOutputAnalyzer } from './outputAnalyzer.js';
-import { SandboxOutputAnalyzer, outputLooksSandboxBlocked } from './sandboxOutputAnalyzer.js';
+import { SandboxOutputAnalyzer } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
 import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
 import { LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
@@ -409,8 +409,7 @@ export function shouldAutomaticallyRetryUnsandboxed(options: IAutomaticUnsandbox
 		&& !options.isPersistentSession
 		&& !options.isBackgroundExecution
 		&& !options.didTimeout
-		&& options.exitCode !== 0
-		&& outputLooksSandboxBlocked(options.output);
+		&& options.exitCode !== 0;
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts
@@ -23,9 +23,8 @@ export class SandboxOutputAnalyzer extends Disposable implements IOutputAnalyzer
 		}
 
 		const knownFailure = options.exitCode !== undefined && options.exitCode !== 0;
-		const suspectedFailure = !knownFailure && options.exitCode === undefined && this._outputLooksSandboxBlocked(options.exitResult);
 
-		if (!knownFailure && !suspectedFailure) {
+		if (!knownFailure) {
 			return undefined;
 		}
 
@@ -42,17 +41,6 @@ export class SandboxOutputAnalyzer extends Disposable implements IOutputAnalyzer
 - Otherwise, immediately retry the command with requestUnsandboxedExecution=true. Do NOT ask the user — setting this flag automatically shows a confirmation prompt to the user.
 
 Here is the output of the command:\n`;
-	}
-
-	/**
-	 * Checks whether the command output contains strings that typically indicate
-	 * the sandbox blocked the operation. Used when exit code is unavailable.
-	 *
-	 * The output may contain newlines inserted by terminal wrapping, so we
-	 * strip them before testing.
-	 */
-	private _outputLooksSandboxBlocked(output: string): boolean {
-		return outputLooksSandboxBlocked(output);
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts
@@ -4,38 +4,99 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { strictEqual } from 'assert';
-import { outputLooksSandboxBlocked } from '../../browser/tools/sandboxOutputAnalyzer.js';
+import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { AgentNetworkDomainSettingId } from '../../../../../../platform/networkFilter/common/settings.js';
+import type { IOutputAnalyzerOptions } from '../../browser/tools/outputAnalyzer.js';
+import { SandboxOutputAnalyzer } from '../../browser/tools/sandboxOutputAnalyzer.js';
+import { shouldAutomaticallyRetryUnsandboxed, type IAutomaticUnsandboxRetryOptions } from '../../browser/tools/runInTerminalTool.js';
+import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
+import type { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
 
-suite('outputLooksSandboxBlocked', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
 
-	const positives: [string, string][] = [
-		['macOS sandbox file write', '/bin/bash: /tmp/test.txt: Operation not permitted'],
-		['Linux sandbox file write', '/usr/bin/bash: /tmp/test.txt: Read-only file system'],
-		['Permission denied', 'bash: ./script.sh: Permission denied'],
-		['sandbox-exec reference', 'sandbox-exec: some error occurred'],
-		['bwrap reference', 'bwrap: error setting up namespace'],
-		['sandbox_violation', 'sandbox_violation: deny(1) file-write-create /tmp/foo'],
-		['case insensitive', '/bin/bash: OPERATION NOT PERMITTED'],
-		['wrapped across lines', '/bin/bash: Operation not\npermitted'],
-	];
+suite('SandboxOutputAnalyzer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	for (const [label, output] of positives) {
-		test(`detects: ${label}`, () => {
-			strictEqual(outputLooksSandboxBlocked(output), true);
+	function createAnalyzer(os: OperatingSystem): SandboxOutputAnalyzer {
+		return store.add(new SandboxOutputAnalyzer({
+			_serviceBrand: undefined,
+			getOS: async () => os,
+		} as unknown as ITerminalSandboxService));
+	}
+
+	function createOptions(overrides?: Partial<IOutputAnalyzerOptions>): IOutputAnalyzerOptions {
+		return {
+			exitCode: 1,
+			exitResult: 'Operation not permitted',
+			commandLine: 'touch /tmp/test.txt',
+			isSandboxWrapped: true,
+			...overrides,
+		};
+	}
+
+	test('returns undefined when the command was not sandbox wrapped', async () => {
+		const analyzer = createAnalyzer(OperatingSystem.Linux);
+
+		strictEqual(await analyzer.analyze(createOptions({ isSandboxWrapped: false })), undefined);
+	});
+
+	for (const [label, exitCode] of [
+		['successful', 0],
+		['missing', undefined],
+	] as const) {
+		test(`ignores sandbox-like output when the exit code is ${label}`, async () => {
+			const analyzer = createAnalyzer(OperatingSystem.Linux);
+
+			strictEqual(await analyzer.analyze(createOptions({ exitCode })), undefined);
 		});
 	}
 
-	const negatives: [string, string][] = [
-		['normal output', 'hello world'],
-		['empty output', ''],
-		['unrelated error', 'Error: ENOENT: no such file or directory'],
-	];
+	for (const [label, os, fileSystemSetting] of [
+		['Linux', OperatingSystem.Linux, TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem],
+		['macOS', OperatingSystem.Macintosh, TerminalChatAgentToolsSettingId.AgentSandboxMacFileSystem],
+	] as const) {
+		test(`returns ${label} remediation guidance for failed sandboxed commands`, async () => {
+			const analyzer = createAnalyzer(os);
 
-	for (const [label, output] of negatives) {
-		test(`ignores: ${label}`, () => {
-			strictEqual(outputLooksSandboxBlocked(output), false);
+			strictEqual(await analyzer.analyze(createOptions()), `Command failed while running in sandboxed mode. If the command failed due to sandboxing:
+- If it would be reasonable to extend the sandbox rules, work with the user to update allowWrite for file system access problems in ${fileSystemSetting}, or to add required domains to ${AgentNetworkDomainSettingId.AllowedNetworkDomains}.
+- Otherwise, immediately retry the command with requestUnsandboxedExecution=true. Do NOT ask the user — setting this flag automatically shows a confirmation prompt to the user.
+
+Here is the output of the command:\n`);
+		});
+	}
+});
+
+suite('shouldAutomaticallyRetryUnsandboxed', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createOptions(overrides?: Partial<IAutomaticUnsandboxRetryOptions>): IAutomaticUnsandboxRetryOptions {
+		return {
+			didSandboxWrapCommand: true,
+			requestUnsandboxedExecution: false,
+			isPersistentSession: false,
+			isBackgroundExecution: false,
+			didTimeout: false,
+			exitCode: 1,
+			output: 'hello world',
+			...overrides,
+		};
+	}
+
+	test('retries failed sandboxed commands without inspecting output text', () => {
+		strictEqual(shouldAutomaticallyRetryUnsandboxed(createOptions({ output: 'completed with a generic error message' })), true);
+	});
+
+	for (const [label, overrides] of [
+		['the command was not sandbox wrapped', { didSandboxWrapCommand: false }],
+		['unsandboxed execution was already requested', { requestUnsandboxedExecution: true }],
+		['the execution is persistent', { isPersistentSession: true }],
+		['the execution is in the background', { isBackgroundExecution: true }],
+		['the execution timed out', { didTimeout: true }],
+		['the command succeeded', { exitCode: 0 }],
+	] as const) {
+		test(`does not retry when ${label}`, () => {
+			strictEqual(shouldAutomaticallyRetryUnsandboxed(createOptions(overrides)), false);
 		});
 	}
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -476,8 +476,12 @@ suite('RunInTerminalTool', () => {
 			output: '/bin/bash: /workspace/out.txt: Operation not permitted',
 		};
 
-		test('should retry completed foreground sandbox commands when output indicates sandbox block', () => {
+		test('should retry completed foreground sandbox commands regardless of output text', () => {
 			strictEqual(shouldAutomaticallyRetryUnsandboxed(baseRetryOptions), true);
+			strictEqual(shouldAutomaticallyRetryUnsandboxed({
+				...baseRetryOptions,
+				output: 'regular command failure',
+			}), true);
 		});
 
 		test('should not retry when the command is already unsandboxed', () => {
@@ -487,7 +491,7 @@ suite('RunInTerminalTool', () => {
 			}), false);
 		});
 
-		test('should not retry background, timed-out, successful, or non-sandbox-blocked results', () => {
+		test('should not retry background, timed-out, or successful results', () => {
 			strictEqual(shouldAutomaticallyRetryUnsandboxed({
 				...baseRetryOptions,
 				isBackgroundExecution: true,
@@ -499,10 +503,6 @@ suite('RunInTerminalTool', () => {
 			strictEqual(shouldAutomaticallyRetryUnsandboxed({
 				...baseRetryOptions,
 				exitCode: 0,
-			}), false);
-			strictEqual(shouldAutomaticallyRetryUnsandboxed({
-				...baseRetryOptions,
-				output: 'regular command failure',
 			}), false);
 		});
 


### PR DESCRIPTION
Fixes #312718

## Summary

This change removes the remaining sandbox-output text heuristics from the terminal chat agent sandbox flow.

- stop gating `shouldAutomaticallyRetryUnsandboxed` on `outputLooksSandboxBlocked`
- only surface sandbox remediation guidance from `SandboxOutputAnalyzer` for explicit non-zero exit failures
- replace the old helper-focused unit tests with behavior-focused coverage for the analyzer and retry logic

## Testing

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sandboxOutputAnalyzer.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts`
- `./scripts/test.sh --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxOutputAnalyzer.test.ts`