### PR TITLE
Agents welcome: theme selection step

### DIFF
--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -94,11 +94,26 @@ export interface IEnvironmentService {
 	agentSessionsWorkspace?: URI;
 
 	/**
+	 * When running as the embedded Agents app, the data home of the host
+	 * VS Code application (e.g. `~/.vscode-insiders`). This is the base
+	 * directory from which `hostUserRoamingDataHome`, `hostExtensionsHome`,
+	 * and similar host paths are derived. `undefined` when not running as
+	 * embedded.
+	 */
+	readonly hostUserHome?: URI;
+
+	/**
 	 * When running as the embedded Agents app, the user roaming data home of
 	 * the host VS Code application (i.e. the default profile's settings/User
 	 * directory). `undefined` when not running as embedded.
 	 */
 	readonly hostUserRoamingDataHome?: URI;
+
+	/**
+	 * When running as the embedded Agents app, the extensions directory of
+	 * the host VS Code application. `undefined` when not running as embedded.
+	 */
+	readonly hostExtensionsHome?: URI;
 
 	// --- Policy
 	policyFile?: URI;

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -7,7 +7,7 @@ import { toLocalISOString } from '../../../base/common/date.js';
 import { memoize } from '../../../base/common/decorators.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
 import { dirname, join, normalize, resolve } from '../../../base/common/path.js';
-import { env } from '../../../base/common/process.js';
+import { env, platform } from '../../../base/common/process.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { NativeParsedArgs } from './argv.js';
@@ -297,6 +297,70 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 
 	set continueOn(value: string | undefined) {
 		this.args['continueOn'] = value;
+	}
+
+	@memoize
+	get hostUserHome(): URI | undefined {
+		if (!this.productService.embedded) {
+			return undefined;
+		}
+		if (!this.isBuilt) {
+			return undefined;
+		}
+		const quality = this.productService.quality;
+		let hostDataFolderName: string;
+		if (quality === 'stable') {
+			hostDataFolderName = '.vscode';
+		} else if (quality === 'insider') {
+			hostDataFolderName = '.vscode-insiders';
+		} else if (quality === 'exploration') {
+			hostDataFolderName = '.vscode-exploration';
+		} else {
+			return undefined;
+		}
+		return joinPath(this.userHome, hostDataFolderName);
+	}
+
+	@memoize
+	get hostUserRoamingDataHome(): URI | undefined {
+		if (!this.hostUserHome) {
+			return undefined;
+		}
+		const quality = this.productService.quality;
+		let hostProductName: string;
+		if (quality === 'stable') {
+			hostProductName = 'Code';
+		} else if (quality === 'insider') {
+			hostProductName = 'Code - Insiders';
+		} else if (quality === 'exploration') {
+			hostProductName = 'Code - Exploration';
+		} else {
+			return undefined;
+		}
+
+		let appDataPath: string;
+		switch (platform) {
+			case 'win32':
+				appDataPath = env['APPDATA'] || join(this.paths.homeDir, 'AppData', 'Roaming');
+				break;
+			case 'darwin':
+				appDataPath = join(this.paths.homeDir, 'Library', 'Application Support');
+				break;
+			default:
+				appDataPath = env['XDG_CONFIG_HOME'] || join(this.paths.homeDir, '.config');
+				break;
+		}
+
+		const hostUserDataPath = join(appDataPath, hostProductName);
+		return joinPath(URI.file(hostUserDataPath), 'User').with({ scheme: Schemas.vscodeUserData });
+	}
+
+	@memoize
+	get hostExtensionsHome(): URI | undefined {
+		if (!this.hostUserHome) {
+			return undefined;
+		}
+		return joinPath(this.hostUserHome, 'extensions');
 	}
 
 	get args(): NativeParsedArgs { return this._args; }

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -4,11 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { homedir, tmpdir } from 'os';
-import { memoize } from '../../../base/common/decorators.js';
-import { INodeProcess } from '../../../base/common/platform.js';
-import { joinPath } from '../../../base/common/resources.js';
-import { URI } from '../../../base/common/uri.js';
-import { Schemas } from '../../../base/common/network.js';
 import { NativeParsedArgs } from '../common/argv.js';
 import { IDebugParams } from '../common/environment.js';
 import { AbstractNativeEnvironmentService, parseDebugParams } from '../common/environmentService.js';
@@ -23,33 +18,6 @@ export class NativeEnvironmentService extends AbstractNativeEnvironmentService {
 			tmpDir: tmpdir(),
 			userDataDir: getUserDataPath(args, productService.nameShort)
 		}, productService);
-	}
-
-	@memoize
-	get hostUserRoamingDataHome(): URI | undefined {
-		if (!(process as INodeProcess).isEmbeddedApp) {
-			return undefined;
-		}
-		if (!this.isBuilt) {
-			return undefined;
-		}
-		const quality = this.productService.quality;
-		let hostProductName: string;
-		if (quality === 'stable') {
-			hostProductName = 'Code';
-		} else if (quality === 'insider') {
-			hostProductName = 'Code - Insiders';
-		} else if (quality === 'exploration') {
-			hostProductName = 'Code - Exploration';
-		} else {
-			return undefined;
-		}
-
-		// Honor the same env-var overrides that the host VS Code itself uses
-		// (portable mode and VSCODE_APPDATA), but intentionally skip --user-data-dir
-		// because that CLI arg belongs to the Agents app, not the host.
-		const hostUserDataPath = getUserDataPath(this.args, hostProductName);
-		return joinPath(URI.file(hostUserDataPath), 'User').with({ scheme: Schemas.vscodeUserData });
 	}
 }
 

--- a/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
+++ b/src/vs/platform/userDataProfile/electron-main/userDataProfile.ts
@@ -40,7 +40,7 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IFileService fileService: IFileService,
 		@ILogService logService: ILogService,
-		@IProductService private readonly productService: IProductService,
+		@IProductService productService: IProductService,
 	) {
 		super(stateService, uriIdentityService, environmentService, fileService, logService);
 		this.agentPluginsHome = URI.file(getAgentPluginsPath(environmentService.args, environmentService.userHome, productService.dataFolderName));
@@ -58,7 +58,7 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 		if (!hostUserRoamingDataHome) {
 			return defaultProfile;
 		}
-		const hostAgentPluginsHome = getHostAgentPluginsPath(this.nativeEnvironmentService, this.productService);
+		const hostAgentPluginsHome = getHostAgentPluginsPath(this.nativeEnvironmentService);
 		return {
 			...defaultProfile,
 			keybindingsResource: joinPath(hostUserRoamingDataHome, 'keybindings.json'),
@@ -77,27 +77,12 @@ export class UserDataProfilesMainService extends UserDataProfilesService impleme
 	}
 }
 
-function getHostAgentPluginsPath(environmentService: INativeEnvironmentService, productService: IProductService): string | undefined {
-	if (!(process as INodeProcess).isEmbeddedApp) {
+function getHostAgentPluginsPath(environmentService: INativeEnvironmentService): string | undefined {
+	const hostUserHome = environmentService.hostUserHome;
+	if (!hostUserHome) {
 		return undefined;
 	}
-	if (!environmentService.isBuilt) {
-		return undefined;
-	}
-
-	const quality = productService.quality;
-	let hostDataFolderName: string;
-	if (quality === 'stable') {
-		hostDataFolderName = '.vscode';
-	} else if (quality === 'insider') {
-		hostDataFolderName = '.vscode-insiders';
-	} else if (quality === 'exploration') {
-		hostDataFolderName = '.vscode-exploration';
-	} else {
-		return undefined;
-	}
-
-	return getAgentPluginsPath(environmentService.args, environmentService.userHome, hostDataFolderName);
+	return joinPath(hostUserHome, 'agent-plugins').fsPath;
 }
 
 function getAgentPluginsPath(args: NativeParsedArgs, userHome: URI, dataFolderName: string): string {

--- a/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
+++ b/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
@@ -445,8 +445,9 @@
 }
 
 .sessions-walkthrough-theme-grid {
-	display: grid;
-	grid-template-columns: repeat(4, minmax(0, 1fr));
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
 	gap: 10px;
 	width: 100%;
 }
@@ -457,6 +458,9 @@
 	cursor: pointer;
 	overflow: hidden;
 	transition: border-color 100ms, transform 100ms;
+	width: calc(25% - 8px);
+	min-width: 120px;
+	box-sizing: border-box;
 }
 
 .sessions-walkthrough-theme-card:hover {
@@ -507,6 +511,41 @@
 	height: auto;
 }
 
+.sessions-walkthrough-vscode-theme-option {
+	display: flex;
+	justify-content: center;
+	margin-top: 16px;
+}
+
+.sessions-walkthrough-vscode-theme-radio {
+	padding: 8px 20px;
+	border-radius: 8px;
+	border: 2px solid var(--vscode-radio-inactiveBorder, var(--vscode-widget-border, rgba(255, 255, 255, 0.1)));
+	background: var(--vscode-radio-inactiveBackground, transparent);
+	color: var(--vscode-radio-inactiveForeground, var(--vscode-foreground));
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: border-color 100ms, background 100ms;
+	text-align: center;
+}
+
+.sessions-walkthrough-vscode-theme-radio:hover {
+	background: var(--vscode-radio-inactiveHoverBackground, color-mix(in srgb, var(--vscode-foreground) 8%, transparent));
+}
+
+.sessions-walkthrough-vscode-theme-radio.selected {
+	border-color: var(--vscode-focusBorder, #007acc);
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder, #007acc);
+	background: var(--vscode-radio-activeBackground, transparent);
+	color: var(--vscode-radio-activeForeground, var(--vscode-foreground));
+}
+
+.sessions-walkthrough-vscode-theme-radio:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
 .sessions-walkthrough-theme-label {
 	padding: 4px 6px;
 	font-size: 12px;
@@ -518,11 +557,12 @@
 .sessions-walkthrough-theme-footer {
 	display: flex;
 	justify-content: center;
+	margin-top: 16px;
 }
 
 @media (max-width: 480px) {
-	.sessions-walkthrough-theme-grid {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+	.sessions-walkthrough-theme-card {
+		width: calc(50% - 8px);
 	}
 }
 

--- a/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
+++ b/src/vs/sessions/contrib/welcome/browser/media/sessionsWalkthrough.css
@@ -423,6 +423,109 @@
 	margin-top: 4px;
 }
 
+/* ---- Theme step ---- */
+
+.sessions-walkthrough-theme-header {
+	text-align: center;
+	margin-bottom: 8px;
+}
+
+.sessions-walkthrough-theme-header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.sessions-walkthrough-theme-header p {
+	margin: 6px 0 0;
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.5;
+}
+
+.sessions-walkthrough-theme-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 10px;
+	width: 100%;
+}
+
+.sessions-walkthrough-theme-card {
+	border-radius: 8px;
+	border: 2px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.1));
+	cursor: pointer;
+	overflow: hidden;
+	transition: border-color 100ms, transform 100ms;
+}
+
+.sessions-walkthrough-theme-card:hover {
+	border-color: var(--vscode-focusBorder, #007acc);
+	transform: translateY(-1px);
+}
+
+.sessions-walkthrough-theme-card:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.sessions-walkthrough-theme-card.selected {
+	border-color: var(--vscode-focusBorder, #007acc);
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder, #007acc);
+}
+
+.monaco-workbench.hc-black .sessions-walkthrough-theme-card,
+.monaco-workbench.hc-light .sessions-walkthrough-theme-card {
+	border-width: 2px;
+	border-color: var(--vscode-contrastBorder);
+}
+
+.monaco-workbench.hc-black .sessions-walkthrough-theme-card:hover,
+.monaco-workbench.hc-light .sessions-walkthrough-theme-card:hover {
+	border-color: var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+}
+
+.monaco-workbench.hc-black .sessions-walkthrough-theme-card:focus-visible,
+.monaco-workbench.hc-light .sessions-walkthrough-theme-card:focus-visible {
+	outline: 2px solid var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+	outline-offset: 2px;
+}
+
+.monaco-workbench.hc-black .sessions-walkthrough-theme-card.selected,
+.monaco-workbench.hc-light .sessions-walkthrough-theme-card.selected {
+	border-color: var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+	box-shadow: 0 0 0 1px var(--vscode-contrastActiveBorder, var(--vscode-focusBorder));
+}
+
+.sessions-walkthrough-theme-preview {
+	overflow: hidden;
+}
+
+.sessions-walkthrough-theme-preview-img {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+.sessions-walkthrough-theme-label {
+	padding: 4px 6px;
+	font-size: 12px;
+	font-weight: 500;
+	text-align: center;
+	color: var(--vscode-foreground);
+}
+
+.sessions-walkthrough-theme-footer {
+	display: flex;
+	justify-content: center;
+}
+
+@media (max-width: 480px) {
+	.sessions-walkthrough-theme-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
 /* Reduced motion */
 
 .monaco-reduce-motion .sessions-walkthrough-overlay,

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -23,6 +23,7 @@ import { CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID } from '../../../../workbench/co
 import { ChatSetupStrategy } from '../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
 import { IExtensionService } from '../../../../workbench/services/extensions/common/extensions.js';
 import { IWorkbenchThemeService } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
+import { IVSCodeThemeImporterService } from '../../../services/vscode/common/vsCodeThemeImporter.js';
 
 export type WalkthroughOutcome = 'completed' | 'dismissed';
 
@@ -55,6 +56,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	private _outcomeResolved = false;
 	private _isShowingWelcome = false;
 	private _isShowingSignIn = false;
+	private _isShowingThemeStep = false;
 
 	/**
 	 * Whether the overlay is currently displaying the signed-in welcome
@@ -96,6 +98,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
+		@IVSCodeThemeImporterService private readonly vsCodeThemeImporter: IVSCodeThemeImporterService,
 		@IWorkbenchThemeService private readonly themeService: IWorkbenchThemeService,
 		@ILogService private readonly logService: ILogService,
 	) {
@@ -111,6 +114,13 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		this._register(toDisposable(() => this.overlay.remove()));
 		this._register(addDisposableListener(this.overlay, EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			if (e.key === 'Escape') {
+				if (this._isShowingThemeStep) {
+					// Remove the theme setting to reset to default
+					this.themeService.setColorTheme(undefined, ConfigurationTarget.USER);
+					this._isShowingWelcome = false;
+					this._isShowingThemeStep = false;
+					this.complete();
+				}
 				e.preventDefault();
 				e.stopPropagation();
 				return;
@@ -329,19 +339,33 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	private _renderThemeStep(): void {
 		const stepDisposables = this.stepDisposables.value = new DisposableStore();
 		this._isShowingWelcome = true;
+		this._isShowingThemeStep = true;
+
+		// Start resolving the parent VS Code theme during the fade-out
+		const parentThemePromise = !isWeb
+			? this.vsCodeThemeImporter.getVSCodeTheme()
+			: Promise.resolve(undefined);
 
 		// Fade out current content, then render theme step
 		this.contentContainer.classList.add('sessions-walkthrough-fade-out');
-		stepDisposables.add(disposableTimeout(() => {
+		stepDisposables.add(disposableTimeout(async () => {
 			if (!this.overlay.isConnected) {
 				return;
 			}
+			const parentTheme = await parentThemePromise;
+			if (!this.overlay.isConnected) {
+				return;
+			}
+			// Only show the VS Code theme option if the parent theme is different from the 4 onboarding themes
+			const allOnboardingThemes = this.productService.onboardingThemes ?? [];
+			const shownThemes = allOnboardingThemes.filter(t => !t.id.startsWith('solarized'));
+			const parentThemeSettingsId = shownThemes.some(t => t.themeId === parentTheme) ? undefined : parentTheme;
 			this.contentContainer.classList.remove('sessions-walkthrough-fade-out');
-			this._renderThemeStepContent(stepDisposables);
+			this._renderThemeStepContent(stepDisposables, parentThemeSettingsId);
 		}, fadeDuration));
 	}
 
-	private _renderThemeStepContent(stepDisposables: DisposableStore): void {
+	private _renderThemeStepContent(stepDisposables: DisposableStore, parentThemeSettingsId: string | undefined): void {
 		this.contentContainer.textContent = '';
 		this.footerContainer.textContent = '';
 		this.disclaimerElement.classList.add('hidden');
@@ -351,22 +375,73 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		append(header, $('h2', undefined, localize('walkthrough.theme.title', "Choose Your Theme")));
 		append(header, $('p', undefined, localize('walkthrough.theme.subtitle', "Pick a color theme to make it yours. You can always change it later.")));
 
-		// Theme grid — exclude solarized variants, show 4 cards
-		const allThemes = this.productService.onboardingThemes ?? [];
-		const themes = allThemes.filter(t => !t.id.startsWith('solarized'));
+		// Build theme list — exclude solarized variants for the base set
+		const allOnboardingThemes = this.productService.onboardingThemes ?? [];
+		const themes = allOnboardingThemes.filter(t => !t.id.startsWith('solarized'));
 
 		const themeGrid = append(this.contentContainer, $('.sessions-walkthrough-theme-grid'));
 		themeGrid.setAttribute('role', 'radiogroup');
 		themeGrid.setAttribute('aria-label', localize('walkthrough.theme.ariaLabel', "Choose a color theme"));
 
-		// Detect current theme to pre-select
+		// Pre-select the onboarding theme matching the current theme, or fall back to first
 		const currentTheme = this.themeService.getColorTheme();
 		let selectedThemeId = themes.find(t => t.themeId === currentTheme.settingsId)?.id ?? themes[0]?.id;
 
 		const themeCards: HTMLElement[] = [];
+		let vscodeThemeBtn: HTMLElement | undefined;
 		for (const theme of themes) {
-			const card = this._createThemeCard(stepDisposables, themeGrid, theme, themeCards, selectedThemeId, id => { selectedThemeId = id; });
+			const card = this._createThemeCard(stepDisposables, themeGrid, theme, themeCards, selectedThemeId, id => {
+				selectedThemeId = id;
+				if (vscodeThemeBtn) {
+					vscodeThemeBtn.classList.remove('selected');
+					vscodeThemeBtn.setAttribute('aria-checked', 'false');
+				}
+			});
 			themeCards.push(card);
+		}
+
+		// Show a VS Code theme option as a radio-style button below the grid
+		if (parentThemeSettingsId) {
+			const parentName = this.productService.embedded?.nameShort ?? 'VS Code';
+			const option = append(this.contentContainer, $('.sessions-walkthrough-vscode-theme-option'));
+			vscodeThemeBtn = append(option, $('div.sessions-walkthrough-vscode-theme-radio'));
+			vscodeThemeBtn.setAttribute('role', 'radio');
+			vscodeThemeBtn.setAttribute('aria-checked', 'false');
+			vscodeThemeBtn.setAttribute('tabindex', '0');
+			const labelText = localize(
+				'walkthrough.theme.useVSCodeTheme',
+				"Use My {0} Theme \u00b7 {1}",
+				parentName,
+				parentThemeSettingsId,
+			);
+			vscodeThemeBtn.textContent = labelText;
+			const selectVSCodeTheme = async () => {
+				for (const c of themeCards) {
+					c.classList.remove('selected');
+					c.setAttribute('aria-checked', 'false');
+				}
+				vscodeThemeBtn!.classList.add('selected');
+				vscodeThemeBtn!.setAttribute('aria-checked', 'true');
+
+				// Apply the theme immediately if it's already available (built-in)
+				const allThemes = await this.themeService.getColorThemes();
+				const match = allThemes.find(t => t.settingsId === parentThemeSettingsId);
+				if (match) {
+					this.themeService.setColorTheme(match.id, ConfigurationTarget.USER);
+				} else {
+					// Theme needs extension install
+					vscodeThemeBtn!.textContent = localize('walkthrough.theme.importing', "Importing theme\u2026");
+					await this.vsCodeThemeImporter.importVSCodeTheme();
+					vscodeThemeBtn!.textContent = labelText;
+				}
+			};
+			stepDisposables.add(addDisposableListener(vscodeThemeBtn, EventType.CLICK, selectVSCodeTheme));
+			stepDisposables.add(addDisposableListener(vscodeThemeBtn, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					vscodeThemeBtn!.click();
+				}
+			}));
 		}
 
 		// Footer with Continue button
@@ -375,10 +450,11 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		continueBtn.textContent = localize('walkthrough.theme.continue', "Continue");
 		stepDisposables.add(addDisposableListener(continueBtn, EventType.CLICK, () => {
 			this._isShowingWelcome = false;
+			this._isShowingThemeStep = false;
 			this.complete();
 		}));
 
-		this.currentFocusableElements = [...themeCards, continueBtn];
+		this.currentFocusableElements = [...themeCards, ...(vscodeThemeBtn ? [vscodeThemeBtn] : []), continueBtn];
 
 		stepDisposables.add(disposableTimeout(() => {
 			if (this.overlay.isConnected) {

--- a/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWalkthrough.ts
@@ -8,7 +8,10 @@ import { disposableTimeout } from '../../../../base/common/async.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { $, addDisposableGenericMouseDownListener, append, EventType, addDisposableListener, getActiveElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { localize } from '../../../../nls.js';
+import { FileAccess } from '../../../../base/common/network.js';
+import { IProductOnboardingTheme } from '../../../../base/common/product.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -19,6 +22,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { ChatSetupStrategy } from '../../../../workbench/contrib/chat/browser/chatSetup/chatSetup.js';
 import { IExtensionService } from '../../../../workbench/services/extensions/common/extensions.js';
+import { IWorkbenchThemeService } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
 
 export type WalkthroughOutcome = 'completed' | 'dismissed';
 
@@ -69,6 +73,17 @@ export class SessionsWalkthroughOverlay extends Disposable {
 	 */
 	get isShowingSignIn(): boolean { return this._isShowingSignIn; }
 
+	/**
+	 * Transition to the theme selection step. Called by external code
+	 * (e.g. the contribution) when the user signs in while the sign-in
+	 * screen is visible, so the user still gets to pick a theme before
+	 * the overlay dismisses.
+	 */
+	showThemeStep(): void {
+		this._isShowingSignIn = false;
+		this._renderThemeStep();
+	}
+
 	/** Resolves when the user completes or dismisses the walkthrough. */
 	readonly outcome: Promise<WalkthroughOutcome> = new Promise(resolve => { this._resolveOutcome = resolve; });
 
@@ -81,6 +96,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IProductService private readonly productService: IProductService,
+		@IWorkbenchThemeService private readonly themeService: IWorkbenchThemeService,
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
@@ -291,7 +307,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 		getStartedBtn.textContent = localize('walkthrough.welcome.getStarted', "Get Started");
 		stepDisposables.add(addDisposableListener(getStartedBtn, EventType.CLICK, () => {
 			this._isShowingWelcome = false;
-			this.complete();
+			this._renderThemeStep();
 		}));
 
 		this.currentFocusableElements = [getStartedBtn, ...this.disclaimerLinks];
@@ -305,6 +321,120 @@ export class SessionsWalkthroughOverlay extends Disposable {
 
 	private _isSignedIn(): boolean {
 		return this.defaultAccountService.currentDefaultAccount !== null;
+	}
+
+	// ------------------------------------------------------------------
+	// Theme Step
+
+	private _renderThemeStep(): void {
+		const stepDisposables = this.stepDisposables.value = new DisposableStore();
+		this._isShowingWelcome = true;
+
+		// Fade out current content, then render theme step
+		this.contentContainer.classList.add('sessions-walkthrough-fade-out');
+		stepDisposables.add(disposableTimeout(() => {
+			if (!this.overlay.isConnected) {
+				return;
+			}
+			this.contentContainer.classList.remove('sessions-walkthrough-fade-out');
+			this._renderThemeStepContent(stepDisposables);
+		}, fadeDuration));
+	}
+
+	private _renderThemeStepContent(stepDisposables: DisposableStore): void {
+		this.contentContainer.textContent = '';
+		this.footerContainer.textContent = '';
+		this.disclaimerElement.classList.add('hidden');
+
+		// Header
+		const header = append(this.contentContainer, $('.sessions-walkthrough-theme-header'));
+		append(header, $('h2', undefined, localize('walkthrough.theme.title', "Choose Your Theme")));
+		append(header, $('p', undefined, localize('walkthrough.theme.subtitle', "Pick a color theme to make it yours. You can always change it later.")));
+
+		// Theme grid — exclude solarized variants, show 4 cards
+		const allThemes = this.productService.onboardingThemes ?? [];
+		const themes = allThemes.filter(t => !t.id.startsWith('solarized'));
+
+		const themeGrid = append(this.contentContainer, $('.sessions-walkthrough-theme-grid'));
+		themeGrid.setAttribute('role', 'radiogroup');
+		themeGrid.setAttribute('aria-label', localize('walkthrough.theme.ariaLabel', "Choose a color theme"));
+
+		// Detect current theme to pre-select
+		const currentTheme = this.themeService.getColorTheme();
+		let selectedThemeId = themes.find(t => t.themeId === currentTheme.settingsId)?.id ?? themes[0]?.id;
+
+		const themeCards: HTMLElement[] = [];
+		for (const theme of themes) {
+			const card = this._createThemeCard(stepDisposables, themeGrid, theme, themeCards, selectedThemeId, id => { selectedThemeId = id; });
+			themeCards.push(card);
+		}
+
+		// Footer with Continue button
+		const actions = append(this.footerContainer, $('.sessions-walkthrough-theme-footer'));
+		const continueBtn = append(actions, $('button.sessions-walkthrough-get-started-btn')) as HTMLButtonElement;
+		continueBtn.textContent = localize('walkthrough.theme.continue', "Continue");
+		stepDisposables.add(addDisposableListener(continueBtn, EventType.CLICK, () => {
+			this._isShowingWelcome = false;
+			this.complete();
+		}));
+
+		this.currentFocusableElements = [...themeCards, continueBtn];
+
+		stepDisposables.add(disposableTimeout(() => {
+			if (this.overlay.isConnected) {
+				continueBtn.focus();
+			}
+		}, 0));
+	}
+
+	private _createThemeCard(stepDisposables: DisposableStore, parent: HTMLElement, theme: IProductOnboardingTheme, allCards: HTMLElement[], selectedThemeId: string, onSelect: (id: string) => void): HTMLElement {
+		const card = append(parent, $('div.sessions-walkthrough-theme-card'));
+		card.setAttribute('role', 'radio');
+		card.setAttribute('aria-checked', theme.id === selectedThemeId ? 'true' : 'false');
+		card.setAttribute('aria-label', theme.label);
+		card.setAttribute('tabindex', '0');
+
+		if (theme.id === selectedThemeId) {
+			card.classList.add('selected');
+		}
+
+		// SVG preview image
+		const preview = append(card, $('div.sessions-walkthrough-theme-preview'));
+		const img = append(preview, $<HTMLImageElement>('img.sessions-walkthrough-theme-preview-img'));
+		img.alt = '';
+		img.src = FileAccess.asBrowserUri(`vs/workbench/contrib/welcomeOnboarding/browser/media/theme-preview-${theme.id}.svg`).toString(true);
+
+		// Label
+		const label = append(card, $('div.sessions-walkthrough-theme-label'));
+		label.textContent = theme.label;
+
+		stepDisposables.add(addDisposableListener(card, EventType.CLICK, () => {
+			onSelect(theme.id);
+			this._applyTheme(theme);
+			for (const c of allCards) {
+				c.classList.remove('selected');
+				c.setAttribute('aria-checked', 'false');
+			}
+			card.classList.add('selected');
+			card.setAttribute('aria-checked', 'true');
+		}));
+
+		stepDisposables.add(addDisposableListener(card, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				card.click();
+			}
+		}));
+
+		return card;
+	}
+
+	private async _applyTheme(theme: IProductOnboardingTheme): Promise<void> {
+		const allThemes = await this.themeService.getColorThemes();
+		const match = allThemes.find(t => t.settingsId === theme.themeId);
+		if (match) {
+			this.themeService.setColorTheme(match.id, ConfigurationTarget.USER);
+		}
 	}
 
 	private async _runSignIn(providerButtons: HTMLButtonElement[], error: HTMLElement, strategy: ChatSetupStrategy, titleEl: HTMLElement, subtitleEl: HTMLElement, signInActions: HTMLElement): Promise<void> {
@@ -339,7 +469,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 						return;
 					}
 				}
-				this.complete();
+				this._renderThemeStep();
 			} else {
 				await this._showErrorAndReset(error, localize('walkthrough.canceledError', "Sign-in was canceled. Please try again."));
 			}
@@ -365,7 +495,7 @@ export class SessionsWalkthroughOverlay extends Disposable {
 			const scopes = this.productService.defaultChatAgent?.providerScopes?.[0]
 				?? ['read:user', 'user:email', 'repo', 'workflow'];
 			await this.authenticationService.createSession('github', scopes, { activateImmediate: true });
-			this.complete();
+			this._renderThemeStep();
 		} catch (err) {
 			this.logService.error('[sessions walkthrough] Web sign-in failed:', err);
 			await this._showErrorAndReset(error, localize('walkthrough.signInError', "Something went wrong. Please try again."));

--- a/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
+++ b/src/vs/sessions/contrib/welcome/browser/welcome.contribution.ts
@@ -66,8 +66,7 @@ export function resetSessionsWelcome(
 	store.add(defaultAccountService.onDidChangeDefaultAccount(account => {
 		if (!walkthrough.isShowingWelcome && walkthrough.isShowingSignIn && account !== null) {
 			storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
-			walkthrough.complete();
-			store.dispose();
+			walkthrough.showThemeStep();
 		}
 	}));
 
@@ -240,7 +239,7 @@ export class SessionsWelcomeContribution extends Disposable implements IWorkbenc
 			if (!welcomeCompletionStored && !walkthrough.isShowingWelcome && walkthrough.isShowingSignIn && account !== null) {
 				welcomeCompletionStored = true;
 				this.storageService.store(WELCOME_COMPLETE_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
-				walkthrough.complete();
+				walkthrough.showThemeStep();
 			}
 		}));
 

--- a/src/vs/sessions/services/vscode/common/vsCodeThemeImporter.ts
+++ b/src/vs/sessions/services/vscode/common/vsCodeThemeImporter.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { parse as parseJSONC } from '../../../../base/common/jsonc.js';
+import { getErrorMessage } from '../../../../base/common/errors.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
+import { IExtensionManagementService } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtensionsScannerService } from '../../../../platform/extensionManagement/common/extensionsScannerService.js';
+import { ExtensionType, IExtensionManifest } from '../../../../platform/extensions/common/extensions.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkbenchThemeService } from '../../../../workbench/services/themes/common/workbenchThemeService.js';
+import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
+
+/** The VS Code configuration key for the active color theme. */
+export const COLOR_THEME_SETTINGS_ID = 'workbench.colorTheme';
+
+/**
+ * Service that reads the parent VS Code installation's active color theme
+ * and can import it into the Agents app — installing the providing extension
+ * from the gallery if necessary.
+ */
+export interface IVSCodeThemeImporterService {
+
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Resolves the parent VS Code's active color theme. Returns `undefined`
+	 * when the parent settings cannot be read or the theme is already one of
+	 * the onboarding themes displayed in the theme picker.
+	 */
+	getVSCodeTheme(): Promise<string | undefined>;
+
+	/**
+	 * Imports the VS Code theme into the Agents app.
+	 */
+	importVSCodeTheme(): Promise<void>;
+}
+
+export const IVSCodeThemeImporterService = createDecorator<IVSCodeThemeImporterService>('vsCodeThemeImporterService');
+
+/**
+ * Describes a color theme from the parent VS Code installation.
+ */
+interface IParentThemeInfo {
+	/** The settingsId of the theme (e.g. "Dark Modern", "Monokai"). */
+	readonly settingsId: string;
+	/**
+	 * The location of the extension that provides this theme.
+	 * `undefined` when the theme is already available (built-in or installed).
+	 */
+	readonly extensionLocation: URI | undefined;
+}
+
+export class VSCodeThemeImporterService extends Disposable implements IVSCodeThemeImporterService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private _parentThemePromise: Promise<IParentThemeInfo | undefined> | undefined;
+
+	constructor(
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IExtensionsScannerService private readonly extensionsScannerService: IExtensionsScannerService,
+		@IFileService private readonly fileService: IFileService,
+		@ILogService private readonly logService: ILogService,
+		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
+		@IWorkbenchThemeService private readonly themeService: IWorkbenchThemeService,
+	) {
+		super();
+	}
+
+	async getVSCodeTheme(): Promise<string | undefined> {
+		if (!this._parentThemePromise) {
+			this._parentThemePromise = this._resolveVSCodeTheme();
+		}
+		const themeInfo = await this._parentThemePromise;
+		return themeInfo?.settingsId;
+	}
+
+	async importVSCodeTheme(): Promise<void> {
+		try {
+			if (!this._parentThemePromise) {
+				this._parentThemePromise = this._resolveVSCodeTheme();
+			}
+			const theme = await this._parentThemePromise;
+			if (!theme) {
+				return;
+			}
+
+			// Install the extension from the host's extensions directory if needed
+			if (theme.extensionLocation) {
+				this.logService.info(`[VSCodeThemeImporter] Installing extension from ${theme.extensionLocation.toString()}`);
+				const profileLocation = this.userDataProfileService.currentProfile.extensionsResource;
+				await this.extensionManagementService.installFromLocation(theme.extensionLocation, profileLocation);
+			}
+
+			// Apply the theme
+			const allThemes = await this.themeService.getColorThemes();
+			const match = allThemes.find(t => t.settingsId === theme.settingsId);
+			if (match) {
+				await this.themeService.setColorTheme(match.id, ConfigurationTarget.USER);
+				return;
+			}
+
+			this.logService.warn(`[VSCodeThemeImporter] Theme ${theme.settingsId} not found after import`);
+		} catch (err) {
+			this.logService.error(`[VSCodeThemeImporter] Failed to import theme:`, err);
+		}
+	}
+
+	private async _resolveVSCodeTheme(): Promise<IParentThemeInfo | undefined> {
+		try {
+			const settingsId = await this._readVSCodeThemeId();
+			if (!settingsId) {
+				return undefined;
+			}
+
+			// Find the extension providing this theme by scanning the host's extensions
+			const extensionLocation = await this._findThemeExtension(settingsId);
+
+			return { settingsId, extensionLocation };
+		} catch (err) {
+			this.logService.warn('[VSCodeThemeImporter] Failed to resolve VS Code theme:', err);
+			return undefined;
+		}
+	}
+
+	/**
+	 * Scans the host VS Code's extensions directory to find which extension
+	 * provides the given theme. Returns the extension location URI, or
+	 * `undefined` if the theme is already available (built-in or installed).
+	 */
+	private async _findThemeExtension(themeSettingsId: string): Promise<URI | undefined> {
+		const allThemes = await this.themeService.getColorThemes();
+		if (allThemes.find(t => t.settingsId === themeSettingsId)) {
+			return undefined;
+		}
+
+		const hostExtensionsHome = this.environmentService.hostExtensionsHome;
+		if (!hostExtensionsHome) {
+			return undefined;
+		}
+
+		try {
+			const scanned = await this.extensionsScannerService.scanOneOrMultipleExtensions(
+				hostExtensionsHome,
+				ExtensionType.User,
+				{},
+			);
+			for (const ext of scanned) {
+				if (this._extensionProvidesTheme(ext.manifest, themeSettingsId)) {
+					return ext.location;
+				}
+			}
+		} catch (err) {
+			this.logService.warn('[VSCodeThemeImporter] Failed to scan host extensions:', err);
+		}
+
+		return undefined;
+	}
+
+	private _extensionProvidesTheme(manifest: IExtensionManifest, themeSettingsId: string): boolean {
+		const themes = manifest.contributes?.themes;
+		if (!Array.isArray(themes)) {
+			return false;
+		}
+		return themes.some(t => {
+			const id = (t as { id?: string; label?: string }).id ?? (t as { label?: string }).label;
+			return id === themeSettingsId;
+		});
+	}
+
+	private async _readVSCodeThemeId(): Promise<string | undefined> {
+		const hostDataHome = this.environmentService.hostUserRoamingDataHome;
+		if (!hostDataHome) {
+			return undefined;
+		}
+
+		try {
+			const settingsUri = joinPath(hostDataHome, 'settings.json');
+			const content = await this.fileService.readFile(settingsUri);
+			const settings = parseJSONC<Record<string, unknown>>(content.value.toString());
+			const themeId = settings[COLOR_THEME_SETTINGS_ID];
+			if (typeof themeId === 'string') {
+				return themeId;
+			}
+			this.logService.warn('[VSCodeThemeImporter] workbench.colorTheme is not set in host settings.json', themeId);
+			return undefined;
+		} catch (e) {
+			this.logService.warn('[VSCodeThemeImporter] Failed to read host settings.json, falling back to default theme', getErrorMessage(e));
+			return undefined;
+		}
+	}
+}
+
+registerSingleton(IVSCodeThemeImporterService, VSCodeThemeImporterService, InstantiationType.Delayed);

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -460,5 +460,6 @@ import './contrib/welcome/browser/welcome.contribution.js';
 import './contrib/policyBlocked/browser/policyBlocked.contribution.js';
 
 import './services/sessions/browser/sessionsManagementService.js';
+import './services/vscode/common/vsCodeThemeImporter.js';
 
 //#endregion


### PR DESCRIPTION
Add a theme selection step to the Agents app welcome walkthrough that lets users pick from preset themes or import their VS Code theme.

- New theme step in welcome walkthrough with Dark Modern, Light Modern, High Contrast presets
- VS Code Theme import button that reads the parent VS Code installation's active theme
- Restructured theme importer service (`services/vscode/common/vsCodeThemeImporter.ts`)
- Added `hostExtensionsHome` (URI) and `hostUserRoamingDataHome` environment properties
- Extension installed from host's extensions directory for seamless theme import
- Escape key resets theme selection and closes walkthrough