### PR TITLE
Fix fish shell integration nonce being scoped to if-block

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
@@ -103,7 +103,7 @@ end
 
 # Handle the shell integration nonce
 if set -q VSCODE_NONCE
-	set -l __vsc_nonce $VSCODE_NONCE
+	set -g __vsc_nonce $VSCODE_NONCE
 	set -e VSCODE_NONCE
 end
 


### PR DESCRIPTION
## Summary

Fixes "Rerun Command" decoration always falling back to the confirmation dialog on fish, because the nonce check fails.

## Root cause

In \`src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish\`:

\`\`\`fish
if set -q VSCODE_NONCE
    set -l __vsc_nonce \$VSCODE_NONCE   # local scope = if-block only
    set -e VSCODE_NONCE
end
\`\`\`

\`set -l\` scopes the variable to the current block (the \`if\`), so by the time \`__vsc_cmd_executed\` (\`--on-event fish_preexec\`) and \`__vsc_cmd_clear\` (\`--on-event fish_cancel\`) reference \`\$__vsc_nonce\`, it is empty.

The bash, zsh and PowerShell integrations all keep the nonce script-global:
- \`shellIntegration-bash.sh\`: \`__vsc_nonce="\$VSCODE_NONCE"\`
- \`shellIntegration-rc.zsh\`: \`__vsc_nonce="\$VSCODE_NONCE"\`
- \`shellIntegration.ps1\`: \`\$Global:__VSCodeState.Nonce = \$env:VSCODE_NONCE\`

## Fix

Use \`set -g\` so the nonce is global like the other integrations.

cc @Tyriar — your code pointer in #183972 (originally lines 64-68, now 105-108) was on the dot.

## Test plan

- [ ] Open fish in the terminal, run any command
- [ ] Click the blue circle → "Rerun Command"
- [ ] Command runs immediately (no confirmation dialog)

Fixes #183972