### PR TITLE
Update @vscode/codicons version to 0.0.46-6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-5",
+        "@vscode/codicons": "^0.0.46-6",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-5",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-5.tgz",
-      "integrity": "sha512-b/j0tBkst5T27DNqL9m2rOzPf/ilybs1w+aJtnSPEQubhXW07d7k8MPOtVUHqr/kLS3phzDC9+NUtVJlDt60Qg==",
+      "version": "0.0.46-6",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-6.tgz",
+      "integrity": "sha512-tuTuuWUmV5nJNCK4xEg7gZzj/3WDlkU4czFZ11UyDb/FetWaj1uvDB6xV9488F/ZY8won8OO3QYGaVif40LEWA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-5",
+    "@vscode/codicons": "^0.0.46-6",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-5",
+        "@vscode/codicons": "^0.0.46-6",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.1",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-5",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-5.tgz",
-      "integrity": "sha512-b/j0tBkst5T27DNqL9m2rOzPf/ilybs1w+aJtnSPEQubhXW07d7k8MPOtVUHqr/kLS3phzDC9+NUtVJlDt60Qg==",
+      "version": "0.0.46-6",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-6.tgz",
+      "integrity": "sha512-tuTuuWUmV5nJNCK4xEg7gZzj/3WDlkU4czFZ11UyDb/FetWaj1uvDB6xV9488F/ZY8won8OO3QYGaVif40LEWA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-5",
+    "@vscode/codicons": "^0.0.46-6",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.1",
     "@vscode/vscode-languagedetection": "1.0.23",


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-6 in both package.json and package-lock.json files to ensure compatibility and access to the latest features. No issues are associated with this change.

