### PR TITLE
fix: use exact match for Responses API tool search model IDs

### DIFF
--- a/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
+++ b/extensions/copilot/src/platform/endpoint/common/chatModelCapabilities.ts
@@ -414,7 +414,7 @@ export function modelSupportsToolSearch(modelId: string, configurationService?: 
 }
 
 function isResponsesApiToolSearchModelId(normalizedModelId: string): boolean {
-	return normalizedModelId.startsWith('gpt-5-4') || normalizedModelId.startsWith('gpt-5-5') || normalizedModelId.startsWith('gpt5-5');
+	return normalizedModelId === 'gpt-5-4' || normalizedModelId === 'gpt-5-5';
 }
 
 export function isResponsesApiToolSearchEnabled(

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApi.spec.ts
@@ -517,7 +517,7 @@ describe('createResponsesRequestBody', () => {
 		services.set(IChatWebSocketManager, wsManager);
 		const accessor = services.createTestingAccessor();
 		const instantiationService = accessor.get(IInstantiationService);
-		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.5-preview', model: 'gpt-5.5-preview' as const };
+		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.5', model: 'gpt-5.5' as const };
 		const messages: Raw.ChatMessage[] = [
 			{
 				role: Raw.ChatRole.User,
@@ -559,7 +559,7 @@ describe('createResponsesRequestBody', () => {
 		services.set(IChatWebSocketManager, wsManager);
 		const accessor = services.createTestingAccessor();
 		const instantiationService = accessor.get(IInstantiationService);
-		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.4-preview', model: 'gpt-5.4-preview' as const };
+		const websocketEndpoint = { ...testEndpoint, family: 'gpt-5.4', model: 'gpt-5.4' as const };
 
 		wsManager.getStatefulMarker = () => 'resp-agent-1';
 		const planMessages: Raw.ChatMessage[] = [
@@ -775,7 +775,7 @@ describe('createResponsesRequestBody', () => {
 		const instantiationService = accessor.get(IInstantiationService);
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
-		const endpoint = { ...testEndpoint, model: 'gpt-5.4-preview', family: 'gpt-5.4-preview' };
+		const endpoint = { ...testEndpoint, model: 'gpt-5.4', family: 'gpt-5.4' };
 		const tools = [
 			{ type: 'function' as const, function: { name: 'tool_search', description: 'Search tools', parameters: {} } },
 			{ type: 'function' as const, function: { name: 'some_mcp_tool', description: 'MCP tool', parameters: {} } },

--- a/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/node/test/responsesApiToolSearch.spec.ts
@@ -92,7 +92,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	function createToolSearchScenario(messages: Raw.ChatMessage[]) {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
@@ -114,7 +114,7 @@ describe('createResponsesRequestBody tools', () => {
 	}
 
 	it('passes tools through without defer_loading when tool search disabled', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
 
@@ -129,7 +129,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('adds client tool_search and defer_loading when enabled', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
@@ -169,7 +169,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('does not defer tools for non-Agent locations', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
@@ -188,7 +188,7 @@ describe('createResponsesRequestBody tools', () => {
 		// `tools: ['my-mcp-server/*']` filters out tool_search. Without this gate, every
 		// MCP tool would be marked deferred and stripped from the request, leaving the
 		// agent with nothing to call.
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, true);
 
@@ -213,7 +213,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('always filters tool_search function tool from tools array', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
 
@@ -235,7 +235,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('converts tool_search history even when feature flag is off', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const configService = accessor.get(IConfigurationService) as InMemoryConfigurationService;
 		configService.setConfig(ConfigKey.ResponsesApiToolSearchEnabled, false);
 
@@ -281,7 +281,7 @@ describe('createResponsesRequestBody tools', () => {
 	});
 
 	it('converts tool_search history when current request has no tools', () => {
-		const endpoint = createMockEndpoint('gpt-5.4-preview');
+		const endpoint = createMockEndpoint('gpt-5.4');
 		const messages: Raw.ChatMessage[] = [
 			{ role: Raw.ChatRole.User, content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' }] },
 			{

--- a/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/chatModelCapabilities.spec.ts
@@ -73,12 +73,21 @@ describe('modelSupportsToolSearch', () => {
 		const experimentationService = {} as IExperimentationService;
 
 		expect(modelSupportsToolSearch('gpt-5.4', configurationService, experimentationService)).toBe(true);
-		expect(modelSupportsToolSearch('gpt-5.4-preview', configurationService, experimentationService)).toBe(true);
 		expect(modelSupportsToolSearch('gpt-5.5', configurationService, experimentationService)).toBe(true);
-		expect(modelSupportsToolSearch('gpt-5.5-preview', configurationService, experimentationService)).toBe(true);
-		expect(modelSupportsToolSearch('gpt5.5-preview', configurationService, experimentationService)).toBe(true);
 		expect(modelSupportsToolSearch('gpt-5.4')).toBe(false);
 		expect(modelSupportsToolSearch('gpt-5.5')).toBe(false);
+	});
+
+	test('rejects suffixed gpt-5.4/5.5 variants (exact match only)', () => {
+		const configurationService = {
+			getExperimentBasedConfig: (key: unknown) => key === ConfigKey.ResponsesApiToolSearchEnabled,
+		} as unknown as IConfigurationService;
+		const experimentationService = {} as IExperimentationService;
+
+		expect(modelSupportsToolSearch('gpt-5.4-mini', configurationService, experimentationService)).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.4-preview', configurationService, experimentationService)).toBe(false);
+		expect(modelSupportsToolSearch('gpt-5.5-preview', configurationService, experimentationService)).toBe(false);
+		expect(modelSupportsToolSearch('gpt5.5-preview', configurationService, experimentationService)).toBe(false);
 	});
 
 	test('rejects other non-Claude models', () => {


### PR DESCRIPTION
## Problem

`gpt-5.4-mini` was incorrectly getting tool search enabled because `isResponsesApiToolSearchModelId` used `startsWith` checks. Any model ID beginning with `gpt-5-4` or `gpt-5-5` would match, including suffixed variants like `-mini` and `-preview`.
