### PR TITLE
ci: switch PR workflows back to 1ES self-hosted runners with JobId

### DIFF
--- a/.github/workflows/pr-linux-cli-test.yml
+++ b/.github/workflows/pr-linux-cli-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linux-cli-test:
     name: ${{ inputs.job_name }}
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=linux-cli-test-${{ inputs.job_name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     env:
       RUSTUP_TOOLCHAIN: ${{ inputs.rustup_toolchain }}
     steps:

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   compile:
     name: Compile
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=compile-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     steps:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=linux-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     env:
       NPM_ARCH: x64
       VSCODE_ARCH: x64
@@ -219,7 +219,7 @@ jobs:
 
   windows:
     name: Windows
-    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64 ]
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64, "JobId=windows-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     env:
       NPM_ARCH: x64
       VSCODE_ARCH: x64

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   windows-test:
     name: ${{ inputs.job_name }}
-    runs-on: windows-2022
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64, "JobId=windows-test-${{ inputs.job_name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     env:
       ARTIFACT_NAME: ${{ (inputs.electron_tests && 'electron') || (inputs.browser_tests && 'browser') || (inputs.remote_tests && 'remote') || 'unknown' }}
       NPM_ARCH: x64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   compile:
     name: Compile & Hygiene
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=compile-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     steps:
       - name: Checkout microsoft/vscode
         uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
 
       - name: Create node_modules archive
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -82,7 +82,7 @@ jobs:
       - name: Compile & Hygiene
         run: npm exec -- npm-run-all2 -lp core-ci hygiene eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check test-build-scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
 
       - name: Check cyclic dependencies
         run: node build/lib/checkCyclicDependencies.ts out-build
@@ -159,7 +159,7 @@ jobs:
 
   copilot-check-test-cache:
     name: Copilot - Check Test Cache
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=copilot-check-test-cache-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     permissions:
       contents: read
       pull-requests: read
@@ -205,7 +205,7 @@ jobs:
 
   copilot-check-telemetry:
     name: Copilot - Check Telemetry
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=copilot-check-telemetry-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     permissions:
       contents: read
     steps:
@@ -224,7 +224,7 @@ jobs:
 
   copilot-linux-tests:
     name: Copilot - Test (Linux)
-    runs-on: ubuntu-22.04
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64, "JobId=copilot-linux-tests-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     permissions:
       contents: read
     steps:
@@ -329,7 +329,7 @@ jobs:
 
   copilot-windows-tests:
     name: Copilot - Test (Windows)
-    runs-on: windows-2022
+    runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64, "JobId=copilot-windows-tests-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" ]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-          GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
+          GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.VSCODE_OSS || secrets.GITHUB_TOKEN }}
 
       - name: Create node_modules archive
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -82,7 +82,7 @@ jobs:
       - name: Compile & Hygiene
         run: npm exec -- npm-run-all2 -lp core-ci hygiene eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check test-build-scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
+          GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.VSCODE_OSS || secrets.GITHUB_TOKEN }}
 
       - name: Check cyclic dependencies
         run: node build/lib/checkCyclicDependencies.ts out-build


### PR DESCRIPTION
## Summary

Re-applies #311975 (reverted in #312033). Switches PR workflow Ubuntu/Windows jobs back to the 1ES self-hosted pools and adds a per-run+attempt `JobId` label to scope each agent to a specific GitHub Actions run, preventing the intermittent 1ES cancellations seen previously.

This time, also wires the `pr.yml` compile job's `GITHUB_TOKEN` back to `secrets.VSCODE_OSS` (with the historical fork-aware fallback). On 1ES pools, the shared egress IPs hit the anonymous **60/hr** \`api.github.com\` rate limit during cross-repo release fetches (\`vscode-js-debug\`, \`vscode-js-debug-companion\`, \`vscode-js-profile-visualizer\`, …), producing 403 fan-out across PRs — that was the actual cause of the failures that triggered the previous revert, not 1ES itself.

<details>
<summary>Session Context</summary>

Investigation of the previous revert (#312033):

- **Root cause was GitHub API rate limiting, not auth/secret rotation.** Failed runs during the #311975 window logged \`status code: 403 (you may be rate limited)\` against \`api.github.com/repos/microsoft/vscode-js-*\`. \`secrets.GITHUB_TOKEN\` is repo-scoped and can't auth cross-repo, so \`build/lib/fetch.ts\` falls back to anonymous; on 1ES pools concurrent jobs share egress IPs and blow through the 60/hr anonymous limit immediately. GH-hosted runners didn't see this because each runner gets a fresh IP from a huge pool.
- **\`VSCODE_OSS\` already exists as a repo secret** (last rotated 2026-03-26) and is already used elsewhere in CI for the same cross-repo fetches — see \`pr-node-modules.yml\` (6 spots). No new secret needed.
- **Fork-aware conditional preserved.** Matches the pattern that existed in \`pr.yml\` before #255987 cleanup: \`head.repo.full_name == github.repository && secrets.VSCODE_OSS || secrets.GITHUB_TOKEN\`. Forks can't read org/repo secrets, so they fall back to the runner-issued token.
- **JobId label format unchanged from #311975:** \`JobId=<jobname>-\${{ github.run_id }}-\${{ github.run_number }}-\${{ github.run_attempt }}\`. Reusable workflows include \`inputs.job_name\` to disambiguate.

Pools (unchanged):
- \`1es-vscode-oss-ubuntu-22.04-x64\`
- \`1es-vscode-oss-windows-2022-x64\`

</details>

## Changes

- \`pr.yml\`: \`compile\`, \`copilot-check-test-cache\`, \`copilot-check-telemetry\`, \`copilot-linux-tests\`, \`copilot-windows-tests\` → 1ES + JobId. \`compile\` job's \`GITHUB_TOKEN\` switched to \`VSCODE_OSS\` (fork-conditional) on the \`Install dependencies\` and \`Compile & Hygiene\` steps.
- \`pr-linux-cli-test.yml\`, \`pr-win32-test.yml\`: reusable test workflows back on 1ES + JobId.
- \`pr-node-modules.yml\`: \`compile\`, \`linux\` back on 1ES + JobId; \`windows\` (already 1ES) gains JobId.

Note: \`pr-linux-test.yml\` is intentionally left on \`ubuntu-24.04\` — that move happened after #311975 to address a fontconfig SIGSEGV.

Closes follow-up to #312033.