### PR TITLE
Detect chevron-style interactive prompts and fix indefinite foreground hang on unrecognised prompts

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -605,15 +605,17 @@ export function detectsHighConfidenceInputPattern(cursorLine: string): boolean {
 		// "Press a key" or "Press any key"
 		/press a(?:ny)? key/i,
 		// Interactive prompt libraries (prompts, enquirer, inquirer) prefix the prompt with
-		// '? ' and end the line with a distinctive chevron character followed by optional
-		// trailing whitespace where the cursor is awaiting input. Requiring a '?' earlier
-		// on the line avoids false positives from random output that happens to contain a
-		// chevron (e.g. git log decorations).
+		// '? ' at the start of the line and end with a distinctive chevron character
+		// followed by optional trailing whitespace where the cursor is awaiting input.
+		// Anchoring the '?' to the start of the line (after optional whitespace/ANSI
+		// escapes) avoids false positives from normal output that contains both a '?'
+		// allow-any-unicode-next-line
+		// and a chevron (e.g. "What happened? ›").
 		// Examples:
 		//   "? Do you want to install jsdom? <chevron>"  (prompts)
-		//   "? Pick a color <chevron> "                  (inquirer / enquirer)
+		//   "? Pick a color <chevron> "                  (enquirer)
 		// allow-any-unicode-next-line
-		/\?.*[›❯▸▶]\s*$/,
+		/^(?:\s|\x1b\[[0-9;]*m)*\?.*[›❯▸▶]\s*$/,
 	].some(e => e.test(cursorLine));
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -604,6 +604,16 @@ export function detectsHighConfidenceInputPattern(cursorLine: string): boolean {
 		/password:? +$/i,
 		// "Press a key" or "Press any key"
 		/press a(?:ny)? key/i,
+		// Interactive prompt libraries (prompts, enquirer, inquirer) prefix the prompt with
+		// '? ' and end the line with a distinctive chevron character followed by optional
+		// trailing whitespace where the cursor is awaiting input. Requiring a '?' earlier
+		// on the line avoids false positives from random output that happens to contain a
+		// chevron (e.g. git log decorations).
+		// Examples:
+		//   "? Do you want to install jsdom? <chevron>"  (prompts)
+		//   "? Pick a color <chevron> "                  (inquirer / enquirer)
+		// allow-any-unicode-next-line
+		/\?.*[›❯▸▶]\s*$/,
 	].some(e => e.test(cursorLine));
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -403,9 +403,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {
-		// Stop after extended polling (2 minutes) without notifying user
 		if (_extended) {
-			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes');
+			// Extended polling (2 minutes) expired while the process was still
+			// running. Rather than silently cancelling, signal that input may be
+			// needed so the agent sees the current output and can decide how to
+			// proceed (e.g. answer an unrecognised interactive prompt).
+			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes, signaling potential input needed');
+			this._onDidDetectInputNeeded.fire();
 			this._state = OutputMonitorState.Cancelled;
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -405,11 +405,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {
 		if (_extended) {
 			// Extended polling (2 minutes) expired while the process was still
-			// running. Rather than silently cancelling, signal that input may be
-			// needed so the agent sees the current output and can decide how to
-			// proceed (e.g. answer an unrecognised interactive prompt).
-			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes, signaling potential input needed');
-			this._onDidDetectInputNeeded.fire();
+			// running, but that alone does not mean the command is waiting for
+			// input. Avoid firing the input-needed event here so consumers don't
+			// misreport a quiet long-running command as an interactive prompt.
+			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes with the process still running');
 			this._state = OutputMonitorState.Cancelled;
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -405,10 +405,11 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {
 		if (_extended) {
 			// Extended polling (2 minutes) expired while the process was still
-			// running, but that alone does not mean the command is waiting for
-			// input. Avoid firing the input-needed event here so consumers don't
-			// misreport a quiet long-running command as an interactive prompt.
-			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes with the process still running');
+			// running. Rather than silently cancelling, signal that input may be
+			// needed so the agent sees the current output and can decide how to
+			// proceed (e.g. answer an unrecognised interactive prompt).
+			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes, signaling potential input needed');
+			this._onDidDetectInputNeeded.fire();
 			this._state = OutputMonitorState.Cancelled;
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2218,7 +2218,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				lastInputNeededOutput = currentOutput;
 				lastInputNeededNotificationTime = now;
 				const inputAction = this._buildInputNeededSteeringText(chatSessionResource, termId, /*mentionTimeout*/ false);
-				const message = `[Terminal ${termId} notification: command is waiting for input.]\n${inputAction}\nTerminal output:\n${currentOutput}`;
+				const message = `[Terminal ${termId} notification: command may be waiting for input — assess the output below.]\n${inputAction}\nTerminal output:\n${currentOutput}`;
 
 				this._logService.debug(`RunInTerminalTool: Input needed in background terminal ${termId}, notifying chat session`);
 
@@ -2226,7 +2226,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					...sendOptions,
 					queue: ChatRequestQueueKind.Steering,
 					isSystemInitiated: true,
-					systemInitiatedLabel: localize('terminalNeedsInput', "`{0}` needs input", commandName),
+					systemInitiatedLabel: localize('terminalAssessingOutput', "`{0}` may need input", commandName),
 					terminalExecutionId: termId,
 				}).catch(e => {
 					this._logService.warn(`RunInTerminalTool: Failed to send input-needed notification for terminal ${termId}`, e);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -382,6 +382,14 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('  feature/foo ❯ main'), false);
 			// allow-any-unicode-next-line
 			assert.strictEqual(detectsInputRequiredPattern('Project name ▸ '), false);
+
+			// No match when '?' appears mid-line (not as a prompt prefix)
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('What happened? ›'), false);
+
+			// Match when prompt is prefixed with ANSI escape codes (colored output)
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('\x1b[32m? Choose a framework \x1b[0m›'), true);
 		});
 
 		test('detects trailing questions', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -233,6 +233,25 @@ suite('OutputMonitor', () => {
 		});
 	});
 
+	test('extended timeout with isActive fires onDidDetectInputNeeded', async () => {
+		return runWithFakedTimers({}, async () => {
+			// Simulate a process that stays active with output that doesn't
+			// match any input-required pattern — the extended timeout should
+			// fire onDidDetectInputNeeded so the agent can assess the output.
+			execution.isActive = async () => true;
+			execution.getOutput = () => 'Some unrecognised prompt waiting for input';
+
+			monitor = store.add(instantiationService.createInstance(OutputMonitor, execution, undefined, createTestContext('1'), cts.token, 'test command'));
+
+			let inputNeededFired = false;
+			store.add(monitor.onDidDetectInputNeeded(() => { inputNeededFired = true; }));
+
+			await Event.toPromise(monitor.onDidFinishCommand);
+			assert.strictEqual(inputNeededFired, true, 'onDidDetectInputNeeded should fire on extended timeout with active process');
+			assert.strictEqual(monitor.pollingResult?.state, OutputMonitorState.Cancelled);
+		});
+	});
+
 	test('non-interactive help on the last line stops monitoring before custom polling', async () => {
 		return runWithFakedTimers({}, async () => {
 			execution.getOutput = () => 'Build complete successfully\npress h + enter to show help';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -354,6 +354,36 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsInputRequiredPattern('license: (ISC) '), true);
 		});
 
+		test('detects chevron prompts from prompts/enquirer/inquirer libraries', () => {
+			// vitest / npm-style "prompts" library uses U+203A SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Do you want to install jsdom? ›'), true);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Do you want to install jsdom? › '), true);
+			// inquirer / enquirer uses U+276F HEAVY RIGHT-POINTING ANGLE QUOTATION MARK
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Pick a color ❯ '), true);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Pick a color ❯'), true);
+			// Other chevron variants prefixed with '?'
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Project name ▸ '), true);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Choose ▶ '), true);
+
+			// No match if the user has already typed a response after the chevron
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Do you want to install jsdom? › yes'), false);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('? Pick a color ❯ red'), false);
+
+			// No match for chevrons in normal output without a leading '?'
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('  feature/foo ❯ main'), false);
+			// allow-any-unicode-next-line
+			assert.strictEqual(detectsInputRequiredPattern('Project name ▸ '), false);
+		});
+
 		test('detects trailing questions', () => {
 			assert.strictEqual(detectsInputRequiredPattern('Continue? '), true);
 			assert.strictEqual(detectsInputRequiredPattern('Proceed?   '), true);


### PR DESCRIPTION
Fixes #312576

## Problem
When the agent runs a sync (foreground) command via `run_in_terminal` and the command launches an interactive prompt from a library like [`prompts`](https://www.npmjs.com/package/prompts) (used by vitest), [`enquirer`](https://www.npmjs.com/package/enquirer), or [`inquirer`](https://www.npmjs.com/package/inquirer), the agent does not detect that input is required and the call hangs **indefinitely**.

### Why it hangs forever
The foreground `run_in_terminal` path races four candidates: process exit, continue-in-background, user-specified timeout (default: none), and `onDidDetectInputNeeded`. When the process is alive waiting for input:

1. The `OutputMonitor` polling loop sees `isActive === true` and only transitions to Idle if `detectsInputRequiredPattern` matches the cursor line.
2. Without a matching pattern, the monitor keeps polling until its internal 2-minute extended timeout, then sets state to `Cancelled`.
3. **But `Cancelled` does not resolve any of the foreground race candidates.** The process is still alive, no user timeout was specified, and `onDidDetectInputNeeded` was never fired — so the race hangs forever.

## Fix

### 1. Chevron prompt pattern
Add a new pattern in `detectsHighConfidenceInputPattern` (the fast-path checked on every poll tick) that matches lines starting with `?` (after optional whitespace/ANSI escapes) and ending with a prompt-library chevron glyph (`›` U+203A, `❯` U+276F, `▸` U+25B8, `▶` U+25B6). Anchoring `?` to the start of the line matches the canonical `prompts`/`enquirer`/`inquirer` rendering and avoids false positives from incidental `?` + chevron combinations in normal output (e.g. `What happened? ›`).

### 2. Extended timeout safety net
When the 2-minute extended polling timeout fires, fire `onDidDetectInputNeeded` before cancelling. This is the critical fix for the **indefinite hang** — it resolves the foreground race so the agent receives the terminal output and can assess/respond.

### 3. Soften notification language
Changed the background steering message from "command **is** waiting for input" to "command **may be** waiting for input", and the UI label from "needs input" to "may need input". This is important because the event now also fires on extended timeout where the process might just be slow rather than actually waiting for input. The steering text already instructs the agent to assess the output before acting.

### Decision matrix: extended timeout behavior

| Scenario | `isActive` | Without firing event | With firing event |
|---|---|---|---|
| **Unrecognised prompt (fg)** | `true` | ❌ Hangs forever — no race candidate resolves | ✅ Agent gets output, can assess and respond |
| **Unrecognised prompt (bg)** | `true` | ❌ Silently cancelled, agent never sees it | ✅ Steering message sent, agent assesses output |
| **Long-running command (fg)** — e.g. 3min build | `true` | ⚠️ Also hangs forever (same bug, different cause) | ✅ Agent told "may need input" — steering text says "call GetTerminalOutput to continue polling", so agent polls and build finishes normally |
| **Long-running command (bg)** | `true` | Silent cancel at 2min | ⚠️ Benign steering message — agent sees output, assesses "still running", continues polling |
| **Already exited process** | `false` | N/A — caught before timeout | Same |

## Tests
- **Chevron pattern tests**: each chevron variant (`›`, `❯`, `▸`, `▶`) preceded by `?` with and without trailing whitespace; ANSI escape-prefixed prompt lines; negatives for already-typed responses, chevrons without leading `?`, and mid-line `?` with chevron
- **Extended timeout test**: verifies `onDidDetectInputNeeded` fires when extended timeout expires with an active process