### PR TITLE
Fix deleting sub-session when it is not active

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -2377,10 +2377,25 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		const removedData: ICopilotChatSession[] = [];
 		for (const [key, adapter] of this._sessionCache) {
 			if (!currentKeys.has(key) && adapter instanceof AgentSessionAdapter) {
-				this._sessionCache.delete(key);
 				removedData.push(adapter);
 				cacheChanged = true;
 			}
+		}
+
+		// Resolve group IDs for removed sessions BEFORE removing them from the
+		// cache and invalidating grouping caches, so that child sessions are
+		// correctly mapped to their parent group.
+		let removedGroupIds: Map<ICopilotChatSession, string> | undefined;
+		if (removedData.length > 0 && this._isMultiChatEnabled()) {
+			removedGroupIds = new Map();
+			for (const removed of removedData) {
+				removedGroupIds.set(removed, this._getGroupIdForChat(removed));
+			}
+		}
+
+		// Now remove from cache and invalidate grouping caches
+		for (const removed of removedData) {
+			this._sessionCache.delete(removed.resource.toString());
 		}
 
 		if (cacheChanged) {
@@ -2389,7 +2404,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		if (addedData.length > 0 || removedData.length > 0 || changedData.length > 0) {
 			if (this._isMultiChatEnabled()) {
-				this._refreshSessionCacheMultiChat(addedData, removedData, changedData);
+				this._refreshSessionCacheMultiChat(addedData, removedData, changedData, removedGroupIds!);
 			} else {
 				this._onDidChangeSessions.fire({
 					added: addedData.map(d => this._chatToSession(d)),
@@ -2404,12 +2419,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		addedData: ICopilotChatSession[],
 		removedData: ICopilotChatSession[],
 		changedData: ICopilotChatSession[],
+		removedGroupIds: Map<ICopilotChatSession, string>,
 	): void {
-		// Track session group IDs for removed chats before they leave the cache
-		const removedGroupIds = new Map<ICopilotChatSession, string>();
-		for (const removed of removedData) {
-			removedGroupIds.set(removed, this._getGroupIdForChat(removed));
-		}
 
 		// Handle removed chats: if a removed chat belongs to a group with
 		// remaining siblings, treat it as a changed event on the parent session


### PR DESCRIPTION
When a child chat in a multi-chat group was removed, `_refreshSessionCache` would first remove it from `_sessionCache` and invalidate grouping caches. Then `_refreshSessionCacheMultiChat` would try to resolve the removed chat's group ID, but since the caches were already rebuilt without the removed chat, `_getGroupIdForChat` fell back to the chat's own ID instead of the parent group's ID.

This caused the child to be treated as a "truly removed" standalone session rather than a group membership change, so no "changed" event was fired for the parent group — which could result in the main session being incorrectly removed.

**Fix:** Resolve group IDs for removed sessions **before** removing them from the cache and invalidating grouping caches, then pass the pre-computed map to `_refreshSessionCacheMultiChat`.

Fixes #311987