### PR TITLE
Bump copilot-chat to 0.46.1

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2,7 +2,7 @@
 	"name": "copilot-chat",
 	"displayName": "GitHub Copilot Chat",
 	"description": "AI chat features powered by Copilot",
-	"version": "0.46.0",
+	"version": "0.46.1",
 	"build": "1",
 	"internalAIKey": "1058ec22-3c95-4951-8443-f26c1f325911",
 	"completionsCoreVersion": "1.378.1799",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.118.0",
+  "version": "1.118.1",
   "distro": "b85ea484c93395a77703478557a49e35ac7c0841",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Patch bump on `release/1.118`:

- `extensions/copilot/package.json`: 0.46.0 → 0.46.1
- `extensions/copilot/package-lock.json` regenerated.
