### PR TITLE
Agents: Enhance account title bar and widget styles

### DIFF
--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -553,6 +553,16 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 
 		// Header: account label + sign-out icon.
 		const headerSection = append(panel, $('.sessions-account-titlebar-panel-header'));
+		const loadedAvatarUrl = !this.isAccountLoading ? this.loadedAvatarUrl : undefined;
+		if (loadedAvatarUrl) {
+			const avatar = append(headerSection, $('img.sessions-account-titlebar-panel-avatar', {
+				alt: this.getAvatarAltText(true),
+				draggable: 'false',
+				src: loadedAvatarUrl,
+			})) as HTMLImageElement;
+			avatar.decoding = 'async';
+			avatar.referrerPolicy = 'no-referrer';
+		}
 		const title = append(headerSection, $('div.sessions-account-titlebar-panel-title'));
 		title.textContent = this.getPanelHeaderLabel();
 		if (partitioned.signOut) {
@@ -708,7 +718,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 
 	private getPanelHeaderLabel(): string {
 		if (this.accountName) {
-			return localize('signedInAsHeader', "Signed in as {0}", this.accountName);
+			return this.accountName;
 		}
 
 		if (this.isAccountLoading) {

--- a/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
+++ b/src/vs/sessions/contrib/accountMenu/browser/account.contribution.ts
@@ -757,6 +757,7 @@ class TitleBarAccountWidget extends BaseActionViewItem {
 			disableProviderOptions: true,
 			disableCompletionsSnooze: true,
 			disableQuickSettingsCollapsible: true,
+			disableContributedSectionsCollapsible: true,
 			...extraOptions,
 		});
 

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -215,7 +215,6 @@
 	font-size: 12px;
 	font-weight: 500;
 	line-height: 18px;
-	color: var(--vscode-descriptionForeground);
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-header-actions {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -202,7 +202,7 @@
 	align-items: center;
 	gap: 6px;
 	min-height: 28px;
-	padding: 6px 8px;
+	padding: 4px 8px;
 	border-bottom: 1px solid var(--vscode-menu-separatorBackground, var(--vscode-disabledForeground));
 }
 
@@ -244,7 +244,7 @@
 	border: none;
 	border-radius: var(--vscode-cornerRadius-medium);
 	background: transparent;
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-icon-foreground, var(--vscode-descriptionForeground));
 	cursor: default;
 	font-size: 14px !important;
 }
@@ -418,7 +418,7 @@
 	width: 16px;
 	height: 16px;
 	flex: 0 0 auto;
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-icon-foreground, var(--vscode-descriptionForeground));
 	/* `!important` to override `.codicon`'s own `font-size` rule. */
 	font-size: 14px !important;
 }

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -206,6 +206,15 @@
 	border-bottom: 1px solid var(--vscode-menu-separatorBackground, var(--vscode-disabledForeground));
 }
 
+.agent-sessions-workbench .sessions-account-titlebar-panel-avatar {
+	flex: 0 0 auto;
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	object-fit: cover;
+	border: 1px solid var(--vscode-commandCenter-border, var(--vscode-contrastBorder, transparent));
+}
+
 .agent-sessions-workbench .sessions-account-titlebar-panel-title {
 	flex: 1 1 auto;
 	min-width: 0;
@@ -514,7 +523,7 @@
 .agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip {
 	display: flex;
 	flex-direction: column;
-	padding: 4px 8px 6px;
+	padding: 4px 8px 8px;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip > div.description {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -317,13 +317,13 @@
 	but style it like the quota-title above, drop the chevron/divider, and
 	force the content open so it reads as a single continuous section. */
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
-	margin-top: 0;
+	margin-top: 4px;
 	padding: 0;
 	border-top: none;
 	background: none;
 	cursor: default;
 	pointer-events: none;
-	font-size: 13px;
+	font-size: 12px;
 	line-height: 18px;
 	font-weight: 400;
 	color: var(--vscode-descriptionForeground);
@@ -348,7 +348,7 @@
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content > .collapsible-inner {
 	gap: 6px;
-	margin-top: 4px;
+	margin-top: 0;
 	margin-bottom: 0;
 }
 
@@ -522,14 +522,13 @@
 .agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip {
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
 	padding: 4px 8px 6px;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip > div.description {
 	margin: 0;
 	padding: 0 2px;
-	font-size: 12px;
+	font-size: 11px;
 	line-height: 16px;
 	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -287,7 +287,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0;
-	padding: 2px 0;
+	padding: 2px 0 6px 0;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section {
@@ -318,7 +318,7 @@
 	force the content open so it reads as a single continuous section. */
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
 	margin-top: 4px;
-	padding: 0;
+	padding: 0 28px 0 0;
 	border-top: none;
 	background: none;
 	cursor: default;
@@ -331,6 +331,10 @@
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-chevron {
 	display: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-label {
+	color: var(--vscode-foreground);
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-status {
@@ -358,12 +362,16 @@
 	line-height: 15px;
 }
 
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .section-detail {
+	padding-bottom: 4px;
+}
+
 .agent-sessions-workbench .sessions-account-titlebar-panel-section-title {
 	padding: 4px 8px 2px;
 	font-size: 12px;
 	font-weight: 500;
 	line-height: 18px;
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-foreground);
 }
 
 /* Subscription section: place "Subscription" label and the dashboard's
@@ -390,6 +398,7 @@
 	gap: 6px;
 	font-size: 12px;
 	line-height: 18px;
+	color: var(--vscode-descriptionForeground);
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section-header > div.header .header-label {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -308,45 +308,29 @@
 	padding-bottom: 0;
 }
 
-/* Collapsible sub-sections (e.g. "Codebase Semantic Index"): drop the
-	standalone-tooltip divider/bold heading and align with the panel's
-	quota-title style above it. */
-/* Flatten collapsible sub-sections (e.g. "Codebase Semantic Index") into
-	the parent Subscription section: keep the header content (label + status)
-	but style it like the quota-title above, drop the chevron/divider, and
-	force the content open so it reads as a single continuous section. */
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
+/* Flatten contributed sub-sections (e.g. "Codebase Semantic Index") into
+	the parent Subscription section. The dashboard renders these non-collapsibly
+	(via `disableContributedSectionsCollapsible`); these rules just align the
+	header typography with the panel's quota-title style above it. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header.non-collapsible {
 	margin-top: 4px;
 	padding: 0 28px 0 0;
 	border-top: none;
 	background: none;
-	cursor: default;
-	pointer-events: none;
 	font-size: 12px;
 	line-height: 18px;
 	font-weight: 400;
 	color: var(--vscode-descriptionForeground);
 }
 
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-chevron {
-	display: none;
-}
-
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-label {
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header.non-collapsible .collapsible-label {
 	color: var(--vscode-foreground);
 }
 
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-status {
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header.non-collapsible .collapsible-status {
 	margin-left: auto;
 	font-size: 11px;
 	line-height: 15px;
-}
-
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content,
-.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed {
-	display: block;
-	grid-template-rows: none;
-	transition: none;
 }
 
 .agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content > .collapsible-inner {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountTitleBarWidget.css
@@ -309,6 +309,55 @@
 	padding-bottom: 0;
 }
 
+/* Collapsible sub-sections (e.g. "Codebase Semantic Index"): drop the
+	standalone-tooltip divider/bold heading and align with the panel's
+	quota-title style above it. */
+/* Flatten collapsible sub-sections (e.g. "Codebase Semantic Index") into
+	the parent Subscription section: keep the header content (label + status)
+	but style it like the quota-title above, drop the chevron/divider, and
+	force the content open so it reads as a single continuous section. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header {
+	margin-top: 0;
+	padding: 0;
+	border-top: none;
+	background: none;
+	cursor: default;
+	pointer-events: none;
+	font-size: 13px;
+	line-height: 18px;
+	font-weight: 400;
+	color: var(--vscode-descriptionForeground);
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-chevron {
+	display: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-header .collapsible-status {
+	margin-left: auto;
+	font-size: 11px;
+	line-height: 15px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content.collapsed {
+	display: block;
+	grid-template-rows: none;
+	transition: none;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .collapsible-content > .collapsible-inner {
+	gap: 6px;
+	margin-top: 4px;
+	margin-bottom: 0;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .section-description,
+.agent-sessions-workbench .sessions-account-titlebar-panel-section .chat-status-bar-entry-tooltip .section-detail {
+	font-size: 11px;
+	line-height: 15px;
+}
+
 .agent-sessions-workbench .sessions-account-titlebar-panel-section-title {
 	padding: 4px 8px 2px;
 	font-size: 12px;
@@ -464,6 +513,36 @@
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
 	cursor: default;
+}
+
+/* Signed-out CTA inside the embedded chat status dashboard
+	(e.g. "Sign in to use AI Features"). The dashboard ships its own
+	default-styled <Button>; align it with the rest of the account menu
+	by tightening spacing and matching the panel's primary-action look. */
+.agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 4px 8px 6px;
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip > div.description {
+	margin: 0;
+	padding: 0 2px;
+	font-size: 12px;
+	line-height: 16px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.agent-sessions-workbench .sessions-account-titlebar-panel-section.subscription .chat-status-bar-entry-tooltip > .monaco-button {
+	width: 100%;
+	height: 26px;
+	margin: 0;
+	padding: 0 12px;
+	border-radius: var(--vscode-cornerRadius-medium);
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1;
 }
 
 /* Motion animations */

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
@@ -133,6 +133,7 @@
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .quota-indicator .quota-title {
 	font-size: 12px;
 	margin-bottom: 0;
+	color: var(--vscode-foreground);
 }
 
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .collapsible-inner {

--- a/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
+++ b/src/vs/sessions/contrib/accountMenu/browser/media/accountWidget.css
@@ -130,11 +130,6 @@
 	padding: 8px 10px 8px 8px;
 }
 
-.sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .quota-indicator {
-	margin-bottom: 8px;
-	padding: 0 8px;
-}
-
 .sessions-account-titlebar-panel-content .chat-status-bar-entry-tooltip .quota-indicator .quota-title {
 	font-size: 12px;
 	margin-bottom: 0;

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -76,6 +76,8 @@ export interface IChatStatusDashboardOptions {
 	disableCompletionsSnooze?: boolean;
 	/** When true, the Quick Settings region is rendered always-expanded without a collapsible header. */
 	disableQuickSettingsCollapsible?: boolean;
+	/** When true, contributed sections are rendered always-expanded without a collapsible header button. */
+	disableContributedSectionsCollapsible?: boolean;
 	/**
 	 * When provided, the title header (plan name + manage / CTA actions) is
 	 * rendered into this caller-owned container instead of inline at the top
@@ -352,19 +354,26 @@ export class ChatStatusDashboard extends DomWidget {
 	}
 
 	private renderContributedSections(contributedEntries: ChatStatusEntry[]): void {
+		const nonCollapsible = !!this.options?.disableContributedSectionsCollapsible;
 		for (const item of contributedEntries) {
 			const storageKey = ChatStatusDashboard.CONTRIBUTED_COLLAPSED_KEY_PREFIX + item.id;
-			const collapsed = this.storageService.getBoolean(storageKey, StorageScope.PROFILE, true);
+			const collapsed = !nonCollapsible && this.storageService.getBoolean(storageKey, StorageScope.PROFILE, true);
 
 			const headerLabel = typeof item.label === 'string' ? item.label : item.label.label;
 			const headerLink = typeof item.label === 'string' ? undefined : item.label.link;
 			const linkDescription = typeof item.label === 'string' ? undefined : item.label.helpText;
 
-			const disclosureHeader = this.element.appendChild($('button.collapsible-header'));
-			disclosureHeader.setAttribute('aria-expanded', String(!collapsed));
-
-			const chevron = disclosureHeader.appendChild($('span.collapsible-chevron'));
-			chevron.classList.add(...ThemeIcon.asClassNameArray(collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+			const disclosureHeader = this.element.appendChild(
+				nonCollapsible
+					? $('div.collapsible-header.non-collapsible')
+					: $('button.collapsible-header')
+			);
+			let chevron: HTMLElement | undefined;
+			if (!nonCollapsible) {
+				disclosureHeader.setAttribute('aria-expanded', String(!collapsed));
+				chevron = disclosureHeader.appendChild($('span.collapsible-chevron'));
+				chevron.classList.add(...ThemeIcon.asClassNameArray(collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+			}
 
 			disclosureHeader.appendChild($('span.collapsible-label', undefined, headerLabel));
 
@@ -380,16 +389,18 @@ export class ChatStatusDashboard extends DomWidget {
 				collapsibleInner.inert = true;
 			}
 
-			const toggle = () => {
-				const isCollapsed = collapsibleContent.classList.toggle('collapsed');
-				collapsibleInner.inert = isCollapsed;
-				disclosureHeader.setAttribute('aria-expanded', String(!isCollapsed));
-				chevron.className = 'collapsible-chevron';
-				chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
-				this.storageService.store(storageKey, isCollapsed, StorageScope.PROFILE, StorageTarget.USER);
-			};
+			if (!nonCollapsible) {
+				const toggle = () => {
+					const isCollapsed = collapsibleContent.classList.toggle('collapsed');
+					collapsibleInner.inert = isCollapsed;
+					disclosureHeader.setAttribute('aria-expanded', String(!isCollapsed));
+					chevron!.className = 'collapsible-chevron';
+					chevron!.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
+					this.storageService.store(storageKey, isCollapsed, StorageScope.PROFILE, StorageTarget.USER);
+				};
 
-			this._store.add(addDisposableListener(disclosureHeader, EventType.CLICK, () => toggle()));
+				this._store.add(addDisposableListener(disclosureHeader, EventType.CLICK, () => toggle()));
+			}
 
 			// Use a single disposable store for all contributed section content
 			const sectionDisposables = this._store.add(new MutableDisposable());


### PR DESCRIPTION
This pull request enhances the account title bar and embedded chat status dashboard UI for improved clarity and consistency, especially around contributed sections and avatar display. The main changes include support for non-collapsible contributed dashboard sections, improved avatar rendering, and several visual polish updates to align with design standards.

<img width="382" height="305" alt="image" src="https://github.com/user-attachments/assets/80561093-7084-49b4-b8ad-ae8270b77c44" />


**Dashboard contributed sections improvements:**
- Added support for rendering contributed dashboard sections as always-expanded (non-collapsible) when the `disableContributedSectionsCollapsible` option is set, including updated markup and logic in `ChatStatusDashboard` and new styles to visually flatten these sections. [[1]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780R79-R80) [[2]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R770) [[3]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780R357-R376) [[4]](diffhunk://#diff-85eacf69735bedb245ad13db53774159c477b055c15223fa1d0347806a00f780R392-R403) [[5]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430R320-R366)
- Updated the account menu to pass the new `disableContributedSectionsCollapsible` option to the dashboard.

**Account title bar improvements:**
- The account avatar is now displayed in the title bar when available, with proper styling and accessibility attributes. [[1]](diffhunk://#diff-768eee1abde7d03ea3c077879d415ffd5975ec47f18d4bafc8183dda3f08f1f3R556-R565) [[2]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L205-R217)
- The account name is now shown directly as the panel header label, instead of the localized "Signed in as ..." string.

**Visual and style updates:**
- Refined paddings, font sizes, and color usage for better alignment, clarity, and consistency across the account title bar and dashboard sections. [[1]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L205-R217) [[2]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L218) [[3]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L239-R247) [[4]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L290-R298) [[5]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430R393) [[6]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430L371-R421) [[7]](diffhunk://#diff-873df101dce2d2c0eaaac1d4078778b428835b0a79934e0c97f6b8d058972430R519-R547) [[8]](diffhunk://#diff-710571e192bcf18882122e92962ce54701f3f7a3c5a4b7e1d32315e21be0a8b5L133-R136)
- Improved the appearance of the signed-out call-to-action in the dashboard, ensuring the button and description match the overall panel style.

These changes collectively improve usability and visual coherence in the account menu and embedded dashboard experience.