### PR TITLE
agentHost: small cli polishes

### DIFF
--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -187,6 +187,9 @@ pub struct Auth {
 	storage: Arc<std::sync::Mutex<Option<StorageWithLastRead>>>,
 	/// Prefix for keyring entries, derived from the namespace.
 	keyring_prefix: String,
+	/// When set, restricts authentication to only this provider.
+	/// The user will not be prompted to choose a provider.
+	forced_provider: Option<AuthProvider>,
 }
 
 trait StorageImplementation: Send + Sync {
@@ -423,7 +426,14 @@ impl Auth {
 			file_storage_path: paths.root().join(filename),
 			storage: Arc::new(std::sync::Mutex::new(None)),
 			keyring_prefix,
+			forced_provider: None,
 		}
+	}
+
+	/// Restricts this `Auth` instance to only allow the given provider.
+	/// When set, the user will not be prompted to choose a provider.
+	pub fn set_provider(&mut self, provider: AuthProvider) {
+		self.forced_provider = Some(provider);
 	}
 
 	fn with_storage<T, F>(&self, op: F) -> T
@@ -731,6 +741,10 @@ impl Auth {
 	}
 
 	async fn prompt_for_provider(&self) -> Result<AuthProvider, AnyError> {
+		if let Some(provider) = self.forced_provider {
+			return Ok(provider);
+		}
+
 		if !*IS_INTERACTIVE_CLI {
 			info!(
 				self.log,

--- a/cli/src/commands/agent_host.rs
+++ b/cli/src/commands/agent_host.rs
@@ -138,7 +138,8 @@ pub async fn agent_host(ctx: CommandContext, mut args: AgentHostArgs) -> Result<
 	let mut _tunnel_handle: Option<crate::tunnels::dev_tunnels::ActiveTunnel> = None;
 	let mut tunnel_name: Option<String> = None;
 	if args.tunnel {
-		let auth = Auth::new(&ctx.paths, ctx.log.clone());
+		let mut auth = Auth::new(&ctx.paths, ctx.log.clone());
+		auth.set_provider(crate::auth::AuthProvider::Github);
 		let mut dt = DevTunnels::new_remote_tunnel(&ctx.log, auth, &ctx.paths);
 
 		let mut tunnel = if let Some(existing) =
@@ -183,12 +184,8 @@ pub async fn agent_host(ctx: CommandContext, mut args: AgentHostArgs) -> Result<
 	}
 
 	output::print_banner_header(&format!("{product} Agent Host"), started.elapsed());
-	if let Some(name) = &tunnel_name {
-		let tunnel_url = match constants::EDITOR_WEB_URL {
-			Some(base) => format!("{base}/agents?tunnel={name}"),
-			None => format!("(set VSCODE_CLI_TUNNEL_EDITOR_WEB_URL)/agents?tunnel={name}"),
-		};
-		output::print_banner_line("Tunnel", &tunnel_url);
+	if let (Some(base), Some(name)) = (constants::EDITOR_WEB_URL, &tunnel_name) {
+		output::print_banner_line("Tunnel", &format!("{base}/agents/tunnel/{name}"));
 	}
 	output::print_network_lines(bound_addr.port(), addr.ip(), &token_suffix);
 	output::print_banner_footer();

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -24,7 +24,7 @@ export interface NativeParsedArgs {
 		};
 	};
 	'serve-web'?: INativeCliOptions;
-	'agent-host'?: INativeCliOptions;
+	'agent'?: INativeCliOptions;
 	chat?: {
 		_: string[];
 		'add-file'?: string[];

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -45,7 +45,7 @@ export type OptionDescriptions<T> = {
 	Subcommand<T[P]>
 };
 
-export const NATIVE_CLI_COMMANDS = ['tunnel', 'serve-web', 'agent-host'] as const;
+export const NATIVE_CLI_COMMANDS = ['tunnel', 'serve-web', 'agent'] as const;
 
 export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'chat': {
@@ -71,9 +71,9 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 			'telemetry-level': { type: 'string' },
 		}
 	},
-	'agent-host': {
+	'agent': {
 		type: 'subcommand',
-		description: 'Run a server that hosts agents.',
+		description: 'Start and interact with AI agent hosts.',
 		options: {
 			'cli-data-dir': { type: 'string', args: 'dir', description: localize('cliDataDir', "Directory where CLI metadata should be stored.") },
 			'disable-telemetry': { type: 'boolean' },


### PR DESCRIPTION
- Mark agent-host > agent as a native cli command
- Update to final tunnel URI format
- Lock to Github auth for agent host tunnels (matching agents app logic)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
