### PR TITLE
Refactor titlebar action handling and improve CSS legibility for "Open in Agents" widget

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -698,13 +698,17 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				}
 			}
 
-			// --- Leading Global Actions (rendered before layout controls; opt-in via TitleBarLeadingActionsGroup)
+			// --- Leading Global Actions (rendered before layout controls; opt-in via TitleBarLeadingActionsGroup).
+			// Use a scratch bucket so non-leading actions don't leak into the shared `secondary` (overflow) list here;
+			// they are added by the trailing global-actions pass below.
 			if (this.globalToolbarMenu) {
+				const leading: IToolbarActions = { primary: [], secondary: [] };
 				fillInActionBarActions(
 					this.globalToolbarMenu.getActions(),
-					actions,
+					leading,
 					actionGroup => actionGroup === TitleBarLeadingActionsGroup
 				);
+				actions.primary.push(...leading.primary);
 			}
 
 			// --- Layout Actions
@@ -716,12 +720,13 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				);
 			}
 
-			// --- Global Actions (after layout so e.g. notification bell appears to the right of layout controls)
+			// --- Global Actions (after layout so e.g. notification bell appears to the right of layout controls).
+			// Filter out the leading group up front so it isn't duplicated into the overflow `secondary` bucket.
 			if (this.globalToolbarMenu) {
+				const trailingGroups = this.globalToolbarMenu.getActions().filter(([group]) => group !== TitleBarLeadingActionsGroup);
 				fillInActionBarActions(
-					this.globalToolbarMenu.getActions(),
-					actions,
-					actionGroup => actionGroup !== TitleBarLeadingActionsGroup // already rendered before layout controls
+					trailingGroups,
+					actions
 				);
 			}
 

--- a/src/vs/workbench/electron-browser/actions/media/openInAgents.css
+++ b/src/vs/workbench/electron-browser/actions/media/openInAgents.css
@@ -39,7 +39,7 @@
 	background-position: center center;
 	background-size: contain;
 	/* Keep desaturated for legibility against light/dark titlebar backgrounds; brighten on hover/focus. */
-	filter: grayscale(1) opacity(0.75);
+	filter: grayscale(1);
 	transition: filter 150ms ease;
 }
 

--- a/src/vs/workbench/electron-browser/actions/media/openInAgents.css
+++ b/src/vs/workbench/electron-browser/actions/media/openInAgents.css
@@ -38,7 +38,7 @@
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-size: contain;
-	/* Desaturated at rest; full color on hover/focus. */
+	/* Keep desaturated for legibility against light/dark titlebar backgrounds; brighten on hover/focus. */
 	filter: grayscale(1) opacity(0.75);
 	transition: filter 150ms ease;
 }

--- a/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
+++ b/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
@@ -9,7 +9,7 @@ import { getDefaultHoverDelegate } from '../../../base/browser/ui/hover/hoverDel
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IAction } from '../../../base/common/actions.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
-import { isLinux } from '../../../base/common/platform.js';
+import { isMacintosh, isWindows } from '../../../base/common/platform.js';
 import { localize, localize2 } from '../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { IActionViewItemService } from '../../../platform/actions/browser/actionViewItemService.js';
@@ -116,10 +116,11 @@ class OpenInAgentsAction extends Action2 {
 		);
 
 		// In built builds with a sibling Agents app available, launch it.
-		// Otherwise (dev / OSS / Linux / no sibling), open a new agents window of
-		// the current Electron app. Linux has no sibling app implementation, so
-		// always fall back to the in-process window there.
-		const mode: OpenInAgentsMode = environmentService.isBuilt && hasSibling && !isLinux ? 'siblingApp' : 'newWindow';
+		// Otherwise (dev / OSS / unsupported platform / no sibling), open a new agents window of
+		// the current Electron app. `launchSiblingApp` is only implemented for macOS/Windows
+		// (see `src/vs/platform/native/node/siblingApp.ts`), so gate on actual platform support.
+		const canLaunchSiblingApp = isMacintosh || isWindows;
+		const mode: OpenInAgentsMode = environmentService.isBuilt && hasSibling && canLaunchSiblingApp ? 'siblingApp' : 'newWindow';
 		telemetryService.publicLog2<OpenInAgentsEvent, OpenInAgentsClassification>('vscode.openInAgents', { mode });
 
 		if (mode === 'siblingApp') {

--- a/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
+++ b/src/vs/workbench/electron-browser/actions/openInAgentsAction.ts
@@ -9,6 +9,7 @@ import { getDefaultHoverDelegate } from '../../../base/browser/ui/hover/hoverDel
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IAction } from '../../../base/common/actions.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+import { isLinux } from '../../../base/common/platform.js';
 import { localize, localize2 } from '../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../platform/actions/common/actions.js';
 import { IActionViewItemService } from '../../../platform/actions/browser/actionViewItemService.js';
@@ -82,13 +83,6 @@ class OpenInAgentsAction extends Action2 {
 				group: TitleBarLeadingActionsGroup,
 				order: -1000,
 				when: OpenInAgentsVisibility,
-			}, {
-				// Also surface inside the "Customize Layout..." submenu so users
-				// can toggle the entry on/off from the layout customization UI.
-				id: MenuId.LayoutControlMenuSubmenu,
-				group: '0_workbench_layout',
-				order: -1000,
-				when: OpenInAgentsVisibility,
 			}]
 		});
 	}
@@ -122,9 +116,10 @@ class OpenInAgentsAction extends Action2 {
 		);
 
 		// In built builds with a sibling Agents app available, launch it.
-		// Otherwise (dev / OSS / no sibling), open a new agents window of
-		// the current Electron app.
-		const mode: OpenInAgentsMode = environmentService.isBuilt && hasSibling ? 'siblingApp' : 'newWindow';
+		// Otherwise (dev / OSS / Linux / no sibling), open a new agents window of
+		// the current Electron app. Linux has no sibling app implementation, so
+		// always fall back to the in-process window there.
+		const mode: OpenInAgentsMode = environmentService.isBuilt && hasSibling && !isLinux ? 'siblingApp' : 'newWindow';
 		telemetryService.publicLog2<OpenInAgentsEvent, OpenInAgentsClassification>('vscode.openInAgents', { mode });
 
 		if (mode === 'siblingApp') {


### PR DESCRIPTION
This pull request refines how leading and trailing actions are handled in the title bar, improves platform checks for launching the Agents app, and tweaks the appearance of the "Open in Agents" button for better legibility. The main themes are action bar logic improvements, platform compatibility, and UI polish.

**Action bar logic improvements:**

* Refactored the handling of leading and trailing global actions in `BrowserTitlebarPart` to prevent non-leading actions from leaking into the leading actions bucket and to avoid duplication in the overflow menu. Leading actions are now collected into a scratch bucket, and trailing actions are filtered to exclude the leading group before being added. [[1]](diffhunk://#diff-b538c0831d1bb4a7cad17415451b6679b2f9f9f374aaa5d4ca4372b4eeb6cbe6L701-R711) [[2]](diffhunk://#diff-b538c0831d1bb4a7cad17415451b6679b2f9f9f374aaa5d4ca4372b4eeb6cbe6L719-R729)

**Platform compatibility:**

* Updated the logic for launching the Agents app in `OpenInAgentsAction` to only attempt launching the sibling app on supported platforms (macOS and Windows), ensuring correct behavior on unsupported systems. [[1]](diffhunk://#diff-caf2843f3c58e1a4bbc1645b33b97a3ad13bd7c4ef50d6730b73fb5b87b2caaaR12) [[2]](diffhunk://#diff-caf2843f3c58e1a4bbc1645b33b97a3ad13bd7c4ef50d6730b73fb5b87b2caaaL125-R123)

**UI polish:**

* Adjusted the grayscale filter on the "Open in Agents" button icon to remain desaturated (for better legibility) instead of increasing opacity on hover/focus.
* Removed the "Open in Agents" action from the "Customize Layout..." submenu, so it only appears in the title bar.