### PR TITLE
Agents: Enable tab shrinking in narrow viewports for better accessibility

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -269,6 +269,31 @@
 	--tab-border-top-color: transparent !important;
 }
 
+/* Allow tabs to shrink in narrow viewports so the close button stays reachable.
+ * The default `sizing-fit` rule sets `min-width: fit-content; flex-shrink: 0;`
+ * which prevents the tab from shrinking below its label width and pushes the
+ * close button out of view. */
+.agent-sessions-workbench .part.editor .tabs-container > .tab.sizing-fit {
+	min-width: 0 !important;
+	flex-shrink: 1 !important;
+}
+
+.agent-sessions-workbench .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label,
+.agent-sessions-workbench .part.editor .tabs-container > .tab.sizing-fit .monaco-icon-label > .monaco-icon-label-container {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
+/* Keep the close button reserved within the tab so it remains accessible when
+ * the tab shrinks. Without this the action sits in an `overflow: hidden`
+ * container that only reveals on hover, which combined with the smaller tab
+ * makes the close target hard to hit. */
+.agent-sessions-workbench .part.editor .tabs-container > .tab > .tab-actions {
+	flex: 0 0 auto;
+	overflow: visible;
+}
+
 .agent-sessions-workbench .part.editor .tabs-and-actions-container {
 	--tabs-border-bottom-color: transparent !important;
 	align-items: center;


### PR DESCRIPTION
Allow tabs to shrink in narrow viewports to ensure the close button remains accessible. This change improves usability by preventing the close button from being pushed out of view in smaller window sizes.

