### PR TITLE
Bring back runtime nodePtyShim for Copilot CLI marketplace route

### DIFF
--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -24,6 +24,7 @@ import { basename } from '../../../../util/vs/base/common/resources';
 import { URI } from '../../../../util/vs/base/common/uri';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { getCopilotLogger } from './logger';
+import { ensureNodePtyShim } from './nodePtyShim';
 import { ensureRipgrepShim } from './ripgrepShim';
 import { CancellationToken } from '../../../../util/vs/base/common/cancellation';
 import { getModelCapabilitiesDescription } from '../../../conversation/common/languageModelAccess';
@@ -521,7 +522,7 @@ export class CopilotCLISDK implements ICopilotCLISDK {
 
 	public async getPackage(): Promise<typeof import('@github/copilot/sdk')> {
 		try {
-			// Ensure the ripgrep shim exists before importing the SDK (required for CLI sessions)
+			// Ensure the node-pty and ripgrep shims exist before importing the SDK (required for CLI sessions)
 			await this._ensureShimsPromise;
 			return await import('@github/copilot/sdk');
 		} catch (error) {
@@ -558,7 +559,10 @@ export class CopilotCLISDK implements ICopilotCLISDK {
 		if (await checkFileExists(successfulPlaceholder)) {
 			return;
 		}
-		await ensureRipgrepShim(this.extensionContext.extensionPath, this.envService.appRoot, this.logService);
+		await Promise.all([
+			ensureRipgrepShim(this.extensionContext.extensionPath, this.envService.appRoot, this.logService),
+			ensureNodePtyShim(this.extensionContext.extensionPath, this.envService.appRoot, this.logService),
+		]);
 		await fs.writeFile(successfulPlaceholder, 'Shims created successfully');
 	}
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/nodePtyShim.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/nodePtyShim.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ILogService } from '../../../../platform/log/common/logService';
+
+let shimCreated: Promise<void> | undefined = undefined;
+
+const RETRIABLE_COPY_ERROR_CODES = new Set(['EPERM', 'EBUSY']);
+const MAX_COPY_ATTEMPTS = 6;
+const RETRY_DELAY_BASE_MS = 50;
+const RETRY_DELAY_CAP_MS = 500;
+const MATERIALIZATION_TIMEOUT_MS = 4000;
+const MATERIALIZATION_POLL_INTERVAL_MS = 100;
+
+/**
+ * Copies the node-pty files from VS Code's installation into a @github/copilot location.
+ *
+ * MUST be called before any `import('@github/copilot/sdk')` or `import('@github/copilot')`.
+ *
+ * @github/copilot bundles the node-pty code and it is no longer possible to shim the package
+ * via Node module resolution from a marketplace install location (which lives outside VS
+ * Code's app tree). For built-in installs `require('node-pty')` walks up into VS Code's
+ * own `node_modules` and this shim is a no-op (the `shims.txt` placeholder skips it). For
+ * marketplace installs we copy VS Code's pre-built `pty.node` into the SDK's expected
+ * relative `./prebuilds/{platform}-{arch}` lookup path so the bundled fallback in
+ * `loadNativeModule` succeeds.
+ *
+ * @param extensionPath The extension's path (where to create the shim)
+ * @param vscodeAppRoot VS Code's installation path (where node-pty is located)
+ */
+export async function ensureNodePtyShim(extensionPath: string, vscodeAppRoot: string, logService: ILogService): Promise<void> {
+	if (shimCreated) {
+		return shimCreated;
+	}
+
+	const creation = _ensureNodePtyShim(extensionPath, vscodeAppRoot, logService);
+	shimCreated = creation.catch(error => {
+		shimCreated = undefined;
+		throw error;
+	});
+	return shimCreated;
+}
+
+async function _ensureNodePtyShim(extensionPath: string, vscodeAppRoot: string, logService: ILogService): Promise<void> {
+	const vscodeNodePtyPath = path.join(vscodeAppRoot, 'node_modules', 'node-pty', 'build', 'Release');
+
+	await copyNodePtyFiles(extensionPath, vscodeNodePtyPath, logService);
+}
+
+export async function copyNodePtyFiles(extensionPath: string, sourceNodePtyPath: string, logService: ILogService): Promise<void> {
+	const nodePtyDir = path.join(extensionPath, 'node_modules', '@github', 'copilot', 'sdk', 'prebuilds', process.platform + '-' + process.arch);
+	logService.info(`Creating node-pty shim: source=${sourceNodePtyPath}, dest=${nodePtyDir}`);
+
+	try {
+		await fs.mkdir(nodePtyDir, { recursive: true });
+		const entries = await fs.readdir(sourceNodePtyPath);
+		const uniqueEntries = [...new Set(entries)];
+		logService.info(`Found ${uniqueEntries.length} entries to copy${uniqueEntries.length !== entries.length ? ` (${entries.length - uniqueEntries.length} duplicates ignored)` : ''}: ${uniqueEntries.join(', ')}`);
+
+		await copyNodePtyWithRetries(sourceNodePtyPath, nodePtyDir, uniqueEntries, logService);
+	} catch (error) {
+		logService.error(`Failed to create node-pty shim (source dir: ${sourceNodePtyPath}, extension dir: ${nodePtyDir})`, error);
+		throw error;
+	}
+}
+
+async function copyNodePtyWithRetries(sourceDir: string, destDir: string, entries: string[], logService: ILogService): Promise<void> {
+	const primaryBinary = entries.find(entry => entry.endsWith('.node'));
+	for (let attempt = 1; attempt <= MAX_COPY_ATTEMPTS; attempt++) {
+		try {
+			await fs.cp(sourceDir, destDir, {
+				recursive: true,
+				dereference: true,
+				force: true,
+				filter: async (srcPath) => shouldCopyEntry(srcPath, logService)
+			});
+			logService.trace(`Copied node-pty prebuilds to ${destDir} (attempt ${attempt})`);
+			return;
+		} catch (error) {
+			if (await waitForMaterializedShim(destDir, primaryBinary, logService)) {
+				logService.trace(`Detected node-pty shim materialized at ${destDir} by another extension host`);
+				return;
+			}
+
+			if (!RETRIABLE_COPY_ERROR_CODES.has(error?.code) || attempt === MAX_COPY_ATTEMPTS) {
+				throw error;
+			}
+
+			const delayMs = Math.min(RETRY_DELAY_BASE_MS * Math.pow(2, attempt - 1), RETRY_DELAY_CAP_MS);
+			logService.warn(`Retryable error (${error.code}) copying node-pty shim. Retrying in ${delayMs}ms (attempt ${attempt + 1}/${MAX_COPY_ATTEMPTS})`);
+			await new Promise(resolve => setTimeout(resolve, delayMs));
+		}
+	}
+}
+
+async function shouldCopyEntry(srcPath: string, logService: ILogService): Promise<boolean> {
+	try {
+		const stat = await fs.stat(srcPath);
+		if (stat.isDirectory()) {
+			return true;
+		}
+
+		if (stat.size === 0) {
+			logService.trace(`Skipping ${path.basename(srcPath)}: zero-byte file (likely symlink or special file)`);
+			return false;
+		}
+
+		return true;
+	} catch (error) {
+		logService.warn(`Failed to stat ${srcPath}: ${error?.message ?? error}`);
+		return false;
+	}
+}
+
+async function waitForMaterializedShim(destDir: string, primaryBinary: string | undefined, logService: ILogService): Promise<boolean> {
+	const deadline = Date.now() + MATERIALIZATION_TIMEOUT_MS;
+	while (Date.now() <= deadline) {
+		if (await isShimMaterialized(destDir, primaryBinary)) {
+			logService.trace(`Reusing node-pty shim that materialized at ${destDir}`);
+			return true;
+		}
+
+		await new Promise(resolve => setTimeout(resolve, MATERIALIZATION_POLL_INTERVAL_MS));
+	}
+
+	return false;
+}
+
+async function isShimMaterialized(destDir: string, primaryBinary: string | undefined): Promise<boolean> {
+	if (primaryBinary) {
+		const binaryStat = await fs.stat(path.join(destDir, primaryBinary)).catch(() => undefined);
+		if (binaryStat && binaryStat.isFile() && binaryStat.size > 0) {
+			return true;
+		}
+	}
+
+	const entries = await fs.readdir(destDir).catch(() => []);
+	for (const entry of entries) {
+		const stat = await fs.stat(path.join(destDir, entry)).catch(() => undefined);
+		if (stat && stat.isFile() && stat.size > 0) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
Bringing back runtime part of: https://github.com/microsoft/vscode/pull/310925 
for copilot chat being installed from marketplace route/ vsix recovery. 

Resolves: https://github.com/microsoft/vscode/issues/313609 


Video proof with 1.118:

https://github.com/user-attachments/assets/85fb1b0e-1a6a-494e-8c50-0a754d02e477



