### PR TITLE
Re-parse agent host history prompts to revive slash decorations

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -10,7 +10,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { foreground, listActiveSelectionForeground, registerColor, transparent } from '../../../../../platform/theme/common/colorRegistry.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { IProductService } from '../../../../../platform/product/common/productService.js';
-import { SessionType } from '../../common/chatSessionsService.js';
+import { isAgentHostTarget, SessionType } from '../../common/chatSessionsService.js';
 
 export enum AgentSessionProviders {
 	Local = SessionType.Local,
@@ -118,19 +118,10 @@ export function isFirstPartyAgentSessionProvider(provider: AgentSessionTarget): 
 }
 
 /**
- * Returns whether the given session type is an agent host target.
- * Matches the local agent host (`agent-host-*`) and remote agent hosts (`remote-*`).
- *
- * Note: The `remote-` prefix convention is established by
- * {@link RemoteAgentHostContribution} which generates session types as
- * `remote-{sanitizedAddress}-{provider}`. If future remote providers that
- * are NOT agent hosts need a different prefix, this function must be updated.
+ * Re-exported from `common/chatSessionsService.ts` so existing browser-layer
+ * callers keep working without changing imports.
  */
-export function isAgentHostTarget(target: string): boolean {
-	return target === AgentSessionProviders.AgentHostCopilot ||
-		target.startsWith('agent-host-') ||
-		target.startsWith('remote-');
-}
+export { isAgentHostTarget };
 
 export function getAgentCanContinueIn(provider: AgentSessionTarget): boolean {
 	switch (provider) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -49,9 +49,10 @@ import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IChatTransferService } from '../model/chatTransferService.js';
 import { chatSessionResourceToId, getChatSessionType, isUntitledChatSession, LocalChatSessionUri } from '../model/chatUri.js';
 import { ChatRequestVariableSet, IChatRequestVariableEntry, isPromptTextVariableEntry } from '../attachments/chatVariableEntries.js';
+import { IDynamicVariable } from '../attachments/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { ChatMessageRole, IChatMessage, ILanguageModelsService } from '../languageModels.js';
-import { ILanguageModelToolsService } from '../tools/languageModelToolsService.js';
+import { ILanguageModelToolsService, IToolAndToolSetEnablementMap } from '../tools/languageModelToolsService.js';
 import { ChatSessionOperationLog } from '../model/chatSessionOperationLog.js';
 import { IPromptsService } from '../promptSyntax/service/promptsService.js';
 import { AGENT_DEBUG_LOG_FILE_LOGGING_ENABLED_SETTING, TROUBLESHOOT_COMMAND_NAME, TROUBLESHOOT_SKILL_PATH, COPILOT_SKILL_URI_SCHEME } from '../promptSyntax/promptTypes.js';
@@ -117,6 +118,9 @@ class CancellableRequest implements IDisposable {
 		this._yieldRequested.set(false, undefined);
 	}
 }
+
+const EMPTY_REFERENCES: ReadonlyArray<IDynamicVariable> = Object.freeze([]);
+const EMPTY_TOOL_ENABLEMENT_MAP: IToolAndToolSetEnablementMap = new Map();
 
 export class ChatService extends Disposable implements IChatService {
 	declare _serviceBrand: undefined;
@@ -666,8 +670,8 @@ export class ChatService extends Disposable implements IChatService {
 			if (requestParser) {
 				try {
 					const parsed = requestParser.parseChatRequestWithReferences(
-						[],
-						new Map(),
+						EMPTY_REFERENCES,
+						EMPTY_TOOL_ENABLEMENT_MAP,
 						text,
 						location,
 						{ sessionType: chatSessionType, forcedAgent: agent, attachmentCapabilities: agent?.capabilities },

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -43,7 +43,7 @@ import { chatAgentLeader, ChatRequestAgentPart, ChatRequestAgentSubcommandPart, 
 import { ChatRequestParser } from '../requestParser/chatRequestParser.js';
 import { ChatMcpServersStarting, ChatPendingRequestChangeClassification, ChatPendingRequestChangeEvent, ChatPendingRequestChangeEventName, ChatRequestQueueKind, ChatSendResult, ChatSendResultQueued, ChatSendResultSent, ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatCompleteResponse, IChatDetail, IChatFollowup, IChatModelReference, IChatProgress, IChatQuestionAnswers, IChatSendRequestOptions, IChatSendRequestResponseState, IChatService, IChatSessionStartOptions, IChatUserActionEvent, ResponseModelState } from './chatService.js';
 import { ChatRequestTelemetry, ChatServiceTelemetry } from './chatServiceTelemetry.js';
-import { IChatSessionsService, localChatSessionType } from '../chatSessionsService.js';
+import { IChatSessionsService, isAgentHostTarget, localChatSessionType } from '../chatSessionsService.js';
 import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessionStore.js';
 import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IChatTransferService } from '../model/chatTransferService.js';
@@ -656,6 +656,39 @@ export class ChatService extends Disposable implements IChatService {
 			providedSession.dispose();
 		}));
 
+		// For agent host sessions (local `agent-host-*` and remote `remote-*`),
+		// re-run the request parser on restored history so that decorated parts
+		// (slash commands, prompt slash commands, agent mentions) are revived
+		// in the UI. Other contributed sessions still get a single text part.
+		const isAgentHostSession = isAgentHostTarget(chatSessionType);
+		const requestParser = isAgentHostSession ? this.instantiationService.createInstance(ChatRequestParser) : undefined;
+		const parseAgentHostHistoryPrompt = (text: string, agent: IChatAgentData | undefined): IParsedChatRequest => {
+			if (requestParser) {
+				try {
+					const parsed = requestParser.parseChatRequestWithReferences(
+						[],
+						new Map(),
+						text,
+						location,
+						{ sessionType: chatSessionType, forcedAgent: agent, attachmentCapabilities: agent?.capabilities },
+					);
+					if (parsed.parts.length > 0) {
+						return parsed;
+					}
+				} catch (e) {
+					this.logService.warn(`ChatService#loadRemoteSession: failed to re-parse historical prompt for ${chatSessionType}`, e);
+				}
+			}
+			return {
+				text,
+				parts: [new ChatRequestTextPart(
+					new OffsetRange(0, text.length),
+					{ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: text.length + 1 },
+					text
+				)]
+			};
+		};
+
 		let lastRequest: ChatRequestModel | undefined;
 		for (const message of providedSession.history) {
 			if (message.type === 'request') {
@@ -664,19 +697,11 @@ export class ChatService extends Disposable implements IChatService {
 				}
 
 				const requestText = message.prompt;
-
-				const parsedRequest: IParsedChatRequest = {
-					text: requestText,
-					parts: [new ChatRequestTextPart(
-						new OffsetRange(0, requestText.length),
-						{ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: requestText.length + 1 },
-						requestText
-					)]
-				};
 				const agent =
 					message.participant
 						? this.chatAgentService.getAgent(message.participant) // TODO(jospicer): Remove and always hardcode?
 						: this.chatAgentService.getAgent(chatSessionType);
+				const parsedRequest = parseAgentHostHistoryPrompt(requestText, agent);
 				const modeInfo = message.modeInstructions ? {
 					kind: ChatModeKind.Agent,
 					isBuiltin: message.modeInstructions.isBuiltin ?? false,
@@ -755,16 +780,8 @@ export class ChatService extends Disposable implements IChatService {
 					}
 
 					// Create a new request in the model
-					const requestText = prompt;
-					const parsedRequest: IParsedChatRequest = {
-						text: requestText,
-						parts: [new ChatRequestTextPart(
-							new OffsetRange(0, requestText.length),
-							{ startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: requestText.length + 1 },
-							requestText
-						)]
-					};
 					const agent = this.chatAgentService.getAgent(chatSessionType);
+					const parsedRequest = parseAgentHostHistoryPrompt(prompt, agent);
 					lastRequest = model.addRequest(parsedRequest, { variables: [] }, 0, undefined, agent);
 
 					// Reset progress tracking for the new turn

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -660,21 +660,18 @@ export class ChatService extends Disposable implements IChatService {
 			providedSession.dispose();
 		}));
 
-		// For agent host sessions (local `agent-host-*` and remote `remote-*`),
-		// re-run the request parser on restored history so that decorated parts
-		// (slash commands, prompt slash commands, agent mentions) are revived
-		// in the UI. Other contributed sessions still get a single text part.
 		const isAgentHostSession = isAgentHostTarget(chatSessionType);
 		const requestParser = isAgentHostSession ? this.instantiationService.createInstance(ChatRequestParser) : undefined;
 		const parseAgentHostHistoryPrompt = (text: string, agent: IChatAgentData | undefined): IParsedChatRequest => {
 			if (requestParser) {
 				try {
+					const sessionCapabilities = this.chatSessionService.getCapabilitiesForSessionType(chatSessionType);
 					const parsed = requestParser.parseChatRequestWithReferences(
 						EMPTY_REFERENCES,
 						EMPTY_TOOL_ENABLEMENT_MAP,
 						text,
 						location,
-						{ sessionType: chatSessionType, forcedAgent: agent, attachmentCapabilities: agent?.capabilities },
+						{ sessionType: chatSessionType, forcedAgent: agent, attachmentCapabilities: sessionCapabilities ?? agent?.capabilities },
 					);
 					if (parsed.parts.length > 0) {
 						return parsed;

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -183,6 +183,21 @@ export namespace SessionType {
 }
 
 /**
+ * Returns whether the given session type is an agent host target.
+ * Matches the local agent host (`agent-host-*`) and remote agent hosts (`remote-*`).
+ *
+ * Note: The `remote-` prefix convention is established by
+ * `RemoteAgentHostContribution` which generates session types as
+ * `remote-{sanitizedAddress}-{provider}`. If future remote providers that
+ * are NOT agent hosts need a different prefix, this function must be updated.
+ */
+export function isAgentHostTarget(target: string): boolean {
+	return target === SessionType.AgentHostCopilot ||
+		target.startsWith('agent-host-') ||
+		target.startsWith('remote-');
+}
+
+/**
  * The session type used for local agent chat sessions.
  */
 export const localChatSessionType = SessionType.Local;

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_host__forcedAgent___supportsPromptAttachments_revives__skill_as_prompt_slash_part.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_host__forcedAgent___supportsPromptAttachments_revives__skill_as_prompt_slash_part.0.snap
@@ -1,0 +1,33 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      name: "skill",
+      kind: "prompt"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 28
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 29
+      },
+      text: " plan run a quick plan",
+      kind: "text"
+    }
+  ],
+  text: "/skill plan run a quick plan"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_host__missing_forcedAgent_still_revives__skill_via_no-agent_branch.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_host__missing_forcedAgent_still_revives__skill_via_no-agent_branch.0.snap
@@ -1,0 +1,33 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      name: "skill",
+      kind: "prompt"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 28
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 29
+      },
+      text: " plan run a quick plan",
+      kind: "text"
+    }
+  ],
+  text: "/skill plan run a quick plan"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -227,6 +227,51 @@ suite('ChatRequestParser', () => {
 		return { id: 'agent', name: 'agent', extensionId: nullExtensionDescription.identifier, extensionVersion: undefined, publisherDisplayName: '', extensionDisplayName: '', extensionPublisherId: '', locations: [ChatAgentLocation.Chat], modes: [ChatModeKind.Ask], metadata: {}, slashCommands, disambiguation: [] } satisfies IChatAgentData;
 	};
 
+	test('agent host: forcedAgent + supportsPromptAttachments revives /skill as prompt slash part', async () => {
+		// Mirrors what AgentHostSessionHandler._parsePromptForHistory does
+		// when restoring a session: pass forcedAgent + capabilities + an
+		// empty references/tools map and expect a ChatRequestSlashPromptPart
+		// for /skill <name>.
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
+		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'skill');
+		instantiationService.stub(IPromptsService, promptsService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const forcedAgent = { ...getAgentWithSlashCommands([]), capabilities: { supportsPromptAttachments: true } } satisfies IChatAgentData;
+		const result = parser.parseChatRequestWithReferences(
+			[],
+			new Map(),
+			'/skill plan run a quick plan',
+			ChatAgentLocation.Chat,
+			{ sessionType: 'agent-host-copilot', forcedAgent, attachmentCapabilities: forcedAgent.capabilities },
+		);
+		await assertSnapshot(result);
+	});
+
+	test('agent host: missing forcedAgent still revives /skill via no-agent branch', async () => {
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		const promptsService = mockObject<IPromptsService>()({ _serviceBrand: undefined });
+		promptsService.isValidSlashCommandName.callsFake((command: string) => command === 'skill');
+		instantiationService.stub(IPromptsService, promptsService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequestWithReferences(
+			[],
+			new Map(),
+			'/skill plan run a quick plan',
+			ChatAgentLocation.Chat,
+			{ sessionType: 'agent-host-copilot' },
+		);
+		await assertSnapshot(result);
+	});
+
 	test('agent with subcommand after text', async () => {
 		const agentsService = mockObject<IChatAgentService>()({ _serviceBrand: undefined, hasToolsAgent: false, onDidChangeAgents: Event.None });
 		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);


### PR DESCRIPTION
When restoring an agent host session (local `agent-host-*` or remote `remote-*`), historical prompts were wrapped in a single `ChatRequestTextPart`, losing decorations for slash commands, prompt slash commands (e.g. `/skill`), and agent mentions.

## Changes

- **`chatServiceImpl.ts`**: For agent host sessions, re-run historical prompts through `ChatRequestParser` so decorated parts are revived in the UI. The parser is created once per session load and reused at both call sites (initial history replay and the streamed-progress branch). Falls back to a plain `ChatRequestTextPart` on parse failure or empty parse result.
- **`chatSessionsService.ts`**: Move `isAgentHostTarget` from the browser layer into common (where `ChatService` lives).
- **`agentSessions.ts`**: Re-export `isAgentHostTarget` from common so existing browser-layer callers keep working.
- **`chatRequestParser.test.ts`**: Two snapshot tests for `/skill` parsing — one with `forcedAgent + supportsPromptAttachments`, one with no `forcedAgent` (fallback path).

(Written by Copilot)