### PR TITLE
Terminal: prevent paste auto-exec when clipboard has trailing newline

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminalClipboard.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminalClipboard.ts
@@ -50,10 +50,13 @@ export async function shouldPasteTerminalText(accessor: ServicesAccessor, text: 
 			return true;
 		}
 
-		const textForLines = text.split(/\r?\n/);
-		// Ignore check when a command is copied with a trailing new line
+		// When a command is copied with a trailing new line, strip the trailing newline so the
+		// command is not automatically executed on paste. This mitigates a clipboard hijacking
+		// scenario where a malicious page replaces clipboard contents with a command followed by
+		// a newline; pasting (especially via right click) would otherwise immediately execute it.
+		// The user can still review the pasted text and press Enter to run it.
 		if (textForLines.length === 2 && textForLines[1].trim().length === 0) {
-			return true;
+			return { modifiedText: text.replace(/(?:\r?\n)+$/, '') };
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminalClipboard.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminalClipboard.ts
@@ -56,7 +56,7 @@ export async function shouldPasteTerminalText(accessor: ServicesAccessor, text: 
 		// a newline; pasting (especially via right click) would otherwise immediately execute it.
 		// The user can still review the pasted text and press Enter to run it.
 		if (textForLines.length === 2 && textForLines[1].trim().length === 0) {
-			return { modifiedText: text.replace(/(?:\r?\n)+$/, '') };
+			return { modifiedText: textForLines[0] };
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/clipboard/test/browser/terminalClipboard.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/test/browser/terminalClipboard.test.ts
@@ -57,7 +57,11 @@ suite('TerminalClipboard', function () {
 			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo', undefined), true);
 		});
 		test('Single line string with trailing new line', async () => {
-			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', undefined), true);
+			// Auto: strip the trailing newline to avoid auto-executing the command on paste
+			// (mitigates clipboard hijack auto-exec via right-click paste).
+			strictEqual(JSON.stringify(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', undefined)), JSON.stringify({ modifiedText: 'foo' }));
+			// Auto with bracketed paste mode: shell handles newline literally, safe to paste as-is.
+			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', true), true);
 
 			setConfigValue('always');
 			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', undefined), false);

--- a/src/vs/workbench/contrib/terminalContrib/clipboard/test/browser/terminalClipboard.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/test/browser/terminalClipboard.test.ts
@@ -60,8 +60,12 @@ suite('TerminalClipboard', function () {
 			// Auto: strip the trailing newline to avoid auto-executing the command on paste
 			// (mitigates clipboard hijack auto-exec via right-click paste).
 			strictEqual(JSON.stringify(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', undefined)), JSON.stringify({ modifiedText: 'foo' }));
+			strictEqual(JSON.stringify(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n ', undefined)), JSON.stringify({ modifiedText: 'foo' }));
+			strictEqual(JSON.stringify(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n\t', undefined)), JSON.stringify({ modifiedText: 'foo' }));
 			// Auto with bracketed paste mode: shell handles newline literally, safe to paste as-is.
 			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', true), true);
+			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n ', true), true);
+			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n\t', true), true);
 
 			setConfigValue('always');
 			strictEqual(await instantiationService.invokeFunction(shouldPasteTerminalText, 'foo\n', undefined), false);


### PR DESCRIPTION
Fixes an MSRC-reported issue where pasting clipboard text containing a trailing newline into the integrated terminal would automatically execute the command.

## Repro

1. A page calls `navigator.clipboard.writeText('calc.exe\\n')`.
2. User right-clicks (or Ctrl+V) into a cmd / PowerShell terminal.
3. `calc.exe` runs immediately, before the user reviews it.

## Root cause

`shouldPasteTerminalText` (in `terminalContrib/clipboard`) special-cases the default `auto` value of `terminal.integrated.enableMultiLinePasteWarning` and returns `true` (paste as-is) whenever the text is a single command followed by a trailing newline — even when bracketed paste mode is not active. The trailing `\n` is then sent verbatim to the shell, which executes the command.

## Fix

In `auto` mode and when bracketed paste mode is **not** enabled, strip the trailing newline(s) before pasting (return `{ modifiedText }`). The command appears at the prompt; the user must press Enter to run it. Bracketed-paste-aware shells continue to receive the original text unchanged. Updated the existing unit test to cover both branches.