### PR TITLE
Complete revert of @github/copilot 1.0.38 bump (regenerate lockfile)

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -3203,26 +3203,26 @@
 			"license": "MIT"
 		},
 		"node_modules/@github/copilot": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.38.tgz",
-			"integrity": "sha512-GjtKCiFczeKuECOuxkBkJYb8estSnhxgh4iQ9BTkWg4y3EWYl2VaMCXCu9KkVPf/fwy/URt1l8Rf4M4tZxVZAA==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
+			"integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"bin": {
 				"copilot": "npm-loader.js"
 			},
 			"optionalDependencies": {
-				"@github/copilot-darwin-arm64": "1.0.38",
-				"@github/copilot-darwin-x64": "1.0.38",
-				"@github/copilot-linux-arm64": "1.0.38",
-				"@github/copilot-linux-x64": "1.0.38",
-				"@github/copilot-win32-arm64": "1.0.38",
-				"@github/copilot-win32-x64": "1.0.38"
+				"@github/copilot-darwin-arm64": "1.0.34",
+				"@github/copilot-darwin-x64": "1.0.34",
+				"@github/copilot-linux-arm64": "1.0.34",
+				"@github/copilot-linux-x64": "1.0.34",
+				"@github/copilot-win32-arm64": "1.0.34",
+				"@github/copilot-win32-x64": "1.0.34"
 			}
 		},
 		"node_modules/@github/copilot-darwin-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.38.tgz",
-			"integrity": "sha512-JyzyQ/VUC30QBOnOoqBbfAlMbIycKVqIOepeTdArNk+oER8qfQ9LqQPxA6FDqCQl3GAMclzqZGL9jK7I2WldhA==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
+			"integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -3236,9 +3236,9 @@
 			}
 		},
 		"node_modules/@github/copilot-darwin-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.38.tgz",
-			"integrity": "sha512-2Wv/4KPY2XC6JRGvJzavrk/RBmbH3Z5pNZZslL0BW2+AeZsoYqmVrA/1pxUs+KSVaGDC420dqS7uZ6u/mg23oQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
+			"integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
 			"cpu": [
 				"x64"
 			],
@@ -3252,9 +3252,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.38.tgz",
-			"integrity": "sha512-s+rNuvL3pKkZ6orZZoKcsbNDlu79f6/EBj5ovo2pJ6iBI3YMNwUM8AZq9pcFUpZCaLJ6E7GGZoujRMbpjKP/wQ==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
+			"integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3268,9 +3268,9 @@
 			}
 		},
 		"node_modules/@github/copilot-linux-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.38.tgz",
-			"integrity": "sha512-8aAXJ0Qv+4naW4FcsqQNzgGykaiYe5q7ZO55ZuUMQ92ZY+Kae5kTttwiZ325T9CdeNHVT9f+aMx8gAGVWxfvFg==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
+			"integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
 			"cpu": [
 				"x64"
 			],
@@ -3284,9 +3284,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-arm64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.38.tgz",
-			"integrity": "sha512-M7Da1h25IsnYyw9LBCatxgQUsu+C5+xJsHMZeR8dnxRF/kt75Ksqk1+pWp8oBk1BqK9ahTgb4zFqCfFDhmUO3w==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
+			"integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3300,9 +3300,9 @@
 			}
 		},
 		"node_modules/@github/copilot-win32-x64": {
-			"version": "1.0.38",
-			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.38.tgz",
-			"integrity": "sha512-PhAUhWRbg718Uc+a6RXqoGN8fGYD+Rj5FWQPQ3rbmgZitPRzlT/WrQaWj0BenRERUjLshPuxSm1GJUB4Kyc/7Q==",
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
+			"integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
 			"cpu": [
 				"x64"
 			],


### PR DESCRIPTION
Follow-up to #313125. That PR only changed the spec in `extensions/copilot/package.json` from `^1.0.38` back to `^1.0.34`, but left the resolved lockfile entries pointing at 1.0.38 tarballs. Since `^1.0.34` satisfies 1.0.38, `npm ci` would still install 1.0.38 and reintroduce the broken Copilot CLI tool-dispatch / permission-prompt regression.

This PR completes the revert of #312947 by also reverting the lockfile changes (1.0.38 → 1.0.34 resolved versions, tarballs, and integrity hashes). Spec remains `^1.0.34` as set by #313125.

Verified: no `1.0.38` strings remain in `extensions/copilot/package-lock.json`.

cc @rebornix @DonJayamanne @alexdima

(Companion PR for `main`: #313213.)
