### PR TITLE
Fixes extension editor readmes in modals

### DIFF
--- a/src/vs/base/browser/overlayLayoutElement.ts
+++ b/src/vs/base/browser/overlayLayoutElement.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { setParentFlowTo } from './dom.js';
+import { getComputedStyle, setParentFlowTo } from './dom.js';
 import { IDisposable } from '../common/lifecycle.js';
 import { generateUuid } from '../common/uuid.js';
 
@@ -101,6 +101,24 @@ export class OverlayLayoutElement implements IDisposable {
 		}
 
 		this._updateClipping(options?.clippingContainer);
+		this._updateZIndex(anchorElement);
+	}
+
+	/**
+	 * Walk up from the anchor element to find the nearest ancestor with an explicit
+	 * z-index and place the overlay one level above it. This ensures the overlay sits
+	 * above modal layers or other stacking contexts.
+	 */
+	private _updateZIndex(anchorElement: HTMLElement): void {
+		let zIndex = '';
+		for (let el: HTMLElement | null = anchorElement; el; el = el.parentElement) {
+			const computed = getComputedStyle(el).zIndex;
+			if (computed && computed !== 'auto') {
+				zIndex = String(Number(computed) + 1);
+				break;
+			}
+		}
+		this.content.style.zIndex = zIndex;
 	}
 
 	private _updateClipping(clippingContainer: HTMLElement | undefined): void {

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -722,13 +722,6 @@ export class ExtensionEditor extends EditorPane {
 
 			this.contentDisposables.add(webview.onDidScroll(() => this.initialScrollProgress.set(webviewIndex, webview.initialScrollProgress)));
 
-			const removeLayoutParticipant = arrays.insert(this.layoutParticipants, {
-				layout: () => {
-					webview.setAnchorElement(container);
-				}
-			});
-			this.contentDisposables.add(toDisposable(removeLayoutParticipant));
-
 			let isDisposed = false;
 			this.contentDisposables.add(toDisposable(() => { isDisposed = true; }));
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1942,12 +1942,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		const modalEditorContainer = this.editorGroupsService.activeModalEditorPart?.modalElement;
-		let clippingContainer: HTMLElement | undefined;
-		if (DOM.isHTMLElement(modalEditorContainer) && modalEditorContainer.contains(anchorElement)) {
-			clippingContainer = modalEditorContainer;
-		} else {
-			clippingContainer = this.layoutService.getContainer(DOM.getWindow(this.getDomNode()), Parts.EDITOR_PART);
-		}
+		const isModal = DOM.isHTMLElement(modalEditorContainer) && modalEditorContainer.contains(anchorElement);
+		const clippingContainer = isModal ? undefined : this.layoutService.getContainer(DOM.getWindow(this.getDomNode()), Parts.EDITOR_PART);
 
 		this._overlayContainer.style.visibility = 'visible';
 		this._overlayLayout.setAnchorElement(anchorElement, { clippingContainer });

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -191,9 +191,6 @@ export class WebviewEditor extends EditorPane {
 		const isModal = isHTMLElement(modalEditorContainer) && this._element && modalEditorContainer.contains(this._element);
 		this._clippingContainer = isModal ? undefined : this._workbenchLayoutService.getContainer(this.window, Parts.EDITOR_PART);
 
-		// When shown in a modal editor, the webview overlay must sit above the modal layer
-		input.webview.container.style.zIndex = isModal ? '2541' : ''; // One over the modal z-index
-
 		this._webviewVisibleDisposables.clear();
 
 		// Webviews are not part of the normal editor dom, so we have to register our own drag and drop handler on them.


### PR DESCRIPTION
Fixes #305931

Takes advantage of the anchor based layout we already use but fixes an issue with the z-index. Previously this fix only worked for the `webviewEditor`

Also aligns the notebook editor with the webvieweditor for clipping and modals

