### PR TITLE
Clarify async vs sync mode guidance for run_in_terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -114,7 +114,8 @@ function createPowerShellModelDescription(shell: string, isSandboxEnabled: boole
 		'- Use Get-Command to verify cmdlet/function availability',
 		'',
 		'Async Mode:',
-		'- For long-running tasks (e.g., servers), use mode=async',
+		'- Use mode=async ONLY for processes that should keep running while you do other work (servers, watchers, dev daemons)',
+		'- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync and omit the timeout so the command runs to completion before your turn ends',
 		'- Returns a terminal ID for checking status and runtime later',
 		'- Use Start-Job for background PowerShell jobs',
 		'',
@@ -200,7 +201,8 @@ Program Execution:
 - Use which or command -v to verify command availability
 
 Async Mode:
-- For long-running tasks (e.g., servers), use mode=async
+- Use mode=async ONLY for processes that should keep running while you do other work (servers, watchers, dev daemons)
+- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync and omit the timeout so the command runs to completion before your turn ends
 - Returns a terminal ID for checking status and runtime later
 
 Use ${TerminalToolId.SendToTerminal} to send commands or input to a terminal session.`];
@@ -323,7 +325,7 @@ export async function createRunInTerminalToolData(
 		toolReferenceName: TOOL_REFERENCE_NAME,
 		legacyToolReferenceFullNames: LEGACY_TOOL_REFERENCE_FULL_NAMES,
 		displayName: localize('runInTerminalTool.displayName', 'Run in Terminal'),
-		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion (optionally capped by timeout); if still running when timeout elapses, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n\nTimeout parameter: Only set 'timeout' when you want a hard cap on how long the tool tracks the command. Omit it to let the command run to completion. Package installs, builds, and long-running scripts should usually omit the timeout rather than guessing a value.\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Do NOT poll or sleep to wait for completion.`,
+		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion (optionally capped by timeout); if still running when timeout elapses, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n- Prefer mode='sync' for one-shot long-running commands (package installs, builds, downloads, test suites) where you have no parallel work to do; only use mode='async' when you need the process to keep running while you do something else (servers, watchers, dev daemons).\n\nTimeout parameter: Only set 'timeout' when you want a hard cap on how long the tool tracks the command. Omit it to let the command run to completion. Package installs, builds, and long-running scripts should usually omit the timeout rather than guessing a value.\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Do NOT poll or sleep to wait for completion.`,
 		userDescription: localize('runInTerminalTool.userDescription', 'Run commands in the terminal'),
 		source: ToolDataSource.Internal,
 		icon: Codicon.terminal,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -115,7 +115,7 @@ function createPowerShellModelDescription(shell: string, isSandboxEnabled: boole
 		'',
 		'Async Mode:',
 		'- Use mode=async ONLY for processes that should keep running while you do other work (servers, watchers, dev daemons)',
-		'- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync and omit the timeout so the command runs to completion before your turn ends',
+		'- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync with a generous timeout (e.g. 600000 / 10 min for installs, longer for big builds) so the command can complete before your turn ends',
 		'- Returns a terminal ID for checking status and runtime later',
 		'- Use Start-Job for background PowerShell jobs',
 		'',
@@ -202,7 +202,7 @@ Program Execution:
 
 Async Mode:
 - Use mode=async ONLY for processes that should keep running while you do other work (servers, watchers, dev daemons)
-- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync and omit the timeout so the command runs to completion before your turn ends
+- For one-shot long-running commands where you have nothing to do until they finish (package installs, builds, downloads, test suites), use mode=sync with a generous timeout (e.g. 600000 / 10 min for installs, longer for big builds) so the command can complete before your turn ends
 - Returns a terminal ID for checking status and runtime later
 
 Use ${TerminalToolId.SendToTerminal} to send commands or input to a terminal session.`];
@@ -325,7 +325,7 @@ export async function createRunInTerminalToolData(
 		toolReferenceName: TOOL_REFERENCE_NAME,
 		legacyToolReferenceFullNames: LEGACY_TOOL_REFERENCE_FULL_NAMES,
 		displayName: localize('runInTerminalTool.displayName', 'Run in Terminal'),
-		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion (optionally capped by timeout); if still running when timeout elapses, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n- Prefer mode='sync' for one-shot long-running commands (package installs, builds, downloads, test suites) where you have no parallel work to do; only use mode='async' when you need the process to keep running while you do something else (servers, watchers, dev daemons).\n\nTimeout parameter: Only set 'timeout' when you want a hard cap on how long the tool tracks the command. Omit it to let the command run to completion. Package installs, builds, and long-running scripts should usually omit the timeout rather than guessing a value.\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Do NOT poll or sleep to wait for completion.`,
+		modelDescription: `${modelDescription}\n\nExecution mode:\n- mode='sync': wait for completion (optionally capped by timeout); if still running when timeout elapses, return with a terminal ID.\n- mode='async': wait for an initial idle/output signal, then return with terminal output snapshot and ID. Timeout caps how long to wait for the initial idle/output signal.\n- Prefer mode='sync' for commands that will prompt for interactive input (e.g., npm init, interactive installers, configuration wizards).\n\nTimeout parameter: For one-shot long-running commands, set a generous timeout as a safety net (e.g. 600000 for installs, longer for big builds). Omit timeout only for processes that should run indefinitely (servers, daemons). If the timeout elapses, you get a terminal ID and can check output later.\n\nTerminal notifications: When an async command finishes or a sync command times out, you will be automatically notified on your next turn with the exit code and terminal output. You will also be notified if the terminal needs input. Do NOT poll or sleep to wait for completion.`,
 		userDescription: localize('runInTerminalTool.userDescription', 'Run commands in the terminal'),
 		source: ToolDataSource.Internal,
 		icon: Codicon.terminal,


### PR DESCRIPTION
## Problem

The current Async Mode guidance says only:

> For long-running tasks (e.g., servers), use mode=async

Models read "long-running" broadly and fire `mode=async` for one-shot commands like `pip install`, `make`, `pytest`, model downloads, etc. Because async returns after an initial idle/output signal, the agent then has nothing to do — and ends its turn while the background command is still running. In environments where the chat session can close before the background-completion notification fires, this causes early termination of the work.

## Expected behavior change by scenario

| Scenario | Before | After |
|---|---|---|
| `npm install` / `pip install` / `cargo build` | Often async → agent ends turn mid-install, user has to re-prompt | sync with generous timeout → agent waits, sees real exit code, can react to failures |
| `pytest` / `npm test` / long test suite | Often async → agent gets initial-idle snapshot, misses later failures | sync → agent gets full output and can analyze failures |
| Model / dataset download | Often async → orphan process keeps running after turn | sync → completes, exit code observed |
| `npm start` / dev server | async (correct today) | async (still correct — explicitly carved out) |
| File watcher (`tsc --watch`, `vite`) | async (correct today) | async (still correct — explicitly carved out) |
| Long sandboxed build the user wants to multitask around | async | async — agent should do other work while it runs |

## Examples seen in eval run `25136645365` (terminalbench2 / claude-opus-4.6)

- `compile-compcert`: agent fired `opam install` async, ended turn mid-install
- `train-fasttext`: `python3 train.py` async, agent polled then quit with "Let me wait a bit more"
- `mcmc-sampling-stan`: R package install async, ended turn before `rstan` was actually installed
- `rstan-to-pystan`: ran pystan analysis async, ended turn before it finished

## Fix

Reword the Async Mode guidance to give a clear discriminator: **async is for processes that should keep running while the agent does other work** (servers, watchers, dev daemons). One-shot long commands (installs, builds, downloads, test suites) should use `mode=sync` with a **generous explicit timeout** (e.g. 10 min for installs, longer for big builds) so the command can complete before the turn ends — but the worst case is bounded if it hangs.

Updated in three places:

1. PowerShell description `Async Mode:` block
2. Generic POSIX description `Async Mode:` block
3. `Execution mode` section in `createRunInTerminalToolData` `modelDescription`

## Risks / tradeoffs

- **Hang risk:** sync commands with no/very long timeout block until they finish (or timeout, or the user cancels). Mitigated by recommending a *generous but explicit* timeout rather than omitting it. Existing safeguards (idle detection, interactive-prompt detection, hang recovery) still apply.
- **Underestimated timeout:** if the model picks a too-short timeout for a real install, the command times out and continues in the background — same shape as today, agent gets a notification when it finishes.
- **No effect on the parallel case:** servers / watchers / daemons still go through async; that path is explicitly preserved.
