### PR TITLE
chat: improve ChatApprovedAccountOrganizations restriction messaging

### DIFF
--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -112,18 +112,18 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 	}
 
 	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
-		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by organization policy"));
+		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by your administrator"));
 
-		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
+		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required by Your Administrator")));
 
 		const description = append(card, $('p'));
 		if (options.accountName) {
 			append(description, document.createTextNode(
-				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use Agents.", options.accountName)
+				localize('accountGate.descriptionWithAccount', "The account \"{0}\" is not a member of an organization that your administrator allows for Agents.", options.accountName)
 			));
 		} else {
 			append(description, document.createTextNode(
-				localize('accountGate.descriptionNoAccount', "Sign in with a GitHub account from an approved organization to use Agents.")
+				localize('accountGate.descriptionNoAccount', "Your administrator restricts Agents to members of the organizations below.")
 			));
 		}
 
@@ -132,7 +132,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		if (hasConcreteOrgs) {
 			const orgSection = append(card, $('div.sessions-policy-blocked-orgs'));
 			append(orgSection, $('p.sessions-policy-blocked-orgs-label', undefined,
-				localize('accountGate.approvedOrgs', "Approved organizations:")
+				localize('accountGate.approvedOrgs', "Allowed organizations:")
 			));
 			const orgList = append(orgSection, $('ul'));
 			for (const org of approvedOrgs) {
@@ -141,8 +141,6 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		}
 
 		const footer = append(card, $('p.sessions-policy-blocked-footer'));
-		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
-		append(footer, document.createTextNode(' '));
 		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
 		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
 		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';

--- a/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
+++ b/src/vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked.ts
@@ -114,7 +114,7 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 	private _renderAccountPolicyGate(card: HTMLElement, options: ISessionsBlockedOverlayOptions): void {
 		this.overlay.setAttribute('aria-label', localize('accountGate.aria', "Sign-in required by your administrator"));
 
-		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required by Your Administrator")));
+		append(card, $('h2', undefined, localize('accountGate.title', "Sign-In Required")));
 
 		const description = append(card, $('p'));
 		if (options.accountName) {
@@ -141,6 +141,8 @@ export class SessionsPolicyBlockedOverlay extends Disposable {
 		}
 
 		const footer = append(card, $('p.sessions-policy-blocked-footer'));
+		append(footer, document.createTextNode(localize('accountGate.contactAdmin', "Contact your administrator for more information.")));
+		append(footer, document.createTextNode(' '));
 		const learnMore = append(footer, $('a.sessions-policy-blocked-link')) as HTMLAnchorElement;
 		learnMore.textContent = localize('accountGate.learnMore', "Learn more");
 		learnMore.href = 'https://code.visualstudio.com/docs/enterprise/overview';

--- a/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
+++ b/src/vs/workbench/services/policies/browser/accountPolicyGateContribution.ts
@@ -145,7 +145,6 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 			return;
 		}
 
-		const reason = info.reason;
 		const accountName = this.defaultAccountService.currentDefaultAccount?.accountName;
 		const approvedOrgs = info.approvedOrganizations ?? [];
 		const hasConcreteOrgs = approvedOrgs.length > 0 && !approvedOrgs.includes('*');
@@ -153,34 +152,30 @@ export class AccountPolicyGateContribution extends Disposable implements IWorkbe
 		// Notifications render as plain inline text — comma-separate orgs.
 		const orgList = approvedOrgs.join(', ');
 		let message: string;
-		if (reason === AccountPolicyGateUnsatisfiedReason.OrgNotApproved) {
-			if (accountName && hasConcreteOrgs) {
-				message = localize(
-					'accountPolicy.notification.orgWithAccount',
-					"The account \"{0}\" is not a member of an approved organization ({1}). Sign into an approved GitHub account to use AI features. Contact your administrator for more information.",
-					accountName,
-					orgList
-				);
-			} else if (accountName) {
-				message = localize(
-					'accountPolicy.notification.orgWithAccountNoList',
-					"The account \"{0}\" is not a member of an approved organization. Sign into an approved GitHub account to use AI features. Contact your administrator for more information.",
-					accountName
-				);
-			} else {
-				message = localize('accountPolicy.notification.org', "Sign in with a GitHub account from an approved organization to use AI features. Contact your administrator for more information.");
-			}
+		if (accountName && hasConcreteOrgs) {
+			message = localize(
+				'accountPolicy.notification.orgWithAccount',
+				"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}. The account \"{1}\" is not a member of any of these.",
+				orgList,
+				accountName
+			);
+		} else if (accountName) {
+			message = localize(
+				'accountPolicy.notification.orgWithAccountNoList',
+				"Your administrator restricts AI features to specific GitHub accounts. The account \"{0}\" does not qualify.",
+				accountName
+			);
+		} else if (hasConcreteOrgs) {
+			message = localize(
+				'accountPolicy.notification.signinWithOrgs',
+				"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}.",
+				orgList
+			);
 		} else {
-			// noAccount / wrongProvider
-			if (hasConcreteOrgs) {
-				message = localize(
-					'accountPolicy.notification.signinWithOrgs',
-					"Sign in with a GitHub account from an approved organization ({0}) to use AI features.",
-					orgList
-				);
-			} else {
-				message = localize('accountPolicy.notification.signin', "Sign in with an approved GitHub account to use AI features. Contact your administrator for more information.");
-			}
+			message = localize(
+				'accountPolicy.notification.signin',
+				"Your administrator restricts AI features to specific GitHub accounts."
+			);
 		}
 
 		const handleDisposables = new DisposableStore();


### PR DESCRIPTION
Reframes the `ChatApprovedAccountOrganizations` gate messaging to clearly attribute the restriction to the administrator, rather than using passive "approved organization" language that could imply VS Code itself controls the list.

## Changes

**Notifications** (`accountPolicyGateContribution.ts`):
- New shape: *"Your administrator restricts AI features to GitHub accounts in the following organizations: {orgs}. The account "{name}" is not a member of any of these."*
- Unified the previously split `OrgNotApproved` vs `noAccount/wrongProvider` branches into a single consistent message shape
- Removed "Contact your administrator for more information." and "Sign into an approved GitHub account" — the org list and Sign In button are self-explanatory
- Wildcard (`*`) case: *"Your administrator restricts AI features to specific GitHub accounts. The account "{name}" does not qualify."*

**Splash screen** (`sessionsPolicyBlocked.ts`):
- Title: **"Sign-In Required by Your Administrator"** (was "Sign-In Required")
- Body (with account): *"The account "{name}" is not a member of an organization that your administrator allows for Agents."*
- Body (no account): *"Your administrator restricts Agents to members of the organizations below."*
- Org list heading: **"Allowed organizations:"** (was "Approved organizations:")
- Footer: dropped "Contact your administrator for more information." — the title already names the source

Refs #312534