### PR TITLE
Default triggered breakpoint dropdown to first available breakpoint #312509

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -277,11 +277,18 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 		const breakpointOptions = this.buildBreakpointOptions();
 
 		const index = this.availableBreakpoints.findIndex((bp) => this.breakpoint?.triggeredBy === bp.getId());
+		let selectedIndex: number;
 		if (index !== -1) {
 			this.triggeredByBreakpointInput = this.availableBreakpoints[index];
+			selectedIndex = index + 1;
+		} else if (this.availableBreakpoints.length > 0) {
+			this.triggeredByBreakpointInput = this.availableBreakpoints[0];
+			selectedIndex = 1;
+		} else {
+			selectedIndex = 0;
 		}
 
-		const selectBreakpointBox = this.selectBreakpointBox = this.store.add(new SelectBox(breakpointOptions, index + 1, this.contextViewService, defaultSelectBoxStyles, { ariaLabel: nls.localize('selectBreakpoint', 'Select breakpoint'), useCustomDrawn: !hasNativeContextMenu(this._configurationService) }));
+		const selectBreakpointBox = this.selectBreakpointBox = this.store.add(new SelectBox(breakpointOptions, selectedIndex, this.contextViewService, defaultSelectBoxStyles, { ariaLabel: nls.localize('selectBreakpoint', 'Select breakpoint'), useCustomDrawn: !hasNativeContextMenu(this._configurationService) }));
 		this.store.add(selectBreakpointBox.onDidSelect(e => {
 			if (e.index === 0) {
 				this.triggeredByBreakpointInput = undefined;
@@ -347,6 +354,10 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 				// The selected breakpoint was removed, clear the selection
 				this.triggeredByBreakpointInput = undefined;
 			}
+		}
+		if (!this.triggeredByBreakpointInput && this.availableBreakpoints.length > 0) {
+			this.triggeredByBreakpointInput = this.availableBreakpoints[0];
+			selectedIndex = 1;
 		}
 
 		const breakpointOptions = this.buildBreakpointOptions();

--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -285,6 +285,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 			this.triggeredByBreakpointInput = this.availableBreakpoints[0];
 			selectedIndex = 1;
 		} else {
+			this.triggeredByBreakpointInput = undefined;
 			selectedIndex = 0;
 		}
 


### PR DESCRIPTION
Summary
- Default the "Add Triggered Breakpoint" dropdown to the first available breakpoint instead of "None" when no triggeredBy is set, so users can confirm with OK in one click.
- Apply the same fallback in updateTriggerBreakpointList when the list refreshes and no selection is held.
- Clear triggeredByBreakpointInput in the empty-state branch of createTriggerBreakpointInput to avoid stale in-memory selection when no breakpoints exist.

Motivation
- Previous workflow required: add breakpoint → open dialog → click dropdown → pick breakpoint → OK. The "None" option is disabled, so it could never be a valid final selection — defaulting to it just forced an extra click. New flow: add breakpoint → open dialog → OK.

Changes
- [src/vs/workbench/contrib/debug/browser/breakpointWidget.ts](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts): updated createTriggerBreakpointInput and updateTriggerBreakpointList selection logic.

Test plan
 - [ ] Add a breakpoint, then "Add Triggered Breakpoint..." on another line → dropdown preselects the existing breakpoint.
 - [ ] Edit an existing triggered breakpoint → dropdown shows its current triggeredBy target.
 - [ ] Open dialog with no other breakpoints present → dropdown shows "None", OK closes without setting trigger.
 - [ ] Remove the selected trigger breakpoint while dialog open → selection falls back to next available or "None".