### PR TITLE
Agents: Refactor account menu and chat status dashboard for improved UI

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -558,7 +558,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		if (partitioned.signOut) {
 			const headerActionsContainer = append(headerSection, $('.sessions-account-titlebar-panel-header-actions'));
 			this.createPanelButton(headerActionsContainer, partitioned.signOut, panelStore, {
-				className: 'sessions-account-titlebar-panel-header-action',
+				classNames: ['sessions-account-titlebar-panel-header-action'],
 				icon: this.getHeaderActionIcon(partitioned.signOut),
 			});
 		}
@@ -572,7 +572,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			const personalizeActionsContainer = append(personalizeSection, $('.sessions-account-titlebar-panel-actions'));
 			for (const action of partitioned.personalize) {
 				this.createPanelButton(personalizeActionsContainer, action, panelStore, {
-					className: 'sessions-account-titlebar-panel-action with-icon',
+					classNames: ['sessions-account-titlebar-panel-action', 'with-icon'],
 					icon: this.getPersonalizeActionIcon(action),
 					includeLabel: true,
 				});
@@ -593,7 +593,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				}
 				lastWasSeparator = false;
 				this.createPanelButton(actionsSection, action, panelStore, {
-					className: 'sessions-account-titlebar-panel-action',
+					classNames: ['sessions-account-titlebar-panel-action'],
 					includeLabel: true,
 					checked: !!action.checked,
 				});
@@ -637,9 +637,18 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		const personalizeMap = new Map<string, IAction>();
 		const other: IAction[] = [];
 
+		const pushSeparator = () => {
+			// Collapse runs and skip leading separators so groups whose only
+			// items get filtered (e.g. update.*) don't leave orphans behind.
+			if (other.length === 0 || other[other.length - 1] instanceof Separator) {
+				return;
+			}
+			other.push(new Separator());
+		};
+
 		for (const action of rawActions) {
 			if (action instanceof Separator) {
-				other.push(action);
+				pushSeparator();
 				continue;
 			}
 			if (action.id === SIGN_OUT_ACTION_ID) {
@@ -659,6 +668,11 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			other.push(action);
 		}
 
+		// Trim trailing separator left after filtering.
+		if (other.length > 0 && other[other.length - 1] instanceof Separator) {
+			other.pop();
+		}
+
 		// Preserve canonical personalize order.
 		const personalize = PERSONALIZE_ACTION_IDS
 			.map(id => personalizeMap.get(id))
@@ -671,9 +685,10 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		parent: HTMLElement,
 		action: IAction,
 		panelStore: DisposableStore,
-		options: { className: string; icon?: ThemeIcon; includeLabel?: boolean; checked?: boolean },
+		options: { classNames: readonly string[]; icon?: ThemeIcon; includeLabel?: boolean; checked?: boolean },
 	): HTMLButtonElement {
-		const button = append(parent, $(`button.${options.className.replace(/\s+/g, '.')}`, { type: 'button' })) as HTMLButtonElement;
+		const button = append(parent, $('button', { type: 'button' })) as HTMLButtonElement;
+		button.classList.add(...options.classNames);
 		button.disabled = !action.enabled;
 		button.setAttribute('aria-label', action.tooltip || action.label);
 		if (options.checked) {
@@ -721,7 +736,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				return Codicon.symbolColor;
 			case 'workbench.action.openSettings':
 				return Codicon.settingsGear;
-			case 'workbench.action.agenticSignOut':
+			case SIGN_OUT_ACTION_ID:
 				return Codicon.signOut;
 			default:
 				return Codicon.circleLargeFilled;

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -35,7 +35,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { isWindows, isMacintosh } from '../../../../base/common/platform.js';
 import { UpdateHoverWidget } from './updateHoverWidget.js';
 import { ChatEntitlement, ChatEntitlementService, IChatEntitlementService } from '../../../../workbench/services/chat/common/chatEntitlementService.js';
-import { ChatStatusDashboard } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
+import { ChatStatusDashboard, IChatStatusDashboardOptions } from '../../../../workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { getAccountProfileImageUrl, getAccountTitleBarBadgeKey, getAccountTitleBarState, resolveAccountInfo } from '../../../browser/accountTitleBarState.js';
@@ -608,22 +608,10 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			const subscriptionHeader = append(subscriptionSection, $('.sessions-account-titlebar-panel-section-header'));
 			const subscriptionHeading = append(subscriptionHeader, $('div.sessions-account-titlebar-panel-section-title', { id: subscriptionId }));
 			subscriptionHeading.textContent = localize('sessionsAccountMenu.subscription', "Subscription");
-			const dashboard = this.createCopilotHoverContent();
+			// Render the dashboard's title header (plan name + manage / CTA actions)
+			// directly into our section header row via the dashboard's public API.
+			const dashboard = this.createCopilotHoverContent({ titleHeaderContainer: subscriptionHeader });
 			append(subscriptionSection, dashboard);
-			// Move the dashboard's plan-name + manage-action header into our section header row,
-			// so the plan name and settings button appear right-aligned next to "Subscription".
-			// The dashboard is wrapped in a `display: contents` div, hence reaching one level in.
-			// Note: the dashboard renders the title header synchronously and never re-creates it,
-			// so a one-time move is safe today. Tolerate non-`.header` first children defensively.
-			const tooltipRoot = dashboard.firstElementChild;
-			if (tooltipRoot) {
-				for (const child of Array.from(tooltipRoot.children)) {
-					if (child.classList.contains('header')) {
-						subscriptionHeader.appendChild(child);
-						break;
-					}
-				}
-			}
 		} else if (!this.isAccountLoading) {
 			const summary = append(contentSection, $('.sessions-account-titlebar-panel-summary'));
 			summary.textContent = this.lastState.ariaLabel;
@@ -760,7 +748,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		return !this.chatEntitlementService.sentiment.hidden && !!this.accountName;
 	}
 
-	private createCopilotHoverContent(): HTMLElement {
+	private createCopilotHoverContent(extraOptions?: Partial<IChatStatusDashboardOptions>): HTMLElement {
 		const store = new DisposableStore();
 		this.copilotDashboardStore.value = store;
 		const dashboardElement = ChatStatusDashboard.instantiateInContents(this.instantiationService, store, {
@@ -769,6 +757,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			disableProviderOptions: true,
 			disableCompletionsSnooze: true,
 			disableQuickSettingsCollapsible: true,
+			...extraOptions,
 		});
 
 		store.add(disposableWindowInterval(mainWindow, () => {

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -242,6 +242,17 @@ MenuRegistry.appendMenuItem(AccountMenu, {
 	order: 2,
 });
 
+// Keyboard Shortcuts (hidden on phone — no keybindings UI on mobile)
+MenuRegistry.appendMenuItem(AccountMenu, {
+	command: {
+		id: 'workbench.action.openGlobalKeybindings',
+		title: localize('keyboardShortcuts', "Keyboard Shortcuts"),
+	},
+	when: IsPhoneLayoutContext.negate(),
+	group: '2_settings',
+	order: 3,
+});
+
 // Update actions
 registerUpdateMenuItems(AccountMenu, '3_updates');
 
@@ -547,6 +558,32 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			}
 		}
 
+		const personalizeActions = this.getPersonalizeActions();
+		if (personalizeActions.length > 0) {
+			const personalizeSection = append(panel, $('.sessions-account-titlebar-panel-section'));
+			const personalizeHeading = append(personalizeSection, $('.sessions-account-titlebar-panel-section-title'));
+			personalizeHeading.textContent = localize('personalize', "Personalize");
+			const personalizeActionsContainer = append(personalizeSection, $('.sessions-account-titlebar-panel-actions'));
+
+			for (const action of personalizeActions) {
+				const button = append(personalizeActionsContainer, $('button.sessions-account-titlebar-panel-action.with-icon', { type: 'button' })) as HTMLButtonElement;
+				button.disabled = !action.enabled;
+				button.setAttribute('aria-label', action.tooltip || action.label);
+				const iconElement = append(button, $('span.sessions-account-titlebar-panel-action-icon'));
+				iconElement.classList.add(...ThemeIcon.asClassNameArray(this.getPersonalizeActionIcon(action)));
+				const labelElement = append(button, $('span.sessions-account-titlebar-panel-action-label'));
+				append(labelElement, ...renderLabelWithIcons(action.label));
+
+				panelStore.add(addDisposableListener(button, EventType.CLICK, async event => {
+					event.preventDefault();
+					event.stopPropagation();
+					this.hoverService.hideHover(true);
+					this.clickPanelDisposable.clear();
+					await Promise.resolve(action.run());
+				}));
+			}
+		}
+
 		const actions = this.getPanelActions();
 		if (actions.length > 0) {
 			const actionsSection = append(panel, $('.sessions-account-titlebar-panel-actions'));
@@ -580,7 +617,19 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 
 		const contentSection = append(panel, $('.sessions-account-titlebar-panel-content'));
 		if (this.shouldShowCopilotDashboardHover()) {
-			append(contentSection, this.createCopilotHoverContent());
+			const subscriptionSection = append(contentSection, $('.sessions-account-titlebar-panel-section.subscription'));
+			const subscriptionHeader = append(subscriptionSection, $('.sessions-account-titlebar-panel-section-header'));
+			const subscriptionHeading = append(subscriptionHeader, $('.sessions-account-titlebar-panel-section-title'));
+			subscriptionHeading.textContent = localize('subscription', "Subscription");
+			const dashboard = this.createCopilotHoverContent();
+			append(subscriptionSection, dashboard);
+			// Move the dashboard's plan-name + manage action header into our section header row,
+			// so the plan name and settings button appear right-aligned next to "Subscription".
+			const tooltipRoot = dashboard.firstElementChild;
+			const dashboardHeader = tooltipRoot?.firstElementChild;
+			if (dashboardHeader && dashboardHeader.classList.contains('header')) {
+				subscriptionHeader.appendChild(dashboardHeader);
+			}
 		} else if (!this.isAccountLoading) {
 			const summary = append(contentSection, $('.sessions-account-titlebar-panel-summary'));
 			summary.textContent = this.lastState.ariaLabel;
@@ -607,11 +656,25 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		fillInActionBarActions(menu.getActions(), rawActions);
 		menu.dispose();
 
-		const themeAction = rawActions.find(action => !(action instanceof Separator) && action.id === 'workbench.action.selectTheme');
-		const settingsAction = rawActions.find(action => !(action instanceof Separator) && action.id === 'workbench.action.openSettings');
 		const signOutAction = rawActions.find(action => !(action instanceof Separator) && action.id === 'workbench.action.agenticSignOut');
 
-		return [themeAction, settingsAction, signOutAction].filter((action): action is IAction => !!action);
+		return [signOutAction].filter((action): action is IAction => !!action);
+	}
+
+	private getPersonalizeActions(): IAction[] {
+		const menu = this.menuService.createMenu(AccountMenu, this.contextKeyService);
+		const rawActions: IAction[] = [];
+		fillInActionBarActions(menu.getActions(), rawActions);
+		menu.dispose();
+
+		const ids = [
+			'workbench.action.openSettings',
+			'workbench.action.openGlobalKeybindings',
+			'workbench.action.selectTheme',
+		];
+		return ids
+			.map(id => rawActions.find(action => !(action instanceof Separator) && action.id === id))
+			.filter((action): action is IAction => !!action);
 	}
 
 	private getPanelActions(): IAction[] {
@@ -632,6 +695,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 
 			return action.id !== 'workbench.action.agenticSignOut'
 				&& action.id !== 'workbench.action.openSettings'
+				&& action.id !== 'workbench.action.openGlobalKeybindings'
 				&& action.id !== 'workbench.action.selectTheme'
 				&& !action.id.startsWith('update.');
 		});
@@ -645,6 +709,19 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 				return Codicon.settingsGear;
 			case 'workbench.action.agenticSignOut':
 				return Codicon.signOut;
+			default:
+				return Codicon.circleLargeFilled;
+		}
+	}
+
+	private getPersonalizeActionIcon(action: IAction): ThemeIcon {
+		switch (action.id) {
+			case 'workbench.action.openSettings':
+				return Codicon.settingsGear;
+			case 'workbench.action.openGlobalKeybindings':
+				return Codicon.keyboard;
+			case 'workbench.action.selectTheme':
+				return Codicon.symbolColor;
 			default:
 				return Codicon.circleLargeFilled;
 		}

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -53,6 +53,14 @@ const SessionsTitleBarAccountWidgetAction = 'sessions.action.titleBarAccountWidg
 const SessionsTitleBarUpdateWidgetAction = 'sessions.action.titleBarUpdateWidget';
 const SESSIONS_ACCOUNT_TITLEBAR_PANEL_WIDTH = 360;
 
+const PERSONALIZE_ACTION_IDS: readonly string[] = [
+	'workbench.action.openSettings',
+	'workbench.action.openGlobalKeybindings',
+	'workbench.action.selectTheme',
+];
+const SIGN_OUT_ACTION_ID = 'workbench.action.agenticSignOut';
+const SIGN_IN_ACTION_ID = 'workbench.action.agenticSignIn';
+
 function shouldHideSessionsTitleBarUpdateWidget(type: StateType): boolean {
 	return type === StateType.Uninitialized
 		|| type === StateType.Idle
@@ -246,7 +254,7 @@ MenuRegistry.appendMenuItem(AccountMenu, {
 MenuRegistry.appendMenuItem(AccountMenu, {
 	command: {
 		id: 'workbench.action.openGlobalKeybindings',
-		title: localize('keyboardShortcuts', "Keyboard Shortcuts"),
+		title: localize('sessionsAccountMenu.keyboardShortcuts', "Keyboard Shortcuts"),
 	},
 	when: IsPhoneLayoutContext.negate(),
 	group: '2_settings',
@@ -535,61 +543,47 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 
 	private createCombinedPanelContent(panelStore: DisposableStore): HTMLElement {
 		const panel = $('div.sessions-account-titlebar-panel');
+
+		// Build the menu actions once and partition them.
+		const menu = this.menuService.createMenu(AccountMenu, this.contextKeyService);
+		const rawActions: IAction[] = [];
+		fillInActionBarActions(menu.getActions(), rawActions);
+		menu.dispose();
+		const partitioned = this.partitionMenuActions(rawActions);
+
+		// Header: account label + sign-out icon.
 		const headerSection = append(panel, $('.sessions-account-titlebar-panel-header'));
 		const title = append(headerSection, $('div.sessions-account-titlebar-panel-title'));
 		title.textContent = this.getPanelHeaderLabel();
-		const headerActions = this.getHeaderActions();
-		if (headerActions.length > 0) {
+		if (partitioned.signOut) {
 			const headerActionsContainer = append(headerSection, $('.sessions-account-titlebar-panel-header-actions'));
-			for (const action of headerActions) {
-				const button = append(headerActionsContainer, $('button.sessions-account-titlebar-panel-header-action', { type: 'button' })) as HTMLButtonElement;
-				button.disabled = !action.enabled;
-				button.setAttribute('aria-label', action.tooltip || action.label);
-				button.title = action.tooltip || action.label;
-				button.classList.add(...ThemeIcon.asClassNameArray(this.getHeaderActionIcon(action)));
-
-				panelStore.add(addDisposableListener(button, EventType.CLICK, async event => {
-					event.preventDefault();
-					event.stopPropagation();
-					this.hoverService.hideHover(true);
-					this.clickPanelDisposable.clear();
-					await Promise.resolve(action.run());
-				}));
-			}
+			this.createPanelButton(headerActionsContainer, partitioned.signOut, panelStore, {
+				className: 'sessions-account-titlebar-panel-header-action',
+				icon: this.getHeaderActionIcon(partitioned.signOut),
+			});
 		}
 
-		const personalizeActions = this.getPersonalizeActions();
-		if (personalizeActions.length > 0) {
-			const personalizeSection = append(panel, $('.sessions-account-titlebar-panel-section'));
-			const personalizeHeading = append(personalizeSection, $('.sessions-account-titlebar-panel-section-title'));
-			personalizeHeading.textContent = localize('personalize', "Personalize");
+		// Personalize section.
+		if (partitioned.personalize.length > 0) {
+			const personalizeId = 'sessions-account-personalize-title';
+			const personalizeSection = append(panel, $('section.sessions-account-titlebar-panel-section', { 'aria-labelledby': personalizeId }));
+			const personalizeHeading = append(personalizeSection, $('div.sessions-account-titlebar-panel-section-title', { id: personalizeId }));
+			personalizeHeading.textContent = localize('sessionsAccountMenu.personalize', "Personalize");
 			const personalizeActionsContainer = append(personalizeSection, $('.sessions-account-titlebar-panel-actions'));
-
-			for (const action of personalizeActions) {
-				const button = append(personalizeActionsContainer, $('button.sessions-account-titlebar-panel-action.with-icon', { type: 'button' })) as HTMLButtonElement;
-				button.disabled = !action.enabled;
-				button.setAttribute('aria-label', action.tooltip || action.label);
-				const iconElement = append(button, $('span.sessions-account-titlebar-panel-action-icon'));
-				iconElement.classList.add(...ThemeIcon.asClassNameArray(this.getPersonalizeActionIcon(action)));
-				const labelElement = append(button, $('span.sessions-account-titlebar-panel-action-label'));
-				append(labelElement, ...renderLabelWithIcons(action.label));
-
-				panelStore.add(addDisposableListener(button, EventType.CLICK, async event => {
-					event.preventDefault();
-					event.stopPropagation();
-					this.hoverService.hideHover(true);
-					this.clickPanelDisposable.clear();
-					await Promise.resolve(action.run());
-				}));
+			for (const action of partitioned.personalize) {
+				this.createPanelButton(personalizeActionsContainer, action, panelStore, {
+					className: 'sessions-account-titlebar-panel-action with-icon',
+					icon: this.getPersonalizeActionIcon(action),
+					includeLabel: true,
+				});
 			}
 		}
 
-		const actions = this.getPanelActions();
-		if (actions.length > 0) {
+		// Other panel actions (sign-in, etc.) — only render if there's at least one non-separator action.
+		if (partitioned.other.some(a => !(a instanceof Separator))) {
 			const actionsSection = append(panel, $('.sessions-account-titlebar-panel-actions'));
 			let lastWasSeparator = true;
-
-			for (const action of actions) {
+			for (const action of partitioned.other) {
 				if (action instanceof Separator) {
 					if (!lastWasSeparator) {
 						append(actionsSection, $('.sessions-account-titlebar-panel-separator'));
@@ -597,38 +591,38 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 					}
 					continue;
 				}
-
 				lastWasSeparator = false;
-				const button = append(actionsSection, $('button.sessions-account-titlebar-panel-action', { type: 'button' })) as HTMLButtonElement;
-				button.disabled = !action.enabled;
-				button.setAttribute('aria-label', action.tooltip || action.label);
-				button.classList.toggle('checked', !!action.checked);
-				append(button, ...renderLabelWithIcons(action.label));
-
-				panelStore.add(addDisposableListener(button, EventType.CLICK, async event => {
-					event.preventDefault();
-					event.stopPropagation();
-					this.hoverService.hideHover(true);
-					this.clickPanelDisposable.clear();
-					await Promise.resolve(action.run());
-				}));
+				this.createPanelButton(actionsSection, action, panelStore, {
+					className: 'sessions-account-titlebar-panel-action',
+					includeLabel: true,
+					checked: !!action.checked,
+				});
 			}
 		}
 
+		// Subscription / Copilot dashboard.
 		const contentSection = append(panel, $('.sessions-account-titlebar-panel-content'));
 		if (this.shouldShowCopilotDashboardHover()) {
-			const subscriptionSection = append(contentSection, $('.sessions-account-titlebar-panel-section.subscription'));
+			const subscriptionId = 'sessions-account-subscription-title';
+			const subscriptionSection = append(contentSection, $('section.sessions-account-titlebar-panel-section.subscription', { 'aria-labelledby': subscriptionId }));
 			const subscriptionHeader = append(subscriptionSection, $('.sessions-account-titlebar-panel-section-header'));
-			const subscriptionHeading = append(subscriptionHeader, $('.sessions-account-titlebar-panel-section-title'));
-			subscriptionHeading.textContent = localize('subscription', "Subscription");
+			const subscriptionHeading = append(subscriptionHeader, $('div.sessions-account-titlebar-panel-section-title', { id: subscriptionId }));
+			subscriptionHeading.textContent = localize('sessionsAccountMenu.subscription', "Subscription");
 			const dashboard = this.createCopilotHoverContent();
 			append(subscriptionSection, dashboard);
-			// Move the dashboard's plan-name + manage action header into our section header row,
+			// Move the dashboard's plan-name + manage-action header into our section header row,
 			// so the plan name and settings button appear right-aligned next to "Subscription".
+			// The dashboard is wrapped in a `display: contents` div, hence reaching one level in.
+			// Note: the dashboard renders the title header synchronously and never re-creates it,
+			// so a one-time move is safe today. Tolerate non-`.header` first children defensively.
 			const tooltipRoot = dashboard.firstElementChild;
-			const dashboardHeader = tooltipRoot?.firstElementChild;
-			if (dashboardHeader && dashboardHeader.classList.contains('header')) {
-				subscriptionHeader.appendChild(dashboardHeader);
+			if (tooltipRoot) {
+				for (const child of Array.from(tooltipRoot.children)) {
+					if (child.classList.contains('header')) {
+						subscriptionHeader.appendChild(child);
+						break;
+					}
+				}
 			}
 		} else if (!this.isAccountLoading) {
 			const summary = append(contentSection, $('.sessions-account-titlebar-panel-summary'));
@@ -636,6 +630,77 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		}
 
 		return panel;
+	}
+
+	private partitionMenuActions(rawActions: IAction[]): { signOut: IAction | undefined; personalize: IAction[]; other: IAction[] } {
+		let signOut: IAction | undefined;
+		const personalizeMap = new Map<string, IAction>();
+		const other: IAction[] = [];
+
+		for (const action of rawActions) {
+			if (action instanceof Separator) {
+				other.push(action);
+				continue;
+			}
+			if (action.id === SIGN_OUT_ACTION_ID) {
+				signOut = action;
+				continue;
+			}
+			if (PERSONALIZE_ACTION_IDS.includes(action.id)) {
+				personalizeMap.set(action.id, action);
+				continue;
+			}
+			if (action.id.startsWith('update.')) {
+				continue;
+			}
+			if (this.isAccountLoading && action.id === SIGN_IN_ACTION_ID) {
+				continue;
+			}
+			other.push(action);
+		}
+
+		// Preserve canonical personalize order.
+		const personalize = PERSONALIZE_ACTION_IDS
+			.map(id => personalizeMap.get(id))
+			.filter((a): a is IAction => !!a);
+
+		return { signOut, personalize, other };
+	}
+
+	private createPanelButton(
+		parent: HTMLElement,
+		action: IAction,
+		panelStore: DisposableStore,
+		options: { className: string; icon?: ThemeIcon; includeLabel?: boolean; checked?: boolean },
+	): HTMLButtonElement {
+		const button = append(parent, $(`button.${options.className.replace(/\s+/g, '.')}`, { type: 'button' })) as HTMLButtonElement;
+		button.disabled = !action.enabled;
+		button.setAttribute('aria-label', action.tooltip || action.label);
+		if (options.checked) {
+			button.classList.add('checked');
+		}
+
+		if (options.icon && options.includeLabel) {
+			const iconElement = append(button, $('span.sessions-account-titlebar-panel-action-icon'));
+			iconElement.classList.add(...ThemeIcon.asClassNameArray(options.icon));
+			const labelElement = append(button, $('span.sessions-account-titlebar-panel-action-label'));
+			append(labelElement, ...renderLabelWithIcons(action.label));
+		} else if (options.icon) {
+			button.title = action.tooltip || action.label;
+			button.classList.add(...ThemeIcon.asClassNameArray(options.icon));
+		} else {
+			append(button, ...renderLabelWithIcons(action.label));
+		}
+
+		panelStore.add(addDisposableListener(button, EventType.CLICK, async event => {
+			event.preventDefault();
+			event.stopPropagation();
+			this.hoverService.hideHover(true);
+			this.clickPanelDisposable.clear();
+			await Promise.resolve(action.run());
+		}));
+
+		return button;
 	}
 
 	private getPanelHeaderLabel(): string {
@@ -648,57 +713,6 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 		}
 
 		return localize('accountMenuHeaderFallback', "Account");
-	}
-
-	private getHeaderActions(): IAction[] {
-		const menu = this.menuService.createMenu(AccountMenu, this.contextKeyService);
-		const rawActions: IAction[] = [];
-		fillInActionBarActions(menu.getActions(), rawActions);
-		menu.dispose();
-
-		const signOutAction = rawActions.find(action => !(action instanceof Separator) && action.id === 'workbench.action.agenticSignOut');
-
-		return [signOutAction].filter((action): action is IAction => !!action);
-	}
-
-	private getPersonalizeActions(): IAction[] {
-		const menu = this.menuService.createMenu(AccountMenu, this.contextKeyService);
-		const rawActions: IAction[] = [];
-		fillInActionBarActions(menu.getActions(), rawActions);
-		menu.dispose();
-
-		const ids = [
-			'workbench.action.openSettings',
-			'workbench.action.openGlobalKeybindings',
-			'workbench.action.selectTheme',
-		];
-		return ids
-			.map(id => rawActions.find(action => !(action instanceof Separator) && action.id === id))
-			.filter((action): action is IAction => !!action);
-	}
-
-	private getPanelActions(): IAction[] {
-		const menu = this.menuService.createMenu(AccountMenu, this.contextKeyService);
-		const rawActions: IAction[] = [];
-		fillInActionBarActions(menu.getActions(), rawActions);
-		menu.dispose();
-
-		return rawActions.filter(action => {
-			if (action instanceof Separator) {
-				return true;
-			}
-
-			// Hide sign-in while account is still loading
-			if (this.isAccountLoading && action.id === 'workbench.action.agenticSignIn') {
-				return false;
-			}
-
-			return action.id !== 'workbench.action.agenticSignOut'
-				&& action.id !== 'workbench.action.openSettings'
-				&& action.id !== 'workbench.action.openGlobalKeybindings'
-				&& action.id !== 'workbench.action.selectTheme'
-				&& !action.id.startsWith('update.');
-		});
 	}
 
 	private getHeaderActionIcon(action: IAction): ThemeIcon {
@@ -739,6 +753,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			disableModelSelection: true,
 			disableProviderOptions: true,
 			disableCompletionsSnooze: true,
+			disableQuickSettingsCollapsible: true,
 		});
 
 		store.add(disposableWindowInterval(mainWindow, () => {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -296,31 +296,16 @@
 	padding: 6px 0 0;
 }
 
-/* Suppress internal dividers from the embedded chat status dashboard
-	so the section headings provide the only visual grouping. */
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip div.header,
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
-	border-top: none;
-	border-bottom: none;
-}
-
+/* The embedded chat status dashboard ships dividers/HRs and header borders
+	intended for its standalone tooltip presentation. The section headings
+	provide the only visual grouping we want here. */
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip hr {
 	display: none;
 }
 
-/* Quick Settings: drop the collapsible behavior — always expanded, no header chevron. */
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
-	display: none;
-}
-
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content,
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed {
-	grid-template-rows: 1fr;
-}
-
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content > .collapsible-inner,
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed > .collapsible-inner {
-	visibility: visible;
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip div.header {
+	border-bottom: none;
+	padding-bottom: 0;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section-title {
@@ -332,7 +317,9 @@
 }
 
 /* Subscription section: place "Subscription" label and the dashboard's
-	plan-name + manage-action header on a single right-aligned row. */
+	plan-name + manage-action header on a single right-aligned row.
+	The dashboard's `div.header` is reparented into this row at runtime,
+	so it's no longer matched by chatStatus.css rules. */
 .agent-sessions-workbench .sessions-account-titlebar-panel-section-header {
 	display: flex;
 	align-items: center;
@@ -351,9 +338,6 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	margin: 0 !important;
-	padding: 0 !important;
-	border: none !important;
 	font-size: 12px;
 	line-height: 18px;
 }

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -303,7 +303,8 @@
 	display: none;
 }
 
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip div.header {
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip > div.header,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .contribution > div.header {
 	border-bottom: none;
 	padding-bottom: 0;
 }
@@ -368,6 +369,7 @@
 	height: 16px;
 	flex: 0 0 auto;
 	color: var(--vscode-descriptionForeground);
+	/* `!important` to override `.codicon`'s own `font-size` rule. */
 	font-size: 14px !important;
 }
 

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -202,7 +202,8 @@
 	align-items: center;
 	gap: 6px;
 	min-height: 28px;
-	padding: 6px 8px 0;
+	padding: 6px 8px;
+	border-bottom: 1px solid var(--vscode-menu-separatorBackground, var(--vscode-disabledForeground));
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-title {
@@ -289,6 +290,116 @@
 	padding: 2px 0;
 }
 
+.agent-sessions-workbench .sessions-account-titlebar-panel-section {
+	display: flex;
+	flex-direction: column;
+	padding: 6px 0 0;
+}
+
+/* Suppress internal dividers from the embedded chat status dashboard
+	so the section headings provide the only visual grouping. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip div.header,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
+	border-top: none;
+	border-bottom: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip hr {
+	display: none;
+}
+
+/* Quick Settings: drop the collapsible behavior — always expanded, no header chevron. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
+	display: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed {
+	grid-template-rows: 1fr;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content > .collapsible-inner,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed > .collapsible-inner {
+	visibility: visible;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-title {
+	padding: 4px 8px 2px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 18px;
+	color: var(--vscode-descriptionForeground);
+}
+
+/* Subscription section: place "Subscription" label and the dashboard's
+	plan-name + manage-action header on a single right-aligned row. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 10px 2px 8px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-header .sessions-account-titlebar-panel-section-title {
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 0;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-header > div.header {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin: 0 !important;
+	padding: 0 !important;
+	border: none !important;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-header > div.header .header-label {
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground);
+	font-weight: 400;
+	font-size: 11px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section-header > div.header .monaco-action-bar {
+	flex: 0 0 auto;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-action.with-icon {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	height: 24px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-action-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	flex: 0 0 auto;
+	color: var(--vscode-descriptionForeground);
+	font-size: 14px !important;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-action.with-icon:hover .sessions-account-titlebar-panel-action-icon,
+.agent-sessions-workbench .sessions-account-titlebar-panel-action.with-icon:focus-visible .sessions-account-titlebar-panel-action-icon {
+	color: inherit;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-action-label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .agent-sessions-workbench .sessions-account-titlebar-panel-separator {
 	height: 1px;
 	margin: 5px 0;
@@ -302,7 +413,7 @@
 	box-sizing: border-box;
 	height: 24px;
 	margin: 0 4px;
-	padding: 0 16px;
+	padding: 0 6px;
 	border: none;
 	border-radius: var(--vscode-cornerRadius-medium);
 	background: transparent;

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
@@ -135,9 +135,14 @@
 	padding: 0 8px;
 }
 
+.sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .quota-indicator .quota-title {
+	font-size: 12px;
+	margin-bottom: 0;
+}
+
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .collapsible-header {
 	margin-top: 0;
-	padding: 8px 10px 8px 8px;
+	padding: 0 10px 6px 8px;
 }
 
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .collapsible-inner {
@@ -145,11 +150,20 @@
 }
 
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .contribution .header {
-	padding: 0 10px 8px 8px;
+	padding: 0 10px 0 8px;
+	margin-bottom: 0;
+	line-height: 18px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip div.header .monaco-action-bar {
+	color: var(--vscode-foreground);
 }
 
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .contribution .body {
-	padding: 0 10px 4px 8px;
+	padding: 0 10px 0 8px;
+	line-height: 16px;
+	color: var(--vscode-descriptionForeground);
 }
 
 .monaco-workbench .part.sidebar > .sidebar-footer .account-widget-update .account-widget-update-button {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
@@ -140,11 +140,6 @@
 	margin-bottom: 0;
 }
 
-.sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .collapsible-header {
-	margin-top: 0;
-	padding: 0 10px 6px 8px;
-}
-
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .collapsible-inner {
 	padding-top: 0;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -73,6 +73,8 @@ export interface IChatStatusDashboardOptions {
 	disableProviderOptions?: boolean;
 	/** When true, disables the completions snooze button. */
 	disableCompletionsSnooze?: boolean;
+	/** When true, the Quick Settings region is rendered always-expanded without a collapsible header. */
+	disableQuickSettingsCollapsible?: boolean;
 }
 
 export class ChatStatusDashboard extends DomWidget {
@@ -263,15 +265,20 @@ export class ChatStatusDashboard extends DomWidget {
 	}
 
 	private renderQuickSettings(contributedEntries: ChatStatusEntry[]): void {
-		const collapsed = this.storageService.getBoolean(ChatStatusDashboard.QUICK_SETTINGS_COLLAPSED_KEY, StorageScope.PROFILE, true);
+		const nonCollapsible = !!this.options?.disableQuickSettingsCollapsible;
+		const collapsed = !nonCollapsible && this.storageService.getBoolean(ChatStatusDashboard.QUICK_SETTINGS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
-		const disclosureHeader = this.element.appendChild($('button.collapsible-header'));
-		disclosureHeader.setAttribute('aria-expanded', String(!collapsed));
+		let disclosureHeader: HTMLElement | undefined;
+		let chevron: HTMLElement | undefined;
+		if (!nonCollapsible) {
+			disclosureHeader = this.element.appendChild($('button.collapsible-header'));
+			disclosureHeader.setAttribute('aria-expanded', String(!collapsed));
 
-		const chevron = disclosureHeader.appendChild($('span.collapsible-chevron'));
-		chevron.classList.add(...ThemeIcon.asClassNameArray(collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+			chevron = disclosureHeader.appendChild($('span.collapsible-chevron'));
+			chevron.classList.add(...ThemeIcon.asClassNameArray(collapsed ? Codicon.chevronRight : Codicon.chevronDown));
 
-		disclosureHeader.appendChild($('span.collapsible-label', undefined, localize('quickSettingsTab', "Quick Settings")));
+			disclosureHeader.appendChild($('span.collapsible-label', undefined, localize('quickSettingsTab', "Quick Settings")));
+		}
 
 		const collapsibleContent = this.element.appendChild($('div.collapsible-content'));
 		const collapsibleInner = collapsibleContent.appendChild($('div.collapsible-inner'));
@@ -279,15 +286,17 @@ export class ChatStatusDashboard extends DomWidget {
 			collapsibleContent.classList.add('collapsed');
 		}
 
-		const toggle = () => {
-			const isCollapsed = collapsibleContent.classList.toggle('collapsed');
-			disclosureHeader.setAttribute('aria-expanded', String(!isCollapsed));
-			chevron.className = 'collapsible-chevron';
-			chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
-			this.storageService.store(ChatStatusDashboard.QUICK_SETTINGS_COLLAPSED_KEY, isCollapsed, StorageScope.PROFILE, StorageTarget.USER);
-		};
+		if (disclosureHeader && chevron) {
+			const toggle = () => {
+				const isCollapsed = collapsibleContent.classList.toggle('collapsed');
+				disclosureHeader!.setAttribute('aria-expanded', String(!isCollapsed));
+				chevron!.className = 'collapsible-chevron';
+				chevron!.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
+				this.storageService.store(ChatStatusDashboard.QUICK_SETTINGS_COLLAPSED_KEY, isCollapsed, StorageScope.PROFILE, StorageTarget.USER);
+			};
 
-		this._store.add(addDisposableListener(disclosureHeader, EventType.CLICK, () => toggle()));
+			this._store.add(addDisposableListener(disclosureHeader, EventType.CLICK, () => toggle()));
+		}
 
 		this.renderInlineSuggestionsContent(collapsibleInner);
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -75,6 +75,13 @@ export interface IChatStatusDashboardOptions {
 	disableCompletionsSnooze?: boolean;
 	/** When true, the Quick Settings region is rendered always-expanded without a collapsible header. */
 	disableQuickSettingsCollapsible?: boolean;
+	/**
+	 * When provided, the title header (plan name + manage / CTA actions) is
+	 * rendered into this caller-owned container instead of inline at the top
+	 * of the dashboard. Use this to embed the title header in a host layout
+	 * without reaching into the dashboard's private DOM.
+	 */
+	titleHeaderContainer?: HTMLElement;
 }
 
 export class ChatStatusDashboard extends DomWidget {
@@ -133,7 +140,8 @@ export class ChatStatusDashboard extends DomWidget {
 		let headerAdditionalSpendButton: Button | undefined;
 		if (hasUsageSection) {
 			const planName = getChatPlanName(this.chatEntitlementService.entitlement);
-			const header = this.renderHeader(this.element, this._store, planName, toAction({
+			const headerHost = this.options?.titleHeaderContainer ?? this.element;
+			const header = this.renderHeader(headerHost, this._store, planName, toAction({
 				id: 'workbench.action.manageCopilot',
 				label: localize('quotaLabel', "Manage Chat"),
 				tooltip: localize('quotaTooltip', "Manage Chat"),


### PR DESCRIPTION
This pull request significantly refactors and improves the account menu in the sessions title bar, focusing on clearer organization, extensibility, and better user experience. The main changes include restructuring the menu actions into logical sections (Personalize, Subscription, etc.), updating the UI to match these changes, and enhancing the subscription dashboard integration. The CSS has been updated to support the new layout and improve visual clarity.

<img width="373" height="279" alt="image" src="https://github.com/user-attachments/assets/87a4305a-35a2-4473-b2ef-bbf0970cd2c2" />


**Menu logic and UI structure:**

- Refactored the account menu logic to partition actions into "Personalize", "Sign Out", and "Subscription" groups, enabling clearer sectioning in the UI and easier future extensibility. The "Personalize" section now includes Settings, Keybindings, and Theme actions, and the "Sign Out" action is consistently separated. (`src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`) [[1]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R56-R63) [[2]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R546-R626) [[3]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3L592-R730)

- Added a "Keyboard Shortcuts" action to the account menu (hidden on mobile), and ensured all "Personalize" actions have appropriate icons and labels. (`src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`) [[1]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R253-R263) [[2]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3L646-R758)

**Subscription dashboard integration:**

- Improved the embedding of the Copilot subscription dashboard, including moving its header into a unified "Subscription" section and disabling its collapsible quick settings region for a more streamlined appearance in the title bar. (`src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`, `src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts`) [[1]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R546-R626) [[2]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R771) [[3]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780R76-R77) [[4]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780L266-R299)

**Styling and layout:**

- Updated CSS to support the new menu structure, including section headers, action buttons with icons, and unified styling for the subscription dashboard. This includes adjustments for padding, colors, alignment, and hiding unnecessary dashboard dividers. (`src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css`, `src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css`) [[1]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L205-R206) [[2]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430R293-R388) [[3]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L305-R402) [[4]](diffhunk://#diff-710571e192bcf18882122e92962ce54701f3f7a3c5a4b7e1d32315e21be0a8b5L138-R161)

**Extensibility and maintainability:**

- Centralized action IDs for "Personalize", "Sign In", and "Sign Out" actions, and improved code organization by removing redundant methods and clarifying action handling. (`src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts`) [[1]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R56-R63) [[2]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3L592-R730)

Overall, these changes make the account menu more intuitive, visually organized, and easier to extend in the future.
