### PR TITLE
Fix divide-by-zero panic in CLI unzip for small archives

### DIFF
--- a/cli/src/util/zipper.rs
+++ b/cli/src/util/zipper.rs
@@ -52,7 +52,7 @@ where
 		zip::ZipArchive::new(file).map_err(|e| wrap(e, "failed to open zip archive"))?;
 
 	let skip_segments_no = usize::from(should_skip_first_segment(&mut archive));
-	let report_progress_every = archive.len() / 20;
+	let report_progress_every = (archive.len() / 20).max(1);
 
 	for i in 0..archive.len() {
 		if i % report_progress_every == 0 {


### PR DESCRIPTION
When the downloaded update archive contained fewer than 20 entries, `archive.len() / 20` evaluated to `0`, and the subsequent `i % report_progress_every` operation in `unzip_file` panicked:

```
thread 'main' panicked at cli/src/util/zipper.rs:58:6:
attempt to calculate the remainder with a divisor of zero
```

This reproduced when running `code-insiders update`. Clamp the divisor to a minimum of `1` so progress is reported on every iteration for small archives instead of panicking.

(Written by Copilot)

Fix https://github.com/microsoft/vscode/issues/313390