### PR TITLE
[release/1.118] On agent mode change, ignore stateful marker

### DIFF
--- a/extensions/copilot/src/extension/agents/vscode-node/test/planAgentProvider.spec.ts
+++ b/extensions/copilot/src/extension/agents/vscode-node/test/planAgentProvider.spec.ts
@@ -18,7 +18,7 @@ import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { buildAgentMarkdown } from '../agentTypes';
+import { buildAgentMarkdown, DEFAULT_READ_TOOLS } from '../agentTypes';
 import { PlanAgentProvider } from '../planAgentProvider';
 
 suite('PlanAgentProvider', () => {
@@ -247,6 +247,24 @@ suite('PlanAgentProvider', () => {
 		const content = await getAgentContent(agents[0]);
 
 		assert.ok(content.includes('vscode/askQuestions'));
+	});
+
+	test('exposes only default read tools plus agent and askQuestions in plan mode by default', async () => {
+		const provider = createProvider();
+		const agents = await provider.provideCustomAgents({}, {} as any);
+
+		assert.equal(agents.length, 1);
+		const content = await getAgentContent(agents[0]);
+
+		const toolsMatch = content.match(/tools: \[([^\]]+)\]/);
+		assert.ok(toolsMatch, 'Tools list not found in agent content');
+		const actualTools = (toolsMatch[1].match(/'([^']+)'/g) || []).map(tool => tool.slice(1, -1)).sort();
+		const expectedTools = [...DEFAULT_READ_TOOLS, 'agent', 'vscode/askQuestions'].sort();
+
+		assert.deepStrictEqual(actualTools, expectedTools);
+		assert.ok(!actualTools.includes('edit'));
+		assert.ok(!actualTools.includes('createFile'));
+		assert.ok(!actualTools.includes('apply_patch'));
 	});
 
 	test('has correct label property', () => {

--- a/extensions/copilot/src/extension/intents/node/editCodeIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/editCodeIntent.ts
@@ -123,7 +123,7 @@ export class EditCodeIntent implements IIntent {
 				const { references } = await renderPromptElement(this.instantiationService, endpoint, ToolCallResultWrapper, { toolCallResults }, undefined, token);
 				foundReferences.push(...toNewChatReferences(variables, references));
 				// TODO: how should we splice in the assistant message?
-				conversation = new Conversation(conversation.sessionId, [...conversation.turns.slice(0, -1), new Turn(latestTurn.id, latestTurn.request, undefined)]);
+				conversation = new Conversation(conversation.sessionId, [...conversation.turns.slice(0, -1), new Turn(latestTurn.id, latestTurn.request, undefined, [], undefined, undefined, false, latestTurn.modeInstructions)]);
 			}
 			return { conversation, request: { ...request, references: [...request.references, ...foundReferences], toolReferences: request.toolReferences.filter((r) => r.name !== CodebaseTool.toolName) } };
 		}

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -192,6 +192,10 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 	private readonly _onDidReceiveResponse = this._register(new Emitter<IToolCallingResponseEvent>());
 	public readonly onDidReceiveResponse = this._onDidReceiveResponse.event;
 
+	protected get currentToolCallRounds(): readonly IToolCallRound[] {
+		return this.toolCallRounds;
+	}
+
 	private get turn() {
 		return this.options.conversation.getLatestTurn();
 	}

--- a/extensions/copilot/src/extension/prompt/common/conversation.ts
+++ b/extensions/copilot/src/extension/prompt/common/conversation.ts
@@ -80,6 +80,7 @@ export class Turn {
 			request.editedFileEvents,
 			request.acceptedConfirmationData,
 			isToolCallLimitAcceptance(request) || isContinueOnError(request) || isSwitchToAutoOnRateLimit(request),
+			request.modeInstructions2,
 		);
 	}
 
@@ -90,7 +91,8 @@ export class Turn {
 		private readonly _toolReferences: readonly InternalToolReference[] = [],
 		readonly editedFileEvents?: ChatRequestEditedFileEvent[],
 		readonly acceptedConfirmationData?: unknown[],
-		readonly isContinuation = false
+		readonly isContinuation = false,
+		readonly modeInstructions?: ChatRequest['modeInstructions2'],
 	) { }
 
 	get promptVariables(): ChatVariablesCollection | undefined {

--- a/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatParticipantRequestHandler.ts
@@ -395,7 +395,10 @@ function createTurnFromVSCodeChatHistoryTurns(
 		{ message: chatRequestTurn.prompt, type: 'user' },
 		new ChatVariablesCollection(chatRequestTurn.references),
 		chatRequestTurn.toolReferences.map(InternalToolReference.from),
-		chatRequestAsTurn2.editedFileEvents
+		chatRequestAsTurn2.editedFileEvents,
+		undefined,
+		false,
+		chatRequestAsTurn2.modeInstructions2,
 	);
 
 	// Take just the content messages

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -695,8 +695,10 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 		const rawEffort = this.options.request.modelConfiguration?.reasoningEffort;
 		const reasoningEffort = typeof rawEffort === 'string' ? rawEffort : undefined;
 		const isSubagent = !!this.options.request.subAgentInvocationId;
+		const ignoreStatefulMarker = this.shouldIgnoreStatefulMarkerForModeChange();
 		return this.options.invocation.endpoint.makeChatRequest2({
 			...opts,
+			ignoreStatefulMarker,
 			modelCapabilities: {
 				...opts.modelCapabilities,
 				enableThinking: isThinkingLocation && opts.modelCapabilities?.enableThinking,
@@ -735,6 +737,24 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 				: undefined,
 			enableRetryOnFilter: true
 		}, token);
+	}
+
+	private shouldIgnoreStatefulMarkerForModeChange(): boolean {
+		if (this.options.invocation.endpoint.apiType !== 'responses') {
+			return false;
+		}
+
+		const previousModeInstructions = this.options.conversation.turns.at(-2)?.modeInstructions;
+		if (!previousModeInstructions && !this.options.request.modeInstructions2) {
+			return false;
+		}
+
+		const modeChanged = !areModeInstructionsEqual(previousModeInstructions, this.options.request.modeInstructions2);
+		if (modeChanged) {
+			this._logService.trace('[DefaultIntentRequestHandler] Ignoring stateful marker because mode instructions changed between requests');
+		}
+
+		return modeChanged;
 	}
 
 	protected override async getAvailableTools(outputStream: ChatResponseStream | undefined, token: CancellationToken): Promise<LanguageModelToolInformation[]> {
@@ -792,4 +812,40 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 
 interface IInternalRequestResult extends IToolCallLoopResult {
 	lastRequestTelemetry: ChatTelemetry;
+}
+
+type ModeInstructions = NonNullable<ChatRequest['modeInstructions2']>;
+type ModeInstructionMetadata = ModeInstructions['metadata'];
+
+function areModeInstructionsEqual(a: ChatRequest['modeInstructions2'], b: ChatRequest['modeInstructions2']): boolean {
+	if (!a || !b) {
+		return a === b;
+	}
+
+	return a.uri?.toString() === b.uri?.toString()
+		&& a.name === b.name
+		&& a.content === b.content
+		&& a.isBuiltin === b.isBuiltin
+		&& serializeModeInstructionMetadata(a.metadata) === serializeModeInstructionMetadata(b.metadata);
+}
+
+function normalizeModeInstructionMetadata(metadata: ModeInstructionMetadata): Record<string, boolean | string | number> | undefined {
+	if (!metadata) {
+		return undefined;
+	}
+
+	const entries = Object.entries(metadata).sort(([left], [right]) => left.localeCompare(right));
+	if (entries.length === 0) {
+		return undefined;
+	}
+
+	return entries.reduce<Record<string, boolean | string | number>>((result, [key, value]) => {
+		result[key] = value;
+		return result;
+	}, {});
+}
+
+function serializeModeInstructionMetadata(metadata: ModeInstructionMetadata): string | undefined {
+	const normalizedMetadata = normalizeModeInstructionMetadata(metadata);
+	return normalizedMetadata ? JSON.stringify(normalizedMetadata) : undefined;
 }

--- a/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
+++ b/extensions/copilot/src/extension/prompt/node/defaultIntentRequestHandler.ts
@@ -695,10 +695,10 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 		const rawEffort = this.options.request.modelConfiguration?.reasoningEffort;
 		const reasoningEffort = typeof rawEffort === 'string' ? rawEffort : undefined;
 		const isSubagent = !!this.options.request.subAgentInvocationId;
-		const ignoreStatefulMarker = this.shouldIgnoreStatefulMarkerForModeChange();
+		const modeChanged = this.didModeChangeSincePreviousRequest();
 		return this.options.invocation.endpoint.makeChatRequest2({
 			...opts,
-			ignoreStatefulMarker,
+			modeChanged,
 			modelCapabilities: {
 				...opts.modelCapabilities,
 				enableThinking: isThinkingLocation && opts.modelCapabilities?.enableThinking,
@@ -739,8 +739,20 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 		}, token);
 	}
 
-	private shouldIgnoreStatefulMarkerForModeChange(): boolean {
+	private didModeChangeSincePreviousRequest(): boolean {
 		if (this.options.invocation.endpoint.apiType !== 'responses') {
+			return false;
+		}
+
+		// Once a mode-switched turn has successfully produced a fresh responses-api
+		// stateful marker, later requests in the same turn should resume from that
+		// new chain instead of continuing to invalidate previous_response_id.
+		// This is especially important for websocket follow-up requests after tool
+		// calls: keeping modeChanged=true for the entire turn would force the full
+		// pre-switch history back into every follow-up request, which can pull the
+		// model back toward the prior mode (for example implementation after
+		// switching into Plan mode).
+		if (this.currentToolCallRounds.some(round => !!round.statefulMarker)) {
 			return false;
 		}
 
@@ -751,7 +763,7 @@ class DefaultToolCallingLoop extends ToolCallingLoop<IDefaultToolLoopOptions> {
 
 		const modeChanged = !areModeInstructionsEqual(previousModeInstructions, this.options.request.modeInstructions2);
 		if (modeChanged) {
-			this._logService.trace('[DefaultIntentRequestHandler] Ignoring stateful marker because mode instructions changed between requests');
+			this._logService.trace('[DefaultIntentRequestHandler] Detected mode instructions changed between requests');
 		}
 
 		return modeChanged;

--- a/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -220,10 +220,11 @@ suite('defaultIntentRequestHandler', () => {
 		await handler.getResult();
 
 		expect(requestSpy).toHaveBeenCalledOnce();
-		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBe(true);
+		expect(requestSpy.mock.calls[0][0].modeChanged).toBe(true);
+		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBeUndefined();
 	});
 
-	test('does not ignore stateful marker when mode instructions are unchanged on responses api requests', async () => {
+	test('preserves default stateful marker behavior when mode instructions are unchanged on responses api requests', async () => {
 		const request = new TestChatRequest();
 		(request as any).modeInstructions2 = { name: 'Agent', content: 'agent instructions', isBuiltin: true };
 		(endpoint as any).apiType = 'responses';
@@ -239,7 +240,8 @@ suite('defaultIntentRequestHandler', () => {
 		await handler.getResult();
 
 		expect(requestSpy).toHaveBeenCalledOnce();
-		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBe(false);
+		expect(requestSpy.mock.calls[0][0].modeChanged).toBe(false);
+		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBeUndefined();
 	});
 
 	test('makes a tool call turn', async () => {

--- a/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
+++ b/extensions/copilot/src/extension/prompt/node/test/defaultIntentRequestHandler.spec.ts
@@ -204,6 +204,44 @@ suite('defaultIntentRequestHandler', () => {
 		expect(result.metadata?.resolvedModel).toBe('gpt-4o-resolved');
 	});
 
+	test('ignores stateful marker when mode instructions changed on responses api requests', async () => {
+		const request = new TestChatRequest();
+		(request as any).modeInstructions2 = { name: 'Agent', content: 'agent instructions', isBuiltin: true };
+		(endpoint as any).apiType = 'responses';
+		const requestSpy = vi.spyOn(endpoint, 'makeChatRequest2');
+		const previousTurn = new Turn(generateUuid(), { message: 'previous', type: 'user' }, undefined, [], undefined, undefined, false, { name: 'Plan', content: 'plan instructions', isBuiltin: true } as any);
+		const handler = makeHandler({ request, turns: [previousTurn] });
+		chatResponse[0] = 'some response here :)';
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+		};
+
+		await handler.getResult();
+
+		expect(requestSpy).toHaveBeenCalledOnce();
+		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBe(true);
+	});
+
+	test('does not ignore stateful marker when mode instructions are unchanged on responses api requests', async () => {
+		const request = new TestChatRequest();
+		(request as any).modeInstructions2 = { name: 'Agent', content: 'agent instructions', isBuiltin: true };
+		(endpoint as any).apiType = 'responses';
+		const requestSpy = vi.spyOn(endpoint, 'makeChatRequest2');
+		const previousTurn = new Turn(generateUuid(), { message: 'previous', type: 'user' }, undefined, [], undefined, undefined, false, { name: 'Agent', content: 'agent instructions', isBuiltin: true } as any);
+		const handler = makeHandler({ request, turns: [previousTurn] });
+		chatResponse[0] = 'some response here :)';
+		promptResult = {
+			...nullRenderPromptResult(),
+			messages: [{ role: Raw.ChatRole.User, content: [toTextPart('hello world!')] }],
+		};
+
+		await handler.getResult();
+
+		expect(requestSpy).toHaveBeenCalledOnce();
+		expect(requestSpy.mock.calls[0][0].ignoreStatefulMarker).toBe(false);
+	});
+
 	test('makes a tool call turn', async () => {
 		const handler = makeHandler();
 		chatResponse[0] = [{

--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -57,6 +57,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	// undefined if the connection is new or the summary state changed). Never fall
 	// back to the HTTP marker lookup in that case.
 	const ignoreStatefulMarker = !!options.ignoreStatefulMarker || !!options.useWebSocket;
+	const modeChanged = !!options.modeChanged;
 
 	// Tool search: when enabled, split tools into non-deferred (included in the request) and deferred
 	// (excluded from the request entirely). Uses OpenAI's client-executed tool search protocol: we add
@@ -124,7 +125,7 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 
 	const body: IEndpointBody = {
 		model,
-		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, toolsMap),
+		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, toolsMap, modeChanged),
 		stream: true,
 		tools: finalTools.length > 0 ? finalTools : undefined,
 		// Only a subset of completion post options are supported, and some
@@ -290,7 +291,7 @@ function resolveWebSocketStatefulMarker(accessor: ServicesAccessor, options: ICr
 	return wsManager.getStatefulMarker(options.conversationId);
 }
 
-function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined, toolsMap?: Map<string, OpenAiFunctionTool>): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
+function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined, toolsMap?: Map<string, OpenAiFunctionTool>, modeChanged: boolean = false): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
 	const latestCompactionMessageIndex = getLatestCompactionMessageIndex(messages);
 	const latestCompactionMessage = latestCompactionMessageIndex !== undefined ? createCompactionRoundTripMessage(messages[latestCompactionMessageIndex]) : undefined;
 
@@ -310,6 +311,11 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 			previousResponseId = statefulMarkerAndIndex.statefulMarker;
 			markerIndex = statefulMarkerAndIndex.index;
 		}
+	}
+
+	if (modeChanged) {
+		previousResponseId = undefined;
+		markerIndex = undefined;
 	}
 
 	if (markerIndex !== undefined) {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -460,6 +460,159 @@ describe('createResponsesRequestBody', () => {
 		services.dispose();
 	});
 
+	it('does not reuse a websocket stateful marker when modeChanged is true', () => {
+		const services = createPlatformServices();
+		const wsManager = new NullChatWebSocketManager();
+		wsManager.getStatefulMarker = () => 'resp-prev';
+		services.set(IChatWebSocketManager, wsManager);
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'before marker' }],
+			},
+			createStatefulMarkerMessage(testEndpoint.model, 'resp-prev'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'after marker' }],
+			},
+		];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, { ...createRequestOptions(messages, true), conversationId: 'conv-1', modeChanged: true }, testEndpoint.model, testEndpoint));
+
+		expect(body.previous_response_id).toBeUndefined();
+		expect(body.input).toHaveLength(2);
+		expect(body.input?.[0]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'before marker' }],
+		});
+		expect(body.input?.[1]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'after marker' }],
+		});
+
+		accessor.dispose();
+		services.dispose();
+	});
+
+	it('reuses the newly established websocket marker on follow-up requests after switching into plan mode', () => {
+		const services = createPlatformServices();
+		const wsManager = new NullChatWebSocketManager();
+		wsManager.getStatefulMarker = () => 'resp-plan-1';
+		services.set(IChatWebSocketManager, wsManager);
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.5-preview', model: 'gpt-5.5-preview' as const };
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'implementation context before switching modes' }],
+			},
+			createStatefulMarkerMessage(websocketEndpoint.model, 'resp-agent-1'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'switch to plan mode' }],
+			},
+			createStatefulMarkerMessage(websocketEndpoint.model, 'resp-plan-1'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'plan follow up' }],
+			},
+		];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(
+			servicesAccessor,
+			{ ...createRequestOptions(messages, true), conversationId: 'conv-plan-1' },
+			websocketEndpoint.model,
+			websocketEndpoint,
+		));
+
+		expect(body.previous_response_id).toBe('resp-plan-1');
+		expect(body.input).toHaveLength(1);
+		expect(body.input?.[0]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'plan follow up' }],
+		});
+
+		accessor.dispose();
+		services.dispose();
+	});
+
+	it('treats websocket requests from agent to plan and back to implementation as separate mode changes', () => {
+		const services = createPlatformServices();
+		const wsManager = new NullChatWebSocketManager();
+		services.set(IChatWebSocketManager, wsManager);
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.4-preview', model: 'gpt-5.4-preview' as const };
+
+		wsManager.getStatefulMarker = () => 'resp-agent-1';
+		const planMessages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'agent context before switching to plan' }],
+			},
+			createStatefulMarkerMessage(websocketEndpoint.model, 'resp-agent-1'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'plan this change' }],
+			},
+		];
+
+		const planBody = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(
+			servicesAccessor,
+			{ ...createRequestOptions(planMessages, true), conversationId: 'conv-mode-change', modeChanged: true },
+			websocketEndpoint.model,
+			websocketEndpoint,
+		));
+
+		expect(planBody.previous_response_id).toBeUndefined();
+		expect(planBody.input).toHaveLength(2);
+		expect(planBody.input?.[0]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'agent context before switching to plan' }],
+		});
+		expect(planBody.input?.[1]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'plan this change' }],
+		});
+
+		wsManager.getStatefulMarker = () => 'resp-plan-1';
+		const implementationMessages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'plan context before switching back to implementation' }],
+			},
+			createStatefulMarkerMessage(websocketEndpoint.model, 'resp-plan-1'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'start implementation' }],
+			},
+		];
+
+		const implementationBody = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(
+			servicesAccessor,
+			{ ...createRequestOptions(implementationMessages, true), conversationId: 'conv-mode-change', modeChanged: true },
+			websocketEndpoint.model,
+			websocketEndpoint,
+		));
+
+		expect(implementationBody.previous_response_id).toBeUndefined();
+		expect(implementationBody.input).toHaveLength(2);
+		expect(implementationBody.input?.[0]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'plan context before switching back to implementation' }],
+		});
+		expect(implementationBody.input?.[1]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'start implementation' }],
+		});
+
+		accessor.dispose();
+		services.dispose();
+	});
+
 	it('includes the newest compaction item in non-websocket requests when it predates the stateful marker', () => {
 		const services = createPlatformServices();
 		const accessor = services.createTestingAccessor();
@@ -487,6 +640,39 @@ describe('createResponsesRequestBody', () => {
 			encrypted_content: 'enc_http',
 		});
 		expect(body.input).toContainEqual({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'after marker' }],
+		});
+
+		accessor.dispose();
+		services.dispose();
+	});
+
+	it('does not reuse an HTTP stateful marker when modeChanged is true', () => {
+		const services = createPlatformServices();
+		const accessor = services.createTestingAccessor();
+		const instantiationService = accessor.get(IInstantiationService);
+		const messages: Raw.ChatMessage[] = [
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'before marker' }],
+			},
+			createStatefulMarkerMessage(testEndpoint.model, 'resp-prev'),
+			{
+				role: Raw.ChatRole.User,
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'after marker' }],
+			},
+		];
+
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, { ...createRequestOptions(messages, false), modeChanged: true }, testEndpoint.model, testEndpoint));
+
+		expect(body.previous_response_id).toBeUndefined();
+		expect(body.input).toHaveLength(2);
+		expect(body.input?.[0]).toMatchObject({
+			role: 'user',
+			content: [{ type: 'input_text', text: 'before marker' }],
+		});
+		expect(body.input?.[1]).toMatchObject({
 			role: 'user',
 			content: [{ type: 'input_text', text: 'after marker' }],
 		});

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -171,6 +171,7 @@ export interface IMakeChatRequestOptions {
 	messages: Raw.ChatMessage[];
 	/** Enable WebSocket transport for this request when supported. */
 	useWebSocket?: boolean;
+	/** Disable Responses API stateful marker reuse, preventing previous_response_id-based history slicing. */
 	ignoreStatefulMarker?: boolean;
 	/** Streaming callback for each response part. */
 	finishedCb: FinishedCallback | undefined;

--- a/extensions/copilot/src/platform/networking/common/networking.ts
+++ b/extensions/copilot/src/platform/networking/common/networking.ts
@@ -173,6 +173,8 @@ export interface IMakeChatRequestOptions {
 	useWebSocket?: boolean;
 	/** Disable Responses API stateful marker reuse, preventing previous_response_id-based history slicing. */
 	ignoreStatefulMarker?: boolean;
+	/** Indicates whether the request's mode instructions changed from the previous turn. */
+	modeChanged?: boolean;
 	/** Streaming callback for each response part. */
 	finishedCb: FinishedCallback | undefined;
 	/** Location where the chat message is being sent. */


### PR DESCRIPTION
Backport of #312951.

Fixes #312554

## Problem
When a Responses API conversation switches modes (for example, Agent -> Plan), we intentionally treat the next request as a mode change so it does not reuse the previous `previous_response_id` / stateful marker.

That part is correct for the first request after the switch, but websocket follow-up requests after tool calls were still effectively being treated as "mode changed" for too long. In practice, that meant a follow-up request in the same turn could fail to anchor on the newly established plan-mode websocket chain and could be pulled back toward earlier implementation-mode context.

This is especially noticeable with websocket-enabled Responses API models, where the connection carries forward the latest response marker. After the first successful request in the new mode, follow-up requests in the same turn should continue from that new-mode chain rather than continually invalidating it.

Parallel tool calls do not need separate handling here: `modeChanged` is evaluated per follow-up model request, not per individual tool call. A round may contain multiple tool calls, but once that round establishes a fresh stateful marker, later follow-up requests in the same turn should use the new marker.

## Fix
Updated `DefaultIntentRequestHandler.didModeChangeSincePreviousRequest()` so that:

- the first Responses API request after a mode switch still returns `modeChanged = true`
- but once the current turn has produced a fresh Responses API stateful marker, later requests in that same turn return `modeChanged = false`

This keeps the original protection against reusing the old chain across a mode switch, while allowing websocket follow-up requests after tool calls to resume from the newly established mode-specific chain.

In other words:

- Agent -> Plan: first plan request does **not** reuse the old websocket marker
- after that request succeeds and establishes a fresh plan marker, later follow-up requests in the same turn **do** reuse the new plan marker
- Plan -> Agent (start implementation): the first implementation request is again treated as a fresh mode change

## Tests
Added websocket-focused Responses API coverage in `src/platform/endpoint/node/test/responsesApi.spec.ts` for:

- not reusing a websocket stateful marker when `modeChanged` is `true`
- reusing the newly established websocket marker on follow-up requests after switching into Plan mode
- treating Agent -> Plan and Plan -> Agent ("start implementation") websocket requests as separate mode changes

This keeps the regression coverage on the websocket path, which is the relevant path for the affected Responses API models.