### PR TITLE
Add bottom-edge padding to _getPositionOutsideEditor

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -551,8 +551,9 @@ class MouseDownOperation extends Disposable {
 			return MouseTarget.createOutsideEditor(mouseColumn, new Position(aboveLineNumber, 1), 'above', outsideDistance);
 		}
 
-		if (e.posy > editorContent.y + editorContent.height) {
-			const outsideDistance = e.posy - editorContent.y - editorContent.height;
+		const bottomEdgePadding = 5;
+		if (e.posy > editorContent.y + editorContent.height - bottomEdgePadding) {
+			const outsideDistance = Math.max(0, e.posy - editorContent.y - editorContent.height);
 			const verticalOffset = viewLayout.getCurrentScrollTop() + e.relativePos.y;
 			const viewZoneData = HitTestContext.getZoneAtCoord(this._context, verticalOffset);
 			if (viewZoneData) {


### PR DESCRIPTION
Fixes #251735

Implements the fix proposed by @aiday-mar in the issue thread: "add a padding and allow the cursor to be considered outside of the editor when the cursor reaches that padding."

When the editor's bottom edge sits flush with the screen's bottom edge (e.g. status bar disabled), the mouse pointer is physically clipped a pixel or two above `editorContent.y + editorContent.height`. The strict `>` check therefore never fires, and drag-select / cursor extension toward the last visible line is impossible.

Adds a small (5px) padding band so positions within the band are treated as outside-below. `outsideDistance` is clamped at `0` to keep the magnitude non-negative when the cursor is within the padding band but still inside the geometric content area.

The above-edge path is unchanged; that case isn't symmetric — the editor's top is bounded by the title/menu bar in practice.