### PR TITLE
Fix stale onCommandFinished filter to compare by marker identity

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -126,9 +126,15 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			// command's finished event before our new command has even started —
 			// causing the new command to be reported as having instantly exited
 			// 130 and cascading to every subsequent command on the same terminal.
-			const staleExecutingCommand = this._commandDetection.executingCommandObject;
-			const onCommandFinishedFiltered = staleExecutingCommand
-				? Event.filter(this._commandDetection.onCommandFinished, e => e !== staleExecutingCommand, store)
+			//
+			// Compare by marker identity rather than command object identity
+			// because `executingCommandObject` creates a new wrapper each call
+			// via `promoteToFullCommand()`, while `onCommandFinished` creates
+			// another. Both share the same xterm `IMarker` from
+			// `commandStartMarker`.
+			const staleMarker = this._commandDetection.executingCommandObject?.marker;
+			const onCommandFinishedFiltered = staleMarker
+				? Event.filter(this._commandDetection.onCommandFinished, e => e.marker !== staleMarker, store)
 				: this._commandDetection.onCommandFinished;
 
 			const idlePromptPromise = trackIdleOnPrompt(this._instance, idlePollInterval, store, idlePollInterval, this._logService);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -110,9 +110,16 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			// finished event before our new command has even started — causing
 			// the new command to be reported as having instantly exited 130 and
 			// cascading to every subsequent command on the same terminal.
-			const staleExecutingCommand = this._commandDetection.executingCommandObject;
-			const onCommandFinishedFiltered = staleExecutingCommand
-				? Event.filter(this._commandDetection.onCommandFinished, e => e !== staleExecutingCommand, store)
+			//
+			// Compare by marker identity rather than command object identity
+			// because `executingCommandObject` calls `promoteToFullCommand()`
+			// which creates a new wrapper each time, while `onCommandFinished`
+			// creates yet another wrapper. Both wrappers share the same
+			// underlying xterm `IMarker` reference from `commandStartMarker`,
+			// so marker identity is a reliable stable comparison.
+			const staleMarker = this._commandDetection.executingCommandObject?.marker;
+			const onCommandFinishedFiltered = staleMarker
+				? Event.filter(this._commandDetection.onCommandFinished, e => e.marker !== staleMarker, store)
 				: this._commandDetection.onCommandFinished;
 
 			// Subscribe to terminal lifecycle events BEFORE any awaits so that we


### PR DESCRIPTION
The exit-130 cascade filter introduced in PR #313414 compared command objects by reference identity (e !== staleExecutingCommand). This worked for AHP terminals where executingCommandObject returns the same object reference, but failed for standard CommandDetectionCapability where executingCommandObject calls promoteToFullCommand() which creates a new wrapper object each time. The onCommandFinished event also creates a separate wrapper via promoteToFullCommand(). Since these are different objects, the identity check (e !== staleExecutingCommand) always passed, making the filter a no-op.

Fix: compare by the underlying xterm IMarker reference (commandStartMarker) which is shared between both promoted wrappers, providing a stable identity.

Evidence from eval runs 25181796216 and 25181764231 (agent build c64d40ebc3 which includes PR #313414):
- Exit-130 cascade still present in 8 and 5 tasks respectively
- Pattern: 30s data-idle fallback abandons command, next command gets sequence D (runCommand sends ^C), exit 130 fires within 1ms
- Filter was present in build but never caught the stale event

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
