### PR TITLE
Fix DisposableStore reference leak in terminal execute strategies

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -69,6 +69,13 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 	private readonly _onDidCreateStartMarker = this._register(new Emitter<IXtermMarker | undefined>);
 	public onDidCreateStartMarker: Event<IXtermMarker | undefined> = this._onDidCreateStartMarker.event;
 
+	/**
+	 * Tracks per-execute() DisposableStores so they can be cleaned up if the
+	 * strategy is disposed mid-flight, AND removed from this collection on
+	 * successful completion to avoid accumulating stale references when
+	 * execute() is invoked many times on the same strategy instance.
+	 */
+	private readonly _executionStores = this._register(new DisposableStore());
 
 	constructor(
 		private readonly _instance: ITerminalInstance,
@@ -82,9 +89,12 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 
 	async execute(commandLine: string, token: CancellationToken, commandId?: string, _commandLineForMetadata?: string): Promise<ITerminalExecuteStrategyResult> {
 		const store = new DisposableStore();
-		// Register with strategy lifetime so listeners are cleaned up if
-		// the strategy is disposed while execute() is still running.
-		this._register(store);
+		// Track with strategy lifetime so listeners are cleaned up if the
+		// strategy is disposed while execute() is still running. Using a
+		// dedicated DisposableStore (rather than this._register) lets us
+		// remove the entry on completion so we don't accumulate stale
+		// references across many execute() calls.
+		this._executionStores.add(store);
 
 		try {
 			// If the terminal is already disposed or its pty has already exited
@@ -260,7 +270,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 				exitCode,
 			};
 		} finally {
-			store.dispose();
+			this._executionStores.delete(store);
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -54,6 +54,14 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 	private readonly _onDidCreateStartMarker = this._register(new Emitter<IXtermMarker | undefined>);
 	public onDidCreateStartMarker: Event<IXtermMarker | undefined> = this._onDidCreateStartMarker.event;
 
+	/**
+	 * Tracks per-execute() DisposableStores so they can be cleaned up if the
+	 * strategy is disposed mid-flight, AND removed from this collection on
+	 * successful completion to avoid accumulating stale references when
+	 * execute() is invoked many times on the same strategy instance.
+	 */
+	private readonly _executionStores = this._register(new DisposableStore());
+
 	constructor(
 		private readonly _instance: ITerminalInstance,
 		private readonly _commandDetection: ICommandDetectionCapability,
@@ -65,11 +73,13 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 
 	async execute(commandLine: string, token: CancellationToken, commandId?: string, commandLineForMetadata?: string): Promise<ITerminalExecuteStrategyResult> {
 		const store = new DisposableStore();
-		// Register the store with this strategy's disposable chain so that if
-		// the strategy is disposed while execute() is still running (e.g. the
-		// session is torn down), accumulated Event.toPromise listeners on
-		// shared emitters like onCommandFinished are cleaned up immediately.
-		this._register(store);
+		// Track the store so that if the strategy is disposed while execute()
+		// is still running (e.g. the session is torn down), accumulated
+		// Event.toPromise listeners on shared emitters like onCommandFinished
+		// are cleaned up immediately. Using a dedicated DisposableStore (rather
+		// than this._register) lets us remove the entry on completion so we
+		// don't accumulate stale references across many execute() calls.
+		this._executionStores.add(store);
 		try {
 			// If the terminal is already disposed or its pty has already exited
 			// (e.g. the shell from a previous command died before this one was
@@ -212,7 +222,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 				exitCode,
 			};
 		} finally {
-			store.dispose();
+			this._executionStores.delete(store);
 		}
 	}
 


### PR DESCRIPTION
Fixes #313368

### Problem

`RichExecuteStrategy.execute()` and `BasicExecuteStrategy.execute()` each create a per-call `DisposableStore` and register it on the strategy via `this._register(store)` (introduced in #310157). The `finally { store.dispose(); }` runs the children's disposers but does **not** remove the entry from the parent's `_toDispose` Set — only `DisposableStore.delete(child)` does. So every successful `execute()` leaves a stale (already-disposed) `DisposableStore` referenced by the strategy. A colleague observed 28 such retained stores on a single long-lived strategy.

### Fix

Track in-flight stores in a dedicated `_executionStores` DisposableStore field and `delete(store)` on completion. This preserves the mid-flight disposal cleanup behavior from #310157 (if the strategy is disposed while `execute()` is awaiting, the in-flight store is cleaned up) while clearing the reference on the happy path.