### PR TITLE
Drop spurious uri-list entries that are encoded plain text

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
@@ -224,8 +224,27 @@ async function extractUriList(dataTransfer: IReadonlyVSDataTransfer): Promise<{ 
 	}
 
 	const strUriList = await urlListEntry.asString();
+
+	// Some browsers (notably Safari on iPadOS) synthesize a `text/uri-list`
+	// entry from any plain text that vaguely looks like a URL — e.g. copying
+	// `foo: bar` produces a uri-list of `foo:%20bar` because of the colon.
+	// Pasting then prefers the percent-encoded uri-list over the plain text.
+	// Drop uri-list entries that are just a percent-encoded form of the
+	// accompanying plain text. See https://github.com/microsoft/vscode/issues/235666.
+	const plainTextEntry = dataTransfer.get(Mimes.text);
+	const plainText = plainTextEntry ? await plainTextEntry.asString() : undefined;
+
 	const entries: { readonly uri: URI; readonly originalText: string }[] = [];
 	for (const entry of UriList.parse(strUriList)) {
+		if (plainText !== undefined && entry !== plainText) {
+			try {
+				if (decodeURIComponent(entry) === plainText) {
+					continue;
+				}
+			} catch {
+				// invalid percent encoding, fall through
+			}
+		}
 		try {
 			entries.push({ uri: URI.parse(entry), originalText: entry });
 		} catch {


### PR DESCRIPTION
## Summary

Fixes Safari on iPadOS pasting \`foo: bar\` as \`foo:%20bar\`. The same root cause covers any plain text containing a colon being silently URL-encoded on paste.

## Root cause

Safari iPadOS synthesizes a \`text/uri-list\` clipboard entry from any text matching \`scheme:value\` — copying \`foo: bar\` produces a uri-list of \`foo:%20bar\` alongside the plain \`text/plain\` entry. Then:

1. \`DefaultTextPasteOrDropEditProvider.getEdit\` deliberately suppresses itself whenever \`dataTransfer.has(Mimes.uriList)\` is true — per @mjbvz's comment in [the file](https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts), "typically the uri-list contains the same text as the text entry so showing both is confusing."
2. \`PathProvider.getEdit\` runs \`extractUriList\` which \`URI.parse\`s \`foo:%20bar\` (a valid URI with scheme \`foo\`).
3. Since the scheme isn't \`file\`, the path provider falls through to \`originalText\` — which is \`foo:%20bar\` — and pastes the encoded form.

This matches the user-reported behavior exactly, including why \` foo: bar\` (with leading space) works (Safari doesn't synthesize the uri-list since the text doesn't start with a valid scheme) and why \`editor.pasteAs.enabled: false\` is the workaround (PathProvider never runs).

## Fix

In \`extractUriList\`, drop any uri-list entry whose \`decodeURIComponent\` matches the accompanying \`text/plain\` entry. Once filtered out, \`PathProvider.getEdit\` returns no entries, the default text provider takes over, and the paste lands as plain text correctly.

Real URL copies (https://example.com, file paths) leave their uri-list and text/plain in agreement before decoding and pass through unchanged.

## Test plan

- [ ] iPadOS Safari: copy \`foo: bar\` from a textarea, paste into a vscode.dev editor. Pastes as \`foo: bar\`, not \`foo:%20bar\`.
- [ ] Copy a real URL (https://example.com) from any source, paste into the editor. Still pastes as the URL.
- [ ] Drag a file from explorer onto an editor. File path still inserts as before.

cc @mjbvz — your comment in #235666 pointed at this controller; the fix is one function over in defaultProviders.ts where the actual selection between providers happens.

Fixes #235666