### PR TITLE
Execution Subagent Async Behaviour

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -124,10 +124,6 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		const endpoint = await this.getEndpoint();
 		const maxExecutionTurns = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolCallLimit, this._experimentationService);
 
-		// If a previous render observed any timed-out terminal commands, tell the
-		// prompt to nudge the model to stop issuing tool calls and produce its
-		// <final_answer>. The natural "no tool calls" exit then ends the loop.
-		const hadTimeoutsBefore = this._timedOutCommands.length > 0;
 		const render = (hasTimedOutCommand: boolean) => PromptRenderer.create(
 			this.instantiationService,
 			endpoint,
@@ -139,6 +135,12 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 			}
 		).render(progress, token);
 
+		// If a previous render observed any timed-out terminal commands, tell the
+		// prompt to nudge the model to stop issuing tool calls and produce its
+		// <final_answer>. Even with `getAvailableTools` returning [], the model
+		// may still attempt a (failed) tool call and trigger another iteration,
+		// so the nudge needs to persist across iterations.
+		const hadTimeoutsBefore = this._timedOutCommands.length > 0;
 		let result = await render(hadTimeoutsBefore);
 
 		// After rendering, scan the rendered tool results for timeouts. Every tool
@@ -239,6 +241,12 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 	}
 
 	protected async getAvailableTools(): Promise<LanguageModelToolInformation[]> {
+		// If any previous terminal call timed out, expose no tools so the model
+		// cannot make further calls and is forced to produce its <final_answer>.
+		if (this._timedOutCommands.length > 0) {
+			return [];
+		}
+
 		const endpoint = await this.getEndpoint();
 		const allTools = this.toolsService.getEnabledTools(this.options.request, endpoint);
 

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -22,7 +22,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseProgressPart, ChatResponseReferencePart, LanguageModelToolResult2 } from '../../../vscodeTypes';
 import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
-import { ExecutionSubagentPrompt, ITimedOutCommand } from '../../prompts/node/agent/executionSubagentPrompt';
+import { ExecutionSubagentPrompt, IBackgroundCommand } from '../../prompts/node/agent/executionSubagentPrompt';
 import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
 import { ToolResultMetadata } from '../../prompts/node/panel/toolCalling';
 import { ToolName } from '../../tools/common/toolNames';
@@ -44,12 +44,14 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 
 	public static readonly ID = 'executionSubagentTool';
 
-	/** Terminal calls from previous rounds that timed out, deduped by toolCallId. */
-	private readonly _timedOutCommands: ITimedOutCommand[] = [];
-	private readonly _seenTimedOutCallIds = new Set<string>();
+	/** Terminal calls from previous rounds that the subagent is no longer
+	 * awaiting (timeout-moved-to-background or async-from-start), deduped by
+	 * toolCallId. */
+	private readonly _backgroundCommands: IBackgroundCommand[] = [];
+	private readonly _seenBackgroundCallIds = new Set<string>();
 
-	public get timedOutCommands(): readonly ITimedOutCommand[] {
-		return this._timedOutCommands;
+	public get backgroundCommands(): readonly IBackgroundCommand[] {
+		return this._backgroundCommands;
 	}
 
 	constructor(
@@ -124,34 +126,35 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		const endpoint = await this.getEndpoint();
 		const maxExecutionTurns = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolCallLimit, this._experimentationService);
 
-		const render = (hasTimedOutCommand: boolean) => PromptRenderer.create(
+		const render = (hasBackgroundCommand: boolean) => PromptRenderer.create(
 			this.instantiationService,
 			endpoint,
 			ExecutionSubagentPrompt,
 			{
 				promptContext: buildpromptContext,
 				maxExecutionTurns,
-				hasTimedOutCommand,
+				hasBackgroundCommand,
 			}
 		).render(progress, token);
 
-		// If a previous render observed any timed-out terminal commands, tell the
+		// If a previous render observed any background terminal commands, tell the
 		// prompt to nudge the model to stop issuing tool calls and produce its
 		// <final_answer>. Even with `getAvailableTools` returning [], the model
 		// may still attempt a (failed) tool call and trigger another iteration,
 		// so the nudge needs to persist across iterations.
-		const hadTimeoutsBefore = this._timedOutCommands.length > 0;
-		let result = await render(hadTimeoutsBefore);
+		const hadBackgroundBefore = this._backgroundCommands.length > 0;
+		let result = await render(hadBackgroundBefore);
 
-		// After rendering, scan the rendered tool results for timeouts. Every tool
-		// call rendered into the prompt (including those executed just now during
-		// this render) emits a ToolResultMetadata entry on `result.metadata`.
-		this.collectTimedOutCommands(buildpromptContext, result);
+		// After rendering, scan the rendered tool results for background commands.
+		// Every tool call rendered into the prompt (including those executed just
+		// now during this render) emits a ToolResultMetadata entry on
+		// `result.metadata`.
+		this.collectBackgroundCommands(buildpromptContext, result);
 
-		// If a timeout was first detected during this render, the nudge wasn't in
-		// the prompt we just built. Re-render with the nudge so the LLM in this
-		// same iteration sees the instruction to produce <final_answer>.
-		if (!hadTimeoutsBefore && this._timedOutCommands.length > 0) {
+		// If a background command was first detected during this render, the nudge
+		// wasn't in the prompt we just built. Re-render with the nudge so the LLM
+		// in this same iteration sees the instruction to produce <final_answer>.
+		if (!hadBackgroundBefore && this._backgroundCommands.length > 0) {
 			const cache = buildpromptContext.toolCallResults;
 			// Write to the tool result cache so that the second render doesn't
 			// re-run all tool calls that happened during the first render
@@ -166,7 +169,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		return result;
 	}
 
-	private collectTimedOutCommands(buildpromptContext: IBuildPromptContext, result: IBuildPromptResult): void {
+	private collectBackgroundCommands(buildpromptContext: IBuildPromptContext, result: IBuildPromptResult): void {
 		const lastRound = buildpromptContext.toolCallRounds?.at(-1);
 		if (!lastRound) {
 			return;
@@ -174,55 +177,72 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 
 		// Index only this round's terminal calls. Calls from earlier rounds were
 		// already evaluated on prior iterations.
-		const terminalCallsById = new Map<string, string>();
+		interface ITerminalCall {
+			readonly command: string;
+			/** True if the model called the tool with mode="async" or
+			 *  isBackground=true, regardless of how it actually ran. */
+			readonly invokedAsAsync: boolean;
+		}
+		const terminalCallsById = new Map<string, ITerminalCall>();
 		for (const tc of lastRound.toolCalls) {
-			if (tc.name !== ToolName.CoreRunInTerminal || this._seenTimedOutCallIds.has(tc.id)) {
+			if (tc.name !== ToolName.CoreRunInTerminal || this._seenBackgroundCallIds.has(tc.id)) {
 				continue;
 			}
 			let command = '';
+			let invokedAsAsync = false;
 			try {
-				const args = JSON.parse(tc.arguments) as { command?: unknown };
+				const args = JSON.parse(tc.arguments) as { command?: unknown; mode?: unknown; isBackground?: unknown };
 				if (typeof args?.command === 'string') {
 					command = args.command;
 				}
+				invokedAsAsync = args?.mode === 'async' || args?.isBackground === true;
 			} catch {
-				// arguments may not be valid JSON on partial rounds; skip command extraction
+				// arguments may not be valid JSON on partial rounds; skip extraction
 			}
-			terminalCallsById.set(tc.id, command);
+			terminalCallsById.set(tc.id, { command, invokedAsAsync });
 		}
 		if (terminalCallsById.size === 0) {
 			return;
 		}
 
 		for (const meta of result.metadata.getAll(ToolResultMetadata)) {
-			const command = terminalCallsById.get(meta.toolCallId);
-			if (command === undefined) {
+			const call = terminalCallsById.get(meta.toolCallId);
+			if (!call) {
 				continue;
 			}
-			const timeoutInfo = this.getTerminalTimeoutInfo(meta.result);
-			if (!timeoutInfo) {
+			const termId = this.getTerminalId(meta.result);
+			if (!termId) {
+				// No termId means the call didn't produce a terminal (e.g., errored
+				// before execution). Nothing to track or note about.
 				continue;
 			}
-			this._seenTimedOutCallIds.add(meta.toolCallId);
-			this._timedOutCommands.push({
-				command,
-				termId: timeoutInfo.termId,
-				timeoutMs: timeoutInfo.timeoutMs,
-			});
+			const timeoutMs = this.getTimeoutMsIfTimedOut(meta.result);
+			if (timeoutMs !== undefined) {
+				this._seenBackgroundCallIds.add(meta.toolCallId);
+				this._backgroundCommands.push({
+					command: call.command,
+					termId,
+					reason: 'timeout',
+					timeoutMs,
+				});
+			} else if (call.invokedAsAsync) {
+				this._seenBackgroundCallIds.add(meta.toolCallId);
+				this._backgroundCommands.push({
+					command: call.command,
+					termId,
+					reason: 'async',
+				});
+			}
 		}
 	}
 
 	/**
-	 * Returns timeout details if `toolResult` is a `run_in_terminal` result that
-	 * timed out and was moved to the background, otherwise `undefined`.
-	 *
-	 * `run_in_terminal` sets a structured `timedOut: true` flag on `toolMetadata`
-	 * (along with `id` and `timeoutMs`) when a sync command exceeds its timeout.
-	 * See vscode core: runInTerminalTool.ts. `toolMetadata` is exposed on tool
-	 * results via the chatParticipantPrivate proposed API and is not on the public
+	 * Reads the `id` (terminal ID) field from a `run_in_terminal` tool result's
+	 * `toolMetadata`, if present. `toolMetadata` is exposed on tool results via
+	 * the chatParticipantPrivate proposed API and is not on the public
 	 * LanguageModelToolResult2 type, so we narrow with an `in` check.
 	 */
-	private getTerminalTimeoutInfo(toolResult: LanguageModelToolResult2): { termId: string; timeoutMs?: number } | undefined {
+	private getTerminalId(toolResult: LanguageModelToolResult2): string | undefined {
 		if (!('toolMetadata' in toolResult)) {
 			return undefined;
 		}
@@ -230,20 +250,36 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		if (!metadata || typeof metadata !== 'object') {
 			return undefined;
 		}
-		const m = metadata as { timedOut?: unknown; id?: unknown; timeoutMs?: unknown };
-		if (m.timedOut !== true || typeof m.id !== 'string') {
+		const m = metadata as { id?: unknown };
+		return typeof m.id === 'string' ? m.id : undefined;
+	}
+
+	/**
+	 * Returns the configured timeout (ms) if the result indicates a sync
+	 * `run_in_terminal` call timed out and was moved to the background; returns
+	 * `undefined` otherwise. See vscode core: runInTerminalTool.ts which sets
+	 * `timedOut: true` and `timeoutMs` on `toolMetadata` for that case.
+	 */
+	private getTimeoutMsIfTimedOut(toolResult: LanguageModelToolResult2): number | undefined {
+		if (!('toolMetadata' in toolResult)) {
 			return undefined;
 		}
-		return {
-			termId: m.id,
-			timeoutMs: typeof m.timeoutMs === 'number' ? m.timeoutMs : undefined,
-		};
+		const metadata = (toolResult as { toolMetadata?: unknown }).toolMetadata;
+		if (!metadata || typeof metadata !== 'object') {
+			return undefined;
+		}
+		const m = metadata as { timedOut?: unknown; timeoutMs?: unknown };
+		if (m.timedOut !== true) {
+			return undefined;
+		}
+		return typeof m.timeoutMs === 'number' ? m.timeoutMs : undefined;
 	}
 
 	protected async getAvailableTools(): Promise<LanguageModelToolInformation[]> {
-		// If any previous terminal call timed out, expose no tools so the model
-		// cannot make further calls and is forced to produce its <final_answer>.
-		if (this._timedOutCommands.length > 0) {
+		// If any previous terminal call has moved to the background (timeout or
+		// async), expose no tools so the model cannot make further calls and is
+		// forced to produce its <final_answer>.
+		if (this._backgroundCommands.length > 0) {
 			return [];
 		}
 

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -22,7 +22,7 @@ import { ITelemetryService } from '../../../platform/telemetry/common/telemetry'
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseProgressPart, ChatResponseReferencePart, LanguageModelToolResult2 } from '../../../vscodeTypes';
 import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
-import { ExecutionSubagentPrompt, IBackgroundCommand } from '../../prompts/node/agent/executionSubagentPrompt';
+import { ExecutionSubagentPrompt } from '../../prompts/node/agent/executionSubagentPrompt';
 import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
 import { ToolResultMetadata } from '../../prompts/node/panel/toolCalling';
 import { ToolName } from '../../tools/common/toolNames';
@@ -38,6 +38,17 @@ export interface IExecutionSubagentToolCallingLoopOptions extends IToolCallingLo
 	subAgentInvocationId?: string;
 	/** The tool_call_id from the parent agent's LLM response that triggered this subagent invocation. */
 	parentToolCallId?: string;
+}
+
+/** A terminal command that is no longer being awaited by the subagent — either
+ * it timed out and was moved to the background, or the model invoked it in
+ * async/background mode from the start. */
+export interface IBackgroundCommand {
+	readonly command: string;
+	readonly termId: string;
+	readonly reason: 'timeout' | 'async';
+	/** Only set when `reason === 'timeout'`. */
+	readonly timeoutMs?: number;
 }
 
 export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecutionSubagentToolCallingLoopOptions> {

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -124,25 +124,42 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		const endpoint = await this.getEndpoint();
 		const maxExecutionTurns = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolCallLimit, this._experimentationService);
 
-		// If the previous render observed any timed-out terminal commands, tell the
+		// If a previous render observed any timed-out terminal commands, tell the
 		// prompt to nudge the model to stop issuing tool calls and produce its
 		// <final_answer>. The natural "no tool calls" exit then ends the loop.
-		const renderer = PromptRenderer.create(
+		const hadTimeoutsBefore = this._timedOutCommands.length > 0;
+		const render = (hasTimedOutCommand: boolean) => PromptRenderer.create(
 			this.instantiationService,
 			endpoint,
 			ExecutionSubagentPrompt,
 			{
 				promptContext: buildpromptContext,
 				maxExecutionTurns,
-				hasTimedOutCommand: this._timedOutCommands.length > 0,
+				hasTimedOutCommand,
 			}
-		);
-		const result = await renderer.render(progress, token);
+		).render(progress, token);
+
+		let result = await render(hadTimeoutsBefore);
 
 		// After rendering, scan the rendered tool results for timeouts. Every tool
 		// call rendered into the prompt (including those executed just now during
 		// this render) emits a ToolResultMetadata entry on `result.metadata`.
 		this.collectTimedOutCommands(buildpromptContext, result);
+
+		// If a timeout was first detected during this render, the nudge wasn't in
+		// the prompt we just built. Re-render with the nudge so the LLM in this
+		// same iteration sees the instruction to produce <final_answer>.
+		if (!hadTimeoutsBefore && this._timedOutCommands.length > 0) {
+			const cache = buildpromptContext.toolCallResults;
+			// Write to the tool result cache so that the second render doesn't
+			// re-run all tool calls that happened during the first render
+			if (cache) {
+				for (const meta of result.metadata.getAll(ToolResultMetadata)) {
+					cache[meta.toolCallId] = meta.result;
+				}
+			}
+			result = await render(true);
+		}
 
 		return result;
 	}
@@ -212,11 +229,11 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 			return undefined;
 		}
 		const m = metadata as { timedOut?: unknown; id?: unknown; timeoutMs?: unknown };
-		if (m.timedOut !== true) {
+		if (m.timedOut !== true || typeof m.id !== 'string') {
 			return undefined;
 		}
 		return {
-			termId: typeof m.id === 'string' ? m.id : '',
+			termId: m.id,
 			timeoutMs: typeof m.timeoutMs === 'number' ? m.timeoutMs : undefined,
 		};
 	}

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -20,10 +20,11 @@ import { IRequestLogger } from '../../../platform/requestLogger/common/requestLo
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
-import { ChatResponseProgressPart, ChatResponseReferencePart } from '../../../vscodeTypes';
+import { ChatResponseProgressPart, ChatResponseReferencePart, LanguageModelToolResult2 } from '../../../vscodeTypes';
 import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
-import { ExecutionSubagentPrompt } from '../../prompts/node/agent/executionSubagentPrompt';
+import { ExecutionSubagentPrompt, ITimedOutCommand } from '../../prompts/node/agent/executionSubagentPrompt';
 import { PromptRenderer } from '../../prompts/node/base/promptRenderer';
+import { ToolResultMetadata } from '../../prompts/node/panel/toolCalling';
 import { ToolName } from '../../tools/common/toolNames';
 import { IToolsService } from '../../tools/common/toolsService';
 import { IBuildPromptContext } from '../common/intents';
@@ -42,6 +43,14 @@ export interface IExecutionSubagentToolCallingLoopOptions extends IToolCallingLo
 export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecutionSubagentToolCallingLoopOptions> {
 
 	public static readonly ID = 'executionSubagentTool';
+
+	/** Terminal calls from previous rounds that timed out, deduped by toolCallId. */
+	private readonly _timedOutCommands: ITimedOutCommand[] = [];
+	private readonly _seenTimedOutCallIds = new Set<string>();
+
+	public get timedOutCommands(): readonly ITimedOutCommand[] {
+		return this._timedOutCommands;
+	}
 
 	constructor(
 		options: IExecutionSubagentToolCallingLoopOptions,
@@ -114,16 +123,102 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 	protected async buildPrompt(buildpromptContext: IBuildPromptContext, progress: Progress<ChatResponseReferencePart | ChatResponseProgressPart>, token: CancellationToken): Promise<IBuildPromptResult> {
 		const endpoint = await this.getEndpoint();
 		const maxExecutionTurns = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentToolCallLimit, this._experimentationService);
+
+		// If the previous render observed any timed-out terminal commands, tell the
+		// prompt to nudge the model to stop issuing tool calls and produce its
+		// <final_answer>. The natural "no tool calls" exit then ends the loop.
 		const renderer = PromptRenderer.create(
 			this.instantiationService,
 			endpoint,
 			ExecutionSubagentPrompt,
 			{
 				promptContext: buildpromptContext,
-				maxExecutionTurns
+				maxExecutionTurns,
+				hasTimedOutCommand: this._timedOutCommands.length > 0,
 			}
 		);
-		return await renderer.render(progress, token);
+		const result = await renderer.render(progress, token);
+
+		// After rendering, scan the rendered tool results for timeouts. Every tool
+		// call rendered into the prompt (including those executed just now during
+		// this render) emits a ToolResultMetadata entry on `result.metadata`.
+		this.collectTimedOutCommands(buildpromptContext, result);
+
+		return result;
+	}
+
+	private collectTimedOutCommands(buildpromptContext: IBuildPromptContext, result: IBuildPromptResult): void {
+		const lastRound = buildpromptContext.toolCallRounds?.at(-1);
+		if (!lastRound) {
+			return;
+		}
+
+		// Index only this round's terminal calls. Calls from earlier rounds were
+		// already evaluated on prior iterations.
+		const terminalCallsById = new Map<string, string>();
+		for (const tc of lastRound.toolCalls) {
+			if (tc.name !== ToolName.CoreRunInTerminal || this._seenTimedOutCallIds.has(tc.id)) {
+				continue;
+			}
+			let command = '';
+			try {
+				const args = JSON.parse(tc.arguments) as { command?: unknown };
+				if (typeof args?.command === 'string') {
+					command = args.command;
+				}
+			} catch {
+				// arguments may not be valid JSON on partial rounds; skip command extraction
+			}
+			terminalCallsById.set(tc.id, command);
+		}
+		if (terminalCallsById.size === 0) {
+			return;
+		}
+
+		for (const meta of result.metadata.getAll(ToolResultMetadata)) {
+			const command = terminalCallsById.get(meta.toolCallId);
+			if (command === undefined) {
+				continue;
+			}
+			const timeoutInfo = this.getTerminalTimeoutInfo(meta.result);
+			if (!timeoutInfo) {
+				continue;
+			}
+			this._seenTimedOutCallIds.add(meta.toolCallId);
+			this._timedOutCommands.push({
+				command,
+				termId: timeoutInfo.termId,
+				timeoutMs: timeoutInfo.timeoutMs,
+			});
+		}
+	}
+
+	/**
+	 * Returns timeout details if `toolResult` is a `run_in_terminal` result that
+	 * timed out and was moved to the background, otherwise `undefined`.
+	 *
+	 * `run_in_terminal` sets a structured `timedOut: true` flag on `toolMetadata`
+	 * (along with `id` and `timeoutMs`) when a sync command exceeds its timeout.
+	 * See vscode core: runInTerminalTool.ts. `toolMetadata` is exposed on tool
+	 * results via the chatParticipantPrivate proposed API and is not on the public
+	 * LanguageModelToolResult2 type, so we narrow with an `in` check.
+	 */
+	private getTerminalTimeoutInfo(toolResult: LanguageModelToolResult2): { termId: string; timeoutMs?: number } | undefined {
+		if (!('toolMetadata' in toolResult)) {
+			return undefined;
+		}
+		const metadata = (toolResult as { toolMetadata?: unknown }).toolMetadata;
+		if (!metadata || typeof metadata !== 'object') {
+			return undefined;
+		}
+		const m = metadata as { timedOut?: unknown; id?: unknown; timeoutMs?: unknown };
+		if (m.timedOut !== true) {
+			return undefined;
+		}
+		return {
+			termId: typeof m.id === 'string' ? m.id : '',
+			timeoutMs: typeof m.timeoutMs === 'number' ? m.timeoutMs : undefined,
+		};
 	}
 
 	protected async getAvailableTools(): Promise<LanguageModelToolInformation[]> {
@@ -131,10 +226,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		const allTools = this.toolsService.getEnabledTools(this.options.request, endpoint);
 
 		const allowedExecutionTools = new Set([
-			ToolName.CoreRunInTerminal,
-			ToolName.CoreGetTerminalOutput,
-			ToolName.CoreSendToTerminal,
-			ToolName.CoreKillTerminal,
+			ToolName.CoreRunInTerminal
 		]);
 
 		return allTools.filter(tool => allowedExecutionTools.has(tool.name as ToolName));

--- a/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
@@ -11,8 +11,17 @@ import { SafetyRules } from '../base/safetyRules';
 import { TerminalStatePromptElement } from '../base/terminalState';
 import { ChatToolCalls } from '../panel/toolCalling';
 
+export interface ITimedOutCommand {
+	readonly command: string;
+	readonly termId: string;
+	readonly timeoutMs?: number;
+}
+
 export interface ExecutionSubagentPromptProps extends GenericBasePromptElementProps {
 	readonly maxExecutionTurns: number;
+	/** True if a previous {@link ToolName.CoreRunInTerminal} call timed out; the
+	 * model is told to stop calling tools and emit its `<final_answer>`. */
+	readonly hasTimedOutCommand?: boolean;
 }
 
 /**
@@ -81,6 +90,11 @@ export class ExecutionSubagentPrompt extends PromptElement<ExecutionSubagentProm
 				{isLastTurn && (
 					<UserMessage priority={900}>
 						OK, your allotted iterations are finished. Show the &lt;final_answer&gt;.
+					</UserMessage>
+				)}
+				{!isLastTurn && this.props.hasTimedOutCommand && (
+					<UserMessage priority={900}>
+						A previous {ToolName.CoreRunInTerminal} call timed out. Do not call any more tools. Show the &lt;final_answer&gt;.
 					</UserMessage>
 				)}
 			</>

--- a/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
@@ -87,14 +87,9 @@ export class ExecutionSubagentPrompt extends PromptElement<ExecutionSubagentProm
 					toolCallResults={toolCallResults}
 					toolCallMode={CopilotToolMode.FullContext}
 				/>
-				{isLastTurn && (
+				{(isLastTurn || this.props.hasTimedOutCommand) && (
 					<UserMessage priority={900}>
 						OK, your allotted iterations are finished. Show the &lt;final_answer&gt;.
-					</UserMessage>
-				)}
-				{!isLastTurn && this.props.hasTimedOutCommand && (
-					<UserMessage priority={900}>
-						A previous {ToolName.CoreRunInTerminal} call timed out. Do not call any more tools. Show the &lt;final_answer&gt;.
 					</UserMessage>
 				)}
 			</>

--- a/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
@@ -11,17 +11,23 @@ import { SafetyRules } from '../base/safetyRules';
 import { TerminalStatePromptElement } from '../base/terminalState';
 import { ChatToolCalls } from '../panel/toolCalling';
 
-export interface ITimedOutCommand {
+/** A terminal command that is no longer being awaited by the subagent — either
+ * it timed out and was moved to the background, or the model invoked it in
+ * async/background mode from the start. */
+export interface IBackgroundCommand {
 	readonly command: string;
 	readonly termId: string;
+	readonly reason: 'timeout' | 'async';
+	/** Only set when `reason === 'timeout'`. */
 	readonly timeoutMs?: number;
 }
 
 export interface ExecutionSubagentPromptProps extends GenericBasePromptElementProps {
 	readonly maxExecutionTurns: number;
-	/** True if a previous {@link ToolName.CoreRunInTerminal} call timed out; the
-	 * model is told to stop calling tools and emit its `<final_answer>`. */
-	readonly hasTimedOutCommand?: boolean;
+	/** True if a previous {@link ToolName.CoreRunInTerminal} call timed out or was
+	 * invoked in async/background mode; the model is told to stop calling tools
+	 * and emit its `<final_answer>`. */
+	readonly hasBackgroundCommand?: boolean;
 }
 
 /**
@@ -87,7 +93,7 @@ export class ExecutionSubagentPrompt extends PromptElement<ExecutionSubagentProm
 					toolCallResults={toolCallResults}
 					toolCallMode={CopilotToolMode.FullContext}
 				/>
-				{(isLastTurn || this.props.hasTimedOutCommand) && (
+				{(isLastTurn || this.props.hasBackgroundCommand) && (
 					<UserMessage priority={900}>
 						OK, your allotted iterations are finished. Show the &lt;final_answer&gt;.
 					</UserMessage>

--- a/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
@@ -11,17 +11,6 @@ import { SafetyRules } from '../base/safetyRules';
 import { TerminalStatePromptElement } from '../base/terminalState';
 import { ChatToolCalls } from '../panel/toolCalling';
 
-/** A terminal command that is no longer being awaited by the subagent — either
- * it timed out and was moved to the background, or the model invoked it in
- * async/background mode from the start. */
-export interface IBackgroundCommand {
-	readonly command: string;
-	readonly termId: string;
-	readonly reason: 'timeout' | 'async';
-	/** Only set when `reason === 'timeout'`. */
-	readonly timeoutMs?: number;
-}
-
 export interface ExecutionSubagentPromptProps extends GenericBasePromptElementProps {
 	readonly maxExecutionTurns: number;
 	/** True if a previous {@link ToolName.CoreRunInTerminal} call timed out or was

--- a/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/executionSubagentPrompt.tsx
@@ -82,9 +82,14 @@ export class ExecutionSubagentPrompt extends PromptElement<ExecutionSubagentProm
 					toolCallResults={toolCallResults}
 					toolCallMode={CopilotToolMode.FullContext}
 				/>
-				{(isLastTurn || this.props.hasBackgroundCommand) && (
+				{isLastTurn && (
 					<UserMessage priority={900}>
 						OK, your allotted iterations are finished. Show the &lt;final_answer&gt;.
+					</UserMessage>
+				)}
+				{!isLastTurn && this.props.hasBackgroundCommand && (
+					<UserMessage priority={900}>
+						One or more commands are running in the background. You do not have the ability to monitor them. Show the &lt;final_answer&gt;.
 					</UserMessage>
 				)}
 			</>

--- a/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
+++ b/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
@@ -106,9 +106,10 @@ class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 			subagentResponse = `The execution subagent request failed with this message:\n${loopResult.response.type}: ${loopResult.response.reason}`;
 		}
 
-		// If any terminal commands timed out during the subagent's run, append a
-		// Note line for each on the line(s) immediately after the final </final_answer>.
-		subagentResponse = appendTimeoutNotesToFinalAnswer(subagentResponse, loop.timedOutCommands);
+		// If any terminal commands moved to the background (timeout or async) during
+		// the subagent's run, append a Note line for each on the line(s) immediately
+		// after the final </final_answer>.
+		subagentResponse = appendBackgroundCommandNotesToFinalAnswer(subagentResponse, loop.backgroundCommands);
 
 		// toolMetadata will be automatically included in exportAllPromptLogsAsJsonCommand
 		const result = new ExtendedLanguageModelToolResult([new LanguageModelTextPart(subagentResponse)]);
@@ -132,18 +133,25 @@ class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 ToolRegistry.registerTool(ExecutionSubagentTool);
 
 /**
- * Appends a `Note: ...` line for each timed-out terminal command on the line(s)
- * immediately after the final `</final_answer>` of the subagent's response. If
- * no `<final_answer>` block is present, appends the notes to the end of the response.
+ * Appends a `Note: ...` line for each stopped terminal command (timed out or
+ * invoked in async/background mode) on the line(s) immediately after the final
+ * `</final_answer>` of the subagent's response. If no `<final_answer>` block is
+ * present, appends the notes to the end of the response.
  */
-function appendTimeoutNotesToFinalAnswer(response: string, timedOutCommands: ReadonlyArray<{ command: string; termId: string; timeoutMs?: number }>): string {
-	if (timedOutCommands.length === 0) {
+function appendBackgroundCommandNotesToFinalAnswer(
+	response: string,
+	backgroundCommands: ReadonlyArray<{ command: string; termId: string; reason: 'timeout' | 'async'; timeoutMs?: number }>,
+): string {
+	if (backgroundCommands.length === 0) {
 		return response;
 	}
 
-	const notes = timedOutCommands.map(c => {
-		const timeoutText = c.timeoutMs !== undefined ? ` after ${c.timeoutMs} ms` : '';
-		return `Note: The command \`${c.command}\` timed out${timeoutText}. It may still be running in terminal ID ${c.termId}.`;
+	const notes = backgroundCommands.map(c => {
+		if (c.reason === 'timeout') {
+			const timeoutText = c.timeoutMs !== undefined ? ` after ${c.timeoutMs} ms` : '';
+			return `Note: The command \`${c.command}\` timed out${timeoutText}. It may still be running in terminal ID ${c.termId}.`;
+		}
+		return `Note: The command \`${c.command}\` was started in the background. It may still be running in terminal ID ${c.termId}.`;
 	}).join('\n');
 
 	const closingTag = '</final_answer>';

--- a/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
+++ b/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
@@ -106,6 +106,10 @@ class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 			subagentResponse = `The execution subagent request failed with this message:\n${loopResult.response.type}: ${loopResult.response.reason}`;
 		}
 
+		// If any terminal commands timed out during the subagent's run, append a
+		// Note line for each on the line(s) immediately after the final </final_answer>.
+		subagentResponse = appendTimeoutNotesToFinalAnswer(subagentResponse, loop.timedOutCommands);
+
 		// toolMetadata will be automatically included in exportAllPromptLogsAsJsonCommand
 		const result = new ExtendedLanguageModelToolResult([new LanguageModelTextPart(subagentResponse)]);
 		result.toolMetadata = toolMetadata;
@@ -126,3 +130,29 @@ class ExecutionSubagentTool implements ICopilotTool<IExecutionSubagentParams> {
 }
 
 ToolRegistry.registerTool(ExecutionSubagentTool);
+
+/**
+ * Appends a `Note: ...` line for each timed-out terminal command on the line(s)
+ * immediately after the final `</final_answer>` of the subagent's response. If
+ * no `<final_answer>` block is present, appends the notes to the end of the response.
+ */
+function appendTimeoutNotesToFinalAnswer(response: string, timedOutCommands: ReadonlyArray<{ command: string; termId: string; timeoutMs?: number }>): string {
+	if (timedOutCommands.length === 0) {
+		return response;
+	}
+
+	const notes = timedOutCommands.map(c => {
+		const timeoutText = c.timeoutMs !== undefined ? ` after ${c.timeoutMs} ms` : '';
+		return `Note: The command \`${c.command}\` timed out${timeoutText}. It may still be running in terminal ID ${c.termId}.`;
+	}).join('\n');
+
+	const closingTag = '</final_answer>';
+	const closeIdx = response.lastIndexOf(closingTag);
+	if (closeIdx === -1) {
+		return response.length > 0 ? `${response}\n\n${notes}` : notes;
+	}
+	const insertAt = closeIdx + closingTag.length;
+	const before = response.slice(0, insertAt);
+	const after = response.slice(insertAt).replace(/^\s*/, '');
+	return after.length > 0 ? `${before}\n${notes}\n${after}` : `${before}\n${notes}`;
+}

--- a/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
+++ b/extensions/copilot/src/extension/tools/node/executionSubagentTool.ts
@@ -16,7 +16,7 @@ import { IInstantiationService } from '../../../util/vs/platform/instantiation/c
 import { ChatResponseNotebookEditPart, ChatResponseTextEditPart, ChatToolInvocationPart, ExtendedLanguageModelToolResult, LanguageModelTextPart, MarkdownString } from '../../../vscodeTypes';
 import { Conversation, Turn } from '../../prompt/common/conversation';
 import { IBuildPromptContext } from '../../prompt/common/intents';
-import { ExecutionSubagentToolCallingLoop } from '../../prompt/node/executionSubagentToolCallingLoop';
+import { ExecutionSubagentToolCallingLoop, IBackgroundCommand } from '../../prompt/node/executionSubagentToolCallingLoop';
 import { ToolName } from '../common/toolNames';
 import { CopilotToolMode, ICopilotTool, ToolRegistry } from '../common/toolsRegistry';
 
@@ -140,7 +140,7 @@ ToolRegistry.registerTool(ExecutionSubagentTool);
  */
 function appendBackgroundCommandNotesToFinalAnswer(
 	response: string,
-	backgroundCommands: ReadonlyArray<{ command: string; termId: string; reason: 'timeout' | 'async'; timeoutMs?: number }>,
+	backgroundCommands: readonly IBackgroundCommand[],
 ): string {
 	if (backgroundCommands.length === 0) {
 		return response;


### PR DESCRIPTION
The execution subagent doesn't work well with async terminals (see #308048). The system prompt asks it to refrain from calling `run_in_terminal` async, but it is still possible for a sync terminal call to become async once the timeout expires.

The old workaround was to give the subagent access to tools like `get_terminal_output` and `kill_terminal` so that it could monitor background terminals. Drawbacks:
1. The subagent call itself is not async, so the main agent remains blocked while waiting for the subagent to finish. Given that, it is undesirable to give the subagent the ability to run commands with unbounded time horizons.
2. The main agent can relinquish control of long-running commands and get a ping when they complete. The subagent cannot. 
3. The subagent is being developed as an extremely lightweight custom model. It struggles to handle an expanded toolset.

The proposed solution is:
1.  Automatically detect when a terminal call times out OR is called async (despite being explicitly instructed not to)
2. Prompt the subagent to finish and return the `<final_answer>`, and take away its tools to force its hand.
4. Append the command(s) that timed out along with its terminal ID, to the subagent's response that is sent back to the main agent. This way, the main agent can take further action using `get_terminal_output`, `kill_terminal`, etc.

Analysis of telemetry shows that only 10% of all subagent trajectories contain at least one terminal call that times out, so it is acceptable for the subagent to hand back control to the main agent when it encounters such a scenario.

Another minority scenario (~1.1% of all subagent trajectories, from telemetry) is when a command waits on user input. To account for such cases, the subagent's system prompt instructs it to re-run the command with a pipe `echo y | ....` or `yes | ...`. This circumvents the need for an additional tool `send_output_to_terminal`.

Tagging @roblourens and @meganrogge for review.