### PR TITLE
agent-host: persist untitled URI → backend session mapping across handler recreation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { raceTimeout } from '../../../../../../base/common/async.js';
 import { encodeBase64 } from '../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { BugIndicatingError, isCancellationError } from '../../../../../../base/common/errors.js';
@@ -344,7 +345,34 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 	private readonly _activeSessions = new ResourceMap<AgentHostChatSession>();
 	/** Maps UI resource keys to resolved backend session URIs. */
-	private readonly _sessionToBackend = new ResourceMap<URI>();
+	/**
+	 * Maps a chat session URI (as known to the workbench) to the backend
+	 * session URI (as known to the agent host).
+	 *
+	 * This is **static** so it survives disposal/recreation of the handler
+	 * instance. When the tunnel to the agent host reconnects, the
+	 * `RemoteAgentHostContribution` tears down and re-creates the entire
+	 * agent store (including this handler). Without persistence, an
+	 * already-open chat widget that holds an `untitled-<uuid>` URI would
+	 * see a cache miss on its next message and we would create a brand
+	 * new backend session — surfacing a spurious tree item and orphaning
+	 * the original session. Keeping the mapping process-wide lets the
+	 * recreated handler reattach to the existing backend session.
+	 *
+	 * Keys include the provider scheme (e.g. `agent-host-copilot:`) so
+	 * different providers cannot collide. Entries are evicted when the
+	 * chat session is closed (see `AgentHostChatSession` dispose path) or
+	 * when the backend signals `notify/sessionRemoved`.
+	 */
+	private static readonly _sessionToBackend = new ResourceMap<URI>();
+
+	/**
+	 * Test-only: clear the static mapping so tests don't leak state to
+	 * each other.
+	 */
+	public static _resetForTests(): void {
+		AgentHostSessionHandler._sessionToBackend.clear();
+	}
 	/** Per-session subscription to chat model pending request changes. */
 	private readonly _pendingMessageSubscriptions = this._register(new DisposableResourceMap());
 	/** Per-session subscription watching for server-initiated turns. */
@@ -399,7 +427,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		this._register(autorun(reader => {
 			const tools = this._clientToolsObs.read(reader);
 			const defs = tools.map(toolDataToDefinition);
-			for (const [, backendSession] of this._sessionToBackend) {
+			for (const [, backendSession] of AgentHostSessionHandler._sessionToBackend) {
 				const state = this._getSessionState(backendSession.toString());
 				if (state?.activeClient?.clientId === this._config.connection.clientId) {
 					this._dispatchAction({
@@ -451,7 +479,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		if (config.customizations) {
 			this._register(autorun(reader => {
 				const refs = config.customizations!.read(reader);
-				for (const [, backendSession] of this._sessionToBackend) {
+				for (const [, backendSession] of AgentHostSessionHandler._sessionToBackend) {
 					const state = this._getSessionState(backendSession.toString());
 					if (state?.activeClient?.clientId === this._config.connection.clientId) {
 						this._dispatchActiveClient(backendSession, refs);
@@ -459,6 +487,21 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}
 			}));
 		}
+
+		// Evict static `_sessionToBackend` entries when the host signals that a
+		// backend session is gone. Without this, a chat session URI could
+		// remain mapped to a stale backend URI and `_tryReattachToBackendSession`
+		// would have to discover the staleness on the next request.
+		this._register(this._config.connection.onDidNotification(n => {
+			if (n.type === 'notify/sessionRemoved') {
+				const removedKey = n.session.toString();
+				for (const [chatUri, backendUri] of AgentHostSessionHandler._sessionToBackend) {
+					if (backendUri.toString() === removedKey) {
+						AgentHostSessionHandler._sessionToBackend.delete(chatUri);
+					}
+				}
+			}
+		}));
 
 		this._registerAgent();
 	}
@@ -475,7 +518,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		let activeTurnId: string | undefined;
 		if (!isUntitled) {
 			resolvedSession = this._resolveSessionUri(sessionResource);
-			this._sessionToBackend.set(sessionResource, resolvedSession);
+			AgentHostSessionHandler._sessionToBackend.set(sessionResource, resolvedSession);
 			try {
 				const sub = this._ensureSessionSubscription(resolvedSession.toString());
 				// Wait for the subscription to hydrate from the server
@@ -538,7 +581,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			sessionResource,
 			history,
 			(request: IChatSessionRequestHistoryItem | undefined, token: CancellationToken) => {
-				resolvedSession ??= this._sessionToBackend.get(sessionResource);
+				resolvedSession ??= AgentHostSessionHandler._sessionToBackend.get(sessionResource);
 				if (!resolvedSession) {
 					throw new BugIndicatingError('Cannot fork session before the initial request');
 				}
@@ -548,7 +591,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			initialProgress,
 			() => {
 				this._activeSessions.delete(sessionResource);
-				this._sessionToBackend.delete(sessionResource);
+				AgentHostSessionHandler._sessionToBackend.delete(sessionResource);
 				this._pendingMessageSubscriptions.deleteAndDispose(sessionResource);
 				this._serverTurnWatchers.deleteAndDispose(sessionResource);
 				this._pendingHistoryTurns.delete(sessionResource);
@@ -557,7 +600,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}
 			},
 			() => {
-				const backend = resolvedSession ?? this._sessionToBackend.get(sessionResource);
+				const backend = resolvedSession ?? AgentHostSessionHandler._sessionToBackend.get(sessionResource);
 				if (!backend) {
 					// Nothing to cancel. Treat as a successful noop so ChatService
 					// does not install a phantom pending request.
@@ -644,11 +687,28 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	): Promise<IChatAgentResult> {
 		this._logService.info(`[AgentHost] _invokeAgent called for resource: ${request.sessionResource.toString()}`);
 
-		// Resolve or create backend session
-		let resolvedSession = this._sessionToBackend.get(request.sessionResource);
+		// Resolve or create backend session.
+		//
+		// `_sessionToBackend` is static and persists across handler disposal/
+		// recreation. When the agent host tunnel reconnects, the workbench
+		// tears down and re-creates this handler — but the static map still
+		// remembers the URI → backend-session mapping. On a hit we reattach
+		// to the existing backend session (re-establishing this handler's
+		// subscriptions) instead of creating a new one. On a miss (or if the
+		// reattach fails because the host genuinely lost the session) we
+		// create a fresh backend session.
+		let resolvedSession = AgentHostSessionHandler._sessionToBackend.get(request.sessionResource);
+		if (resolvedSession) {
+			const reattached = await this._tryReattachToBackendSession(request.sessionResource, resolvedSession);
+			if (!reattached) {
+				this._logService.warn(`[AgentHost] Backend session ${resolvedSession.toString()} no longer exists, creating a new one for ${request.sessionResource.toString()}`);
+				AgentHostSessionHandler._sessionToBackend.delete(request.sessionResource);
+				resolvedSession = undefined;
+			}
+		}
 		if (!resolvedSession) {
 			resolvedSession = await this._createAndSubscribe(request.sessionResource, this._createModelSelection(request.userSelectedModelId, request.modelConfiguration), undefined, request.agentHostSessionConfig, getAgentHostBranchNameHint(request.message));
-			this._sessionToBackend.set(request.sessionResource, resolvedSession);
+			AgentHostSessionHandler._sessionToBackend.set(request.sessionResource, resolvedSession);
 		}
 
 		await this._handleTurn(resolvedSession, request, progress, cancellationToken);
@@ -2135,6 +2195,50 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		};
 	}
 
+	/**
+	 * Reattach this handler to an existing backend session that was previously
+	 * created (possibly by a now-disposed handler instance — see the static
+	 * `_sessionToBackend` map).
+	 *
+	 * The subscription / pending-message-sync / server-turn-watcher /
+	 * active-client-claim wiring is all per-handler and gets thrown away when
+	 * the handler is disposed, so we re-establish it here. All four helpers
+	 * are idempotent (the subscription is refcounted and the watchers replace
+	 * any prior entry on the same session resource).
+	 *
+	 * Returns `false` if the backend session no longer exists on the host
+	 * (e.g. host process restart vs. just a tunnel reconnect). The caller is
+	 * expected to evict the stale mapping and create a fresh session.
+	 */
+	private async _tryReattachToBackendSession(sessionResource: URI, backendSession: URI): Promise<boolean> {
+		this._logService.trace(`[AgentHost] Reattaching to backend session: ${backendSession.toString()}`);
+
+		const sessionStr = backendSession.toString();
+		const sub = this._ensureSessionSubscription(sessionStr);
+
+		// Wait until the subscription either hydrates with state or fails. The
+		// subscription does not fire `onDidChange` on failure (see
+		// `BaseAgentSubscription.setError`) so we race the change event with a
+		// timeout and then re-check `value` / `_getSessionState` below.
+		if (!this._getSessionState(sessionStr) && !(sub.value instanceof Error)) {
+			await raceTimeout(Event.toPromise(sub.onDidChange), 10_000);
+		}
+
+		// If the subscription resolved to an error (most commonly the host
+		// signalling "no such session") or never hydrated, the backend session
+		// is gone or unreachable.
+		if (sub.value instanceof Error || !this._getSessionState(sessionStr)) {
+			this._releaseSessionSubscription(sessionStr);
+			return false;
+		}
+
+		this._ensurePendingMessageSubscription(sessionResource, backendSession);
+		this._watchForServerInitiatedTurns(backendSession, sessionResource);
+		this._dispatchActiveClient(backendSession, this._config.customizations?.get() ?? []);
+
+		return true;
+	}
+
 	/** Creates a new backend session and subscribes to its state. */
 	private async _createAndSubscribe(sessionResource: URI, model: ModelSelection | undefined, fork?: { session: URI; turnIndex: number; turnId: string }, sessionConfig?: Record<string, unknown>, branchNameHint?: string): Promise<URI> {
 		const config = branchNameHint ? { ...sessionConfig, [SessionConfigKey.BranchNameHint]: branchNameHint } : sessionConfig;
@@ -2345,7 +2449,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		if (!requestedDir || requestedDir.scheme !== 'file') {
 			return uri;
 		}
-		const backendSession = this._sessionToBackend.get(sessionResource);
+		const backendSession = AgentHostSessionHandler._sessionToBackend.get(sessionResource);
 		const rawResolvedDir = backendSession ? this._getSessionState(backendSession.toString())?.summary.workingDirectory : undefined;
 		const resolvedDir = typeof rawResolvedDir === 'string' ? URI.parse(rawResolvedDir) : rawResolvedDir;
 		if (!resolvedDir || resolvedDir.scheme !== 'file') {
@@ -2421,7 +2525,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			session.dispose();
 		}
 		this._activeSessions.clear();
-		this._sessionToBackend.clear();
+		// Note: `_sessionToBackend` is intentionally NOT cleared here. It is
+		// static and must survive disposal so that a recreated handler (e.g.
+		// after a host reconnect) can reattach to existing backend sessions
+		// instead of creating spurious new ones.
 		for (const ref of this._sessionSubscriptions.values()) {
 			ref.dispose();
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -350,11 +350,13 @@ class MockChatWidgetService extends mock<IChatWidgetService>() {
 
 // ---- Helpers ----------------------------------------------------------------
 
-function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined }, authServiceOverride?: Partial<IAuthenticationService>) {
+function createTestServices(disposables: DisposableStore, workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined }, authServiceOverride?: Partial<IAuthenticationService>, existingAgentHostService?: MockAgentHostService) {
 	const instantiationService = disposables.add(new TestInstantiationService());
 
-	const agentHostService = new MockAgentHostService();
-	disposables.add(toDisposable(() => agentHostService.dispose()));
+	const agentHostService = existingAgentHostService ?? new MockAgentHostService();
+	if (!existingAgentHostService) {
+		disposables.add(toDisposable(() => agentHostService.dispose()));
+	}
 
 	const chatAgentService = new MockChatAgentService();
 	const chatWidgetService = new MockChatWidgetService();
@@ -443,8 +445,8 @@ function createTestServices(disposables: DisposableStore, workingDirectoryResolv
 	return { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService };
 }
 
-function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined } }) {
-	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride);
+function createContribution(disposables: DisposableStore, opts?: { authServiceOverride?: Partial<IAuthenticationService>; workingDirectoryResolver?: { resolve(sessionResource: URI): URI | undefined }; existingAgentHostService?: MockAgentHostService }) {
+	const { instantiationService, agentHostService, chatAgentService, chatWidgetService, chatService } = createTestServices(disposables, opts?.workingDirectoryResolver, opts?.authServiceOverride, opts?.existingAgentHostService);
 
 	const listController = disposables.add(instantiationService.createInstance(AgentHostSessionListController, 'agent-host-copilot', 'copilot', agentHostService, undefined, 'local'));
 	const sessionHandler = disposables.add(instantiationService.createInstance(AgentHostSessionHandler, {
@@ -459,6 +461,10 @@ function createContribution(disposables: DisposableStore, opts?: { authServiceOv
 	const contribution = disposables.add(instantiationService.createInstance(AgentHostContribution));
 
 	return { contribution, listController, sessionHandler, agentHostService, chatAgentService, chatWidgetService, chatService };
+}
+
+function createContributionWithExistingService(disposables: DisposableStore, existingAgentHostService: MockAgentHostService) {
+	return createContribution(disposables, { existingAgentHostService });
 }
 
 function makeRequest(overrides: Partial<{ message: string; sessionResource: URI; variables: IChatAgentRequest['variables']; userSelectedModelId: string; modelConfiguration: Record<string, unknown>; agentHostSessionConfig: Record<string, string>; agentId: string }> = {}): IChatAgentRequest {
@@ -619,7 +625,13 @@ suite('AgentHostChatContribution', () => {
 
 	const disposables = new DisposableStore();
 
-	teardown(() => disposables.clear());
+	teardown(() => {
+		disposables.clear();
+		// The static `_sessionToBackend` map persists across handler disposal
+		// (intentionally — see AgentHostSessionHandler). Reset it between
+		// tests so URI mappings from one test don't leak into another.
+		AgentHostSessionHandler._resetForTests();
+	});
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	// ---- Registration ---------------------------------------------------
@@ -873,6 +885,81 @@ suite('AgentHostChatContribution', () => {
 
 			// Should create a new SDK session, not use "untitled-abc123" literally
 			assert.ok(AgentSession.id(URI.parse(session)).startsWith('sdk-session-'));
+		}));
+
+		test('reattaches to existing backend session after handler is recreated (host reconnect on untitled URI)', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+			// This is the bug from microsoft/vscode#313360.
+			// Repro:
+			//  1. User starts a new session from the welcome screen → the chat
+			//     widget gets an `untitled-<uuid>` URI.
+			//  2. User sends first message → handler creates backend session
+			//     `sdk-session-1` and remembers `untitled-X → sdk-session-1`.
+			//  3. The agent host tunnel reconnects → the workbench tears down
+			//     and re-creates the handler (instance-state is gone).
+			//  4. User sends another message in the SAME widget. Without the
+			//     static `_sessionToBackend`, the new handler would call
+			//     `createSession` again and surface a spurious sibling
+			//     session in the tree, orphaning the first one.
+			//
+			// `_sessionToBackend` is static so the recreated handler reattaches
+			// to `sdk-session-1` instead of creating a new one.
+			const sessionResource = URI.from({ scheme: 'agent-host-copilot', path: '/untitled-reconnect-bug' });
+
+			// --- Handler #1: send first message, gets a fresh backend session.
+			const firstHandlerDisposables = disposables.add(new DisposableStore());
+			const first = createContribution(firstHandlerDisposables);
+			const agentHostService = first.agentHostService;
+
+			{
+				const registered = first.chatAgentService.registeredAgents.get('agent-host-copilot')!;
+				const turnPromise = registered.impl.invoke(
+					makeRequest({ message: 'First', sessionResource }),
+					() => { }, [], CancellationToken.None,
+				);
+				await timeout(10);
+				const dispatch = agentHostService.turnActions[0];
+				const action = dispatch.action as ITurnStartedAction;
+				agentHostService.fireAction({ action: dispatch.action, serverSeq: 1, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+				agentHostService.fireAction({ action: { type: 'session/turnComplete', session: action.session, turnId: action.turnId } as SessionAction, serverSeq: 2, origin: undefined });
+				await turnPromise;
+			}
+
+			assert.strictEqual(agentHostService.createSessionCalls.length, 1, 'first message should create a new backend session');
+			const firstBackendSession = (agentHostService.turnActions[0].action as ITurnStartedAction).session;
+
+			// --- Simulate a tunnel reconnect: dispose handler #1, create handler #2.
+			// We reuse the SAME mock connection (`agentHostService`) — that
+			// represents the host, which keeps the existing backend session
+			// across a tunnel reconnect.
+			firstHandlerDisposables.dispose();
+
+			const secondHandlerDisposables = disposables.add(new DisposableStore());
+			const second = createContributionWithExistingService(secondHandlerDisposables, agentHostService);
+
+			// --- Handler #2: send another message on the SAME chat URI.
+			{
+				const registered = second.chatAgentService.registeredAgents.get('agent-host-copilot')!;
+				const turnPromise = registered.impl.invoke(
+					makeRequest({ message: 'Second', sessionResource }),
+					() => { }, [], CancellationToken.None,
+				);
+				await timeout(10);
+				const dispatch = agentHostService.turnActions[1];
+				assert.ok(dispatch, 'handler #2 should have dispatched a turnStarted');
+				const action = dispatch.action as ITurnStartedAction;
+				agentHostService.fireAction({ action: dispatch.action, serverSeq: 3, origin: { clientId: agentHostService.clientId, clientSeq: dispatch.clientSeq } });
+				agentHostService.fireAction({ action: { type: 'session/turnComplete', session: action.session, turnId: action.turnId } as SessionAction, serverSeq: 4, origin: undefined });
+				await turnPromise;
+			}
+
+			// The bug: a second `createSession` call would happen and the second
+			// turn would target a different backend session URI.
+			assert.strictEqual(agentHostService.createSessionCalls.length, 1, 'recreated handler must NOT create a second backend session');
+			assert.strictEqual(
+				(agentHostService.turnActions[1].action as ITurnStartedAction).session,
+				firstBackendSession,
+				'recreated handler must dispatch the second turn against the original backend session',
+			);
 		}));
 		test('passes raw model id extracted from language model identifier', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);


### PR DESCRIPTION
Fixes [#313360](https://github.com/microsoft/vscode/issues/313360).

## Problem

When the agent host tunnel reconnects, `RemoteAgentHostContribution` disposes and recreates the `AgentHostSessionHandler` (the `clientId` changes). For chat sessions opened via the welcome screen "New Session" flow, the resource stays as `agent-host-copilot:/untitled-<uuid>` — the agent-host controller doesn't implement `newChatSessionItem`, so the URI is never swapped for the real backend URI.

Previously the URI → backend session mapping lived in an instance field on the handler, so it was lost on recreation. The next message sent on the same already-open chat widget missed the cache and called `createSession` again, producing a spurious second tree item for what is logically the same session.

## Fix

Promote the `_sessionToBackend` map to a `static readonly` field that survives handler disposal, with eviction wired to `notify/sessionRemoved`.

On a cache hit after the handler is recreated, reattach to the existing backend subscription via the new `_tryReattachToBackendSession` helper and re-establish the per-instance housekeeping (pending-message subscription, server-turn watcher, active-client dispatch) instead of creating a new session. If the cached backend turns out to be stale (e.g. the host process restarted and forgot the session), fall back to creating a fresh one.

## Why static is safe

- Map keys include the provider scheme (`agent-host-copilot:`), so no cross-provider collision.
- The two autoruns gated on `activeClient?.clientId === connection.clientId` naturally skip stale-handler entries.
- Entries are evicted when the chat session disposes (closing the widget).
- Backend sessions persist on the host across tunnel reconnects (protocol guarantee).

## Test

Added `reattaches to existing backend session after handler is recreated (host reconnect on untitled URI)`:

1. Create handler #1, send first message → 1 `createSession` call, capture backend URI.
2. Dispose handler #1, create handler #2 with the **same** `agentHostService`.
3. Send a second message on the same `/untitled-reconnect-bug` URI.
4. Assert `createSessionCalls.length === 1` (no spurious second session) and the second turn targets the same backend session.

Full `AgentHostChatContribution` suite (107 tests) passes.

(Written by Copilot)