### PR TITLE
Bump version to 1.118.1 / copilot-chat 0.46.2

### DIFF
--- a/extensions/copilot/package-lock.json
+++ b/extensions/copilot/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copilot-chat",
-	"version": "0.46.1",
+	"version": "0.46.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copilot-chat",
-			"version": "0.46.1",
+			"version": "0.46.2",
 			"hasInstallScript": true,
 			"license": "SEE LICENSE IN LICENSE.txt",
 			"dependencies": {

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2,7 +2,7 @@
 	"name": "copilot-chat",
 	"displayName": "GitHub Copilot Chat",
 	"description": "AI chat features powered by Copilot",
-	"version": "0.46.1",
+	"version": "0.46.2",
 	"build": "1",
 	"internalAIKey": "1058ec22-3c95-4951-8443-f26c1f325911",
 	"completionsCoreVersion": "1.378.1799",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-oss-dev",
-  "version": "1.118.0",
+  "version": "1.118.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-oss-dev",
-      "version": "1.118.0",
+      "version": "1.118.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.118.0",
+  "version": "1.118.1",
   "distro": "b85ea484c93395a77703478557a49e35ac7c0841",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
- Root `package.json`: 1.118.0 → 1.118.1
- `extensions/copilot/package.json`: 0.46.1 → 0.46.2

Lockfiles updated.
