### PR TITLE
agentHost: improve update pickup and fix startup-failure wedge

### DIFF
--- a/cli/src/tunnels/agent_host.rs
+++ b/cli/src/tunnels/agent_host.rs
@@ -33,7 +33,7 @@ use crate::util::sync::{new_barrier, Barrier, BarrierOpener};
 use super::paths::{get_server_folder_name, SERVER_FOLDER_NAME};
 
 /// How often to check for server updates.
-pub const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+pub const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 /// How often to re-check whether the server has exited when an update is pending.
 pub const UPDATE_POLL_INTERVAL: Duration = Duration::from_secs(10 * 60);
 /// How long to wait for the server to signal readiness.
@@ -243,7 +243,10 @@ impl AgentHostManager {
 					if let Some(o) = opener.take() {
 						o.open(Err(format!("Server exited before ready: {e:?}")));
 					}
-					break;
+					// Child has already exited; don't store it in `running`,
+					// otherwise the manager would be wedged with a dead child
+					// forever and ensure_server() would never restart.
+					return;
 				}
 			}
 
@@ -259,10 +262,6 @@ impl AgentHostManager {
 				child,
 				commit: release.commit.clone(),
 			});
-		}
-
-		if !ready {
-			return;
 		}
 
 		info!(self.log, "[{}]: Server ready", commit_prefix);


### PR DESCRIPTION
Two fixes to the agent host update logic in `cli/src/tunnels/agent_host.rs`:

1. **Shorten background update check interval from 24h to 6h.** Newly published server versions are picked up sooner after the server auto-shuts down (via `--enable-remote-auto-shutdown`).

2. **Fix startup-failure wedge.** When the child server process exited before signaling readiness, `run_server` would still store the (now-dead) `Child` into `self.running` and skip spawning the cleanup task. From then on `running.is_some()` was permanently true, so `ensure_server` would forever return the original opener's `Err` and never attempt a restart. The child is now left out of `running` on the early-exit path; `self.ready` still has the `Err` for the original caller, but subsequent `ensure_server` calls fall through to a fresh `start_server`.

No synchronous update check is added on the connection path, to keep boot time fast.
