### PR TITLE
Detach rewriter: also wrap sync-mode commands ending in trailing &

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -30,15 +30,28 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	}
 
 	rewrite(options: ICommandLineRewriterOptions): ICommandLineRewriterResult | undefined {
-		if (!options.isBackground) {
-			return undefined;
-		}
-
 		if (!this._configurationService.getValue(TerminalChatAgentToolsSettingId.DetachBackgroundProcesses)) {
 			return undefined;
 		}
 
+		// Detach when:
+		//   1. The tool was invoked with mode='async' (isBackground=true), OR
+		//   2. The command line ends with a single trailing `&` (POSIX background operator).
+		// Case (2) catches commands that the agent intended to background even when called
+		// in mode='sync' — without this, the trailing `&` silently produces a SIGHUP'd
+		// process that dies as soon as the tool's shell tears down.
+		const trimmedForCheck = options.commandLine.trimEnd();
+		const endsWithBareBackgroundAmp = /(?:^|[^&])&$/.test(trimmedForCheck);
+		if (!options.isBackground && !endsWithBareBackgroundAmp) {
+			return undefined;
+		}
+
 		if (options.os === OperatingSystem.Windows) {
+			// PowerShell does not have a POSIX-style trailing `&` background operator,
+			// so only rewrite explicit async-mode commands here.
+			if (!options.isBackground) {
+				return undefined;
+			}
 			return this._rewriteForPowerShell(options);
 		}
 


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#7605

When the `chat.tools.terminal.detachBackgroundProcesses` setting is enabled, also wrap commands with `nohup` when the agent passed `mode='sync'` but the command line ends with a single trailing `&` (POSIX background operator, distinct from `&&`).

Previously the rewriter only fired for `mode='async'` (legacy `isBackground: true`). When the agent used `mode='sync'` + `&`, the `&` was interpreted by the foreground shell and the process was SIGHUP'd as soon as the tool's terminal was disposed — fine for interactive UX, but it breaks eval harnesses where the eval step connects to the service from a fresh process and gets `Connection refused`.

### Evidence

terminalbench2 run `25136645365` (claude-opus-4.6) had three failures attributable to this:

- `hf-model-inference` — `python app.py > /app/server.log 2>&1 &`
- `install-windows-3.11` — `qemu-system-i386 ... -vnc :1 -qmp ... -monitor ...` (no daemonize)
- `qemu-alpine-ssh` — `nohup expect setup_vm.exp > /app/vm_output.log 2>&1 &` in sync mode

In all three the agent's same-turn verification (`curl`, `ps aux`, `ss -tlnp`) confirmed the service was alive — it just didn't survive to the eval phase.

### Behavior

- Setting still gates the rewrite, so default users are unaffected.
- Eval harnesses already set `chat.tools.terminal.detachBackgroundProcesses=true` (see `vscode-copilot-evaluation/src/vsCodeApplication.ts`), so they pick this up automatically.
- PowerShell has no equivalent trailing-`&` operator, so the Windows path remains async-only.
- Existing nohup/`shell -c` wrapping of compound constructs and the de-duplication of an already-trailing `&` continue to work.
