### PR TITLE
Show previous version in `--update-extensions` output

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagementCLI.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementCLI.ts
@@ -149,6 +149,7 @@ export class ExtensionManagementCLI {
 		const availableVersions = await this.extensionGalleryService.getExtensions(installedExtensionsQuery, { compatible: true }, CancellationToken.None);
 
 		const extensionsToUpdate: InstallExtensionInfo[] = [];
+		const previousVersionsByExtension = new Map<string, string>();
 		for (const newVersion of availableVersions) {
 			for (const oldVersion of installedExtensions) {
 				if (areSameExtensions(oldVersion.identifier, newVersion.identifier) && gt(newVersion.version, oldVersion.manifest.version)) {
@@ -156,6 +157,7 @@ export class ExtensionManagementCLI {
 						extension: newVersion,
 						options: { operation: InstallOperation.Update, installPreReleaseVersion: oldVersion.preRelease, profileLocation, isApplicationScoped: oldVersion.isApplicationScoped }
 					});
+					previousVersionsByExtension.set(newVersion.identifier.id.toLowerCase(), oldVersion.manifest.version);
 				}
 			}
 		}
@@ -172,7 +174,13 @@ export class ExtensionManagementCLI {
 			if (extensionResult.error) {
 				this.logger.error(localize('errorUpdatingExtension', "Error while updating extension {0}: {1}", extensionResult.identifier.id, getErrorMessage(extensionResult.error)));
 			} else {
-				this.logger.info(localize('successUpdate', "Extension '{0}' v{1} was successfully updated.", extensionResult.identifier.id, extensionResult.local?.manifest.version));
+				const previousVersion = previousVersionsByExtension.get(extensionResult.identifier.id.toLowerCase());
+				const updatedVersion = extensionResult.local?.manifest.version;
+				if (previousVersion && updatedVersion) {
+					this.logger.info(localize('successUpdateWithVersions', "Extension '{0}' was successfully updated from v{1} to v{2}.", extensionResult.identifier.id, previousVersion, updatedVersion));
+				} else {
+					this.logger.info(localize('successUpdate', "Extension '{0}' v{1} was successfully updated.", extensionResult.identifier.id, updatedVersion));
+				}
 			}
 		}
 	}

--- a/src/vs/platform/extensionManagement/test/common/extensionManagementCLI.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionManagementCLI.test.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { ExtensionType } from '../../../extensions/common/extensions.js';
+import type { ILogger } from '../../../log/common/log.js';
+import type { IProductService } from '../../../product/common/productService.js';
+import { InstallOperation, type IExtensionGalleryService, type IExtensionManagementService, type IGalleryExtension, type ILocalExtension, type InstallExtensionInfo } from '../../common/extensionManagement.js';
+import { ExtensionManagementCLI } from '../../common/extensionManagementCLI.js';
+
+suite('ExtensionManagementCLI', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('updateExtensions reports the previous and updated versions', async () => {
+		const installedExtension = {
+			identifier: { id: 'publisher.extension', uuid: 'uuid' },
+			manifest: { version: '1.0.0' },
+			preRelease: false,
+			isApplicationScoped: false,
+			type: ExtensionType.User
+		} as unknown as ILocalExtension;
+
+		const galleryExtension = {
+			identifier: installedExtension.identifier,
+			version: '1.2.3'
+		} as unknown as IGalleryExtension;
+
+		const messages: string[] = [];
+		const logger = {
+			info: (message: string) => messages.push(message),
+			trace: () => undefined,
+			error: (message: string) => assert.fail(message)
+		} as unknown as ILogger;
+
+		const extensionManagementService = {
+			async getInstalled() {
+				return [installedExtension];
+			},
+			async installGalleryExtensions(extensionsToInstall: InstallExtensionInfo[]) {
+				assert.strictEqual(extensionsToInstall.length, 1);
+				assert.strictEqual(extensionsToInstall[0].extension, galleryExtension);
+
+				return [{
+					identifier: galleryExtension.identifier,
+					operation: InstallOperation.Update,
+					local: {
+						...installedExtension,
+						manifest: {
+							...installedExtension.manifest,
+							version: galleryExtension.version
+						}
+					}
+				}];
+			}
+		} as unknown as IExtensionManagementService;
+
+		const extensionGalleryService = {
+			async getExtensions() {
+				return [galleryExtension];
+			}
+		} as unknown as IExtensionGalleryService;
+
+		const productService = { quality: 'stable', builtInExtensionsEnabledWithAutoUpdates: [] } as unknown as IProductService;
+		const cli = new ExtensionManagementCLI([], logger, extensionManagementService, extensionGalleryService, productService);
+
+		await cli.updateExtensions();
+
+		assert.deepStrictEqual(messages, [
+			'Updating extensions: publisher.extension',
+			'Extension \'publisher.extension\' was successfully updated from v1.0.0 to v1.2.3.'
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Updates `code --update-extensions` success output to include both the previously installed version and the updated version.

## Changes

- Record the installed version and candidate update version for each extension selected for update.
- Use the recorded versions when reporting successful update results.
- Leave update selection, installation behavior, and error handling unchanged.
- Keep the previous success message as a fallback if either version is unavailable.

Before:

```text
Extension 'publisher.extension' 1.2.3 was successfully updated.
```

After:

```text
Extension 'publisher.extension' was successfully updated from 1.2.2 to 1.2.3.
```

## Validation

- Ran `npm run eslint`.
- Ran `npm run compile`.
- Ran `.\scripts\test.bat --runGlob "vs/platform/extensionManagement/test/common/extensionManagementCLI.test.js"`.
- Ran `.\scripts\test.bat`; locally completed with 21,597 passing and 353 pending, with one unrelated `Request Service > Kerberos lookup` failure: `InitializeSecurityContext: The specified target is unknown or unreachable`.

Fixes #312936.