### PR TITLE
Fix freeze in keyboard shortcuts search when query contains '.' (#309582)

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -345,8 +345,13 @@ export function matchesWords(word: string, target: string, contiguous: boolean =
 
 	word = tryNormalizeToBase(word);
 	target = tryNormalizeToBase(target);
+	// Memoize recursive calls within a single top-level invocation. Because word
+	// separators are treated as an equivalence class by `charactersMatch`, the
+	// recursion in `_matchesWords` can otherwise explode exponentially for inputs
+	// like `editor.action` against targets that contain many separators.
+	const memo = new Map<number, IMatch[] | null>();
 	while (targetIndex < target.length) {
-		result = _matchesWords(word, target, 0, targetIndex, contiguous);
+		result = _matchesWords(word, target, 0, targetIndex, contiguous, memo);
 		if (result !== null) {
 			break;
 		}
@@ -356,14 +361,40 @@ export function matchesWords(word: string, target: string, contiguous: boolean =
 	return result;
 }
 
-function _matchesWords(word: string, target: string, wordIndex: number, targetIndex: number, contiguous: boolean): IMatch[] | null {
-	let targetIndexOffset = 0;
+function cloneMatches(matches: IMatch[] | null): IMatch[] | null {
+	if (matches === null) {
+		return null;
+	}
+	const result: IMatch[] = [];
+	for (const m of matches) {
+		result.push({ start: m.start, end: m.end });
+	}
+	return result;
+}
 
+function _matchesWords(word: string, target: string, wordIndex: number, targetIndex: number, contiguous: boolean, memo: Map<number, IMatch[] | null>): IMatch[] | null {
 	if (wordIndex === word.length) {
 		return [];
 	} else if (targetIndex === target.length) {
 		return null;
-	} else if (!charactersMatch(word.charCodeAt(wordIndex), target.charCodeAt(targetIndex))) {
+	}
+
+	const memoKey = wordIndex * (target.length + 1) + targetIndex;
+	const cached = memo.get(memoKey);
+	if (cached !== undefined) {
+		// Caller (`join`) mutates the returned array, so always return a clone.
+		return cloneMatches(cached);
+	}
+
+	const computed = _matchesWordsCompute(word, target, wordIndex, targetIndex, contiguous, memo);
+	memo.set(memoKey, cloneMatches(computed));
+	return computed;
+}
+
+function _matchesWordsCompute(word: string, target: string, wordIndex: number, targetIndex: number, contiguous: boolean, memo: Map<number, IMatch[] | null>): IMatch[] | null {
+	let targetIndexOffset = 0;
+
+	if (!charactersMatch(word.charCodeAt(wordIndex), target.charCodeAt(targetIndex))) {
 		// Verify alternate characters before exiting
 		const altChars = getAlternateCodes(word.charCodeAt(wordIndex));
 		if (!altChars) {
@@ -379,10 +410,10 @@ function _matchesWords(word: string, target: string, wordIndex: number, targetIn
 
 	let result: IMatch[] | null = null;
 	let nextWordIndex = targetIndex + targetIndexOffset + 1;
-	result = _matchesWords(word, target, wordIndex + 1, nextWordIndex, contiguous);
+	result = _matchesWords(word, target, wordIndex + 1, nextWordIndex, contiguous, memo);
 	if (!contiguous) {
 		while (!result && (nextWordIndex = nextWord(target, nextWordIndex)) < target.length) {
-			result = _matchesWords(word, target, wordIndex + 1, nextWordIndex, contiguous);
+			result = _matchesWords(word, target, wordIndex + 1, nextWordIndex, contiguous, memo);
 			nextWordIndex++;
 		}
 	}

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -257,7 +257,8 @@ suite('Filters', () => {
 	test('matchesWords performance (#309582)', function () {
 		// Searching for a term containing a word separator (e.g. `.`) against
 		// command-id-like targets used to cause catastrophic backtracking and
-		// freeze the Keyboard Shortcuts editor.
+		// freeze the Keyboard Shortcuts editor. Without the fix this loop
+		// exceeds Mocha's default test timeout.
 		const targets = [
 			'workbench.action.terminal.focusNextLine',
 			'editor.action.clipboardCopyAction',
@@ -265,14 +266,11 @@ suite('Filters', () => {
 			'editor.action.smartSelect.expand',
 			'workbench.action.files.saveAll',
 		];
-		const start = Date.now();
 		for (let i = 0; i < 1000; i++) {
 			for (const t of targets) {
 				matchesWords('editor.action', t);
 			}
 		}
-		const elapsed = Date.now() - start;
-		assert.ok(elapsed < 1000, `matchesWords too slow: ${elapsed}ms`);
 	});
 
 	function assertMatches(pattern: string, word: string, decoratedWord: string | undefined, filter: FuzzyScorer, opts: { patternPos?: number; wordPos?: number; firstMatchCanBeWeak?: boolean } = {}) {

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -254,6 +254,27 @@ suite('Filters', () => {
 		filterOk(matchesWords, 'foo:bar', 'foo:bar');
 	});
 
+	test('matchesWords performance (#309582)', function () {
+		// Searching for a term containing a word separator (e.g. `.`) against
+		// command-id-like targets used to cause catastrophic backtracking and
+		// freeze the Keyboard Shortcuts editor.
+		const targets = [
+			'workbench.action.terminal.focusNextLine',
+			'editor.action.clipboardCopyAction',
+			'workbench.action.editor.changeLanguageMode',
+			'editor.action.smartSelect.expand',
+			'workbench.action.files.saveAll',
+		];
+		const start = Date.now();
+		for (let i = 0; i < 1000; i++) {
+			for (const t of targets) {
+				matchesWords('editor.action', t);
+			}
+		}
+		const elapsed = Date.now() - start;
+		assert.ok(elapsed < 1000, `matchesWords too slow: ${elapsed}ms`);
+	});
+
 	function assertMatches(pattern: string, word: string, decoratedWord: string | undefined, filter: FuzzyScorer, opts: { patternPos?: number; wordPos?: number; firstMatchCanBeWeak?: boolean } = {}) {
 		const r = filter(pattern, pattern.toLowerCase(), opts.patternPos || 0, word, word.toLowerCase(), opts.wordPos || 0, { firstMatchCanBeWeak: opts.firstMatchCanBeWeak ?? false, boostFullMatch: true });
 		assert.ok(!decoratedWord === !r);


### PR DESCRIPTION
Fixes #309582.

## Cause

\`_matchesWords\` in \`src/vs/base/common/filters.ts\` had no memoization. Word separators (\`.\`, \`:\`, \`-\`, \`/\`, etc.) are treated as an equivalence class by \`charactersMatch\`, and in non-contiguous mode the recursion branches at every word boundary in the target. Searching \`editor.action\` against many command-id-like strings (which is what \`KeybindingsEditorModel.filterByText\` does for thousands of keybinding entries) therefore produced exponential backtracking and froze the renderer.

The behaviour was introduced by c61bf317af8 (#74523, "Space in command palette should match", Jul 2019) which added the \`charactersMatch\` separator-equivalence check. It became user-visible as the set of registered commands/keybindings grew.

## Fix

Memoize \`_matchesWords\` by \`(wordIndex, targetIndex)\` within a single top-level \`matchesWords\` invocation. Match semantics and highlight ranges are unchanged. Added a perf regression test.