### PR TITLE
sessions: deduplicate sessions across providers

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/baseAgentHostSessionsProvider.ts
@@ -84,6 +84,7 @@ export class AgentHostSessionAdapter implements ISession {
 	readonly mainChat: IChat;
 	readonly chats: IObservable<readonly IChat[]>;
 	readonly capabilities = { supportsMultipleChats: false };
+	readonly deduplicationKey: string;
 
 	readonly agentProvider: string;
 
@@ -107,6 +108,7 @@ export class AgentHostSessionAdapter implements ISession {
 			throw new Error(`Agent session URI has no provider scheme: ${metadata.session.toString()}`);
 		}
 		this.agentProvider = agentProvider;
+		this.deduplicationKey = metadata.session.toString();
 		this.resource = URI.from({ scheme: resourceScheme, path: `/${rawId}` });
 		this.sessionId = toSessionId(providerId, this.resource);
 		this.providerId = providerId;

--- a/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/services/sessions/browser/sessionsManagementService.ts
@@ -20,6 +20,7 @@ import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from './sess
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../common/sessionsProvider.js';
 import { IChat, ISession, isWorkspaceAgentSessionType, SessionStatus, ISessionType } from '../common/session.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../common/agentHostSessionsProvider.js';
 
 const ACTIVE_SESSION_STATES_KEY = 'agentSessions.activeSessionStates';
 
@@ -162,7 +163,7 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 		for (const provider of this.sessionsProvidersService.getProviders()) {
 			sessions.push(...provider.getSessions());
 		}
-		return sessions;
+		return deduplicateSessions(sessions);
 	}
 
 	getSession(resource: URI): ISession | undefined {
@@ -519,3 +520,32 @@ class SessionsManagementService extends Disposable implements ISessionsManagemen
 }
 
 registerSingleton(ISessionsManagementService, SessionsManagementService, InstantiationType.Delayed);
+
+/**
+ * Removes duplicate sessions across providers. When multiple sessions share
+ * the same {@link ISession.deduplicationKey}, the session from the local
+ * agent host provider is preferred; otherwise the first occurrence wins.
+ */
+export function deduplicateSessions(sessions: ISession[]): ISession[] {
+	const seen = new Map<string, ISession>();
+	for (const session of sessions) {
+		const key = session.deduplicationKey;
+		if (!key) {
+			continue;
+		}
+		const existing = seen.get(key);
+		if (!existing) {
+			seen.set(key, session);
+		} else if (existing.providerId !== LOCAL_AGENT_HOST_PROVIDER_ID && session.providerId === LOCAL_AGENT_HOST_PROVIDER_ID) {
+			seen.set(key, session);
+		}
+	}
+
+	return sessions.filter(s => {
+		const key = s.deduplicationKey;
+		if (!key) {
+			return true;
+		}
+		return seen.get(key) === s;
+	});
+}

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -230,6 +230,13 @@ export interface ISession {
 	readonly mainChat: IChat;
 	/** Capabilities of this session. */
 	readonly capabilities: ISessionCapabilities;
+	/**
+	 * Optional key used to deduplicate sessions across providers. When
+	 * multiple sessions share the same key, only one is kept by
+	 * {@link ISessionsManagementService.getSessions}. Local providers are
+	 * preferred over remote ones.
+	 */
+	readonly deduplicationKey?: string;
 }
 
 /**

--- a/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
+++ b/src/vs/sessions/services/sessions/test/browser/sessionsManagementService.test.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { constObservable } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { LOCAL_AGENT_HOST_PROVIDER_ID } from '../../../../common/agentHostSessionsProvider.js';
+import { IChat, ISession } from '../../common/session.js';
+import { deduplicateSessions } from '../../browser/sessionsManagementService.js';
+
+const stubChat: IChat = {
+	resource: URI.parse('test:///chat'),
+	createdAt: new Date(),
+	title: constObservable('Chat'),
+	updatedAt: constObservable(new Date()),
+	status: constObservable(0),
+	changes: constObservable([]),
+	modelId: constObservable(undefined),
+	mode: constObservable(undefined),
+	isArchived: constObservable(false),
+	isRead: constObservable(true),
+	description: constObservable(undefined),
+	lastTurnEnd: constObservable(undefined),
+};
+
+function stubSession(overrides: Partial<ISession> & Pick<ISession, 'sessionId' | 'providerId'>): ISession {
+	return {
+		resource: URI.parse(`test:///${overrides.sessionId}`),
+		sessionType: 'test',
+		icon: Codicon.vm,
+		createdAt: new Date(),
+		workspace: constObservable(undefined),
+		title: constObservable('Test'),
+		updatedAt: constObservable(new Date()),
+		status: constObservable(0),
+		changes: constObservable([]),
+		modelId: constObservable(undefined),
+		mode: constObservable(undefined),
+		loading: constObservable(false),
+		isArchived: constObservable(false),
+		isRead: constObservable(true),
+		description: constObservable(undefined),
+		lastTurnEnd: constObservable(undefined),
+		gitHubInfo: constObservable(undefined),
+		chats: constObservable([]),
+		mainChat: stubChat,
+		capabilities: { supportsMultipleChats: false },
+		...overrides,
+	};
+}
+
+suite('deduplicateSessions', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns all sessions when no deduplication keys are set', () => {
+		const s1 = stubSession({ sessionId: 'a', providerId: 'p1' });
+		const s2 = stubSession({ sessionId: 'b', providerId: 'p2' });
+		const result = deduplicateSessions([s1, s2]);
+		assert.deepStrictEqual(result, [s1, s2]);
+	});
+
+	test('removes duplicate when same deduplicationKey appears across providers', () => {
+		const local = stubSession({ sessionId: 'local-1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
+		const remote = stubSession({ sessionId: 'remote-1', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
+		const result = deduplicateSessions([remote, local]);
+		assert.deepStrictEqual(result, [local]);
+	});
+
+	test('prefers local provider over remote regardless of order', () => {
+		const local = stubSession({ sessionId: 'local-1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
+		const remote = stubSession({ sessionId: 'remote-1', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
+
+		// local first
+		assert.deepStrictEqual(deduplicateSessions([local, remote]), [local]);
+		// remote first
+		assert.deepStrictEqual(deduplicateSessions([remote, local]), [local]);
+	});
+
+	test('keeps first occurrence when no local provider exists among duplicates', () => {
+		const r1 = stubSession({ sessionId: 'r1', providerId: 'agenthost-a', deduplicationKey: 'copilot:///abc123' });
+		const r2 = stubSession({ sessionId: 'r2', providerId: 'agenthost-b', deduplicationKey: 'copilot:///abc123' });
+		const result = deduplicateSessions([r1, r2]);
+		assert.deepStrictEqual(result, [r1]);
+	});
+
+	test('does not deduplicate sessions with different keys', () => {
+		const s1 = stubSession({ sessionId: 's1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///aaa' });
+		const s2 = stubSession({ sessionId: 's2', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///bbb' });
+		const result = deduplicateSessions([s1, s2]);
+		assert.deepStrictEqual(result, [s1, s2]);
+	});
+
+	test('mixes sessions with and without deduplication keys', () => {
+		const keyed1 = stubSession({ sessionId: 'k1', providerId: LOCAL_AGENT_HOST_PROVIDER_ID, deduplicationKey: 'copilot:///abc123' });
+		const keyed2 = stubSession({ sessionId: 'k2', providerId: 'agenthost-tunnel', deduplicationKey: 'copilot:///abc123' });
+		const noKey = stubSession({ sessionId: 'nk', providerId: 'copilot-chat' });
+		const result = deduplicateSessions([keyed2, noKey, keyed1]);
+		assert.deepStrictEqual(result, [noKey, keyed1]);
+	});
+});


### PR DESCRIPTION
- When both a local and remote agent host provide the same session
  (e.g. Copilot coding agent), sessions appeared duplicated in the
  sidebar because getSessions() returned entries from all providers
  without deduplication.
- Adds a `deduplicationKey` to ISession so providers can signal that
  two session objects represent the same underlying session.
- Implements deduplicateSessions() in SessionsManagementService that
  prefers the local agent host provider when duplicates exist, keeping
  the UI responsive while preserving remote-only sessions.

Fixes https://github.com/microsoft/vscode/issues/313103

(Commit message generated by Copilot)