### PR TITLE
Fix transform-case actions changing strings and comments

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -752,6 +752,11 @@ export interface IEditorOptions {
 	 */
 	trimWhitespaceOnDelete?: boolean;
 	/**
+	 * Configuration options for case-transformation actions
+	 * (Transform to Uppercase / Lowercase / Title Case / Snake Case / Camel Case / Pascal Case / Kebab Case).
+	 */
+	transformCase?: ITransformCaseOptions;
+	/**
 	 * The font family
 	 */
 	fontFamily?: string;
@@ -1540,6 +1545,57 @@ class EditorComments extends BaseEditorOption<EditorOption.comments, IEditorComm
 		return {
 			insertSpace: boolean(input.insertSpace, this.defaultValue.insertSpace),
 			ignoreEmptyLines: boolean(input.ignoreEmptyLines, this.defaultValue.ignoreEmptyLines),
+		};
+	}
+}
+
+//#endregion
+
+//#region transformCase
+
+/**
+ * Configuration options for editor case-transformation actions
+ * (Transform to Uppercase / Lowercase / Title Case / Snake Case / Camel Case / Pascal Case / Kebab Case).
+ */
+export interface ITransformCaseOptions {
+	/**
+	 * When `true`, ranges classified as strings or comments by the active language's
+	 * tokenizer are left untouched by the case-transformation actions.
+	 * Defaults to `false` for backwards compatibility.
+	 */
+	skipStringsAndComments?: boolean;
+}
+
+/**
+ * @internal
+ */
+export type EditorTransformCaseOptions = Readonly<Required<ITransformCaseOptions>>;
+
+class EditorTransformCase extends BaseEditorOption<EditorOption.transformCase, ITransformCaseOptions, EditorTransformCaseOptions> {
+
+	constructor() {
+		const defaults: EditorTransformCaseOptions = {
+			skipStringsAndComments: false,
+		};
+		super(
+			EditorOption.transformCase, 'transformCase', defaults,
+			{
+				'editor.transformCase.skipStringsAndComments': {
+					type: 'boolean',
+					default: defaults.skipStringsAndComments,
+					description: nls.localize('transformCase.skipStringsAndComments', "Controls whether the case-transformation actions (Transform to Uppercase, Lowercase, Title Case, Snake Case, Camel Case, Pascal Case, Kebab Case) leave ranges classified as strings or comments by the active language's tokenizer untouched.")
+				},
+			}
+		);
+	}
+
+	public validate(_input: unknown): EditorTransformCaseOptions {
+		if (!_input || typeof _input !== 'object') {
+			return this.defaultValue;
+		}
+		const input = _input as Unknown<ITransformCaseOptions>;
+		return {
+			skipStringsAndComments: boolean(input.skipStringsAndComments, this.defaultValue.skipStringsAndComments),
 		};
 	}
 }
@@ -5911,6 +5967,7 @@ export const enum EditorOption {
 	suggestSelection,
 	tabCompletion,
 	tabIndex,
+	transformCase,
 	trimWhitespaceOnDelete,
 	unicodeHighlighting,
 	unusualLineTerminators,
@@ -6721,6 +6778,7 @@ export const EditorOptions = {
 		EditorOption.tabIndex, 'tabIndex',
 		0, -1, Constants.MAX_SAFE_SMALL_INTEGER
 	)),
+	transformCase: register(new EditorTransformCase()),
 	trimWhitespaceOnDelete: register(new EditorBooleanOption(
 		EditorOption.trimWhitespaceOnDelete, 'trimWhitespaceOnDelete', false,
 		{ description: nls.localize('trimWhitespaceOnDelete', "Controls whether the editor will also delete the next line's indentation whitespace when deleting a newline.") }

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -22,6 +22,7 @@ import { EnterOperation } from '../../../common/cursor/cursorTypeEditOperations.
 import { TypeOperations } from '../../../common/cursor/cursorTypeOperations.js';
 import { ICommand } from '../../../common/editorCommon.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
+import { StandardTokenType } from '../../../common/encodedTokenAttributes.js';
 import { ILanguageConfigurationService } from '../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../common/model.js';
 import { CopyLinesCommand } from './copyLinesCommand.js';
@@ -1125,6 +1126,7 @@ export abstract class AbstractCaseAction extends EditorAction {
 		}
 
 		const wordSeparators = editor.getOption(EditorOption.wordSeparators);
+		const skipStringsAndComments = editor.getOption(EditorOption.transformCase).skipStringsAndComments;
 		const textEdits: ISingleEditOperation[] = [];
 
 		for (const selection of selections) {
@@ -1137,8 +1139,17 @@ export abstract class AbstractCaseAction extends EditorAction {
 				}
 
 				const wordRange = new Range(cursor.lineNumber, word.startColumn, cursor.lineNumber, word.endColumn);
+				if (skipStringsAndComments && isRangeInStringOrComment(model, wordRange)) {
+					continue;
+				}
 				const text = model.getValueInRange(wordRange);
 				textEdits.push(EditOperation.replace(wordRange, this._modifyText(text, wordSeparators)));
+			} else if (skipStringsAndComments) {
+				const codeRanges = splitRangeAroundStringsAndComments(model, selection);
+				for (const codeRange of codeRanges) {
+					const text = model.getValueInRange(codeRange);
+					textEdits.push(EditOperation.replace(codeRange, this._modifyText(text, wordSeparators)));
+				}
 			} else {
 				const text = model.getValueInRange(selection);
 				textEdits.push(EditOperation.replace(selection, this._modifyText(text, wordSeparators)));
@@ -1151,6 +1162,90 @@ export abstract class AbstractCaseAction extends EditorAction {
 	}
 
 	protected abstract _modifyText(text: string, wordSeparators: string): string;
+}
+
+function isStringOrCommentTokenType(tokenType: StandardTokenType): boolean {
+	return tokenType === StandardTokenType.String || tokenType === StandardTokenType.Comment;
+}
+
+/**
+ * Returns true when the entire `range` is classified as either a string or a comment by the
+ * model's tokenizer. The check is conservative: when tokens are not yet available the function
+ * forces tokenization for the affected lines so the caller gets a deterministic answer.
+ */
+function isRangeInStringOrComment(model: ITextModel, range: Range): boolean {
+	if (range.isEmpty()) {
+		return false;
+	}
+	for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+		model.tokenization.forceTokenization(lineNumber);
+		const lineTokens = model.tokenization.getLineTokens(lineNumber);
+		const lineLength = model.getLineLength(lineNumber);
+		const startOffset = lineNumber === range.startLineNumber ? range.startColumn - 1 : 0;
+		const endOffset = lineNumber === range.endLineNumber ? Math.min(range.endColumn - 1, lineLength) : lineLength;
+		if (startOffset >= endOffset) {
+			continue;
+		}
+		const startTokenIndex = lineTokens.findTokenIndexAtOffset(startOffset);
+		// findTokenIndexAtOffset uses a half-open lookup; for the end side we look at the last
+		// token strictly inside the range (endOffset - 1).
+		const endTokenIndex = lineTokens.findTokenIndexAtOffset(endOffset - 1);
+		for (let i = startTokenIndex; i <= endTokenIndex; i++) {
+			if (!isStringOrCommentTokenType(lineTokens.getStandardTokenType(i))) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+/**
+ * Splits a non-empty `range` into one or more sub-ranges that exclude any portions classified as
+ * strings or comments by the model's tokenizer. The original range is returned unchanged when the
+ * model has no tokens for it (e.g. plaintext) or when no string/comment tokens are present.
+ */
+function splitRangeAroundStringsAndComments(model: ITextModel, range: Range): Range[] {
+	if (range.isEmpty()) {
+		return [];
+	}
+	const result: Range[] = [];
+	let pendingStartLine = range.startLineNumber;
+	let pendingStartColumn = range.startColumn;
+	const flushPending = (endLine: number, endColumn: number) => {
+		if (endLine > pendingStartLine || endColumn > pendingStartColumn) {
+			result.push(new Range(pendingStartLine, pendingStartColumn, endLine, endColumn));
+		}
+	};
+
+	for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+		model.tokenization.forceTokenization(lineNumber);
+		const lineTokens = model.tokenization.getLineTokens(lineNumber);
+		const lineLength = model.getLineLength(lineNumber);
+		const startOffset = lineNumber === range.startLineNumber ? range.startColumn - 1 : 0;
+		const endOffset = lineNumber === range.endLineNumber ? Math.min(range.endColumn - 1, lineLength) : lineLength;
+		if (startOffset >= endOffset) {
+			continue;
+		}
+
+		const startTokenIndex = lineTokens.findTokenIndexAtOffset(startOffset);
+		const endTokenIndex = lineTokens.findTokenIndexAtOffset(endOffset - 1);
+		for (let i = startTokenIndex; i <= endTokenIndex; i++) {
+			const tokenType = lineTokens.getStandardTokenType(i);
+			const tokenStart = Math.max(lineTokens.getStartOffset(i), startOffset);
+			const tokenEnd = Math.min(lineTokens.getEndOffset(i), endOffset);
+			if (tokenStart >= tokenEnd) {
+				continue;
+			}
+			if (isStringOrCommentTokenType(tokenType)) {
+				flushPending(lineNumber, tokenStart + 1);
+				pendingStartLine = lineNumber;
+				pendingStartColumn = tokenEnd + 1;
+			}
+		}
+	}
+
+	flushPending(range.endLineNumber, range.endColumn);
+	return result;
 }
 
 export class UpperCaseAction extends AbstractCaseAction {

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { CoreEditingCommands } from '../../../../browser/coreCommands.js';
 import type { ICodeEditor } from '../../../../browser/editorBrowser.js';
@@ -10,11 +11,15 @@ import { EditorAction } from '../../../../browser/editorExtensions.js';
 import { Position } from '../../../../common/core/position.js';
 import { Selection } from '../../../../common/core/selection.js';
 import { Handler } from '../../../../common/editorCommon.js';
+import { MetadataConsts, StandardTokenType } from '../../../../common/encodedTokenAttributes.js';
+import { EncodedTokenizationResult, ITokenizationSupport, TokenizationRegistry } from '../../../../common/languages.js';
+import { ILanguageService } from '../../../../common/languages/language.js';
+import { NullState } from '../../../../common/languages/nullTokenize.js';
 import { ITextModel } from '../../../../common/model.js';
 import { ViewModel } from '../../../../common/viewModel/viewModelImpl.js';
 import { CamelCaseAction, PascalCaseAction, DeleteAllLeftAction, DeleteAllRightAction, DeleteDuplicateLinesAction, DeleteLinesAction, IndentLinesAction, InsertLineAfterAction, InsertLineBeforeAction, JoinLinesAction, KebabCaseAction, LowerCaseAction, SnakeCaseAction, SortLinesAscendingAction, SortLinesDescendingAction, TitleCaseAction, TransposeAction, UpperCaseAction, ReverseLinesAction } from '../../browser/linesOperations.js';
 import { withTestCodeEditor } from '../../../../test/browser/testCodeEditor.js';
-import { createTextModel } from '../../../../test/common/testTextModel.js';
+import { createModelServices, createTextModel, instantiateTextModel } from '../../../../test/common/testTextModel.js';
 
 function assertSelection(editor: ICodeEditor, expected: Selection | Selection[]): void {
 	if (!Array.isArray(expected)) {
@@ -1361,6 +1366,218 @@ suite('Editor Contrib - Line Operations', () => {
 
 			}
 		);
+	});
+
+	suite('transformCase.skipStringsAndComments', () => {
+		// Lightweight tokenizer for the tests below: any character inside paired single quotes is
+		// classified as a string and any text following `//` to end-of-line is classified as a
+		// comment. Everything else is `Other`. The tokenizer is deliberately tiny so the tests
+		// can stay focused on the case-action's skip behaviour rather than language plumbing.
+		const TEST_LANGUAGE_ID = 'transformCaseSkipTestLang';
+
+		function makeTokenizationSupport(encodedLanguageId: number): ITokenizationSupport {
+			const otherMetadata = (
+				(encodedLanguageId << MetadataConsts.LANGUAGEID_OFFSET)
+				| (StandardTokenType.Other << MetadataConsts.TOKEN_TYPE_OFFSET)
+			) >>> 0;
+			const stringMetadata = (
+				(encodedLanguageId << MetadataConsts.LANGUAGEID_OFFSET)
+				| (StandardTokenType.String << MetadataConsts.TOKEN_TYPE_OFFSET)
+			) >>> 0;
+			const commentMetadata = (
+				(encodedLanguageId << MetadataConsts.LANGUAGEID_OFFSET)
+				| (StandardTokenType.Comment << MetadataConsts.TOKEN_TYPE_OFFSET)
+			) >>> 0;
+
+			return {
+				getInitialState: () => NullState,
+				tokenize: undefined!,
+				tokenizeEncoded: (line, _hasEOL, state) => {
+					type RawToken = { offset: number; metadata: number };
+					const raw: RawToken[] = [];
+					const pushIfNew = (offset: number, metadata: number) => {
+						if (raw.length === 0 || raw[raw.length - 1].metadata !== metadata) {
+							raw.push({ offset, metadata });
+						}
+					};
+					let i = 0;
+					while (i < line.length) {
+						if (line[i] === '/' && line[i + 1] === '/') {
+							pushIfNew(i, commentMetadata);
+							i = line.length;
+							break;
+						}
+						if (line[i] === '\'') {
+							pushIfNew(i, stringMetadata);
+							i++;
+							while (i < line.length && line[i] !== '\'') {
+								i++;
+							}
+							if (i < line.length) {
+								i++; // consume closing quote
+							}
+							pushIfNew(i, otherMetadata);
+							continue;
+						}
+						pushIfNew(i, otherMetadata);
+						i++;
+					}
+					if (raw.length === 0) {
+						pushIfNew(0, otherMetadata);
+					}
+					const result = new Uint32Array(raw.length * 2);
+					for (let t = 0; t < raw.length; t++) {
+						result[2 * t] = raw[t].offset;
+						result[2 * t + 1] = raw[t].metadata;
+					}
+					return new EncodedTokenizationResult(result, [], state);
+				}
+			};
+		}
+
+		function withTokenizedTestEditor(
+			lines: string[],
+			options: { skipStringsAndComments: boolean },
+			callback: (editor: ICodeEditor, model: ITextModel) => void
+		): void {
+			const disposables = new DisposableStore();
+			const instantiationService = createModelServices(disposables);
+			const languageService = instantiationService.get(ILanguageService);
+			disposables.add(languageService.registerLanguage({ id: TEST_LANGUAGE_ID }));
+			const encodedLanguageId = languageService.languageIdCodec.encodeLanguageId(TEST_LANGUAGE_ID);
+			disposables.add(TokenizationRegistry.register(TEST_LANGUAGE_ID, makeTokenizationSupport(encodedLanguageId)));
+			const model = disposables.add(instantiateTextModel(instantiationService, lines.join('\n'), TEST_LANGUAGE_ID));
+			for (let lineNumber = 1; lineNumber <= model.getLineCount(); lineNumber++) {
+				model.tokenization.forceTokenization(lineNumber);
+			}
+			withTestCodeEditor(model, { transformCase: { skipStringsAndComments: options.skipStringsAndComments } }, (editor) => {
+				callback(editor, model);
+			});
+			disposables.dispose();
+		}
+
+		test('default behaviour is unchanged: strings are upper-cased', () => {
+			withTokenizedTestEditor(
+				[`const greeting = 'hello world';`],
+				{ skipStringsAndComments: false },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `CONST GREETING = 'HELLO WORLD';`);
+				}
+			);
+		});
+
+		test('uppercase preserves string literals when skipStringsAndComments is on', () => {
+			withTokenizedTestEditor(
+				[`const greeting = 'hello world';`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `CONST GREETING = 'hello world';`);
+				}
+			);
+		});
+
+		test('lowercase preserves string literals when skipStringsAndComments is on', () => {
+			withTokenizedTestEditor(
+				[`CONST GREETING = 'HELLO WORLD';`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new LowerCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `const greeting = 'HELLO WORLD';`);
+				}
+			);
+		});
+
+		test('uppercase preserves line comments when skipStringsAndComments is on', () => {
+			withTokenizedTestEditor(
+				[`var x = 1; // keep me lowercase`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `VAR X = 1; // keep me lowercase`);
+				}
+			);
+		});
+
+		test('title case preserves string literals when skipStringsAndComments is on', () => {
+			withTokenizedTestEditor(
+				[`select * from users where name = 'john doe'`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new TitleCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `Select * From Users Where Name = 'john doe'`);
+				}
+			);
+		});
+
+		test('multiple strings on a single line are all preserved', () => {
+			withTokenizedTestEditor(
+				[`const a = 'first'; const b = 'second';`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					editor.setSelection(new Selection(1, 1, 1, model.getLineMaxColumn(1)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `CONST A = 'first'; CONST B = 'second';`);
+				}
+			);
+		});
+
+		test('cursor inside a string with empty selection is left untouched', () => {
+			withTokenizedTestEditor(
+				[`const greeting = 'hello world';`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					// cursor is in column 22, which is inside the 'hello world' string literal
+					editor.setSelection(new Selection(1, 22, 1, 22));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `const greeting = 'hello world';`);
+				}
+			);
+		});
+
+		test('cursor inside an identifier with empty selection is still transformed', () => {
+			withTokenizedTestEditor(
+				[`const greeting = 'hello world';`],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					// cursor is in column 9, inside the `greeting` identifier (column 7..15)
+					editor.setSelection(new Selection(1, 9, 1, 9));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `const GREETING = 'hello world';`);
+				}
+			);
+		});
+
+		test('multi-line selection preserves strings on each line', () => {
+			withTokenizedTestEditor(
+				[
+					`const a = 'first';`,
+					`const b = 'second';`,
+				],
+				{ skipStringsAndComments: true },
+				(editor, model) => {
+					const action = new UpperCaseAction();
+					editor.setSelection(new Selection(1, 1, 2, model.getLineMaxColumn(2)));
+					executeAction(action, editor);
+					assert.strictEqual(model.getLineContent(1), `CONST A = 'first';`);
+					assert.strictEqual(model.getLineContent(2), `CONST B = 'second';`);
+				}
+			);
+		});
 	});
 
 	suite('DeleteAllRightAction', () => {


### PR DESCRIPTION
## Summary

Adds a new opt-in editor setting `editor.transformCase.skipStringsAndComments` (boolean, default `false`). When enabled, the case-transformation actions — Transform to Uppercase, Lowercase, Title Case, Snake Case, Camel Case, Pascal Case, Kebab Case — leave ranges classified as strings or comments by the active language's tokenizer untouched.

Default behavior is preserved: with the setting off, the actions take the original code path and produce byte-identical output to before.

Fixes #149616

## Implementation

- New structured editor option `editor.transformCase` in `src/vs/editor/common/config/editorOptions.ts`, mirroring the `editor.comments.*` group so future sub-keys can be added without churn.
- Skip logic lives in `AbstractCaseAction.run()` in `src/vs/editor/contrib/linesOperations/browser/linesOperations.ts`. Two helpers:
  - `isRangeInStringOrComment` — used when the user invokes the action with an empty selection (cursor in a word). Returns true only when every covered token is `StandardTokenType.String` or `StandardTokenType.Comment`.
  - `splitRangeAroundStringsAndComments` — used for non-empty selections. Walks the line tokens and emits a list of "code" sub-ranges that exclude any string/comment spans. Each surviving sub-range is transformed independently via the existing `_modifyText(text, wordSeparators)` hook, which means every concrete action — Upper/Lower/Title/Snake/Camel/Pascal/Kebab — inherits the new behavior without per-action plumbing.
- Uses `model.tokenization.forceTokenization` + `findTokenIndexAtOffset`, the same pattern as `TrimTrailingWhitespaceCommand`.

## Test plan

- [x] 9 new unit tests in `linesOperations.test.ts` covering:
  - Default-off behavior is unchanged (string is upper-cased).
  - Uppercase / Lowercase / Title Case all preserve string literals when the setting is on.
  - Line comments are preserved.
  - Multiple strings on a single line are all preserved.
  - Cursor inside a string with empty selection is left untouched.
  - Cursor inside an identifier with empty selection is still transformed.
  - Multi-line selection preserves strings on each line.
- [ ] Manual: open a JS/TS file with strings and comments, set `"editor.transformCase.skipStringsAndComments": true`, select code, run "Transform to Uppercase" — strings and comments untouched.

The custom mocha tests use a tiny tokenizer (`'…'` = string, `//…EOL` = comment) so the test is focused on the skip behavior rather than language plumbing.