### PR TITLE
Recover from terminal hangs when shell integration breaks or the pty exits

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -254,11 +254,11 @@ export async function trackIdleOnPrompt(
 	// fires, so this is purely a fallback for the broken-handshake path.
 	const hardCapScheduler = store.add(new RunOnceScheduler(() => {
 		if (state === TerminalState.Initial || state === TerminalState.Prompt) {
-			log?.(`Hard cap fired after 5 minutes in state ${stateNames[state]} (dataEvents=${dataEventCount})`);
+			log?.(`Hard cap fired after 60s in state ${stateNames[state]} (dataEvents=${dataEventCount})`);
 			setState(TerminalState.PromptAfterExecuting, 'hardCap');
 			scheduler.schedule();
 		}
-	}, 5 * 60_000));
+	}, 60_000));
 	hardCapScheduler.schedule();
 	// Only schedule when a prompt sequence (A) is seen after an execute sequence (C). This prevents
 	// cases where the command is executed before the prompt is written. While not perfect, sitting

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -243,6 +243,23 @@ export async function trackIdleOnPrompt(
 			scheduler.schedule();
 		}
 	}, 30_000));
+	// Hard wall-clock safety net for the case where shell integration never
+	// engages at all — no OSC `C`/`D` is ever parsed so state never advances
+	// to Executing, and yet the existing data-idle fallbacks somehow fail to
+	// fire (e.g. because data arrives in a single event before listeners are
+	// active, or because `onData` throttling masks idle periods). Without
+	// this, trackIdleOnPrompt can block the rich strategy for the lifetime
+	// of the chat request. Genuinely long-running commands with working
+	// shell integration reach Executing/PromptAfterExecuting before this
+	// fires, so this is purely a fallback for the broken-handshake path.
+	const hardCapScheduler = store.add(new RunOnceScheduler(() => {
+		if (state === TerminalState.Initial || state === TerminalState.Prompt) {
+			log?.(`Hard cap fired after 5 minutes in state ${stateNames[state]} (dataEvents=${dataEventCount})`);
+			setState(TerminalState.PromptAfterExecuting, 'hardCap');
+			scheduler.schedule();
+		}
+	}, 5 * 60_000));
+	hardCapScheduler.schedule();
 	// Only schedule when a prompt sequence (A) is seen after an execute sequence (C). This prevents
 	// cases where the command is executed before the prompt is written. While not perfect, sitting
 	// on an A without a C following shortly after is a very good indicator that the command is done

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2287,12 +2287,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// will never fire — the pty exited before shell integration could
 		// emit the end marker. Output captured here is whatever was buffered
 		// up until disposal.
+		// Capture the execution reference now — by the time onDisposed fires,
+		// onDidDisposeInstance listeners may have already removed it from
+		// _activeExecutions.
+		const executionForDisposal = RunInTerminalTool._activeExecutions.get(termId);
 		store.add(terminalInstance.onDisposed(() => {
 			if (handleSessionCancelled()) {
 				return;
 			}
-			const execution = RunInTerminalTool._activeExecutions.get(termId);
-			const currentOutput = execution?.getOutput() ?? '';
+			const currentOutput = executionForDisposal?.getOutput() ?? '';
 			const exitCode = terminalInstance.exitCode;
 			const exitCodeText = exitCode !== undefined ? ` with exit code ${exitCode}` : '';
 			disposeNotification();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -2282,9 +2282,31 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}));
 
 		// Clean up all background resources when the terminal is disposed
-		// (e.g. user closes the terminal) to avoid leaking listeners and monitors.
+		// (e.g. user closes the terminal). Send a completion notification so
+		// the agent isn't left waiting for an `onCommandFinished` event that
+		// will never fire — the pty exited before shell integration could
+		// emit the end marker. Output captured here is whatever was buffered
+		// up until disposal.
 		store.add(terminalInstance.onDisposed(() => {
+			if (handleSessionCancelled()) {
+				return;
+			}
+			const execution = RunInTerminalTool._activeExecutions.get(termId);
+			const currentOutput = execution?.getOutput() ?? '';
+			const exitCode = terminalInstance.exitCode;
+			const exitCodeText = exitCode !== undefined ? ` with exit code ${exitCode}` : '';
 			disposeNotification();
+			const message = `[Terminal ${termId} notification: terminal exited${exitCodeText}. The terminal process ended before the command could complete normally; further commands cannot be sent to this terminal ID.]\nTerminal output:\n${currentOutput}`;
+			this._logService.debug(`RunInTerminalTool: Background terminal ${termId} disposed${exitCodeText}, notifying chat session`);
+			this._chatService.sendRequest(chatSessionResource, message, {
+				...sendOptions,
+				queue: ChatRequestQueueKind.Steering,
+				isSystemInitiated: true,
+				systemInitiatedLabel: localize('terminalProcessExited', "`{0}` terminal exited", commandName),
+				terminalExecutionId: termId,
+			}).catch(e => {
+				this._logService.warn(`RunInTerminalTool: Failed to send terminal-exited notification for terminal ${termId}`, e);
+			});
 		}));
 
 		// When a checkpoint is restored, requests are removed from the model.


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/313296

Two related fixes uncovered while diagnosing eval run [`25120748970`](https://github.com/microsoft/vscode-copilot-evaluation/actions/runs/25120748970), where 11 of 47 benchmarks hit the 1-hour outer timeout because the `RunInTerminalTool` flow never produced a result — even though the underlying terminals were alive and reachable.

### 1. Hard-cap fallback in `trackIdleOnPrompt`

10 of the 11 hung runs logged:

> `Shell integration failed to add capabilities within 10 seconds`

Inspecting their full logs showed:
- No `Finished rich` line ever logged for the hung command.
- Zero OSC `C`/`D` sequences ever parsed (no `trackIdleOnPrompt` state transitions logged).
- The rich strategy's `Promise.race` never resolved by *any* arm — `onCommandFinished` (SI never engaged), `onDisposed`/`onExit` (pty alive), `onCancellationRequested` (not cancelled), and `trackIdleOnPrompt` (state stuck in `Initial`).

The existing fallbacks in `trackIdleOnPrompt` cover *partial* SI failure:
- `initialFallbackScheduler` (10 s, fires only if no data has arrived).
- `executingFallbackScheduler` from #312854 (30 s data-idle, gated on `state === Executing` — i.e. at least one OSC `C`/`D` must have parsed).

Neither covers the case where data *does* arrive but no OSC sequence is ever parsed (broken handshake from the start of the command). Both schedulers get cancelled by `onData` and the function blocks for the rest of the chat request.

This adds a 1-minute wall-clock `hardCapScheduler` that fires only if state is still `Initial` or `Prompt` — i.e. SI never engaged. Working SI completes via `onCommandFinished` long before; long-running commands with working SI advance past `Prompt` and the cap is a no-op for them.

### 2. Notify chat session when a background terminal disposes

In `runInTerminalTool.ts#_registerCompletionNotification`, the `onDisposed` handler previously just tore down listeners. If a backgrounded terminal's pty exits before `commandDetection.onCommandFinished` fires (process crash, user closes the terminal, shell exits), the agent is left silently waiting for a notification that will never arrive — exactly what happened in `build-pov-ray`.

Now the handler captures whatever output was buffered, reads `exitCode`, and sends a `Steering`-queued steering message using the same `userSelectedModelId`/`modeInfo`/`userSelectedTools` as the regular completion path, with a new `terminalProcessExited` localize label.

### Risk

Both changes are no-ops on every working path:
- Hard cap: only fires if `state` never advanced past `Prompt` after 5 min.
- Disposal notification: only fires if `onDisposed` reaches the handler before `_backgroundNotifications` was already cleared.

No user-visible UI changes; the only effect on agent transcripts is an extra steering message in the previously-silent failure modes.
