### PR TITLE
Add keyboard scrolling to the parameter hints widget

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
@@ -70,6 +70,42 @@ export class ParameterHintsController extends Disposable implements IEditorContr
 	trigger(context: TriggerContext): void {
 		this.model.trigger(context, 0);
 	}
+
+	focus(): void {
+		this.widget.rawValue?.focus();
+	}
+
+	scrollUp(): void {
+		this.widget.rawValue?.scrollUp();
+	}
+
+	scrollDown(): void {
+		this.widget.rawValue?.scrollDown();
+	}
+
+	scrollLeft(): void {
+		this.widget.rawValue?.scrollLeft();
+	}
+
+	scrollRight(): void {
+		this.widget.rawValue?.scrollRight();
+	}
+
+	pageUp(): void {
+		this.widget.rawValue?.pageUp();
+	}
+
+	pageDown(): void {
+		this.widget.rawValue?.pageDown();
+	}
+
+	goToTop(): void {
+		this.widget.rawValue?.goToTop();
+	}
+
+	goToBottom(): void {
+		this.widget.rawValue?.goToBottom();
+	}
 }
 
 export class TriggerParameterHintsAction extends EditorAction {
@@ -95,8 +131,223 @@ export class TriggerParameterHintsAction extends EditorAction {
 	}
 }
 
+export class FocusParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.focusParameterHints',
+			label: nls.localize2('parameterHints.focus.label', "Focus Parameter Hints"),
+			precondition: Context.Visible,
+			metadata: {
+				description: nls.localize2('parameterHints.focus.description', 'Move focus to the parameter hints widget so its contents can be scrolled with the keyboard.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.focus();
+	}
+}
+
+export class ScrollUpParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollUpParameterHints',
+			label: nls.localize2('parameterHints.scrollUp.label', "Scroll Up Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.UpArrow,
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.scrollUp.description', 'Scroll up the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.scrollUp();
+	}
+}
+
+export class ScrollDownParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollDownParameterHints',
+			label: nls.localize2('parameterHints.scrollDown.label', "Scroll Down Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.DownArrow,
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.scrollDown.description', 'Scroll down the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.scrollDown();
+	}
+}
+
+export class ScrollLeftParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollLeftParameterHints',
+			label: nls.localize2('parameterHints.scrollLeft.label', "Scroll Left Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.LeftArrow,
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.scrollLeft.description', 'Scroll left the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.scrollLeft();
+	}
+}
+
+export class ScrollRightParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollRightParameterHints',
+			label: nls.localize2('parameterHints.scrollRight.label', "Scroll Right Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.RightArrow,
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.scrollRight.description', 'Scroll right the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.scrollRight();
+	}
+}
+
+export class PageUpParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.pageUpParameterHints',
+			label: nls.localize2('parameterHints.pageUp.label', "Page Up Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.PageUp,
+				secondary: [KeyMod.Alt | KeyCode.UpArrow],
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.pageUp.description', 'Page up the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.pageUp();
+	}
+}
+
+export class PageDownParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.pageDownParameterHints',
+			label: nls.localize2('parameterHints.pageDown.label', "Page Down Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.PageDown,
+				secondary: [KeyMod.Alt | KeyCode.DownArrow],
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.pageDown.description', 'Page down the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.pageDown();
+	}
+}
+
+export class GoToTopParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.goToTopParameterHints',
+			label: nls.localize2('parameterHints.goToTop.label', "Go To Top Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.Home,
+				secondary: [KeyMod.CtrlCmd | KeyCode.UpArrow],
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.goToTop.description', 'Go to the top of the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.goToTop();
+	}
+}
+
+export class GoToBottomParameterHintsAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.goToBottomParameterHints',
+			label: nls.localize2('parameterHints.goToBottom.label', "Go To Bottom Parameter Hints"),
+			precondition: Context.Focused,
+			kbOpts: {
+				kbExpr: Context.Focused,
+				primary: KeyCode.End,
+				secondary: [KeyMod.CtrlCmd | KeyCode.DownArrow],
+				weight: KeybindingWeight.EditorContrib
+			},
+			metadata: {
+				description: nls.localize2('parameterHints.goToBottom.description', 'Go to the bottom of the parameter hints widget.')
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		ParameterHintsController.get(editor)?.goToBottom();
+	}
+}
+
 registerEditorContribution(ParameterHintsController.ID, ParameterHintsController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(TriggerParameterHintsAction);
+registerEditorAction(FocusParameterHintsAction);
+registerEditorAction(ScrollUpParameterHintsAction);
+registerEditorAction(ScrollDownParameterHintsAction);
+registerEditorAction(ScrollLeftParameterHintsAction);
+registerEditorAction(ScrollRightParameterHintsAction);
+registerEditorAction(PageUpParameterHintsAction);
+registerEditorAction(PageDownParameterHintsAction);
+registerEditorAction(GoToTopParameterHintsAction);
+registerEditorAction(GoToBottomParameterHintsAction);
 
 const weight = KeybindingWeight.EditorContrib + 75;
 
@@ -116,7 +367,7 @@ registerEditorCommand(new ParameterHintsCommand({
 
 registerEditorCommand(new ParameterHintsCommand({
 	id: 'showPrevParameterHint',
-	precondition: ContextKeyExpr.and(Context.Visible, Context.MultipleSignatures),
+	precondition: ContextKeyExpr.and(Context.Visible, Context.MultipleSignatures, Context.Focused.toNegated()),
 	handler: x => x.previous(),
 	kbOpts: {
 		weight: weight,
@@ -129,7 +380,7 @@ registerEditorCommand(new ParameterHintsCommand({
 
 registerEditorCommand(new ParameterHintsCommand({
 	id: 'showNextParameterHint',
-	precondition: ContextKeyExpr.and(Context.Visible, Context.MultipleSignatures),
+	precondition: ContextKeyExpr.and(Context.Visible, Context.MultipleSignatures, Context.Focused.toNegated()),
 	handler: x => x.next(),
 	kbOpts: {
 		weight: weight,

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
@@ -29,6 +29,8 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 
 const $ = dom.$;
 
+const HORIZONTAL_SCROLLING_BY = 30;
+
 const parameterHintsNextIcon = registerIcon('parameter-hints-next', Codicon.chevronDown, nls.localize('parameterHintsNextIcon', 'Icon for show next parameter hint.'));
 const parameterHintsPreviousIcon = registerIcon('parameter-hints-previous', Codicon.chevronUp, nls.localize('parameterHintsPreviousIcon', 'Icon for show previous parameter hint.'));
 
@@ -38,10 +40,12 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 
 	private readonly renderDisposeables = this._register(new DisposableStore());
 	private readonly keyVisible: IContextKey<boolean>;
+	private readonly keyFocused: IContextKey<boolean>;
 	private readonly keyMultipleSignatures: IContextKey<boolean>;
 
 	private domNodes?: {
 		readonly element: HTMLElement;
+		readonly wrapper: HTMLElement;
 		readonly signature: HTMLElement;
 		readonly docs: HTMLElement;
 		readonly overloads: HTMLElement;
@@ -63,6 +67,7 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 		super();
 
 		this.keyVisible = Context.Visible.bindTo(contextKeyService);
+		this.keyFocused = Context.Focused.bindTo(contextKeyService);
 		this.keyMultipleSignatures = Context.MultipleSignatures.bindTo(contextKeyService);
 	}
 
@@ -70,6 +75,10 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 		const element = $('.editor-widget.parameter-hints-widget');
 		const wrapper = dom.append(element, $('.phwrapper'));
 		wrapper.tabIndex = -1;
+
+		const focusTracker = this._register(dom.trackFocus(wrapper));
+		this._register(focusTracker.onDidFocus(() => this.keyFocused.set(true)));
+		this._register(focusTracker.onDidBlur(() => this.keyFocused.set(false)));
 
 		const controls = dom.append(wrapper, $('.controls'));
 		const previous = dom.append(controls, $('.button' + ThemeIcon.asCSSSelector(parameterHintsPreviousIcon)));
@@ -100,6 +109,7 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 
 		this.domNodes = {
 			element,
+			wrapper,
 			signature,
 			overloads,
 			docs,
@@ -164,6 +174,7 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 		}
 
 		this.keyVisible.reset();
+		this.keyFocused.reset();
 		this.visible = false;
 		this.announcedLabel = null;
 		this.domNodes?.element.classList.remove('visible');
@@ -336,6 +347,73 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 	previous(): void {
 		this.editor.focus();
 		this.model.previous();
+	}
+
+	public focus(): void {
+		this.domNodes?.wrapper.focus();
+	}
+
+	public scrollUp(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollTop = this.domNodes.scrollbar.getScrollPosition().scrollTop;
+		const fontInfo = this.editor.getOption(EditorOption.fontInfo);
+		this.domNodes.scrollbar.setScrollPosition({ scrollTop: scrollTop - fontInfo.lineHeight });
+	}
+
+	public scrollDown(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollTop = this.domNodes.scrollbar.getScrollPosition().scrollTop;
+		const fontInfo = this.editor.getOption(EditorOption.fontInfo);
+		this.domNodes.scrollbar.setScrollPosition({ scrollTop: scrollTop + fontInfo.lineHeight });
+	}
+
+	public scrollLeft(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollLeft = this.domNodes.scrollbar.getScrollPosition().scrollLeft;
+		this.domNodes.scrollbar.setScrollPosition({ scrollLeft: scrollLeft - HORIZONTAL_SCROLLING_BY });
+	}
+
+	public scrollRight(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollLeft = this.domNodes.scrollbar.getScrollPosition().scrollLeft;
+		this.domNodes.scrollbar.setScrollPosition({ scrollLeft: scrollLeft + HORIZONTAL_SCROLLING_BY });
+	}
+
+	public pageUp(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollTop = this.domNodes.scrollbar.getScrollPosition().scrollTop;
+		const scrollHeight = this.domNodes.scrollbar.getScrollDimensions().height;
+		this.domNodes.scrollbar.setScrollPosition({ scrollTop: scrollTop - scrollHeight });
+	}
+
+	public pageDown(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		const scrollTop = this.domNodes.scrollbar.getScrollPosition().scrollTop;
+		const scrollHeight = this.domNodes.scrollbar.getScrollDimensions().height;
+		this.domNodes.scrollbar.setScrollPosition({ scrollTop: scrollTop + scrollHeight });
+	}
+
+	public goToTop(): void {
+		this.domNodes?.scrollbar.setScrollPosition({ scrollTop: 0 });
+	}
+
+	public goToBottom(): void {
+		if (!this.domNodes) {
+			return;
+		}
+		this.domNodes.scrollbar.setScrollPosition({ scrollTop: this.domNodes.scrollbar.getScrollDimensions().scrollHeight });
 	}
 
 	getDomNode(): HTMLElement {

--- a/src/vs/editor/contrib/parameterHints/browser/provideSignatureHelp.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/provideSignatureHelp.ts
@@ -18,6 +18,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 
 export const Context = {
 	Visible: new RawContextKey<boolean>('parameterHintsVisible', false),
+	Focused: new RawContextKey<boolean>('parameterHintsFocused', false),
 	MultipleSignatures: new RawContextKey<boolean>('parameterHintsMultipleSignatures', false),
 };
 


### PR DESCRIPTION
## Summary

Adds keyboard scrolling to the parameter hints widget, mirroring the hover widget's keyboard scroll feature (#139717) as alexdima requested in the linked issue.

A new context key `parameterHintsFocused` is wired via `dom.trackFocus` on the widget's existing `.phwrapper` element. While the widget is focused, nine new editor actions become active:

- `editor.action.focusParameterHints` — moves focus to the widget. No default keybinding (`Ctrl+K Ctrl+I` is owned by hover; users can bind via the Keyboard Shortcuts UI).
- `editor.action.scrollUp/Down/Left/RightParameterHints` — `↑`/`↓`/`←`/`→`. Vertical scroll uses `fontInfo.lineHeight`; horizontal uses a `HORIZONTAL_SCROLLING_BY = 30` constant, matching hover.
- `editor.action.pageUp/DownParameterHints` — `PageUp`/`PageDown` (primary) plus `Alt+↑`/`Alt+↓` (secondary). Scrolls by the widget's visible height.
- `editor.action.goToTop/BottomParameterHints` — `Home`/`End` (primary) plus `Ctrl+↑`/`Ctrl+↓` (secondary).

Fixes #167264

## Implementation

- `parameterHintsWidget.ts` — added scroll methods (`scrollUp/Down/Left/Right`, `pageUp/Down`, `goToTop/Bottom`) that operate on the existing `DomScrollableElement`. Added a `dom.trackFocus` on the wrapper that drives the new `parameterHintsFocused` context key.
- `provideSignatureHelp.ts` — added the `Context.Focused` raw context key (`parameterHintsFocused`).
- `parameterHints.ts` — added a `focus()` controller passthrough plus 9 new `EditorAction` subclasses (one per command). All are weight `EditorContrib` and gated by `Context.Focused`.

### One material divergence reviewers should weigh in on

The existing `showPrevParameterHint` / `showNextParameterHint` commands (default `Alt+↑/↓` for overload navigation, `weight = EditorContrib + 75`) had their preconditions extended with `Context.Focused.toNegated()`. Without this, the higher-weight overload commands match the same keys as the new `pageUp/Down` scroll commands and always win, so scroll never fires once the widget is focused.

The behavioral consequence: while the widget is **not** focused (the typing flow), `Alt+↑/↓` continue to navigate overloads exactly as today. Once the user invokes \"Focus Parameter Hints\", `Alt+↑/↓` switches to PageUp/PageDown. This matches the hover model where editor-text-focus and widget-focus drive different command sets on the same keys.

If maintainers prefer overloads to remain navigable while focused, this precondition tweak can be reverted at the cost of removing `Alt+↑/↓` as a secondary on `pageUp/DownParameterHints`.

## Test plan

The repo has no widget DOM unit-test harness in `parameterHints/test/browser/` (only `parameterHintsModel.test.ts`), so this PR does not introduce one. The scroll math is one-line arithmetic mirrored verbatim from `contentHoverWidget.ts`.

Manual verification:

- [ ] Type a function call to bring up parameter hints, then run \"Focus Parameter Hints\" from the command palette. Widget gains focus.
- [ ] With the widget focused, `↑/↓` scrolls the docs by one line; `←/→` scrolls horizontally; `PageUp/PageDown` (and `Alt+↑/↓`) scrolls by visible height; `Home/End` (and `Ctrl+↑/↓`) jump to extents.
- [ ] With the widget unfocused (still visible), `Alt+↑/↓` continues to navigate overloads as today.
- [ ] Pressing `Esc` (or causing the widget to hide) clears the `parameterHintsFocused` context key.