### PR TITLE
Fix nohup wrapping for env var assignments, shell operators, and cd/exec builtins

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -109,29 +109,36 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	private _rewriteForPosix(options: ICommandLineRewriterOptions): ICommandLineRewriterResult {
 		const trimmed = options.commandLine.trimEnd();
 
+		// Check for a trailing background `&` (not `&&`) on the original command.
+		// When wrapping in `shell -c`, we strip the trailing `&` from the inner
+		// command and always place it outside the quotes to avoid double-backgrounding.
+		const endsWithBackgroundAmp = /(?:^|[^&])&$/.test(trimmed);
+
 		// nohup only accepts a simple external command as its argument — it cannot exec
 		// compound statements (for/while/if/case) or shell builtins (eval/set/export/source).
 		// Wrap those in `<shell> -c '...'` so the whole construct runs as a single executable.
 		let commandToWrap = trimmed;
 		if (this._needsShellCWrapper(trimmed)) {
+			// Strip trailing `&` before quoting — we'll add the outer `&` below.
+			const innerCommand = endsWithBackgroundAmp ? trimmed.replace(/\s*&$/, '') : trimmed;
 			if (isFish(options.shell, options.os)) {
 				// Fish does not support the POSIX '\'' escape inside single-quoted strings.
 				// Use a double-quoted string and escape backslash and double-quote instead.
-				const escaped = trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+				const escaped = innerCommand.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 				commandToWrap = `${options.shell} -c "${escaped}"`;
 			} else {
 				// bash/zsh: escape single quotes for use inside a single-quoted shell -c '...' string.
-				const escaped = trimmed.replace(/'/g, `'\\''`);
+				const escaped = innerCommand.replace(/'/g, `'\\''`);
 				commandToWrap = `${options.shell} -c '${escaped}'`;
 			}
 		}
 
-		// If the command already ends with a single trailing `&` (background operator,
-		// as opposed to `&&` for command chaining), don't append another one.
-		const endsWithBackgroundAmp = /(?:^|[^&])&$/.test(commandToWrap);
-		const rewritten = endsWithBackgroundAmp
-			? `nohup ${commandToWrap}`
-			: `nohup ${commandToWrap} &`;
+		// Always append `&` unless the (unwrapped) command already has a trailing `&`
+		// and we didn't wrap it in shell -c (in which case the `&` is still present).
+		const needsTrailingAmp = !(/(?:^|[^&])&$/.test(commandToWrap));
+		const rewritten = needsTrailingAmp
+			? `nohup ${commandToWrap} &`
+			: `nohup ${commandToWrap}`;
 		return {
 			rewritten,
 			reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
@@ -169,7 +176,7 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 			// simple command; the rest would be lost or misinterpreted.
 			// A single trailing `&` is handled separately (not matched here) since it's
 			// just a background operator that nohup can coexist with.
-			/\||\|\||&&|;/.test(trimmed)
+			/(?:\|\||&&|[|;]|&(?!&)(?!\s*$))/.test(trimmed)
 		);
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -7,7 +7,7 @@ import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { OperatingSystem } from '../../../../../../../base/common/platform.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
-import { isFish, isPowerShell } from '../../runInTerminalHelpers.js';
+import { isBash, isFish, isPowerShell, isZsh } from '../../runInTerminalHelpers.js';
 import type { ICommandLineRewriter, ICommandLineRewriterOptions, ICommandLineRewriterResult } from './commandLineRewriter.js';
 
 /**
@@ -136,9 +136,17 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 		// Always append `&` unless the (unwrapped) command already has a trailing `&`
 		// and we didn't wrap it in shell -c (in which case the `&` is still present).
 		const needsTrailingAmp = !(/(?:^|[^&])&$/.test(commandToWrap));
+
+		// `disown` removes the job from the shell's job table so it won't print
+		// `[1]+  Done  nohup ...` notifications that contaminate subsequent command
+		// output and can cause spurious SIGINT (exit 130). Only bash/zsh support
+		// `disown`; fish handles it differently (no contamination observed).
+		const supportsDisown = isBash(options.shell, options.os) || isZsh(options.shell, options.os);
+		const disownSuffix = supportsDisown ? ' disown' : '';
+
 		const rewritten = needsTrailingAmp
-			? `nohup ${commandToWrap} &`
-			: `nohup ${commandToWrap}`;
+			? `nohup ${commandToWrap} &${disownSuffix}`
+			: `nohup ${commandToWrap}${disownSuffix}`;
 		return {
 			rewritten,
 			reasoning: 'Wrapped background command with nohup to survive terminal shutdown',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineBackgroundDetachRewriter.ts
@@ -140,9 +140,13 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 	}
 
 	/**
-	 * Returns true when the command uses shell compound constructs or builtins that
-	 * `nohup` cannot exec directly. Such commands must be wrapped in `<shell> -c '...'` before
-	 * being passed to nohup.
+	 * Returns true when the command uses shell constructs that `nohup` cannot exec
+	 * directly. Such commands must be wrapped in `<shell> -c '...'` before being
+	 * passed to nohup.
+	 *
+	 * `nohup` only accepts a single simple external command (plus its arguments).
+	 * Anything that requires shell parsing — compound statements, builtins, shell
+	 * operators, or inline variable assignments — must go through a shell wrapper.
 	 */
 	private _needsShellCWrapper(commandLine: string): boolean {
 		const trimmed = commandLine.trimStart();
@@ -150,13 +154,22 @@ export class CommandLineBackgroundDetachRewriter extends Disposable implements I
 			// Bash compound command keywords — syntax constructs that are not executables.
 			/^(for|while|until|if|case|select|function)\b/.test(trimmed) ||
 			// Shell builtins — these only run meaningfully inside the current shell; nohup
-			// cannot exec them (eval, set, export, source, unset, declare, etc.).
-			/^(eval|set|export|source|unset|declare|typeset|local|readonly|alias)\b/.test(trimmed) ||
+			// cannot exec them (eval, set, export, source, unset, declare, cd, exec, etc.).
+			/^(eval|set|export|source|unset|declare|typeset|local|readonly|alias|cd|exec)\b/.test(trimmed) ||
 			// `. file` (dot-source builtin). Exclude `./script` (relative path) by requiring
 			// whitespace after the dot.
 			/^\.\s/.test(trimmed) ||
 			// Compound groupings: subshell `( ... )` or brace group `{ ...; }`.
-			/^[{(]/.test(trimmed)
+			/^[{(]/.test(trimmed) ||
+			// Inline environment variable assignments before a command (e.g. `VAR=val cmd`).
+			// nohup would try to exec `VAR=val` as a program name.
+			/^[A-Za-z_][A-Za-z0-9_]*=/.test(trimmed) ||
+			// Shell operators: pipes, command chains (&&, ||), semicolons, or background
+			// operators (&) in the middle of the command. nohup only execs the first
+			// simple command; the rest would be lost or misinterpreted.
+			// A single trailing `&` is handled separately (not matched here) since it's
+			// just a background operator that nohup can coexist with.
+			/\||\|\||&&|;/.test(trimmed)
 		);
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
@@ -77,9 +77,9 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 			});
 		});
 
-		test('should not duplicate trailing & when command ends with chained background command', () => {
+		test('should wrap chained commands in shell -c to preserve shell semantics', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cd /app && python3 service.py &', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup cd /app && python3 service.py &',
+				rewritten: `nohup /bin/bash -c 'cd /app && python3 service.py &' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cd /app && python3 service.py &',
 			});
@@ -180,6 +180,82 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 				rewritten: 'nohup python3 app.py &',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'python3 app.py',
+			});
+		});
+	});
+
+	suite('POSIX inline env var assignments', () => {
+		test('single env var assignment before command should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('OPAMROOT=/root/.opam opam install menhir', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam opam install menhir' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'OPAMROOT=/root/.opam opam install menhir',
+			});
+		});
+
+		test('multiple env var assignments before command should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('OPAMROOT=/root/.opam OPAMYES=1 opam install menhir', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam OPAMYES=1 opam install menhir' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'OPAMROOT=/root/.opam OPAMYES=1 opam install menhir',
+			});
+		});
+
+		test('env var with quoted value should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('FOO="a b" cmd', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'FOO="a b" cmd' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'FOO="a b" cmd',
+			});
+		});
+
+		test('env command should NOT trigger env var detection', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('env FOO=1 cmd', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: 'nohup env FOO=1 cmd &',
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'env FOO=1 cmd',
+			});
+		});
+	});
+
+	suite('POSIX shell operator wrapping', () => {
+		test('pipe should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('cat log.txt | grep error', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'cat log.txt | grep error' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'cat log.txt | grep error',
+			});
+		});
+
+		test('semicolon chain should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('cmd1; cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'cmd1; cmd2' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'cmd1; cmd2',
+			});
+		});
+
+		test('&& chain should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('mkdir -p /tmp/build && make', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'mkdir -p /tmp/build && make' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'mkdir -p /tmp/build && make',
+			});
+		});
+
+		test('|| chain should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('cmd1 || cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'cmd1 || cmd2' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'cmd1 || cmd2',
+			});
+		});
+
+		test('cd builtin should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('cd /app', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'cd /app' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'cd /app',
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
@@ -55,7 +55,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 	suite('POSIX (bash)', () => {
 		test('should wrap with nohup on Linux', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('python3 app.py', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup python3 app.py &',
+				rewritten: 'nohup python3 app.py & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'python3 app.py',
 			});
@@ -63,7 +63,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should wrap with nohup on macOS', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('flask run', '/bin/bash', OperatingSystem.Macintosh, true)), {
-				rewritten: 'nohup flask run &',
+				rewritten: 'nohup flask run & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'flask run',
 			});
@@ -71,7 +71,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should not duplicate trailing & when command already backgrounds itself', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('pypi-server ... &', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup pypi-server ... &',
+				rewritten: 'nohup pypi-server ... & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'pypi-server ... &',
 			});
@@ -79,7 +79,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should wrap chained commands in shell -c to preserve shell semantics', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cd /app && python3 service.py &', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cd /app && python3 service.py' &`,
+				rewritten: `nohup /bin/bash -c 'cd /app && python3 service.py' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cd /app && python3 service.py &',
 			});
@@ -87,7 +87,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should trim trailing whitespace before detecting existing &', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('node server.js &   ', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup node server.js &',
+				rewritten: 'nohup node server.js & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'node server.js &   ',
 			});
@@ -97,7 +97,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 	suite('POSIX shell -c wrapping for compound commands and builtins', () => {
 		test('for loop should be wrapped using bash shell path', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('for i in $(seq 1 90); do echo $i; sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' &`,
+				rewritten: `nohup /bin/bash -c 'for i in $(seq 1 90); do echo $i; sleep 1; done' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'for i in $(seq 1 90); do echo $i; sleep 1; done',
 			});
@@ -105,7 +105,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('while loop should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('while true; do sleep 1; done', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'while true; do sleep 1; done' &`,
+				rewritten: `nohup /bin/bash -c 'while true; do sleep 1; done' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'while true; do sleep 1; done',
 			});
@@ -113,7 +113,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('if statement should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('if [ -f file ]; then cat file; fi', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'if [ -f file ]; then cat file; fi' &`,
+				rewritten: `nohup /bin/bash -c 'if [ -f file ]; then cat file; fi' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'if [ -f file ]; then cat file; fi',
 			});
@@ -121,7 +121,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('eval builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('eval $SETUP_ENV && opam install coq --yes', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'eval $SETUP_ENV && opam install coq --yes' &`,
+				rewritten: `nohup /bin/bash -c 'eval $SETUP_ENV && opam install coq --yes' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'eval $SETUP_ENV && opam install coq --yes',
 			});
@@ -129,7 +129,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('set builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('set -e; cmd1; cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'set -e; cmd1; cmd2' &`,
+				rewritten: `nohup /bin/bash -c 'set -e; cmd1; cmd2' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'set -e; cmd1; cmd2',
 			});
@@ -137,7 +137,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('export builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('export PATH="/usr/local/bin:$PATH"; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'export PATH="/usr/local/bin:$PATH"; myapp' &`,
+				rewritten: `nohup /bin/bash -c 'export PATH="/usr/local/bin:$PATH"; myapp' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'export PATH="/usr/local/bin:$PATH"; myapp',
 			});
@@ -145,7 +145,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('dot-source builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('. /etc/profile; myapp', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c '. /etc/profile; myapp' &`,
+				rewritten: `nohup /bin/bash -c '. /etc/profile; myapp' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: '. /etc/profile; myapp',
 			});
@@ -153,7 +153,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('relative path ./script should NOT be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('./start.sh', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup ./start.sh &',
+				rewritten: 'nohup ./start.sh & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: './start.sh',
 			});
@@ -161,7 +161,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('brace group should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('{ cmd1; cmd2; }', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c '{ cmd1; cmd2; }' &`,
+				rewritten: `nohup /bin/bash -c '{ cmd1; cmd2; }' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: '{ cmd1; cmd2; }',
 			});
@@ -169,7 +169,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('single quotes in command should be properly escaped', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions(`for f in *.txt; do echo 'file:' $f; done`, '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'for f in *.txt; do echo '\\''file:'\\'' $f; done' &`,
+				rewritten: `nohup /bin/bash -c 'for f in *.txt; do echo '\\''file:'\\'' $f; done' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: `for f in *.txt; do echo 'file:' $f; done`,
 			});
@@ -177,7 +177,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('simple external command should NOT be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('python3 app.py', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup python3 app.py &',
+				rewritten: 'nohup python3 app.py & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'python3 app.py',
 			});
@@ -187,7 +187,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 	suite('POSIX inline env var assignments', () => {
 		test('single env var assignment before command should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('OPAMROOT=/root/.opam opam install menhir', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam opam install menhir' &`,
+				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam opam install menhir' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'OPAMROOT=/root/.opam opam install menhir',
 			});
@@ -195,7 +195,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('multiple env var assignments before command should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('OPAMROOT=/root/.opam OPAMYES=1 opam install menhir', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam OPAMYES=1 opam install menhir' &`,
+				rewritten: `nohup /bin/bash -c 'OPAMROOT=/root/.opam OPAMYES=1 opam install menhir' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'OPAMROOT=/root/.opam OPAMYES=1 opam install menhir',
 			});
@@ -203,7 +203,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('env var with quoted value should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('FOO="a b" cmd', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'FOO="a b" cmd' &`,
+				rewritten: `nohup /bin/bash -c 'FOO="a b" cmd' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'FOO="a b" cmd',
 			});
@@ -211,7 +211,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('env command should NOT trigger env var detection', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('env FOO=1 cmd', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup env FOO=1 cmd &',
+				rewritten: 'nohup env FOO=1 cmd & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'env FOO=1 cmd',
 			});
@@ -221,7 +221,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 	suite('POSIX shell operator wrapping', () => {
 		test('pipe should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cat log.txt | grep error', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cat log.txt | grep error' &`,
+				rewritten: `nohup /bin/bash -c 'cat log.txt | grep error' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cat log.txt | grep error',
 			});
@@ -229,7 +229,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('semicolon chain should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cmd1; cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cmd1; cmd2' &`,
+				rewritten: `nohup /bin/bash -c 'cmd1; cmd2' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cmd1; cmd2',
 			});
@@ -237,7 +237,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('&& chain should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('mkdir -p /tmp/build && make', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'mkdir -p /tmp/build && make' &`,
+				rewritten: `nohup /bin/bash -c 'mkdir -p /tmp/build && make' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'mkdir -p /tmp/build && make',
 			});
@@ -245,7 +245,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('|| chain should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cmd1 || cmd2', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cmd1 || cmd2' &`,
+				rewritten: `nohup /bin/bash -c 'cmd1 || cmd2' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cmd1 || cmd2',
 			});
@@ -253,7 +253,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('cd builtin should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cd /app', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cd /app' &`,
+				rewritten: `nohup /bin/bash -c 'cd /app' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cd /app',
 			});
@@ -261,7 +261,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('mid-command & (background operator) should be wrapped in shell -c', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('server start & client connect', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'server start & client connect' &`,
+				rewritten: `nohup /bin/bash -c 'server start & client connect' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'server start & client connect',
 			});
@@ -271,7 +271,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 	suite('POSIX (zsh)', () => {
 		test('should wrap with nohup', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('node server.js', '/bin/zsh', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup node server.js &',
+				rewritten: 'nohup node server.js & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'node server.js',
 			});
@@ -279,7 +279,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('for loop should be wrapped using zsh shell path', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('for i in $(seq 1 10); do echo $i; done', '/bin/zsh', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/zsh -c 'for i in $(seq 1 10); do echo $i; done' &`,
+				rewritten: `nohup /bin/zsh -c 'for i in $(seq 1 10); do echo $i; done' & disown`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'for i in $(seq 1 10); do echo $i; done',
 			});
@@ -367,7 +367,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should still wrap psql when -c is passed (non-interactive)', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('psql -c "select 1"', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup psql -c "select 1" &',
+				rewritten: 'nohup psql -c "select 1" & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'psql -c "select 1"',
 			});
@@ -375,7 +375,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should still wrap mysql when -e is passed (non-interactive)', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('mysql -e "show databases"', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup mysql -e "show databases" &',
+				rewritten: 'nohup mysql -e "show databases" & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'mysql -e "show databases"',
 			});
@@ -383,7 +383,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should still wrap ssh when running a remote command (non-interactive)', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('ssh -T user@host', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup ssh -T user@host &',
+				rewritten: 'nohup ssh -T user@host & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'ssh -T user@host',
 			});
@@ -391,7 +391,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should still wrap sudo when -n is passed (non-interactive)', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('sudo -n systemctl restart nginx', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: 'nohup sudo -n systemctl restart nginx &',
+				rewritten: 'nohup sudo -n systemctl restart nginx & disown',
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'sudo -n systemctl restart nginx',
 			});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineBackgroundDetachRewriter.test.ts
@@ -79,7 +79,7 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 
 		test('should wrap chained commands in shell -c to preserve shell semantics', () => {
 			deepStrictEqual(rewriter.rewrite(createOptions('cd /app && python3 service.py &', '/bin/bash', OperatingSystem.Linux, true)), {
-				rewritten: `nohup /bin/bash -c 'cd /app && python3 service.py &' &`,
+				rewritten: `nohup /bin/bash -c 'cd /app && python3 service.py' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cd /app && python3 service.py &',
 			});
@@ -256,6 +256,14 @@ suite('CommandLineBackgroundDetachRewriter', () => {
 				rewritten: `nohup /bin/bash -c 'cd /app' &`,
 				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
 				forDisplay: 'cd /app',
+			});
+		});
+
+		test('mid-command & (background operator) should be wrapped in shell -c', () => {
+			deepStrictEqual(rewriter.rewrite(createOptions('server start & client connect', '/bin/bash', OperatingSystem.Linux, true)), {
+				rewritten: `nohup /bin/bash -c 'server start & client connect' &`,
+				reasoning: 'Wrapped background command with nohup to survive terminal shutdown',
+				forDisplay: 'server start & client connect',
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -461,7 +461,7 @@ suite('RunInTerminalTool', () => {
 
 			const terminalData = preparedInvocation.toolSpecificData as IChatTerminalToolInvocationData;
 			strictEqual(terminalData.commandLine.forDisplay, 'echo hello');
-			strictEqual(terminalData.commandLine.toolEdited, 'nohup sandbox-runtime echo hello &');
+			strictEqual(terminalData.commandLine.toolEdited, 'nohup sandbox-runtime echo hello & disown');
 		});
 	});
 


### PR DESCRIPTION

The background detach rewriter now correctly wraps commands in shell -c when they use:

 - Inline env var assignments (e.g. VAR=val cmd) that nohup would try to exec as a program name
 - Shell operators (|, &&, ||, ;) where nohup would only exec the first command in the chain
 - cd and exec builtins that nohup cannot exec directly
 - Mid-command & (background operator) that was not detected by the operator regex

Previously these commands would fail silently or behave incorrectly when wrapped with nohup. For example:

 nohup OPAMROOT=/root/.opam opam install menhir &

would fail with 'No such file or directory' because nohup tried to execute OPAMROOT=/root/.opam as a command.

Now they are properly wrapped:

 nohup /bin/bash -c 'OPAMROOT=/root/.opam opam install menhir' & disown

Fixes

 1. Env var assignments — detect VAR=val cmd pattern and wrap in shell -c
 2. Shell operators — detect pipes, chains (&&, ||), semicolons, and mid-command &
 3. Builtins — added cd and exec to the builtin list requiring shell -c wrapping
 4. Double-& bug — when wrapping in shell -c, strip trailing & from inner command before quoting to avoid 
nohup bash -c 'cmd &' & (two backgrounding operators)
 5. Job completion contamination — added disown after nohup cmd & for bash/zsh to remove the job from the 
shell's job table, preventing [1]+ Done nohup ... notifications from contaminating subsequent command output 
and causing spurious SIGINT (exit 130)

Before/After: disown

Before: When a nohup'd background process completes in a reused terminal, bash prints a job completion notice
on the next prompt:

 $ echo hello
 ^C[1]+  Done                    nohup python3 server.py
 hello

This ^C[1]+ Done output contaminates the next command's captured output and can cause exit code 130 (SIGINT).

After: With nohup cmd & disown, the job is removed from bash's job table immediately. No [1]+ Done
notification, no ^C, no contamination. The nohup'd process still runs normally — disown only affects bash's
bookkeeping. Scoped to bash/zsh only (fish left unchanged).