### PR TITLE
Support packageManager field in package.json for npm task detection

### DIFF
--- a/extensions/npm/src/preferred-pm.ts
+++ b/extensions/npm/src/preferred-pm.ts
@@ -23,6 +23,40 @@ async function pathExists(filePath: string) {
 	return true;
 }
 
+const SUPPORTED_PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+
+async function readPackageManagerField(packageJsonPath: string): Promise<string | undefined> {
+	try {
+		const bytes = await workspace.fs.readFile(Uri.file(packageJsonPath));
+		const json = JSON.parse(new TextDecoder().decode(bytes));
+		const value = json?.packageManager;
+		if (typeof value !== 'string') {
+			return undefined;
+		}
+		// Corepack format: "<name>@<version>[+<hash>]"
+		const name = value.split('@', 1)[0].trim();
+		return SUPPORTED_PACKAGE_MANAGERS.has(name) ? name : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function findPackageManagerFromField(pkgPath: string): Promise<string | undefined> {
+	let result: string | undefined;
+	await findUp(async directory => {
+		const candidate = path.join(directory, 'package.json');
+		if (await pathExists(candidate)) {
+			const name = await readPackageManagerField(candidate);
+			if (name) {
+				result = name;
+				return candidate;
+			}
+		}
+		return undefined;
+	}, { cwd: pkgPath });
+	return result;
+}
+
 async function isBunPreferred(pkgPath: string): Promise<PreferredProperties> {
 	if (await pathExists(path.join(pkgPath, 'bun.lockb'))) {
 		return { isPreferred: true, hasLockfile: true };
@@ -71,6 +105,12 @@ async function isNPMPreferred(pkgPath: string): Promise<PreferredProperties> {
 export async function findPreferredPM(pkgPath: string): Promise<{ name: string; multipleLockFilesDetected: boolean }> {
 	const detectedPackageManagerNames: string[] = [];
 	const detectedPackageManagerProperties: PreferredProperties[] = [];
+
+	const fromField = await findPackageManagerFromField(pkgPath);
+	if (fromField) {
+		detectedPackageManagerNames.push(fromField);
+		detectedPackageManagerProperties.push({ isPreferred: true, hasLockfile: false });
+	}
 
 	const npmPreferred = await isNPMPreferred(pkgPath);
 	if (npmPreferred.isPreferred) {

--- a/extensions/npm/src/preferred-pm.ts
+++ b/extensions/npm/src/preferred-pm.ts
@@ -14,6 +14,12 @@ interface PreferredProperties {
 	hasLockfile: boolean;
 }
 
+type PreferredPMResult = { name: string; multipleLockFilesDetected: boolean };
+
+const SUPPORTED_PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+
+const preferredPMCache = new Map<string, Promise<PreferredPMResult>>();
+
 async function pathExists(filePath: string) {
 	try {
 		await workspace.fs.stat(Uri.file(filePath));
@@ -22,8 +28,6 @@ async function pathExists(filePath: string) {
 	}
 	return true;
 }
-
-const SUPPORTED_PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
 
 async function readPackageManagerField(packageJsonPath: string): Promise<string | undefined> {
 	try {
@@ -101,9 +105,6 @@ async function isNPMPreferred(pkgPath: string): Promise<PreferredProperties> {
 	const lockfileExists = await pathExists(path.join(pkgPath, 'package-lock.json'));
 	return { isPreferred: lockfileExists, hasLockfile: lockfileExists };
 }
-
-type PreferredPMResult = { name: string; multipleLockFilesDetected: boolean };
-const preferredPMCache = new Map<string, Promise<PreferredPMResult>>();
 
 export function invalidatePreferredPMCache() {
 	preferredPMCache.clear();

--- a/extensions/npm/src/preferred-pm.ts
+++ b/extensions/npm/src/preferred-pm.ts
@@ -102,7 +102,23 @@ async function isNPMPreferred(pkgPath: string): Promise<PreferredProperties> {
 	return { isPreferred: lockfileExists, hasLockfile: lockfileExists };
 }
 
-export async function findPreferredPM(pkgPath: string): Promise<{ name: string; multipleLockFilesDetected: boolean }> {
+type PreferredPMResult = { name: string; multipleLockFilesDetected: boolean };
+const preferredPMCache = new Map<string, Promise<PreferredPMResult>>();
+
+export function invalidatePreferredPMCache() {
+	preferredPMCache.clear();
+}
+
+export function findPreferredPM(pkgPath: string): Promise<PreferredPMResult> {
+	let cached = preferredPMCache.get(pkgPath);
+	if (!cached) {
+		cached = computePreferredPM(pkgPath);
+		preferredPMCache.set(pkgPath, cached);
+	}
+	return cached;
+}
+
+async function computePreferredPM(pkgPath: string): Promise<PreferredPMResult> {
 	const detectedPackageManagerNames: string[] = [];
 	const detectedPackageManagerProperties: PreferredProperties[] = [];
 

--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import minimatch from 'minimatch';
 import { Utils } from 'vscode-uri';
-import { findPreferredPM } from './preferred-pm';
+import { findPreferredPM, invalidatePreferredPMCache } from './preferred-pm';
 import { readScripts } from './readScripts';
 
 const excludeRegex = new RegExp('^(node_modules|.vscode-test)$', 'i');
@@ -88,6 +88,7 @@ export class NpmTaskProvider implements TaskProvider {
 
 export function invalidateTasksCache() {
 	cachedTasks = undefined;
+	invalidatePreferredPMCache();
 }
 
 const buildNames: string[] = ['build', 'compile', 'watch'];


### PR DESCRIPTION
## Background

The built-in `npm` extension auto-detects which package manager to use (`npm` / `yarn` / `pnpm` / `bun`) for the script-runner / install tasks via [`extensions/npm/src/preferred-pm.ts`](https://github.com/microsoft/vscode/blob/main/extensions/npm/src/preferred-pm.ts). The detection order today is:

1. `package-lock.json` → `npm`
2. `pnpm-lock.yaml` (incl. walk-up) → `pnpm`
3. `yarn.lock` **or** any ancestor `package.json` with a `workspaces` field → `yarn`
4. `bun.lockb` / `bun.lock` → `bun`

Because the yarn detector also fires on `workspaces` (the legacy yarn-workspaces shape) and runs before `bun`, **a Bun monorepo gets detected as yarn even when the only lockfile is `bun.lock` and the root `package.json` declares `"packageManager": "bun@..."`.** Yarn 1.22 then chokes on the Corepack-shaped `packageManager` value and produces a confusing error.

The Corepack-standard `packageManager` field (supported by Node ≥16.9, used by all four managers) is currently ignored by this detection.

## Change

Add a check for the `packageManager` field that runs **before** the lockfile heuristics:

- New `readPackageManagerField` parses `\"<name>@<version>\"` and accepts `npm` / `pnpm` / `yarn` / `bun`.
- New `findPackageManagerFromField` walks up via `find-up` to locate the closest ancestor `package.json` that has a valid `packageManager` field — needed for monorepos where child `package.json` files don't repeat the field.
- `findPreferredPM` consults the field first; the entry is recorded with `hasLockfile: false`, so it doesn't inflate the existing multi-lockfile warning.

If no `packageManager` field is set, behavior is unchanged.

## Reproduction

1. Clone any Bun-workspaces repo (e.g. https://github.com/sst/opencode):
   - root `package.json` has `\"packageManager\": \"bun@1.3.13\"` and `\"workspaces\": [\"packages/*\"]`
   - the only lockfile is `bun.lock`
2. Open the folder in VS Code with default settings (`npm.scriptRunner` / `npm.packageManager` left at `\"auto\"`).
3. Run any script via the npm Scripts view or a generated task.

**Before:** task runs as `yarn run <script>`. Yarn 1.22 errors:

```
error This project's package.json defines \"packageManager\": \"yarn@bun@1.3.13\". However the current global version of Yarn is 1.22.22.
```

(yarn 1's diagnostic prepends `yarn@` to whatever it parsed, hence the doubled prefix.)

**After:** task runs as `bun run <script>`.

## Notes

- No new dependencies; `find-up` is already used by `preferred-pm.ts`.
- Workaround for users on older builds: set `\"npm.scriptRunner\": \"bun\"` (and `\"npm.packageManager\": \"bun\"`) in workspace settings.