### PR TITLE
Fix generic local Agent Host skill labels

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts
@@ -12,7 +12,7 @@ import { localize } from '../../../../nls.js';
 import type { IAgentToolCompleteEvent, IAgentToolReadyEvent, IAgentToolStartEvent } from '../../common/agentService.js';
 import { stripRedundantCdPrefix } from '../../common/commandLineHelpers.js';
 import { StringOrMarkdown } from '../../common/state/protocol/state.js';
-import { basename } from '../../../../base/common/resources.js';
+import { basename, dirname } from '../../../../base/common/resources.js';
 
 // =============================================================================
 // Copilot CLI built-in tool interfaces
@@ -441,6 +441,27 @@ export function getSkillSyntheticToolCallId(eventId: string | undefined, data: I
 	return `synth-skill-${hash(seed).toString(16)}`;
 }
 
+function getSkillDisplayName(data: ICopilotSkillInvokedData): string {
+	if (!isGenericSkillName(data.name) || !data.path) {
+		return data.name;
+	}
+
+	const skillUri = URI.file(data.path);
+	if (!isSkillFileName(basename(skillUri))) {
+		return data.name;
+	}
+
+	return basename(dirname(skillUri)) || data.name;
+}
+
+function isGenericSkillName(name: string): boolean {
+	return isSkillFileName(name) || name.toLowerCase() === 'skill';
+}
+
+function isSkillFileName(name: string): boolean {
+	return name.toLowerCase() === 'skill.md';
+}
+
 /**
  * Synthesizes the `tool_start` and `tool_complete` agent progress events that
  * represent a successful `skill.invoked` lifecycle event. Used by both the
@@ -454,6 +475,7 @@ export function synthesizeSkillToolEvents(
 ): { start: IAgentToolStartEvent; complete: IAgentToolCompleteEvent } {
 	const toolCallId = getSkillSyntheticToolCallId(eventId, data);
 	const displayName = localize('toolName.skill', "Read Skill");
+	const skillName = getSkillDisplayName(data);
 	// Use the skill name as the link text rather than the basename: every skill
 	// file is named SKILL.md, so `Reading skill [plan]` reads better than the
 	// always-identical `Reading skill [SKILL.md]`. The client may further upgrade
@@ -464,14 +486,14 @@ export function synthesizeSkillToolEvents(
 	// syntax (`\` and `]`); a full markdown escape would leave visible
 	// backslashes in renderers (like the skill pill) that extract link text
 	// without re-parsing markdown.
-	const escapedName = escapeMarkdownLinkLabel(data.name);
+	const escapedName = escapeMarkdownLinkLabel(skillName);
 	const skillLink = data.path ? `[${escapedName}](${URI.file(data.path)})` : undefined;
 	const invocationMessage: StringOrMarkdown = skillLink
 		? md(localize('toolInvoke.skill', "Reading skill {0}", skillLink))
-		: localize('toolInvoke.skillName', "Reading skill {0}", data.name);
+		: localize('toolInvoke.skillName', "Reading skill {0}", skillName);
 	const pastTenseMessage: StringOrMarkdown = skillLink
 		? md(localize('toolComplete.skill', "Read skill {0}", skillLink))
-		: localize('toolComplete.skillName', "Read skill {0}", data.name);
+		: localize('toolComplete.skillName', "Read skill {0}", skillName);
 	const start: IAgentToolStartEvent = {
 		session,
 		type: 'tool_start',

--- a/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts
@@ -311,6 +311,11 @@ suite('skill events', () => {
 			{ name: 'plan' },
 			undefined,
 		);
+		const genericName = synthesizeSkillToolEvents(
+			session,
+			{ name: 'SKILL', path: '/abs/repo/skills/review/SKILL.md' },
+			'evt-456',
+		);
 
 		assert.deepStrictEqual({
 			skillIsHidden: isHiddenTool('skill'),
@@ -324,6 +329,8 @@ suite('skill events', () => {
 			noPathToolCallId: noPath.start.toolCallId,
 			noPathInvocation: noPath.start.invocationMessage,
 			noPathPastTense: noPath.complete.result.pastTenseMessage,
+			genericNameInvocation: genericName.start.invocationMessage,
+			genericNamePastTense: genericName.complete.result.pastTenseMessage,
 		}, {
 			skillIsHidden: true,
 			withPathToolCallId: 'synth-skill-evt-123',
@@ -336,6 +343,8 @@ suite('skill events', () => {
 			noPathToolCallId: 'synth-skill-2108d652',
 			noPathInvocation: 'Reading skill plan',
 			noPathPastTense: 'Read skill plan',
+			genericNameInvocation: { markdown: 'Reading skill [review](file:///abs/repo/skills/review/SKILL.md)' },
+			genericNamePastTense: { markdown: 'Read skill [review](file:///abs/repo/skills/review/SKILL.md)' },
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
+++ b/src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts
@@ -271,7 +271,7 @@ suite('mapSessionEvents', () => {
 				{
 					type: 'skill.invoked',
 					id: 'evt-42',
-					data: { name: 'plan', path: '/abs/repo/skills/plan/SKILL.md' },
+					data: { name: 'SKILL', path: '/abs/repo/skills/plan/SKILL.md' },
 				},
 				{
 					type: 'user.message',


### PR DESCRIPTION
Local Agent Host skill invocation events can report a generic name such as `SKILL` while also including the resolved path to the loaded `.../<skill-name>/SKILL.md` file. Because every skill entrypoint uses the same filename, rendering the reported name directly makes every local skill appear as `SKILL` in chat progress.

Normalize that display name at the skill event synthesis boundary. If the reported name is `SKILL` or `SKILL.md` and the resolved path points to a `SKILL.md` file, derive the rendered label from the parent skill folder. Events that already provide a meaningful skill name continue to use it unchanged.

Add regression coverage for both live skill event synthesis and history replay mapping so a payload like `{ name: 'SKILL', path: '/repo/skills/plan/SKILL.md' }` renders as `plan` instead of `SKILL`.

Fixes #313069

Tests:

- ./scripts/test.sh --run src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts --run src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts --grep "skill events"

- node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/node/copilot/copilotToolDisplay.ts src/vs/platform/agentHost/test/node/copilotToolDisplay.test.ts src/vs/platform/agentHost/test/node/mapSessionEvents.test.ts

- npm run valid-layers-check

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
