### PR TITLE
sessions: keep chevron and home button always visible in customizations header

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -83,11 +83,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		headerButton.label = localize('customizations', "Customizations");
 		this._headerButton = headerButton;
 
-		const chevronContainer = DOM.append(headerButton.element, $('span.customization-link-counts'));
-		const chevron = DOM.append(chevronContainer, $('.ai-customization-chevron'));
-		const headerTotalCount = DOM.append(chevronContainer, $('span.ai-customization-header-total.hidden'));
-		chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
-
 		const headerActions = DOM.append(header, $('.ai-customization-header-actions'));
 		const openOverviewLabel = localize('openCustomizationsOverview', "Open Customizations Overview");
 		const openOverviewButton = this._register(new Button(headerActions, {
@@ -107,6 +102,14 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			e?.preventDefault();
 			this._openWelcomePage();
 		}));
+
+		// Chevron at far right (outside the link button so it sits to the
+		// right of the home overview action). Clicking the chevron toggles
+		// collapse — same as clicking the header label.
+		const chevronContainer = DOM.append(header, $('span.customization-link-counts'));
+		const headerTotalCount = DOM.append(chevronContainer, $('span.ai-customization-header-total.hidden'));
+		const chevron = DOM.append(chevronContainer, $('.ai-customization-chevron'));
+		chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
 
 		// Toolbar container
 		const toolbarContainer = DOM.append(container, $('.ai-customization-toolbar-content.sidebar-action-list'));
@@ -172,6 +175,11 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
+		this._register(DOM.addDisposableListener(chevronContainer, DOM.EventType.CLICK, e => {
+			e.preventDefault();
+			e.stopPropagation();
+			toggleCollapse();
+		}));
 	}
 
 	private async _openWelcomePage(): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -6,6 +6,7 @@
 import '../../../browser/media/sidebarActionButton.css';
 import './media/customizationsToolbar.css';
 import * as DOM from '../../../../base/browser/dom.js';
+import { Gesture, EventType as TouchEventType } from '../../../../base/browser/touch.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, derived } from '../../../../base/common/observable.js';
@@ -106,7 +107,11 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		// Chevron at far right (outside the link button so it sits to the
 		// right of the home overview action). Clicking the chevron toggles
 		// collapse — same as clicking the header label.
-		const chevronContainer = DOM.append(header, $('span.customization-link-counts'));
+		const toggleCollapseLabel = localize('toggleCustomizationsCollapse', "Toggle Customizations Section");
+		const chevronContainer = DOM.append(header, $<HTMLButtonElement>('button.ai-customization-collapse-toggle'));
+		chevronContainer.type = 'button';
+		chevronContainer.setAttribute('aria-label', toggleCollapseLabel);
+		chevronContainer.title = toggleCollapseLabel;
 		const headerTotalCount = DOM.append(chevronContainer, $('span.ai-customization-header-total.hidden'));
 		const chevron = DOM.append(chevronContainer, $('.ai-customization-chevron'));
 		chevron.classList.add(...ThemeIcon.asClassNameArray(isCollapsed ? Codicon.chevronRight : Codicon.chevronDown));
@@ -175,11 +180,13 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		};
 
 		this._register(headerButton.onDidClick(() => toggleCollapse()));
-		this._register(DOM.addDisposableListener(chevronContainer, DOM.EventType.CLICK, e => {
-			e.preventDefault();
-			e.stopPropagation();
-			toggleCollapse();
-		}));
+		this._register(Gesture.addTarget(chevronContainer));
+		for (const eventType of [DOM.EventType.CLICK, TouchEventType.Tap]) {
+			this._register(DOM.addDisposableListener(chevronContainer, eventType, e => {
+				DOM.EventHelper.stop(e, true);
+				toggleCollapse();
+			}));
+		}
 	}
 
 	private async _openWelcomePage(): Promise<void> {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -48,13 +48,6 @@
 
 .ai-customization-toolbar .ai-customization-chevron {
 	flex-shrink: 0;
-	opacity: 0;
-}
-
-.ai-customization-toolbar .ai-customization-header:not(.collapsed) .customization-link-button:hover .ai-customization-chevron,
-.ai-customization-toolbar .ai-customization-header:not(.collapsed) .customization-link-button:focus-within .ai-customization-chevron,
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button:hover .ai-customization-chevron,
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button:focus-within .ai-customization-chevron {
 	opacity: 0.7;
 }
 
@@ -65,14 +58,8 @@
 	line-height: 1;
 }
 
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button:not(:hover):not(:focus-within) .ai-customization-header-total:not(.hidden) {
+.ai-customization-toolbar .ai-customization-header.collapsed .ai-customization-header-total:not(.hidden) {
 	display: inline;
-}
-
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button:hover .ai-customization-header-total,
-.ai-customization-toolbar .ai-customization-header.collapsed .customization-link-button:focus-within .ai-customization-header-total,
-.ai-customization-toolbar .ai-customization-header:not(.collapsed) .customization-link-button .ai-customization-header-total {
-	display: none;
 }
 
 /* Button container - fills available space */
@@ -86,7 +73,6 @@
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
-	margin-right: 4px;
 }
 
 .ai-customization-toolbar .ai-customization-overview-button.monaco-button {
@@ -126,15 +112,19 @@
 	font-weight: 500;
 }
 
-/* Counts - floating right inside the button */
+/* Counts + chevron — sit at the far right of the header */
 .ai-customization-toolbar .customization-link-counts {
-	position: absolute;
-	right: 8px;
-	top: 50%;
-	transform: translateY(-50%);
+	flex-shrink: 0;
 	display: flex;
 	align-items: center;
 	gap: 6px;
+	padding: 0 4px;
+	cursor: pointer;
+	border-radius: 4px;
+}
+
+.ai-customization-toolbar .customization-link-counts:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .ai-customization-toolbar .customization-link-counts.hidden {

--- a/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/customizationsToolbar.css
@@ -58,7 +58,7 @@
 	line-height: 1;
 }
 
-.ai-customization-toolbar .ai-customization-header.collapsed .ai-customization-header-total:not(.hidden) {
+.ai-customization-toolbar .ai-customization-header.collapsed .ai-customization-collapse-toggle .ai-customization-header-total:not(.hidden) {
 	display: inline;
 }
 
@@ -112,19 +112,40 @@
 	font-weight: 500;
 }
 
-/* Counts + chevron — sit at the far right of the header */
+/* Counts - floating right inside the per-item link button */
 .ai-customization-toolbar .customization-link-counts {
+	position: absolute;
+	right: 8px;
+	top: 50%;
+	transform: translateY(-50%);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+/* Header collapse toggle (chevron + optional total count). Sits at the far right of the header, after the home/overview button. */
+.ai-customization-toolbar .ai-customization-collapse-toggle {
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	padding: 0 4px;
-	cursor: pointer;
+	height: 24px;
+	border: none;
 	border-radius: 4px;
+	background: transparent;
+	color: inherit;
+	font-family: inherit;
+	cursor: pointer;
 }
 
-.ai-customization-toolbar .customization-link-counts:hover {
+.ai-customization-toolbar .ai-customization-collapse-toggle:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.ai-customization-toolbar .ai-customization-collapse-toggle:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
 }
 
 .ai-customization-toolbar .customization-link-counts.hidden {


### PR DESCRIPTION
## What

Reworks the layout of the Agents sidebar **Customizations** header so the collapse chevron sits at the far right and the home/overview button sits immediately to its left. Both are now always visible.

## Why

Previously the chevron was absolutely positioned inside the `Customizations` link button and only appeared on hover, while the home button sat to its right. The result looked unbalanced (see attached screenshot in the issue) and the chevron — the primary affordance for the collapse interaction — was hidden until the user moused over the row.

Making both always-visible and giving the chevron its own slot at the far right matches a more conventional collapsible-section layout and keeps the entry-point to the customizations overview discoverable at a glance.

## Changes

- `aiCustomizationShortcutsWidget.ts`
  - Chevron container moved out of the link button; appended as the last child of the header (so it renders to the right of the home action).
  - Added a click handler on the chevron container that toggles collapse, mirroring the header label click.
- `customizationsToolbar.css`
  - Removed `position: absolute` from `.customization-link-counts`; it now flows as a flex child at the far right.
  - Removed hover-gated opacity rules on `.ai-customization-chevron` — chevron is always shown at `opacity: 0.7`.
  - Simplified header-total visibility so it shows when collapsed regardless of hover state.
  - Added a subtle hover background on the chevron click target.

## Layout

`[Customizations …………………………………]  [🏠]  [⌄]`

- Clicking the **Customizations** label or the **chevron** toggles collapse.
- Clicking **🏠** opens the customizations overview editor.

## Validation

- `npm run compile-check-ts-native` passes.
- Existing widget tests don't depend on chevron DOM placement.