### PR TITLE
Filter non-deferred tools from Responses tool search output

### DIFF
--- a/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
+++ b/extensions/copilot/src/platform/endpoint/node/responsesApi.ts
@@ -122,10 +122,15 @@ export function createResponsesRequestBody(accessor: ServicesAccessor, options: 
 	const toolsMap = options.requestOptions?.tools
 		? new Map(options.requestOptions.tools.map(t => [t.function.name, t]))
 		: undefined;
+	const shouldLoadToolFromToolSearch = shouldDeferTools ? (name: string) => !toolDeferralService!.isNonDeferredTool(name) : undefined;
 
 	const body: IEndpointBody = {
 		model,
-		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, toolsMap, modeChanged),
+		...rawMessagesToResponseAPI(model, options.messages, ignoreStatefulMarker, webSocketStatefulMarker, {
+			toolsMap,
+			shouldLoadToolFromToolSearch,
+			modeChanged,
+		}),
 		stream: true,
 		tools: finalTools.length > 0 ? finalTools : undefined,
 		// Only a subset of completion post options are supported, and some
@@ -291,7 +296,14 @@ function resolveWebSocketStatefulMarker(accessor: ServicesAccessor, options: ICr
 	return wsManager.getStatefulMarker(options.conversationId);
 }
 
-function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined, toolsMap?: Map<string, OpenAiFunctionTool>, modeChanged: boolean = false): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
+interface RawMessagesToResponseAPIOptions {
+	readonly toolsMap?: Map<string, OpenAiFunctionTool>;
+	readonly shouldLoadToolFromToolSearch?: (name: string) => boolean;
+	readonly modeChanged?: boolean;
+}
+
+function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMessage[], ignoreStatefulMarker: boolean, webSocketStatefulMarker: string | undefined, options: RawMessagesToResponseAPIOptions = {}): { input: OpenAI.Responses.ResponseInputItem[]; previous_response_id?: string } {
+	const { toolsMap, shouldLoadToolFromToolSearch, modeChanged = false } = options;
 	const latestCompactionMessageIndex = getLatestCompactionMessageIndex(messages);
 	const latestCompactionMessage = latestCompactionMessageIndex !== undefined ? createCompactionRoundTripMessage(messages[latestCompactionMessageIndex]) : undefined;
 
@@ -389,7 +401,7 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
 							.filter(c => c.type === Raw.ChatCompletionContentPartKind.Text)
 							.map(c => c.text)
 							.join('');
-						const loadedTools = toolsMap ? buildToolSearchOutputTools(resultText, toolsMap) : [];
+						const loadedTools = toolsMap ? buildToolSearchOutputTools(resultText, toolsMap, shouldLoadToolFromToolSearch) : [];
 						for (const t of loadedTools) {
 							toolSearchLoadedTools.add(t.name);
 						}
@@ -437,13 +449,13 @@ function rawMessagesToResponseAPI(modelId: string, messages: readonly Raw.ChatMe
  * Converts a JSON array of tool names (from ToolSearchTool) into full tool definitions
  * for the tool_search_output. Falls back to an empty array on parse failure.
  */
-function buildToolSearchOutputTools(resultText: string, toolsMap: Map<string, OpenAiFunctionTool>): ToolSearchLoadedTool[] {
+function buildToolSearchOutputTools(resultText: string, toolsMap: Map<string, OpenAiFunctionTool>, shouldLoadToolFromToolSearch: ((name: string) => boolean) | undefined): ToolSearchLoadedTool[] {
 	let toolNames: unknown;
 	try { toolNames = JSON.parse(resultText); } catch { return []; }
 	if (!Array.isArray(toolNames)) { return []; }
 
 	return toolNames
-		.filter((name): name is string => typeof name === 'string' && name !== CUSTOM_TOOL_SEARCH_NAME && toolsMap.has(name))
+		.filter((name): name is string => typeof name === 'string' && name !== CUSTOM_TOOL_SEARCH_NAME && toolsMap.has(name) && shouldLoadToolFromToolSearch?.(name) === true)
 		.map(name => {
 			const tool = toolsMap.get(name)!;
 			return {

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -8,10 +8,14 @@ import type { OpenAI } from 'openai';
 import { describe, expect, it } from 'vitest';
 import { TokenizerType } from '../../../../util/common/tokenizer';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
+import { ChatLocation } from '../../../chat/common/commonTypes';
+import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
+import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
 import { ILogService } from '../../../log/common/logService';
 import { isOpenAIContextManagementResponse } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
 import { openAIContextManagementCompactionType, OpenAIContextManagementResponse } from '../../../networking/common/openai';
+import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
 import { IChatWebSocketManager, NullChatWebSocketManager } from '../../../networking/node/chatWebSocketManager';
 import { TelemetryData } from '../../../telemetry/common/telemetryData';
 import { SpyingTelemetryService } from '../../../telemetry/node/spyingTelemetryService';
@@ -95,6 +99,16 @@ const createCompactionAssistantMessage = (compaction: OpenAIContextManagementRes
 		}
 	}]
 });
+
+type ResponseFunctionCallInputItem = OpenAI.Responses.ResponseInputItem & {
+	type: 'function_call';
+	name: string;
+	namespace?: string;
+};
+
+function isFunctionCallInputItem(item: OpenAI.Responses.ResponseInputItem, name: string): item is ResponseFunctionCallInputItem {
+	return item.type === 'function_call' && 'name' in item && item.name === name;
+}
 
 describe('responseApiInputToRawMessagesForLogging', () => {
 
@@ -756,11 +770,15 @@ describe('createResponsesRequestBody', () => {
 
 	it('adds namespace field only to function_call for tools loaded via tool_search_output', () => {
 		const services = createPlatformServices();
+		services.define(IToolDeferralService, { _serviceBrand: undefined, isNonDeferredTool: (name: string) => name === 'read_file' || name === 'tool_search' });
 		const accessor = services.createTestingAccessor();
 		const instantiationService = accessor.get(IInstantiationService);
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+		const endpoint = { ...testEndpoint, model: 'gpt-5.4-preview', family: 'gpt-5.4-preview' };
 		const tools = [
 			{ type: 'function' as const, function: { name: 'tool_search', description: 'Search tools', parameters: {} } },
-			{ type: 'function' as const, function: { name: 'grep_search', description: 'Grep files', parameters: {} } },
+			{ type: 'function' as const, function: { name: 'some_mcp_tool', description: 'MCP tool', parameters: {} } },
 			{ type: 'function' as const, function: { name: 'read_file', description: 'Read a file', parameters: {} } },
 		];
 		const messages: Raw.ChatMessage[] = [
@@ -774,32 +792,34 @@ describe('createResponsesRequestBody', () => {
 				content: [],
 				toolCalls: [{ id: 'ts_1', type: 'function', function: { name: 'tool_search', arguments: '{"query":"search"}' } }],
 			},
-			// tool_search returns grep_search
+			// tool_search returns some_mcp_tool
 			{
 				role: Raw.ChatRole.Tool,
-				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: '["grep_search"]' }],
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: '["some_mcp_tool"]' }],
 				toolCallId: 'ts_1',
 			},
-			// Assistant calls grep_search (loaded via tool_search) and read_file (not loaded via tool_search)
+			// Assistant calls some_mcp_tool (loaded via tool_search) and read_file (not loaded via tool_search)
 			{
 				role: Raw.ChatRole.Assistant,
 				content: [],
 				toolCalls: [
-					{ id: 'call_grep', type: 'function', function: { name: 'grep_search', arguments: '{"q":"hello"}' } },
+					{ id: 'call_mcp', type: 'function', function: { name: 'some_mcp_tool', arguments: '{"q":"hello"}' } },
 					{ id: 'call_read', type: 'function', function: { name: 'read_file', arguments: '{"path":"foo.ts"}' } },
 				],
 			},
 		];
 
-		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, { ...createRequestOptions(messages, false), requestOptions: { tools } }, testEndpoint.model, testEndpoint));
+		const body = instantiationService.invokeFunction(servicesAccessor => createResponsesRequestBody(servicesAccessor, { ...createRequestOptions(messages, false), location: ChatLocation.Agent, requestOptions: { tools } }, endpoint.model, endpoint));
 
-		// grep_search was loaded via tool_search_output — should have namespace
-		const grepCall = (body.input as unknown[]).find((item: any) => item.type === 'function_call' && item.name === 'grep_search') as any;
-		expect(grepCall).toBeDefined();
-		expect(grepCall.namespace).toBe('grep_search');
+		const input = body.input as OpenAI.Responses.ResponseInputItem[];
+
+		// some_mcp_tool was loaded via tool_search_output — should have namespace
+		const mcpCall = input.find(item => isFunctionCallInputItem(item, 'some_mcp_tool'));
+		expect(mcpCall).toBeDefined();
+		expect(mcpCall?.namespace).toBe('some_mcp_tool');
 
 		// read_file was NOT loaded via tool_search — should NOT have namespace
-		const readCall = (body.input as unknown[]).find((item: any) => item.type === 'function_call' && item.name === 'read_file') as any;
+		const readCall = input.find(item => isFunctionCallInputItem(item, 'read_file'));
 		expect(readCall).toBeDefined();
 		expect(readCall).not.toHaveProperty('namespace');
 

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -10,7 +10,7 @@ import { IInstantiationService } from '../../../../util/vs/platform/instantiatio
 import { ChatLocation } from '../../../chat/common/commonTypes';
 import { ConfigKey, IConfigurationService } from '../../../configuration/common/configurationService';
 import { InMemoryConfigurationService } from '../../../configuration/test/common/inMemoryConfigurationService';
-import { IResponseDelta } from '../../../networking/common/fetch';
+import { IResponseDelta, OpenAiFunctionTool } from '../../../networking/common/fetch';
 import { IChatEndpoint, ICreateEndpointBodyOptions } from '../../../networking/common/networking';
 import { IToolDeferralService } from '../../../networking/common/toolDeferralService';
 import { TelemetryData } from '../../../telemetry/common/telemetryData';
@@ -64,6 +64,17 @@ function createMockOptions(overrides: Partial<ICreateEndpointBodyOptions> = {}):
 	} as ICreateEndpointBodyOptions;
 }
 
+function createFunctionTool(name: string, description: string, properties: Record<string, object>, required: string[] = []): OpenAiFunctionTool {
+	return {
+		type: 'function',
+		function: {
+			name,
+			description,
+			parameters: { type: 'object', properties, ...(required.length ? { required } : {}) }
+		}
+	};
+}
+
 describe('createResponsesRequestBody tools', () => {
 	let disposables: DisposableStore;
 	let services: ReturnType<typeof createPlatformServices>;
@@ -79,6 +90,28 @@ describe('createResponsesRequestBody tools', () => {
 		services.define(IToolDeferralService, { _serviceBrand: undefined, isNonDeferredTool: (name: string) => coreNonDeferred.has(name) });
 		accessor = services.createTestingAccessor();
 	});
+
+	function createToolSearchScenario(messages: Raw.ChatMessage[]) {
+		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
+		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
+
+		const options = createMockOptions({
+			messages,
+			requestOptions: {
+				tools: [
+					createFunctionTool('file_search', 'Find files', { query: { type: 'string' } }, ['query']),
+					createFunctionTool('read_file', 'Read a file', { path: { type: 'string' } }, ['path']),
+					createFunctionTool('some_mcp_tool', 'An MCP tool', { input: { type: 'string' } }, ['input']),
+					createFunctionTool('tool_search', 'Search tools', { query: { type: 'string' } }, ['query']),
+				]
+			}
+		});
+
+		return accessor.get(IInstantiationService).invokeFunction(
+			createResponsesRequestBody, options, endpoint.model, endpoint
+		);
+	}
 
 	it('passes tools through without defer_loading when tool search disabled', () => {
 		const endpoint = createMockEndpoint('gpt-5.4-preview');
@@ -238,9 +271,9 @@ describe('createResponsesRequestBody tools', () => {
 		expect(toolSearchOutput.execution).toBe('client');
 		expect(toolSearchOutput.call_id).toBe('call_ts1');
 
-		// tool_search_output should not include tool_search itself in loaded tools
+		// No tools are currently deferred, so historical tool_search_output should not redeclare them.
 		const loadedToolNames = (toolSearchOutput.tools as any[]).map((t: any) => t.name);
-		expect(loadedToolNames).not.toContain('tool_search');
+		expect(loadedToolNames).toEqual([]);
 
 		// Should not have any function_call with name tool_search
 		const badFunctionCall = input.find(i => i.type === 'function_call' && i.name === 'tool_search');
@@ -281,6 +314,70 @@ describe('createResponsesRequestBody tools', () => {
 			tools: [],
 		});
 		expect(input.find(i => i.type === 'function_call' && i.name === 'tool_search')).toBeUndefined();
+	});
+
+	it('excludes non-deferred tools from tool_search_output history', () => {
+		const messages: Raw.ChatMessage[] = [
+			{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Find file tools' }] },
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [],
+				toolCalls: [{ id: 'call_ts_file', type: 'function', function: { name: 'tool_search', arguments: '{"query":"file tools"}' } }],
+			},
+			{
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'call_ts_file',
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: '["file_search","some_mcp_tool"]' }],
+			},
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [],
+				toolCalls: [
+					{ id: 'call_file', type: 'function', function: { name: 'file_search', arguments: '{"query":"*.ts"}' } },
+					{ id: 'call_mcp', type: 'function', function: { name: 'some_mcp_tool', arguments: '{"input":"x"}' } },
+				],
+			},
+		];
+
+		const body = createToolSearchScenario(messages);
+
+		const input = body.input as Array<{ type?: string; name?: string; namespace?: string; tools?: Array<{ name: string }> }>;
+		const toolSearchOutput = input.find(i => i.type === 'tool_search_output');
+		const fileSearchCall = input.find(i => i.type === 'function_call' && i.name === 'file_search');
+		const mcpToolCall = input.find(i => i.type === 'function_call' && i.name === 'some_mcp_tool');
+
+		expect({
+			loadedToolNames: toolSearchOutput?.tools?.map(t => t.name),
+			fileSearchNamespace: fileSearchCall?.namespace,
+			mcpToolNamespace: mcpToolCall?.namespace,
+		}).toEqual({
+			loadedToolNames: ['some_mcp_tool'],
+			fileSearchNamespace: undefined,
+			mcpToolNamespace: 'some_mcp_tool',
+		});
+	});
+
+	it('does not load tools from tool_search_output when only non-deferred tools are returned', () => {
+		const messages: Raw.ChatMessage[] = [
+			{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Find core tools' }] },
+			{
+				role: Raw.ChatRole.Assistant,
+				content: [],
+				toolCalls: [{ id: 'call_ts_core', type: 'function', function: { name: 'tool_search', arguments: '{"query":"core tools"}' } }],
+			},
+			{
+				role: Raw.ChatRole.Tool,
+				toolCallId: 'call_ts_core',
+				content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: '["file_search","read_file"]' }],
+			},
+		];
+
+		const body = createToolSearchScenario(messages);
+
+		const input = body.input as Array<{ type?: string; tools?: Array<{ name: string }> }>;
+		const toolSearchOutput = input.find(i => i.type === 'tool_search_output');
+
+		expect(toolSearchOutput?.tools?.map(t => t.name)).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
Addresses #312622

Prevents non-deferred tools from being re-declared in Responses API tool_search_output history. These tools are already available in the top-level tools list, and reloading file_search there can collide with non deferred tool name.

Adds regression coverage for file_search returned by tool_search.