### PR TITLE
Execution Subagent: Use main agent endpoint for Powershell

### DIFF
--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -29,6 +29,7 @@ import { ToolName } from '../../tools/common/toolNames';
 import { IToolsService } from '../../tools/common/toolsService';
 import { IBuildPromptContext } from '../common/intents';
 import { IBuildPromptResult } from './intents';
+import { ITerminalService } from '../../../platform/terminal/common/terminalService';
 
 export interface IExecutionSubagentToolCallingLoopOptions extends IToolCallingLoopOptions {
 	request: ChatRequest;
@@ -83,6 +84,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		@IFileSystemService fileSystemService: IFileSystemService,
 		@IOTelService otelService: IOTelService,
 		@IGitService gitService: IGitService,
+		@ITerminalService private readonly terminalService: ITerminalService,
 	) {
 		super(options, instantiationService, endpointProvider, logService, requestLogger, authenticationChatUpgradeService, telemetryService, configurationService, experimentationService, chatHookService, sessionTranscriptService, fileSystemService, otelService, gitService);
 	}
@@ -109,8 +111,13 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 	private async getEndpoint() {
 		const modelName = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentModel, this._experimentationService) as ChatEndpointFamily | undefined;
 		const useAgenticProxy = this._configurationService.getExperimentBasedConfig(ConfigKey.Advanced.ExecutionSubagentUseAgenticProxy, this._experimentationService);
+		const shellType = this.terminalService.terminalShellType;
 
 		if (useAgenticProxy) {
+			// Our custom models are not trained for powershell yet. Fall back to main agent endpoint.
+			if (shellType === 'powershell') {
+				return await this.endpointProvider.getChatEndpoint(this.options.request);
+			}
 			// Use agentic proxy with ExecutionSubagentModel or default to DEFAULT_AGENTIC_PROXY_MODEL
 			const agenticProxyModel = modelName || ExecutionSubagentToolCallingLoop.DEFAULT_AGENTIC_PROXY_MODEL;
 			return this.instantiationService.createInstance(ProxyAgenticEndpoint, agenticProxyModel);

--- a/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
+++ b/extensions/copilot/src/extension/prompt/node/executionSubagentToolCallingLoop.ts
@@ -19,6 +19,7 @@ import { IOTelService } from '../../../platform/otel/common/otelService';
 import { IRequestLogger } from '../../../platform/requestLogger/common/requestLogger';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
+import { ITerminalService } from '../../../platform/terminal/common/terminalService';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { ChatResponseProgressPart, ChatResponseReferencePart, LanguageModelToolResult2 } from '../../../vscodeTypes';
 import { IToolCallingLoopOptions, ToolCallingLoop, ToolCallingLoopFetchOptions } from '../../intents/node/toolCallingLoop';
@@ -29,7 +30,6 @@ import { ToolName } from '../../tools/common/toolNames';
 import { IToolsService } from '../../tools/common/toolsService';
 import { IBuildPromptContext } from '../common/intents';
 import { IBuildPromptResult } from './intents';
-import { ITerminalService } from '../../../platform/terminal/common/terminalService';
 
 export interface IExecutionSubagentToolCallingLoopOptions extends IToolCallingLoopOptions {
 	request: ChatRequest;
@@ -114,7 +114,7 @@ export class ExecutionSubagentToolCallingLoop extends ToolCallingLoop<IExecution
 		const shellType = this.terminalService.terminalShellType;
 
 		if (useAgenticProxy) {
-			// Our custom models are not trained for powershell yet. Fall back to main agent endpoint.
+			// Our custom models are not trained for PowerShell yet. Fall back to main agent endpoint.
 			if (shellType === 'powershell') {
 				return await this.endpointProvider.getChatEndpoint(this.options.request);
 			}


### PR DESCRIPTION
Our custom execution subagent models aren't trained for Powershell. This PR adds a check for terminal type, and falls back to the main agent endpoint if it is Powershell.