### PR TITLE
Anchor IgnoreFile patterns to the normalized directory path

### DIFF
--- a/src/vs/workbench/services/search/common/ignoreFile.ts
+++ b/src/vs/workbench/services/search/common/ignoreFile.ts
@@ -9,10 +9,11 @@ import { startsWithIgnoreCase } from '../../../../base/common/strings.js';
 export class IgnoreFile {
 
 	private isPathIgnored: (path: string, isDir: boolean, parent?: IgnoreFile) => boolean;
+	private readonly location: string;
 
 	constructor(
 		contents: string,
-		private readonly location: string,
+		location: string,
 		private readonly parent?: IgnoreFile,
 		private readonly ignoreCase = false) {
 		if (location[location.length - 1] === '\\') {
@@ -21,6 +22,11 @@ export class IgnoreFile {
 		if (location[location.length - 1] !== '/') {
 			location += '/';
 		}
+		// Assign the field after normalization. Using a parameter property
+		// would capture the value before the trailing slash is appended,
+		// which causes patterns to be tested against an unanchored path
+		// (see #226136).
+		this.location = location;
 		this.isPathIgnored = this.parseIgnoreFile(contents, this.location, this.parent);
 	}
 


### PR DESCRIPTION
## Summary

Fixes a classic TypeScript parameter-property gotcha that caused \`IgnoreFile\` (used by \`explorer.excludeGitIgnore\` and the file-search worker) to test patterns against an unanchored directory path.

## Root cause

In \`src/vs/workbench/services/search/common/ignoreFile.ts\`:

\`\`\`ts
constructor(
    contents: string,
    private readonly location: string,   // <-- parameter property
    ...
) {
    if (location[location.length - 1] !== '/') {
        location += '/';                 // <-- mutates local only
    }
    this.isPathIgnored = this.parseIgnoreFile(contents, this.location, this.parent);
    // ^^ this.location is the un-normalized original argument
}
\`\`\`

Parameter properties auto-assign \`this.location = location\` before the constructor body runs, so the trailing-slash normalization in the body never reaches the field. \`parseIgnoreFile\` then received e.g. \`/test\` instead of \`/test/\`.

For a \`/test/.gitignore\` containing the pattern \`test\`:
- \`'/test'.startsWith('/test')\` → true → the matcher tests the parent directory itself
- glob \`**/test\` matches \`/test\` → folder marked ignored
- The explorer (when \`explorer.excludeGitIgnore\` is enabled) hides the entire \`test\` folder, instead of only \`test/test\` inside it.

\`git check-ignore\` itself gives the correct answer — only the in-process matcher in \`IgnoreFile\` was wrong. The other call site (\`localFileSearch.ts\`) happens to always pass a path with a trailing slash, so it didn't surface this bug.

## Fix

Drop the parameter property and assign \`this.location\` after normalization. Single-file, 7-line change.

## Test plan

- [ ] In a workspace with \`/test/.gitignore\` containing just \`test\`, enable \`explorer.excludeGitIgnore\` → the \`test\` folder still appears, only \`test/test\` inside is hidden
- [ ] Existing search-worker behavior unchanged (it always passes a trailing-slash path)

Fixes #226136