### PR TITLE
sessions: use strong foreground for session titles

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -214,6 +214,10 @@
 		font-size: 13px;
 	}
 
+	&:not(.archived) .session-title {
+		color: var(--vscode-strongForeground);
+	}
+
 	.session-time {
 		display: flex;
 		align-items: center;
@@ -371,11 +375,11 @@
 .monaco-list-row:not(.selected) .session-item.in-progress .session-title {
 	background: linear-gradient(
 		90deg,
-		var(--vscode-foreground) 0%,
-		var(--vscode-foreground) 30%,
+		var(--vscode-strongForeground) 0%,
+		var(--vscode-strongForeground) 30%,
 		var(--vscode-chat-thinkingShimmer) 50%,
-		var(--vscode-foreground) 70%,
-		var(--vscode-foreground) 100%
+		var(--vscode-strongForeground) 70%,
+		var(--vscode-strongForeground) 100%
 	);
 	background-size: 400% 100%;
 	background-clip: text;
@@ -390,8 +394,8 @@
 		background: none;
 		background-clip: border-box;
 		-webkit-background-clip: border-box;
-		color: var(--vscode-foreground);
-		-webkit-text-fill-color: var(--vscode-foreground);
+		color: var(--vscode-strongForeground);
+		-webkit-text-fill-color: var(--vscode-strongForeground);
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -390,7 +390,7 @@
 
 .vs-dark .monaco-list-row:not(.selected) .session-item.in-progress .session-title,
 .hc-black .monaco-list-row:not(.selected) .session-item.in-progress .session-title {
-	background: linear-gradient(
+	background-image: linear-gradient(
 		90deg,
 		var(--vscode-strongForeground) 0%,
 		var(--vscode-strongForeground) 30%,

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -214,7 +214,7 @@
 		font-size: 13px;
 	}
 
-	&:not(.archived) .session-title {
+	.session-title {
 		color: var(--vscode-strongForeground);
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -388,6 +388,18 @@
 	animation: session-title-shimmer 3s linear infinite;
 }
 
+.vs-dark .monaco-list-row:not(.selected) .session-item.in-progress .session-title,
+.hc-black .monaco-list-row:not(.selected) .session-item.in-progress .session-title {
+	background: linear-gradient(
+		90deg,
+		var(--vscode-strongForeground) 0%,
+		var(--vscode-strongForeground) 30%,
+		var(--vscode-descriptionForeground) 50%,
+		var(--vscode-strongForeground) 70%,
+		var(--vscode-strongForeground) 100%
+	);
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.monaco-list-row:not(.selected) .session-item.in-progress .session-title {
 		animation: none;


### PR DESCRIPTION
## Summary

Resolves https://github.com/microsoft/vscode/issues/310018

- update the sessions app leftbar list so all session title text, including archived items, uses `--vscode-strongForeground`
- keep the in-progress session title shimmer using the stronger title color while preserving the existing text masking and animation
- adjust the dark theme shimmer highlight stop to use `descriptionForeground` so the shimmer remains visible against `strongForeground` text
- preserve the existing archived-row detail muting and list selection behavior

## Testing
- `npm run compile-check-ts-native --silent`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/sessions/browser/media/sessionsList.css`
- `npm run precommit`