### PR TITLE
fix: resolve layout clipping in customization management editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -497,6 +497,8 @@ export class AICustomizationListWidget extends Disposable {
 	private readonly collapsedGroups = new Set<string>();
 	private _layoutDeferred = false;
 	private readonly dropdownActionDisposables = this._register(new DisposableStore());
+	private lastHeight = 0;
+	private lastWidth = 0;
 
 	private readonly delayedFilter = new Delayer<void>(200);
 
@@ -1172,6 +1174,9 @@ export class AICustomizationListWidget extends Disposable {
 	private commitDisplayEntries(): void {
 		this.list.splice(0, this.list.length, this.displayEntries);
 		this.updateEmptyState();
+		if (this.lastHeight > 0 && this.searchAndButtonContainer.offsetHeight > 0) {
+			this.layout(this.lastHeight, this.lastWidth);
+		}
 	}
 
 	/**
@@ -1375,6 +1380,9 @@ export class AICustomizationListWidget extends Disposable {
 	 * Layouts the widget.
 	 */
 	layout(height: number, width: number): void {
+		this.lastHeight = height;
+		this.lastWidth = width;
+
 		this.element.style.height = `${height}px`;
 		this.searchInput.layout();
 
@@ -1388,7 +1396,7 @@ export class AICustomizationListWidget extends Disposable {
 			this._layoutDeferred = true;
 			DOM.getWindow(this.element).requestAnimationFrame(() => {
 				try {
-					this.layout(height, width);
+					this.layout(this.lastHeight, this.lastWidth);
 				} finally {
 					this._layoutDeferred = false;
 				}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -260,8 +260,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private splitViewContainer!: HTMLElement;
 	private splitView!: SplitView<number>;
 	private sidebarContainer!: HTMLElement;
+	private sidebarSectionsListContainer!: HTMLElement;
 	private sectionsList!: WorkbenchList<ISectionItem>;
 	private contentContainer!: HTMLElement;
+	private contentInner!: HTMLElement;
 	private listWidget!: AICustomizationListWidget;
 	private mcpListWidget: McpListWidget | undefined;
 	private pluginListWidget: PluginListWidget | undefined;
@@ -431,7 +433,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 			layout: (width, _, height) => {
 				this.sidebarContainer.style.width = `${width}px`;
 				if (height !== undefined) {
-					this.sectionsList.layout(height - 8, width);
+					this.sidebarContainer.style.height = `${height}px`;
+					this.sectionsList.layout(
+						this.sidebarSectionsListContainer.clientHeight,
+						this.sidebarSectionsListContainer.clientWidth
+					);
 				}
 			},
 		}, savedWidth, undefined, true);
@@ -445,15 +451,17 @@ export class AICustomizationManagementEditor extends EditorPane {
 			layout: (width, _, height) => {
 				this.contentContainer.style.width = `${width}px`;
 				if (height !== undefined) {
-					this.listWidget.layout(height - 16, width - 24);
-					this.mcpListWidget?.layout(height - 16, width - 24);
-					this.pluginListWidget?.layout(height - 16, width - 24);
+					this.contentContainer.style.height = `${height}px`;
+					const contentHeight = this.contentInner.clientHeight;
+					const contentWidth = this.contentInner.clientWidth;
+					this.listWidget.layout(contentHeight, contentWidth);
+					this.mcpListWidget?.layout(contentHeight, contentWidth);
+					this.pluginListWidget?.layout(contentHeight, contentWidth);
 					const modelsFooterHeight = this.modelsFooterElement?.offsetHeight || 80;
-					this.modelsWidget?.layout(height - 16 - modelsFooterHeight, width);
+					this.modelsWidget?.layout(Math.max(0, contentHeight - modelsFooterHeight), contentWidth);
 					if (this.viewMode === 'editor' && this.embeddedEditor) {
 						const editorHeaderHeight = 50;
-						const padding = 24;
-						this.embeddedEditor.layout({ width: Math.max(0, width - padding), height: Math.max(0, height - editorHeaderHeight - padding) });
+						this.embeddedEditor.layout({ width: contentWidth, height: Math.max(0, contentHeight - editorHeaderHeight) });
 					}
 					// Embedded MCP/plugin detail panes use a plain DOM widget that flows with
 					// the container; no explicit layout call is needed here.
@@ -528,7 +536,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.createSidebarHeader(sidebarContent);
 
 		// Main sections list container (takes remaining space)
-		const sectionsListContainer = DOM.append(sidebarContent, $('.sidebar-sections-list'));
+		const sectionsListContainer = this.sidebarSectionsListContainer = DOM.append(sidebarContent, $('.sidebar-sections-list'));
 
 		this.sectionsList = this.editorDisposables.add(this.instantiationService.createInstance(
 			WorkbenchList<ISectionItem>,
@@ -795,7 +803,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private createContent(): void {
-		const contentInner = DOM.append(this.contentContainer, $('.content-inner'));
+		const contentInner = this.contentInner = DOM.append(this.contentContainer, $('.content-inner'));
 
 		// Welcome page (shown when no section is selected)
 		this.createWelcomePage(contentInner);
@@ -1031,6 +1039,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Load items for the new section (only for prompts-based sections)
 		if (this.isPromptsSection(section)) {
 			void this.listWidget.setSection(section);
+		}
+
+		if (this.dimension) {
+			this.layout(this.dimension);
 		}
 
 		this.ensureSectionsListReflectsActiveSection(section);
@@ -1379,6 +1391,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.dimension = dimension;
 
 		if (this.container && this.splitView) {
+			this.splitViewContainer.style.width = `${dimension.width}px`;
 			this.splitViewContainer.style.height = `${dimension.height}px`;
 			this.splitView.layout(dimension.width, dimension.height);
 		}


### PR DESCRIPTION
Replace hard-coded padding offsets with actual container measurements using clientHeight/clientWidth on sidebar and content-inner containers. Add dimension persistence (lastHeight/lastWidth) to the list widget so layout is replayed after entry changes or visibility transitions.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
