### PR TITLE
agent-host: fix skill names, descriptions, and prompt attachments

### DIFF
--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -435,6 +435,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			supportsDelegation: false,
 			capabilities: {
 				supportsCheckpoints: true,
+				supportsPromptAttachments: true,
 			},
 		}));
 

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostCustomizationHarness.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostCustomizationHarness.ts
@@ -486,16 +486,21 @@ export class RemoteAgentCustomizationItemProvider extends Disposable implements 
 			let uri = child.resource;
 			if (promptType === PromptsType.skill) {
 				const meta = skillMetadata![i];
-				const fallbackName = child.isDirectory ? child.name : stripPromptFileExtensions(child.name);
-				displayName = meta?.name ?? fallbackName;
-				description = meta?.description;
 				// For folder-style skills the canonical resource for the skill
 				// is its `SKILL.md`; downstream code (slash-command resolution,
 				// chat input decorations) calls `parseNew(item.uri)` and would
-				// otherwise try to read the directory as a file.
+				// otherwise try to read the directory as a file. If we couldn't
+				// read `SKILL.md`, skip the entry rather than emit a URI that
+				// will fail to parse downstream.
 				if (child.isDirectory) {
+					if (!meta) {
+						continue;
+					}
 					uri = joinPath(child.resource, SKILL_FILENAME);
 				}
+				const fallbackName = child.isDirectory ? child.name : stripPromptFileExtensions(child.name);
+				displayName = meta?.name ?? fallbackName;
+				description = meta?.description;
 			} else {
 				displayName = stripPromptFileExtensions(child.name);
 			}

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostCustomizationHarness.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostCustomizationHarness.ts
@@ -9,7 +9,9 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { extname } from '../../../../base/common/path.js';
-import { basename } from '../../../../base/common/resources.js';
+import { basename, joinPath } from '../../../../base/common/resources.js';
+import { SKILL_FILENAME } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
+import { PromptFileParser } from '../../../../workbench/contrib/chat/common/promptSyntax/promptFileParser.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -431,7 +433,7 @@ export class RemoteAgentCustomizationItemProvider extends Disposable implements 
 				if (!promptType) {
 					continue;
 				}
-				children.push(...this._collectFromTypeDir(stat.stat.children, promptType, groupKey));
+				children.push(...await this._collectFromTypeDir(stat.stat.children, promptType, groupKey, token));
 			}
 			children.sort((a, b) => `${a.type}:${a.name}`.localeCompare(`${b.type}:${b.name}`));
 		} catch (err) {
@@ -449,27 +451,59 @@ export class RemoteAgentCustomizationItemProvider extends Disposable implements 
 	 * `SKILL.md`, and synced bundles may preserve per-skill
 	 * subdirectories; flat skill files can still appear for legacy
 	 * bundles, so both layouts are accepted.
+	 *
+	 * For skills, the `SKILL.md` frontmatter is read so that the item's
+	 * description (and a frontmatter-supplied name, when present) can be
+	 * surfaced — without it the UI would only show the folder name with
+	 * no description.
 	 */
-	private _collectFromTypeDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], promptType: PromptsType, groupKey: string): ICustomizationItem[] {
-		const items: ICustomizationItem[] = [];
+	private async _collectFromTypeDir(entries: readonly { name: string; resource: URI; isDirectory: boolean }[], promptType: PromptsType, groupKey: string, token: CancellationToken): Promise<ICustomizationItem[]> {
+		type Entry = { name: string; resource: URI; isDirectory: boolean };
+		const eligible: Entry[] = [];
 		for (const child of entries) {
 			// Skip dotfiles (e.g. .DS_Store)
 			if (child.name.startsWith('.')) {
 				continue;
 			}
+			if (promptType !== PromptsType.skill && child.isDirectory) {
+				continue;
+			}
+			eligible.push(child);
+		}
+
+		const skillMetadata = promptType === PromptsType.skill
+			? await Promise.all(eligible.map(child => this._readSkillMetadata(child, token)))
+			: undefined;
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const items: ICustomizationItem[] = [];
+		for (let i = 0; i < eligible.length; i++) {
+			const child = eligible[i];
 			let displayName: string;
+			let description: string | undefined;
+			let uri = child.resource;
 			if (promptType === PromptsType.skill) {
-				displayName = child.isDirectory ? child.name : stripPromptFileExtensions(child.name);
-			} else {
+				const meta = skillMetadata![i];
+				const fallbackName = child.isDirectory ? child.name : stripPromptFileExtensions(child.name);
+				displayName = meta?.name ?? fallbackName;
+				description = meta?.description;
+				// For folder-style skills the canonical resource for the skill
+				// is its `SKILL.md`; downstream code (slash-command resolution,
+				// chat input decorations) calls `parseNew(item.uri)` and would
+				// otherwise try to read the directory as a file.
 				if (child.isDirectory) {
-					continue;
+					uri = joinPath(child.resource, SKILL_FILENAME);
 				}
+			} else {
 				displayName = stripPromptFileExtensions(child.name);
 			}
 			items.push({
-				uri: child.resource,
+				uri,
 				type: promptType,
 				name: displayName,
+				description,
 				storage: PromptsStorage.plugin,
 				groupKey,
 				extensionId: undefined,
@@ -477,6 +511,27 @@ export class RemoteAgentCustomizationItemProvider extends Disposable implements 
 			});
 		}
 		return items;
+	}
+
+	/**
+	 * Reads `SKILL.md` for a skill entry and returns its frontmatter
+	 * `name` / `description`. Returns `undefined` when the file cannot
+	 * be read or parsed — the caller falls back to the folder name and
+	 * leaves the description empty.
+	 */
+	private async _readSkillMetadata(entry: { name: string; resource: URI; isDirectory: boolean }, token: CancellationToken): Promise<{ name: string | undefined; description: string | undefined } | undefined> {
+		const skillFileUri = entry.isDirectory ? joinPath(entry.resource, SKILL_FILENAME) : entry.resource;
+		try {
+			const content = await this._fileService.readFile(skillFileUri);
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+			const parsed = new PromptFileParser().parse(skillFileUri, content.value.toString());
+			return { name: parsed.header?.name, description: parsed.header?.description };
+		} catch (err) {
+			this._logService.trace(`[RemoteAgentCustomizationItemProvider] Failed to read skill metadata ${skillFileUri.toString()}: ${err}`);
+			return undefined;
+		}
 	}
 }
 

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -320,6 +320,13 @@ suite('RemoteAgentHostCustomizationHarness', () => {
 					return { success: false, stat: undefined } as unknown as IFileStatResult;
 				});
 			}
+			override async readFile(resource: URI): Promise<IFileContent> {
+				if (resource.path.endsWith('/my-skill/SKILL.md')) {
+					const content = '---\n---\n';
+					return { resource, name: 'SKILL.md', value: VSBuffer.fromString(content), mtime: 0, ctime: 0, etag: '', size: content.length, readonly: false, locked: false, executable: false };
+				}
+				throw new Error('ENOENT');
+			}
 		};
 
 		const provider = disposables.add(new RemoteAgentCustomizationItemProvider(

--- a/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -12,7 +12,9 @@ import { type IAgentConnection } from '../../../../../platform/agentHost/common/
 import { ActionType, type ActionEnvelope, type INotification, type StateAction } from '../../../../../platform/agentHost/common/state/sessionActions.js';
 import { CustomizationStatus, type AgentInfo, type CustomizationRef, type RootState, type SessionCustomization } from '../../../../../platform/agentHost/common/state/protocol/state.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
-import { IFileService, type IFileStatResult } from '../../../../../platform/files/common/files.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { IFileService, type IFileContent, type IFileStat, type IFileStatResult } from '../../../../../platform/files/common/files.js';
+import { PromptsType } from '../../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -639,5 +641,72 @@ suite('RemoteAgentHostCustomizationHarness', () => {
 		assert.ok(items.find(i => i.name === 'Client B'), 'should have Client B');
 		const keys = items.map(i => i.itemKey);
 		assert.strictEqual(new Set(keys).size, 2, 'all item keys should be unique');
+	});
+
+	test('provider parses skill metadata, rewrites folder URIs to SKILL.md, and skips unreadable folder skills', async () => {
+		const connection = disposables.add(new MockAgentConnection());
+		const controller = disposables.add(new RemoteAgentPluginController(
+			'Test Host',
+			'test-authority',
+			connection,
+			{} as IFileDialogService,
+			createNotificationService(),
+			{} as IAICustomizationWorkspaceService,
+		));
+		const plugin: CustomizationRef = { uri: 'file:///plugins/skills-bundle', displayName: 'Skills Bundle' };
+
+		connection.setRootState({ agents: [createAgentInfo([plugin])] });
+
+		// Build a synthetic plugin that contains a `skills/` directory with:
+		//  - `valid-skill/` folder (SKILL.md parses with name + description)
+		//  - `broken-skill/` folder (SKILL.md read fails — entry should be skipped)
+		//  - `legacy.skill.md` flat file (kept as-is, name from filename)
+		const skillsDirChildren: IFileStat[] = [
+			{ name: 'valid-skill', resource: URI.parse('vscode-agent-host://test/plugins/skills-bundle/skills/valid-skill'), isFile: false, isDirectory: true, isSymbolicLink: false, children: undefined },
+			{ name: 'broken-skill', resource: URI.parse('vscode-agent-host://test/plugins/skills-bundle/skills/broken-skill'), isFile: false, isDirectory: true, isSymbolicLink: false, children: undefined },
+			{ name: 'legacy.skill.md', resource: URI.parse('vscode-agent-host://test/plugins/skills-bundle/skills/legacy.skill.md'), isFile: true, isDirectory: false, isSymbolicLink: false, children: undefined },
+		];
+
+		const fileService = new class extends mock<IFileService>() {
+			override async canHandleResource() { return true; }
+			override async resolveAll(toResolve: { resource: URI }[]): Promise<IFileStatResult[]> {
+				return toResolve.map(({ resource }) => {
+					if (resource.path.endsWith('/skills')) {
+						return {
+							success: true,
+							stat: { name: 'skills', resource, isFile: false, isDirectory: true, isSymbolicLink: false, children: skillsDirChildren },
+						};
+					}
+					return { success: false };
+				});
+			}
+			override async readFile(resource: URI): Promise<IFileContent> {
+				if (resource.path.endsWith('/valid-skill/SKILL.md')) {
+					const content = '---\nname: Pretty Name\ndescription: A friendly skill description\n---\n\n# Body\n';
+					return { resource, name: 'SKILL.md', value: VSBuffer.fromString(content), mtime: 0, ctime: 0, etag: '', size: content.length, readonly: false, locked: false, executable: false };
+				}
+				throw new Error('ENOENT');
+			}
+		};
+
+		const provider = disposables.add(new RemoteAgentCustomizationItemProvider(
+			createAgentInfo([plugin]),
+			connection,
+			'test-authority',
+			controller,
+			fileService,
+			new NullLogService(),
+		));
+
+		const items = await provider.provideChatSessionCustomizations(CancellationToken.None);
+
+		const skillItems = items.filter(i => i.type === PromptsType.skill);
+		assert.deepStrictEqual(
+			skillItems.map(i => ({ name: i.name, description: i.description, uri: i.uri.toString() })).sort((a, b) => a.name.localeCompare(b.name)),
+			[
+				{ name: 'Pretty Name', description: 'A friendly skill description', uri: 'vscode-agent-host://test/plugins/skills-bundle/skills/valid-skill/SKILL.md' },
+				{ name: 'legacy', description: undefined, uri: 'vscode-agent-host://test/plugins/skills-bundle/skills/legacy.skill.md' },
+			].sort((a, b) => a.name.localeCompare(b.name)),
+		);
 	});
 });

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts
@@ -174,6 +174,7 @@ export class AgentHostContribution extends Disposable implements IWorkbenchContr
 			supportsDelegation: !this._isSessionsWindow,
 			capabilities: {
 				supportsCheckpoints: true,
+				supportsPromptAttachments: true,
 			},
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -6,7 +6,8 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
-import { basename, isEqualOrParent } from '../../../../../../base/common/resources.js';
+import { ResourceMap } from '../../../../../../base/common/map.js';
+import { basename, dirname, isEqualOrParent } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { type URI as ProtocolURI } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
 import { type CustomizationRef } from '../../../../../../platform/agentHost/common/state/sessionState.js';
@@ -110,19 +111,42 @@ export class LocalAgentHostCustomizationItemProvider extends Disposable implemen
 	}
 
 	async provideChatSessionCustomizations(token: CancellationToken): Promise<ICustomizationItem[]> {
-		const enumerated = await enumerateLocalCustomizationsForHarness(this._promptsService, this._syncProvider, token);
+		const [enumerated, skills] = await Promise.all([
+			enumerateLocalCustomizationsForHarness(this._promptsService, this._syncProvider, token),
+			this._promptsService.findAgentSkills(token),
+		]);
 		if (token.isCancellationRequested) {
 			return [];
 		}
-		return enumerated.map(file => ({
-			uri: file.uri,
-			type: file.type,
-			name: getFriendlyName(basename(file.uri)),
-			storage: file.storage,
-			enabled: !file.disabled,
-			extensionId: undefined,
-			pluginUri: undefined,
-		}));
+		// Skill files are conventionally named SKILL.md inside a per-skill
+		// folder, so the filename is not a useful display name. Look up the
+		// parsed skill metadata (name + description from frontmatter) and
+		// fall back to the parent folder name when a skill failed to parse.
+		const skillByUri = new ResourceMap<{ name: string; description: string | undefined }>();
+		for (const skill of skills ?? []) {
+			skillByUri.set(skill.uri, { name: skill.name, description: skill.description });
+		}
+		return enumerated.map(file => {
+			let name: string;
+			let description: string | undefined;
+			if (file.type === PromptsType.skill) {
+				const parsed = skillByUri.get(file.uri);
+				name = parsed?.name ?? basename(dirname(file.uri)) ?? basename(file.uri);
+				description = parsed?.description;
+			} else {
+				name = getFriendlyName(basename(file.uri));
+			}
+			return {
+				uri: file.uri,
+				type: file.type,
+				name,
+				description,
+				storage: file.storage,
+				enabled: !file.disabled,
+				extensionId: undefined,
+				pluginUri: undefined,
+			};
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts
@@ -131,7 +131,7 @@ export class LocalAgentHostCustomizationItemProvider extends Disposable implemen
 			let description: string | undefined;
 			if (file.type === PromptsType.skill) {
 				const parsed = skillByUri.get(file.uri);
-				name = parsed?.name ?? basename(dirname(file.uri)) ?? basename(file.uri);
+				name = parsed?.name ?? basename(dirname(file.uri));
 				description = parsed?.description;
 			} else {
 				name = getFriendlyName(basename(file.uri));


### PR DESCRIPTION
## What

Three related fixes to how Agent Host (AH) skill customizations surface in the chat UI, plus a missing capability flag.

### 1. Local AH skill names and descriptions
`LocalAgentHostCustomizationItemProvider` was deriving skill names from the filename, which always yielded `"SKILL"` (since skills live as `<folder>/SKILL.md`). It also exposed no description.

Fix: in parallel with `listPromptFilesForStorage`, fetch `IPromptsService.findAgentSkills(...)`, build a `ResourceMap` keyed by SKILL.md URI, and use the parsed frontmatter `name`/`description` for skill items. Falls back to the parent folder name if metadata can't be found.

### 2. Remote AH skill descriptions
`RemoteAgentHostCustomizationHarness._collectFromTypeDir` previously emitted skill items with only the folder name and no description.

Fix: when the entry is a skill directory, asynchronously read the `SKILL.md` inside it via `IFileService` and parse it with `PromptFileParser` to populate name + description. Failure falls back to the folder name silently.

### 3. Remote AH skill URI pointed at a directory
Decorations were failing for remote skills with:

```
Unable to read file 'vscode-synced-customization:/.../skills/svg-diagram'
(Error: ... that is actually a directory)
```

The remote provider was emitting the skill folder URI as `item.uri`. Downstream `resolvePromptSlashCommand` and `InputEditorDecorations.updateAsyncInputEditorDecorations` call `parseNew(item.uri)`, which is a file read.

Fix: emit `joinPath(folder, SKILL.md)` as the item URI so the parser receives a real file.

### 4. `supportsPromptAttachments`
Both AH chat session contributions (local and remote) now declare `supportsPromptAttachments: true` on their capabilities so prompt attachment UI surfaces correctly.

## Files changed

- `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLocalCustomizations.ts`
- `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution.ts`
- `src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostCustomizationHarness.ts`
- `src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts`

## Notes for reviewers

- Skill metadata extraction is now duplicated between the local provider (uses `findAgentSkills`), the remote provider (uses `PromptFileParser` directly), and `AgenticPromptsService.discoverBuiltinSkills`. A shared helper would be a reasonable follow-up but the data sources differ enough (local index vs. remote AHP filesystem walks) that it wasn't pursued here.
- Decoration-on-reload for AH sessions is a separate, known issue: AH sessions reconstruct user messages from raw AHP state without re-parsing slash commands, so historical requests render without the skill decoration. Not addressed in this PR.

(Written by Copilot)