### PR TITLE
Making sign in button default 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/agentTitleBarStatusWidget.ts
@@ -71,7 +71,6 @@ type AgentStatusClickClassification = {
 
 // Action IDs
 const TOGGLE_CHAT_ACTION_ID = 'workbench.action.chat.toggle';
-const CHAT_SETUP_ACTION_ID = 'workbench.action.chat.triggerSetup';
 const OPEN_CHAT_QUOTA_EXCEEDED_DIALOG = 'workbench.action.chat.openQuotaExceededDialog';
 const QUICK_OPEN_ACTION_ID = 'workbench.action.quickOpenWithModes';
 
@@ -232,7 +231,6 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 				|| e.affectsConfiguration(ChatConfiguration.UnifiedAgentsBar)
 				|| e.affectsConfiguration(ChatConfiguration.ChatViewSessionsEnabled)
 				|| e.affectsConfiguration(ChatConfiguration.AIDisabled)
-				|| e.affectsConfiguration(ChatConfiguration.SignInTitleBarEnabled)
 				|| e.affectsConfiguration('disableAICustomizations')
 				|| e.affectsConfiguration('workbench.disableAICustomizations')
 			) {
@@ -861,21 +859,14 @@ export class AgentTitleBarStatusWidget extends BaseActionViewItem {
 		// Special case 2: User has exceeded quota (needs to upgrade)
 		const chatSentiment = this.chatEntitlementService.sentiment;
 		const chatQuotaExceeded = this.chatEntitlementService.quotas.chat?.percentRemaining === 0;
-		const signedOut = this.chatEntitlementService.entitlement === ChatEntitlement.Unknown;
-		const anonymous = this.chatEntitlementService.anonymous;
 		const free = this.chatEntitlementService.entitlement === ChatEntitlement.Free;
 
 		let primaryActionId = TOGGLE_CHAT_ACTION_ID;
 		let primaryActionTitle = localize('toggleChat', "Toggle Chat");
 		let primaryActionIcon = Codicon.chatSparkle;
 
-		const signInTitleBarEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.SignInTitleBarEnabled);
 		if (chatSentiment.completed && !chatSentiment.disabled) {
-			if (signedOut && !anonymous && !signInTitleBarEnabled) {
-				primaryActionId = CHAT_SETUP_ACTION_ID;
-				primaryActionTitle = localize('signInToChatSetup', "Sign in to use AI features...");
-				primaryActionIcon = Codicon.chatSparkleError;
-			} else if (chatQuotaExceeded && free) {
+			if (chatQuotaExceeded && free) {
 				primaryActionId = OPEN_CHAT_QUOTA_EXCEEDED_DIALOG;
 				primaryActionTitle = localize('chatQuotaExceededButton', "GitHub Copilot Free plan chat messages quota reached. Click for details.");
 				primaryActionIcon = Codicon.chatSparkleWarning;

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1528,15 +1528,6 @@ configurationRegistry.registerConfiguration({
 				mode: 'auto'
 			}
 		},
-		[ChatConfiguration.SignInTitleBarEnabled]: {
-			type: 'boolean',
-			description: nls.localize('chat.signInTitleBar', "Controls whether to show a sign-in button in the title bar for users who are not signed in."),
-			default: false,
-			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
-		},
 		[ChatConfiguration.RestoreLastPanelSession]: {
 			type: 'boolean',
 			description: nls.localize('chat.restoreLastPanelSession', "Controls whether the last session is restored in panel after restart."),

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -383,7 +383,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 						order: 0, // same position as the update button
 						when: ContextKeyExpr.and(
 							IsWebContext.negate(),
-							ContextKeyExpr.has(`config.${ChatConfiguration.SignInTitleBarEnabled}`),
+
 							ChatContextKeys.Entitlement.signedOut,
 							ChatContextKeys.Setup.hidden.negate(),
 							ChatContextKeys.Setup.disabledInWorkspace.negate(),

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -22,7 +22,6 @@ import { disposableWindowInterval } from '../../../../../base/browser/dom.js';
 import { isNewUser } from './chatStatus.js';
 import product from '../../../../../platform/product/common/product.js';
 import { isCompletionsEnabled } from '../../../../../editor/common/services/completionsEnablement.js';
-import { ChatConfiguration } from '../../common/constants.js';
 
 export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribution {
 
@@ -85,7 +84,7 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		this._register(this.editorService.onDidActiveEditorChange(() => this.onDidActiveEditorChange()));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(product.defaultChatAgent?.completionsEnablementSetting) || e.affectsConfiguration(ChatConfiguration.SignInTitleBarEnabled)) {
+			if (e.affectsConfiguration(product.defaultChatAgent?.completionsEnablementSetting)) {
 				this.update();
 			}
 		}));
@@ -113,18 +112,17 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 		if (isNewUser(this.chatEntitlementService)) {
 			const entitlement = this.chatEntitlementService.entitlement;
 
-			// Finish Setup
+			// Sign In
 			if (
 				this.chatEntitlementService.sentiment.later ||	// user skipped setup
 				entitlement === ChatEntitlement.Available ||	// user is entitled
 				isProUser(entitlement) ||						// user is already pro
 				entitlement === ChatEntitlement.Free			// user is already free
 			) {
-				const finishSetup = localize('finishSetup', "Finish Setup");
+				const signIn = localize('signInSetup', "Sign In");
 
-				text = `$(copilot) ${finishSetup}`;
-				ariaLabel = finishSetup;
-				kind = 'prominent';
+				text = `$(copilot) ${signIn}`;
+				ariaLabel = signIn;
 			}
 		} else {
 			const chatQuotaExceeded = this.chatEntitlementService.quotas.chat?.percentRemaining === 0;
@@ -148,17 +146,9 @@ export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribu
 
 			// Signed out
 			else if (this.chatEntitlementService.entitlement === ChatEntitlement.Unknown) {
-				const signInExperiment = this.configurationService.getValue<boolean>(ChatConfiguration.SignInTitleBarEnabled);
-				if (signInExperiment) {
-					const signIn = localize('signIn', "Sign In");
-					text = `$(copilot) ${signIn}`;
-					ariaLabel = signIn;
-				} else {
-					const signedOut = localize('notSignedIn', "Signed out");
-					text = `${this.chatEntitlementService.anonymous ? '$(copilot)' : '$(copilot-not-connected)'} ${signedOut}`;
-					ariaLabel = signedOut;
-					kind = 'prominent';
-				}
+				const signIn = localize('signIn', "Sign In");
+				text = `$(copilot) ${signIn}`;
+				ariaLabel = signIn;
 			}
 
 			// Free Quota Exceeded

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -61,7 +61,6 @@ export enum ChatConfiguration {
 	ExplainChangesEnabled = 'chat.editing.explainChanges.enabled',
 	RevealNextChangeOnResolve = 'chat.editing.revealNextChangeOnResolve',
 	GrowthNotificationEnabled = 'chat.growthNotification.enabled',
-	SignInTitleBarEnabled = 'chat.signInTitleBar.enabled',
 
 	ChatCustomizationHarnessSelectorEnabled = 'chat.customizations.harnessSelector.enabled',
 	AutopilotEnabled = 'chat.autopilot.enabled',


### PR DESCRIPTION
Key changes:

**Removal of "Sign In" Title Bar Feature:**
* Deleted the `SignInTitleBarEnabled` configuration and all related code, including its registration in the configuration schema and references throughout the chat UI logic. [[1]](diffhunk://#diff-63ebcc188cf5338e8b62aedeef03d66cb436e5a171d924d55de83edc65bb8568L1531-L1539) [[2]](diffhunk://#diff-f92851ad97eb17f27d267f36b103e8d831725fea8f46a2ae9252e80a4d2a8187L64) [[3]](diffhunk://#diff-c2c0ef7e303cb779c2d5fd8d0c80f712e59b5a8eccb1cea0cd8085ddc3cd87d4L235) [[4]](diffhunk://#diff-c2c0ef7e303cb779c2d5fd8d0c80f712e59b5a8eccb1cea0cd8085ddc3cd87d4L864-R869) [[5]](diffhunk://#diff-503b5a275763be885d53bfacc4e798e25a755849990ceb09c599dad5a8c9558cL386-R386) [[6]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5L88-R87)

**Chat Status Bar and UI Updates:**
* Updated the chat status bar to always show a "Sign In" prompt when the user is signed out, regardless of configuration, and replaced the "Finish Setup" text with "Sign In" for clarity. [[1]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5L116-R125) [[2]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5L151-L161)

**Code Cleanup:**
* Removed unused imports and constants related to the deleted feature, such as `ChatConfiguration.SignInTitleBarEnabled` and `CHAT_SETUP_ACTION_ID`. [[1]](diffhunk://#diff-85a2c8a3b2aa02a2e8a7c5841692f46f5a72a603f89e76a494c6c5eb2cc7eec5L25) [[2]](diffhunk://#diff-c2c0ef7e303cb779c2d5fd8d0c80f712e59b5a8eccb1cea0cd8085ddc3cd87d4L74)

These changes streamline the chat sign-in experience and remove unnecessary experimental toggles from the codebase.<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
