### PR TITLE
fix: skip setYieldRequested for terminal-originated steering messages

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -880,12 +880,13 @@ export class ChatService extends Disposable implements IChatService {
 		model.addPendingRequest(requestModel, options.queue ?? ChatRequestQueueKind.Queued, { ...options, queue: undefined });
 
 		if (options.queue === ChatRequestQueueKind.Steering && !options.terminalExecutionId) {
-			// Only yield the active request for non-terminal steering messages.
-			// Terminal notifications (input-needed / command-completed) carry a
-			// terminalExecutionId — the model already received the terminal state
-			// as a tool result in its current turn and may be handling it. Yielding
-			// would kill that turn prematurely. The queued steering request will
-			// still be processed after the current turn completes.
+			// Steering requests only set yieldRequested for non-terminal messages.
+			// Terminal steering notifications (input-needed / command-completed)
+			// carry a terminalExecutionId. In that case, the model already received
+			// the terminal state as a tool result in its current turn and may still
+			// be handling it. Yielding would kill that turn prematurely, so the
+			// steering request remains queued and is processed after the current
+			// turn completes.
 			this.setYieldRequested(sessionResource);
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -879,7 +879,13 @@ export class ChatService extends Disposable implements IChatService {
 
 		model.addPendingRequest(requestModel, options.queue ?? ChatRequestQueueKind.Queued, { ...options, queue: undefined });
 
-		if (options.queue === ChatRequestQueueKind.Steering) {
+		if (options.queue === ChatRequestQueueKind.Steering && !options.terminalExecutionId) {
+			// Only yield the active request for non-terminal steering messages.
+			// Terminal notifications (input-needed / command-completed) carry a
+			// terminalExecutionId — the model already received the terminal state
+			// as a tool result in its current turn and may be handling it. Yielding
+			// would kill that turn prematurely. The queued steering request will
+			// still be processed after the current turn completes.
 			this.setYieldRequested(sessionResource);
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -661,7 +661,7 @@ suite('ChatService', () => {
 		await response.data.responseCompletePromise;
 	});
 
-	test('terminal steering message does not trigger setYieldRequested', async () => {
+	test('terminal steering message does not call setYieldRequested(true)', async () => {
 		const requestStarted = new DeferredPromise<void>();
 		const completeRequest = new DeferredPromise<void>();
 		let yieldRequestedWithTrue = false;

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -661,6 +661,54 @@ suite('ChatService', () => {
 		await response.data.responseCompletePromise;
 	});
 
+	test('terminal steering message does not trigger setYieldRequested', async () => {
+		const requestStarted = new DeferredPromise<void>();
+		const completeRequest = new DeferredPromise<void>();
+		let yieldRequestedWithTrue = false;
+
+		const slowAgent: IChatAgentImplementation = {
+			async invoke(request, progress, history, token) {
+				requestStarted.complete();
+				await completeRequest.p;
+				return {};
+			},
+			setYieldRequested(requestId: string, value: boolean) {
+				if (value) {
+					yieldRequestedWithTrue = true;
+				}
+			},
+		};
+
+		testDisposables.add(chatAgentService.registerAgent('slowAgent', { ...getAgentData('slowAgent'), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation('slowAgent', slowAgent));
+
+		const testService = createChatService();
+		const modelRef = testDisposables.add(startSessionModel(testService));
+		const model = modelRef.object;
+
+		// Start a request that will wait
+		const response = await testService.sendRequest(model.sessionResource, 'first request', { agentId: 'slowAgent' });
+		ChatSendResult.assertSent(response);
+
+		// Wait for the agent to start processing
+		await requestStarted.p;
+
+		// Queue a terminal steering message while the first request is still in progress
+		const steeringResponse = await testService.sendRequest(model.sessionResource, 'terminal needs input', {
+			agentId: 'slowAgent',
+			queue: ChatRequestQueueKind.Steering,
+			terminalExecutionId: 'term-123',
+		});
+		assert.strictEqual(steeringResponse.kind, 'queued');
+
+		// setYieldRequested(true) should NOT be called for terminal-originated steering messages
+		assert.strictEqual(yieldRequestedWithTrue, false, 'setYieldRequested(true) should not be called for terminal steering messages');
+
+		// Complete the first request
+		completeRequest.complete();
+		await response.data.responseCompletePromise;
+	});
+
 	test('multiple steering messages are combined into a single request', async () => {
 		const requestStarted = new DeferredPromise<void>();
 		const completeRequest = new DeferredPromise<void>();


### PR DESCRIPTION
## Problem

When the terminal output monitor detects a command may need input, it sends a steering request with `ChatRequestQueueKind.Steering`. The `queuePendingRequest` method in `chatServiceImpl.ts` unconditionally calls `setYieldRequested(true)` for all steering messages, which propagates to the tool calling loop and **breaks the model's current turn** before it can process the `run_in_terminal` tool result that already contains the input-needed information.

This causes the model to hang — the original turn is killed, and the follow-up steering message often produces no meaningful response since the context is lost.

## Evidence from eval runs

### Run 25181796216 (claude-opus-4.6, terminalbench2)

**nginx-request-logging** (resolved=false):
- Request 0 (user task): The model called `run_in_terminal` with `apt-get update && apt-get install -y nginx curl && mkdir -p /var/www/html /var/log/nginx`. The tool result returned *"Note: The command is running in terminal ID 62c7e3c5-... and may be waiting for input."*
- The response ends abruptly at part [4] (`toolInvocationSerialized` for `run_in_terminal`) with no result — the turn was killed by `yieldRequested` before the model could process the tool result
- Request 1 (system steering): `systemInitiatedLabel: "apt-get update && apt-get install -y nginx curl && mkdir -p /var/www/html /var/log/nginx may need input"` — only produced `mcpServersStarting`, no meaningful agent response

### Run 25181764231 (gpt-5.4, terminalbench2)

4 benchmarks had "may need input" steering messages:
- **nginx-request-logging** (resolved=false): Same pattern — steering message with `terminalExecutionId: 7680cda4-...` yielded the turn
- **custom-memory-heap-crash** (resolved=false)
- **make-doom-for-mips** (resolved=false)
- fix-ocaml-gc (resolved=true — model recovered)

## Root cause

In `chatServiceImpl.ts`, `queuePendingRequest`:

```typescript
if (options.queue === ChatRequestQueueKind.Steering) {
    setYieldRequested(sessionResource);  // fires for ALL steering, including terminal
}
```

The `setYieldRequested` observable propagates through an autorun to `chatAgentService.setYieldRequested(agent.id, request.id, true)`, which the tool calling loop checks at two points:
- Line 948: `if (lastResult && this.options.yieldRequested?.()) { break; }` — breaks the tool loop
- Line 1287: `if (iterationNumber > 0 && this.options.yieldRequested?.()) { throw new CancellationError(); }` — cancels entirely

Terminal-originated steering messages should **not** yield the current turn because:
1. The model already receives the "may be waiting for input" information via the inline tool result
2. The steering message is a backup notification, not an urgent interruption
3. Yielding prevents the model from acting on the tool result it just received

## Fix

Add a guard to skip `setYieldRequested` when the steering request has a `terminalExecutionId`:

```typescript
if (options.queue === ChatRequestQueueKind.Steering && !options.terminalExecutionId) {
    setYieldRequested(sessionResource);
}
```

The steering request still queues and processes after the current turn via `processNextPendingRequest`.