### PR TITLE
Use tracked edit operations in AutoIndentOnPasteCommand

### DIFF
--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -340,7 +340,7 @@ export class AutoIndentOnPasteCommand implements ICommand {
 
 	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
 		for (const edit of this._edits) {
-			builder.addEditOperation(Range.lift(edit.range), edit.text);
+			builder.addTrackedEditOperation(Range.lift(edit.range), edit.text);
 		}
 
 		let selectionIsSet = false;


### PR DESCRIPTION
Fixes #230320

When pasting a large blob (the linked issue cites a multi-thousand line markdown file), `AutoIndentOnPasteCommand` produces one `addEditOperation` per line. With ≥1000 untracked operations, `PieceTreeTextBuffer.applyEdits` collapses them into a single mega-edit via `_reduceOperations` (see `pieceTreeTextBuffer.ts` lines 247-254 and 420-432). The mega-edit's range engulfs the tracked initial selection, so the decoration collapses to the start of the merged region — which matches aiday-mar's diagnosis ("initial selection 2000 but `computeCursorState` returns 1769") and explains why the cursor jumps to the middle of the pasted content.

Switching to `addTrackedEditOperation` flips `hadTrackedEditOperation` (`cursor.ts:925`), marks the first op `_isTracked` (`pieceTreeTextBuffer.ts:808`), and sets `canReduceOperations = false`, so each per-line indent edit is applied independently. The cursor decoration sits outside every individual edit's range and is preserved correctly, matching the &lt;1000-line behaviour.

The behaviour for small pastes (where the bug never manifested) is unchanged because tracking is the same in either path; only the buffer's reduction path differs.