### PR TITLE
feat: AgentMemoryService session cache + AgentMemoryCachePrimer

### DIFF
--- a/extensions/copilot/src/extension/extension/vscode-node/services.ts
+++ b/extensions/copilot/src/extension/extension/vscode-node/services.ts
@@ -138,6 +138,7 @@ import { FixCookbookService, IFixCookbookService } from '../../prompts/node/inli
 import { WorkspaceMutationManager } from '../../testing/node/setupTestsFileManager';
 import { AgentMemoryService, IAgentMemoryService } from '../../tools/common/agentMemoryService';
 import { IMemoryCleanupService, MemoryCleanupService } from '../../tools/common/memoryCleanupService';
+import { AgentMemoryCachePrimer, IAgentMemoryCachePrimer } from '../../tools/node/agentMemoryCachePrimer';
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { ToolDeferralService } from '../../tools/common/toolDeferralService';
 import { IToolsService } from '../../tools/common/toolsService';
@@ -168,6 +169,7 @@ export function registerServices(builder: IInstantiationServiceBuilder, extensio
 	builder.define(IToolsService, new SyncDescriptor(ToolsService));
 	builder.define(IToolDeferralService, new ToolDeferralService());
 	builder.define(IAgentMemoryService, new SyncDescriptor(AgentMemoryService));
+	builder.define(IAgentMemoryCachePrimer, new SyncDescriptor(AgentMemoryCachePrimer));
 	builder.define(IMemoryCleanupService, new SyncDescriptor(MemoryCleanupService));
 	builder.define(IChatDiskSessionResources, new SyncDescriptor(ChatDiskSessionResources));
 	builder.define(IRequestLogger, new SyncDescriptor(RequestLogger));

--- a/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
+++ b/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
@@ -3,8 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestType } from '@vscode/copilot-api';
+import {
+	fetchMemoryPrompts,
+	storeMemory,
+	type MemoryApiOptions,
+	type MemoryPromptResponse,
+	type StoreMemoryRequest,
+} from '@github/copilot-agentic-tools/memory';
 import { IAuthenticationService } from '../../../platform/authentication/common/authentication';
+import { IChatSessionService } from '../../../platform/chat/common/chatSessionService';
 import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICAPIClientService } from '../../../platform/endpoint/common/capiClient';
 import { getGithubRepoIdFromFetchUrl, getOrderedRemoteUrlsFromContext, IGitService, toGithubNwo } from '../../../platform/git/common/gitService';
@@ -14,98 +21,68 @@ import { IWorkspaceService } from '../../../platform/workspace/common/workspaceS
 import { createServiceIdentifier } from '../../../util/common/services';
 import { Disposable } from '../../../util/vs/base/common/lifecycle';
 
-/**
- * Repository memory entry format aligned with CAPI service contract.
- * Supports both new format (citations as string[]) and legacy format (citations as string).
- */
-export interface RepoMemoryEntry {
-	subject: string;
-	fact: string;
-	citations?: string | string[];
-	reason?: string;
-	category?: string;
-}
+const INTEGRATION_ID = 'vscode-chat';
 
 /**
- * Type guard to validate if an object is a valid RepoMemoryEntry.
- * Accepts both new format (citations: string[]) and legacy format (citations: string).
- */
-export function isRepoMemoryEntry(obj: unknown): obj is RepoMemoryEntry {
-	if (typeof obj !== 'object' || obj === null) {
-		return false;
-	}
-	const entry = obj as Record<string, unknown>;
-
-	// Required fields
-	if (typeof entry.subject !== 'string' || typeof entry.fact !== 'string') {
-		return false;
-	}
-
-	// Optional fields
-	if (entry.citations !== undefined) {
-		const isString = typeof entry.citations === 'string';
-		const isStringArray = Array.isArray(entry.citations) && entry.citations.every(c => typeof c === 'string');
-		if (!isString && !isStringArray) {
-			return false;
-		}
-	}
-
-	if (entry.reason !== undefined && typeof entry.reason !== 'string') {
-		return false;
-	}
-
-	if (entry.category !== undefined && typeof entry.category !== 'string') {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Normalize citations field to string[] format.
- * Handles backward compatibility for legacy string format.
- */
-export function normalizeCitations(citations: string | string[] | undefined): string[] | undefined {
-	if (citations === undefined) {
-		return undefined;
-	}
-	if (typeof citations === 'string') {
-		return citations.split(',').map(c => c.trim()).filter(c => c.length > 0);
-	}
-	return citations;
-}
-
-/**
- * Service for managing repository memories via the Copilot Memory service (CAPI).
- * Memories are stored in the cloud and available when Copilot Memory is enabled for the repository.
+ * Service for managing memories via the Copilot Memory service (CAPI).
+ * Delegates to @github/copilot-agentic-tools/memory for all API calls.
  */
 export interface IAgentMemoryService {
 	readonly _serviceBrand: undefined;
 
 	/**
-	 * Check if Copilot Memory is enabled for the current repository.
-	 * Makes a lightweight API call to the enablement check endpoint.
-	 * Returns false if not enabled or if the check fails.
-	 */
-	checkMemoryEnabled(): Promise<boolean>;
-
-	/**
-	 * Get repo memories from Copilot Memory service.
-	 * Returns undefined if Copilot Memory is not enabled or if fetching fails.
-	 */
-	getRepoMemories(limit?: number): Promise<RepoMemoryEntry[] | undefined>;
-
-	/**
 	 * Store a repo memory to Copilot Memory service.
-	 * Returns true if stored successfully, false if Copilot Memory is not enabled or if storing fails.
 	 */
-	storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean>;
+	storeRepoMemory(memory: StoreMemoryRequest, baseModel?: string): Promise<boolean>;
+
+	/**
+	 * Store a user-scoped memory to Copilot Memory service.
+	 */
+	storeUserMemory(memory: StoreMemoryRequest, baseModel?: string): Promise<boolean>;
+
+
+	/**
+	 * Fetch the unified memory prompt from the /prompt endpoint.
+	 * Returns the full MemoryPromptResponse including storeToolDefinition,
+	 * or undefined on failure. Caches the result per conversation.
+	 */
+	getMemoryPrompt(repoNwo?: string, sessionId?: string): Promise<MemoryPromptResponse | undefined>;
+
+	/**
+	 * Returns the cached MemoryPromptResponse for a specific session, or undefined if
+	 * getMemoryPrompt() has not yet been called successfully for that session.
+	 */
+	getCachedMemoryPrompt(sessionId?: string): MemoryPromptResponse | undefined;
+
+	/**
+	 * Clear cached memory prompts for a specific session or all sessions.
+	 */
+	clearCache(sessionId?: string): void;
 }
 
 export const IAgentMemoryService = createServiceIdentifier<IAgentMemoryService>('IAgentMemoryService');
 
 export class AgentMemoryService extends Disposable implements IAgentMemoryService {
 	declare readonly _serviceBrand: undefined;
+
+	// Conversation-scoped cache - one entry per conversation, cleared on conversation end
+	private _conversationMemoryCache = new Map<string, MemoryPromptResponse>();
+	// Deduplicates concurrent getMemoryPrompt calls for the same session
+	private _inflightPrompts = new Map<string, Promise<MemoryPromptResponse | undefined>>();
+
+	override dispose(): void {
+		this._conversationMemoryCache.clear();
+		this._inflightPrompts.clear();
+		super.dispose();
+	}
+
+	getCachedMemoryPrompt(sessionId?: string): MemoryPromptResponse | undefined {
+		if (!sessionId) {
+			const responses = Array.from(this._conversationMemoryCache.values());
+			return responses.length > 0 ? responses[0] : undefined;
+		}
+		return this._conversationMemoryCache.get(sessionId);
+	}
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -114,16 +91,18 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		@IWorkspaceService private readonly workspaceService: IWorkspaceService,
 		@IConfigurationService private readonly configService: IConfigurationService,
 		@IExperimentationService private readonly experimentationService: IExperimentationService,
-		@IAuthenticationService private readonly authenticationService: IAuthenticationService
+		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
+		@IChatSessionService private readonly chatSessionService: IChatSessionService,
 	) {
 		super();
+		
+		// Clear cache when conversations end to ensure fresh data for new conversations
+		this._register(this.chatSessionService.onDidDisposeChatSession(sessionId => {
+			this.clearCache(sessionId);
+		}));
 	}
 
-	/**
-	 * Get the GitHub repository NWO (name with owner) for the current workspace.
-	 * Returns the NWO in lowercase format (e.g., "microsoft/vscode").
-	 */
-	private async getRepoNwo(): Promise<string | undefined> {
+	async getRepoNwo(): Promise<string | undefined> {
 		try {
 			const workspaceFolders = this.workspaceService.getWorkspaceFolders();
 			if (!workspaceFolders || workspaceFolders.length === 0) {
@@ -135,7 +114,6 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return undefined;
 			}
 
-			// Try to get GitHub repo info from remote URLs
 			for (const remoteUrl of getOrderedRemoteUrlsFromContext(repo)) {
 				const repoId = getGithubRepoIdFromFetchUrl(remoteUrl);
 				if (repoId) {
@@ -150,17 +128,28 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		}
 	}
 
-	/**
-	 * Check if the chat.copilotMemory.enabled config is enabled.
-	 * Uses experiment-based configuration for gradual rollout.
-	 */
 	private isCAPIMemorySyncConfigEnabled(): boolean {
 		return this.configService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
 	}
 
-	async checkMemoryEnabled(): Promise<boolean> {
+	private getBaseUrl(): string {
+		return new URL('.', this.capiClientService.capiPingURL).toString().replace(/\/$/, '');
+	}
+
+	private async getToken(): Promise<string | undefined> {
+		const session = await this.authenticationService.getGitHubSession('any', { silent: true });
+		return session?.accessToken;
+	}
+
+	private makeLogger() {
+		return {
+			info: (msg: string) => this.logService.info(`[AgentMemoryService] ${msg}`),
+			error: (msg: string) => this.logService.error(`[AgentMemoryService] ${msg}`),
+		};
+	}
+
+	async storeRepoMemory(memory: StoreMemoryRequest, baseModel?: string): Promise<boolean> {
 		try {
-			// Check if CAPI sync is enabled via config
 			if (!this.isCAPIMemorySyncConfigEnabled()) {
 				return false;
 			}
@@ -170,164 +159,154 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 				return false;
 			}
 
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
-				this.logService.warn('[AgentMemoryService] No GitHub session available for memory enablement check');
+			const token = await this.getToken();
+			if (!token) {
+				this.logService.warn('[AgentMemoryService] No GitHub authentication token available for storing memory');
 				return false;
 			}
 
-			// Make API call to check enablement
-			const response = await this.capiClientService.makeRequest<Response>({
-				method: 'GET',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo,
-				action: 'enabled'
-			});
+			const [owner, repo] = repoNwo.split('/');
+			const options = {
+				scope: 'repository' as const,
+				owner,
+				repo,
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				agent: 'vscode',
+				baseModel,
+				logger: this.makeLogger(),
+			};
 
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Memory enablement check failed: ${response.statusText}`);
-				return false;
+			const result = await storeMemory(memory, options);
+			if (!result.success) {
+				this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${result.error}`);
+			} else {
+				this.logService.debug(`[AgentMemoryService] Successfully stored repo memory`);
 			}
-
-			const data = await response.json() as { enabled?: boolean };
-			const enabled = data?.enabled ?? false;
-
-			this.logService.info(`[AgentMemoryService] Copilot Memory enabled for ${repoNwo}: ${enabled}`);
-			return enabled;
-		} catch (error) {
-			this.logService.warn(`[AgentMemoryService] Failed to check memory enablement: ${error}`);
-			return false;
-		}
-	}
-
-	async getRepoMemories(limit: number = 10): Promise<RepoMemoryEntry[] | undefined> {
-		try {
-			// Check if Copilot Memory is enabled
-			const enabled = await this.checkMemoryEnabled();
-			if (!enabled) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping repo memory fetch');
-				return undefined;
-			}
-
-			const repoNwo = await this.getRepoNwo();
-			if (!repoNwo) {
-				return undefined;
-			}
-
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
-				this.logService.warn('[AgentMemoryService] No GitHub session available for fetching memories');
-				return undefined;
-			}
-
-			// Fetch memories from Copilot Memory service
-			const response = await this.capiClientService.makeRequest<Response>({
-				method: 'GET',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo,
-				action: 'recent',
-				limit
-			});
-
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to fetch memories: ${response.statusText}`);
-				return undefined;
-			}
-
-			const data = await response.json() as Array<{
-				subject: string;
-				fact: string;
-				citations?: string[];
-				reason?: string;
-				category?: string;
-			}>;
-
-			if (!data || !Array.isArray(data)) {
-				return undefined;
-			}
-
-			// Transform response to RepoMemoryEntry format
-			const memories: RepoMemoryEntry[] = data
-				.filter(isRepoMemoryEntry)
-				.map(entry => ({
-					subject: entry.subject,
-					fact: entry.fact,
-					citations: entry.citations,
-					reason: entry.reason,
-					category: entry.category
-				}));
-
-			this.logService.info(`[AgentMemoryService] Fetched ${memories.length} repo memories for ${repoNwo}`);
-			return memories.length > 0 ? memories : undefined;
-		} catch (error) {
-			this.logService.warn(`[AgentMemoryService] Failed to fetch repo memories: ${error}`);
-			return undefined;
-		}
-	}
-
-	async storeRepoMemory(memory: RepoMemoryEntry): Promise<boolean> {
-		try {
-			// Check if Copilot Memory is enabled
-			const enabled = await this.checkMemoryEnabled();
-			if (!enabled) {
-				this.logService.debug('[AgentMemoryService] Copilot Memory not enabled, skipping repo memory store');
-				return false;
-			}
-
-			const repoNwo = await this.getRepoNwo();
-			if (!repoNwo) {
-				return false;
-			}
-
-			// Normalize citations to array format for CAPI
-			const citations = normalizeCitations(memory.citations) ?? [];
-
-			// Get OAuth token for API call
-			const session = await this.authenticationService.getGitHubSession('any', { silent: true });
-			if (!session) {
-				this.logService.warn('[AgentMemoryService] No GitHub session available for storing memory');
-				return false;
-			}
-
-			// Store memory to Copilot Memory service
-			const response = await this.capiClientService.makeRequest<Response>({
-				method: 'PUT',
-				headers: {
-					'Authorization': `Bearer ${session.accessToken}`
-				},
-				json: {
-					subject: memory.subject,
-					fact: memory.fact,
-					citations,
-					reason: memory.reason,
-					category: memory.category,
-					source: { agent: 'vscode' }
-				}
-			}, {
-				type: RequestType.CopilotAgentMemory,
-				repo: repoNwo
-			});
-
-			if (!response.ok) {
-				this.logService.warn(`[AgentMemoryService] Failed to store memory: ${response.statusText}`);
-				return false;
-			}
-
-			this.logService.info(`[AgentMemoryService] Stored repo memory for ${repoNwo}: ${memory.subject}`);
-			return true;
+			return result.success;
 		} catch (error) {
 			this.logService.warn(`[AgentMemoryService] Failed to store repo memory: ${error}`);
 			return false;
 		}
 	}
+
+	async storeUserMemory(memory: StoreMemoryRequest, baseModel?: string): Promise<boolean> {
+		try {
+			if (!this.isCAPIMemorySyncConfigEnabled()) {
+				return false;
+			}
+
+			const token = await this.getToken();
+			if (!token) {
+				this.logService.warn('[AgentMemoryService] No GitHub authentication token available for storing user memory');
+				return false;
+			}
+
+			const options = {
+				scope: 'user' as const,
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				agent: 'vscode',
+				baseModel,
+				logger: this.makeLogger(),
+			};
+
+			const result = await storeMemory(memory, options);
+			if (!result.success) {
+				this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${result.error}`);
+			} else {
+				this.logService.debug(`[AgentMemoryService] Successfully stored user memory`);
+			}
+			return result.success;
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to store user memory: ${error}`);
+			return false;
+		}
+	}
+
+
+	async getMemoryPrompt(repoNwo?: string, sessionId?: string): Promise<MemoryPromptResponse | undefined> {
+		if (!this.isCAPIMemorySyncConfigEnabled()) {
+			return undefined;
+		}
+
+		if (sessionId) {
+			const cached = this._conversationMemoryCache.get(sessionId);
+			if (cached) {
+				this.logService.debug(`[AgentMemoryService] Using cached memory prompt for conversation: ${sessionId}`);
+				return cached;
+			}
+			const inflight = this._inflightPrompts.get(sessionId);
+			if (inflight) {
+				return inflight;
+			}
+			this.logService.debug(`[AgentMemoryService] Cache miss for conversation: ${sessionId}, cache size: ${this._conversationMemoryCache.size}`);
+		} else {
+			this.logService.debug(`[AgentMemoryService] No sessionId provided, skipping cache lookup`);
+		}
+
+		const promise = this._fetchMemoryPrompt(repoNwo, sessionId);
+		if (sessionId) {
+			this._inflightPrompts.set(sessionId, promise);
+			void promise.finally(() => this._inflightPrompts.delete(sessionId));
+		}
+		return promise;
+	}
+
+	private async _fetchMemoryPrompt(repoNwo?: string, sessionId?: string): Promise<MemoryPromptResponse | undefined> {
+		try {
+			const resolvedRepoNwo = repoNwo ?? await this.getRepoNwo();
+
+			const token = await this.getToken();
+			if (!token) {
+				this.logService.warn('[AgentMemoryService] No GitHub authentication token available for fetching memory prompt');
+				return undefined;
+			}
+
+			const baseOptions = {
+				token,
+				integrationId: INTEGRATION_ID,
+				baseUrl: this.getBaseUrl(),
+				logger: this.makeLogger(),
+			};
+
+			let options: MemoryApiOptions;
+			if (resolvedRepoNwo) {
+				const [owner, repo] = resolvedRepoNwo.split('/');
+				options = { scope: 'repository', owner, repo, ...baseOptions };
+			} else {
+				options = { scope: 'user', ...baseOptions };
+			}
+
+			const response = await fetchMemoryPrompts(options);
+			if (response) {
+				this.logService.info(`[AgentMemoryService] Fetched memory prompt (${response.memoriesContext.memoriesCount} memories)${sessionId ? ` for conversation: ${sessionId}` : ''}`);
+				if (sessionId) {
+					this._conversationMemoryCache.set(sessionId, response);
+				}
+			}
+			return response;
+		} catch (error) {
+			this.logService.warn(`[AgentMemoryService] Failed to fetch memory prompt: ${error}`);
+			return undefined;
+		}
+	}
+
+	/**
+	 * Clear cached memory for a specific conversation (called when conversation ends)
+	 */
+	clearCache(sessionId?: string): void {
+		if (sessionId) {
+			const deleted = this._conversationMemoryCache.delete(sessionId);
+			this.logService.debug(`[AgentMemoryService] Cleared cache for conversation: ${sessionId} (found: ${deleted})`);
+		} else {
+			// Clear all conversations
+			const count = this._conversationMemoryCache.size;
+			this._conversationMemoryCache.clear();
+			this.logService.debug(`[AgentMemoryService] Cleared all conversation caches (${count} entries)`);
+		}
+	}
+
 }

--- a/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
+++ b/extensions/copilot/src/extension/tools/common/agentMemoryService.ts
@@ -95,7 +95,7 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 		@IChatSessionService private readonly chatSessionService: IChatSessionService,
 	) {
 		super();
-		
+
 		// Clear cache when conversations end to ensure fresh data for new conversations
 		this._register(this.chatSessionService.onDidDisposeChatSession(sessionId => {
 			this.clearCache(sessionId);
@@ -283,7 +283,7 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 			const response = await fetchMemoryPrompts(options);
 			if (response) {
 				this.logService.info(`[AgentMemoryService] Fetched memory prompt (${response.memoriesContext.memoriesCount} memories)${sessionId ? ` for conversation: ${sessionId}` : ''}`);
-				if (sessionId) {
+				if (sessionId && this._inflightPrompts.has(sessionId)) {
 					this._conversationMemoryCache.set(sessionId, response);
 				}
 			}
@@ -300,11 +300,13 @@ export class AgentMemoryService extends Disposable implements IAgentMemoryServic
 	clearCache(sessionId?: string): void {
 		if (sessionId) {
 			const deleted = this._conversationMemoryCache.delete(sessionId);
+			this._inflightPrompts.delete(sessionId);
 			this.logService.debug(`[AgentMemoryService] Cleared cache for conversation: ${sessionId} (found: ${deleted})`);
 		} else {
 			// Clear all conversations
 			const count = this._conversationMemoryCache.size;
 			this._conversationMemoryCache.clear();
+			this._inflightPrompts.clear();
 			this.logService.debug(`[AgentMemoryService] Cleared all conversation caches (${count} entries)`);
 		}
 	}

--- a/extensions/copilot/src/extension/tools/common/test/agentMemoryService.spec.ts
+++ b/extensions/copilot/src/extension/tools/common/test/agentMemoryService.spec.ts
@@ -3,127 +3,279 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { describe, expect, it } from 'vitest';
-import { isRepoMemoryEntry, normalizeCitations } from '../agentMemoryService';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemoryPromptResponse } from '@github/copilot-agentic-tools/memory';
+import { TestLogService } from '../../../../platform/testing/common/testLogService';
+import { AgentMemoryService } from '../agentMemoryService';
+
+vi.mock('@github/copilot-agentic-tools/memory', () => ({
+	fetchMemoryPrompts: vi.fn(),
+	storeMemory: vi.fn(),
+}));
+
+import { fetchMemoryPrompts, storeMemory } from '@github/copilot-agentic-tools/memory';
+
+const mockResponse: MemoryPromptResponse = {
+	memoriesContext: { prompt: 'mem prompt', promptVersion: '1.0', memoriesCount: 5 },
+	storeInstructions: { prompt: 'store instructions', promptVersion: '1.0' },
+	toolDefinition: { name: 'store_memory', description: 'Store a memory', definitionVersion: '1.1.1' },
+	storeToolDefinition: { name: 'store_memory', description: 'Store a memory', definitionVersion: '1.1.1' },
+};
+
+const memory = { subject: 'test', fact: 'a fact', citations: [], reason: 'useful' };
+
+function makeDeps({ enabled = true, token = 'tok', repoNwo = 'owner/repo' } = {}) {
+	const disposeFns: ((sessionId: string) => void)[] = [];
+	const chatSessionService = {
+		onDidDisposeChatSession: (fn: (sessionId: string) => void) => {
+			disposeFns.push(fn);
+			return { dispose: () => { } };
+		},
+		fireDispose: (sessionId: string) => disposeFns.forEach(fn => fn(sessionId)),
+	};
+
+	const workspaceFolders = repoNwo ? [{ uri: { fsPath: '/repo' } }] : [];
+	const mockRepo = repoNwo ? {
+		remoteFetchUrls: [`https://github.com/${repoNwo}.git`],
+		remotes: ['origin'],
+		worktrees: [],
+	} : undefined;
+
+	return {
+		logService: new TestLogService(),
+		capiClientService: { capiPingURL: 'https://api.github.com/copilot_internal/v2/_ping' },
+		gitService: {
+			getRepository: vi.fn().mockResolvedValue(mockRepo),
+		},
+		workspaceService: { getWorkspaceFolders: vi.fn().mockReturnValue(workspaceFolders) },
+		configService: { getExperimentBasedConfig: vi.fn().mockReturnValue(enabled) },
+		experimentationService: {},
+		authenticationService: {
+			getGitHubSession: vi.fn().mockResolvedValue(token ? { accessToken: token } : undefined),
+		},
+		chatSessionService,
+	};
+}
+
+function makeService(deps = makeDeps()) {
+	return new (AgentMemoryService as any)(
+		deps.logService,
+		deps.capiClientService,
+		deps.gitService,
+		deps.workspaceService,
+		deps.configService,
+		deps.experimentationService,
+		deps.authenticationService,
+		deps.chatSessionService,
+	) as AgentMemoryService;
+}
 
 describe('AgentMemoryService', () => {
-	describe('isRepoMemoryEntry', () => {
-		it('should return true for valid entry with required fields only', () => {
-			const entry: unknown = {
-				subject: 'testing',
-				fact: 'Use vitest for unit tests'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(true);
+	beforeEach(() => {
+		vi.mocked(fetchMemoryPrompts).mockResolvedValue(mockResponse);
+		vi.mocked(storeMemory).mockResolvedValue({ success: true });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getMemoryPrompt — cache lifecycle', () => {
+		it('fetches and caches response when sessionId is provided', async () => {
+			const svc = makeService();
+			const result = await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(result).toBe(mockResponse);
+			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return true for valid entry with all fields', () => {
-			const entry: unknown = {
-				subject: 'testing',
-				fact: 'Use vitest for unit tests',
-				citations: ['src/test.ts:10'],
-				reason: 'Important for consistency',
-				category: 'general'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(true);
+		it('returns cached response on second call with same sessionId', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			const result = await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(result).toBe(mockResponse);
+			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return true for entry with legacy string citations', () => {
-			const entry: unknown = {
-				subject: 'testing',
-				fact: 'Use vitest for unit tests',
-				citations: 'src/test.ts:10, src/other.ts:20'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(true);
+		it('fetches independently for different sessionIds', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			await svc.getMemoryPrompt(undefined, 'session-2');
+			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(2);
 		});
 
-		it('should return false for null', () => {
-			expect(isRepoMemoryEntry(null)).toBe(false);
+		it('does not cache when no sessionId is provided', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, undefined);
+			await svc.getMemoryPrompt(undefined, undefined);
+			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(2);
 		});
 
-		it('should return false for undefined', () => {
-			expect(isRepoMemoryEntry(undefined)).toBe(false);
+		it('returns undefined when config is disabled', async () => {
+			const svc = makeService(makeDeps({ enabled: false }));
+			const result = await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(result).toBeUndefined();
+			expect(vi.mocked(fetchMemoryPrompts)).not.toHaveBeenCalled();
 		});
 
-		it('should return false for non-object', () => {
-			expect(isRepoMemoryEntry('string')).toBe(false);
-			expect(isRepoMemoryEntry(123)).toBe(false);
+		it('returns undefined when auth token is missing', async () => {
+			const svc = makeService(makeDeps({ token: '' }));
+			const result = await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(result).toBeUndefined();
 		});
 
-		it('should return false for missing subject', () => {
-			const entry: unknown = {
-				fact: 'Use vitest for unit tests'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(false);
-		});
-
-		it('should return false for missing fact', () => {
-			const entry: unknown = {
-				subject: 'testing'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(false);
-		});
-
-		it('should return false for non-string subject', () => {
-			const entry: unknown = {
-				subject: 123,
-				fact: 'Use vitest for unit tests'
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(false);
-		});
-
-		it('should return false for invalid citations type', () => {
-			const entry: unknown = {
-				subject: 'testing',
-				fact: 'Use vitest for unit tests',
-				citations: 123
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(false);
-		});
-
-		it('should return false for citations array with non-string elements', () => {
-			const entry: unknown = {
-				subject: 'testing',
-				fact: 'Use vitest for unit tests',
-				citations: [123, 'src/test.ts:10']
-			};
-			expect(isRepoMemoryEntry(entry)).toBe(false);
+		it('returns undefined and does not throw when fetchMemoryPrompts throws', async () => {
+			vi.mocked(fetchMemoryPrompts).mockRejectedValue(new Error('network error'));
+			const svc = makeService();
+			const result = await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(result).toBeUndefined();
 		});
 	});
 
-	describe('normalizeCitations', () => {
-		it('should return undefined for undefined input', () => {
-			expect(normalizeCitations(undefined)).toBeUndefined();
+	describe('getCachedMemoryPrompt', () => {
+		it('returns cached response for a known sessionId', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(svc.getCachedMemoryPrompt('session-1')).toBe(mockResponse);
 		});
 
-		it('should split comma-separated string into array', () => {
-			const result = normalizeCitations('src/a.ts:10, src/b.ts:20');
-			expect(result).toEqual(['src/a.ts:10', 'src/b.ts:20']);
+		it('returns undefined for an unknown sessionId', async () => {
+			const svc = makeService();
+			expect(svc.getCachedMemoryPrompt('unknown')).toBeUndefined();
 		});
 
-		it('should trim whitespace from citations', () => {
-			const result = normalizeCitations('  src/a.ts:10  ,  src/b.ts:20  ');
-			expect(result).toEqual(['src/a.ts:10', 'src/b.ts:20']);
+		it('returns first cached entry when no sessionId is provided', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(svc.getCachedMemoryPrompt()).toBe(mockResponse);
 		});
 
-		it('should filter out empty citations', () => {
-			const result = normalizeCitations('src/a.ts:10, , src/b.ts:20');
-			expect(result).toEqual(['src/a.ts:10', 'src/b.ts:20']);
+		it('returns undefined when cache is empty and no sessionId is provided', () => {
+			const svc = makeService();
+			expect(svc.getCachedMemoryPrompt()).toBeUndefined();
+		});
+	});
+
+	describe('clearCache', () => {
+		it('removes a specific session from the cache', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			svc.clearCache('session-1');
+			expect(svc.getCachedMemoryPrompt('session-1')).toBeUndefined();
 		});
 
-		it('should return array input unchanged', () => {
-			const input = ['src/a.ts:10', 'src/b.ts:20'];
-			const result = normalizeCitations(input);
-			expect(result).toEqual(input);
+		it('does not remove other sessions when clearing a specific one', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			await svc.getMemoryPrompt(undefined, 'session-2');
+			svc.clearCache('session-1');
+			expect(svc.getCachedMemoryPrompt('session-2')).toBe(mockResponse);
 		});
 
-		it('should handle single citation string', () => {
-			const result = normalizeCitations('src/a.ts:10');
-			expect(result).toEqual(['src/a.ts:10']);
+		it('clears all sessions when called without sessionId', async () => {
+			const svc = makeService();
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			await svc.getMemoryPrompt(undefined, 'session-2');
+			svc.clearCache();
+			expect(svc.getCachedMemoryPrompt('session-1')).toBeUndefined();
+			expect(svc.getCachedMemoryPrompt('session-2')).toBeUndefined();
 		});
 
-		it('should handle empty string', () => {
-			const result = normalizeCitations('');
-			expect(result).toEqual([]);
+		it('clears session cache when onDidDisposeChatSession fires', async () => {
+			const deps = makeDeps();
+			const svc = makeService(deps);
+			await svc.getMemoryPrompt(undefined, 'session-1');
+			expect(svc.getCachedMemoryPrompt('session-1')).toBe(mockResponse);
+			deps.chatSessionService.fireDispose('session-1');
+			expect(svc.getCachedMemoryPrompt('session-1')).toBeUndefined();
+		});
+	});
+
+	describe('storeRepoMemory', () => {
+		it('returns true on success', async () => {
+			const result = await makeService().storeRepoMemory(memory);
+			expect(result).toBe(true);
+			expect(vi.mocked(storeMemory)).toHaveBeenCalledWith(
+				memory,
+				expect.objectContaining({ scope: 'repository', agent: 'vscode' }),
+			);
+		});
+
+		it('returns false when config is disabled', async () => {
+			const result = await makeService(makeDeps({ enabled: false })).storeRepoMemory(memory);
+			expect(result).toBe(false);
+			expect(vi.mocked(storeMemory)).not.toHaveBeenCalled();
+		});
+
+		it('returns false when auth token is missing', async () => {
+			const result = await makeService(makeDeps({ token: '' })).storeRepoMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('returns false when repo NWO cannot be resolved', async () => {
+			const result = await makeService(makeDeps({ repoNwo: '' })).storeRepoMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('returns false when storeMemory reports failure', async () => {
+			vi.mocked(storeMemory).mockResolvedValue({ success: false, error: 'server error' });
+			const result = await makeService().storeRepoMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('returns false and does not throw when storeMemory throws', async () => {
+			vi.mocked(storeMemory).mockRejectedValue(new Error('network error'));
+			const result = await makeService().storeRepoMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('passes baseModel when provided', async () => {
+			await makeService().storeRepoMemory(memory, 'gpt-4o');
+			expect(vi.mocked(storeMemory)).toHaveBeenCalledWith(
+				memory,
+				expect.objectContaining({ baseModel: 'gpt-4o' }),
+			);
+		});
+	});
+
+	describe('storeUserMemory', () => {
+		it('returns true on success', async () => {
+			const result = await makeService().storeUserMemory(memory);
+			expect(result).toBe(true);
+			expect(vi.mocked(storeMemory)).toHaveBeenCalledWith(
+				memory,
+				expect.objectContaining({ scope: 'user', agent: 'vscode' }),
+			);
+		});
+
+		it('returns false when config is disabled', async () => {
+			const result = await makeService(makeDeps({ enabled: false })).storeUserMemory(memory);
+			expect(result).toBe(false);
+			expect(vi.mocked(storeMemory)).not.toHaveBeenCalled();
+		});
+
+		it('returns false when auth token is missing', async () => {
+			const result = await makeService(makeDeps({ token: '' })).storeUserMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('returns false when storeMemory reports failure', async () => {
+			vi.mocked(storeMemory).mockResolvedValue({ success: false, error: 'server error' });
+			const result = await makeService().storeUserMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('returns false and does not throw when storeMemory throws', async () => {
+			vi.mocked(storeMemory).mockRejectedValue(new Error('network error'));
+			const result = await makeService().storeUserMemory(memory);
+			expect(result).toBe(false);
+		});
+
+		it('passes baseModel when provided', async () => {
+			await makeService().storeUserMemory(memory, 'claude-3-5-sonnet');
+			expect(vi.mocked(storeMemory)).toHaveBeenCalledWith(
+				memory,
+				expect.objectContaining({ baseModel: 'claude-3-5-sonnet' }),
+			);
 		});
 	});
 });

--- a/extensions/copilot/src/extension/tools/common/test/agentMemoryService.spec.ts
+++ b/extensions/copilot/src/extension/tools/common/test/agentMemoryService.spec.ts
@@ -103,6 +103,17 @@ describe('AgentMemoryService', () => {
 			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(2);
 		});
 
+		it('deduplicates concurrent calls with the same sessionId', async () => {
+			const svc = makeService();
+			const [r1, r2] = await Promise.all([
+				svc.getMemoryPrompt(undefined, 'session-1'),
+				svc.getMemoryPrompt(undefined, 'session-1'),
+			]);
+			expect(r1).toBe(mockResponse);
+			expect(r2).toBe(mockResponse);
+			expect(vi.mocked(fetchMemoryPrompts)).toHaveBeenCalledTimes(1);
+		});
+
 		it('does not cache when no sessionId is provided', async () => {
 			const svc = makeService();
 			await svc.getMemoryPrompt(undefined, undefined);

--- a/extensions/copilot/src/extension/tools/node/agentMemoryCachePrimer.ts
+++ b/extensions/copilot/src/extension/tools/node/agentMemoryCachePrimer.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
+import { ILogService } from '../../../platform/log/common/logService';
+import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
+import { createServiceIdentifier } from '../../../util/common/services';
+import { IAgentMemoryService } from '../common/agentMemoryService';
+
+export interface IAgentMemoryCachePrimer {
+	readonly _serviceBrand: undefined;
+	/**
+	 * Called at the start of each new agent conversation. Fetches and caches the
+	 * /prompt response so that tool schema and instructions are available for rendering.
+	 */
+	primeCache(sessionId?: string): Promise<void>;
+}
+
+export const IAgentMemoryCachePrimer = createServiceIdentifier<IAgentMemoryCachePrimer>('IAgentMemoryCachePrimer');
+
+export class AgentMemoryCachePrimer implements IAgentMemoryCachePrimer {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExperimentationService private readonly experimentationService: IExperimentationService,
+		@IAgentMemoryService private readonly agentMemoryService: IAgentMemoryService,
+		@ILogService private readonly logService: ILogService,
+	) { }
+
+	async primeCache(sessionId?: string): Promise<void> {
+		const enabled = this.configurationService.getExperimentBasedConfig(ConfigKey.CopilotMemoryEnabled, this.experimentationService);
+		if (!enabled) {
+			return;
+		}
+		// Call with sessionId but let service auto-determine repoNwo to match original working behavior
+		const response = await this.agentMemoryService.getMemoryPrompt(undefined, sessionId);
+		this.logService.info(`[AgentMemoryToolRegistrar] primed memory prompt cache for session ${sessionId || 'default'}, definitionVersion=${response?.storeToolDefinition?.definitionVersion ?? 'none'}`);
+	}
+}

--- a/extensions/copilot/src/extension/tools/node/agentMemoryCachePrimer.ts
+++ b/extensions/copilot/src/extension/tools/node/agentMemoryCachePrimer.ts
@@ -37,6 +37,14 @@ export class AgentMemoryCachePrimer implements IAgentMemoryCachePrimer {
 		}
 		// Call with sessionId but let service auto-determine repoNwo to match original working behavior
 		const response = await this.agentMemoryService.getMemoryPrompt(undefined, sessionId);
-		this.logService.info(`[AgentMemoryToolRegistrar] primed memory prompt cache for session ${sessionId || 'default'}, definitionVersion=${response?.storeToolDefinition?.definitionVersion ?? 'none'}`);
+		if (!sessionId) {
+			this.logService.debug('[AgentMemoryCachePrimer] fetched memory prompt without caching because no sessionId was provided');
+			return;
+		}
+		if (!response) {
+			this.logService.debug(`[AgentMemoryCachePrimer] did not prime memory prompt cache for session ${sessionId} because no prompt response was returned`);
+			return;
+		}
+		this.logService.info(`[AgentMemoryCachePrimer] primed memory prompt cache for session ${sessionId}, definitionVersion=${response.storeToolDefinition?.definitionVersion ?? 'none'}`);
 	}
 }


### PR DESCRIPTION
## Summary

This PR is the first in a stack of three that implement user-scoped agent memories. It focuses on the caching layer and service infrastructure with no new user-facing behavior is introduced here.

**Changes:**

1. **`AgentMemoryService` — session-keyed cache + stampede guard**
   - `getMemoryPrompt()` now checks a per-session cache (`Map<sessionId, MemoryPromptResponse>`) before making a network request.
   - A second `_inflightPrompts: Map<string, Promise<MemoryPromptResponse | undefined>>` map deduplicates concurrent callers that arrive before the first response lands. Without this, multiple tools resolving in parallel on turn 0 would each fire a separate fetch.
   - Both maps are cleared when the chat session disposes (`onDidDisposeChatSession`).

2. **`AgentMemoryCachePrimer` — renamed from `AgentMemoryToolRegistrar`**
   - The old name implied it registered VS Code tools. It doesn't — it warms the memory cache before the first tool call. Renamed to reflect actual behavior:
     - File: `agentMemoryToolRegistrar.ts` → `agentMemoryCachePrimer.ts`
     - Interface: `IAgentMemoryToolRegistrar` → `IAgentMemoryCachePrimer`
     - Class: `AgentMemoryToolRegistrar` → `AgentMemoryCachePrimer`
     - Method: `registerMemoryTools()` → `primeCache()`
   - Registered in `services.ts` alongside `AgentMemoryService`.

3. **Test coverage** (`agentMemoryService.spec.ts`)
   - Cache hit: second call with same session ID returns cached value without a second fetch.
   - Stampede guard: two concurrent calls resolve to the same promise and produce one fetch.
   - Cache eviction: cache is cleared when the session disposes.

## What's NOT in this PR

- The `store_memory` tool and turn-0 fix are in PR2.
- The `MemoryContextPrompt` migration (CAPI coexistence) is in PR3.

## Test plan

- [ ] Confirm `AgentMemoryService` unit tests pass (`npm run test:unit`)
- [ ] Confirm no compilation errors in watch output
- [ ] Verify `AgentMemoryCachePrimer` import resolves correctly in `agentIntent.ts` (part of PR2/PR3 stack)