### PR TITLE
otel: support gen_ai.response.time_to_first_chunk in sqlite store

### DIFF
--- a/extensions/copilot/src/platform/otel/node/sqlite/otelSqliteStore.ts
+++ b/extensions/copilot/src/platform/otel/node/sqlite/otelSqliteStore.ts
@@ -288,12 +288,18 @@ export class OTelSqliteStore {
 
 	/**
 	 * Coalesce TTFT from foreground extension (`copilot_chat.time_to_first_token`, ms)
-	 * and CLI runtime (`github.copilot.time_to_first_chunk`, seconds → ms).
+	 * and CLI runtime. The CLI runtime historically emitted `github.copilot.time_to_first_chunk`
+	 * (seconds) but is migrating to the OTel GenAI semconv attribute
+	 * `gen_ai.response.time_to_first_chunk` (also seconds). Accept both for forward/backward
+	 * compatibility while the runtime rollout completes.
+	 *
+	 * @see https://github.com/open-telemetry/semantic-conventions/pull/3607 (semconv addition)
 	 */
 	private _ttftMs(span: ICompletedSpanData): number | null {
 		const foreground = this._attr(span, CopilotChatAttr.TIME_TO_FIRST_TOKEN);
 		if (foreground !== null) { return foreground as number; }
-		const cli = span.attributes['github.copilot.time_to_first_chunk'];
+		const cli = span.attributes['gen_ai.response.time_to_first_chunk']
+			?? span.attributes['github.copilot.time_to_first_chunk'];
 		if (cli === undefined) { return null; }
 		const sec = typeof cli === 'number' ? cli : parseFloat(String(cli));
 		return isNaN(sec) ? null : Math.round(sec * 1000);

--- a/extensions/copilot/src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts
+++ b/extensions/copilot/src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts
@@ -238,4 +238,33 @@ describe('OTelSqliteStore', () => {
 		const spans = store.getSpansByTraceId('trace-both');
 		expect(spans[0].ttft_ms).toBe(500);
 	});
+
+	it('denormalizes gen_ai.response.time_to_first_chunk (seconds) into ttft_ms (ms)', () => {
+		store.insertSpan(makeSpan({
+			spanId: 'cli-chat-new',
+			traceId: 'trace-cli-new',
+			attributes: {
+				'gen_ai.operation.name': 'chat',
+				'gen_ai.response.time_to_first_chunk': 0.4386763570001349,
+			},
+		}));
+
+		const spans = store.getSpansByTraceId('trace-cli-new');
+		expect(spans[0].ttft_ms).toBe(439);
+	});
+
+	it('prefers gen_ai.response.time_to_first_chunk over legacy github.copilot.time_to_first_chunk', () => {
+		store.insertSpan(makeSpan({
+			spanId: 'cli-chat-both',
+			traceId: 'trace-cli-both',
+			attributes: {
+				'gen_ai.operation.name': 'chat',
+				'gen_ai.response.time_to_first_chunk': 0.5,
+				'github.copilot.time_to_first_chunk': 0.9,
+			},
+		}));
+
+		const spans = store.getSpansByTraceId('trace-cli-both');
+		expect(spans[0].ttft_ms).toBe(500);
+	});
 });


### PR DESCRIPTION
## Summary

The CLI agent runtime is migrating from the vendor-prefixed attribute `github.copilot.time_to_first_chunk` to the new OTel GenAI semantic-conventions attribute `gen_ai.response.time_to_first_chunk`. Both encode time-to-first-chunk in seconds. To stay green before, during, and after the runtime rollout, the OTel sqlite store's `_ttftMs()` now reads **either** attribute (preferring the new one) when denormalizing TTFT into the `ttft_ms` column.

## Changes

- **`extensions/copilot/src/platform/otel/node/sqlite/otelSqliteStore.ts`** — `_ttftMs()` checks `gen_ai.response.time_to_first_chunk` first, falls back to `github.copilot.time_to_first_chunk`.
- **`extensions/copilot/src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts`** — Adds two unit tests:
  1. New attribute alone is denormalized to `ttft_ms` (ms).
  2. New attribute wins when both are present.

`gen_ai.request.stream` (the other new attribute in the upstream PR) has no current consumer here, so no shim is needed — it flows through as a normal span attribute.

## Verification

```
npx vitest --run --pool=forks src/platform/otel/node/sqlite/test/otelSqliteStore.spec.ts
# Test Files  1 passed (1) / Tests  13 passed (13)
```

## References

- OTel semconv addition: https://github.com/open-telemetry/semantic-conventions/pull/3607