### PR TITLE
agents: bump @github/copilot to 1.0.38

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -230,8 +230,24 @@ function getElectron(arch: string): () => NodeJS.ReadWriteStream {
 
 async function main(arch: string = process.arch): Promise<void> {
 	const electronPath = path.join(root, '.build', 'electron');
+	const versionMarker = path.join(electronPath, '.version');
+	const expectedVersion = msBuildId ? `${electronVersion}-${msBuildId}-${arch}` : `${electronVersion}-${arch}`;
+
+	// Skip download if the correct version is already present
+	try {
+		const cachedVersion = fs.readFileSync(versionMarker, 'utf8').trim();
+		if (cachedVersion === expectedVersion) {
+			return;
+		}
+	} catch {
+		// Marker doesn't exist or can't be read, proceed with download
+	}
+
 	await util.rimraf(electronPath)();
 	await util.streamToPromise(getElectron(arch)());
+
+	// Write version marker after successful download
+	fs.writeFileSync(versionMarker, expectedVersion);
 }
 
 if (import.meta.main) {

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -230,24 +230,8 @@ function getElectron(arch: string): () => NodeJS.ReadWriteStream {
 
 async function main(arch: string = process.arch): Promise<void> {
 	const electronPath = path.join(root, '.build', 'electron');
-	const versionMarker = path.join(electronPath, '.version');
-	const expectedVersion = msBuildId ? `${electronVersion}-${msBuildId}-${arch}` : `${electronVersion}-${arch}`;
-
-	// Skip download if the correct version is already present
-	try {
-		const cachedVersion = fs.readFileSync(versionMarker, 'utf8').trim();
-		if (cachedVersion === expectedVersion) {
-			return;
-		}
-	} catch {
-		// Marker doesn't exist or can't be read, proceed with download
-	}
-
 	await util.rimraf(electronPath)();
 	await util.streamToPromise(getElectron(arch)());
-
-	// Write version marker after successful download
-	fs.writeFileSync(versionMarker, expectedVersion);
 }
 
 if (import.meta.main) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.34",
+        "@github/copilot": "^1.0.38",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -1072,26 +1072,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
-      "integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
+      "integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.34",
-        "@github/copilot-darwin-x64": "1.0.34",
-        "@github/copilot-linux-arm64": "1.0.34",
-        "@github/copilot-linux-x64": "1.0.34",
-        "@github/copilot-win32-arm64": "1.0.34",
-        "@github/copilot-win32-x64": "1.0.34"
+        "@github/copilot-darwin-arm64": "1.0.38",
+        "@github/copilot-darwin-x64": "1.0.38",
+        "@github/copilot-linux-arm64": "1.0.38",
+        "@github/copilot-linux-x64": "1.0.38",
+        "@github/copilot-win32-arm64": "1.0.38",
+        "@github/copilot-win32-x64": "1.0.38"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
-      "integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
+      "integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
       "cpu": [
         "arm64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
-      "integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
+      "integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
       "cpu": [
         "x64"
       ],
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
-      "integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
+      "integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
       "cpu": [
         "arm64"
       ],
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
-      "integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
+      "integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
       "cpu": [
         "x64"
       ],
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
-      "integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
+      "integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
       "cpu": [
         "arm64"
       ],
@@ -1192,9 +1192,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
-      "integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
+      "integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.34",
+    "@github/copilot": "^1.0.38",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.34",
+        "@github/copilot": "^1.0.38",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -81,26 +81,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
-      "integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
+      "integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.34",
-        "@github/copilot-darwin-x64": "1.0.34",
-        "@github/copilot-linux-arm64": "1.0.34",
-        "@github/copilot-linux-x64": "1.0.34",
-        "@github/copilot-win32-arm64": "1.0.34",
-        "@github/copilot-win32-x64": "1.0.34"
+        "@github/copilot-darwin-arm64": "1.0.38",
+        "@github/copilot-darwin-x64": "1.0.38",
+        "@github/copilot-linux-arm64": "1.0.38",
+        "@github/copilot-linux-x64": "1.0.38",
+        "@github/copilot-win32-arm64": "1.0.38",
+        "@github/copilot-win32-x64": "1.0.38"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
-      "integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
+      "integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
-      "integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
+      "integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
-      "integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
+      "integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
-      "integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
+      "integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
       "cpu": [
         "x64"
       ],
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
-      "integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
+      "integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
       "cpu": [
         "arm64"
       ],
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
-      "integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
+      "integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.34",
+    "@github/copilot": "^1.0.38",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",


### PR DESCRIPTION
Bumps `@github/copilot` from `^1.0.34` to `^1.0.38` in both the root and `remote/` `package.json` (and regenerates the corresponding lockfiles). This tracks the version already pinned in `extensions/copilot/package.json`, per the standing rule that the agent host's copy of `@github/copilot` should follow the bundled Copilot extension's pin.

`@github/copilot-sdk` is unchanged (`^0.2.2`); the SDK's `peerDependency`-style `"@github/copilot": "^1.0.21"` is satisfied by 1.0.38.

### Verification

- `npm run compile-check-ts-native` clean.
- `npm run compile` clean.
- Real-SDK integration test passes:
  ```
  AGENT_HOST_REAL_SDK=1 ./scripts/test-integration.sh \
    --run src/vs/platform/agentHost/test/node/protocol/toolApprovalRealSdk.integrationTest.ts \
    --grep "listModels returns well-shaped"
  ```
  This is the safety net for SDK-shape drift; it confirms the synthetic `auto` router model still surfaces correctly through the `ICopilotModelInfo` wrapper added in the previous bump.

No source changes required — the only `@github/copilot` reference in `src/` is the runtime CLI entry-point path in `copilotAgent.ts`, which is version-agnostic. All TS imports come from `@github/copilot-sdk`.

(Written by Copilot)