### PR TITLE
Fix cd to recent directory failing on PowerShell paths with spaces

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
@@ -10,6 +10,7 @@ import { ITextModelContentProvider, ITextModelService } from '../../../../../edi
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputButton, IQuickInputButtonWithToggle, IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickInputButtonLocation } from '../../../../../platform/quickinput/common/quickInput.js';
+import { GeneralShellType } from '../../../../../platform/terminal/common/terminal.js';
 import { ITerminalCommand, TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { collapseTildePath } from '../../../../../platform/terminal/common/terminalEnvironment.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
@@ -352,7 +353,15 @@ export async function showRunRecentQuickPick(
 		const result = quickPick.activeItems[0];
 		let text: string;
 		if (type === 'cwd') {
-			text = `cd ${await instance.preparePathForShell(result.rawLabel)}`;
+			// preparePathForShell returns the PowerShell call-operator form
+			// `& '...'` for paths with spaces or quotes, which is meant for
+			// invoking executables — not for use as an argument to `cd`.
+			// Quote the path directly here for PowerShell. See #232258.
+			if (instance.shellType === GeneralShellType.PowerShell) {
+				text = `cd '${result.rawLabel.replace(/'/g, '\'\'')}'`;
+			} else {
+				text = `cd ${await instance.preparePathForShell(result.rawLabel)}`;
+			}
 		} else { // command
 			text = result.rawLabel;
 		}


### PR DESCRIPTION
## Summary

In the terminal "Go to Recent Directory" (Ctrl+G) quickpick, selecting a PowerShell path with spaces produced an invalid command like \`cd & 'C:\path with space\'\` which PowerShell could not execute.

## Root cause

\`terminalRunRecentQuickPick.ts\` line 355 builds the command as:

\`\`\`ts
text = \`cd \${await instance.preparePathForShell(result.rawLabel)}\`;
\`\`\`

\`preparePathForShell\` (in \`terminalEnvironment.ts\`) returns PowerShell's **call-operator** form \`& '...'\` for paths with spaces or quotes — that form is meant for **invoking executables**, not as an argument. So the result becomes \`cd & 'C:\path with space\'\` which PowerShell interprets as garbage.

\`preparePathForShell\` is also used by \`sendPath\` (in \`terminalInstance.ts\`) where the call-operator form is correct (the path is being invoked). The bug is that one caller uses the result as an argument.

## Fix

Special-case PowerShell in the cwd quickpick branch and build \`cd '...'\` directly with PowerShell's single-quote escape rules (doubling embedded single quotes — the same escaping \`preparePathForShell\` uses on its quoted output). Single-file change, leaves \`preparePathForShell\` semantics intact for its other use sites.

## Test plan

- [ ] In PowerShell terminal, cd into multiple folders including one with spaces (e.g. \`Program Files\`)
- [ ] Press Ctrl+G, select the path with spaces → \`cd 'C:\Program Files'\` runs successfully
- [ ] Same with paths containing single quotes (escaped to \`''\`)
- [ ] Bash/zsh/fish unaffected (still go through \`preparePathForShell\`)

cc @Tyriar — you reopened this issue after the duplicate close. cc @albertosantini — your investigation pointed at the exact lines.

Fixes #232258