### PR TITLE
Add 'pane' search keyword to editor group settings

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -286,12 +286,14 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.editor.splitSizingDistribute', "Splits all the editor groups to equal parts."),
 					localize('workbench.editor.splitSizingSplit', "Splits the active editor group to equal parts.")
 				],
-				'description': localize('splitSizing', "Controls the size of editor groups when splitting them.")
+				'description': localize('splitSizing', "Controls the size of editor groups when splitting them."),
+				'keywords': ['pane']
 			},
 			'workbench.editor.splitOnDragAndDrop': {
 				'type': 'boolean',
 				'default': true,
-				'description': localize('splitOnDragAndDrop', "Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.")
+				'description': localize('splitOnDragAndDrop', "Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area."),
+				'keywords': ['pane']
 			},
 			'workbench.editor.dragToOpenWindow': {
 				'type': 'boolean',
@@ -343,7 +345,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.closeEmptyGroups': {
 				'type': 'boolean',
 				'description': localize('closeEmptyGroups', "Controls the behavior of empty editor groups when the last tab in the group is closed. When enabled, empty groups will automatically close. When disabled, empty groups will remain part of the grid."),
-				'default': true
+				'default': true,
+				'keywords': ['pane']
 			},
 			'workbench.editor.revealIfOpen': {
 				'type': 'boolean',


### PR DESCRIPTION
Fixes #65795

@roblourens confirmed in 2018 that adding "pane" as a synonym for "editor group" in settings search would be reasonable. Adds the `keywords` array (the documented search-synonym field on `IConfigurationPropertySchema`) to the three editor-group settings most directly affected:

- `workbench.editor.splitSizing`
- `workbench.editor.splitOnDragAndDrop`
- `workbench.editor.closeEmptyGroups`

These are the settings where searching "pane" most obviously fails to surface relevant results today (each is described in terms of "editor group" / "splitting" but never uses the word "pane"). Searches that used "pane" terminology now return them via the existing keyword-search code path in `preferencesSearch.ts`.