### PR TITLE
Revert Copilot CLI bump to 1.0.38 on main

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -13,7 +13,7 @@
 				"@anthropic-ai/claude-agent-sdk": "0.2.112",
 				"@anthropic-ai/sdk": "^0.82.0",
 				"@github/blackbird-external-ingest-utils": "^0.3.0",
-				"@github/copilot": "^1.0.38",
+				"@github/copilot": "^1.0.34",
 				"@google/genai": "^1.22.0",
 				"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 				"@microsoft/tiktokenizer": "^1.0.10",

--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -13,7 +13,7 @@
 				"@anthropic-ai/claude-agent-sdk": "0.2.112",
 				"@anthropic-ai/sdk": "^0.82.0",
 				"@github/blackbird-external-ingest-utils": "^0.3.0",
-				"@github/copilot": "^1.0.34",
+				"@github/copilot": "1.0.34",
 				"@google/genai": "^1.22.0",
 				"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 				"@microsoft/tiktokenizer": "^1.0.10",
@@ -3202,26 +3202,26 @@
 			"license": "MIT"
 		},
 		"node_modules/@github/copilot": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
-			"integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
+			"integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"bin": {
 				"copilot": "npm-loader.js"
 			},
 			"optionalDependencies": {
-				"@github/copilot-darwin-arm64": "1.0.38",
-				"@github/copilot-darwin-x64": "1.0.38",
-				"@github/copilot-linux-arm64": "1.0.38",
-				"@github/copilot-linux-x64": "1.0.38",
-				"@github/copilot-win32-arm64": "1.0.38",
-				"@github/copilot-win32-x64": "1.0.38"
+				"@github/copilot-darwin-arm64": "1.0.34",
+				"@github/copilot-darwin-x64": "1.0.34",
+				"@github/copilot-linux-arm64": "1.0.34",
+				"@github/copilot-linux-x64": "1.0.34",
+				"@github/copilot-win32-arm64": "1.0.34",
+				"@github/copilot-win32-x64": "1.0.34"
 			}
 		},
 		"node_modules/@github/copilot-darwin-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
-			"integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
+			"integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3235,9 +3235,9 @@
 			}
 		},
 		"node_modules/@github/copilot-darwin-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
-			"integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
+			"integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
 			"cpu": [
 				"x64"
 			],
@@ -3251,9 +3251,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
-			"integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
+			"integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3267,9 +3267,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
-			"integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
+			"integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
 			"cpu": [
 				"x64"
 			],
@@ -3283,9 +3283,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
-			"integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
+			"integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3299,9 +3299,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
-			"integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
+			"integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
 			"cpu": [
 				"x64"
 			],

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6551,7 +6551,7 @@
 		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@github/blackbird-external-ingest-utils": "^0.3.0",
-		"@github/copilot": "^1.0.34",
+		"@github/copilot": "1.0.34",
 		"@google/genai": "^1.22.0",
 		"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 		"@microsoft/tiktokenizer": "^1.0.10",

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -6551,7 +6551,7 @@
 		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@github/blackbird-external-ingest-utils": "^0.3.0",
-		"@github/copilot": "^1.0.38",
+		"@github/copilot": "^1.0.34",
 		"@google/genai": "^1.22.0",
 		"@humanwhocodes/gitignore-to-minimatch": "1.0.2",
 		"@microsoft/tiktokenizer": "^1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.34",
+        "@github/copilot": "1.0.34",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.38",
+        "@github/copilot": "^1.0.34",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -1072,26 +1072,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
-      "integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
+      "integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.38",
-        "@github/copilot-darwin-x64": "1.0.38",
-        "@github/copilot-linux-arm64": "1.0.38",
-        "@github/copilot-linux-x64": "1.0.38",
-        "@github/copilot-win32-arm64": "1.0.38",
-        "@github/copilot-win32-x64": "1.0.38"
+        "@github/copilot-darwin-arm64": "1.0.34",
+        "@github/copilot-darwin-x64": "1.0.34",
+        "@github/copilot-linux-arm64": "1.0.34",
+        "@github/copilot-linux-x64": "1.0.34",
+        "@github/copilot-win32-arm64": "1.0.34",
+        "@github/copilot-win32-x64": "1.0.34"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
-      "integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
+      "integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
-      "integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
+      "integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
       "cpu": [
         "x64"
       ],
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
-      "integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
+      "integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
       "cpu": [
         "arm64"
       ],
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
-      "integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
+      "integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
       "cpu": [
         "x64"
       ],
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
-      "integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
+      "integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
       "cpu": [
         "arm64"
       ],
@@ -1192,9 +1192,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
-      "integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
+      "integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.34",
+    "@github/copilot": "1.0.34",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.38",
+    "@github/copilot": "^1.0.34",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.34",
+        "@github/copilot": "1.0.34",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.49",
-        "@github/copilot": "^1.0.38",
+        "@github/copilot": "^1.0.34",
         "@github/copilot-sdk": "^0.2.2",
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
@@ -81,26 +81,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
-      "integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
+      "integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.38",
-        "@github/copilot-darwin-x64": "1.0.38",
-        "@github/copilot-linux-arm64": "1.0.38",
-        "@github/copilot-linux-x64": "1.0.38",
-        "@github/copilot-win32-arm64": "1.0.38",
-        "@github/copilot-win32-x64": "1.0.38"
+        "@github/copilot-darwin-arm64": "1.0.34",
+        "@github/copilot-darwin-x64": "1.0.34",
+        "@github/copilot-linux-arm64": "1.0.34",
+        "@github/copilot-linux-x64": "1.0.34",
+        "@github/copilot-win32-arm64": "1.0.34",
+        "@github/copilot-win32-x64": "1.0.34"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
-      "integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
+      "integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
-      "integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
+      "integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
       "cpu": [
         "x64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
-      "integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
+      "integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
-      "integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
+      "integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
       "cpu": [
         "x64"
       ],
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
-      "integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
+      "integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
       "cpu": [
         "arm64"
       ],
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
-      "integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
+      "integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
       "cpu": [
         "x64"
       ],

--- a/remote/package.json
+++ b/remote/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.34",
+    "@github/copilot": "1.0.34",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",

--- a/remote/package.json
+++ b/remote/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.49",
-    "@github/copilot": "^1.0.38",
+    "@github/copilot": "^1.0.34",
     "@github/copilot-sdk": "^0.2.2",
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",


### PR DESCRIPTION
Reverts the `@github/copilot` 1.0.34 → 1.0.38 bump on `main` to match `release/1.118`.

Insiders is broken: 1.0.38 of the Copilot CLI breaks tool dispatch / permission prompts ("Permission denied and could not request permission from user"). The release branch has already been reverted via #313125; this brings `main` to the same state.

Two reverts are needed because the bump landed on main in two PRs:
- #312954 (cherry-pick from release) — bumped `extensions/copilot`. Revert is the cherry-pick of #313125.
- #313073 (main-only) — bumped root + remote `package.json` for the agents agent host. Reverted directly here.

After this PR all three consumers (`extensions/copilot`, root, `remote/`) are pinned at `^1.0.34`, matching `release/1.118`.

cc @rebornix @DonJayamanne @alexdima
