### PR TITLE
Fix loss of simple link hrefs in rich-text copy (in agent chats, etc)

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -11,7 +11,7 @@ import { KeyCode } from '../common/keyCodes.js';
 import { DisposableStore, IDisposable } from '../common/lifecycle.js';
 import * as marked from '../common/marked/marked.js';
 import { parse } from '../common/marshalling.js';
-import { FileAccess, Schemas } from '../common/network.js';
+import { FileAccess, matchesSomeScheme, Schemas } from '../common/network.js';
 import { cloneAndChange } from '../common/objects.js';
 import { basename as pathBasename } from '../common/path.js';
 import { basename, dirname, resolvePath } from '../common/resources.js';
@@ -361,6 +361,15 @@ function rewriteRenderedLinks(markdown: IMarkdownString, options: MarkdownRender
 		}
 	}
 
+	// When an action handler is registered we intercept clicks via `data-href`, so
+	// preserving the real `href` for the standard "external" link schemes
+	// (`http`, `https`, `mailto`) allows rich-text copy/paste to retain the actual
+	// URL instead of replacing every href in the copied rich text with the URL
+	// `vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html`
+	// which is the result of how Electron rich-text copying resolving the absolute
+	// URL for links with href="".
+	const preserveExternalHrefs = !!options.actionHandler;
+
 	// eslint-disable-next-line no-restricted-syntax
 	for (const el of root.querySelectorAll('a')) {
 		const href = el.getAttribute('href'); // Get the raw 'href' attribute value as text, not the resolved 'href'
@@ -377,6 +386,9 @@ function rewriteRenderedLinks(markdown: IMarkdownString, options: MarkdownRender
 				resolvedHref = resolveWithBaseUri(URI.from(markdown.baseUri), href);
 			}
 			el.dataset.href = resolvedHref;
+			if (preserveExternalHrefs && matchesSomeScheme(resolvedHref, Schemas.http, Schemas.https, Schemas.mailto)) {
+				el.setAttribute('href', resolvedHref);
+			}
 		}
 	}
 }

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -364,10 +364,9 @@ function rewriteRenderedLinks(markdown: IMarkdownString, options: MarkdownRender
 	// When an action handler is registered we intercept clicks via `data-href`, so
 	// preserving the real `href` for the standard "external" link schemes
 	// (`http`, `https`, `mailto`) allows rich-text copy/paste to retain the actual
-	// URL instead of replacing every href in the copied rich text with the URL
-	// `vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html`
-	// which is the result of how Electron rich-text copying resolving the absolute
-	// URL for links with href="".
+	// URL instead of replacing every href in the copied rich text with a URL like
+	// `vscode-file://.../workbench.html`, which is what Electron produces when it
+	// resolves the absolute URL for links with href="" during rich-text copying.
 	const preserveExternalHrefs = !!options.actionHandler;
 
 	// eslint-disable-next-line no-restricted-syntax

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -326,6 +326,64 @@ suite('MarkdownRenderer', () => {
 		assert.strictEqual(result.innerHTML, `<p><a href="" title="./foo" draggable="false" data-href="https://example.com/path/foo">text</a> <a href="" data-href="https://example.com/path/bar">bar</a> <img src="https://example.com/path/cat.gif"></p>`);
 	});
 
+	suite('Copy-safe href preservation', () => {
+		// Regression coverage for rich-text copy mangling links to
+		// `vscode-file://vscode-app/.../workbench.html`. When an action handler is wired
+		// up to intercept clicks via `data-href`, copy-safe external schemes
+		// (http/https/mailto) must keep their real `href` so rich-text copy/paste and
+		// "Copy Link" produce the actual URL.
+
+		const noopActionHandler = () => { };
+
+		test('preserves href for http/https/mailto links when actionHandler is provided', () => {
+			const md = new MarkdownString(`[web](https://example.com/page) [insecure](http://example.com/) [mail](mailto:user@example.com)`, {});
+
+			const result = store.add(renderMarkdown(md, { actionHandler: noopActionHandler })).element;
+			const anchors = result.querySelectorAll('a');
+			assert.strictEqual(anchors.length, 3);
+
+			const observed = Array.from(anchors).map(a => ({
+				href: a.getAttribute('href'),
+				dataHref: a.getAttribute('data-href'),
+			}));
+			assert.deepStrictEqual(observed, [
+				{ href: 'https://example.com/page', dataHref: 'https://example.com/page' },
+				{ href: 'http://example.com/', dataHref: 'http://example.com/' },
+				{ href: 'mailto:user@example.com', dataHref: 'mailto:user@example.com' },
+			]);
+		});
+
+		test('does not preserve href for non-copy-safe schemes such as command:', () => {
+			const md = new MarkdownString(`[run](command:doFoo)`, { isTrusted: true });
+
+			const result = store.add(renderMarkdown(md, { actionHandler: noopActionHandler })).element;
+			const anchor = result.querySelector('a')!;
+			assert.strictEqual(anchor.getAttribute('href'), '');
+			assert.strictEqual(anchor.getAttribute('data-href'), 'command:doFoo');
+		});
+
+		test('does not preserve href when no actionHandler is provided', () => {
+			// Without an action handler nothing intercepts clicks, so we must keep the
+			// historical safe behaviour of clearing href to avoid navigating the workbench.
+			const md = new MarkdownString(`[web](https://example.com/page)`, {});
+
+			const result = store.add(renderMarkdown(md)).element;
+			const anchor = result.querySelector('a')!;
+			assert.strictEqual(anchor.getAttribute('href'), '');
+			assert.strictEqual(anchor.getAttribute('data-href'), 'https://example.com/page');
+		});
+
+		test('preserves resolved href for relative links against an https baseUri', () => {
+			const md = new MarkdownString(`[text](./foo)`, { isTrusted: true });
+			md.baseUri = URI.parse('https://example.com/path/');
+
+			const result = store.add(renderMarkdown(md, { actionHandler: noopActionHandler })).element;
+			const anchor = result.querySelector('a')!;
+			assert.strictEqual(anchor.getAttribute('href'), 'https://example.com/path/foo');
+			assert.strictEqual(anchor.getAttribute('data-href'), 'https://example.com/path/foo');
+		});
+	});
+
 	test('Should use decoded file path as title for file:// links', () => {
 		const fileUri = URI.file('/home/user/project/lib.d.ts');
 		const md = new MarkdownString(`[log](${fileUri.toString()})`, {});

--- a/src/vs/workbench/contrib/chat/test/browser/widget/__snapshots__/ChatMarkdownRenderer_supportHtml_with_one-line_markdown.1.snap
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/__snapshots__/ChatMarkdownRenderer_supportHtml_with_one-line_markdown.1.snap
@@ -1,6 +1,6 @@
 <div class="rendered-markdown">
 
 <ol>
-<li><a href="" title="" draggable="false" data-href="https://example.com"><em>hello</em></a> test <strong>text</strong></li>
+<li><a href="https://example.com" title="" draggable="false" data-href="https://example.com"><em>hello</em></a> test <strong>text</strong></li>
 </ol>
 </div>


### PR DESCRIPTION
Fixes #313539

The renderer was unconditionally setting `href=""` on every `<a>` while setting up the link for clicks to be intercepted via the sibling `data-href` attribute. Clicks need to be intercepted by the action handler so that they open in an external browser rather than navigating the Electron window, so this interception is important, but clearing the href is a step too far because it ruins rich-text copy. Electron's rich-text copy resolves the empty href against the workbench's `workbench.html` URL, so pasting into other apps produced the mangled `vscode-file://…/workbench.html` link. Thankfully, clearing the href is an unnecessary step. 

The fix preserves the original `href` only for the established "external link" schemes (`http`, `https`, `mailto`) — the same triple already used by the notebook output webview and the various extension/MCP/agent webview click handlers — so the visible behavior in copy/paste is restored without widening the attack surface for schemes that need scrubbing (e.g. `command:`, `file:`). It is gated on `options.actionHandler` because that is the signal that the caller has installed click interception via `data-href`; callers that render without an action handler keep the original behavior. Click routing itself is untouched: the `data-href` path still drives in-IDE opening, so trusted-domain prompting and `IOpenerService` validation continue to apply.

Unit tests demonstrate the necessary behavior in order for rich-text copy to function. These changes have also been tested and verified manually by building and running `code.bat`.

Related, but not addressed by this PR: https://github.com/microsoft/vscode/issues/312422

This single fix affects multiple UI areas, not just agent chats. 

### Affected areas

Direct `renderMarkdown(..., { actionHandler })` callers:

- [Editor inline message banner](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/message/browser/messageController.ts#L71)
- [Custom select-box description](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts#L890)
- [Code action description](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/platform/actionWidget/browser/actionList.ts#L305)
- [Code action menu description](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/platform/actionWidget/browser/actionList.ts#L1320)

Routed through `IMarkdownRendererService.render()` (default action handler is auto-installed) — editor surfaces:

- [Unicode highlighter banner](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/unicodeHighlighter/browser/bannerController.ts#L86)
- [Suggest widget docs](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/suggest/browser/suggestWidgetDetails.ts#L178)
- [Simple suggest widget docs](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/services/suggest/browser/simpleSuggestWidgetDetails.ts#L199)
- [Parameter hints widget](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts#L271)
- [Code hover (markdown)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts#L525)
- [Inline completions hint](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts#L156)
- [Glyph (gutter) hover](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/editor/contrib/hover/browser/glyphHoverWidget.ts#L150)

Workbench surfaces:

- [Tree view messages](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/browser/parts/views/treeView.ts#L933)
- [Workbench-wide markdown accessor](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/browser/workbench.ts#L148)
- [Custom dialog body](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts#L102)
- [Settings UI descriptions](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/preferences/browser/settingsTree.ts#L1097)
- [Settings UI tooltip](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/preferences/browser/settingsTree.ts#L1950)
- [Comments view](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/comments/browser/commentNode.ts#L214)
- [SCM input description](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/scm/browser/scmInput.ts#L782)
- [Post-update notification (feature list)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts#L200)
- [Post-update notification (markdown)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/update/browser/postUpdateWidget.ts#L215)
- [Extension features tab descriptions](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts#L154)
- [Extension features tab markdown](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts#L700)
- [Getting Started details page](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts#L1665)
- [Inline Chat terms disclaimer](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts#L326)

Chat content (via `ChatContentMarkdownRenderer`):

- [Chat content (list renderer)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts#L272)
- [Chat content (welcome widget)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts#L1114)
- [MCP servers interaction part](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersInteractionContentPart.ts#L185)
- [Disabled Claude hooks part](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDisabledClaudeHooksContentPart.ts#L45)
- [Chat tip content part](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts#L150)

Agent sessions surfaces:

- [Sessions list description (in-progress)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts#L369)
- [Sessions list description (completed)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts#L381)
- [Sessions list description (other)](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts#L393)
- [Sessions list approval label](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts#L466)
- [Agent feedback comment widget](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts#L242)
- [Agent feedback comment list](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts#L398)
- [Welcome agent sessions description](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts#L748)

Not affected (separate webview-HTML pipeline through `markdownDocumentRenderer.ts`; the document sanitizer keeps `href` and clicks are routed via `webview.onDidClickLink`):

- [Extension README](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts)
- [Agent plugin editor body](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts)
- [MCP server editor body](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts)
- [Release notes](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts)
- [Walkthrough markdown body](https://github.com/microsoft/vscode/blob/161a11c507a5f092f1c8867dbf417e68238d9dda/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts)