### PR TITLE
Add 'hint' and 'info' search keywords to editor.hover.enabled

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2368,7 +2368,8 @@ class EditorHover extends BaseEditorOption<EditorOption.hover, IEditorHoverOptio
 						nls.localize('hover.enabled.off', "Hover is disabled."),
 						nls.localize('hover.enabled.onKeyboardModifier', "Hover is shown when holding `{0}` or `Alt` (the opposite modifier of `#editor.multiCursorModifier#`)", platform.isMacintosh ? `Command` : `Control`)
 					],
-					description: nls.localize('hover.enabled', "Controls whether the hover is shown.")
+					description: nls.localize('hover.enabled', "Controls whether the hover is shown."),
+					keywords: ['hint', 'info', 'tooltip']
 				},
 				'editor.hover.delay': {
 					type: 'number',


### PR DESCRIPTION
Fixes #56902

@roblourens confirmed in 2018 ("Yeah makes sense") that adding "hint"/"info" as synonyms for "hover" in settings search would be reasonable. Implements that via the `keywords` array on the gateway hover setting.

Adds `keywords: ['hint', 'info', 'tooltip']` to `editor.hover.enabled` only — the gateway setting that surfaces all editor.hover.* in the search panel. Searching "hint", "info", or "tooltip" now returns the hover settings, which the existing keyword-search code path in `preferencesSearch.ts` uses by joining `setting.keywords` into the searchable lines alongside the description.

Scope kept narrow to the gateway setting per the maintainer's "Yeah makes sense" — doesn't blanket-apply to every hover sub-setting.