### PR TITLE
terminalChat: fix OutputMonitor dispose race that stalls run_in_terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -102,7 +102,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private _command = '';
 	private _invocationContext: IToolInvocationContext | undefined;
 	private _currentMonitoringCts: CancellationTokenSource | undefined;
-
 	/**
 	 * Tracks whether onDidFinishCommand has fired so the event is delivered at
 	 * most once. The event must fire synchronously during dispose so consumers
@@ -117,6 +116,30 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		}
 		this._didFinish = true;
 		this._onDidFinishCommand.fire();
+	}
+
+	override dispose(): void {
+		// Deliver onDidFinishCommand to consumers BEFORE super.dispose() tears
+		// down the emitter. Field-initialized disposables (including
+		// _onDidFinishCommand) are registered before any disposable added in
+		// the constructor body and are disposed first by DisposableStore in
+		// insertion order. Without this override, consumers awaiting
+		// `Event.toPromise(onDidFinishCommand)` would race with emitter
+		// teardown and hang when dispose lands while _startMonitoring is still
+		// in flight.
+		if (!this._didFinish) {
+			// Synthesize a Cancelled pollingResult so consumers that read
+			// `monitor.pollingResult` after awaiting onDidFinishCommand always
+			// see a defined value with the output collected so far.
+			this._pollingResult ??= {
+				state: OutputMonitorState.Cancelled,
+				output: this._execution.getOutput(),
+				pollDurationMs: 0,
+				resources: undefined,
+			};
+		}
+		this._fireFinishedOnce();
+		super.dispose();
 	}
 
 	constructor(
@@ -139,33 +162,11 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		// the async monitoring loop's token becomes isCancellationRequested=true and
 		// the loop exits promptly — CancellationTokenSource.dispose() alone does
 		// not set isCancellationRequested.
-		//
-		// Crucially, also fire onDidFinishCommand synchronously here so that
-		// consumers awaiting `Event.toPromise(monitor.onDidFinishCommand)` are
-		// released before super.dispose() tears down the emitter. Without this,
-		// if dispose races the async _startMonitoring, the finally block fires
-		// the event after the emitter is dead and the awaiting promise never
-		// resolves — the agent appears to hang on the run_in_terminal call.
 		const cts = new CancellationTokenSource(token);
 		this._currentMonitoringCts = cts;
 		this._register(toDisposable(() => {
 			this._currentMonitoringCts?.cancel();
 			this._currentMonitoringCts?.dispose();
-			// If the async monitoring loop has not reached its finally block yet,
-			// surface a synthetic Cancelled pollingResult so consumers that read
-			// `monitor.pollingResult` after awaiting onDidFinishCommand always see
-			// a defined value with the output collected so far. Also clear the
-			// idle input listener so we don't leak the FunctionDisposable.
-			if (!this._didFinish) {
-				this._pollingResult ??= {
-					state: OutputMonitorState.Cancelled,
-					output: this._execution.getOutput(),
-					pollDurationMs: 0,
-					resources: undefined,
-				};
-				this._userInputListener.clear();
-			}
-			this._fireFinishedOnce();
 		}));
 
 		// Start async to ensure listeners are set up.

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -103,6 +103,22 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private _invocationContext: IToolInvocationContext | undefined;
 	private _currentMonitoringCts: CancellationTokenSource | undefined;
 
+	/**
+	 * Tracks whether onDidFinishCommand has fired so the event is delivered at
+	 * most once. The event must fire synchronously during dispose so consumers
+	 * awaiting `Event.toPromise(onDidFinishCommand)` are unblocked before the
+	 * underlying emitter is torn down by super.dispose().
+	 */
+	private _didFinish = false;
+
+	private _fireFinishedOnce(): void {
+		if (this._didFinish) {
+			return;
+		}
+		this._didFinish = true;
+		this._onDidFinishCommand.fire();
+	}
+
 	constructor(
 		private readonly _execution: IExecution,
 		private readonly _pollFn: ((execution: IExecution, token: CancellationToken, taskService: ITaskService) => Promise<IPollingResult | undefined>) | undefined,
@@ -123,11 +139,33 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		// the async monitoring loop's token becomes isCancellationRequested=true and
 		// the loop exits promptly — CancellationTokenSource.dispose() alone does
 		// not set isCancellationRequested.
+		//
+		// Crucially, also fire onDidFinishCommand synchronously here so that
+		// consumers awaiting `Event.toPromise(monitor.onDidFinishCommand)` are
+		// released before super.dispose() tears down the emitter. Without this,
+		// if dispose races the async _startMonitoring, the finally block fires
+		// the event after the emitter is dead and the awaiting promise never
+		// resolves — the agent appears to hang on the run_in_terminal call.
 		const cts = new CancellationTokenSource(token);
 		this._currentMonitoringCts = cts;
 		this._register(toDisposable(() => {
 			this._currentMonitoringCts?.cancel();
 			this._currentMonitoringCts?.dispose();
+			// If the async monitoring loop has not reached its finally block yet,
+			// surface a synthetic Cancelled pollingResult so consumers that read
+			// `monitor.pollingResult` after awaiting onDidFinishCommand always see
+			// a defined value with the output collected so far. Also clear the
+			// idle input listener so we don't leak the FunctionDisposable.
+			if (!this._didFinish) {
+				this._pollingResult ??= {
+					state: OutputMonitorState.Cancelled,
+					output: this._execution.getOutput(),
+					pollDurationMs: 0,
+					resources: undefined,
+				};
+				this._userInputListener.clear();
+			}
+			this._fireFinishedOnce();
 		}));
 
 		// Start async to ensure listeners are set up.
@@ -231,7 +269,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			};
 			// Clean up idle input listener if still active
 			this._userInputListener.clear();
-			this._onDidFinishCommand.fire();
+			// Fire at most once. If dispose() already fired the event synchronously
+			// (e.g. the monitor was torn down before this async loop reached its
+			// finally), skip firing on a potentially disposed emitter.
+			this._fireFinishedOnce();
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -500,6 +500,28 @@ suite('OutputMonitor', () => {
 				monitor.dispose();
 			});
 		});
+
+		test('disposing while monitoring is in-flight still resolves onDidFinishCommand', async () => {
+			// Regression: if dispose() races the async _startMonitoring loop, the loop's
+			// finally block fires onDidFinishCommand AFTER super.dispose() has already
+			// torn down the emitter. Consumers awaiting Event.toPromise(onDidFinishCommand)
+			// would never resolve and the agent would hang on the run_in_terminal call.
+			//
+			// Fix: dispose() must fire onDidFinishCommand synchronously, before the
+			// emitter is disposed. It must also surface a Cancelled pollingResult so
+			// consumers that read monitor.pollingResult after awaiting the event see a
+			// defined value rather than undefined.
+			return runWithFakedTimers({}, async () => {
+				monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+				const finished = Event.toPromise(monitor.onDidFinishCommand);
+				// Dispose immediately, before the deferred _startMonitoring even starts.
+				monitor.dispose();
+				// Must resolve — would hang prior to the synchronous-fire-on-dispose fix.
+				await finished;
+				assert.ok(monitor.pollingResult, 'pollingResult should be defined after dispose-induced finish');
+				assert.strictEqual(monitor.pollingResult!.state, OutputMonitorState.Cancelled);
+			});
+		});
 	});
 
 	suite('detectsGenericPressAnyKeyPattern', () => {


### PR DESCRIPTION
## Summary

Fixes a race in `OutputMonitor` where disposing the monitor while its async `_startMonitoring` loop is still in flight causes `onDidFinishCommand` to never resolve for consumers. The agent then hangs on the `run_in_terminal` tool call until the chat driver's 1-hour timeout fires.

## Root cause

[`OutputMonitor`](../blob/main/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts) starts an async polling loop in `_startMonitoring` and fires `_onDidFinishCommand` from a `finally` block. The constructor registers a disposable that cancels the inner CTS so the loop exits promptly, but it does **not** fire the event synchronously.

When `dispose()` is called mid-flight:

1. `super.dispose()` tears down the `_onDidFinishCommand` `Emitter` and clears its listeners.
2. The async loop later reaches its `finally` block and calls `.fire()` on the dead emitter — a no-op.
3. The consumer in [`runInTerminalTool.ts`](../blob/main/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts) is awaiting `Event.toPromise(outputMonitor.onDidFinishCommand)`. Its listener was already cleared, so the promise never resolves.
4. The tool invocation strands. `executeChatCommandAndWait` eventually times out at the driver's hard cap.

The pattern was introduced by the `timeout(0).then(_startMonitoring).finally(fire)` shape in [c48248dd6ba](https://github.com/microsoft/vscode/commit/c48248dd6ba) and made externally reachable when [PR #307199](https://github.com/microsoft/vscode/pull/307199) wired `OutputMonitor` to chat session lifecycle disposal.

## Fix

1. Add a `_didFinish` flag and a private `_fireFinishedOnce()` so the event fires at most once.
2. Fire `onDidFinishCommand` **synchronously from the disposable**, before `super.dispose()` runs, so consumers awaiting `Event.toPromise(...)` are released while the emitter is still live.
3. On the dispose path, synthesize a `Cancelled` `IPollingResult` so consumers that read `monitor.pollingResult` after the event always see a defined value.
4. Replace the bare `.fire()` in the async finally block with `_fireFinishedOnce()` so the late path is a no-op when dispose already won.

## Validation against eval failures

Verified against [`.vscode-eval/25073061392`](https://github.com/microsoft/vscode-copilot-evaluation/) — a `terminalbench2` run with **64 raw `X_AGENT_STILL_RESPONDING` failures (32 unique tests)**, every one timing out at the driver's 1h cap (`Timeout of 3600000ms exceeded while waiting for chat command to complete`).

**15 of the 32** unique failures show the exact signature of this bug: in `terminal.log`, the last `RunInTerminalTool: Using \`<strategy>\` execute strategy ...` line has **no matching `Finished \`<strategy>\` execute strategy`** — i.e., `OutputMonitor.onDidFinishCommand` never resolved for that command and the agent fell silent for the rest of the hour.

Concrete example from `terminalbench2.eval.x86_64.winning-avg-corewars-output`:

```
2026-04-28 19:45:18.154 [info] RunInTerminalTool: Finished `rich` execute strategy ... (prior command, OK)
2026-04-28 19:45:28.819 [info] RunInTerminalTool: Using `rich` execute strategy for command ` set -e ...`
<no further log lines for 54 minutes>
2026-04-28 20:39:31    chat driver fires 1h timeout → X_AGENT_STILL_RESPONDING
```

Matching tests:

| Test | last "Using strategy" timestamp |
|---|---|
| adaptive-rejection-sampler | 19:35:24.971 |
| caffe-cifar-10 | 19:32:06.594 |
| circuit-fibsqrt | 19:32:53.282 |
| compile-compcert | 19:32:54.511 |
| dna-insert | 19:32:10.368 |
| fix-ocaml-gc | 19:31:39.738 |
| install-windows-3.11 | 15:31:46.320 |
| mailman | 19:34:14.363 |
| make-doom-for-mips | 19:31:03.722 |
| merge-diff-arc-agi-task | 19:31:06.965 |
| nginx-request-logging | 19:33:17.061 |
| qemu-alpine-ssh | 19:38:26.491 |
| qemu-startup | 19:33:21.743 |
| rstan-to-pystan | 19:41:06.952 |
| winning-avg-corewars | 19:45:28.819 |

The remaining 17 timeouts have matched `Using`/`Finished` counts, indicating a different stall mode (e.g. auth/model-fetch failures observed in `video-processing`) and are out of scope for this PR.

## Test

Added a regression test in `outputMonitor.test.ts` that disposes the monitor while `_startMonitoring` is in flight and asserts that:

- `Event.toPromise(monitor.onDidFinishCommand)` resolves
- `monitor.pollingResult` is defined and has state `Cancelled`

## Risk

Low. Behavior change is scoped to the dispose path:

- Before: emitter dies before `.fire()` runs; consumers may strand.
- After: emitter fires once synchronously on dispose; late `.fire()` from the async finally is a no-op via `_didFinish`.

`pollingResult` was previously left as `undefined` on a mid-flight dispose; now it's a `Cancelled` snapshot. Any consumer that did a truthy/optional check on `pollingResult` is unaffected; the new value carries the most accurate state.
