### PR TITLE
sessions: count remote plugin customizations

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -238,7 +238,9 @@ Skills that are directly invoked by UI elements (toolbar buttons, menu items) ar
 
 ### Count Consistency
 
-Counts shown in the sidebar (per-link badges and the header total in `AICustomizationShortcutsWidget`) are driven by the same `IAICustomizationItemsModel` singleton (`workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts`) that feeds the customizations editor's list widget. The model owns the per-active-harness `ProviderCustomizationItemSource` cache and exposes per-section `IObservable<readonly IAICustomizationListItem[]>`; sidebar consumers `read` `.length` from those observables. There is exactly one discovery path, so editor and sidebar counts cannot diverge. McpServers and Plugins use their own service observables (`IMcpService.servers`, `IAgentPluginService.plugins`) directly.
+Counts shown in the sidebar (per-link badges and the header total in `AICustomizationShortcutsWidget`) are driven by the same `IAICustomizationItemsModel` singleton (`workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts`) that feeds the customizations editor's list widget. The model owns the per-active-harness `ProviderCustomizationItemSource` cache and exposes per-section `IObservable<readonly IAICustomizationListItem[]>`; sidebar consumers `read` `.length` from those observables. There is exactly one discovery path, so editor and sidebar counts cannot diverge. McpServers use `IMcpService.servers` directly. Plugins use `IAICustomizationItemsModel.getPluginCount()`, which combines locally installed plugins from `IAgentPluginService.plugins` with plugin rows supplied by the active remote customization provider.
+
+Provider-supplied customization rows that include an explicit storage origin are treated as authoritative even when no local URI inference is available. In particular, `storage: PromptsStorage.plugin` keeps AHP remote host plugin customizations out of the User group when no local `pluginUri` exists, and `storage: BUILTIN_STORAGE` keeps provider-supplied built-ins in the Built-in group.
 
 ### Sidebar Overview Entrypoint
 

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -22,7 +22,6 @@ import { IAICustomizationItemsModel } from '../../../../workbench/contrib/chat/b
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { CUSTOMIZATION_ITEMS } from './customizationsToolbar.contribution.js';
 import { Menus } from '../../../browser/menus.js';
-import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
@@ -45,7 +44,6 @@ export class AICustomizationShortcutsWidget extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IMcpService private readonly mcpService: IMcpService,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IAICustomizationItemsModel private readonly itemsModel: IAICustomizationItemsModel,
 		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 		@IEditorService private readonly editorService: IEditorService,
@@ -64,7 +62,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 			container.classList.add('collapsed');
 		}
 
-		// Header (clickable to toggle)
+		// Header
 		const header = DOM.append(container, $('.ai-customization-header'));
 		header.classList.toggle('collapsed', isCollapsed);
 
@@ -151,7 +149,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 				} else if (config.isMcp) {
 					total += this.mcpService.servers.read(reader).length;
 				} else if (config.isPlugins) {
-					total += this.agentPluginService.plugins.read(reader).length;
+					total += this.itemsModel.getPluginCount().read(reader);
 				}
 			}
 			return total;

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -27,7 +27,6 @@ import { Button } from '../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { IAgentPluginService } from '../../../../workbench/contrib/chat/common/plugins/agentPluginService.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 
@@ -100,8 +99,8 @@ export const CUSTOMIZATION_ITEMS: ICustomizationItemConfig[] = [
 /**
  * Custom ActionViewItem for each customization link in the toolbar.
  * Renders icon + label + a single count badge driven by the same
- * `IAICustomizationItemsModel` observables that feed the customizations
- * editor — so the badge always matches the editor's count exactly.
+ * observables that feed the customizations editor — so the badge always
+ * matches the editor's count exactly.
  */
 export class CustomizationLinkViewItem extends ActionViewItem {
 
@@ -115,7 +114,6 @@ export class CustomizationLinkViewItem extends ActionViewItem {
 		private readonly _config: ICustomizationItemConfig,
 		@IAICustomizationItemsModel private readonly _itemsModel: IAICustomizationItemsModel,
 		@IMcpService private readonly _mcpService: IMcpService,
-		@IAgentPluginService private readonly _agentPluginService: IAgentPluginService,
 	) {
 		super(undefined, action, { ...options, icon: false, label: false });
 		this._viewItemDisposables = this._register(new DisposableStore());
@@ -167,7 +165,7 @@ export class CustomizationLinkViewItem extends ActionViewItem {
 			return this._mcpService.servers.read(reader).length;
 		}
 		if (this._config.isPlugins) {
-			return this._agentPluginService.plugins.read(reader).length;
+			return this._itemsModel.getPluginCount().read(reader);
 		}
 		return 0;
 	}

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -106,6 +106,7 @@ interface ICustomizationCounts {
 	readonly instructions?: number;
 	readonly prompts?: number;
 	readonly hooks?: number;
+	readonly plugins?: number;
 }
 
 function createMockItemsModel(counts?: ICustomizationCounts): IAICustomizationItemsModel {
@@ -119,6 +120,7 @@ function createMockItemsModel(counts?: ICustomizationCounts): IAICustomizationIt
 		[AICustomizationManagementSection.Prompts, observableValue('promptsItems', fakeItems(counts?.prompts ?? 0))],
 		[AICustomizationManagementSection.Hooks, observableValue('hooksItems', fakeItems(counts?.hooks ?? 0))],
 	]);
+	const pluginCount = observableValue('pluginsCount', counts?.plugins ?? 0);
 
 	return new class extends mock<IAICustomizationItemsModel>() {
 		override getItems(section: ItemsModelSection) {
@@ -127,6 +129,9 @@ function createMockItemsModel(counts?: ICustomizationCounts): IAICustomizationIt
 		override getCount(section: ItemsModelSection): IObservable<number> {
 			const items = sectionItems.get(section)!;
 			return observableValue(`${section}-count`, items.get().length);
+		}
+		override getPluginCount(): IObservable<number> {
+			return pluginCount;
 		}
 	}();
 }

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts
@@ -109,6 +109,10 @@ function createMockItemsModel(): IAICustomizationItemsModel {
 		override getCount(_section: ItemsModelSection): IObservable<number> {
 			return zeroCount;
 		}
+
+		override getPluginCount(): IObservable<number> {
+			return zeroCount;
+		}
 	}();
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationDebugPanel.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IPromptsService, PromptsStorage, IPromptPath } from '../../common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
-import { AICustomizationManagementSection, sectionToPromptType } from './aiCustomizationManagement.js';
+import { type AICustomizationPromptsStorage, AICustomizationManagementSection, BUILTIN_STORAGE, sectionToPromptType } from './aiCustomizationManagement.js';
 import { ICustomizationHarnessService, ICustomizationItemProvider, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
 import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 
@@ -16,7 +16,7 @@ import { IAgentPluginService } from '../../common/plugins/agentPluginService.js'
  * Snapshot of the list widget's internal state, passed in to avoid coupling.
  */
 export interface IDebugWidgetState {
-	readonly allItems: readonly { readonly name?: string; readonly storage?: PromptsStorage; readonly groupKey?: string }[];
+	readonly allItems: readonly { readonly name?: string; readonly storage?: AICustomizationPromptsStorage; readonly groupKey?: string }[];
 	readonly displayEntries: readonly { type: string; label?: string; count?: number; collapsed?: boolean }[];
 }
 
@@ -273,6 +273,7 @@ function appendWidgetState(lines: string[], state: IDebugWidgetState): void {
 	lines.push(`    user:      ${state.allItems.filter(i => i.storage === PromptsStorage.user).length}`);
 	lines.push(`    extension: ${state.allItems.filter(i => i.storage === PromptsStorage.extension).length}`);
 	lines.push(`    plugin:    ${state.allItems.filter(i => i.storage === PromptsStorage.plugin).length}`);
+	lines.push(`    built-in:  ${state.allItems.filter(i => i.storage === BUILTIN_STORAGE).length}`);
 
 	for (const item of state.allItems) {
 		lines.push(`    - ${item.name} [storage=${item.storage ?? '?'}, groupKey=${item.groupKey ?? '(none)'}]`);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
@@ -7,6 +7,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { registerIcon } from '../../../../../platform/theme/common/iconRegistry.js';
+import { type AICustomizationPromptsStorage, BUILTIN_STORAGE } from '../../common/aiCustomizationWorkspaceService.js';
 import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 
 /**
@@ -82,12 +83,13 @@ export const mcpServerIcon = registerIcon('ai-customization-mcp-server', Codicon
 /**
  * Returns the icon for a given storage type.
  */
-export function storageToIcon(storage: PromptsStorage): ThemeIcon {
+export function storageToIcon(storage: AICustomizationPromptsStorage): ThemeIcon {
 	switch (storage) {
 		case PromptsStorage.local: return workspaceIcon;
 		case PromptsStorage.user: return userIcon;
 		case PromptsStorage.extension: return extensionIcon;
 		case PromptsStorage.plugin: return pluginIcon;
+		case BUILTIN_STORAGE: return builtinIcon;
 		default: return instructionsIcon;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource.ts
@@ -29,7 +29,7 @@ import { HOOK_METADATA } from '../../common/promptSyntax/hookTypes.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { storageToIcon } from './aiCustomizationIcons.js';
-import { BUILTIN_STORAGE } from './aiCustomizationManagement.js';
+import { type AICustomizationPromptsStorage, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
 import { extractExtensionIdFromPath } from './aiCustomizationListWidgetUtils.js';
 
 // #region Interfaces
@@ -44,7 +44,7 @@ export interface IAICustomizationListItem {
 	readonly filename: string;
 	readonly description?: string;
 	/** Storage origin. Set by core when items come from promptsService; omitted for external provider items. */
-	readonly storage?: PromptsStorage;
+	readonly storage?: AICustomizationPromptsStorage;
 	readonly promptType: PromptsType;
 	readonly disabled: boolean;
 	/** When set, overrides `storage` for display grouping purposes. */
@@ -230,10 +230,17 @@ export class AICustomizationItemNormalizer {
 		};
 	}
 
-	private inferStorageAndGroup(item: ICustomizationItem): { storage: PromptsStorage; groupKey?: string; isBuiltin?: boolean; extensionId?: string; pluginUri?: URI } {
+	private inferStorageAndGroup(item: ICustomizationItem): { storage: AICustomizationPromptsStorage; groupKey?: string; isBuiltin?: boolean; extensionId?: string; pluginUri?: URI } {
 		const groupKey = item.groupKey;
-		const isBuiltin = groupKey === BUILTIN_STORAGE;
+		const hasBuiltinStorage = item.storage === (BUILTIN_STORAGE as unknown as PromptsStorage);
+		const isBuiltin = groupKey === BUILTIN_STORAGE || hasBuiltinStorage;
 
+		if (hasBuiltinStorage) {
+			return { storage: BUILTIN_STORAGE, groupKey: groupKey ?? BUILTIN_STORAGE, isBuiltin: true, extensionId: item.extensionId };
+		}
+		if (item.storage === PromptsStorage.plugin) {
+			return { storage: PromptsStorage.plugin, pluginUri: item.pluginUri, groupKey, isBuiltin };
+		}
 		if (item.extensionId) {
 			const extensionIdentifier = new ExtensionIdentifier(item.extensionId);
 			if (isChatExtensionItem(extensionIdentifier, this.productService)) {
@@ -243,6 +250,9 @@ export class AICustomizationItemNormalizer {
 		}
 		if (item.pluginUri) {
 			return { storage: PromptsStorage.plugin, pluginUri: item.pluginUri, groupKey, isBuiltin };
+		}
+		if (item.storage) {
+			return { storage: item.storage, groupKey, isBuiltin };
 		}
 
 		const uri = item.uri;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
@@ -114,8 +114,14 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 	private readonly fetchSeq = new Map<ItemsModelSection, number>();
 	/** Promise of the most recent fetch per section (resolves regardless of stale-discard). */
 	private readonly perSectionPending = new Map<ItemsModelSection, Promise<void>>();
-	private readonly remotePluginCount = observableValue<number>('aiCustomizationRemotePluginCount', 0);
-	private readonly pluginCount = derived(reader => this.agentPluginService.plugins.read(reader).length + this.remotePluginCount.read(reader));
+	private readonly remotePluginNames = observableValue<readonly string[]>('aiCustomizationRemotePluginNames', []);
+	private readonly pluginCount = derived(reader => {
+		const installed = this.agentPluginService.plugins.read(reader);
+		const installedNames = new Set(installed.map(p => (p.label ?? '').toLowerCase()));
+		const remoteNames = this.remotePluginNames.read(reader);
+		const uniqueRemote = remoteNames.filter(name => name && !installedNames.has(name.toLowerCase()));
+		return installed.length + uniqueRemote.length;
+	});
 	private pluginCountObserved = false;
 	private pluginFetchSeq = 0;
 	/**
@@ -295,13 +301,15 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 		const seq = ++this.pluginFetchSeq;
 		const descriptor = this.harnessService.getActiveDescriptor();
 		const provider = descriptor.itemProvider;
-		const pending = provider
+		const pending: Promise<readonly string[]> = provider
 			? provider.provideChatSessionCustomizations(CancellationToken.None).then(items => {
-				return (items ?? []).filter(item => isPluginCustomizationItem(item) && item.groupKey !== 'remote-client').length;
+				return (items ?? [])
+					.filter(item => isPluginCustomizationItem(item) && item.groupKey !== 'remote-client')
+					.map(item => item.name ?? '');
 			})
-			: Promise.resolve(0);
+			: Promise.resolve<readonly string[]>([]);
 
-		pending.then(count => {
+		pending.then(names => {
 			if (this._store.isDisposed) {
 				return;
 			}
@@ -311,7 +319,7 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 			if (this.getActiveItemSource() !== source) {
 				return;
 			}
-			this.remotePluginCount.set(count, undefined);
+			this.remotePluginNames.set(names, undefined);
 		}, e => {
 			if (!this._store.isDisposed) {
 				onUnexpectedError(e);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemsModel.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
 import { Disposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { autorun, derived, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
@@ -14,7 +15,7 @@ import { IProductService } from '../../../../../platform/product/common/productS
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
-import { ICustomizationHarnessService, ICustomizationItemProvider, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, ICustomizationItemProvider, IHarnessDescriptor, isPluginCustomizationItem } from '../../common/customizationHarnessService.js';
 import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
@@ -24,8 +25,10 @@ import { PromptsServiceCustomizationItemProvider } from './promptsServiceCustomi
 /**
  * The set of sections whose items are sourced from the customization
  * harness pipeline (extension-contributed providers, sync providers,
- * and the prompts-service fallback). McpServers / Plugins / Models
- * have their own dedicated services and are not modeled here.
+ * and the prompts-service fallback). McpServers / Models have their
+ * own dedicated services and are not modeled here. Plugins keep a
+ * dedicated count observable because remote harnesses can contribute
+ * plugin rows through the same provider pipeline.
  */
 export const ITEMS_MODEL_SECTIONS = [
 	AICustomizationManagementSection.Agents,
@@ -71,6 +74,13 @@ export interface IAICustomizationItemsModel {
 	getCount(section: ItemsModelSection): IObservable<number>;
 
 	/**
+	 * Returns an observable of the Plugins section count. This combines
+	 * locally installed plugins with plugin rows supplied by the active
+	 * customization harness provider.
+	 */
+	getPluginCount(): IObservable<number>;
+
+	/**
 	 * The fallback item provider used when the active descriptor has neither
 	 * an `itemProvider` nor a `syncProvider`. Exposed for the debug report.
 	 */
@@ -104,6 +114,10 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 	private readonly fetchSeq = new Map<ItemsModelSection, number>();
 	/** Promise of the most recent fetch per section (resolves regardless of stale-discard). */
 	private readonly perSectionPending = new Map<ItemsModelSection, Promise<void>>();
+	private readonly remotePluginCount = observableValue<number>('aiCustomizationRemotePluginCount', 0);
+	private readonly pluginCount = derived(reader => this.agentPluginService.plugins.read(reader).length + this.remotePluginCount.read(reader));
+	private pluginCountObserved = false;
+	private pluginFetchSeq = 0;
 	/**
 	 * Sections that have been observed at least once. The model only fetches on
 	 * demand: first `getItems`/`getCount` for a section triggers an initial fetch,
@@ -118,7 +132,7 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 		@ILabelService labelService: ILabelService,
-		@IAgentPluginService agentPluginService: IAgentPluginService,
+		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IProductService productService: IProductService,
 		@IFileService private readonly fileService: IFileService,
 		@IPathService private readonly pathService: IPathService,
@@ -129,7 +143,7 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 			workspaceContextService,
 			workspaceService,
 			labelService,
-			agentPluginService,
+			this.agentPluginService,
 			productService,
 		);
 		this.promptsServiceItemProvider = new PromptsServiceCustomizationItemProvider(
@@ -179,6 +193,11 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 		return this.perSectionCount.get(section)!;
 	}
 
+	getPluginCount(): IObservable<number> {
+		this.markPluginCountObserved();
+		return this.pluginCount;
+	}
+
 	getActiveItemSource(): IAICustomizationItemSource {
 		return this.getOrCreateSource(this.harnessService.getActiveDescriptor());
 	}
@@ -198,6 +217,14 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 		}
 		this.observedSections.add(section);
 		this.refetchSection(section, this.getActiveItemSource());
+	}
+
+	private markPluginCountObserved(): void {
+		if (this.pluginCountObserved || this._store.isDisposed) {
+			return;
+		}
+		this.pluginCountObserved = true;
+		this.refetchPluginCount(this.getActiveItemSource());
 	}
 
 	private getOrCreateSource(descriptor: IHarnessDescriptor): IAICustomizationItemSource {
@@ -232,6 +259,9 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 		for (const section of this.observedSections) {
 			this.refetchSection(section, source);
 		}
+		if (this.pluginCountObserved) {
+			this.refetchPluginCount(source);
+		}
 	}
 
 	private refetchSection(section: ItemsModelSection, source: IAICustomizationItemSource): void {
@@ -259,6 +289,34 @@ export class AICustomizationItemsModel extends Disposable implements IAICustomiz
 			onUnexpectedError(e);
 		});
 		this.perSectionPending.set(section, pending);
+	}
+
+	private refetchPluginCount(source: IAICustomizationItemSource): void {
+		const seq = ++this.pluginFetchSeq;
+		const descriptor = this.harnessService.getActiveDescriptor();
+		const provider = descriptor.itemProvider;
+		const pending = provider
+			? provider.provideChatSessionCustomizations(CancellationToken.None).then(items => {
+				return (items ?? []).filter(item => isPluginCustomizationItem(item) && item.groupKey !== 'remote-client').length;
+			})
+			: Promise.resolve(0);
+
+		pending.then(count => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			if (this.pluginFetchSeq !== seq) {
+				return;
+			}
+			if (this.getActiveItemSource() !== source) {
+				return;
+			}
+			this.remotePluginCount.set(count, undefined);
+		}, e => {
+			if (!this._store.isDisposed) {
+				onUnexpectedError(e);
+			}
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -984,11 +984,15 @@ export class PluginListWidget extends Disposable {
 		const entries: IPluginListEntry[] = [];
 		let isFirst = true;
 
+		const installedNames = new Set(this.installedItems.map(item => item.name.toLowerCase()));
 		const remoteGroups = new Map<string, IPluginRemoteItemEntry[]>();
 		for (const item of this.remoteItems) {
 			const key = item.groupKey ?? 'remote-host';
 			if (key === 'remote-client') {
 				continue; // client-synced items are already shown in "Enabled Locally"
+			}
+			if (item.name && installedNames.has(item.name.toLowerCase())) {
+				continue; // plugin is also locally installed; show it once in "Enabled Locally"
 			}
 			let group = remoteGroups.get(key);
 			if (!group) {
@@ -1039,7 +1043,17 @@ export class PluginListWidget extends Disposable {
 	 * (the same source used to build group headers).
 	 */
 	get itemCount(): number {
-		return this.remoteItems.filter(item => item.groupKey !== 'remote-client').length + this.installedItems.length;
+		const installedNames = new Set(this.installedItems.map(item => item.name.toLowerCase()));
+		const uniqueRemote = this.remoteItems.filter(item => {
+			if (item.groupKey === 'remote-client') {
+				return false;
+			}
+			if (item.name && installedNames.has(item.name.toLowerCase())) {
+				return false;
+			}
+			return true;
+		});
+		return uniqueRemote.length + this.installedItems.length;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -36,7 +36,7 @@ import { pluginIcon } from './aiCustomizationIcons.js';
 import { formatDisplayName, truncateToFirstLine } from './aiCustomizationListWidget.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { CustomizationGroupHeaderRenderer, ICustomizationGroupHeaderEntry, CUSTOMIZATION_GROUP_HEADER_HEIGHT, CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR } from './customizationGroupHeaderRenderer.js';
-import { ICustomizationHarnessService, type ICustomizationItem, type ICustomizationItemAction } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, isPluginCustomizationItem, type ICustomizationItem, type ICustomizationItemAction } from '../../common/customizationHarnessService.js';
 import { Checkbox } from '../../../../../base/browser/ui/toggle/toggle.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../../common/constants.js';
@@ -904,7 +904,7 @@ export class PluginListWidget extends Disposable {
 		try {
 			const provided = await provider.provideChatSessionCustomizations(CancellationToken.None) ?? [];
 			return provided.filter(item =>
-				item.type === 'plugin'
+				isPluginCustomizationItem(item)
 				&& (!query
 					|| item.name.toLowerCase().includes(query)
 					|| item.description?.toLowerCase().includes(query)
@@ -1039,7 +1039,7 @@ export class PluginListWidget extends Disposable {
 	 * (the same source used to build group headers).
 	 */
 	get itemCount(): number {
-		return this.remoteItems.length + this.installedItems.length;
+		return this.remoteItems.filter(item => item.groupKey !== 'remote-client').length + this.installedItems.length;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -190,6 +190,10 @@ export interface ICustomizationItem {
 	readonly actions?: readonly ICustomizationItemAction[];
 }
 
+export function isPluginCustomizationItem(item: { readonly type: string }): boolean {
+	return item.type === 'plugin' || item.type === AICustomizationManagementSection.Plugins;
+}
+
 /**
  * Provider interface for extension-contributed harnesses that supply
  * customization items directly from their SDK.

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -337,5 +337,27 @@ suite('AICustomizationItemsModel', () => {
 				providerA_callCount: callsAfterInitialCount,
 			});
 		});
+
+		test('plugin count dedupes provider plugins that are also installed locally', async () => {
+			providerA_items = [{
+				uri: URI.parse('agent-host://test-authority/plugins/model-council'),
+				type: 'plugin',
+				name: 'model-council',
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: undefined,
+			}];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+			assert.strictEqual(count.get(), 1, 'before local install: only the harness-reported plugin counts');
+
+			plugins.set([createLocalPlugin('model-council')], undefined);
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 1, 'after local install: harness duplicate is folded into the local count');
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -360,4 +360,220 @@ suite('AICustomizationItemsModel', () => {
 			assert.strictEqual(count.get(), 1, 'after local install: harness duplicate is folded into the local count');
 		});
 	});
+
+	suite('data sources', () => {
+
+		let disposables: DisposableStore;
+		let instaService: TestInstantiationService;
+
+		let providerDidChange: Emitter<void>;
+		let providerItems: ICustomizationItem[];
+		let plugins: ISettableObservable<readonly IAgentPlugin[]>;
+
+		setup(() => {
+			disposables = new DisposableStore();
+			providerDidChange = disposables.add(new Emitter<void>());
+			providerItems = [];
+			plugins = observableValue<readonly IAgentPlugin[]>('plugins', []);
+
+			const provider: ICustomizationItemProvider = {
+				onDidChange: providerDidChange.event,
+				provideChatSessionCustomizations: (_token: CancellationToken) => Promise.resolve(providerItems.slice()),
+			};
+			const descriptor: IHarnessDescriptor = {
+				id: 'A',
+				label: 'A',
+				icon: Codicon.settingsGear,
+				getStorageSourceFilter: (): IStorageSourceFilter => ({ sources: [PromptsStorage.local, PromptsStorage.user] }),
+				itemProvider: provider,
+			};
+			const activeHarness = observableValue('activeHarness', 'A');
+			const availableHarnesses = observableValue<readonly IHarnessDescriptor[]>('availableHarnesses', [descriptor]);
+
+			instaService = workbenchInstantiationService({}, disposables);
+			instaService.stub(IPromptsService, {
+				onDidChangeCustomAgents: Event.None,
+				onDidChangeSlashCommands: Event.None,
+				onDidChangeSkills: Event.None,
+				onDidChangeHooks: Event.None,
+				onDidChangeInstructions: Event.None,
+				listPromptFiles: async () => [],
+				getCustomAgents: async () => [],
+				findAgentSkills: async () => [],
+				getHooks: async () => undefined,
+				getInstructionFiles: async () => [],
+				getDisabledPromptFiles: () => new ResourceSet(),
+			});
+			instaService.stub(IAICustomizationWorkspaceService, {
+				activeProjectRoot: observableValue('test', undefined),
+				getActiveProjectRoot: () => undefined,
+				managementSections: [AICustomizationManagementSection.Agents],
+				isSessionsWindow: false,
+				welcomePageFeatures: { showGettingStartedBanner: false },
+				getStorageSourceFilter: () => ({ sources: [] }),
+				getSkillUIIntegrations: () => new Map(),
+				hasOverrideProjectRoot: observableValue('test', false),
+				commitFiles: async () => { },
+				deleteFiles: async () => { },
+				generateCustomization: async () => { },
+				setOverrideProjectRoot: () => { },
+				clearOverrideProjectRoot: () => { },
+			});
+			instaService.stub(ICustomizationHarnessService, {
+				activeHarness,
+				availableHarnesses,
+				setActiveHarness: (id: string) => activeHarness.set(id, undefined),
+				getStorageSourceFilter: () => ({ sources: [] }),
+				getActiveDescriptor: () => availableHarnesses.get().find(d => d.id === activeHarness.get())!,
+				findHarnessById: (id: string) => availableHarnesses.get().find(d => d.id === id),
+				registerExternalHarness: () => ({ dispose() { } }),
+			});
+			instaService.stub(IAgentPluginService, {
+				plugins,
+				enablementModel: {
+					readEnabled: () => ContributionEnablementState.EnabledProfile,
+					setEnabled: () => { },
+					remove: () => { },
+				},
+			});
+		});
+
+		teardown(() => disposables.dispose());
+
+		function localPlugin(name: string): IAgentPlugin {
+			return {
+				uri: URI.parse(`plugin-test://${name}`),
+				label: name,
+				enablement: observableValue('pluginEnablement', ContributionEnablementState.EnabledProfile),
+				remove: () => { },
+				hooks: observableValue('pluginHooks', []),
+				commands: observableValue('pluginCommands', []),
+				skills: observableValue('pluginSkills', []),
+				agents: observableValue('pluginAgents', []),
+				instructions: observableValue('pluginInstructions', []),
+				mcpServerDefinitions: observableValue('pluginMcpServerDefinitions', []),
+			};
+		}
+
+		function harnessPluginRow(name: string, overrides: Partial<ICustomizationItem> = {}): ICustomizationItem {
+			return {
+				uri: URI.parse(`agent-host://t/plugins/${name}`),
+				type: 'plugin',
+				name,
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: undefined,
+				...overrides,
+			};
+		}
+
+		function providerSkill(name: string, uri: string = `agent-host://t/skills/${name}/SKILL.md`): ICustomizationItem {
+			return {
+				uri: URI.parse(uri),
+				type: PromptsType.skill,
+				name,
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: true,
+			};
+		}
+
+		function providerOfType(type: PromptsType, name: string): ICustomizationItem {
+			return {
+				uri: URI.parse(`agent-host://t/${type}/${name}`),
+				type,
+				name,
+				// Hooks pre-expanded items are kept under `plugin` storage; using
+				// plugin storage uniformly avoids the file-system expansion path
+				// in tests for non-hook types as well.
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: true,
+			};
+		}
+
+		const sectionsByType = [
+			[AICustomizationManagementSection.Agents, PromptsType.agent],
+			[AICustomizationManagementSection.Skills, PromptsType.skill],
+			[AICustomizationManagementSection.Instructions, PromptsType.instructions],
+			[AICustomizationManagementSection.Prompts, PromptsType.prompt],
+			[AICustomizationManagementSection.Hooks, PromptsType.hook],
+		] as const;
+
+		for (const [section, type] of sectionsByType) {
+			test(`getCount(${section}) mirrors provider items filtered by type=${type}`, async () => {
+				providerItems = [
+					providerOfType(type, 'a'),
+					providerOfType(type, 'b'),
+					providerOfType(PromptsType.agent, 'unrelated-1'),
+					providerOfType(PromptsType.skill, 'unrelated-2'),
+				];
+
+				const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+				const count = model.getCount(section);
+				await model.whenSectionLoaded(section);
+
+				const expected = providerItems.filter(i => i.type === type).length;
+				assert.strictEqual(count.get(), expected, `${section} count should equal provider items where type === ${type}`);
+			});
+		}
+
+		test('getCount reacts to provider onDidChange for observed sections', async () => {
+			providerItems = [providerSkill('one')];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getCount(AICustomizationManagementSection.Skills);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+			assert.strictEqual(count.get(), 1, 'initial fetch reflects provider state');
+
+			providerItems = [providerSkill('one'), providerSkill('two')];
+			providerDidChange.fire();
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 2, 'count refetches after provider change');
+		});
+
+		test('getPluginCount returns local plugin count when harness has no plugin rows', async () => {
+			providerItems = [providerSkill('not-a-plugin-row')];
+			plugins.set([localPlugin('local-a'), localPlugin('local-b')], undefined);
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 2, 'plugin count uses local plugins when the harness exposes none');
+		});
+
+		test('getPluginCount returns harness plugin row count when no local plugins are installed', async () => {
+			providerItems = [
+				harnessPluginRow('x'),
+				harnessPluginRow('y', { type: AICustomizationManagementSection.Plugins }),
+				harnessPluginRow('synced', { groupKey: 'remote-client' }),
+			];
+			plugins.set([], undefined);
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 2, 'remote-client harness rows are excluded; both internal "plugin" and API "plugins" types are recognised');
+		});
+
+		test('getPluginCount sums local plugins and unique harness plugin rows', async () => {
+			providerItems = [
+				harnessPluginRow('dup'),
+				harnessPluginRow('uniq'),
+			];
+			plugins.set([localPlugin('dup'), localPlugin('local-only')], undefined);
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 3, 'dup is counted once via the local source; uniq adds, local-only adds');
+		});
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts
@@ -11,15 +11,17 @@ import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../../base/common/map.js';
 import { ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { AICustomizationItemsModel } from '../../../browser/aiCustomization/aiCustomizationItemsModel.js';
-import { AICustomizationManagementSection, IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../common/aiCustomizationWorkspaceService.js';
+import { AICustomizationManagementSection, BUILTIN_STORAGE, IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../common/aiCustomizationWorkspaceService.js';
 import { ICustomizationHarnessService, ICustomizationItem, ICustomizationItemProvider, IHarnessDescriptor } from '../../../common/customizationHarnessService.js';
 import { ContributionEnablementState } from '../../../common/enablement.js';
-import { IAgentPluginService } from '../../../common/plugins/agentPluginService.js';
+import { IAgentPluginService, type IAgentPlugin } from '../../../common/plugins/agentPluginService.js';
 import { IPromptsService, PromptsStorage } from '../../../common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../../../common/promptSyntax/promptTypes.js';
 
 suite('AICustomizationItemsModel', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -36,6 +38,7 @@ suite('AICustomizationItemsModel', () => {
 		let providerA_didChange: Emitter<void>;
 		let providerA_callCount: number;
 		let providerA_items: ICustomizationItem[];
+		let plugins: ISettableObservable<readonly IAgentPlugin[]>;
 
 		function createDescriptor(id: string, provider: ICustomizationItemProvider): IHarnessDescriptor {
 			return {
@@ -69,6 +72,7 @@ suite('AICustomizationItemsModel', () => {
 
 			activeHarness = observableValue('activeHarness', 'A');
 			availableHarnesses = observableValue<readonly IHarnessDescriptor[]>('availableHarnesses', [descriptorA, descriptorB]);
+			plugins = observableValue<readonly IAgentPlugin[]>('plugins', []);
 
 			instaService = workbenchInstantiationService({}, disposables);
 
@@ -113,7 +117,7 @@ suite('AICustomizationItemsModel', () => {
 			});
 
 			instaService.stub(IAgentPluginService, {
-				plugins: observableValue('test', []),
+				plugins,
 				enablementModel: {
 					readEnabled: () => ContributionEnablementState.EnabledProfile,
 					setEnabled: () => { },
@@ -121,6 +125,21 @@ suite('AICustomizationItemsModel', () => {
 				},
 			});
 		});
+
+		function createLocalPlugin(name: string): IAgentPlugin {
+			return {
+				uri: URI.parse(`plugin-test://${name}`),
+				label: name,
+				enablement: observableValue('pluginEnablement', ContributionEnablementState.EnabledProfile),
+				remove: () => { },
+				hooks: observableValue('pluginHooks', []),
+				commands: observableValue('pluginCommands', []),
+				skills: observableValue('pluginSkills', []),
+				agents: observableValue('pluginAgents', []),
+				instructions: observableValue('pluginInstructions', []),
+				mcpServerDefinitions: observableValue('pluginMcpServerDefinitions', []),
+			};
+		}
 
 		teardown(() => disposables.dispose());
 
@@ -189,6 +208,134 @@ suite('AICustomizationItemsModel', () => {
 
 			const sourceA2 = model.getActiveItemSource();
 			assert.notStrictEqual(sourceA1, sourceA2);
+		});
+
+		test('preserves provider-supplied plugin storage when pluginUri is omitted', async () => {
+			providerA_items = [{
+				uri: URI.parse('agent-host://test-authority/plugins/my-plugin/skills/my-skill/SKILL.md'),
+				type: PromptsType.skill,
+				name: 'My Skill',
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: true,
+			}];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const items = model.getItems(AICustomizationManagementSection.Skills);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+
+			assert.deepStrictEqual(items.get().map(item => ({
+				name: item.name,
+				storage: item.storage,
+			})), [{
+				name: 'My Skill',
+				storage: PromptsStorage.plugin,
+			}]);
+		});
+
+		test('preserves provider-supplied builtin storage when groupKey is omitted', async () => {
+			providerA_items = [{
+				uri: URI.parse('agent-host://test-authority/builtin/skills/github/SKILL.md'),
+				type: PromptsType.skill,
+				name: 'Built-in Skill',
+				storage: BUILTIN_STORAGE as unknown as PromptsStorage,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: true,
+			}];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const items = model.getItems(AICustomizationManagementSection.Skills);
+			await model.whenSectionLoaded(AICustomizationManagementSection.Skills);
+
+			assert.deepStrictEqual(items.get().map(item => ({
+				name: item.name,
+				storage: item.storage,
+				groupKey: item.groupKey,
+				isBuiltin: item.isBuiltin,
+			})), [{
+				name: 'Built-in Skill',
+				storage: BUILTIN_STORAGE,
+				groupKey: BUILTIN_STORAGE,
+				isBuiltin: true,
+			}]);
+		});
+
+		test('plugin count includes provider-supplied plugin items', async () => {
+			providerA_items = [
+				{
+					uri: URI.parse('agent-host://test-authority/plugins/remote-one'),
+					type: 'plugin',
+					name: 'Remote One',
+					storage: PromptsStorage.plugin,
+					extensionId: undefined,
+					pluginUri: undefined,
+					userInvocable: undefined,
+				},
+				{
+					uri: URI.parse('agent-host://test-authority/plugins/remote-two'),
+					type: AICustomizationManagementSection.Plugins,
+					name: 'Remote Two',
+					storage: PromptsStorage.plugin,
+					extensionId: undefined,
+					pluginUri: undefined,
+					userInvocable: undefined,
+				},
+				{
+					uri: URI.parse('agent-host://test-authority/plugins/remote-two/skills/my-skill/SKILL.md'),
+					type: PromptsType.skill,
+					name: 'My Skill',
+					storage: PromptsStorage.plugin,
+					extensionId: undefined,
+					pluginUri: undefined,
+					userInvocable: true,
+				},
+				{
+					uri: URI.parse('agent-host://test-authority/plugins/local-synced'),
+					type: 'plugin',
+					name: 'Local Synced',
+					storage: PromptsStorage.plugin,
+					groupKey: 'remote-client',
+					extensionId: undefined,
+					pluginUri: undefined,
+					userInvocable: undefined,
+				},
+			];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+
+			assert.strictEqual(count.get(), 2);
+		});
+
+		test('local plugin changes update plugin count without refetching provider customizations', async () => {
+			providerA_items = [{
+				uri: URI.parse('agent-host://test-authority/plugins/remote-one'),
+				type: 'plugin',
+				name: 'Remote One',
+				storage: PromptsStorage.plugin,
+				extensionId: undefined,
+				pluginUri: undefined,
+				userInvocable: undefined,
+			}];
+
+			const model = disposables.add(instaService.createInstance(AICustomizationItemsModel));
+			const count = model.getPluginCount();
+			await timeout(0);
+			const callsAfterInitialCount = providerA_callCount;
+
+			plugins.set([createLocalPlugin('local-one')], undefined);
+			await timeout(0);
+
+			assert.deepStrictEqual({
+				count: count.get(),
+				providerA_callCount,
+			}, {
+				count: 2,
+				providerA_callCount: callsAfterInitialCount,
+			});
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts
@@ -212,6 +212,7 @@ suite('aiCustomizationListWidget', () => {
 			instaService.stub(IAICustomizationItemsModel, {
 				getItems: () => observableValue('test', [] as readonly never[]),
 				getCount: () => observableValue('test', 0),
+				getPluginCount: () => observableValue('test', 0),
 				getActiveItemSource: () => ({ onDidChange: Event.None, fetchItems: async () => [] }),
 				getPromptsServiceItemProvider: () => ({ onDidChange: Event.None, provideChatSessionCustomizations: async () => undefined }),
 			});


### PR DESCRIPTION
## Summary
- Preserve provider-declared plugin and built-in storage while normalizing customization items, even when AHP remote items do not have local plugin URIs.
- Include active remote provider plugin rows in the Agents sidebar Plugins count while excluding locally synced `remote-client` rows.
- Keep the Plugins list count aligned with displayed rows and avoid remote provider refetches when only local installed plugins change.
- Preserve the newer `origin/main` customizations header collapse-toggle/touch handling.

## Testing
- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts $(git --no-pager diff --name-only -- 'src/**/*.ts' 'src/**/*.md')`
- `npm run valid-layers-check`
- `npm run transpile-client -- --quiet`
- `env -u ELECTRON_RUN_AS_NODE ./scripts/test.sh --run src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationItemsModel.test.ts --run src/vs/workbench/contrib/chat/test/browser/aiCustomization/aiCustomizationListWidget.test.ts --run src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.test.ts`