### PR TITLE
fix: semantic index status hangs forever in non-git workspaces

### DIFF
--- a/extensions/copilot/src/platform/ignore/node/remoteContentExclusion.ts
+++ b/extensions/copilot/src/platform/ignore/node/remoteContentExclusion.ts
@@ -55,6 +55,8 @@ export class RemoteContentExclusion implements IDisposable {
 	// Cache of repository root paths to their metadata to avoid calling getRepositoryFetchUrls for every file
 	// This is critical for performance when there are many files in a workspace
 	private readonly _repoRootCache: Map<string, RepoMetadata> = new Map();
+	// Set of parent directory paths confirmed to have no git repo (exact match, not prefix)
+	private readonly _noRepoDirCache: Set<string> = new Set();
 
 	constructor(
 		private readonly _gitService: IGitService,
@@ -80,6 +82,12 @@ export class RemoteContentExclusion implements IDisposable {
 			}
 		}));
 
+		// When a repo is opened, clear the no-repo directory cache since
+		// newly discovered repos may cover previously-cached directories
+		this._disposables.push(this._gitService.onDidOpenRepository(() => {
+			this._noRepoDirCache.clear();
+		}));
+
 		this._fileReadLimiter = new Limiter<string | Uint8Array>(10);
 		this._disposables.push(this._fileReadLimiter);
 	}
@@ -100,6 +108,12 @@ export class RemoteContentExclusion implements IDisposable {
 		// This is critical for performance when there are many files in a workspace
 		let repoMetadata = this.findCachedRepoMetadataForFile(file);
 
+		// Check the no-repo directory cache (exact match on parent directory)
+		const fileParentDir = file.path.substring(0, file.path.lastIndexOf('/'));
+		if (!repoMetadata && this._noRepoDirCache.has(fileParentDir)) {
+			repoMetadata = { repoRootPath: '', fetchUrls: [NON_GIT_FILE_KEY] };
+		}
+
 		// If not in cache, query the git extension (this is expensive for many files)
 		if (!repoMetadata) {
 			const repo = await raceCancellationError(this._gitService.getRepositoryFetchUrls(file), token);
@@ -107,6 +121,9 @@ export class RemoteContentExclusion implements IDisposable {
 			// Cache the result for future lookups
 			if (repoMetadata) {
 				this._repoRootCache.set(repoMetadata.repoRootPath, repoMetadata);
+			} else {
+				// Cache that this directory has no git repo to avoid redundant lookups
+				this._noRepoDirCache.add(fileParentDir);
 			}
 		}
 
@@ -219,6 +236,7 @@ export class RemoteContentExclusion implements IDisposable {
 		this._disposables.forEach(d => d.dispose());
 		this._disposables = [];
 		this._contentExclusionCache.clear();
+		this._noRepoDirCache.clear();
 	}
 
 	private shouldFetchContentExclusionRules(repoInfo: RepoMetadata | undefined): boolean {

--- a/extensions/copilot/src/platform/ignore/node/remoteContentExclusion.ts
+++ b/extensions/copilot/src/platform/ignore/node/remoteContentExclusion.ts
@@ -108,8 +108,8 @@ export class RemoteContentExclusion implements IDisposable {
 		// This is critical for performance when there are many files in a workspace
 		let repoMetadata = this.findCachedRepoMetadataForFile(file);
 
-		// Check the no-repo directory cache (exact match on parent directory)
-		const fileParentDir = file.path.substring(0, file.path.lastIndexOf('/'));
+		// Check the no-repo directory cache (exact match on parent directory, case-insensitive)
+		const fileParentDir = file.path.substring(0, file.path.lastIndexOf('/')).toLowerCase();
 		if (!repoMetadata && this._noRepoDirCache.has(fileParentDir)) {
 			repoMetadata = { repoRootPath: '', fetchUrls: [NON_GIT_FILE_KEY] };
 		}

--- a/extensions/copilot/src/platform/networking/node/baseFetchFetcher.ts
+++ b/extensions/copilot/src/platform/networking/node/baseFetchFetcher.ts
@@ -44,9 +44,13 @@ export abstract class BaseFetchFetcher implements IFetcher {
 			throw new Error(`Illegal arguments! 'method' must be 'GET', 'POST', or 'PUT'!`);
 		}
 
-		const signal = options.signal ?? new AbortController().signal;
-		if (signal && !(signal instanceof AbortSignal)) {
+		let signal: AbortSignal = options.signal instanceof AbortSignal ? options.signal : new AbortController().signal;
+		if (options.signal && !(options.signal instanceof AbortSignal)) {
 			throw new Error(`Illegal arguments! 'signal' must be an instance of AbortSignal!`);
+		}
+		if (options.timeout !== undefined && options.timeout > 0) {
+			const timeoutSignal = AbortSignal.timeout(options.timeout);
+			signal = AbortSignal.any([signal, timeoutSignal]);
 		}
 
 		const internalId = generateUuid();

--- a/extensions/copilot/src/platform/networking/node/baseFetchFetcher.ts
+++ b/extensions/copilot/src/platform/networking/node/baseFetchFetcher.ts
@@ -48,9 +48,11 @@ export abstract class BaseFetchFetcher implements IFetcher {
 		if (options.signal && !(options.signal instanceof AbortSignal)) {
 			throw new Error(`Illegal arguments! 'signal' must be an instance of AbortSignal!`);
 		}
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 		if (options.timeout !== undefined && options.timeout > 0) {
-			const timeoutSignal = AbortSignal.timeout(options.timeout);
-			signal = AbortSignal.any([signal, timeoutSignal]);
+			const timeoutController = new AbortController();
+			timeoutId = setTimeout(() => timeoutController.abort(), options.timeout);
+			signal = AbortSignal.any([signal, timeoutController.signal]);
 		}
 
 		const internalId = generateUuid();
@@ -64,6 +66,10 @@ export abstract class BaseFetchFetcher implements IFetcher {
 			const outcome = e && !isAbortError(e) ? 'error' as const : 'cancel' as const;
 			this._reportEvent({ internalId, timestamp: Date.now(), outcome, phase: 'requestResponse', fetcher: this._fetcherId, hostname, reason: e });
 			throw e;
+		} finally {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+			}
 		}
 	}
 

--- a/extensions/copilot/src/platform/networking/node/nodeFetcher.ts
+++ b/extensions/copilot/src/platform/networking/node/nodeFetcher.ts
@@ -48,9 +48,13 @@ export class NodeFetcher implements IFetcher {
 			throw new Error(`Illegal arguments! 'method' must be 'GET', 'POST', or 'PUT'!`);
 		}
 
-		const signal = options.signal ?? new AbortController().signal;
-		if (signal && !(signal instanceof AbortSignal)) {
+		let signal: AbortSignal = options.signal instanceof AbortSignal ? options.signal : new AbortController().signal;
+		if (options.signal && !(options.signal instanceof AbortSignal)) {
 			throw new Error(`Illegal arguments! 'signal' must be an instance of AbortSignal!`);
+		}
+		if (options.timeout !== undefined && options.timeout > 0) {
+			const timeoutSignal = AbortSignal.timeout(options.timeout);
+			signal = AbortSignal.any([signal, timeoutSignal]);
 		}
 
 		const internalId = generateUuid();

--- a/extensions/copilot/src/platform/networking/node/nodeFetcher.ts
+++ b/extensions/copilot/src/platform/networking/node/nodeFetcher.ts
@@ -52,9 +52,11 @@ export class NodeFetcher implements IFetcher {
 		if (options.signal && !(options.signal instanceof AbortSignal)) {
 			throw new Error(`Illegal arguments! 'signal' must be an instance of AbortSignal!`);
 		}
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 		if (options.timeout !== undefined && options.timeout > 0) {
-			const timeoutSignal = AbortSignal.timeout(options.timeout);
-			signal = AbortSignal.any([signal, timeoutSignal]);
+			const timeoutController = new AbortController();
+			timeoutId = setTimeout(() => timeoutController.abort(), options.timeout);
+			signal = AbortSignal.any([signal, timeoutController.signal]);
 		}
 
 		const internalId = generateUuid();
@@ -68,6 +70,10 @@ export class NodeFetcher implements IFetcher {
 			const outcome = e && !isAbortError(e) ? 'error' as const : 'cancel' as const;
 			this._reportEvent({ internalId, timestamp: Date.now(), outcome, phase: 'requestResponse', fetcher: NodeFetcher.ID, hostname, reason: e });
 			throw e;
+		} finally {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+			}
 		}
 	}
 
@@ -99,6 +105,8 @@ export class NodeFetcher implements IFetcher {
 
 	private _fetch(url: string, method: 'GET' | 'POST' | 'PUT', headers: { [name: string]: string }, body: string | undefined, signal: AbortSignal, internalId: string, hostname: string): Promise<Response> {
 		return new Promise((resolve, reject) => {
+			signal.throwIfAborted();
+
 			const module = url.startsWith('https:') ? https : http;
 			const req = module.request(url, { method, headers }, res => {
 				if (signal.aborted) {
@@ -122,6 +130,12 @@ export class NodeFetcher implements IFetcher {
 			});
 			req.setTimeout(60 * 1000); // time out after 60s of receiving no data
 			req.on('error', reject);
+
+			const onAbort = () => {
+				req.destroy(makeAbortError(signal));
+			};
+			signal.addEventListener('abort', onAbort, { once: true });
+			req.on('close', () => signal.removeEventListener('abort', onAbort));
 
 			if (body) {
 				req.write(body);

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -105,7 +105,6 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@IGithubAvailableEmbeddingTypesService private readonly _availableEmbeddingTypes: IGithubAvailableEmbeddingTypesService,
 		@ILogService private readonly _logService: ILogService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -125,13 +124,10 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 			return this._impl;
 		}
 
-		const startTime = Date.now();
-		let outcome: string = 'noEmbeddingType';
 		try {
 			const best = await this._availableEmbeddingTypes.getPreferredType(silent);
 			// Double check that we haven't initialized in the meantime
 			if (this._impl) {
-				outcome = 'alreadyInitialized';
 				return this._impl;
 			}
 
@@ -140,29 +136,11 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 				this._impl = this._register(this._instantiationService.createInstance(WorkspaceChunkSearchServiceImpl, best));
 				this._register(this._impl.onDidChangeIndexState(() => this._onDidChangeIndexState.fire()));
 				this._onDidChangeIndexState.fire();
-				outcome = 'success';
 
 				return this._impl;
 			}
 		} catch {
-			outcome = 'error';
 			return undefined;
-		} finally {
-			/* __GDPR__
-				"workspaceChunkSearch.tryInit" : {
-					"owner": "mjbvz",
-					"comment": "Tracks cold workspace chunk search initialization duration and outcome. Not fired for fast paths (no auth, already initialized).",
-					"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time in milliseconds for getPreferredType and initialization" },
-					"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome: success, noEmbeddingType, alreadyInitialized, or error" },
-					"silent": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether this was a silent initialization attempt" }
-				}
-			*/
-			this._telemetryService.sendMSFTTelemetryEvent('workspaceChunkSearch.tryInit', {
-				outcome,
-				silent: String(silent),
-			}, {
-				durationMs: Date.now() - startTime,
-			});
 		}
 	}
 

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -105,6 +105,7 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
 		@IGithubAvailableEmbeddingTypesService private readonly _availableEmbeddingTypes: IGithubAvailableEmbeddingTypesService,
 		@ILogService private readonly _logService: ILogService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -124,6 +125,8 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 			return this._impl;
 		}
 
+		const startTime = Date.now();
+		let outcome: string = 'noEmbeddingType';
 		try {
 			const best = await this._availableEmbeddingTypes.getPreferredType(silent);
 			// Double check that we haven't initialized in the meantime
@@ -136,11 +139,29 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 				this._impl = this._register(this._instantiationService.createInstance(WorkspaceChunkSearchServiceImpl, best));
 				this._register(this._impl.onDidChangeIndexState(() => this._onDidChangeIndexState.fire()));
 				this._onDidChangeIndexState.fire();
+				outcome = 'success';
 
 				return this._impl;
 			}
 		} catch {
+			outcome = 'error';
 			return undefined;
+		} finally {
+			/* __GDPR__
+				"workspaceChunkSearch.tryInit" : {
+					"owner": "mjbvz",
+					"comment": "Tracks cold workspace chunk search initialization duration and outcome. Not fired for fast paths (no auth, already initialized).",
+					"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time in milliseconds for getPreferredType and initialization" },
+					"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome: success, noEmbeddingType, or error" },
+					"silent": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether this was a silent initialization attempt" }
+				}
+			*/
+			this._telemetryService.sendMSFTTelemetryEvent('workspaceChunkSearch.tryInit', {
+				outcome,
+				silent: String(silent),
+			}, {
+				durationMs: Date.now() - startTime,
+			});
 		}
 	}
 

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/workspaceChunkSearchService.ts
@@ -131,6 +131,7 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 			const best = await this._availableEmbeddingTypes.getPreferredType(silent);
 			// Double check that we haven't initialized in the meantime
 			if (this._impl) {
+				outcome = 'alreadyInitialized';
 				return this._impl;
 			}
 
@@ -152,7 +153,7 @@ export class WorkspaceChunkSearchService extends Disposable implements IWorkspac
 					"owner": "mjbvz",
 					"comment": "Tracks cold workspace chunk search initialization duration and outcome. Not fired for fast paths (no auth, already initialized).",
 					"durationMs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Time in milliseconds for getPreferredType and initialization" },
-					"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome: success, noEmbeddingType, or error" },
+					"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The outcome: success, noEmbeddingType, alreadyInitialized, or error" },
 					"silent": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Whether this was a silent initialization attempt" }
 				}
 			*/


### PR DESCRIPTION
Fixes #313070

## Problem

In non-git workspaces (e.g. large Firefox source tree), the "Codebase Semantic Index" tooltip shows **"Checking index status" forever** and the Copilot Chat output log fills with thousands of repeated trace lines like:

```
[GitServiceImpl][getRepositoryFetchUrls] No repository root found
[GitServiceImpl][getRepositoryFetchUrls] URI: file:///...
```

## Root Causes Fixed

### 1. HTTP timeout never enforced (`baseFetchFetcher.ts`, `nodeFetcher.ts`)

`FetchOptions.timeout` (set to 30s by `networkRequest()`) was silently ignored by all fetcher implementations:
- `BaseFetchFetcher` passed `signal` to `_fetchImpl` but never used `timeout`
- `NodeFetcher._fetch()` called `req.setTimeout(60_000)` **without a callback** — per Node.js docs, this is a no-op that fires the event but does NOT abort the request
- No `cancelToken` was passed in `doGetAvailableTypes()`, so no abort signal existed

If the embeddings endpoint hangs, `_cached` promise never resolves → `tryInit()` hangs forever → status stuck permanently.

**Fix:** Use `AbortSignal.timeout(ms)` + `AbortSignal.any([callerSignal, timeoutSignal])` in both `BaseFetchFetcher.fetch()` and `NodeFetcher.fetch()`.

### 3. Missing negative cache for git lookups (`remoteContentExclusion.ts`)

`RemoteContentExclusion.isIgnored()` called `getRepositoryFetchUrls(file)` for **every file**. When no repo was found, `getRepositoryInfo()` returned `undefined`, so the `if (repoMetadata)` guard skipped caching — triggering a redundant git extension call for every subsequent file.

**Fix:** Add `_noRepoDirCache: Set<string>` using exact parent-directory matching. When a git lookup returns no repo, cache the file's parent directory. Clear the cache on `onDidOpenRepository` to handle newly-opened repos.

The exact-match approach (vs. prefix matching used by `_repoRootCache`) ensures nested repos are never incorrectly masked by a parent directory's negative result.

## Telemetry Added

Added `workspaceChunkSearch.tryInit` event to track cold-initialization duration and outcome (`success` / `noEmbeddingType` / `error`). This will help quantify how often the timeout path is hit and how long initialization takes.

## Testing

- TypeScript compilation: ✅ clean
- Unit tests: ✅ 29/29 pass (`remoteContentExclusion`, networking tests)
- Pre-commit hooks: ✅ tsfmt + ESLint clean

## Not Fixed (tracked in #313070)

Root Cause 2: `CodeSearchRepoTracker._initializedGitReposP` has a 30s `raceTimeout` blocking wait. Separate fix needed by feature owner.