### PR TITLE
Prunes stale closed repository entries (#313551)

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -699,6 +699,17 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 		} catch (err) {
 			// noop
 			this.logger.trace(`[Model][openRepository] Opening repository for path='${repoPath}' failed. Error:${err}`);
+
+			// Prune stale closed-repository entries:
+			// if the user explicitly asked to reopen a closed repo and the path no longer exists on disk, drop the entry so it does not stick around forever
+			if (openIfClosed && this._closedRepositoriesManager.isRepositoryClosed(repoPath)) {
+				try {
+					await fs.promises.access(repoPath);
+				} catch {
+					this._closedRepositoriesManager.deleteRepository(repoPath);
+					this.logger.info(`[Model][openRepository] Removed stale closed repository entry: ${repoPath}`);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #313551

 - Removes closed repository records from the manager if the underlying path no longer exists on disk
 - Prevents dead repository entries from persisting when a user attempts to reopen a deleted or moved folder
 
 /cc @lszomoru 