### PR TITLE
MCP: forward W3C traceparent to servers via _meta (SEP-414)

### DIFF
--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -175,6 +175,17 @@ export class ToolsService extends BaseToolsService {
 
 		const startTime = Date.now();
 
+		// Propagate W3C trace context to MCP tools so server-side spans can be correlated
+		// with this `execute_tool` span (MCP SEP-414, see #302301). Only set if not already
+		// supplied by the caller and OTel produced a real span context.
+		const optionsWithTrace = options as vscode.LanguageModelToolInvocationOptions<Object> & { traceparent?: string };
+		if (!optionsWithTrace.traceparent) {
+			const ctx = span.getSpanContext();
+			if (ctx) {
+				optionsWithTrace.traceparent = `00-${ctx.traceId}-${ctx.spanId}-01`;
+			}
+		}
+
 		return vscode.lm.invokeTool(getContributedToolName(name), options, token).then(
 			result => {
 				span.setStatus(SpanStatusCode.OK);

--- a/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
+++ b/extensions/copilot/src/extension/tools/vscode-node/toolsService.ts
@@ -175,14 +175,22 @@ export class ToolsService extends BaseToolsService {
 
 		const startTime = Date.now();
 
-		// Propagate W3C trace context to MCP tools so server-side spans can be correlated
-		// with this `execute_tool` span (MCP SEP-414, see #302301). Only set if not already
-		// supplied by the caller and OTel produced a real span context.
-		const optionsWithTrace = options as vscode.LanguageModelToolInvocationOptions<Object> & { traceparent?: string };
-		if (!optionsWithTrace.traceparent) {
-			const ctx = span.getSpanContext();
-			if (ctx) {
-				optionsWithTrace.traceparent = `00-${ctx.traceId}-${ctx.spanId}-01`;
+		// Propagate W3C trace context to tool invocations so downstream spans can be
+		// correlated with this `execute_tool` span. MCP tools forward this onto
+		// `_meta.traceparent`/`_meta.tracestate` of the JSON-RPC `tools/call` payload
+		// (MCP SEP-414, see #302301). Only set if not already supplied by the caller.
+		const optionsWithTrace = options as vscode.LanguageModelToolInvocationOptions<Object> & { traceparent?: string; tracestate?: string };
+		const ctx = span.getSpanContext();
+		if (ctx) {
+			if (!optionsWithTrace.traceparent) {
+				// Preserve the upstream W3C trace flags when available. Fall back to `01`
+				// (sampled) so downstream MCP servers continue to participate in the trace
+				// when the abstraction does not surface flags (e.g. tests, in-memory impl).
+				const flags = (ctx.traceFlags ?? 0x01).toString(16).padStart(2, '0');
+				optionsWithTrace.traceparent = `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
+			}
+			if (!optionsWithTrace.tracestate && ctx.traceState) {
+				optionsWithTrace.tracestate = ctx.traceState;
 			}
 		}
 

--- a/extensions/copilot/src/platform/otel/common/otelService.ts
+++ b/extensions/copilot/src/platform/otel/common/otelService.ts
@@ -15,6 +15,14 @@ export const IOTelService = createServiceIdentifier<IOTelService>('IOTelService'
 export interface TraceContext {
 	readonly traceId: string;
 	readonly spanId: string;
+	/**
+	 * W3C trace flags from the source span context (e.g. `0x01` for sampled). Optional
+	 * because not all impls preserve it; consumers that build a W3C `traceparent` should
+	 * fall back to a sampled value when unset.
+	 */
+	readonly traceFlags?: number;
+	/** W3C tracestate serialized as a comma-separated key=value list, when present. */
+	readonly traceState?: string;
 }
 
 /**

--- a/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
+++ b/extensions/copilot/src/platform/otel/node/otelServiceImpl.ts
@@ -344,7 +344,7 @@ export class NodeOTelService implements IOTelService {
 		if (!ctx.traceId || !ctx.spanId) {
 			return undefined;
 		}
-		return { traceId: ctx.traceId, spanId: ctx.spanId };
+		return { traceId: ctx.traceId, spanId: ctx.spanId, traceFlags: ctx.traceFlags, traceState: ctx.traceState?.serialize() };
 	}
 
 	// ── Trace Context Store ── (for cross-boundary propagation)
@@ -620,7 +620,9 @@ class RealSpanHandle implements ISpanHandle {
 
 	getSpanContext(): TraceContext | undefined {
 		const ctx = this._span.spanContext();
-		return ctx.traceId && ctx.spanId ? { traceId: ctx.traceId, spanId: ctx.spanId } : undefined;
+		return ctx.traceId && ctx.spanId
+			? { traceId: ctx.traceId, spanId: ctx.spanId, traceFlags: ctx.traceFlags, traceState: ctx.traceState?.serialize() }
+			: undefined;
 	}
 
 	end(): void {

--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -193,6 +193,8 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			options.chatInteractionId = dto.chatInteractionId;
 			options.chatSessionResource = URI.revive(dto.context?.sessionResource);
 			options.subAgentInvocationId = dto.subAgentInvocationId;
+			options.traceparent = dto.traceparent;
+			options.tracestate = dto.tracestate;
 		}
 
 		if (isProposedApiEnabled(item.extension, 'chatParticipantAdditions') && dto.modelId) {

--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -130,6 +130,8 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 				subAgentInvocationId: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.subAgentInvocationId : undefined,
 				chatStreamToolCallId: isProposedApiEnabled(extension, 'chatParticipantAdditions') ? options.chatStreamToolCallId : undefined,
 				preToolUseResult: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.preToolUseResult : undefined,
+				traceparent: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.traceparent : undefined,
+				tracestate: isProposedApiEnabled(extension, 'chatParticipantPrivate') ? options.tracestate : undefined,
 			}, token);
 
 			const dto: Dto<IToolResult> = result instanceof SerializableObjectWithBuffers ? result.value : result;

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -197,6 +197,14 @@ export interface IToolInvocation {
 	selectedCustomButton?: string;
 	/** Pre-tool-use hook result passed from the extension, if the hook was already executed externally. */
 	preToolUseResult?: IExternalPreToolUseHookResult;
+	/**
+	 * Optional W3C trace context `traceparent` value identifying the parent distributed
+	 * tracing span for this tool invocation. Forwarded to MCP tool implementations as
+	 * `_meta.traceparent` (MCP SEP-414).
+	 */
+	traceparent?: string;
+	/** Optional W3C trace context `tracestate` value paired with {@link traceparent}. */
+	tracestate?: string;
 }
 
 export interface IToolInvocationContext {

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -266,7 +266,12 @@ class McpToolImplementation implements IToolImpl {
 			content: []
 		};
 
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, { chatRequestId: invocation.chatRequestId, chatSessionResource: invocation.context?.sessionResource }, token);
+		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, {
+			chatRequestId: invocation.chatRequestId,
+			chatSessionResource: invocation.context?.sessionResource,
+			traceparent: invocation.traceparent,
+			tracestate: invocation.tracestate,
+		}, token);
 		const details: Mutable<IToolResultInputOutputDetails> = {
 			input: JSON.stringify(invocation.parameters, undefined, 2),
 			output: [],

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -1199,6 +1199,14 @@ export class McpTool implements IMcpTool {
 			if (context?.chatRequestId) {
 				meta['vscode.requestId'] = context.chatRequestId;
 			}
+			// Propagate W3C trace context to the MCP server (MCP SEP-414) so server-side
+			// spans can be correlated with the client trace.
+			if (context?.traceparent) {
+				meta['traceparent'] = context.traceparent;
+				if (context.tracestate) {
+					meta['tracestate'] = context.tracestate;
+				}
+			}
 
 			const taskHint = this._definition.execution?.taskSupport;
 			const serverSupportsTasksForTools = h.capabilities.tasks?.requests?.tools?.call !== undefined;

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -453,6 +453,13 @@ export interface IMcpPromptMessage extends MCP.PromptMessage { }
 export interface IMcpToolCallContext {
 	chatSessionResource: URI | undefined;
 	chatRequestId?: string;
+	/**
+	 * Optional W3C trace context `traceparent` value to forward to the MCP server
+	 * via `_meta.traceparent` on the JSON-RPC `tools/call` request (MCP SEP-414).
+	 */
+	traceparent?: string;
+	/** Optional W3C trace context `tracestate` value paired with {@link traceparent}. */
+	tracestate?: string;
 }
 
 /**

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
@@ -381,6 +381,34 @@ suite('Workbench - MCP - ServerRequestHandler', () => {
 			assert.strictEqual(e.name, 'Canceled');
 		}
 	});
+
+	test('callTool forwards _meta.traceparent to the JSON-RPC payload (MCP SEP-414)', async () => {
+		const traceparent = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+		const tracestate = 'rojo=00f067aa0ba902b7';
+
+		const callPromise = handler.callTool({
+			name: 'echo',
+			arguments: { hello: 'world' },
+			_meta: { traceparent, tracestate, progressToken: 'tok-1' },
+		});
+
+		const sentMessages = transport.getSentMessages();
+		const callRequest = sentMessages[2] as MCP.JSONRPCRequest & MCP.CallToolRequest;
+		assert.strictEqual(callRequest.method, 'tools/call');
+		assert.deepStrictEqual(callRequest.params._meta, {
+			traceparent,
+			tracestate,
+			progressToken: 'tok-1',
+		});
+
+		transport.simulateReceiveMessage({
+			jsonrpc: MCP.JSONRPC_VERSION,
+			id: callRequest.id,
+			result: { content: [] },
+		});
+
+		await callPromise;
+	});
 });
 
 suite.skip('Workbench - MCP - McpTask', () => { // TODO@connor4312 https://github.com/microsoft/vscode/issues/280126

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -304,6 +304,17 @@ declare module 'vscode' {
 		 */
 		subAgentInvocationId?: string;
 		/**
+		 * W3C trace context `traceparent` header value identifying the active distributed
+		 * tracing span. When provided to a tool implementation backed by an MCP server, this
+		 * value is forwarded as `_meta.traceparent` on the JSON-RPC `tools/call` request so
+		 * downstream servers can correlate their spans (MCP SEP-414).
+		 */
+		traceparent?: string;
+		/**
+		 * Optional W3C trace context `tracestate` header value paired with `traceparent`.
+		 */
+		tracestate?: string;
+		/**
 		 * Pre-tool-use hook result, if the hook was already executed by the caller.
 		 * When provided, the tools service will skip executing its own preToolUse hook
 		 * and use this result for permission decisions and input modifications instead.


### PR DESCRIPTION
Plumbs the active `execute_tool` span's W3C `traceparent` (and optional `tracestate`) through `LanguageModelToolInvocationOptions` → `IMcpToolCallContext` → the JSON-RPC `tools/call` payload's `_meta`, so MCP server-side spans can be parented to the VS Code client trace.

Verified end-to-end against an Aspire dashboard: server spans now appear nested under the client `execute_tool` span in the same trace.

<img width="3603" height="1194" alt="image" src="https://github.com/user-attachments/assets/17395ad5-f50f-4882-b3ee-27d5721a2f68" />


Refs #302301