### PR TITLE
ci: start the full app to verify signature on macOS

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -185,7 +185,23 @@ jobs:
           APP_NAME="`ls $APP_ROOT | head -n 1`"
           APP_PATH="$APP_ROOT/$APP_NAME"
           codesign -dv --deep --verbose=4 "$APP_PATH"
-          "$APP_PATH/Contents/Resources/app/bin/code" --export-default-configuration=.build
+          BINARY_NAME=$(node -p "require(\"$APP_PATH/Contents/Resources/app/product.json\").nameShort")
+          TIMERS_FILE="$(Build.ArtifactStagingDirectory)/startup-timers.txt"
+          "$APP_PATH/Contents/MacOS/$BINARY_NAME" \
+            --prof-append-timers "$TIMERS_FILE" \
+            --user-data-dir "$(Agent.TempDirectory)/vscode-verify" \
+            --extensions-dir "$(Agent.TempDirectory)/vscode-verify-ext" \
+            --disable-extensions --disable-telemetry --skip-welcome \
+            --skip-release-notes --disable-updates --disable-experiments \
+            --disable-workspace-trust
+          if [ ! -f "$TIMERS_FILE" ]; then
+            echo "ERROR: VS Code failed to start — startup timers were not written."
+            echo "This may indicate a binary was killed by AMFI due to restricted entitlements."
+            exit 1
+          fi
+          echo "Startup timers:"
+          cat "$TIMERS_FILE"
+        timeoutInMinutes: 2
         displayName: Verify signature
 
       - script: |

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -369,7 +369,7 @@ steps:
         fi
         echo "Startup timers:"
         cat "$TIMERS_FILE"
-      timeoutInMinutes: 2
+      timeoutInMinutes: 3
       displayName: Verify signature
 
     - script: |

--- a/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
+++ b/build/azure-pipelines/darwin/steps/product-build-darwin-compile.yml
@@ -353,7 +353,23 @@ steps:
         APP_NAME="`ls $APP_ROOT | head -n 1`"
         APP_PATH="$APP_ROOT/$APP_NAME"
         codesign -dv --deep --verbose=4 "$APP_PATH"
-        "$APP_PATH/Contents/Resources/app/bin/code" --export-default-configuration=.build
+        BINARY_NAME=$(node -p "require(\"$APP_PATH/Contents/Resources/app/product.json\").nameShort")
+        TIMERS_FILE="$(Build.ArtifactStagingDirectory)/startup-timers.txt"
+        "$APP_PATH/Contents/MacOS/$BINARY_NAME" \
+          --prof-append-timers "$TIMERS_FILE" \
+          --user-data-dir "$(Agent.TempDirectory)/vscode-verify" \
+          --extensions-dir "$(Agent.TempDirectory)/vscode-verify-ext" \
+          --disable-extensions --disable-telemetry --skip-welcome \
+          --skip-release-notes --disable-updates --disable-experiments \
+          --disable-workspace-trust
+        if [ ! -f "$TIMERS_FILE" ]; then
+          echo "ERROR: VS Code failed to start — startup timers were not written."
+          echo "This may indicate a binary was killed by AMFI due to restricted entitlements."
+          exit 1
+        fi
+        echo "Startup timers:"
+        cat "$TIMERS_FILE"
+      timeoutInMinutes: 2
       displayName: Verify signature
 
     - script: |


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/312734#issuecomment-4333334191

Use `--prof-append-timers` to start the full workbench that gives better conformance to all the required processes launching on the signed application.

Also removed the `export-default-configuration` which seems like a no-op today cc @roblourens 