### PR TITLE
Bump copilot engines.vscode to ^1.118.1

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -23,7 +23,7 @@
 	"icon": "assets/copilot.png",
 	"pricing": "Trial",
 	"engines": {
-		"vscode": "^1.118.0",
+		"vscode": "^1.118.1",
 		"npm": ">=9.0.0",
 		"node": ">=22.14.0"
 	},


### PR DESCRIPTION
Bump `engines.vscode` in `extensions/copilot/package.json` from `^1.118.0` to `^1.118.1` to match the recovery release.
