### PR TITLE
Fix RunInTerminalTool hang when shell exits before/during execute()

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -87,6 +87,25 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 		this._register(store);
 
 		try {
+			// If the terminal is already disposed or its pty has already exited
+			// (e.g. the shell from a previous command died before this one was
+			// requested), Event.toPromise(onExit/onDisposed) will subscribe to an
+			// emitter that has already fired and never resolve, hanging the
+			// run-in-terminal tool until the agent's outer timeout. Detect this
+			// up front and resolve immediately with the captured exit code.
+			if (this._instance.isDisposed) {
+				this._log('Terminal already disposed at strategy entry');
+				throw new Error('The terminal was closed');
+			}
+			if (this._instance.exitCode !== undefined) {
+				this._log(`Terminal pty already exited at strategy entry (code=${this._instance.exitCode})`);
+				return {
+					output: undefined,
+					exitCode: this._instance.exitCode,
+					additionalInformation: `Command exited with code ${this._instance.exitCode}`,
+				};
+			}
+
 			const idlePollInterval = this._configurationService.getValue<number>(TerminalChatAgentToolsSettingId.IdlePollInterval) ?? 1000;
 
 			const idlePromptPromise = trackIdleOnPrompt(this._instance, idlePollInterval, store, idlePollInterval);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -90,7 +90,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			// If the terminal is already disposed or its pty has already exited
 			// (e.g. the shell from a previous command died before this one was
 			// requested), Event.toPromise(onExit/onDisposed) will subscribe to an
-			// emitter that has already fired and never resolve, hanging the
+			// emitter that has already fired and never resolves, hanging the
 			// run-in-terminal tool until the agent's outer timeout. Detect this
 			// up front and resolve immediately with the captured exit code.
 			if (this._instance.isDisposed) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -71,16 +71,30 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 		// shared emitters like onCommandFinished are cleaned up immediately.
 		this._register(store);
 		try {
-			// Ensure xterm is available
-			this._log('Waiting for xterm');
-			const xterm = await this._instance.xtermReadyPromise;
-			if (!xterm) {
-				throw new Error('Xterm is not available');
+			// If the terminal is already disposed or its pty has already exited
+			// (e.g. the shell from a previous command died before this one was
+			// requested), Event.toPromise(onExit/onDisposed) will subscribe to an
+			// emitter that has already fired and never resolve, hanging the
+			// run-in-terminal tool until the agent's outer timeout. Detect this
+			// up front and resolve immediately with the captured exit code.
+			if (this._instance.isDisposed) {
+				this._log('Terminal already disposed at strategy entry');
+				throw new Error('The terminal was closed');
 			}
-			const alternateBufferPromise = createAltBufferPromise(xterm, store, this._log.bind(this));
+			if (this._instance.exitCode !== undefined) {
+				this._log(`Terminal pty already exited at strategy entry (code=${this._instance.exitCode})`);
+				return {
+					output: undefined,
+					exitCode: this._instance.exitCode,
+					additionalInformation: `Command exited with code ${this._instance.exitCode}`,
+				};
+			}
 
 			const idlePollInterval = this._configurationService.getValue<number>(TerminalChatAgentToolsSettingId.IdlePollInterval) ?? 1000;
 
+			// Subscribe to terminal lifecycle events BEFORE any awaits so that we
+			// don't miss events that fire while we're waiting for xterm to be
+			// ready (e.g. the pty exits during xtermReadyPromise resolution).
 			const onDone = Promise.race([
 				Event.toPromise(this._commandDetection.onCommandFinished, store).then(e => {
 					this._log('onDone via end event');
@@ -104,6 +118,14 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 					this._log('onDone via idle prompt');
 				}),
 			]);
+
+			// Ensure xterm is available
+			this._log('Waiting for xterm');
+			const xterm = await this._instance.xtermReadyPromise;
+			if (!xterm) {
+				throw new Error('Xterm is not available');
+			}
+			const alternateBufferPromise = createAltBufferPromise(xterm, store, this._log.bind(this));
 
 			const markerRecreation = setupRecreatingStartMarker(
 				xterm,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -74,7 +74,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			// If the terminal is already disposed or its pty has already exited
 			// (e.g. the shell from a previous command died before this one was
 			// requested), Event.toPromise(onExit/onDisposed) will subscribe to an
-			// emitter that has already fired and never resolve, hanging the
+			// emitter that has already fired and never resolves, hanging the
 			// run-in-terminal tool until the agent's outer timeout. Detect this
 			// up front and resolve immediately with the captured exit code.
 			if (this._instance.isDisposed) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/basicExecuteStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/basicExecuteStrategy.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual } from 'assert';
+import { strictEqual, rejects } from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -66,5 +66,67 @@ suite('BasicExecuteStrategy', () => {
 		const result = await strategy.execute('exit 1', CancellationToken.None);
 
 		strictEqual(result.exitCode, 1);
+	});
+
+	test('returns immediately with captured exit code when pty has already exited before execute()', async () => {
+		// Simulates the scenario where the shell process from a previous command
+		// has already died, so onExit has already fired and Event.toPromise(onExit)
+		// would never resolve. The strategy must short-circuit using the
+		// instance's already-captured exitCode.
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const onExitEmitter = new Emitter<number | undefined>();
+		const instance = {
+			xtermReadyPromise: Promise.resolve({}),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: onExitEmitter.event,
+			isDisposed: false,
+			exitCode: 1,
+			sendText: () => { throw new Error('sendText should not be called when pty already exited'); },
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new BasicExecuteStrategy(
+			instance,
+			() => false,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		const result = await strategy.execute('Rscript /app/ars.R', CancellationToken.None);
+
+		strictEqual(result.exitCode, 1);
+		strictEqual(result.output, undefined);
+		strictEqual(result.additionalInformation, 'Command exited with code 1');
+	});
+
+	test('throws "The terminal was closed" when instance is already disposed before execute()', async () => {
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const instance = {
+			xtermReadyPromise: Promise.resolve({}),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: Event.None,
+			isDisposed: true,
+			exitCode: undefined,
+			sendText: () => { throw new Error('sendText should not be called when terminal is disposed'); },
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new BasicExecuteStrategy(
+			instance,
+			() => false,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		await rejects(
+			() => strategy.execute('echo hello', CancellationToken.None),
+			/The terminal was closed/
+		);
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/richExecuteStrategy.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strictEqual } from 'assert';
+import { rejects, strictEqual } from 'assert';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -160,5 +160,65 @@ suite('RichExecuteStrategy', () => {
 		const result = await strategy.execute('bad-command', CancellationToken.None);
 
 		strictEqual(result.exitCode, 127);
+	});
+
+	test('returns immediately with captured exit code when pty has already exited before execute()', async () => {
+		// Simulates the scenario where the shell process from a previous command
+		// has already died, so onExit has already fired and Event.toPromise(onExit)
+		// would never resolve. The strategy must short-circuit using the
+		// instance's already-captured exitCode.
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const onExitEmitter = new Emitter<number | undefined>();
+		const instance = {
+			xtermReadyPromise: Promise.resolve({}),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: onExitEmitter.event,
+			isDisposed: false,
+			exitCode: 1,
+			runCommand: () => { throw new Error('runCommand should not be called when pty already exited'); },
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new RichExecuteStrategy(
+			instance,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		const result = await strategy.execute('Rscript /app/ars.R', CancellationToken.None);
+
+		strictEqual(result.exitCode, 1);
+		strictEqual(result.output, undefined);
+		strictEqual(result.additionalInformation, 'Command exited with code 1');
+	});
+
+	test('throws "The terminal was closed" when instance is already disposed before execute()', async () => {
+		const onCommandFinishedEmitter = new Emitter<{ getOutput(): string; exitCode: number }>();
+		const instance = {
+			xtermReadyPromise: Promise.resolve({}),
+			onData: Event.None,
+			onDisposed: Event.None,
+			onExit: Event.None,
+			isDisposed: true,
+			exitCode: undefined,
+			runCommand: () => { throw new Error('runCommand should not be called when terminal is disposed'); },
+		} as unknown as ITerminalInstance;
+		const commandDetection = {
+			onCommandFinished: onCommandFinishedEmitter.event,
+		} as unknown as ICommandDetectionCapability;
+		const strategy = store.add(new RichExecuteStrategy(
+			instance,
+			commandDetection,
+			new TestConfigurationService(),
+			createLogService(),
+		));
+
+		await rejects(
+			() => strategy.execute('echo hello', CancellationToken.None),
+			/The terminal was closed/
+		);
 	});
 });


### PR DESCRIPTION
Fixes #313248

## Problem

In benchmark eval run [`25073061392`](https://github.com/microsoft/vscode-copilot-evaluation/actions/runs/25073061392), 16 tests failed with `X_AGENT_STILL_RESPONDING` (60-minute outer timeout). All 16 traced to the same hang in `RunInTerminalTool` rich execute strategy. The same bug was independently confirmed in run [`25115115244`](https://github.com/microsoft/vscode-copilot-evaluation/actions/runs/25115115244), where 13/89 tasks timed out with the identical pattern — shell process died (exit codes 1/2/22/127/130), `onExit` already fired, `Event.toPromise` hung forever.

<img width="967" height="558" alt="Screenshot 2026-04-29 at 12 12 39 PM" src="https://github.com/user-attachments/assets/79ad0973-fcc1-40a9-a6b7-74144af367e8" />

The build under test already had #312827 (`onExit` listener) and #312854 (downgrade rich → basic on broken shell integration), so the listener wasn't missing. The actual bug was a subscription-ordering / already-fired-emitter race.

`RichExecuteStrategy.execute()` wired `onExit` / `onDisposed` *after* `await this._instance.xtermReadyPromise`. Two failure modes from this:

1. **Already-dead instance.** If the pty had exited before `execute()` was entered, `_onExit` had already fired and been disposed (see `terminalInstance._onProcessExit`). `Event.toPromise(onExit)` then subscribed to a dead emitter and never resolved — hang until the agent's 60-min outer timeout.
2. **Race during `xtermReadyPromise`.** If the pty exits during xterm init, the events fire before our subscription is attached and are missed.

`BasicExecuteStrategy` already wired its race before the await, but had the same upfront-already-dead hole.

## Fix

In both `richExecuteStrategy.ts` and `basicExecuteStrategy.ts`:

1. **Synchronous early-out** at the top of `execute()`:
   - `instance.isDisposed` → throw `"The terminal was closed"` (matches existing `onDisposed` race branch).
   - `instance.exitCode !== undefined` → resolve immediately with the captured exit code and `additionalInformation: 'Command exited with code N'`.
2. In rich, **move the `Promise.race([...])` lifecycle subscriptions before `await xtermReadyPromise`** so `onExit` / `onDisposed` are wired synchronously at function entry. Closes the in-flight death race.

## Tests

Added unit tests to both `richExecuteStrategy.test.ts` and `basicExecuteStrategy.test.ts`:
- `returns immediately with captured exit code when pty has already exited before execute()`
- `throws "The terminal was closed" when instance is already disposed before execute()`

`runCommand` / `sendText` are stubbed to throw, proving the early-out path doesn't try to write to a dead shell.

