### PR TITLE
nes: hardcode nextcursorline cursor placement to beforeLine, remove config

### DIFF
--- a/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
+++ b/extensions/copilot/src/extension/xtab/node/xtabProvider.ts
@@ -16,7 +16,7 @@ import { DocumentId } from '../../../platform/inlineEdits/common/dataTypes/docum
 import { Edits } from '../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageContextEntry, LanguageContextResponse } from '../../../platform/inlineEdits/common/dataTypes/languageContext';
 import { LanguageId } from '../../../platform/inlineEdits/common/dataTypes/languageId';
-import { NextCursorLinePrediction, NextCursorLinePredictionCursorPlacement } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
+import { NextCursorLinePrediction } from '../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import * as xtabPromptOptions from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { AggressivenessSetting, EarlyDivergenceCancellationMode, isAggressivenessStrategy, LanguageContextLanguages, LanguageContextOptions } from '../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../platform/inlineEdits/common/inlineEditLogContext';
@@ -1199,8 +1199,7 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		const nextCursorLineOneBased = nextCursorLineZeroBased + 1;
 		const nextCursorLine = promptPieces.activeDoc.documentAfterEditsLines.at(nextCursorLineZeroBased);
 
-		const cursorPlacement = this.configService.getExperimentBasedConfig(ConfigKey.TeamInternal.InlineEditsNextCursorPredictionCursorPlacement, this.expService);
-		const nextCursorColumn = XtabProvider.getNextCursorColumn(nextCursorLine, cursorPlacement);
+		const nextCursorColumn = XtabProvider.getNextCursorColumn(nextCursorLine);
 
 		switch (nextCursorLinePrediction) {
 			case NextCursorLinePrediction.Jump: {
@@ -1565,19 +1564,8 @@ export class XtabProvider implements IStatelessNextEditProvider {
 		}, [edits, []]);
 	}
 
-	public static getNextCursorColumn(nextCursorLine: string | undefined, cursorPlacement: NextCursorLinePredictionCursorPlacement): number {
-		let nextCursorColumn: number;
-		switch (cursorPlacement) {
-			case NextCursorLinePredictionCursorPlacement.BeforeLine:
-				nextCursorColumn = (nextCursorLine?.match(/^(\s*)/)?.at(1)?.length ?? 0) + 1;
-				break;
-			case NextCursorLinePredictionCursorPlacement.AfterLine:
-				nextCursorColumn = (nextCursorLine?.length ?? 0) + 1;
-				break;
-			default:
-				assertNever(cursorPlacement);
-		}
-		return nextCursorColumn;
+	public static getNextCursorColumn(nextCursorLine: string | undefined): number {
+		return (nextCursorLine?.match(/^(\s*)/)?.at(1)?.length ?? 0) + 1;
 	}
 }
 

--- a/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
+++ b/extensions/copilot/src/extension/xtab/test/node/xtabProvider.spec.ts
@@ -13,7 +13,6 @@ import { InMemoryConfigurationService } from '../../../../platform/configuration
 import { DocumentId } from '../../../../platform/inlineEdits/common/dataTypes/documentId';
 import { Edits } from '../../../../platform/inlineEdits/common/dataTypes/edit';
 import { LanguageId } from '../../../../platform/inlineEdits/common/dataTypes/languageId';
-import { NextCursorLinePredictionCursorPlacement } from '../../../../platform/inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import { DEFAULT_OPTIONS, EarlyDivergenceCancellationMode, LanguageContextLanguages, LintOptionShowCode, LintOptionWarning, ModelConfiguration, PromptingStrategy, ResponseFormat } from '../../../../platform/inlineEdits/common/dataTypes/xtabPromptOptions';
 import { InlineEditRequestLogContext } from '../../../../platform/inlineEdits/common/inlineEditLogContext';
 import { IInlineEditsModelService } from '../../../../platform/inlineEdits/common/inlineEditsModelService';
@@ -3468,52 +3467,34 @@ suite('filterOutEditsWithSubstrings', () => {
 
 suite('getNextCursorColumn', () => {
 
-	const { BeforeLine, AfterLine } = NextCursorLinePredictionCursorPlacement;
-
 	/** Inserts a `|` cursor marker at the computed column position (1-based). */
-	function colWithMarker(line: string | undefined, placement: NextCursorLinePredictionCursorPlacement): string {
-		const column = XtabProvider.getNextCursorColumn(line, placement);
+	function colWithMarker(line: string | undefined): string {
+		const column = XtabProvider.getNextCursorColumn(line);
 		const s = line ?? '';
 		return s.slice(0, column - 1) + '|' + s.slice(column - 1);
 	}
 
-	test('BeforeLine: indented with spaces', () => {
-		expect(colWithMarker('    const x = 1;', BeforeLine)).toMatchInlineSnapshot(`"    |const x = 1;"`);
+	test('indented with spaces', () => {
+		expect(colWithMarker('    const x = 1;')).toMatchInlineSnapshot(`"    |const x = 1;"`);
 	});
 
-	test('BeforeLine: indented with tabs', () => {
-		expect(colWithMarker('\t\treturn;', BeforeLine)).toMatchInlineSnapshot(`"		|return;"`);
+	test('indented with tabs', () => {
+		expect(colWithMarker('\t\treturn;')).toMatchInlineSnapshot(`"		|return;"`);
 	});
 
-	test('BeforeLine: no leading whitespace', () => {
-		expect(colWithMarker('function foo() {', BeforeLine)).toMatchInlineSnapshot(`"|function foo() {"`);
+	test('no leading whitespace', () => {
+		expect(colWithMarker('function foo() {')).toMatchInlineSnapshot(`"|function foo() {"`);
 	});
 
-	test('BeforeLine: empty string', () => {
-		expect(colWithMarker('', BeforeLine)).toMatchInlineSnapshot(`"|"`);
+	test('empty string', () => {
+		expect(colWithMarker('')).toMatchInlineSnapshot(`"|"`);
 	});
 
-	test('BeforeLine: whitespace-only line', () => {
-		expect(colWithMarker('   ', BeforeLine)).toMatchInlineSnapshot(`"   |"`);
+	test('whitespace-only line', () => {
+		expect(colWithMarker('   ')).toMatchInlineSnapshot(`"   |"`);
 	});
 
-	test('BeforeLine: undefined', () => {
-		expect(colWithMarker(undefined, BeforeLine)).toMatchInlineSnapshot(`"|"`);
-	});
-
-	test('AfterLine: normal line', () => {
-		expect(colWithMarker('const x = 1;', AfterLine)).toMatchInlineSnapshot(`"const x = 1;|"`);
-	});
-
-	test('AfterLine: empty string', () => {
-		expect(colWithMarker('', AfterLine)).toMatchInlineSnapshot(`"|"`);
-	});
-
-	test('AfterLine: undefined', () => {
-		expect(colWithMarker(undefined, AfterLine)).toMatchInlineSnapshot(`"|"`);
-	});
-
-	test('AfterLine: trailing whitespace', () => {
-		expect(colWithMarker('abc   ', AfterLine)).toMatchInlineSnapshot(`"abc   |"`);
+	test('undefined', () => {
+		expect(colWithMarker(undefined)).toMatchInlineSnapshot(`"|"`);
 	});
 });

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -15,7 +15,6 @@ import { ICopilotTokenStore } from '../../authentication/common/copilotTokenStor
 import { packageJson } from '../../env/common/packagejson';
 import { ImportChanges } from '../../inlineEdits/common/dataTypes/importFilteringOptions';
 import { JointCompletionsProviderStrategy, JointCompletionsProviderTriggerChangeStrategy } from '../../inlineEdits/common/dataTypes/jointCompletionsProviderOptions';
-import { NextCursorLinePredictionCursorPlacement } from '../../inlineEdits/common/dataTypes/nextCursorLinePrediction';
 import * as triggerOptions from '../../inlineEdits/common/dataTypes/triggerOptions';
 import * as xtabHistoryOptions from '../../inlineEdits/common/dataTypes/xtabHistoryOptions';
 import * as xtabPromptOptions from '../../inlineEdits/common/dataTypes/xtabPromptOptions';
@@ -818,7 +817,6 @@ export namespace ConfigKey {
 		export const InlineEditsXtabRecentlyViewedDocumentsMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.recentlyViewedDocuments.maxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.maxTokens);
 		export const InlineEditsXtabRecentlyViewedIncludeLineNumbers = defineTeamInternalSetting<xtabPromptOptions.IncludeLineNumbersOption>('chat.advanced.inlineEdits.xtabProvider.recentlyViewedDocuments.includeLineNumbers', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.recentlyViewedDocuments.includeLineNumbers);
 		export const InlineEditsNextCursorPredictionRecentSnippetsIncludeLineNumbers = defineTeamInternalSetting<xtabPromptOptions.IncludeLineNumbersOption>('chat.advanced.inlineEdits.nextCursorPrediction.recentSnippets.includeLineNumbers', ConfigType.ExperimentBased, xtabPromptOptions.IncludeLineNumbersOption.None);
-		export const InlineEditsNextCursorPredictionCursorPlacement = defineTeamInternalSetting<NextCursorLinePredictionCursorPlacement>('chat.advanced.inlineEdits.nextCursorPrediction.cursorPlacement', ConfigType.ExperimentBased, NextCursorLinePredictionCursorPlacement.AfterLine, NextCursorLinePredictionCursorPlacement.VALIDATOR);
 		export const InlineEditsXtabDiffNEntries = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.diffNEntries', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.diffHistory.nEntries);
 		export const InlineEditsXtabDiffMaxTokens = defineTeamInternalSetting<number>('chat.advanced.inlineEdits.xtabProvider.diffMaxTokens', ConfigType.ExperimentBased, xtabPromptOptions.DEFAULT_OPTIONS.diffHistory.maxTokens);
 		export const InlineEditsXtabDiffMergeStrategy = defineTeamInternalSetting<xtabHistoryOptions.DiffHistoryMergeStrategy>('chat.advanced.inlineEdits.xtabProvider.diffMergeStrategy', ConfigType.ExperimentBased, xtabHistoryOptions.DiffHistoryMergeStrategy.SameStartLine, xtabHistoryOptions.DiffHistoryMergeStrategy.VALIDATOR);

--- a/extensions/copilot/src/platform/inlineEdits/common/dataTypes/nextCursorLinePrediction.ts
+++ b/extensions/copilot/src/platform/inlineEdits/common/dataTypes/nextCursorLinePrediction.ts
@@ -3,18 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { vEnum } from '../../../configuration/common/validator';
-
 export enum NextCursorLinePrediction {
 	Jump = 'jump',
 	OnlyWithEdit = 'onlyWithEdit',
-}
-
-export enum NextCursorLinePredictionCursorPlacement {
-	BeforeLine = 'beforeLine',
-	AfterLine = 'afterLine',
-}
-
-export namespace NextCursorLinePredictionCursorPlacement {
-	export const VALIDATOR = vEnum(NextCursorLinePredictionCursorPlacement.BeforeLine, NextCursorLinePredictionCursorPlacement.AfterLine);
 }


### PR DESCRIPTION
## Summary

Hardcodes the next-cursor-line prediction cursor placement to **BeforeLine** (first non-whitespace character of the predicted line) and removes all code supporting the configurable `AfterLine` alternative.

## Changes

- **`nextCursorLinePrediction.ts`** — Removed `NextCursorLinePredictionCursorPlacement` enum, its `VALIDATOR`, and the now-unused `vEnum` import.
- **`configurationService.ts`** — Removed `InlineEditsNextCursorPredictionCursorPlacement` (experiment-based setting `chat.advanced.inlineEdits.nextCursorPrediction.cursorPlacement`) and its import.
- **`xtabProvider.ts`** — Dropped the config read and switch statement; `getNextCursorColumn(line)` now unconditionally returns the column of the first non-whitespace character.
- **`xtabProvider.spec.ts`** — Removed `AfterLine` test cases and the `placement` parameter from `colWithMarker`; kept the `BeforeLine` cases (renamed without prefix).

## Testing

- Type-check (`npx tsgo --noEmit --project tsconfig.json` and `tsconfig.worker.json`): ✅
- `xtabProvider.spec.ts` (176 tests): ✅