### PR TITLE
Don't throw in setRequestTools when agent is gone

### DIFF
--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -537,7 +537,7 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 	setRequestTools(id: string, requestId: string, tools: UserSelectedTools): void {
 		const data = this._agents.get(id);
 		if (!data?.impl) {
-			throw new Error(`No activated agent with id "${id}"`);
+			return;
 		}
 
 		data.impl.setRequestTools?.(requestId, tools);


### PR DESCRIPTION
Fixes #312803

The `autorun` in `chatServiceImpl` that calls `setRequestTools` is per-request and can fire after the target agent has been unregistered (e.g., `setup.vscode` is disposed when Copilot setup completes while a request is still in-flight). Throwing here surfaces as an unhandled error from inside the autorun.

Match the existing pattern used by `setYieldRequested` and `getFollowups` in the same file and silently return when the agent is no longer registered.

There's only one caller of `setRequestTools` (`chatServiceImpl.ts:1266`) and it always passes the id of an agent it just successfully invoked, so the throw was never catching real misuse — only this lifecycle race.