### PR TITLE
ci: drop VSCODE_OSS token conditional from pr.yml compile job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-          GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.VSCODE_OSS || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create node_modules archive
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -82,7 +82,7 @@ jobs:
       - name: Compile & Hygiene
         run: npm exec -- npm-run-all2 -lp core-ci hygiene eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check test-build-scripts
         env:
-          GITHUB_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.VSCODE_OSS || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check cyclic dependencies
         run: node build/lib/checkCyclicDependencies.ts out-build


### PR DESCRIPTION
## Summary

Follow-up to #313128. Removes the `VSCODE_OSS` fork-aware conditional from `pr.yml`'s `compile` job (`Install dependencies` and `Compile & Hygiene` steps), reverting the token back to plain `secrets.GITHUB_TOKEN`.

The `VSCODE_OSS` PAT isn't needed here. The 403s seen during #311975 weren't caused by a missing/wrong token — they were a side effect of an invalidated `node_modules` cache: the `Install dependencies` step ran when it shouldn't have, which produced the cross-repo `api.github.com` traffic that surfaced the 403s in the first place. With a healthy cache, the compile job doesn't make those calls at all, so `GITHUB_TOKEN` (with `permissions: contents: read` from #304929) is sufficient for anything that *does* leak through.

<details>
<summary>Session Context</summary>

- **Real cause of #311975 failures**: the `node_modules` cache key changed and forced `npm ci` + cross-repo release fetches to run on 1ES, where the failure mode showed up as 403s. Token wasn't the issue.
- **`VSCODE_OSS` is still used in `pr-node-modules.yml`** for `npm ci` and built-in extensions — those are the genuinely needed sites and aren't touched here.
- **Other reusable workflows** (`pr-linux-test.yml`, `pr-win32-test.yml`, `pr-darwin-test.yml`) only fetch built-in extensions on cache miss and already work fine on 1ES with `GITHUB_TOKEN`.

</details>