### PR TITLE
Add availableModels to routerDecisionRestricted telemetry

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -183,6 +183,7 @@ export class RouterDecisionFetcher {
 				candidateModel: result.candidate_models?.[0] ?? '',
 				chosenModel: result.chosen_model ?? '',
 				candidateModels: JSON.stringify(result.candidate_models ?? []),
+				availableModels: JSON.stringify(availableModels),
 				stickyOverrideStr: String(result.sticky_override ?? false),
 				hydraScores: result.hydra_scores ? JSON.stringify(result.hydra_scores) : 'null',
 				binaryScores: JSON.stringify(result.scores),


### PR DESCRIPTION
Adds `availableModels` (JSON-stringified array) to the `automode.routerDecisionRestricted` enhanced telemetry event.

**What:** Logs the input model pool (`available_models`) that VS Code sends to the auto-mode router API. This is distinct from `candidateModels` which is the router's ranked output.

**Why:** Per-SKU CoGS analysis shows Enterprise has better cost savings than Pro/Pro+, but we can't determine the root cause without knowing whether CAPI sends different model pools per SKU. The router decision telemetry currently only logs what the router returns, not what it was given to choose from.

**Change:** 1 line addition in `routerDecisionFetcher.ts` -- adds `availableModels: JSON.stringify(availableModels)` to the restricted event properties dict.

**Depends on:**
- github/hydro-schemas#8605 (proto schema -- `available_models` ordinal 181)
- github/copilot-telemetry-service#1445 (protobuf mapping)