### PR TITLE
Include uri when computing external ingest checkpoint

### DIFF
--- a/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
+++ b/extensions/copilot/src/platform/workspaceChunkSearch/node/codeSearch/externalIngestClient.ts
@@ -42,9 +42,10 @@ export interface ExternalIngestFileSet {
 	readonly checkpoint: string;
 }
 
-export function computeCheckpointHash(files: readonly { readonly docSha: Uint8Array }[]): string {
-	const hash = crypto.createHash('sha1');
+export function computeCheckpointHash(files: readonly { readonly uri: URI; readonly docSha: Uint8Array }[]): string {
+	const hash = crypto.createHash('sha256');
 	for (const file of files) {
+		hash.update(file.uri.toString());
 		hash.update(file.docSha);
 	}
 	return hash.digest().toString('base64');


### PR DESCRIPTION
Also bumps to use sha256 since we're changing the hashing

This will cause clients to re-evaluate their checkpoints but should not actually cause a large re-upload because the file hashes themselves haven't changed
