### PR TITLE
Filter stale onCommandFinished in rich/basic execute strategies

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -118,9 +118,22 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 
 			const idlePollInterval = this._configurationService.getValue<number>(TerminalChatAgentToolsSettingId.IdlePollInterval) ?? 1000;
 
+			// Capture any command that is already executing in the terminal at
+			// strategy entry. We may send ETX (Ctrl+C) below to clear pending
+			// input from a prior interaction, which kills that prior command
+			// and produces an `onCommandFinished` event with exit code 130.
+			// Without this filter, the race below would resolve with the prior
+			// command's finished event before our new command has even started —
+			// causing the new command to be reported as having instantly exited
+			// 130 and cascading to every subsequent command on the same terminal.
+			const staleExecutingCommand = this._commandDetection.executingCommandObject;
+			const onCommandFinishedFiltered = staleExecutingCommand
+				? Event.filter(this._commandDetection.onCommandFinished, e => e !== staleExecutingCommand, store)
+				: this._commandDetection.onCommandFinished;
+
 			const idlePromptPromise = trackIdleOnPrompt(this._instance, idlePollInterval, store, idlePollInterval, this._logService);
 			const onDone = Promise.race([
-				Event.toPromise(this._commandDetection.onCommandFinished, store).then(e => {
+				Event.toPromise(onCommandFinishedFiltered, store).then(e => {
 					// When shell integration is basic, it means that the end execution event is
 					// often misfired since we don't have command line verification. Because of this
 					// we make sure the prompt is idle after the end execution event happens.

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -102,11 +102,24 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 
 			const idlePollInterval = this._configurationService.getValue<number>(TerminalChatAgentToolsSettingId.IdlePollInterval) ?? 1000;
 
+			// Capture any command that is already executing in the terminal at
+			// strategy entry. `runCommand` (called below) may send ETX (Ctrl+C)
+			// to clear stale prompt input, which kills that prior command and
+			// produces an `onCommandFinished` event with exit code 130. Without
+			// this filter, the race below resolves with the prior command's
+			// finished event before our new command has even started — causing
+			// the new command to be reported as having instantly exited 130 and
+			// cascading to every subsequent command on the same terminal.
+			const staleExecutingCommand = this._commandDetection.executingCommandObject;
+			const onCommandFinishedFiltered = staleExecutingCommand
+				? Event.filter(this._commandDetection.onCommandFinished, e => e !== staleExecutingCommand, store)
+				: this._commandDetection.onCommandFinished;
+
 			// Subscribe to terminal lifecycle events BEFORE any awaits so that we
 			// don't miss events that fire while we're waiting for xterm to be
 			// ready (e.g. the pty exits during xtermReadyPromise resolution).
 			const onDone = Promise.race([
-				Event.toPromise(this._commandDetection.onCommandFinished, store).then(e => {
+				Event.toPromise(onCommandFinishedFiltered, store).then(e => {
 					this._log('onDone via end event');
 					return {
 						'type': 'success',


### PR DESCRIPTION
## Summary

Fixes the cascading "exit code 130 in <100ms" bug on `richExecuteStrategy` (and defensively on `basicExecuteStrategy`). This is the root cause of most of the spurious-130 occurrences documented in #313412 — distinct from the SIGINT-at-idle-prompt theory addressed in #313414.

## Root cause

`richExecuteStrategy.execute()` sets up a `Promise.race` over `onCommandFinished`, cancellation, terminal disposal, process exit, and idle-on-prompt **before** it calls `this._instance.runCommand(commandLine, ...)`.

`runCommand` in `terminalInstance.ts` does this just before sending the new command text:

```ts
// Determine whether to send ETX (ctrl+c) before running the command.
if (shouldExecute && (!commandDetection || commandDetection.promptInputModel.value.length > 0)) {
    await this.sendText('\x03', false);
    await timeout(100);
}
await this.sendText(commandLine, shouldExecute, !shouldExecute || forceBracketedPasteMode);
```

If a previous command is still running in the terminal (or the prompt has stale typed-but-unexecuted input), the ETX kills the prior command, the shell prints `^C`, and `CommandDetection` fires `onCommandFinished` for that **prior** command with `exitCode = 130`. The race in `execute()` resolves on that event and reports the **new** command — which has not even started — as having instantly exited with code 130. Every subsequent `run_in_terminal` call on the same terminal hits the same path, so one stuck command cascades into 5–10 false failures across the rest of the session.

Eval-log evidence: in `terminalbench2` runs `25141808876` and `25141798563`, the affected benchmarks (`train-fasttext`, `qemu-alpine-ssh`, `opam-package-management`, `pytorch-model-cli`, etc.) all show the same pattern — a long-running compile/install step, then a sequence of short, totally unrelated commands all returning `code=130` in tens of milliseconds.

## Fix

Capture `commandDetection.executingCommandObject` at strategy entry. Filter that specific `ITerminalCommand` out of the `onCommandFinished` subscription so its eventual finished event (whether triggered by ETX or by completing on its own) cannot satisfy the race for our new command:

```ts
const staleExecutingCommand = this._commandDetection.executingCommandObject;
const onCommandFinishedFiltered = staleExecutingCommand
    ? Event.filter(this._commandDetection.onCommandFinished, e => e !== staleExecutingCommand, store)
    : this._commandDetection.onCommandFinished;
```

The same filter is applied defensively to `basicExecuteStrategy` where ETX may also be sent before `sendText` (when `_hasReceivedUserInput()` is true and a prior command is still running).

## Test plan

- Existing `richExecuteStrategy.test.ts` and `basicExecuteStrategy.test.ts` continue to pass.
- Manual: in a session that runs a long silent compile and is force-stopped, then runs `echo hello`, the `echo` step now returns `code=0` with the expected output instead of `code=130` immediately.

Refs #313412
