### PR TITLE
Resolve parent directory when realpath fails with ENOENT in edit confirmation

### DIFF
--- a/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
+++ b/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
@@ -6,6 +6,7 @@
 import { t } from '@vscode/l10n';
 import { realpath } from 'fs/promises';
 import { homedir } from 'os';
+import * as path from 'path';
 import type { LanguageModelChat, PreparedToolInvocation } from 'vscode';
 import { IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { ICustomInstructionsService } from '../../../platform/customInstructions/common/customInstructionsService';
@@ -892,7 +893,24 @@ export function makeUriConfirmationChecker(configuration: IConfigurationService,
 		const toCheck = [normalizePath(uri)];
 		if (uri.scheme === Schemas.file) {
 			try {
-				const linked = await realpath(uri.fsPath);
+				let linked: string;
+				try {
+					linked = await realpath(uri.fsPath);
+				} catch (e) {
+					if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+						// File doesn't exist yet (e.g. CreateFileTool case) — resolve the
+						// parent directory so symlinked parents are still checked.
+						const parentDir = path.dirname(uri.fsPath);
+						try {
+							const resolvedParent = await realpath(parentDir);
+							linked = path.join(resolvedParent, path.basename(uri.fsPath));
+						} catch {
+							linked = uri.fsPath;
+						}
+					} else {
+						throw e;
+					}
+				}
 				assertPathIsSafe(linked);
 
 				if (linked !== uri.fsPath) {
@@ -902,7 +920,7 @@ export function makeUriConfirmationChecker(configuration: IConfigurationService,
 				if ((e as NodeJS.ErrnoException).code === 'EPERM') {
 					return ConfirmationCheckResult.NoPermissions;
 				}
-				// Usually EPERM or ENOENT on the linkedFile
+				// Usually EPERM on the linkedFile
 			}
 		}
 

--- a/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
+++ b/extensions/copilot/src/extension/tools/node/editFileToolUtils.tsx
@@ -904,8 +904,13 @@ export function makeUriConfirmationChecker(configuration: IConfigurationService,
 						try {
 							const resolvedParent = await realpath(parentDir);
 							linked = path.join(resolvedParent, path.basename(uri.fsPath));
-						} catch {
-							linked = uri.fsPath;
+						} catch (parentError) {
+							const code = (parentError as NodeJS.ErrnoException).code;
+							if (code === 'ENOENT' || code === 'ENOTDIR') {
+								linked = uri.fsPath;
+							} else {
+								throw parentError;
+							}
 						}
 					} else {
 						throw e;


### PR DESCRIPTION
## Problem

In `getEditConfirmationCheckerForUri` in `editFileToolUtils.tsx`, when computing whether an edit needs user confirmation, we call `realpath(uri.fsPath)` to follow symlinks before running pattern/platform safety checks. For files that don't exist yet (e.g. `CreateFileTool`), `realpath` throws `ENOENT` and the catch block silently swallows the error. This means symlinked parent directories are never resolved for create-file operations, so a write through a symlinked parent that lands on a sensitive target wouldn't be flagged unless its literal path matches a sensitive pattern.

This is a defense-in-depth gap. Practical exploitation is constrained:
- The user must opt into Copilot Chat in restricted mode (which VS Code already warns about).
- The primary auto-execution vectors (`.vscode/*.json`, dotfiles, system paths) are already covered by pattern-based or platform-based defenses.
- Prompt injection is required and not guaranteed to succeed.

But the gap is real: for newly-created files through symlinks that don't match a sensitive pattern, writes proceed without confirmation.

## Fix

When `realpath` throws `ENOENT`, fall back to resolving the **parent directory** and join the basename. This way symlinked parent dirs are still followed and the resulting path is run through `assertPathIsSafe` and the sensitive-pattern checks. If the parent also doesn't exist, fall back to the original path (existing behavior).

Other errors (notably `EPERM`) are re-thrown so the outer handler can still return `NoPermissions`.