### PR TITLE
OTel: include tool parameters and emit tool definitions on child chat spans

### DIFF
--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -16,7 +16,7 @@ import { ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagemen
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -481,6 +481,12 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 			});
 			// Opt-in: capture input messages in OTel GenAI format
 			if (this._otelService.config.captureContent) {
+				// Tool definitions on the chat span (issue #299934) with `parameters`
+				// per OTel GenAI semantic conventions (issue #300318).
+				const toolDefs = toToolDefinitions(options.tools);
+				if (toolDefs) {
+					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs)));
+				}
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
 					const inputMsgs = messages.map(m => {

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -9,7 +9,7 @@ import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/comm
 import { ILogService } from '../../../platform/log/common/logService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -346,6 +346,12 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 			});
 			// Opt-in: capture input messages in OTel GenAI format
 			if (this._otelService.config.captureContent) {
+				// Tool definitions on the chat span (issue #299934) with `parameters`
+				// per OTel GenAI semantic conventions (issue #300318).
+				const toolDefs = toToolDefinitions(options.tools);
+				if (toolDefs) {
+					otelSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs)));
+				}
 				try {
 					const roleNames: Record<number, string> = { 1: 'user', 2: 'assistant', 3: 'system' };
 					const inputMsgs = messages.map(m => {

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -880,10 +880,17 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 								{ role: 'assistant', parts: [{ type: 'text', content: responseText }] }
 							])));
 						}
-						// Log tool definitions once on the agent span (same set across all turns)
+						// Log tool definitions once on the agent span (same set across all turns).
+						// Includes `parameters` (inputSchema) per OTel GenAI semantic convention so
+						// trace viewers can render full tool signatures (issue #300318).
 						if (result.availableTools.length > 0) {
 							span.setAttribute(GenAiAttr.TOOL_DEFINITIONS, JSON.stringify(
-								result.availableTools.map(t => ({ type: 'function', name: t.name, description: t.description }))
+								result.availableTools.map(t => ({
+									type: 'function',
+									name: t.name,
+									description: t.description,
+									parameters: t.inputSchema,
+								}))
 							));
 						}
 					}
@@ -1192,7 +1199,12 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		if (!this.toolsAvailableEmitted && this.agentSpan && availableTools.length > 0) {
 			this.toolsAvailableEmitted = true;
 			this.agentSpan.addEvent('tools_available', {
-				toolDefinitions: JSON.stringify(availableTools.map(t => ({ type: 'function', name: t.name, description: t.description }))),
+				toolDefinitions: JSON.stringify(availableTools.map(t => ({
+					type: 'function',
+					name: t.name,
+					description: t.description,
+					parameters: t.inputSchema,
+				}))),
 				...(this.chatSessionIdForTools ? { [CopilotChatAttr.CHAT_SESSION_ID]: this.chatSessionIdForTools } : {}),
 			});
 		}

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -884,14 +884,14 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 						// Includes `parameters` (inputSchema) per OTel GenAI semantic convention so
 						// trace viewers can render full tool signatures (issue #300318).
 						if (result.availableTools.length > 0) {
-							span.setAttribute(GenAiAttr.TOOL_DEFINITIONS, JSON.stringify(
+							span.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(
 								result.availableTools.map(t => ({
 									type: 'function',
 									name: t.name,
 									description: t.description,
 									parameters: t.inputSchema,
 								}))
-							));
+							)));
 						}
 					}
 					span.setStatus(SpanStatusCode.OK);
@@ -1199,12 +1199,12 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 		if (!this.toolsAvailableEmitted && this.agentSpan && availableTools.length > 0) {
 			this.toolsAvailableEmitted = true;
 			this.agentSpan.addEvent('tools_available', {
-				toolDefinitions: JSON.stringify(availableTools.map(t => ({
+				toolDefinitions: truncateForOTel(JSON.stringify(availableTools.map(t => ({
 					type: 'function',
 					name: t.name,
 					description: t.description,
 					parameters: t.inputSchema,
-				}))),
+				})))),
 				...(this.chatSessionIdForTools ? { [CopilotChatAttr.CHAT_SESSION_ID]: this.chatSessionIdForTools } : {}),
 			});
 		}

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -27,7 +27,7 @@ import { sendEngineMessagesTelemetry } from '../../../platform/networking/node/c
 import { CAPIWebSocketErrorEvent, IChatWebSocketManager, isCAPIWebSocketError } from '../../../platform/networking/node/chatWebSocketManager';
 import { sendCommunicationErrorTelemetry } from '../../../platform/networking/node/stream';
 import { ChatFailKind, ChatRequestCanceled, ChatRequestFailed, ChatResults, FetchResponseKind } from '../../../platform/openai/node/fetch';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, normalizeProviderMessages, StdAttr, toSystemInstructions, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, ISpanHandle, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { getCurrentCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -295,6 +295,13 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					if (capiMessages) {
 						// Normalize provider-specific content (Anthropic tool_use/tool_result, OpenAI tool messages) to OTel schema
 						otelInferenceSpan.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(normalizeProviderMessages(capiMessages))));
+					}
+					// Tool definitions: emit on every chat span so trace viewers can render the
+					// tool catalog per LLM call (issue #299934). Includes `parameters` per
+					// OTel GenAI semantic conventions (issue #300318).
+					const toolDefs = toToolDefinitions(requestBody.tools);
+					if (toolDefs) {
+						otelInferenceSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs)));
 					}
 				}
 				tokenCount = await countTokens();

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -225,9 +225,11 @@ export function normalizeProviderMessages(messages: ReadonlyArray<Record<string,
  * Accepts the variants emitted by the different request bodies/providers:
  * - OpenAI Chat Completions: `{ type: 'function', function: { name, description, parameters } }`
  * - OpenAI Responses API:    `{ type: 'function', name, description, parameters }`
- * - OpenAI tool search:      `{ type: 'tool_search', description, parameters }`
  * - Anthropic Messages API:  `{ name, description, input_schema }`
  * - VS Code tool info:       `{ name, description, inputSchema }`
+ *
+ * Tools without a name (e.g. OpenAI client-side `tool_search`) are skipped
+ * because OTel `gen_ai.tool.definitions` requires a name per entry.
  *
  * @see https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-tool-definitions
  */

--- a/extensions/copilot/src/platform/otel/common/messageFormatters.ts
+++ b/extensions/copilot/src/platform/otel/common/messageFormatters.ts
@@ -220,21 +220,43 @@ export function normalizeProviderMessages(messages: ReadonlyArray<Record<string,
 }
 
 /**
- * Convert tool definitions to OTel tool definition format.
+ * Convert tool definitions to OTel `gen_ai.tool.definitions` format.
+ *
+ * Accepts the variants emitted by the different request bodies/providers:
+ * - OpenAI Chat Completions: `{ type: 'function', function: { name, description, parameters } }`
+ * - OpenAI Responses API:    `{ type: 'function', name, description, parameters }`
+ * - OpenAI tool search:      `{ type: 'tool_search', description, parameters }`
+ * - Anthropic Messages API:  `{ name, description, input_schema }`
+ * - VS Code tool info:       `{ name, description, inputSchema }`
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-tool-definitions
  */
 export function toToolDefinitions(tools: ReadonlyArray<{
 	type?: string;
-	function?: { name: string; description?: string; parameters?: unknown };
+	name?: string;
+	description?: string;
+	parameters?: unknown;
+	input_schema?: unknown;
+	inputSchema?: unknown;
+	function?: { name?: string; description?: string; parameters?: unknown };
 }> | undefined): OTelToolDefinition[] | undefined {
 	if (!tools || tools.length === 0) {
 		return undefined;
 	}
-	return tools
-		.filter((t): t is typeof t & { function: NonNullable<typeof t['function']> } => !!t.function)
-		.map(t => ({
-			type: 'function' as const,
-			name: t.function.name,
-			description: t.function.description,
-			parameters: t.function.parameters,
-		}));
+	const out: OTelToolDefinition[] = [];
+	for (const t of tools) {
+		const name = t.function?.name ?? t.name;
+		if (!name) {
+			continue;
+		}
+		const description = t.function?.description ?? t.description;
+		const parameters = t.function?.parameters ?? t.parameters ?? t.input_schema ?? t.inputSchema;
+		out.push({
+			type: 'function',
+			name,
+			description,
+			parameters,
+		});
+	}
+	return out.length > 0 ? out : undefined;
 }

--- a/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
+++ b/extensions/copilot/src/platform/otel/common/test/messageFormatters.spec.ts
@@ -243,10 +243,53 @@ describe('toToolDefinitions', () => {
 	it('filters out tools without a function property', () => {
 		const result = toToolDefinitions([
 			{ type: 'function', function: { name: 'a' } },
-			{ type: 'function' }, // no function
+			{ type: 'function' }, // no function and no top-level name → skipped
 		]);
 		expect(result).toHaveLength(1);
 		expect(result![0].name).toBe('a');
+	});
+
+	it('flattens OpenAI Responses API tools (top-level name/parameters)', () => {
+		const result = toToolDefinitions([{
+			type: 'function',
+			name: 'searchCode',
+			description: 'Search the codebase',
+			parameters: { type: 'object', properties: { query: { type: 'string' } } },
+		}]);
+		expect(result).toEqual([{
+			type: 'function',
+			name: 'searchCode',
+			description: 'Search the codebase',
+			parameters: { type: 'object', properties: { query: { type: 'string' } } },
+		}]);
+	});
+
+	it('maps Anthropic input_schema → parameters', () => {
+		const result = toToolDefinitions([{
+			name: 'editFile',
+			description: 'Edit a file',
+			input_schema: { type: 'object', properties: { path: { type: 'string' } } },
+		}]);
+		expect(result).toEqual([{
+			type: 'function',
+			name: 'editFile',
+			description: 'Edit a file',
+			parameters: { type: 'object', properties: { path: { type: 'string' } } },
+		}]);
+	});
+
+	it('maps VS Code inputSchema → parameters', () => {
+		const result = toToolDefinitions([{
+			name: 'runInTerminal',
+			description: 'Run a command',
+			inputSchema: { type: 'object', properties: { command: { type: 'string' } } },
+		}]);
+		expect(result).toEqual([{
+			type: 'function',
+			name: 'runInTerminal',
+			description: 'Run a command',
+			parameters: { type: 'object', properties: { command: { type: 'string' } } },
+		}]);
 	});
 
 	it('returns undefined for empty array', () => {


### PR DESCRIPTION
Fixes #300318
Fixes #299934

## What

OTel `gen_ai.tool.definitions` for chat agent traces was missing two things:

1. **`parameters` (tool input schema)** — only `{ type, name, description }` was emitted, so trace viewers like the Aspire GenAI visualizer rendered tools with no parameter table.
2. **Tool definitions on child `chat {model}` spans** — only the root `invoke_agent` span carried the catalog, so a chat span on its own (e.g. when filtered/expanded in a viewer) appeared without tools even though the model was clearly invoking them.

## Changes

- `toolCallingLoop.ts`: agent root span attribute and `tools_available` event now include `parameters: tool.inputSchema`.
- `chatMLFetcher.ts`: each `chat {model}` child span sets `gen_ai.tool.definitions` from `requestBody.tools` (truncated for OTel attribute limits).
- BYOK `anthropicProvider.ts` / `geminiNativeProvider.ts`: same on their chat spans (gated by `captureContent`).
- `messageFormatters.ts` `toToolDefinitions` extended to normalize all tool variants we emit:
  - OpenAI Chat Completions `{ type: 'function', function: { name, description, parameters } }`
  - OpenAI Responses API `{ type: 'function', name, description, parameters }`
  - Anthropic Messages `{ name, description, input_schema }`
  - VS Code `{ name, description, inputSchema }`
- New unit tests for the additional shapes.

## Verification

End-to-end verified against a local Aspire dashboard with claude-haiku-4.5 (trace `9bb5af1f6353dad136b2879c999b2598`):

| Check | Span | Result |
|---|---|---|
| `parameters` rendered in tool table | `invoke_agent GitHub Copilot Chat` | ✅ `todoList * array<object>` shown |
| Tools tab populated on child span | `chat claude-haiku-4.5` | ✅ 63 definitions |
| `parameters` on child span too | `chat claude-haiku-4.5` | ✅ same parameter table |

Unit tests: 45/45 pass (`messageFormatters.spec.ts`, `genAiEvents.spec.ts`).
Typecheck: clean across `extensions/copilot`.

cc @JamesNK