### PR TITLE
Reuse existing ingest operation if files haven't changed

### DIFF
--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
@@ -37,6 +37,11 @@ export interface ExternalIngestUpdateIndexResult {
 	readonly updatedFileCount: number;
 }
 
+export interface ExternalIngestFileSet {
+	readonly files: readonly ExternalIngestFile[];
+	readonly checkpoint: string;
+}
+
 export function computeCheckpointHash(files: readonly { readonly docSha: Uint8Array }[]): string {
 	const hash = crypto.createHash('sha1');
 	for (const file of files) {
@@ -51,8 +56,7 @@ export function computeCheckpointHash(files: readonly { readonly docSha: Uint8Ar
 export interface IExternalIngestClient {
 	updateIndex(
 		filesetName: string,
-		currentCheckpoint: string | undefined,
-		allFiles: readonly ExternalIngestFile[],
+		fileSet: ExternalIngestFileSet,
 		callTracker: CallTracker,
 		token: CancellationToken,
 		onProgress?: (message: string) => void
@@ -168,13 +172,15 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		throw new ExternalIngestRequestError(`${method} ${pathId} failed with status ${response.status}`, response);
 	}
 
-	async updateIndex(filesetName: string, currentCheckpoint: string | undefined, allFiles: readonly ExternalIngestFile[], inCallTracker: CallTracker, token: CancellationToken, onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
+	async updateIndex(filesetName: string, fileSet: ExternalIngestFileSet, inCallTracker: CallTracker, token: CancellationToken, onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
 		const callTracker = inCallTracker.add('ExternalIngestClient::updateIndex');
 		const authToken = await raceCancellationError(this.getAuthToken(), token);
 		if (!authToken) {
 			this.logService.warn('ExternalIngestClient::updateIndex(): No auth token available');
 			return Result.error(new Error('No auth token available'));
 		}
+
+		const { files: allFiles, checkpoint: newCheckpoint } = fileSet;
 
 		// Initial setup
 		const mappings = new Map</* sha */ string, ExternalIngestFile>();
@@ -204,14 +210,6 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		// Coded symbols used during finalization of the fileset.
 		// TODO: this range should be the entire fileset, right?
 		const codedSymbols = ingestUtils.createCodedSymbols(allDocShas, 0, 1).map((cs) => Buffer.from(cs).toString('base64'));
-
-		// A hash of all docsha hashes. This emulates a differing git commit.
-		const newCheckpoint = computeCheckpointHash(allFiles);
-
-		if (newCheckpoint === currentCheckpoint) {
-			this.logService.info('ExternalIngestClient::updateIndex(): Checkpoint matches current checkpoint, skipping ingest.');
-			return Result.ok({ checkpoint: newCheckpoint, totalFileCount: mappings.size, updatedFileCount: 0 });
-		}
 
 		// Retry loop for 409 Conflict: per the external indexing spec, if any ingestion
 		// endpoint returns 409, discard the ingest_id and restart from CreateCheckpoint.

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
@@ -37,6 +37,14 @@ export interface ExternalIngestUpdateIndexResult {
 	readonly updatedFileCount: number;
 }
 
+export function computeCheckpointHash(files: readonly { readonly docSha: Uint8Array }[]): string {
+	const hash = crypto.createHash('sha1');
+	for (const file of files) {
+		hash.update(file.docSha);
+	}
+	return hash.digest().toString('base64');
+}
+
 /**
  * Interface for the external ingest client that handles indexing and searching files.
  */
@@ -44,7 +52,7 @@ export interface IExternalIngestClient {
 	updateIndex(
 		filesetName: string,
 		currentCheckpoint: string | undefined,
-		allFiles: AsyncIterable<ExternalIngestFile>,
+		allFiles: readonly ExternalIngestFile[],
 		callTracker: CallTracker,
 		token: CancellationToken,
 		onProgress?: (message: string) => void
@@ -160,7 +168,7 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		throw new ExternalIngestRequestError(`${method} ${pathId} failed with status ${response.status}`, response);
 	}
 
-	async updateIndex(filesetName: string, currentCheckpoint: string | undefined, allFiles: AsyncIterable<ExternalIngestFile>, inCallTracker: CallTracker, token: CancellationToken, onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
+	async updateIndex(filesetName: string, currentCheckpoint: string | undefined, allFiles: readonly ExternalIngestFile[], inCallTracker: CallTracker, token: CancellationToken, onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
 		const callTracker = inCallTracker.add('ExternalIngestClient::updateIndex');
 		const authToken = await raceCancellationError(this.getAuthToken(), token);
 		if (!authToken) {
@@ -179,7 +187,7 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		const ingestableCheckStart = performance.now();
 
 		const allDocShas: Uint8Array[] = [];
-		for await (const file of allFiles) {
+		for (const file of allFiles) {
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
 			}
@@ -198,12 +206,7 @@ export class ExternalIngestClient extends Disposable implements IExternalIngestC
 		const codedSymbols = ingestUtils.createCodedSymbols(allDocShas, 0, 1).map((cs) => Buffer.from(cs).toString('base64'));
 
 		// A hash of all docsha hashes. This emulates a differing git commit.
-		const checkpointHash = crypto.createHash('sha1');
-		for (const docSha of allDocShas) {
-			checkpointHash.update(docSha);
-
-		}
-		const newCheckpoint = checkpointHash.digest().toString('base64');
+		const newCheckpoint = computeCheckpointHash(allFiles);
 
 		if (newCheckpoint === currentCheckpoint) {
 			this.logService.info('ExternalIngestClient::updateIndex(): Checkpoint matches current checkpoint, skipping ingest.');

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
@@ -39,7 +39,7 @@ import { IWorkspaceService } from '../../../workspace/common/workspaceService';
 import { StrategySearchSizing, WorkspaceChunkQueryWithEmbeddings } from '../../common/workspaceChunkSearch';
 import { shouldPotentiallyIndexFile } from '../workspaceFileIndex';
 import { CodeSearchRepoStatus, TriggerIndexingError, TriggerRemoteIndexingError } from './codeSearchRepo';
-import { ExternalIngestFile, ExternalIngestRequestError, IExternalIngestClient } from './externalIngestClient';
+import { computeCheckpointHash, ExternalIngestFile, ExternalIngestRequestError, IExternalIngestClient } from './externalIngestClient';
 import { WorkspaceFolderIdMap } from './workspaceFolderIdMap';
 
 const debug = false;
@@ -110,6 +110,8 @@ export class ExternalIngestIndex extends Disposable {
 		progressMessage: string | undefined;
 
 		completed: boolean;
+
+		readonly checkpointHash: string;
 	};
 
 	/**
@@ -322,11 +324,27 @@ export class ExternalIngestIndex extends Disposable {
 
 		const currentCheckpoint = this.getCurrentIndexCheckpoint();
 
+		// Pre-collect all files and compute the checkpoint hash so we can
+		// detect whether the workspace state has actually changed.
+		const allFiles: ExternalIngestFile[] = [];
+		for await (const file of this.getFilesToIndexFromDb(callerToken)) {
+			allFiles.push(file);
+		}
+		const checkpointHash = computeCheckpointHash(allFiles);
+
+		// If there is a running operation with the same checkpoint hash,
+		// the workspace state has not changed — reuse the existing operation.
+		if (this._currentIngestOperation && !this._currentIngestOperation.completed && this._currentIngestOperation.checkpointHash === checkpointHash) {
+			this._logService.info('ExternalIngestIndex::doIngest(): Workspace state unchanged, reusing existing ingest operation');
+			return this._currentIngestOperation.promise;
+		}
+
 		// Track building state
 		const operation: typeof this._currentIngestOperation = {
 			promise: undefined!,
 			progressMessage: undefined,
 			completed: false,
+			checkpointHash,
 		};
 
 		const sw = new StopWatch();
@@ -347,7 +365,7 @@ export class ExternalIngestIndex extends Disposable {
 				const result = await this._client.updateIndex(
 					filesetName,
 					currentCheckpoint,
-					this.getFilesToIndexFromDb(token),
+					allFiles,
 					telemetryInfo.callTracker,
 					token,
 					wrappedOnProgress
@@ -425,7 +443,7 @@ export class ExternalIngestIndex extends Disposable {
 			}
 		});
 
-		// Cancel existing
+		// Cancel existing since workspace state has changed
 		this._currentIngestOperation?.promise.cancel();
 
 		operation.promise = updatePromise;

--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestIndex.ts
@@ -39,7 +39,7 @@ import { IWorkspaceService } from '../../../workspace/common/workspaceService';
 import { StrategySearchSizing, WorkspaceChunkQueryWithEmbeddings } from '../../common/workspaceChunkSearch';
 import { shouldPotentiallyIndexFile } from '../workspaceFileIndex';
 import { CodeSearchRepoStatus, TriggerIndexingError, TriggerRemoteIndexingError } from './codeSearchRepo';
-import { computeCheckpointHash, ExternalIngestFile, ExternalIngestRequestError, IExternalIngestClient } from './externalIngestClient';
+import { computeCheckpointHash, ExternalIngestFile, ExternalIngestFileSet, ExternalIngestRequestError, IExternalIngestClient } from './externalIngestClient';
 import { WorkspaceFolderIdMap } from './workspaceFolderIdMap';
 
 const debug = false;
@@ -332,6 +332,14 @@ export class ExternalIngestIndex extends Disposable {
 		}
 		const checkpointHash = computeCheckpointHash(allFiles);
 
+		const fileSet: ExternalIngestFileSet = { files: allFiles, checkpoint: checkpointHash };
+
+		// If the checkpoint matches the stored one, the index is already up to date.
+		if (checkpointHash === currentCheckpoint) {
+			this._logService.info('ExternalIngestIndex::doIngest(): Checkpoint matches current checkpoint, skipping ingest.');
+			return Result.ok(true);
+		}
+
 		// If there is a running operation with the same checkpoint hash,
 		// the workspace state has not changed — reuse the existing operation.
 		if (this._currentIngestOperation && !this._currentIngestOperation.completed && this._currentIngestOperation.checkpointHash === checkpointHash) {
@@ -364,8 +372,7 @@ export class ExternalIngestIndex extends Disposable {
 			try {
 				const result = await this._client.updateIndex(
 					filesetName,
-					currentCheckpoint,
-					allFiles,
+					fileSet,
 					telemetryInfo.callTracker,
 					token,
 					wrappedOnProgress

--- a/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
@@ -19,7 +19,7 @@ import { FileType } from '../../../filesystem/common/fileTypes';
 import { ISearchService } from '../../../search/common/searchService';
 import { createPlatformServices, TestingServiceCollection } from '../../../test/node/services';
 import { IWorkspaceService, NullWorkspaceService } from '../../../workspace/common/workspaceService';
-import { ExternalIngestClient, ExternalIngestFile, ExternalIngestUpdateIndexResult, IExternalIngestClient } from '../../node/codeSearch/externalIngestClient';
+import { ExternalIngestClient, ExternalIngestFile, ExternalIngestFileSet, ExternalIngestUpdateIndexResult, IExternalIngestClient } from '../../node/codeSearch/externalIngestClient';
 import { ExternalIngestIndex } from '../../node/codeSearch/externalIngestIndex';
 
 const emptyProgressCb: (message: string) => void = () => { };
@@ -40,8 +40,8 @@ function createMockExternalIngestClient(options?: {
 			return Array.from(ingestedFiles.values());
 		},
 		searchCalls,
-		async updateIndex(_filesetName: string, _currentCheckpoint: string | undefined, allFiles: readonly ExternalIngestFile[], _callTracker: CallTracker, _token: CancellationToken, _onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
-			for (const file of allFiles) {
+		async updateIndex(_filesetName: string, fileSet: ExternalIngestFileSet, _callTracker: CallTracker, _token: CancellationToken, _onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
+			for (const file of fileSet.files) {
 				ingestedFiles.set(file.uri, file);
 			}
 			return Result.ok({ checkpoint: 'mock-checkpoint', totalFileCount: ingestedFiles.size, updatedFileCount: ingestedFiles.size });

--- a/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/test/node/externalIngest.spec.ts
@@ -40,8 +40,8 @@ function createMockExternalIngestClient(options?: {
 			return Array.from(ingestedFiles.values());
 		},
 		searchCalls,
-		async updateIndex(_filesetName: string, _currentCheckpoint: string | undefined, allFiles: AsyncIterable<ExternalIngestFile>, _callTracker: CallTracker, _token: CancellationToken, _onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
-			for await (const file of allFiles) {
+		async updateIndex(_filesetName: string, _currentCheckpoint: string | undefined, allFiles: readonly ExternalIngestFile[], _callTracker: CallTracker, _token: CancellationToken, _onProgress?: (message: string) => void): Promise<Result<ExternalIngestUpdateIndexResult, Error>> {
+			for (const file of allFiles) {
 				ingestedFiles.set(file.uri, file);
 			}
 			return Result.ok({ checkpoint: 'mock-checkpoint', totalFileCount: ingestedFiles.size, updatedFileCount: ingestedFiles.size });


### PR DESCRIPTION
We already handled the case where an ingest had completed. This makes it so that any ongoing ingests also should reuse the existing operation as long as the workspace hasn't changed 

