### PR TITLE
Fix deleting forked session showing wrong confirmation dialog

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -1464,18 +1464,22 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		}
 
 		const chatIds = this._getChatIdsInGroup(sessionId);
-		if (chatIds.length <= 1) {
-			// Only one chat — delete the entire session
-			return this.deleteSession(sessionId);
-		}
 
-		// Find the chat matching the URI
+		// Find the chat matching the URI first, before deciding whether to
+		// delete the entire session. This prevents accidentally deleting the
+		// whole session when the grouping cache is stale and chatIds doesn't
+		// include the chat being closed.
 		const chatId = chatIds.find(id => {
 			const chat = this._sessionCache.get(this._localIdFromchatId(id));
 			return chat && chat.resource.toString() === chatUri.toString();
 		});
 		if (!chatId) {
 			return;
+		}
+
+		if (chatIds.length <= 1) {
+			// This is the only chat in the session — delete the entire session
+			return this.deleteSession(sessionId);
 		}
 
 		// Delete the underlying agent session first.


### PR DESCRIPTION
When clicking X on a sub-session tab, `deleteChat` checks `chatIds.length <= 1` before finding the specific chat by URI. If the grouping cache doesn't include the forked chat (e.g. due to stale `sessionParentId` metadata), `_getChatIdsInGroup` returns only the main chat. The `chatIds.length <= 1` check then falls through to `deleteSession`, which shows "delete this session?" and deletes the entire session including the worktree.

**Fix:** Find the specific chat by URI first, then check if it's the last chat. Only fall through to `deleteSession` if the chat IS found AND it's the last one. If the chat isn't in the current grouping result, return early instead of accidentally deleting the whole session.

Fixes #313148