### PR TITLE
Send copilot_plan to auto-intent-service for per-SKU routing

### DIFF
--- a/extensions/copilot/src/platform/authentication/common/copilotToken.ts
+++ b/extensions/copilot/src/platform/authentication/common/copilotToken.ts
@@ -175,6 +175,18 @@ export class CopilotToken {
 		}
 	}
 
+	/**
+	 * Returns the raw copilot_plan string from the token payload without normalization.
+	 * Used when the exact plan value must be preserved (e.g. for per-SKU routing overrides
+	 * where individual_edu, individual_pro_plus, etc. need distinct handling).
+	 */
+	get rawCopilotPlan(): string {
+		if (this.isFreeUser) {
+			return 'free';
+		}
+		return this._info.copilot_plan ?? 'individual';
+	}
+
 	get quotaInfo() {
 		return { quota_snapshots: this._info.quota_snapshots, quota_reset_date: this._info.quota_reset_date };
 	}

--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -78,7 +78,9 @@ export class RouterDecisionFetcher {
 		if (hasImage) {
 			requestBody.has_image = true;
 		}
-		const copilotToken = (await this._authService.getCopilotToken()).token;
+		const copilotTokenObj = await this._authService.getCopilotToken();
+		const copilotToken = copilotTokenObj.token;
+		requestBody.copilot_plan = copilotTokenObj.copilotPlan;
 		const abortController = new AbortController();
 		const timeout = setTimeout(() => abortController.abort(), 1000);
 		let response: Response;

--- a/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
+++ b/extensions/copilot/src/platform/endpoint/node/routerDecisionFetcher.ts
@@ -80,7 +80,7 @@ export class RouterDecisionFetcher {
 		}
 		const copilotTokenObj = await this._authService.getCopilotToken();
 		const copilotToken = copilotTokenObj.token;
-		requestBody.copilot_plan = copilotTokenObj.copilotPlan;
+		requestBody.copilot_plan = copilotTokenObj.rawCopilotPlan;
 		const abortController = new AbortController();
 		const timeout = setTimeout(() => abortController.abort(), 1000);
 		let response: Response;

--- a/extensions/copilot/src/platform/endpoint/test/node/routerDecisionFetcher.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/routerDecisionFetcher.spec.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test, vi } from 'vitest';
+import { RouterDecisionFetcher } from '../../node/routerDecisionFetcher';
+
+describe('RouterDecisionFetcher', () => {
+	test('includes copilot_plan in request body from rawCopilotPlan', async () => {
+		let capturedBody: string | undefined;
+
+		const mockAuthService = {
+			getCopilotToken: vi.fn().mockResolvedValue({
+				token: 'test-token',
+				rawCopilotPlan: 'individual_edu',
+				copilotPlan: 'individual', // normalized — should NOT be used
+			}),
+			onDidChangeCopilotToken: vi.fn(),
+		};
+
+		const mockResponse = {
+			ok: true,
+			text: vi.fn().mockResolvedValue(JSON.stringify({
+				predicted_label: 'no_reasoning',
+				confidence: 0.9,
+				latency_ms: 10,
+				candidate_models: ['gpt-4.1'],
+				scores: { needs_reasoning: 0.1, no_reasoning: 0.9 },
+			})),
+		};
+
+		const mockCapiClient = {
+			makeRequest: vi.fn().mockImplementation((opts: { body?: string }) => {
+				capturedBody = opts.body;
+				return Promise.resolve(mockResponse);
+			}),
+		};
+
+		const mockLogService = {
+			trace: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+
+		const mockTelemetryService = {
+			sendMSFTTelemetryEvent: vi.fn(),
+			sendEnhancedGHTelemetryEvent: vi.fn(),
+		};
+
+		const mockRequestLogger = {
+			addEntry: vi.fn(),
+		};
+
+		const fetcher = new RouterDecisionFetcher(
+			mockCapiClient as any,
+			mockAuthService as any,
+			mockLogService as any,
+			mockTelemetryService as any,
+			mockRequestLogger as any,
+		);
+
+		await fetcher.getRouterDecision(
+			'what is 2+2',
+			'session-token',
+			['gpt-4.1', 'claude-haiku-4.5'],
+		);
+
+		expect(capturedBody).toBeDefined();
+		const parsed = JSON.parse(capturedBody!);
+		expect(parsed.copilot_plan).toBe('individual_edu');
+		expect(parsed.prompt).toBe('what is 2+2');
+		expect(parsed.available_models).toEqual(['gpt-4.1', 'claude-haiku-4.5']);
+	});
+});


### PR DESCRIPTION
## Summary

Send `CopilotToken.copilotPlan` as `copilot_plan` in the router predict request body so the auto-intent-service can apply per-SKU routing overrides.

## Problem

The Hydra router uses a single `shortfall_threshold` (tau) and single set of model capability scores for all Copilot plans. This causes cost regression for Pro/Pro+ users because the config is tuned for Enterprise workloads:

- Pro users send 81.6% trivial prompts, but the Enterprise-tuned tau makes haiku fail eligibility on 58% of them
- This forces expensive codex/gpt-5.4 picks for simple queries like "how to export a list to json"

The auto-intent-service now supports per-SKU routing overrides ([github/auto-intent-service#81](https://github.com/github/auto-intent-service/pull/81)), but it needs the user's plan to look up the right config.

## Change

3-line change in `routerDecisionFetcher.ts`:

```diff
- const copilotToken = (await this._authService.getCopilotToken()).token;
+ const copilotTokenObj = await this._authService.getCopilotToken();
+ const copilotToken = copilotTokenObj.token;
+ requestBody.copilot_plan = copilotTokenObj.copilotPlan;
```

The `copilot_plan` field is added to the predict request body alongside `prompt`, `available_models`, `routing_method`, etc. Values: `individual`, `individual_pro`, `business`, `enterprise`, `free`, `individual_edu`.

## Impact

- The auto-intent-service uses this field to apply per-SKU shortfall thresholds:
  - Pro/Pro+: tau=0.50 (more permissive, routes more to haiku)
  - Enterprise/Business: tau=0.40 (stricter, preserves quality)
  - Free: tau=0.55 (most permissive)
- If the field is missing (older clients), the router falls through to base config (tau=0.45) -- fully backward compatible
- No new telemetry events; the field is logged server-side by auto-intent-service

## Companion PR

- [github/auto-intent-service#81](https://github.com/github/auto-intent-service/pull/81) -- Per-SKU routing overrides (server-side)
