### PR TITLE
Host filter: show loading/empty states instead of hiding the combo

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -106,7 +106,7 @@ The Agent Sessions titlebar includes a custom left toolbar that appears after th
 | Action | ID | Location | Behavior |
 |--------|-----|----------|----------|
 | Toggle Sidebar | `workbench.action.agentToggleSidebarVisibility` | Left toolbar (`TitleBarLeft`) | Toggles primary sidebar visibility |
-| Agent Host Filter | `sessions.agentHostFilter.pick` | Left toolbar (`TitleBarLeft`) | Dropdown indicator of the host the workbench is scoped to; lets the user switch hosts or pick "All Hosts". Visible when at least one remote agent host is known (`sessions.hasAgentHosts`). Renders via a custom `HostFilterActionViewItem`. |
+| Agent Host Filter | `sessions.agentHostFilter.pick` | Left toolbar (`TitleBarLeft`) | Dropdown indicator of the host the workbench is scoped to; lets the user switch hosts. Always visible on web: while initial host discovery is in flight the host icon blinks; once discovery completes with no hosts the icon is shown grayed out; once at least one host is known the label and chevron animate in. Renders via a custom `HostFilterActionViewItem`. |
 | Run Script | `workbench.action.agentSessions.runScript` | Right toolbar (`TitleBarRight`) | Split button: runs configured script or shows configure dialog |
 | Open... | (submenu) | Right toolbar (`TitleBarRight`) | Split button submenu: Open Terminal, Open in VS Code |
 | Toggle Secondary Sidebar | `workbench.action.agentToggleSecondarySidebarVisibility` | Right toolbar (`TitleBarRight`) | Toggles auxiliary bar visibility |

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/agentHostFilterService.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/agentHostFilterService.ts
@@ -47,6 +47,7 @@ export class AgentHostFilterService extends Disposable implements IAgentHostFilt
 
 	private _selectedProviderId: string | undefined;
 	private _hosts: readonly IAgentHostFilterEntry[] = [];
+	private _isLoadingHosts: boolean = true;
 
 	/**
 	 * Subscriptions to the `connectionStatus` observable of every currently
@@ -74,6 +75,18 @@ export class AgentHostFilterService extends Disposable implements IAgentHostFilt
 
 	get hosts(): readonly IAgentHostFilterEntry[] {
 		return this._hosts;
+	}
+
+	get isLoadingHosts(): boolean {
+		return this._isLoadingHosts;
+	}
+
+	notifyInitialDiscoveryComplete(): void {
+		if (!this._isLoadingHosts) {
+			return;
+		}
+		this._isLoadingHosts = false;
+		this._onDidChange.fire();
 	}
 
 	setSelectedProviderId(providerId: string): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/hostFilter.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/hostFilter.contribution.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { localize2 } from '../../../../nls.js';
 import { IActionViewItemService } from '../../../../platform/actions/browser/actionViewItemService.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IsAuxiliaryWindowContext } from '../../../../workbench/common/contextkeys.js';
@@ -17,13 +17,6 @@ import { Menus } from '../../../browser/menus.js';
 import { IAgentHostFilterService } from '../common/agentHostFilter.js';
 import { HostFilterActionViewItem } from './hostFilterActionViewItem.js';
 
-/**
- * Context key that is `true` when at least one remote agent host is known
- * (configured or connected). Controls the visibility of the host filter
- * dropdown in the titlebar.
- */
-const HasAgentHostsContext = new RawContextKey<boolean>('sessions.hasAgentHosts', false);
-
 const PICK_HOST_FILTER_ID = 'sessions.agentHostFilter.pick';
 
 /**
@@ -31,6 +24,11 @@ const PICK_HOST_FILTER_ID = 'sessions.agentHostFilter.pick';
  * is actually handled by {@link HostFilterActionViewItem}, so the action's
  * `run` is a no-op. Gated on `isWeb` via its menu `when` clause so the
  * combo only shows up in the web build.
+ *
+ * Note: the combo is always shown on web (no `HasAgentHostsContext`
+ * gating). When there are no hosts (or the initial discovery is still
+ * in flight) the action view item renders a placeholder icon — see
+ * {@link HostFilterActionViewItem}.
  */
 registerAction2(class PickAgentHostFilterAction extends Action2 {
 	constructor() {
@@ -45,7 +43,6 @@ registerAction2(class PickAgentHostFilterAction extends Action2 {
 				when: ContextKeyExpr.and(
 					IsWebContext,
 					IsAuxiliaryWindowContext.toNegated(),
-					HasAgentHostsContext,
 				),
 			}, {
 				// On phone/mobile layouts the desktop titlebar is replaced
@@ -59,7 +56,6 @@ registerAction2(class PickAgentHostFilterAction extends Action2 {
 				when: ContextKeyExpr.and(
 					IsWebContext,
 					IsAuxiliaryWindowContext.toNegated(),
-					HasAgentHostsContext,
 					IsNewChatSessionContext,
 				),
 			}],
@@ -75,19 +71,11 @@ class AgentHostFilterContribution extends Disposable implements IWorkbenchContri
 
 	static readonly ID = 'sessions.contrib.agentHostFilter';
 
-	private readonly _hasAgentHostsContext: IContextKey<boolean>;
-
 	constructor(
 		@IAgentHostFilterService filterService: IAgentHostFilterService,
 		@IActionViewItemService actionViewItemService: IActionViewItemService,
-		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
-
-		this._hasAgentHostsContext = HasAgentHostsContext.bindTo(contextKeyService);
-		this._update(filterService);
-
-		this._register(filterService.onDidChange(() => this._update(filterService)));
 
 		this._register(actionViewItemService.register(
 			Menus.TitleBarLeftLayout,
@@ -102,10 +90,6 @@ class AgentHostFilterContribution extends Disposable implements IWorkbenchContri
 			(action, _options, instaService) => instaService.createInstance(HostFilterActionViewItem, action),
 			filterService.onDidChange,
 		));
-	}
-
-	private _update(filterService: IAgentHostFilterService): void {
-		this._hasAgentHostsContext.set(filterService.hosts.length > 0);
 	}
 }
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/hostFilterActionViewItem.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/hostFilterActionViewItem.ts
@@ -133,14 +133,39 @@ export class HostFilterActionViewItem extends BaseActionViewItem {
 			: hosts.find(h => h.providerId === selectedId);
 
 		const interactive = hosts.length > 1;
+		const isLoading = this._filterService.isLoadingHosts;
+		const isEmpty = hosts.length === 0;
+
+		// Three rendering modes:
+		//  1. Loading + no hosts known yet → only the host icon, blinking.
+		//  2. Loaded + zero hosts          → only the host icon, grayed out.
+		//  3. Loaded + ≥1 host             → icon + label + (chevron) + connect.
+		this.element.classList.toggle('single-host', !interactive);
+		this.element.classList.toggle('loading', isLoading && isEmpty);
+		this.element.classList.toggle('empty', !isLoading && isEmpty);
 
 		// Dropdown label + aria
-		const text = selected ? selected.label : localize('agentHostFilter.none', "No Host");
+		const text = selected ? selected.label : '';
 		this._labelElement.textContent = text;
 
-		this.element.classList.toggle('single-host', !interactive);
-
-		if (interactive) {
+		if (isEmpty) {
+			// Placeholder mode: dropdown is non-interactive, hide chevron and
+			// connect button, and announce status to screen readers via the
+			// icon's aria-label on the dropdown.
+			this._dropdownElement.removeAttribute('tabindex');
+			this._dropdownElement.removeAttribute('role');
+			this._dropdownElement.removeAttribute('aria-haspopup');
+			this._dropdownElement.setAttribute('aria-label', isLoading
+				? localize('agentHostFilter.aria.loading', "Loading agent hosts…")
+				: localize('agentHostFilter.aria.empty', "No agent hosts available."));
+			this._dropdownHover.value = this._hoverService.setupManagedHover(
+				getDefaultHoverDelegate('element'),
+				this._dropdownElement,
+				() => isLoading
+					? localize('agentHostFilter.hover.loading', "Loading agent hosts…")
+					: localize('agentHostFilter.hover.empty', "No agent hosts available"),
+			);
+		} else if (interactive) {
 			this._dropdownElement.tabIndex = 0;
 			this._dropdownElement.role = 'button';
 			this._dropdownElement.setAttribute('aria-haspopup', 'menu');
@@ -162,7 +187,7 @@ export class HostFilterActionViewItem extends BaseActionViewItem {
 			this._dropdownHover.clear();
 		}
 
-		this._updateConnectButton(selected);
+		this._updateConnectButton(isEmpty ? undefined : selected);
 	}
 
 	private _updateConnectButton(selected: IAgentHostFilterEntry | undefined): void {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/media/hostFilter.css
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/media/hostFilter.css
@@ -73,6 +73,45 @@
 	white-space: nowrap;
 	flex: 1 1 auto;
 	min-width: 0;
+	max-width: 240px;
+	opacity: 1;
+	transition: max-width 220ms ease, opacity 220ms ease, margin-left 220ms ease;
+}
+
+/* --- Loading mode: blink the host icon ---------------------------------- */
+
+.agent-host-filter-combo.loading .agent-host-filter-dropdown,
+.agent-host-filter-combo.empty .agent-host-filter-dropdown {
+	cursor: default;
+}
+
+.agent-host-filter-combo.loading .agent-host-filter-dropdown:hover,
+.agent-host-filter-combo.empty .agent-host-filter-dropdown:hover {
+	background-color: transparent;
+}
+
+.agent-host-filter-combo.loading .agent-host-filter-label,
+.agent-host-filter-combo.empty .agent-host-filter-label {
+	max-width: 0;
+	opacity: 0;
+	margin-left: 0;
+	flex: 0 0 auto;
+}
+
+.agent-host-filter-combo.loading .agent-host-filter-chevron,
+.agent-host-filter-combo.empty .agent-host-filter-chevron {
+	display: none;
+}
+
+.agent-host-filter-combo.loading .agent-host-filter-icon .codicon {
+	animation: agent-host-filter-pulse 1.2s ease-in-out infinite;
+}
+
+/* --- Empty mode: grayed-out icon, no affordance ------------------------- */
+
+.agent-host-filter-combo.empty .agent-host-filter-icon .codicon {
+	color: var(--vscode-disabledForeground, var(--vscode-descriptionForeground));
+	opacity: 0.6;
 }
 
 /* --- Single-host mode: static label, no dropdown affordance ------------- */

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/media/hostFilter.css
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/media/hostFilter.css
@@ -95,7 +95,9 @@
 	max-width: 0;
 	opacity: 0;
 	margin-left: 0;
-	flex: 0 0 auto;
+	flex: 0 0 0;
+	width: 0;
+	overflow: hidden;
 }
 
 .agent-host-filter-combo.loading .agent-host-filter-chevron,

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution.ts
@@ -18,6 +18,7 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { logTunnelConnectAttempt, logTunnelConnectResolved, TunnelConnectErrorCategory, TunnelConnectFailureReason } from '../../../common/sessionsTelemetry.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
+import { IAgentHostFilterService } from '../common/agentHostFilter.js';
 import { RemoteAgentHostSessionsProvider } from './remoteAgentHostSessionsProvider.js';
 
 /** Minimum interval between silent status checks (5 minutes). */
@@ -82,6 +83,7 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		@ILogService private readonly _logService: ILogService,
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 	) {
 		super();
 
@@ -139,7 +141,9 @@ export class TunnelAgentHostContribution extends Disposable implements IWorkbenc
 		}));
 
 		// Silently check status of cached tunnels on startup
-		this._silentStatusCheck();
+		this._silentStatusCheck().finally(() => {
+			this._agentHostFilterService.notifyInitialDiscoveryComplete();
+		});
 	}
 
 	/**

--- a/src/vs/sessions/contrib/remoteAgentHost/common/agentHostFilter.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/common/agentHostFilter.ts
@@ -40,7 +40,7 @@ export const IAgentHostFilterService = createDecorator<IAgentHostFilterService>(
 export interface IAgentHostFilterService {
 	readonly _serviceBrand: undefined;
 
-	/** Fires when {@link selectedProviderId} or {@link hosts} changes. */
+	/** Fires when {@link selectedProviderId}, {@link hosts}, or {@link isLoadingHosts} changes. */
 	readonly onDidChange: Event<void>;
 
 	/** The currently selected providerId, or `undefined` when no hosts are known. */
@@ -48,6 +48,19 @@ export interface IAgentHostFilterService {
 
 	/** All known hosts the user can switch between. */
 	readonly hosts: readonly IAgentHostFilterEntry[];
+
+	/**
+	 * `true` until the first host discovery pass completes (regardless of
+	 * outcome). Used by UI surfaces to render a loading affordance instead
+	 * of an empty / disabled state on startup.
+	 */
+	readonly isLoadingHosts: boolean;
+
+	/**
+	 * Marks the initial host discovery pass as complete. Idempotent — only
+	 * the first call has an effect. Drives {@link isLoadingHosts}.
+	 */
+	notifyInitialDiscoveryComplete(): void;
 
 	/**
 	 * Update the selection. Ignored if `providerId` does not match a


### PR DESCRIPTION
Host filter: show loading/empty states instead of hiding the combo

The host filter dropdown in the agents titlebar was previously hidden
entirely until at least one remote host was discovered. This made the
initial startup feel empty on web/mobile.

Now the combo is always visible on web:
- Loading (initial discovery in flight): only the host icon, blinking.
- Loaded with hosts: label and chevron animate in via CSS transitions.
- Loaded with no hosts / failed: icon shown grayed out, non-interactive.

Implementation:
- Add isLoadingHosts / notifyInitialDiscoveryComplete() to
  IAgentHostFilterService. Starts true, flips to false after the first
  silent status check in TunnelAgentHostContribution.
- HostFilterActionViewItem._update() renders three modes (loading/
  empty/loaded) with appropriate aria labels and hover text.
- CSS: .loading class blinks the icon; .empty class grays it out;
  .agent-host-filter-label uses max-width/opacity transitions so the
  label slides in from the icon position.
- Remove HasAgentHostsContext gating from both desktop and mobile menu
  entries (combo always renders; view item handles visual states).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
