### PR TITLE
OTel: typed constants cleanup + add otel skill

### DIFF
--- a/.github/skills/otel/SKILL.md
+++ b/.github/skills/otel/SKILL.md
@@ -151,15 +151,20 @@ return this._otelService.startActiveSpan('invoke_agent child', { parentTraceCont
 
 ### Content capture
 
-Always gate prompt/response/tool-arg bodies on `otel.config.captureContent`:
+The extension uses two conventions side-by-side; pick the right one for the attribute you're adding.
+
+1. **Always emit (truncated)** — used for inputs/outputs that the Agent Debug Log panel needs to be useful even when OTel export is off (e.g. `gen_ai.tool.call.arguments` in [`toolsService.ts`](../../../extensions/copilot/src/extension/tools/vscode-node/toolsService.ts), and `copilot_chat.hook_input` / `hook_output` in [`chatHookService.ts`](../../../extensions/copilot/src/extension/chat/vscode-node/chatHookService.ts)). The attribute is captured unconditionally but always passed through `truncateForOTel`. Use this for moderate-sized, generally-non-secret arguments / results.
+2. **Gate on `config.captureContent`** — used for full prompt / response / system-instruction bodies (e.g. `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool.definitions` in [`chatMLFetcher.ts`](../../../extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts) and the BYOK providers). These are larger and more likely to contain user secrets.
 
 ```ts
+// Pattern 1 — always emit, always truncate
+span.setAttribute(GenAiAttr.TOOL_CALL_ARGUMENTS, truncateForOTel(JSON.stringify(args)));
+
+// Pattern 2 — gated on captureContent
 if (this._otelService.config.captureContent) {
     span.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(messages)));
 }
 ```
-
-`truncateForOTel` from `messageFormatters.ts` is mandatory for any free-form content attribute — it prevents OTLP batch failures.
 
 ### Debug panel vs OTLP isolation
 
@@ -185,7 +190,7 @@ For sub-process env vars, also update:
 1. Add the attribute key as a constant to `genAiAttributes.ts` (under `GenAiAttr`, `CopilotChatAttr`, or a new domain group). Never inline a raw `'copilot_chat.foo'` literal.
 2. Add it to the public barrel in [`index.ts`](../../../extensions/copilot/src/platform/otel/common/index.ts) if it lives in a new group.
 3. Use `IOTelService.startActiveSpan` (preferred) or `startSpan` — never `BasicTracerProvider` / `getTracer` directly.
-4. Always gate content-bearing attributes on `config.captureContent` and pass the value through `truncateForOTel`.
+4. Pass the value through `truncateForOTel` (mandatory for any free-form content attribute — prevents OTLP batch failures). Decide whether the attribute should be **always-emitted** (debug-panel-essential, e.g. tool args, hook input/output) or **gated on `config.captureContent`** (large prompt/response bodies, system instructions); follow the existing convention for similar data.
 5. If the new operation should reach OTLP, add its op-name to `EXPORTABLE_OPERATION_NAMES` in `otelServiceImpl.ts`.
 6. Document the new attribute in `agent_monitoring.md` (under the relevant span table) **and** add a test in `src/platform/otel/common/test/`.
 
@@ -244,6 +249,7 @@ These are documented in `agent_monitoring_arch.md` — preserve them:
 - ❌ Hard-coded attribute keys: `'copilot_chat.hook_type'` instead of `CopilotChatAttr.HOOK_TYPE`.
 - ❌ Hard-coded provider strings: `'github'` / `'anthropic'` / `'gemini'` instead of `GenAiProviderName.*`.
 - ❌ Magic `SpanStatusCode` numbers (`code: 1`, `code: 2`) — use the enum.
-- ❌ Logging full prompt/response content without `config.captureContent` gating, or without `truncateForOTel`.
+- ❌ Emitting any free-form content attribute without passing it through `truncateForOTel` — OTLP batches will silently drop or fail.
+- ❌ Logging full prompt / response / system-instruction bodies without `config.captureContent` gating (these are pattern 2 above).
 - ❌ Adding a span operation name without deciding whether it's exportable (`EXPORTABLE_OPERATION_NAMES`).
 - ❌ Updating instrumentation without updating `agent_monitoring.md` / `agent_monitoring_arch.md` in the same change.

--- a/.github/skills/otel/SKILL.md
+++ b/.github/skills/otel/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: otel
+description: OpenTelemetry instrumentation for the Copilot Chat extension — covers the four agent execution paths, the IOTelService abstraction, span/metric/event conventions, and the relationship between code and the user/developer monitoring docs. Use when adding/changing OTel spans, metrics, or events; instrumenting a new agent surface; touching the Copilot CLI bridge or Claude span emission; or updating `extensions/copilot/docs/monitoring/agent_monitoring*.md`.
+---
+
+# OpenTelemetry Instrumentation Skill
+
+When adding, changing, or reviewing OTel telemetry in the Copilot Chat extension, **always read the two source-of-truth docs first** and **always keep them in sync with the code you change**.
+
+## 1. Authoritative Documents
+
+The `extensions/copilot/docs/monitoring/` directory contains the two specs that define the OTel contract for the extension. Treat them like the layout / layer specs in `vs/sessions`.
+
+| Document | Path | Audience | Covers |
+|---|---|---|---|
+| User-facing | `extensions/copilot/docs/monitoring/agent_monitoring.md` | Extension users | Quick start, settings, env vars, exported spans/metrics/events, backend setup guides |
+| Architecture | `extensions/copilot/docs/monitoring/agent_monitoring_arch.md` | Developers | Multi-agent strategies, span hierarchies, file structure, instrumentation points, `IOTelService`, configuration channels |
+| Visual flow | `extensions/copilot/docs/monitoring/otel-data-flow.html` | Developers | Renders the bridge data flow for the in-process Copilot CLI agent |
+
+If the implementation changes, **you must update the relevant doc in the same PR**. The arch doc is the most likely to drift; treat divergence as a bug.
+
+## 2. Architecture at a Glance
+
+The extension has four agent execution paths, each with a different OTel strategy:
+
+| Agent | Process Model | Strategy | Debug Panel Source |
+|---|---|---|---|
+| **Foreground** (`toolCallingLoop`) | Extension host | Direct `IOTelService` spans | Extension spans |
+| **Copilot CLI in-process** | Extension host (same process) | **Bridge SpanProcessor** — SDK creates spans natively; bridge forwards to debug panel | SDK native spans via bridge |
+| **Copilot CLI terminal** | Separate terminal process | Forward OTel env vars | N/A (separate process) |
+| **Claude Code** | Child process (Node fork) | **Synthesized from SDK messages** — extension intercepts the Claude SDK message stream in `claudeMessageDispatch.ts` and emits GenAI spans; LLM calls are proxied through `claudeLanguageModelServer.ts` (which calls `chatMLFetcher`, producing standard `chat` spans). | Extension spans |
+
+> **Why asymmetric?** The CLI SDK runs in-process with full trace hierarchy (subagents, permissions, hooks). A bridge captures this directly. Claude runs as a separate process — internal spans are inaccessible, so the extension synthesizes spans by translating SDK messages and proxying the model API.
+
+## 3. Where Things Live (canonical map)
+
+```
+extensions/copilot/src/platform/otel/
+├── common/
+│   ├── otelService.ts          # IOTelService interface + ISpanHandle + injectCompletedSpan
+│   ├── otelConfig.ts           # Config resolution (env → settings → defaults), enabledVia, dbSpanExporter
+│   ├── noopOtelService.ts      # Zero-cost no-op (used by chatLib / tests)
+│   ├── inMemoryOTelService.ts  # ← actually under node/, see below
+│   ├── agentOTelEnv.ts         # deriveCopilotCliOTelEnv / deriveClaudeOTelEnv
+│   ├── genAiAttributes.ts      # ⚠ Single source of truth for attribute keys & enums
+│   ├── genAiEvents.ts          # Event emitter helpers (emit*Event)
+│   ├── genAiMetrics.ts         # GenAiMetrics class
+│   ├── messageFormatters.ts    # truncateForOTel, normalizeProviderMessages, toSystemInstructions, …
+│   ├── workspaceOTelMetadata.ts
+│   ├── sessionUtils.ts
+│   └── index.ts                # ⚠ Public barrel — re-export new helpers/constants here
+└── node/
+    ├── otelServiceImpl.ts      # NodeOTelService + DiagnosticSpanExporter + FilteredSpanExporter + EXPORTABLE_OPERATION_NAMES
+    ├── inMemoryOTelService.ts  # InMemoryOTelService (used when OTel is disabled — feeds debug panel only)
+    ├── fileExporters.ts        # File-based span/log/metric exporters
+    └── sqlite/                 # OTelSqliteStore + SqliteSpanExporter (dbSpanExporter pipeline)
+
+extensions/copilot/src/extension/
+├── chatSessions/
+│   ├── copilotcli/node/
+│   │   ├── copilotCliBridgeSpanProcessor.ts  # Bridge: SDK spans → IOTelService (+ hook span enrichment)
+│   │   ├── copilotcliSession.ts              # Root invoke_agent copilotcli span + traceparent + hook stash
+│   │   └── copilotcliSessionService.ts       # Bridge installation + env var setup
+│   └── claude/
+│       ├── common/claudeMessageDispatch.ts   # execute_tool / execute_hook spans + subagent context wiring
+│       └── node/
+│           ├── claudeOTelTracker.ts          # invoke_agent claude span + per-session token/cost rollup
+│           └── claudeLanguageModelServer.ts  # Local HTTP proxy → chatMLFetcher (chat spans)
+├── chat/vscode-node/
+│   └── chatHookService.ts                    # execute_hook spans for foreground agent hooks
+├── intents/node/toolCallingLoop.ts           # invoke_agent spans for foreground agent
+├── tools/vscode-node/toolsService.ts         # execute_tool spans for foreground tools
+├── prompt/node/chatMLFetcher.ts              # chat spans for all LLM calls
+├── byok/vscode-node/                         # BYOK provider chat spans (anthropicProvider, geminiNativeProvider, …)
+└── trajectory/vscode-node/
+    ├── otelChatDebugLogProvider.ts           # Debug panel data provider
+    ├── otelSpanToChatDebugEvent.ts           # Span → ChatDebugEvent conversion
+    └── otlpFormatConversion.ts               # OTLP ↔ in-memory span format
+```
+
+## 4. Service Layer & Selection
+
+`IOTelService` ([otelService.ts](../../../extensions/copilot/src/platform/otel/common/otelService.ts)) is the only abstraction consumers should depend on — never import the OTel SDK directly outside `node/otelServiceImpl.ts`. Three implementations:
+
+| Class | When Used |
+|---|---|
+| `NoopOTelService` | `chatLib` and tests where no telemetry pipeline is needed — zero cost |
+| `NodeOTelService` | OTel enabled — full SDK, OTLP/file/console export, optional SQLite span exporter |
+| `InMemoryOTelService` | Registered when OTel is **disabled** — no SDK is loaded, but spans/metrics/logs are still captured in-memory so the Agent Debug Log panel keeps working |
+
+Selection happens in [`src/extension/extension/vscode-node/services.ts`](../../../extensions/copilot/src/extension/extension/vscode-node/services.ts): exactly one of `NodeOTelService` or `InMemoryOTelService` is bound to `IOTelService` per extension host based on `resolveOTelConfig().enabled`.
+
+## 5. Span / Metric / Event Conventions
+
+Follow the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/). **Always use the constants from [`genAiAttributes.ts`](../../../extensions/copilot/src/platform/otel/common/genAiAttributes.ts) — never raw string literals.**
+
+| Operation | Span Name | Kind | Constant |
+|---|---|---|---|
+| Agent orchestration | `invoke_agent {agent_name}` | `INTERNAL` | `GenAiOperationName.INVOKE_AGENT` |
+| LLM API call | `chat {model}` | `CLIENT` | `GenAiOperationName.CHAT` |
+| Tool execution | `execute_tool {tool_name}` | `INTERNAL` | `GenAiOperationName.EXECUTE_TOOL` |
+| Hook execution | `execute_hook {hook_type}` | `INTERNAL` | `GenAiOperationName.EXECUTE_HOOK` |
+
+Attribute namespaces:
+
+| Namespace | Constant module | Examples |
+|---|---|---|
+| `gen_ai.*` | `GenAiAttr` | `gen_ai.operation.name`, `gen_ai.usage.input_tokens` |
+| `copilot_chat.*` | `CopilotChatAttr` | `copilot_chat.session_id`, `copilot_chat.chat_session_id`, `copilot_chat.hook_*` |
+| `github.copilot.*` | `CopilotCliSdkAttr` | SDK-emitted hook attributes (read-only — bridge & debug panel) |
+| `claude_code.*` | (raw) | Claude subprocess SDK attributes — only ever observed in OTLP, not produced by the extension |
+
+### Standard span pattern
+
+```ts
+return this._otelService.startActiveSpan(
+    `execute_tool ${name}`,
+    {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+            [GenAiAttr.OPERATION_NAME]: GenAiOperationName.EXECUTE_TOOL,
+            [GenAiAttr.TOOL_NAME]: name,
+            // …
+        },
+    },
+    async (span) => {
+        try {
+            const result = await this._actualWork();
+            span.setStatus(SpanStatusCode.OK);
+            return result;
+        } catch (err) {
+            span.setStatus(SpanStatusCode.ERROR, err instanceof Error ? err.message : String(err));
+            span.setAttribute(StdAttr.ERROR_TYPE, err instanceof Error ? err.constructor.name : 'Error');
+            throw err;
+        }
+    },
+);
+```
+
+### Cross-boundary trace propagation
+
+```ts
+// Parent: store context keyed by something the child knows
+const ctx = this._otelService.getActiveTraceContext();
+if (ctx) { this._otelService.storeTraceContext(`subagent:invocation:${id}`, ctx); }
+
+// Child: retrieve and use as parent
+const parentCtx = this._otelService.getStoredTraceContext(`subagent:invocation:${id}`);
+return this._otelService.startActiveSpan('invoke_agent child', { parentTraceContext: parentCtx, … }, fn);
+```
+
+### Content capture
+
+Always gate prompt/response/tool-arg bodies on `otel.config.captureContent`:
+
+```ts
+if (this._otelService.config.captureContent) {
+    span.setAttribute(GenAiAttr.INPUT_MESSAGES, truncateForOTel(JSON.stringify(messages)));
+}
+```
+
+`truncateForOTel` from `messageFormatters.ts` is mandatory for any free-form content attribute — it prevents OTLP batch failures.
+
+### Debug panel vs OTLP isolation
+
+Spans whose `gen_ai.operation.name` is **not** in `EXPORTABLE_OPERATION_NAMES` (defined in [`otelServiceImpl.ts`](../../../extensions/copilot/src/platform/otel/node/otelServiceImpl.ts)) are visible to the debug panel via `onDidCompleteSpan` but excluded from OTLP and SQLite exporters by `DiagnosticSpanExporter` and `FilteredSpanExporter`. Currently exportable: `chat`, `invoke_agent`, `execute_tool`, `embeddings`, `execute_hook`. **If you add a new operation name that should reach the user's collector, update `EXPORTABLE_OPERATION_NAMES` and document it in `agent_monitoring.md`.**
+
+## 6. Configuration Surface (must stay in sync)
+
+When you add or change a setting/env var/command, update **all three** of:
+
+1. The setting/command registration in [`extensions/copilot/package.json`](../../../extensions/copilot/package.json) (search for `github.copilot.chat.otel`).
+2. `resolveOTelConfig` in [`otelConfig.ts`](../../../extensions/copilot/src/platform/otel/common/otelConfig.ts) — if the setting affects runtime config — and the `enabledVia` channel if it can implicitly enable OTel.
+3. `agent_monitoring.md` ("VS Code Settings", "Environment Variables", "Activation", "Commands" tables) **and** `agent_monitoring_arch.md` ("Activation Channels", "Agent-Specific Env Var Translation" tables).
+
+For sub-process env vars, also update:
+
+- `deriveCopilotCliOTelEnv` / `deriveClaudeOTelEnv` in [`agentOTelEnv.ts`](../../../extensions/copilot/src/platform/otel/common/agentOTelEnv.ts).
+- The corresponding tests in `src/platform/otel/common/test/agentOTelEnv.spec.ts`.
+
+## 7. Procedure Checklists
+
+### When adding a new span / attribute
+
+1. Add the attribute key as a constant to `genAiAttributes.ts` (under `GenAiAttr`, `CopilotChatAttr`, or a new domain group). Never inline a raw `'copilot_chat.foo'` literal.
+2. Add it to the public barrel in [`index.ts`](../../../extensions/copilot/src/platform/otel/common/index.ts) if it lives in a new group.
+3. Use `IOTelService.startActiveSpan` (preferred) or `startSpan` — never `BasicTracerProvider` / `getTracer` directly.
+4. Always gate content-bearing attributes on `config.captureContent` and pass the value through `truncateForOTel`.
+5. If the new operation should reach OTLP, add its op-name to `EXPORTABLE_OPERATION_NAMES` in `otelServiceImpl.ts`.
+6. Document the new attribute in `agent_monitoring.md` (under the relevant span table) **and** add a test in `src/platform/otel/common/test/`.
+
+### When adding a new metric / event
+
+1. Add the helper to `genAiMetrics.ts` or `genAiEvents.ts` (mirror existing static / functional patterns).
+2. Re-export it from `index.ts`.
+3. Add the metric/event row to `agent_monitoring.md` ("Metrics" / "Events" sections) with all attributes documented.
+4. Add a unit test in `src/platform/otel/common/test/genAiMetrics.spec.ts` or `genAiEvents.spec.ts` (assert the exact name + attribute keys).
+
+### When instrumenting a new agent surface
+
+1. Pick a strategy: direct spans (foreground-style), bridge processor (CLI-style), or message-stream synthesis (Claude-style).
+2. Add the new emit site to the **Instrumentation Points** table in `agent_monitoring_arch.md` and the **Span Hierarchies** diagrams.
+3. If you forward OTel env vars to a child process, do it via a new `derive*OTelEnv` helper in `agentOTelEnv.ts` and add a row to the **Agent-Specific Env Var Translation** table.
+4. Wire trace propagation explicitly with `storeTraceContext` / `parentTraceContext` for any subagent or async boundary; do not rely on global active context across processes.
+
+### When changing the Copilot CLI bridge
+
+The bridge (`copilotCliBridgeSpanProcessor.ts`) reaches into `_delegate._activeSpanProcessor._spanProcessors` — internal OTel SDK v2 state. This is documented as a known risk. If you touch it:
+
+- Keep the runtime guard that degrades gracefully if the internal shape changes.
+- Update the **⚠ SDK Internal Access Warning** block in `agent_monitoring_arch.md` if the access pattern changes.
+- Add a unit test in `copilotCliBridgeSpanProcessor.spec.ts`.
+
+## 8. Validation
+
+Before sending a PR that touches OTel code:
+
+```bash
+# From extensions/copilot/
+npx tsc --noEmit --project tsconfig.json
+
+# OTel + Bridge unit tests
+npm test -- --grep "OTel\|Bridge"
+```
+
+Manual sanity checks:
+
+- The Aspire Dashboard quick-start in `agent_monitoring.md` still works end-to-end (one agent message → `invoke_agent` + `chat` + `execute_tool` spans visible at <http://localhost:18888>).
+- The Agent Debug Log panel in VS Code still shows the full span tree for foreground, Copilot CLI, and Claude sessions.
+
+## 9. Known Risks & Limitations
+
+These are documented in `agent_monitoring_arch.md` — preserve them:
+
+- SDK `_spanProcessors` internal access (graceful runtime guard).
+- Two TracerProviders in the same process when CLI SDK is active.
+- `process.env` mutation for the CLI SDK (only OTel-specific vars, set before `LocalSessionManager` ctor).
+- Single `captureContent` flag for the CLI SDK applies to both debug panel and OTLP — document any user-visible change clearly.
+- Claude SDK has no file exporter, and the CLI runtime only supports `otlp-http`.
+
+## 10. Anti-Patterns to Reject
+
+- ❌ Importing `@opentelemetry/api` (or any `@opentelemetry/*` package) from anywhere other than `node/otelServiceImpl.ts`, `fileExporters.ts`, or the CLI bridge processor type imports.
+- ❌ Hard-coded attribute keys: `'copilot_chat.hook_type'` instead of `CopilotChatAttr.HOOK_TYPE`.
+- ❌ Hard-coded provider strings: `'github'` / `'anthropic'` / `'gemini'` instead of `GenAiProviderName.*`.
+- ❌ Magic `SpanStatusCode` numbers (`code: 1`, `code: 2`) — use the enum.
+- ❌ Logging full prompt/response content without `config.captureContent` gating, or without `truncateForOTel`.
+- ❌ Adding a span operation name without deciding whether it's exportable (`EXPORTABLE_OPERATION_NAMES`).
+- ❌ Updating instrumentation without updating `agent_monitoring.md` / `agent_monitoring_arch.md` in the same change.

--- a/extensions/copilot/docs/monitoring/agent_monitoring.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring.md
@@ -71,6 +71,7 @@ Open **Settings** (`Ctrl+,`) and search for `copilot otel`:
 | `github.copilot.chat.otel.otlpEndpoint` | string | `"http://localhost:4318"` | OTLP collector endpoint |
 | `github.copilot.chat.otel.captureContent` | boolean | `false` | Capture full prompt/response content |
 | `github.copilot.chat.otel.outfile` | string | `""` | File path for JSON-lines output |
+| `github.copilot.chat.otel.dbSpanExporter.enabled` | boolean | `false` | Persist OTel spans to a local SQLite database for the **Chat: Export Agent Traces DB** command. Implicitly enables OTel. |
 
 ### Environment Variables
 
@@ -97,7 +98,14 @@ OTel is **off by default** with zero overhead. It activates when:
 
 - `COPILOT_OTEL_ENABLED=true`, or
 - `OTEL_EXPORTER_OTLP_ENDPOINT` is set, or
-- `github.copilot.chat.otel.enabled` is `true`
+- `github.copilot.chat.otel.enabled` is `true`, or
+- `github.copilot.chat.otel.dbSpanExporter.enabled` is `true` (the SDK pipeline must be active to feed the SQLite store).
+
+### Commands
+
+| Command | Description |
+|---|---|
+| **Chat: Export Agent Traces DB** (`github.copilot.chat.otel.exportAgentTracesDB`) | Export the local SQLite span database to a `.db` file. Only available when `github.copilot.chat.otel.dbSpanExporter.enabled` is `true`. |
 
 
 ---
@@ -562,8 +570,9 @@ In your trace viewer, filter by `service.name` to see traces from specific agent
 
 | `service.name` | Source |
 |---|---|
-| `copilot-chat` | Foreground agent, CLI wrapper, and Claude agent spans |
+| `copilot-chat` | Foreground agent, CLI wrapper, and Claude agent spans (extension-emitted) |
 | `github-copilot` | CLI SDK native spans + CLI terminal |
+| `claude-code` | Claude Code subprocess SDK telemetry (when `CLAUDE_CODE_ENABLE_TELEMETRY` is forwarded) |
 
 Within the `copilot-chat` service, distinguish agent types by `gen_ai.agent.name`:
 

--- a/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
+++ b/extensions/copilot/docs/monitoring/agent_monitoring_arch.md
@@ -16,9 +16,9 @@ The extension has four agent execution paths, each with different OTel strategie
 | **Foreground** (toolCallingLoop) | Extension host | Direct `IOTelService` spans | Extension spans |
 | **Copilot CLI in-process** | Extension host (same process) | **Bridge SpanProcessor** — SDK creates spans natively; bridge forwards to debug panel | SDK native spans via bridge |
 | **Copilot CLI terminal** | Separate terminal process | Forward OTel env vars | N/A (separate process) |
-| **Claude Code** | Child process (Node fork) | **Synthetic spans** — extension creates spans from message loop | Extension synthetic spans |
+| **Claude Code** | Child process (Node fork) | **Synthesized from SDK messages** — extension intercepts the Claude SDK message stream in `claudeMessageDispatch.ts` and emits GenAI spans; LLM calls are proxied through `claudeLanguageModelServer.ts` (which calls `chatMLFetcher`, producing standard `chat` spans). | Extension spans |
 
-> **Why asymmetric?** The CLI SDK runs in-process with full trace hierarchy (subagents, permissions, hooks). A bridge captures this directly. Claude runs as a separate process — internal spans are inaccessible, so synthetic spans are the only option.
+> **Why asymmetric?** The CLI SDK runs in-process with full trace hierarchy (subagents, permissions, hooks). A bridge captures this directly. Claude runs as a separate process — internal spans are inaccessible, so the extension synthesizes spans by translating SDK messages and proxying the model API.
 
 ### Copilot CLI Bridge SpanProcessor
 
@@ -77,19 +77,21 @@ invoke_agent (CLIENT)                    ← standalone copilot binary
 └── (independent root traces, no extension link)
 ```
 
-#### Claude Code (synthetic)
+#### Claude Code (synthesized from SDK messages)
+
+The extension intercepts the Claude SDK's message stream in `claudeMessageDispatch.ts` and emits GenAI spans for tool calls and hooks. LLM calls are proxied through a local HTTP server (`claudeLanguageModelServer.ts`) that calls `chatMLFetcher`, producing standard `chat` spans under the active `invoke_agent` context. Subagent (`Agent` / `Task`) tool calls store their `execute_tool` span's trace context in `state.subagentTraceContexts` so subsequent SDK messages with `parent_tool_use_id` are nested underneath as child `chat` and `execute_tool` spans.
 
 ```
-invoke_agent claude (INTERNAL)           ← claudeCodeAgent.ts
-├── chat claude-sonnet-4 (CLIENT)        ← chatMLFetcher.ts (FREE)
-├── execute_hook PreToolUse (INTERNAL)   ← claudeHookRegistry.ts (PR #4578)
-├── execute_tool Read (INTERNAL)         ← message loop (PR #4505)
-├── execute_hook PostToolUse (INTERNAL)  ← claudeHookRegistry.ts (PR #4578)
-├── chat claude-sonnet-4 (CLIENT)
-├── execute_hook PreToolUse (INTERNAL)
+invoke_agent claude (INTERNAL)           ← claudeOTelTracker.ts
+├── chat claude-sonnet-4 (CLIENT)        ← chatMLFetcher.ts via claudeLanguageModelServer
+├── execute_tool Read (INTERNAL)         ← claudeMessageDispatch.ts
+├── execute_tool Agent (INTERNAL)        ← claudeMessageDispatch.ts (subagent)
+│   ├── chat claude-sonnet-4 (CLIENT)    ← parented via subagentTraceContexts
+│   ├── execute_tool Grep (INTERNAL)
+│   └── chat claude-sonnet-4 (CLIENT)
 ├── execute_tool Edit (INTERNAL)
-├── execute_hook PostToolUse (INTERNAL)
-└── (flat hierarchy — no subagent nesting)
+├── chat claude-sonnet-4 (CLIENT)
+└── execute_hook Stop (INTERNAL)         ← claudeMessageDispatch.ts
 ```
 
 ---
@@ -100,29 +102,42 @@ invoke_agent claude (INTERNAL)           ← claudeCodeAgent.ts
 src/platform/otel/
 ├── common/
 │   ├── otelService.ts          # IOTelService interface + ISpanHandle + injectCompletedSpan
-│   ├── otelConfig.ts           # Config resolution (env → settings → defaults)
+│   ├── otelConfig.ts           # Config resolution (env → settings → defaults, kill switch, dbSpanExporter, enabledVia)
 │   ├── noopOtelService.ts      # Zero-cost no-op implementation
 │   ├── agentOTelEnv.ts         # deriveCopilotCliOTelEnv / deriveClaudeOTelEnv
 │   ├── genAiAttributes.ts      # GenAI semantic convention attribute keys
 │   ├── genAiEvents.ts          # Event emitter helpers
 │   ├── genAiMetrics.ts         # GenAiMetrics class (metric recording)
 │   ├── messageFormatters.ts    # Message → OTel JSON schema converters
+│   ├── workspaceOTelMetadata.ts # Workspace/repo attribute helpers
+│   ├── sessionUtils.ts         # Session ID helpers
 │   ├── index.ts                # Public API barrel export
 │   └── test/
 └── node/
-    ├── otelServiceImpl.ts      # NodeOTelService (real SDK implementation)
-    ├── inMemoryOTelService.ts  # InMemoryOTelService (debug panel, no SDK)
+    ├── otelServiceImpl.ts      # NodeOTelService + DiagnosticSpanExporter + FilteredSpanExporter
+    ├── inMemoryOTelService.ts  # InMemoryOTelService (used when OTel is disabled — feeds debug panel only)
     ├── fileExporters.ts        # File-based span/log/metric exporters
+    ├── sqlite/                 # OTelSqliteStore + SqliteSpanExporter (dbSpanExporter pipeline)
     └── test/
 
 src/extension/chatSessions/copilotcli/node/
-├── copilotCliBridgeSpanProcessor.ts  # Bridge: SDK spans → IOTelService
-├── copilotcliSession.ts              # Root invoke_agent span + traceparent
+├── copilotCliBridgeSpanProcessor.ts  # Bridge: SDK spans → IOTelService (+ hook span enrichment)
+├── copilotcliSession.ts              # Root invoke_agent span + traceparent + hook event stash
 └── copilotcliSessionService.ts       # Bridge installation + env var setup
+
+src/extension/chatSessions/claude/
+├── common/claudeMessageDispatch.ts   # execute_tool / execute_hook spans + subagent context wiring
+└── node/
+    ├── claudeOTelTracker.ts          # invoke_agent claude span + per-session token/cost rollup
+    └── claudeLanguageModelServer.ts  # Local HTTP proxy → chatMLFetcher (chat spans)
+
+src/extension/chat/vscode-node/
+└── chatHookService.ts                # execute_hook spans for foreground agent hooks
 
 src/extension/trajectory/vscode-node/
 ├── otelChatDebugLogProvider.ts       # Debug panel data provider
-└── otelSpanToChatDebugEvent.ts       # Span → ChatDebugEvent conversion
+├── otelSpanToChatDebugEvent.ts       # Span → ChatDebugEvent conversion
+└── otlpFormatConversion.ts           # OTLP ↔ in-memory span format
 ```
 
 ### Instrumentation Points
@@ -130,15 +145,17 @@ src/extension/trajectory/vscode-node/
 | File | What Gets Instrumented |
 |---|---|
 | `chatMLFetcher.ts` | `chat` spans — all LLM API calls (foreground + Claude proxy) |
-| `anthropicProvider.ts` | `chat` spans — BYOK Anthropic requests |
+| `anthropicProvider.ts`, `geminiNativeProvider.ts` | `chat` spans — BYOK provider requests |
 | `toolCallingLoop.ts` | `invoke_agent` spans — foreground agent orchestration |
 | `toolsService.ts` | `execute_tool` spans — foreground tool invocations |
-| `copilotcliSession.ts` | `invoke_agent copilotcli` wrapper span + traceparent propagation |
-| `copilotCliBridgeSpanProcessor.ts` | Bridge: SDK `ReadableSpan` → `ICompletedSpanData` |
+| `chatHookService.ts` | `execute_hook` spans — foreground agent hooks |
+| `copilotcliSession.ts` | `invoke_agent copilotcli` wrapper span + traceparent propagation + hook event stash |
+| `copilotCliBridgeSpanProcessor.ts` | Bridge: SDK `ReadableSpan` → `ICompletedSpanData` (with hook-span enrichment) |
 | `copilotcliSessionService.ts` | Bridge installation + OTel env vars for SDK |
 | `copilotCLITerminalIntegration.ts` | OTel env vars forwarded to terminal process |
-| `claudeCodeAgent.ts` | `invoke_agent claude` + `execute_tool` synthetic spans |
-| `claudeHookRegistry.ts` | `execute_hook` spans — Claude hook executions (PR #4578) |
+| `claudeOTelTracker.ts` | `invoke_agent claude` span + per-session token/cost accumulation |
+| `claudeMessageDispatch.ts` | `execute_tool` and `execute_hook` spans for the Claude agent (incl. subagent nesting) |
+| `claudeLanguageModelServer.ts` | Wraps Claude → CAPI proxy requests in the active trace context (chat spans come from `chatMLFetcher`) |
 | `otelSpanToChatDebugEvent.ts` | Span → debug panel event conversion |
 
 ---
@@ -161,9 +178,11 @@ Key methods:
 
 | Class | When Used |
 |---|---|
-| `NoopOTelService` | OTel disabled (default) — zero cost |
-| `NodeOTelService` | OTel enabled — full SDK, OTLP export |
-| `InMemoryOTelService` | Debug panel always-on — no SDK, in-memory only |
+| `NoopOTelService` | Used inside `chatLib` and tests where no telemetry pipeline is needed — zero cost |
+| `NodeOTelService` | OTel enabled — full SDK, OTLP/file/console export, optional SQLite span exporter |
+| `InMemoryOTelService` | Registered when OTel is **disabled** in the extension host — no SDK is loaded, but spans/metrics/logs are still captured in-memory so the Agent Debug Log panel keeps working |
+
+Selection happens in `src/extension/extension/vscode-node/services.ts`: exactly one of `NodeOTelService` or `InMemoryOTelService` is bound to `IOTelService` per extension host based on `resolveOTelConfig().enabled`.
 
 ### Two TracerProviders in Same Process
 
@@ -186,14 +205,31 @@ Both export to the same OTLP endpoint. Bridge processor sits on Provider B, forw
 
 Kill switch: `telemetry.telemetryLevel === 'off'` → all OTel disabled.
 
+### Activation Channels
+
+The resolved config records *how* OTel was enabled in `OTelConfig.enabledVia` (used for adoption telemetry):
+
+| `enabledVia` | Trigger |
+|---|---|
+| `envVar` | `COPILOT_OTEL_ENABLED=true` |
+| `setting` | `github.copilot.chat.otel.enabled` is `true` |
+| `otlpEndpointEnvVar` | `OTEL_EXPORTER_OTLP_ENDPOINT` is set without an explicit enable |
+| `dbSpanExporterOnly` | Only `github.copilot.chat.otel.dbSpanExporter.enabled` is on — implicitly turns OTel on so the SDK pipeline can feed the SQLite store |
+| `disabled` | None of the above (also when `telemetryLevel === 'off'`) |
+
 ### Agent-Specific Env Var Translation
 
-| Extension Config | Copilot CLI Env Var | Claude Code Env Var |
+Only variables not already present in `process.env` are set; explicit user env vars always win.
+
+| Extension Config | Copilot CLI (`deriveCopilotCliOTelEnv`) | Claude Code (`deriveClaudeOTelEnv`) |
 |---|---|---|
-| `enabled` | `COPILOT_OTEL_ENABLED=true` | `CLAUDE_CODE_ENABLE_TELEMETRY=1` |
+| `enabled` | `COPILOT_OTEL_ENABLED=true` | `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_METRICS_EXPORTER=otlp`, `OTEL_LOGS_EXPORTER=otlp` |
 | `otlpEndpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| `captureContent` | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` | `OTEL_LOG_USER_PROMPTS=1` |
-| `fileExporterPath` | `COPILOT_OTEL_FILE_EXPORTER_PATH` | N/A |
+| `otlpProtocol` | (CLI runtime is HTTP-only) | `OTEL_EXPORTER_OTLP_PROTOCOL` (`grpc` or `http/json`) |
+| `captureContent` | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` | `OTEL_LOG_USER_PROMPTS=1`, `OTEL_LOG_TOOL_DETAILS=1` |
+| `fileExporterPath` | `COPILOT_OTEL_FILE_EXPORTER_PATH` (+ `COPILOT_OTEL_EXPORTER_TYPE=file` when `exporterType === 'file'`) | N/A (Claude SDK has no file exporter) |
+
+Standard vars (`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME`) flow via process.env inheritance — no explicit forwarding needed.
 
 ### Debug Panel Always-On Behavior
 
@@ -337,7 +373,12 @@ return this._otel.startActiveSpan('invoke_agent child', { parentTraceContext: pa
 
 The debug panel creates spans with non-standard operation names (`content_event`, `user_message`). These MUST NOT appear in the user's OTLP collector.
 
-`DiagnosticSpanExporter` in `NodeOTelService` filters spans: only `invoke_agent`, `chat`, `execute_tool`, `embeddings`, `execute_hook` are exported. The `execute_hook` operation is used by both the foreground agent (`toolCallingLoop.ts`) and Claude hooks (`claudeHookRegistry.ts`, PR #4578). Debug-panel-only spans are visible via `onDidCompleteSpan` but excluded from OTLP batch export.
+`DiagnosticSpanExporter` and `FilteredSpanExporter` in `NodeOTelService` filter spans before export — only operations in `EXPORTABLE_OPERATION_NAMES` (`invoke_agent`, `chat`, `execute_tool`, `embeddings`, `execute_hook`) reach an exporter:
+
+- `DiagnosticSpanExporter` wraps the user-configured exporter (OTLP / file / console) and additionally logs first-success / failure diagnostics.
+- `FilteredSpanExporter` wraps the SQLite span exporter when `dbSpanExporter` is enabled, so the local DB sees the same standard GenAI spans as the user's collector.
+
+The `execute_hook` operation is used by both the foreground agent (`chatHookService.ts`) and the Claude agent (`claudeMessageDispatch.ts`); CLI-SDK hook spans are remapped to `execute_hook` by the bridge processor (`copilotCliBridgeSpanProcessor.ts`). Debug-panel-only spans remain visible via `onDidCompleteSpan` but are excluded from batch export.
 
 ---
 
@@ -345,19 +386,36 @@ The debug panel creates spans with non-standard operation names (`content_event`
 
 ```
 src/platform/otel/common/test/
-├── agentOTelEnv.spec.ts            # Env var derivation
+├── agentOTelEnv.spec.ts                    # Env var derivation
+├── agentTraceHierarchy.spec.ts             # End-to-end trace shape
+├── byokProviderSpans.spec.ts               # BYOK chat span coverage
+├── capturingOTelService.ts                 # In-memory test double
+├── chatMLFetcherSpanLifecycle.spec.ts      # chat span start/end behavior
 ├── genAiEvents.spec.ts
 ├── genAiMetrics.spec.ts
 ├── messageFormatters.spec.ts
 ├── noopOtelService.spec.ts
-└── otelConfig.spec.ts
+├── otelConfig.spec.ts
+├── serviceRobustness.spec.ts               # Fault tolerance / disposal
+└── workspaceOTelMetadata.spec.ts
 
 src/platform/otel/node/test/
 ├── fileExporters.spec.ts
 └── traceContextPropagation.spec.ts
 
+src/platform/otel/node/sqlite/test/
+└── otelSqliteStore.spec.ts                 # SQLite span store
+
 src/extension/chatSessions/copilotcli/node/test/
-└── copilotCliBridgeSpanProcessor.spec.ts  # Bridge processor tests
+└── copilotCliBridgeSpanProcessor.spec.ts   # Bridge processor tests
+
+src/extension/chatSessions/claude/{common,node}/test/
+├── claudeMessageDispatch.spec.ts           # Claude span emission
+└── claudeCodeAgentOTel.spec.ts             # Claude agent end-to-end
+
+src/extension/trajectory/vscode-node/test/
+├── otelSpanToChatDebugEvent.spec.ts
+└── otlpFormatConversion.spec.ts
 ```
 
 Run with: `npm test -- --grep "OTel\|Bridge"`

--- a/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/anthropicProvider.ts
@@ -16,7 +16,7 @@ import { ContextManagementResponse, CUSTOM_TOOL_SEARCH_NAME, getContextManagemen
 import { IToolDeferralService } from '../../../platform/networking/common/toolDeferralService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -472,7 +472,7 @@ export class AnthropicLMProvider extends AbstractLanguageModelChatProvider {
 				kind: SpanKind.CLIENT,
 				attributes: {
 					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.CHAT,
-					[GenAiAttr.PROVIDER_NAME]: 'anthropic',
+					[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.ANTHROPIC,
 					[GenAiAttr.REQUEST_MODEL]: model.id,
 					[GenAiAttr.AGENT_NAME]: 'AnthropicBYOK',
 					[CopilotChatAttr.MAX_PROMPT_TOKENS]: model.maxInputTokens,

--- a/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/geminiNativeProvider.ts
@@ -9,7 +9,7 @@ import { ChatFetchResponseType, ChatLocation } from '../../../platform/chat/comm
 import { ILogService } from '../../../platform/log/common/logService';
 import { IResponseDelta, OpenAiFunctionTool } from '../../../platform/networking/common/fetch';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, emitInferenceDetailsEvent, GenAiAttr, GenAiMetrics, GenAiOperationName, GenAiProviderName, type OTelModelOptions, StdAttr, toToolDefinitions, truncateForOTel } from '../../../platform/otel/common/index';
 import { IOTelService, SpanKind, SpanStatusCode } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
@@ -337,7 +337,7 @@ export class GeminiNativeBYOKLMProvider extends AbstractLanguageModelChatProvide
 				kind: SpanKind.CLIENT,
 				attributes: {
 					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.CHAT,
-					[GenAiAttr.PROVIDER_NAME]: 'gemini',
+					[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GEMINI,
 					[GenAiAttr.REQUEST_MODEL]: model.id,
 					[GenAiAttr.AGENT_NAME]: 'GeminiBYOK',
 					[CopilotChatAttr.MAX_PROMPT_TOKENS]: model.maxInputTokens,

--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -1003,7 +1003,7 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 			}
 
 			case GenAiOperationName.EXECUTE_HOOK: {
-				const hookType = asString(span.attributes['copilot_chat.hook_type']) ?? span.name;
+				const hookType = asString(span.attributes[CopilotChatAttr.HOOK_TYPE]) ?? span.name;
 				return {
 					ts: span.startTime,
 					dur: duration,
@@ -1017,14 +1017,14 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 						...(span.attributes['copilot_chat.hook_command'] !== undefined
 							? { command: truncate(String(span.attributes['copilot_chat.hook_command']), MAX_ATTR_VALUE_LENGTH) }
 							: {}),
-						...(span.attributes['copilot_chat.hook_input'] !== undefined
-							? { input: truncate(String(span.attributes['copilot_chat.hook_input']), MAX_ATTR_VALUE_LENGTH) }
+						...(span.attributes[CopilotChatAttr.HOOK_INPUT] !== undefined
+							? { input: truncate(String(span.attributes[CopilotChatAttr.HOOK_INPUT]), MAX_ATTR_VALUE_LENGTH) }
 							: {}),
-						...(span.attributes['copilot_chat.hook_output'] !== undefined
-							? { output: truncate(String(span.attributes['copilot_chat.hook_output']), MAX_ATTR_VALUE_LENGTH) }
+						...(span.attributes[CopilotChatAttr.HOOK_OUTPUT] !== undefined
+							? { output: truncate(String(span.attributes[CopilotChatAttr.HOOK_OUTPUT]), MAX_ATTR_VALUE_LENGTH) }
 							: {}),
-						...(span.attributes['copilot_chat.hook_result_kind'] !== undefined
-							? { resultKind: String(span.attributes['copilot_chat.hook_result_kind']) }
+						...(span.attributes[CopilotChatAttr.HOOK_RESULT_KIND] !== undefined
+							? { resultKind: String(span.attributes[CopilotChatAttr.HOOK_RESULT_KIND]) }
 							: {}),
 						...(isError && span.status.message ? { error: span.status.message } : {}),
 					},

--- a/extensions/copilot/src/extension/chat/vscode-node/chatHookService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatHookService.ts
@@ -157,7 +157,7 @@ export class ChatHookService implements IChatHookService {
 						kind: SpanKind.INTERNAL,
 						attributes: {
 							[GenAiAttr.OPERATION_NAME]: GenAiOperationName.EXECUTE_HOOK,
-							'copilot_chat.hook_type': hookType,
+							[CopilotChatAttr.HOOK_TYPE]: hookType,
 							'copilot_chat.hook_command': hookCommand.command,
 							...(chatSessionId ? { [CopilotChatAttr.CHAT_SESSION_ID]: chatSessionId } : {}),
 						},
@@ -166,7 +166,7 @@ export class ChatHookService implements IChatHookService {
 					try {
 						// Capture hook input for debug panel resolve
 						try {
-							span.setAttribute('copilot_chat.hook_input', truncateForOTel(JSON.stringify(commandInput)));
+							span.setAttribute(CopilotChatAttr.HOOK_INPUT, truncateForOTel(JSON.stringify(commandInput)));
 						} catch { /* swallow serialization errors */ }
 
 						const sw = StopWatch.create();
@@ -179,7 +179,7 @@ export class ChatHookService implements IChatHookService {
 						const resultKind = commandResult.kind === HookCommandResultKind.Success ? 'success'
 							: commandResult.kind === HookCommandResultKind.NonBlockingError ? 'non_blocking_error'
 								: 'error';
-						span.setAttribute('copilot_chat.hook_result_kind', resultKind);
+						span.setAttribute(CopilotChatAttr.HOOK_RESULT_KIND, resultKind);
 
 						if (commandResult.kind === HookCommandResultKind.Error || commandResult.kind === HookCommandResultKind.NonBlockingError) {
 							hasError = true;
@@ -195,7 +195,7 @@ export class ChatHookService implements IChatHookService {
 							try {
 								const output = typeof commandResult.result === 'string' ? commandResult.result : JSON.stringify(commandResult.result);
 								if (output) {
-									span.setAttribute('copilot_chat.hook_output', truncateForOTel(output));
+									span.setAttribute(CopilotChatAttr.HOOK_OUTPUT, truncateForOTel(output));
 								}
 							} catch { /* swallow serialization errors */ }
 						}

--- a/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/common/claudeMessageDispatch.ts
@@ -384,7 +384,7 @@ export function handleHookStarted(
 		kind: SpanKind.INTERNAL,
 		attributes: {
 			[GenAiAttr.OPERATION_NAME]: GenAiOperationName.EXECUTE_HOOK,
-			'copilot_chat.hook_type': message.hook_event,
+			[CopilotChatAttr.HOOK_TYPE]: message.hook_event,
 			'copilot_chat.hook_command': message.hook_name,
 			'copilot_chat.hook_id': message.hook_id,
 			[CopilotChatAttr.CHAT_SESSION_ID]: sessionId,

--- a/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
+++ b/extensions/copilot/src/extension/chatSessions/claude/node/claudeOTelTracker.ts
@@ -191,7 +191,7 @@ export class ClaudeOTelTracker {
 			this._currentSpan.setAttribute(CopilotChatAttr.TURN_COUNT, message.num_turns);
 		}
 		if (message.total_cost_usd !== undefined) {
-			this._currentSpan.setAttribute('copilot_chat.total_cost_usd', message.total_cost_usd);
+			this._currentSpan.setAttribute(CopilotChatAttr.TOTAL_COST_USD, message.total_cost_usd);
 		}
 		const responseModel = message.modelUsage ? Object.keys(message.modelUsage)[0] : undefined;
 		if (responseModel) {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCliBridgeSpanProcessor.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCliBridgeSpanProcessor.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../../../platform/otel/common/genAiAttributes';
-import type { ICompletedSpanData, IOTelService, ISpanEventRecord, SpanStatusCode } from '../../../../platform/otel/common/otelService';
+import { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName } from '../../../../platform/otel/common/genAiAttributes';
+import { type ICompletedSpanData, type IOTelService, type ISpanEventRecord, SpanStatusCode } from '../../../../platform/otel/common/otelService';
 
 /**
  * Hook event data stashed by copilotcliSession for bridge enrichment.
@@ -160,8 +160,8 @@ export class CopilotCliBridgeSpanProcessor implements SpanProcessor {
 
 		// SDK native hook spans: enrich with data from session events and
 		// remap to execute_hook so the debug panel shows full details.
-		const invocationId = span.attributes['github.copilot.hook.invocation_id'];
-		if (span.name.startsWith('hook ') && span.attributes['github.copilot.hook.type'] && typeof invocationId === 'string') {
+		const invocationId = span.attributes[CopilotCliSdkAttr.HOOK_INVOCATION_ID];
+		if (span.name.startsWith('hook ') && span.attributes[CopilotCliSdkAttr.HOOK_TYPE] && typeof invocationId === 'string') {
 			const hookEndData = this._hookData.get(invocationId);
 			if (hookEndData?.resultKind) {
 				// hook.end data already arrived — enrich and inject immediately
@@ -186,15 +186,15 @@ export class CopilotCliBridgeSpanProcessor implements SpanProcessor {
 
 		const attrs = { ...span.attributes };
 		attrs[GenAiAttr.OPERATION_NAME] = GenAiOperationName.EXECUTE_HOOK;
-		attrs['copilot_chat.hook_type'] = data.hookType;
+		attrs[CopilotChatAttr.HOOK_TYPE] = data.hookType;
 		if (data.input) {
-			attrs['copilot_chat.hook_input'] = data.input;
+			attrs[CopilotChatAttr.HOOK_INPUT] = data.input;
 		}
 		if (data.output) {
-			attrs['copilot_chat.hook_output'] = data.output;
+			attrs[CopilotChatAttr.HOOK_OUTPUT] = data.output;
 		}
 		if (data.resultKind) {
-			attrs['copilot_chat.hook_result_kind'] = data.resultKind;
+			attrs[CopilotChatAttr.HOOK_RESULT_KIND] = data.resultKind;
 		}
 
 		const enrichedSpan: ICompletedSpanData = {
@@ -202,8 +202,8 @@ export class CopilotCliBridgeSpanProcessor implements SpanProcessor {
 			name: `execute_hook ${data.hookType}`,
 			attributes: attrs,
 			status: data.resultKind === 'error'
-				? { code: 2 as SpanStatusCode, message: data.errorMessage }
-				: { code: 1 as SpanStatusCode },
+				? { code: SpanStatusCode.ERROR, message: data.errorMessage }
+				: { code: SpanStatusCode.OK },
 		};
 		this._otelService.injectCompletedSpan(enrichedSpan);
 	}

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotcliSession.ts
@@ -14,7 +14,7 @@ import { ConfigKey, IConfigurationService } from '../../../../platform/configura
 import { PermissiveAuthRequiredError } from '../../../../platform/github/common/githubService';
 import { ILogService } from '../../../../platform/log/common/logService';
 import { GenAiMetrics } from '../../../../platform/otel/common/genAiMetrics';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName, IOTelService, ISpanHandle, SpanKind, SpanStatusCode, truncateForOTel, resolveWorkspaceOTelMetadata, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
+import { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, IOTelService, ISpanHandle, SpanKind, SpanStatusCode, truncateForOTel, resolveWorkspaceOTelMetadata, workspaceMetadataToOTelAttributes } from '../../../../platform/otel/common/index';
 import { CapturingToken } from '../../../../platform/requestLogger/common/capturingToken';
 import { IRequestLogger, LoggedRequestKind } from '../../../../platform/requestLogger/common/requestLogger';
 import { PromptTokenCategory, PromptTokenLabel } from '../../../../platform/tokenizer/node/promptTokenDetails';
@@ -548,7 +548,7 @@ export class CopilotCLISession extends DisposableStore implements ICopilotCLISes
 				attributes: {
 					[GenAiAttr.OPERATION_NAME]: GenAiOperationName.INVOKE_AGENT,
 					[GenAiAttr.AGENT_NAME]: 'copilotcli',
-					[GenAiAttr.PROVIDER_NAME]: 'github',
+					[GenAiAttr.PROVIDER_NAME]: GenAiProviderName.GITHUB,
 					[GenAiAttr.CONVERSATION_ID]: this.sessionId,
 					[CopilotChatAttr.SESSION_ID]: this.sessionId,
 					[CopilotChatAttr.CHAT_SESSION_ID]: this.sessionId,

--- a/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
+++ b/extensions/copilot/src/extension/intents/node/toolCallingLoop.ts
@@ -770,7 +770,7 @@ export abstract class ToolCallingLoop<TOptions extends IToolCallingLoopOptions =
 					...(chatSessionId ? { [CopilotChatAttr.CHAT_SESSION_ID]: chatSessionId } : {}),
 					...(parentChatSessionId ? { [CopilotChatAttr.PARENT_CHAT_SESSION_ID]: parentChatSessionId } : {}),
 					...(debugLogLabel ? { [CopilotChatAttr.DEBUG_LOG_LABEL]: debugLogLabel } : {}),
-					...(customModeName ? { 'copilot_chat.mode_name': customModeName } : {}),
+					...(customModeName ? { [CopilotChatAttr.MODE_NAME]: customModeName } : {}),
 					...workspaceMetadataToOTelAttributes(resolveWorkspaceOTelMetadata(this._gitService)),
 				},
 				parentTraceContext,

--- a/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
+++ b/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import type { IDebugLogEntry } from '../../../platform/chat/common/chatDebugFileLoggerService';
 import { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName } from '../../../platform/otel/common/index';
-import type { ICompletedSpanData, ISpanEventData, SpanStatusCode } from '../../../platform/otel/common/otelService';
+import { type ICompletedSpanData, type ISpanEventData, SpanStatusCode } from '../../../platform/otel/common/otelService';
 
 // ── Event ID conventions ──
 // {spanId} → direct span mapping (tool calls, model turns, subagent invocations)
@@ -335,9 +335,9 @@ function spanToToolCallEvent(span: ICompletedSpanData): vscode.ChatDebugToolCall
 	evt.toolCallId = asString(span.attributes[GenAiAttr.TOOL_CALL_ID]);
 	evt.input = asString(span.attributes[GenAiAttr.TOOL_CALL_ARGUMENTS]);
 	evt.output = asString(span.attributes[GenAiAttr.TOOL_CALL_RESULT]);
-	evt.result = span.status.code === 1 /* OK */
+	evt.result = span.status.code === SpanStatusCode.OK
 		? vscode.ChatDebugToolCallResult.Success
-		: span.status.code === 2 /* ERROR */
+		: span.status.code === SpanStatusCode.ERROR
 			? vscode.ChatDebugToolCallResult.Error
 			: undefined;
 	evt.durationInMillis = span.endTime - span.startTime;
@@ -375,9 +375,9 @@ function spanToSubagentEvent(span: ICompletedSpanData): vscode.ChatDebugSubagent
 	evt.durationInMillis = span.endTime - span.startTime;
 	const agentDescription = asString(span.attributes[GenAiAttr.AGENT_DESCRIPTION]);
 	evt.description = agentDescription ?? `Subagent: ${agentName}`;
-	evt.status = span.status.code === 1 /* OK */
+	evt.status = span.status.code === SpanStatusCode.OK
 		? vscode.ChatDebugSubagentStatus.Completed
-		: span.status.code === 2 /* ERROR */
+		: span.status.code === SpanStatusCode.ERROR
 			? vscode.ChatDebugSubagentStatus.Failed
 			: vscode.ChatDebugSubagentStatus.Running;
 	const turnCount = asNumber(span.attributes[CopilotChatAttr.TURN_COUNT]);
@@ -400,7 +400,7 @@ function resolveHookExecutionContent(span: ICompletedSpanData): vscode.ChatDebug
 	content.durationInMillis = span.endTime - span.startTime;
 	content.input = asString(span.attributes[CopilotChatAttr.HOOK_INPUT]);
 	content.output = asString(span.attributes[CopilotChatAttr.HOOK_OUTPUT]);
-	if (span.status.code === 2 /* ERROR */ && span.status.message) {
+	if (span.status.code === SpanStatusCode.ERROR && span.status.message) {
 		content.errorMessage = span.status.message;
 	}
 	content.exitCode = asNumber(span.attributes['copilot_chat.hook_exit_code']);
@@ -435,7 +435,7 @@ function spanToHookExecutionEvent(span: ICompletedSpanData): vscode.ChatDebugGen
 function spanToSdkHookEvent(span: ICompletedSpanData): vscode.ChatDebugGenericEvent {
 	const hookType = asString(span.attributes[CopilotCliSdkAttr.HOOK_TYPE]) ?? 'unknown';
 	const durationMs = span.endTime - span.startTime;
-	const isError = span.status.code === 2; /* ERROR */
+	const isError = span.status.code === SpanStatusCode.ERROR;
 	const level = isError ? vscode.ChatDebugLogLevel.Error : vscode.ChatDebugLogLevel.Info;
 	const evt = new vscode.ChatDebugGenericEvent(`Hook: ${hookType}`, level, new Date(span.startTime));
 	evt.id = span.spanId;
@@ -461,9 +461,9 @@ function resolveToolCallContent(span: ICompletedSpanData): vscode.ChatDebugEvent
 	const content = new vscode.ChatDebugEventToolCallContent(toolName);
 	content.input = asString(span.attributes[GenAiAttr.TOOL_CALL_ARGUMENTS]);
 	content.output = asString(span.attributes[GenAiAttr.TOOL_CALL_RESULT]);
-	content.result = span.status.code === 1 /* OK */
+	content.result = span.status.code === SpanStatusCode.OK
 		? vscode.ChatDebugToolCallResult.Success
-		: span.status.code === 2 /* ERROR */
+		: span.status.code === SpanStatusCode.ERROR
 			? vscode.ChatDebugToolCallResult.Error
 			: undefined;
 	content.durationInMillis = span.endTime - span.startTime;
@@ -503,7 +503,7 @@ function resolveModelTurnContent(span: ICompletedSpanData): vscode.ChatDebugEven
 	if (sections.length > 0) {
 		content.sections = sections;
 	}
-	if (span.status.code === 2 /* ERROR */ && span.status.message) {
+	if (span.status.code === SpanStatusCode.ERROR && span.status.message) {
 		content.errorMessage = span.status.message;
 	}
 	return content;

--- a/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
+++ b/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import type { IDebugLogEntry } from '../../../platform/chat/common/chatDebugFileLoggerService';
-import { CopilotChatAttr, GenAiAttr, GenAiOperationName } from '../../../platform/otel/common/index';
+import { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName } from '../../../platform/otel/common/index';
 import type { ICompletedSpanData, ISpanEventData, SpanStatusCode } from '../../../platform/otel/common/otelService';
 
 // ── Event ID conventions ──
@@ -55,7 +55,7 @@ export function completedSpanToDebugEvent(span: ICompletedSpanData): vscode.Chat
 			return spanToGenericEvent(span);
 		default:
 			// SDK native hook spans use 'github.copilot.hook.type' instead of gen_ai.operation.name
-			if (span.name.startsWith('hook ') && asString(span.attributes['github.copilot.hook.type'])) {
+			if (span.name.startsWith('hook ') && asString(span.attributes[CopilotCliSdkAttr.HOOK_TYPE])) {
 				return spanToSdkHookEvent(span);
 			}
 			return undefined;
@@ -386,10 +386,10 @@ function spanToSubagentEvent(span: ICompletedSpanData): vscode.ChatDebugSubagent
 }
 
 function resolveHookExecutionContent(span: ICompletedSpanData): vscode.ChatDebugEventHookContent {
-	const hookType = asString(span.attributes['copilot_chat.hook_type']) ?? 'unknown';
+	const hookType = asString(span.attributes[CopilotChatAttr.HOOK_TYPE]) ?? 'unknown';
 	const content = new vscode.ChatDebugEventHookContent(hookType);
 	content.command = asString(span.attributes['copilot_chat.hook_command']);
-	const resultKind = asString(span.attributes['copilot_chat.hook_result_kind']);
+	const resultKind = asString(span.attributes[CopilotChatAttr.HOOK_RESULT_KIND]);
 	content.result = resultKind === 'success'
 		? vscode.ChatDebugHookResult.Success
 		: resultKind === 'error'
@@ -398,8 +398,8 @@ function resolveHookExecutionContent(span: ICompletedSpanData): vscode.ChatDebug
 				? vscode.ChatDebugHookResult.NonBlockingError
 				: undefined;
 	content.durationInMillis = span.endTime - span.startTime;
-	content.input = asString(span.attributes['copilot_chat.hook_input']);
-	content.output = asString(span.attributes['copilot_chat.hook_output']);
+	content.input = asString(span.attributes[CopilotChatAttr.HOOK_INPUT]);
+	content.output = asString(span.attributes[CopilotChatAttr.HOOK_OUTPUT]);
 	if (span.status.code === 2 /* ERROR */ && span.status.message) {
 		content.errorMessage = span.status.message;
 	}
@@ -408,9 +408,9 @@ function resolveHookExecutionContent(span: ICompletedSpanData): vscode.ChatDebug
 }
 
 function spanToHookExecutionEvent(span: ICompletedSpanData): vscode.ChatDebugGenericEvent {
-	const hookType = asString(span.attributes['copilot_chat.hook_type']) ?? 'unknown';
+	const hookType = asString(span.attributes[CopilotChatAttr.HOOK_TYPE]) ?? 'unknown';
 	const hookCommand = asString(span.attributes['copilot_chat.hook_command']);
-	const resultKind = asString(span.attributes['copilot_chat.hook_result_kind']);
+	const resultKind = asString(span.attributes[CopilotChatAttr.HOOK_RESULT_KIND]);
 	const durationMs = Math.round(span.endTime - span.startTime);
 
 	const name = `Hook: ${hookType}`;
@@ -433,7 +433,7 @@ function spanToHookExecutionEvent(span: ICompletedSpanData): vscode.ChatDebugGen
  * SDK uses span name "hook {type}" and attributes in the github.copilot.hook.* namespace.
  */
 function spanToSdkHookEvent(span: ICompletedSpanData): vscode.ChatDebugGenericEvent {
-	const hookType = asString(span.attributes['github.copilot.hook.type']) ?? 'unknown';
+	const hookType = asString(span.attributes[CopilotCliSdkAttr.HOOK_TYPE]) ?? 'unknown';
 	const durationMs = span.endTime - span.startTime;
 	const isError = span.status.code === 2; /* ERROR */
 	const level = isError ? vscode.ChatDebugLogLevel.Error : vscode.ChatDebugLogLevel.Info;

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -150,11 +150,11 @@ export const CopilotChatAttr = {
 	FILE_RELATIVE_PATH: 'copilot_chat.file.relative_path',
 	/** Hook type / event name (e.g. PreToolUse, PostToolUse, Stop) */
 	HOOK_TYPE: 'copilot_chat.hook_type',
-	/** Serialized hook command input (truncated, content-gated) */
+	/** Serialized hook command input (truncated; emitters may or may not gate on captureContent — used by the Agent Debug Log panel) */
 	HOOK_INPUT: 'copilot_chat.hook_input',
-	/** Serialized hook command output (truncated, content-gated) */
+	/** Serialized hook command output (truncated; emitters may or may not gate on captureContent — used by the Agent Debug Log panel) */
 	HOOK_OUTPUT: 'copilot_chat.hook_output',
-	/** Hook result kind: 'success' or 'error' */
+	/** Hook result kind: 'success', 'error', or 'non_blocking_error' */
 	HOOK_RESULT_KIND: 'copilot_chat.hook_result_kind',
 	/** Custom chat mode name (when a custom mode is active) */
 	MODE_NAME: 'copilot_chat.mode_name',

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -21,6 +21,7 @@ export const GenAiProviderName = {
 	OPENAI: 'openai',
 	ANTHROPIC: 'anthropic',
 	AZURE_AI_OPENAI: 'azure.ai.openai',
+	GEMINI: 'gemini',
 } as const;
 
 // gen_ai.token.type values
@@ -147,6 +148,18 @@ export const CopilotChatAttr = {
 	REPO_REMOTE_URL: 'copilot_chat.repo.remote_url',
 	/** File path relative to the repository root */
 	FILE_RELATIVE_PATH: 'copilot_chat.file.relative_path',
+	/** Hook type / event name (e.g. PreToolUse, PostToolUse, Stop) */
+	HOOK_TYPE: 'copilot_chat.hook_type',
+	/** Serialized hook command input (truncated, content-gated) */
+	HOOK_INPUT: 'copilot_chat.hook_input',
+	/** Serialized hook command output (truncated, content-gated) */
+	HOOK_OUTPUT: 'copilot_chat.hook_output',
+	/** Hook result kind: 'success' or 'error' */
+	HOOK_RESULT_KIND: 'copilot_chat.hook_result_kind',
+	/** Custom chat mode name (when a custom mode is active) */
+	MODE_NAME: 'copilot_chat.mode_name',
+	/** Aggregated session cost in USD (Claude agent) */
+	TOTAL_COST_USD: 'copilot_chat.total_cost_usd',
 } as const;
 
 export type EditSource = 'inline_chat' | 'chat_editing' | 'chat_editing_hunk' | 'apply_patch' | 'replace_string' | 'code_mapper';
@@ -159,4 +172,14 @@ export const StdAttr = {
 	ERROR_TYPE: 'error.type',
 	SERVER_ADDRESS: 'server.address',
 	SERVER_PORT: 'server.port',
+} as const;
+
+/**
+ * Attribute keys emitted by the Copilot CLI SDK's native OTel instrumentation
+ * (read by the bridge processor and the debug panel; the extension itself does
+ * not produce these).
+ */
+export const CopilotCliSdkAttr = {
+	HOOK_TYPE: 'github.copilot.hook.type',
+	HOOK_INVOCATION_ID: 'github.copilot.hook.invocation_id',
 } as const;

--- a/extensions/copilot/src/platform/otel/common/index.ts
+++ b/extensions/copilot/src/platform/otel/common/index.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export { CopilotChatAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
-export { emitAgentTurnEvent, emitInferenceDetailsEvent, emitSessionStartEvent, emitToolCallEvent } from './genAiEvents';
+export { CopilotChatAttr, CopilotCliSdkAttr, GenAiAttr, GenAiOperationName, GenAiProviderName, GenAiTokenType, GenAiToolType, StdAttr } from './genAiAttributes';
+export { emitAgentTurnEvent, emitCloudSessionInvokeEvent, emitEditFeedbackEvent, emitEditHunkActionEvent, emitEditSurvivalEvent, emitInferenceDetailsEvent, emitInlineDoneEvent, emitSessionStartEvent, emitToolCallEvent, emitUserFeedbackEvent } from './genAiEvents';
 export { GenAiMetrics } from './genAiMetrics';
 export { normalizeProviderMessages, toInputMessages, toOutputMessages, toSystemInstructions, toToolDefinitions, truncateForOTel } from './messageFormatters';
 export { NoopOTelService } from './noopOtelService';


### PR DESCRIPTION
## Summary

Two related changes for the Copilot Chat OTel pipeline:

1. **OTel: replace string literals with typed constants** (`52947bb`) — non-functional cleanup that promotes raw OTel attribute keys and provider names to constants in `genAiAttributes.ts`.
2. **Add `otel` skill** (`963e7de`) — new `.github/skills/otel/SKILL.md` documenting the OTel architecture and mandating the two monitoring docs stay in sync with code.

## 1. OTel constant cleanup

No behavior change. Audited `extensions/copilot/src/` for raw OTel string literals and routed them through typed constants:

- `GenAiProviderName.GEMINI` added; `geminiNativeProvider`, `anthropicProvider`, `copilotcliSession` now use `GenAiProviderName.*` instead of raw `'gemini'` / `'anthropic'` / `'github'`.
- `CopilotChatAttr.HOOK_TYPE` / `HOOK_INPUT` / `HOOK_OUTPUT` / `HOOK_RESULT_KIND` / `MODE_NAME` / `TOTAL_COST_USD` added; consumers in `chatHookService`, `claudeMessageDispatch`, `copilotCliBridgeSpanProcessor`, `chatDebugFileLoggerService`, `otelSpanToChatDebugEvent`, `toolCallingLoop`, `claudeOTelTracker` switched over.
- New `CopilotCliSdkAttr` group for SDK-emitted hook attribute keys (`github.copilot.hook.*`); the bridge processor and debug-event mapper now use the constants.
- Magic-number `SpanStatusCode` casts (`code: 1 as SpanStatusCode`, `code: 2 as SpanStatusCode`) replaced with the enum members.
- `src/platform/otel/common/index.ts` now also re-exports `CopilotCliSdkAttr` and the previously-missing event helpers (`emitEditFeedbackEvent`, `emitEditHunkActionEvent`, `emitInlineDoneEvent`, `emitEditSurvivalEvent`, `emitUserFeedbackEvent`, `emitCloudSessionInvokeEvent`).

12 files changed, +64/-41. `tsc --noEmit` clean.

## 2. New `otel` skill

`.github/skills/otel/SKILL.md` is patterned on `tool-rename-deprecation` and `sessions`. It points readers to the two authoritative docs and lays out the development contract:

- Authoritative docs (`agent_monitoring.md` / `agent_monitoring_arch.md`) and the rule that they must move in lockstep with code.
- The four agent execution paths (foreground / Copilot CLI in-process / Copilot CLI terminal / Claude) and their distinct OTel strategies.
- Canonical map of every OTel file (`platform/otel/`, the bridge, Claude OTel tracker, debug-panel mappers).
- `IOTelService` selection logic (`Noop` / `NodeOTelService` / `InMemoryOTelService`) and when each is registered.
- Span / metric / event conventions, content-capture gating with `truncateForOTel`, and the `EXPORTABLE_OPERATION_NAMES` filter that isolates the debug panel from OTLP.
- Configuration surface invariants — the three places (`package.json`, `otelConfig.ts`, the two monitoring docs) that must stay in sync.
- Procedure checklists for adding spans / metrics / events / new agent surfaces, and for changing the Copilot CLI bridge.
- Validation commands and a list of known risks and anti-patterns to reject in review.

## Validation

- `npx tsc --noEmit --project tsconfig.json` (in `extensions/copilot/`) → clean.
- No behavior change in the constant cleanup; existing OTel + Bridge tests continue to pass.

## Risk

Low. The constant cleanup is mechanical and verified by the type checker. The skill is documentation only.
