### PR TITLE
Remove set -e guidance from all shells and prevent reusing dead terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -238,8 +238,7 @@ function createBashModelDescription(isSandboxEnabled: boolean, networkDomains?: 
 		'This tool allows you to execute shell commands in a persistent bash terminal session, preserving environment variables, working directory, and other context across multiple commands.',
 		createGenericDescription(isSandboxEnabled, networkDomains),
 		'- Use [[ ]] for conditional tests instead of [ ]',
-		'- Prefer $() over backticks for command substitution',
-		'- Use set -e at start of complex commands to exit on errors'
+		'- Prefer $() over backticks for command substitution'
 	].join('\n');
 }
 
@@ -251,7 +250,6 @@ function createZshModelDescription(isSandboxEnabled: boolean, networkDomains?: I
 		'- Use jobs, fg, bg for job control',
 		'- Use [[ ]] for conditional tests instead of [ ]',
 		'- Prefer $() over backticks for command substitution',
-		'- Use setopt errexit for strict error handling',
 		'- Take advantage of zsh globbing features (**, extended globs)'
 	].join('\n');
 }
@@ -265,7 +263,6 @@ function createFishModelDescription(isSandboxEnabled: boolean, networkDomains?: 
 		'- Use test expressions for conditionals (no [[ ]] syntax)',
 		'- Prefer command substitution with () syntax',
 		'- Variables are arrays by default, use $var[1] for first element',
-		'- Use set -e for strict error handling',
 		'- Take advantage of fish\'s autosuggestions and completions'
 	].join('\n');
 }
@@ -1866,14 +1863,25 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (!isBackground) {
 			const cachedTerminal = this._sessionTerminalAssociations.get(chatSessionResource);
 			if (cachedTerminal && !cachedTerminal.isBackground && !cachedTerminal.instance.isDisposed) {
-				this._logService.debug(`RunInTerminalTool: Using cached terminal with session resource \`${chatSessionResource}\``);
-				this._terminalToolCreator.refreshShellIntegrationQuality(cachedTerminal);
-				this._terminalChatService.registerTerminalInstanceWithToolSession(terminalToolSessionId, cachedTerminal.instance);
-				// Dispose any previous background notification (e.g. from an earlier
-				// `inputNeeded` race that left an OutputMonitor attached) before reusing
-				// this terminal, so its listeners don't accumulate across invocations.
-				this._backgroundNotifications.deleteAndDispose(cachedTerminal.instance.instanceId);
-				return cachedTerminal;
+				// When the shell process has already exited (e.g. `set -e` killed the
+				// login shell on a previous command failure), reusing the terminal would
+				// cause the execute strategy to hit its early-out check and return the
+				// stale exit code instead of running the new command. Discard the dead
+				// terminal and create a fresh one so the next command starts in a live
+				// shell.
+				if (cachedTerminal.instance.exitCode !== undefined) {
+					this._logService.info(`RunInTerminalTool: Cached terminal shell has exited (code=${cachedTerminal.instance.exitCode}), creating a new terminal`);
+					this._sessionTerminalAssociations.delete(chatSessionResource);
+				} else {
+					this._logService.debug(`RunInTerminalTool: Using cached terminal with session resource \`${chatSessionResource}\``);
+					this._terminalToolCreator.refreshShellIntegrationQuality(cachedTerminal);
+					this._terminalChatService.registerTerminalInstanceWithToolSession(terminalToolSessionId, cachedTerminal.instance);
+					// Dispose any previous background notification (e.g. from an earlier
+					// `inputNeeded` race that left an OutputMonitor attached) before reusing
+					// this terminal, so its listeners don't accumulate across invocations.
+					this._backgroundNotifications.deleteAndDispose(cachedTerminal.instance.instanceId);
+					return cachedTerminal;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Fixes #313296

Companion to #313312. While that PR adds runtime fallbacks (hard-cap timer, disposal notifications), this PR addresses the upstream cause and downstream recovery.

### 1. Remove `set -e` / `setopt errexit` guidance from model descriptions

The tool descriptions for bash, zsh, and fish previously instructed the model to use `set -e` / `setopt errexit` for strict error handling. Since `run_in_terminal` operates in a **persistent login shell**, these options kill the entire shell process when any command fails — making the terminal unusable for subsequent commands. All 11 hung commands in the eval used `set -e`.

These lines were originally added in PR #272153 as general shell best practices, without considering the persistent session context. Removed from all three shells since the same problem would occur if benchmarks ran on zsh or fish.

### 2. Prevent reusing cached terminals whose shell has exited

`_initTerminal` previously checked only `instance.isDisposed` before reusing a cached foreground terminal. A terminal whose shell process exited (e.g. from `set -e`) but whose instance was not yet disposed would be reused. The execute strategy then hits its early-out check (`exitCode !== undefined`) and returns the **stale exit code from the previous command** — the new command never runs.

Now checks `instance.exitCode` as well. When the cached terminal has a dead shell, the association is removed and a fresh terminal is created.

### Risk

- Model description change: purely removes lines; models that already avoid `set -e` are unaffected.
- Terminal reuse check: only triggers when `exitCode` is already set (shell is dead). Live terminals are unaffected.