### PR TITLE
fix: resolve backend session after tunnel reconnection

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -489,25 +489,36 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	async provideChatSessionContent(sessionResource: URI, _token: CancellationToken): Promise<IChatSession> {
 
-		// For untitled (new) sessions, defer backend session creation until the
-		// first request arrives so the user-selected model is available.
-		// For existing sessions we resolve immediately to load history.
-		let resolvedSession: URI | undefined;
-		const isUntitled = sessionResource.path.substring(1).startsWith('untitled-');
+		// Try to resolve the backend session from the resource. For new
+		// (untitled) sessions the cache will be empty and the chat model
+		// will not yet exist, so this returns undefined — backend creation
+		// is deferred until the first request so the user-selected model
+		// is available. For existing sessions we resolve immediately to
+		// load history.
+		let resolvedSession = this._sessionToBackend.get(sessionResource);
+		if (!resolvedSession) {
+			// Attempt to resolve the backend URI and subscribe. If the
+			// subscription hydrates successfully the session exists on
+			// the server; otherwise it's a new session.
+			const candidate = this._resolveSessionUri(sessionResource);
+			const sub = this._ensureSessionSubscription(candidate.toString());
+			if (!this._getSessionState(candidate.toString())) {
+				await new Promise<void>(resolve => {
+					const d = sub.onDidChange(() => { d.dispose(); resolve(); });
+				});
+			}
+			if (this._getSessionState(candidate.toString())) {
+				resolvedSession = candidate;
+				this._sessionToBackend.set(sessionResource, resolvedSession);
+			} else {
+				this._releaseSessionSubscription(candidate.toString());
+			}
+		}
 		const history: IChatSessionHistoryItem[] = [];
 		let initialProgress: IChatProgress[] | undefined;
 		let activeTurnId: string | undefined;
-		if (!isUntitled) {
-			resolvedSession = this._resolveSessionUri(sessionResource);
-			this._sessionToBackend.set(sessionResource, resolvedSession);
+		if (resolvedSession) {
 			try {
-				const sub = this._ensureSessionSubscription(resolvedSession.toString());
-				// Wait for the subscription to hydrate from the server
-				if (!this._getSessionState(resolvedSession.toString())) {
-					await new Promise<void>(resolve => {
-						const d = sub.onDidChange(() => { d.dispose(); resolve(); });
-					});
-				}
 				const sessionState = this._getSessionState(resolvedSession.toString());
 				if (sessionState) {
 					const modelId = this._toLanguageModelId(sessionResource, sessionState.summary.model?.id);
@@ -669,7 +680,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._logService.info(`[AgentHost] _invokeAgent called for resource: ${request.sessionResource.toString()}`);
 
 		// Resolve or create backend session
-		let resolvedSession = this._sessionToBackend.get(request.sessionResource);
+		let resolvedSession = this._resolveBackendSession(request.sessionResource);
 		if (!resolvedSession) {
 			resolvedSession = await this._createAndSubscribe(request.sessionResource, this._createModelSelection(request.userSelectedModelId, request.modelConfiguration), undefined, request.agentHostSessionConfig, getAgentHostBranchNameHint(request.message));
 			this._sessionToBackend.set(request.sessionResource, resolvedSession);
@@ -2300,6 +2311,35 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private _resolveSessionUri(sessionResource: URI): URI {
 		const rawId = sessionResource.path.substring(1);
 		return AgentSession.uri(this._config.provider, rawId);
+	}
+
+	/**
+	 * Resolves the backend session URI for the given UI session resource.
+	 *
+	 * 1. Returns the cached mapping from {@link _sessionToBackend} if present.
+	 * 2. If the chat model already has completed requests, the session was
+	 *    previously committed and its resource encodes the real backend
+	 *    session ID — re-derives and re-subscribes. This handles the case
+	 *    where the mapping was lost (e.g. handler recreated after tunnel
+	 *    reconnection).
+	 * 3. Returns `undefined` for new sessions with no cached mapping
+	 *    (the caller is expected to create a new backend session).
+	 */
+	private _resolveBackendSession(sessionResource: URI): URI | undefined {
+		const cached = this._sessionToBackend.get(sessionResource);
+		if (cached) {
+			return cached;
+		}
+
+		const chatModel = this._chatService.getSession(sessionResource);
+		if (chatModel && chatModel.getRequests().length > 0) {
+			const resolved = this._resolveSessionUri(sessionResource);
+			this._sessionToBackend.set(sessionResource, resolved);
+			this._ensureSessionSubscription(resolved.toString());
+			return resolved;
+		}
+
+		return undefined;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -385,6 +385,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 */
 	private readonly _clientToolCalls = new Map<string, IClientToolCallEntry>();
 
+	private _knownBackendSessionsProbe?: { promise: Promise<ResourceSet>; expiresAt: number };
+
+
 	constructor(
 		config: IAgentHostSessionHandlerConfig,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
@@ -2325,14 +2328,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._ensureSessionSubscription(candidate.toString());
 		return candidate;
 	}
-
-	/**
-	 * In-flight / freshly-completed `listSessions()` probe. Briefly cached so
-	 * a burst of resolutions (e.g. multiple chat tabs reconnecting at the
-	 * same time) shares a single backend round-trip without permanently
-	 * masking new server-side sessions.
-	 */
-	private _knownBackendSessionsProbe?: { promise: Promise<ResourceSet>; expiresAt: number };
 
 	/**
 	 * Returns the set of backend session URIs that the server reports it

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -10,7 +10,7 @@ import { BugIndicatingError, isCancellationError } from '../../../../../../base/
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableResourceMap, DisposableStore, IReference, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
-import { ResourceMap } from '../../../../../../base/common/map.js';
+import { ResourceMap, ResourceSet } from '../../../../../../base/common/map.js';
 import { autorun, derived, IObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
 import { extUriBiasedIgnorePathCase, isEqual } from '../../../../../../base/common/resources.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -490,30 +490,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	async provideChatSessionContent(sessionResource: URI, _token: CancellationToken): Promise<IChatSession> {
 
 		// Try to resolve the backend session from the resource. For new
-		// (untitled) sessions the cache will be empty and the chat model
-		// will not yet exist, so this returns undefined — backend creation
-		// is deferred until the first request so the user-selected model
-		// is available. For existing sessions we resolve immediately to
-		// load history.
-		let resolvedSession = this._sessionToBackend.get(sessionResource);
-		if (!resolvedSession) {
-			// Attempt to resolve the backend URI and subscribe. If the
-			// subscription hydrates successfully the session exists on
-			// the server; otherwise it's a new session.
-			const candidate = this._resolveSessionUri(sessionResource);
-			const sub = this._ensureSessionSubscription(candidate.toString());
-			if (!this._getSessionState(candidate.toString())) {
-				await new Promise<void>(resolve => {
-					const d = sub.onDidChange(() => { d.dispose(); resolve(); });
-				});
-			}
-			if (this._getSessionState(candidate.toString())) {
-				resolvedSession = candidate;
-				this._sessionToBackend.set(sessionResource, resolvedSession);
-			} else {
-				this._releaseSessionSubscription(candidate.toString());
-			}
-		}
+		// (draft) sessions the backend has no record of the URI yet — backend
+		// creation is deferred until the first request so the user-selected
+		// model is available. For existing (committed) sessions we resolve
+		// immediately to load history.
+		let resolvedSession = await this._resolveBackendSession(sessionResource);
 		const history: IChatSessionHistoryItem[] = [];
 		let initialProgress: IChatProgress[] | undefined;
 		let activeTurnId: string | undefined;
@@ -680,7 +661,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._logService.info(`[AgentHost] _invokeAgent called for resource: ${request.sessionResource.toString()}`);
 
 		// Resolve or create backend session
-		let resolvedSession = this._resolveBackendSession(request.sessionResource);
+		let resolvedSession = await this._resolveBackendSession(request.sessionResource);
 		if (!resolvedSession) {
 			resolvedSession = await this._createAndSubscribe(request.sessionResource, this._createModelSelection(request.userSelectedModelId, request.modelConfiguration), undefined, request.agentHostSessionConfig, getAgentHostBranchNameHint(request.message));
 			this._sessionToBackend.set(request.sessionResource, resolvedSession);
@@ -2317,29 +2298,64 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * Resolves the backend session URI for the given UI session resource.
 	 *
 	 * 1. Returns the cached mapping from {@link _sessionToBackend} if present.
-	 * 2. If the chat model already has completed requests, the session was
-	 *    previously committed and its resource encodes the real backend
-	 *    session ID — re-derives and re-subscribes. This handles the case
-	 *    where the mapping was lost (e.g. handler recreated after tunnel
-	 *    reconnection).
-	 * 3. Returns `undefined` for new sessions with no cached mapping
-	 *    (the caller is expected to create a new backend session).
+	 * 2. Otherwise asks the backend (via {@link _probeKnownBackendSessions})
+	 *    whether a session matching this resource exists. If it does, the
+	 *    session was previously committed and we re-bind to it — this
+	 *    handles the case where the mapping was lost (e.g. handler
+	 *    recreated after tunnel reconnection). If not, returns `undefined`
+	 *    so the caller creates a new backend session.
+	 *
+	 * The backend is the only authoritative source for session existence,
+	 * so we never inspect the URI shape (e.g. `untitled-` prefixes) to make
+	 * this decision.
 	 */
-	private _resolveBackendSession(sessionResource: URI): URI | undefined {
+	private async _resolveBackendSession(sessionResource: URI): Promise<URI | undefined> {
 		const cached = this._sessionToBackend.get(sessionResource);
 		if (cached) {
 			return cached;
 		}
 
-		const chatModel = this._chatService.getSession(sessionResource);
-		if (chatModel && chatModel.getRequests().length > 0) {
-			const resolved = this._resolveSessionUri(sessionResource);
-			this._sessionToBackend.set(sessionResource, resolved);
-			this._ensureSessionSubscription(resolved.toString());
-			return resolved;
+		const candidate = this._resolveSessionUri(sessionResource);
+		const known = await this._probeKnownBackendSessions();
+		if (!known.has(candidate)) {
+			return undefined;
 		}
 
-		return undefined;
+		this._sessionToBackend.set(sessionResource, candidate);
+		this._ensureSessionSubscription(candidate.toString());
+		return candidate;
+	}
+
+	/**
+	 * In-flight / freshly-completed `listSessions()` probe. Briefly cached so
+	 * a burst of resolutions (e.g. multiple chat tabs reconnecting at the
+	 * same time) shares a single backend round-trip without permanently
+	 * masking new server-side sessions.
+	 */
+	private _knownBackendSessionsProbe?: { promise: Promise<ResourceSet>; expiresAt: number };
+
+	/**
+	 * Returns the set of backend session URIs that the server reports it
+	 * knows about. Failures degrade to an empty set so resolution falls
+	 * back to creating a new session rather than throwing into the chat
+	 * pipeline.
+	 */
+	private _probeKnownBackendSessions(): Promise<ResourceSet> {
+		const now = Date.now();
+		if (this._knownBackendSessionsProbe && this._knownBackendSessionsProbe.expiresAt > now) {
+			return this._knownBackendSessionsProbe.promise;
+		}
+		const promise = (async () => {
+			try {
+				const list = await this._config.connection.listSessions();
+				return new ResourceSet(list.map(s => s.session));
+			} catch (err) {
+				this._logService.warn(`[AgentHost] listSessions probe failed: ${err}`);
+				return new ResourceSet();
+			}
+		})();
+		this._knownBackendSessionsProbe = { promise, expiresAt: now + 2000 };
+		return promise;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -97,7 +97,22 @@ class MockAgentHostService extends mock<IAgentHostService>() {
 	public nextResolvedWorkingDirectory?: URI;
 
 	override async listSessions(): Promise<IAgentSessionMetadata[]> {
-		return [...this._sessions.values()];
+		// Merge sessions registered via `addSession`/`createSession` with
+		// sessions whose state was directly seeded via `sessionStates.set`,
+		// since on a real backend any session reachable through `subscribe`
+		// is also visible via `listSessions`.
+		const merged = new Map<string, IAgentSessionMetadata>();
+		for (const [id, meta] of this._sessions) {
+			merged.set(id, meta);
+		}
+		for (const resourceStr of this.sessionStates.keys()) {
+			const session = URI.parse(resourceStr);
+			const id = AgentSession.id(session);
+			if (!merged.has(id)) {
+				merged.set(id, { session, startTime: Date.now(), modifiedTime: Date.now() });
+			}
+		}
+		return [...merged.values()];
 	}
 
 	override async createSession(config?: IAgentCreateSessionConfig): Promise<URI> {
@@ -847,6 +862,15 @@ suite('AgentHostChatContribution', () => {
 		test('uses sessionId from agent-host scheme resource', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
+			// Seed the backend with the session so the listSessions probe
+			// finds it and the handler re-binds instead of creating a new
+			// SDK session.
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'existing-session-42'),
+				startTime: 1000,
+				modifiedTime: 2000,
+			});
+
 			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, chatAgentService, disposables, {
 				message: 'Hi',
 				sessionResource: URI.from({ scheme: 'agent-host-copilot', path: '/existing-session-42' }),
@@ -869,6 +893,74 @@ suite('AgentHostChatContribution', () => {
 
 			// Should create a new SDK session, not use "untitled-abc123" literally
 			assert.ok(AgentSession.id(URI.parse(session)).startsWith('sdk-session-'));
+		}));
+
+		test('recovers backend session for committed resource after handler recreation (tunnel reconnect)', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			// Simulates the tunnel-reconnect scenario: the handler is disposed
+			// and recreated, so its `_sessionToBackend` cache is empty. The
+			// existing chat tab still points at a URI whose id matches a
+			// session the backend already has. The handler should probe
+			// `listSessions` and re-bind to that backend session instead of
+			// creating a new one.
+			const { agentHostService, chatAgentService } = createTestServices(disposables);
+
+			// The backend remembers the session across the tunnel drop.
+			agentHostService.addSession({
+				session: AgentSession.uri('copilot', 'sdk-session-existing'),
+				startTime: 1000,
+				modifiedTime: 2000,
+				summary: 'recovered',
+			});
+			const committedResource = URI.from({ scheme: 'agent-host-copilot', path: '/sdk-session-existing' });
+
+			// Skip provideChatSessionContent and invoke the agent directly,
+			// mirroring what happens when ChatService dispatches a request
+			// into an already-open chat after the handler was recreated.
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+			const turnPromise = registered.impl.invoke(
+				makeRequest({ message: 'Hello again', sessionResource: committedResource }),
+				() => { }, [], CancellationToken.None,
+			);
+			await timeout(10);
+
+			const dispatch = agentHostService.dispatchedActions.find(d => d.action.type === 'session/turnStarted');
+			assert.ok(dispatch, 'turnStarted should be dispatched');
+			const action = dispatch.action as ITurnStartedAction;
+			agentHostService.fireAction({ action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+			agentHostService.fireAction({ action: { type: 'session/turnComplete', session: action.session, turnId: action.turnId } as SessionAction, serverSeq: 2, origin: undefined });
+			await turnPromise;
+
+			// The backend session is recovered via the listSessions probe;
+			// no fresh SDK session is created.
+			assert.strictEqual(agentHostService.createSessionCalls.length, 0);
+			assert.strictEqual(AgentSession.id(URI.parse(action.session)), 'sdk-session-existing');
+		}));
+
+		test('does not recover backend session when listSessions probe finds no match', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			// If the URI's derived id is not among the backend's known
+			// sessions, resolution must fall through to creating a fresh
+			// session. This covers both brand-new chats and stale URIs whose
+			// backend session has been deleted server-side.
+			const { agentHostService, chatAgentService } = createTestServices(disposables);
+
+			const unknownResource = URI.from({ scheme: 'agent-host-copilot', path: '/sdk-session-not-on-backend' });
+			const registered = chatAgentService.registeredAgents.get('agent-host-copilot')!;
+			const turnPromise = registered.impl.invoke(
+				makeRequest({ message: 'Hi', sessionResource: unknownResource }),
+				() => { }, [], CancellationToken.None,
+			);
+			await timeout(10);
+
+			const dispatch = agentHostService.dispatchedActions.find(d => d.action.type === 'session/turnStarted');
+			assert.ok(dispatch, 'turnStarted should be dispatched');
+			const action = dispatch.action as ITurnStartedAction;
+			agentHostService.fireAction({ action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+			agentHostService.fireAction({ action: { type: 'session/turnComplete', session: action.session, turnId: action.turnId } as SessionAction, serverSeq: 2, origin: undefined });
+			await turnPromise;
+
+			// A fresh SDK session must be created.
+			assert.strictEqual(agentHostService.createSessionCalls.length, 1);
+			assert.ok(AgentSession.id(URI.parse(action.session)).startsWith('sdk-session-'));
 		}));
 		test('passes raw model id extracted from language model identifier', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);


### PR DESCRIPTION
1. User opens a chat in vscode.dev/agents, has a back-and-forth with the agent — backend session sdk-session-XYZ exists on the host
2. Laptop sleeps. The websocket tunnel drops. On the renderer, the AgentHostSessionHandler is disposed and a fresh one is created when the tunnel comes back.
3. The fresh one starts with an empty _sessionToBackend map.
4. User comes back, types a message in the same chat tab.
5. _invokeAgent runs. It needs to answer: "is this URI tied to a session the backend already has, or is it a fresh chat?"
