### PR TITLE
Fix deprecated terminal sandbox setting fallback

### DIFF
--- a/src/vs/platform/networkFilter/common/networkFilterService.ts
+++ b/src/vs/platform/networkFilter/common/networkFilterService.ts
@@ -11,7 +11,7 @@ import { localize } from '../../../nls.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { AgentSandboxSettingId } from '../../sandbox/common/settings.js';
-import { ITerminalSandboxService } from '../../sandbox/common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxEnablement } from '../../sandbox/common/terminalSandboxService.js';
 import { extractDomainFromUri, isDomainAllowed } from './domainMatcher.js';
 import { AgentNetworkDomainSettingId } from './settings.js';
 
@@ -22,7 +22,7 @@ export const IAgentNetworkFilterService = createDecorator<IAgentNetworkFilterSer
  * integrated browser) based on the configured allowed/denied domain lists.
  *
  * Filtering is active when the `chat.agent.networkFilter` setting is enabled,
- * or when the terminal sandbox service reports that sandboxing is enabled.
+ * or when the terminal sandbox service reports sandboxing is on.
  * When both domain lists are empty, all domains are denied.
  * When a domain appears on the denied list it is always blocked, even if it
  * also matches an entry on the allowed list.
@@ -98,7 +98,7 @@ export class AgentNetworkFilterService extends Disposable implements IAgentNetwo
 	}
 
 	private async updateTerminalSandboxEnabled(): Promise<void> {
-		const enabled = await this.terminalSandboxService.isEnabled();
+		const enabled = (await this.terminalSandboxService.isEnabled()) === TerminalSandboxEnablement.On;
 		if (this.terminalSandboxEnabled === enabled) {
 			return;
 		}

--- a/src/vs/platform/networkFilter/test/common/networkFilterService.test.ts
+++ b/src/vs/platform/networkFilter/test/common/networkFilterService.test.ts
@@ -12,20 +12,20 @@ import { TestConfigurationService } from '../../../configuration/test/common/tes
 import { AgentNetworkFilterService } from '../../common/networkFilterService.js';
 import { AgentNetworkDomainSettingId } from '../../common/settings.js';
 import { AgentSandboxSettingId } from '../../../sandbox/common/settings.js';
-import { ITerminalSandboxService, NullTerminalSandboxService } from '../../../sandbox/common/terminalSandboxService.js';
+import { ITerminalSandboxService, NullTerminalSandboxService, TerminalSandboxEnablement } from '../../../sandbox/common/terminalSandboxService.js';
 
 suite('AgentNetworkFilterService', () => {
 
 	let disposables: DisposableStore;
 	let configService: TestConfigurationService;
-	let terminalSandboxEnabled: boolean;
+	let terminalSandboxEnablement: TerminalSandboxEnablement;
 	let terminalSandboxService: ITerminalSandboxService;
 
 	setup(() => {
 		disposables = new DisposableStore();
 		configService = new TestConfigurationService();
-		terminalSandboxEnabled = false;
-		terminalSandboxService = Object.assign(new NullTerminalSandboxService(), { isEnabled: async () => terminalSandboxEnabled });
+		terminalSandboxEnablement = TerminalSandboxEnablement.Off;
+		terminalSandboxService = Object.assign(new NullTerminalSandboxService(), { isEnabled: async () => terminalSandboxEnablement });
 		configService.setUserConfiguration(AgentNetworkDomainSettingId.NetworkFilter, true);
 		configService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, []);
 		configService.setUserConfiguration(AgentNetworkDomainSettingId.DeniedNetworkDomains, []);
@@ -62,13 +62,24 @@ suite('AgentNetworkFilterService', () => {
 
 	test('network filter disabled with sandbox enabled activates filtering', async () => {
 		configService.setUserConfiguration(AgentNetworkDomainSettingId.NetworkFilter, false);
-		terminalSandboxEnabled = true;
+		terminalSandboxEnablement = TerminalSandboxEnablement.On;
 		configService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, ['example.com']);
 
 		const service = await createService();
 
 		assert.strictEqual(service.isUriAllowed(URI.parse('https://example.com')), true);
 		assert.strictEqual(service.isUriAllowed(URI.parse('https://other.com')), false);
+	});
+
+	test('network filter disabled with sandbox network allowed does not activate filtering', async () => {
+		configService.setUserConfiguration(AgentNetworkDomainSettingId.NetworkFilter, false);
+		terminalSandboxEnablement = TerminalSandboxEnablement.NetworkAllowed;
+		configService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, ['example.com']);
+
+		const service = await createService();
+
+		assert.strictEqual(service.isUriAllowed(URI.parse('https://example.com')), true);
+		assert.strictEqual(service.isUriAllowed(URI.parse('https://other.com')), true);
 	});
 
 	test('denies all domains when both lists are empty', async () => {
@@ -152,7 +163,7 @@ suite('AgentNetworkFilterService', () => {
 		let fired = false;
 		disposables.add(service.onDidChange(() => { fired = true; }));
 
-		terminalSandboxEnabled = true;
+		terminalSandboxEnablement = TerminalSandboxEnablement.On;
 		fireConfigChange(AgentSandboxSettingId.AgentSandboxEnabled);
 		await Promise.resolve();
 

--- a/src/vs/platform/sandbox/common/settings.ts
+++ b/src/vs/platform/sandbox/common/settings.ts
@@ -14,4 +14,5 @@ export const enum AgentSandboxSettingId {
 export const enum AgentSandboxEnabledValue {
 	Off = 'off',
 	On = 'on',
+	AllowNetwork = 'allowNetwork',
 }

--- a/src/vs/platform/sandbox/common/terminalSandboxService.ts
+++ b/src/vs/platform/sandbox/common/terminalSandboxService.ts
@@ -22,6 +22,16 @@ export const enum TerminalSandboxPrerequisiteCheck {
 	Dependencies = 'dependencies',
 }
 
+export const enum TerminalSandboxEnablement {
+	Off = 'off',
+	On = 'on',
+	NetworkAllowed = 'networkAllowed',
+}
+
+export function isTerminalSandboxEnabled(enablement: TerminalSandboxEnablement): boolean {
+	return enablement !== TerminalSandboxEnablement.Off;
+}
+
 export interface ITerminalSandboxPrerequisiteCheckResult {
 	enabled: boolean;
 	sandboxConfigPath: string | undefined;
@@ -70,7 +80,7 @@ export interface ISandboxDependencyInstallResult {
 
 export interface ITerminalSandboxService {
 	readonly _serviceBrand: undefined;
-	isEnabled(): Promise<boolean>;
+	isEnabled(): Promise<TerminalSandboxEnablement>;
 	getOS(): Promise<OperatingSystem>;
 	checkForSandboxingPrereqs(forceRefresh?: boolean): Promise<ITerminalSandboxPrerequisiteCheckResult>;
 	wrapCommand(command: string, requestUnsandboxedExecution?: boolean, shell?: string, commandKeywords?: readonly string[], cwd?: URI): Promise<ITerminalSandboxWrapResult>;
@@ -85,8 +95,8 @@ export interface ITerminalSandboxService {
 export class NullTerminalSandboxService implements ITerminalSandboxService {
 	readonly _serviceBrand: undefined;
 
-	async isEnabled(): Promise<boolean> {
-		return false;
+	async isEnabled(): Promise<TerminalSandboxEnablement> {
+		return TerminalSandboxEnablement.Off;
 	}
 
 	async getOS(): Promise<OperatingSystem> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineSandboxAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineSandboxAnalyzer.ts
@@ -6,7 +6,7 @@
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
-import { ITerminalSandboxService } from '../../../common/terminalSandboxService.js';
+import { isTerminalSandboxEnabled, ITerminalSandboxService } from '../../../common/terminalSandboxService.js';
 import type { ICommandLineAnalyzer, ICommandLineAnalyzerOptions, ICommandLineAnalyzerResult } from './commandLineAnalyzer.js';
 
 export class CommandLineSandboxAnalyzer extends Disposable implements ICommandLineAnalyzer {
@@ -23,7 +23,7 @@ export class CommandLineSandboxAnalyzer extends Disposable implements ICommandLi
 
 	async analyze(_options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
 		const isAutoApproveEnabled = this._isAutoApproveEnabled();
-		if (!(await this._sandboxService.isEnabled())) {
+		if (!isTerminalSandboxEnabled(await this._sandboxService.isEnabled())) {
 			return {
 				isAutoApproveAllowed: isAutoApproveEnabled,
 			};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLinePresenter/sandboxedCommandLinePresenter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLinePresenter/sandboxedCommandLinePresenter.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ITerminalSandboxService } from '../../../common/terminalSandboxService.js';
+import { isTerminalSandboxEnabled, ITerminalSandboxService } from '../../../common/terminalSandboxService.js';
 import type { ICommandLinePresenter, ICommandLinePresenterOptions, ICommandLinePresenterResult } from './commandLinePresenter.js';
 
 /**
@@ -19,7 +19,7 @@ export class SandboxedCommandLinePresenter implements ICommandLinePresenter {
 	}
 
 	async present(options: ICommandLinePresenterOptions): Promise<ICommandLinePresenterResult | undefined> {
-		if (!(await this._sandboxService.isEnabled())) {
+		if (!isTerminalSandboxEnabled(await this._sandboxService.isEnabled())) {
 			return undefined;
 		}
 		return {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -77,7 +77,7 @@ import { clamp } from '../../../../../../base/common/numbers.js';
 import { IOutputAnalyzer } from './outputAnalyzer.js';
 import { SandboxOutputAnalyzer, outputLooksSandboxBlocked } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
+import { isTerminalSandboxEnabled, ITerminalSandboxService, TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxResolvedNetworkDomains } from '../../common/terminalSandboxService.js';
 import { LanguageModelPartAudience } from '../../../../chat/common/languageModels.js';
 import { isSessionAutoApproveLevel, isTerminalAutoApproveAllowed, isToolEligibleForTerminalAutoApproval } from './terminalToolAutoApprove.js';
 import type { IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
@@ -277,13 +277,14 @@ export async function createRunInTerminalToolData(
 	const terminalSandboxService = accessor.get(ITerminalSandboxService);
 
 	const profileFetcher = instantiationService.createInstance(TerminalProfileFetcher);
-	const [shell, os, isSandboxEnabled] = await Promise.all([
+	const [shell, os, sandboxEnablement] = await Promise.all([
 		profileFetcher.getCopilotShell(),
 		profileFetcher.osBackend,
 		terminalSandboxService.isEnabled(),
 	]);
 
-	const networkDomains = isSandboxEnabled ? terminalSandboxService.getResolvedNetworkDomains() : undefined;
+	const isSandboxEnabled = isTerminalSandboxEnabled(sandboxEnablement);
+	const networkDomains = sandboxEnablement === TerminalSandboxEnablement.On ? terminalSandboxService.getResolvedNetworkDomains() : undefined;
 
 	let modelDescription: string;
 	if (shell && os && isPowerShell(shell, os)) {
@@ -528,8 +529,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 	 * Controls whether this tool wires up sandbox-specific command-line
 	 * behavior, including both the {@link CommandLineSandboxRewriter} and the
 	 * {@link CommandLineSandboxAnalyzer}. This is separate from
-	 * ITerminalSandboxService.isEnabled(), which reports whether terminal
-	 * sandboxing is currently enabled for the running window.
+	 * ITerminalSandboxService.isEnabled(), which reports the current terminal
+	 * sandboxing enablement for the running window.
 	 */
 	protected get _enableCommandLineSandboxRewriting() {
 		return true;
@@ -1195,7 +1196,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		);
 
 		const didSandboxWrapCommand = toolSpecificData.commandLine.isSandboxWrapped === true;
-		const isSandboxEnabled = await this._terminalSandboxService.isEnabled();
+		const isSandboxEnabled = isTerminalSandboxEnabled(await this._terminalSandboxService.isEnabled());
 		const commandLineForMetadata = isSandboxEnabled
 			? toolSpecificData.commandLine.forDisplay ?? toolSpecificData.commandLine.original
 			: undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -521,10 +521,11 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 	[AgentSandboxSettingId.AgentSandboxEnabled]: {
 		markdownDescription: localize('agentSandbox.enabledSetting', "Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system."),
 		type: 'string',
-		enum: [AgentSandboxEnabledValue.Off, AgentSandboxEnabledValue.On],
+		enum: [AgentSandboxEnabledValue.Off, AgentSandboxEnabledValue.On, AgentSandboxEnabledValue.AllowNetwork],
 		enumDescriptions: [
 			localize('agentSandbox.enabledSetting.offDescription', 'Disable sandboxing for agent mode tools.'),
 			localize('agentSandbox.enabledSetting.onDescription', 'Enable sandboxing for agent mode tools.'),
+			localize('agentSandbox.enabledSetting.allowNetworkDescription', 'Enable sandboxing for agent mode tools, but do not block commands based on configured network domains.'),
 		],
 		default: AgentSandboxEnabledValue.Off,
 		tags: ['preview'],
@@ -549,6 +550,10 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 					{
 						key: 'agentSandbox.enabledSetting.onDescription',
 						value: localize('agentSandbox.enabledSetting.onDescription', 'Enable sandboxing for agent mode tools.'),
+					},
+					{
+						key: 'agentSandbox.enabledSetting.allowNetworkDescription',
+						value: localize('agentSandbox.enabledSetting.allowNetworkDescription', 'Enable sandboxing for agent mode tools, but do not block commands based on configured network domains.'),
 					},
 				]
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -760,9 +760,14 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		if (setting.userValue !== undefined) {
 			return setting.value;
 		}
+		const userConfiguredKeys = this._configurationService.keys().user;
 		for (const deprecatedId of deprecatedSettingIds) {
 			const deprecated = this._configurationService.inspect<T>(deprecatedId);
-			if (deprecated.userValue !== undefined) {
+			// Some deprecated settings are parent keys of newer settings, for example
+			// `chat.agent.sandbox` and `chat.agent.sandbox.fileSystem.linux`. Inspecting the
+			// parent key can return the namespace object even when the deprecated key itself
+			// was not configured, so only fall back when the exact deprecated key exists.
+			if (deprecated.userValue !== undefined && userConfiguredKeys.includes(deprecatedId)) {
 				this._logService.warn(`TerminalSandboxService: Using deprecated setting ${deprecatedId} because ${settingId} is not set. Please update your settings to use ${settingId} instead.`);
 				return deprecated.value;
 			}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -564,7 +564,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 				denyWritePaths = this._resolveLinuxFileSystemPaths(linuxFileSystemSetting.denyWrite);
 			}
 			const sandboxSettings = {
-				network: allowNetwork ? { enabled: false } : this.getResolvedNetworkDomains(),
+				network: allowNetwork ? { enabled: false, allowedDomains: [], deniedDomains: [] } : this.getResolvedNetworkDomains(),
 				filesystem: {
 					denyRead: denyReadPaths,
 					allowRead: allowReadPaths,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -34,10 +34,10 @@ import { ChatModel } from '../../../chat/common/model/chatModel.js';
 import { ElicitationState, IChatService } from '../../../chat/common/chatService/chatService.js';
 import { SANDBOX_HELPER_CHANNEL_NAME, SandboxHelperChannelClient } from '../../../../../platform/sandbox/common/sandboxHelperIpc.js';
 import { AgentSandboxEnabledValue, AgentSandboxSettingId } from '../../../../../platform/sandbox/common/settings.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ISandboxDependencyInstallOptions, type ISandboxDependencyInstallResult, type ITerminalSandboxPrerequisiteCheckResult, type ITerminalSandboxResolvedNetworkDomains, type ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
+import { isTerminalSandboxEnabled, ITerminalSandboxService, TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck, type ISandboxDependencyInstallOptions, type ISandboxDependencyInstallResult, type ITerminalSandboxPrerequisiteCheckResult, type ITerminalSandboxResolvedNetworkDomains, type ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 import { getTerminalSandboxReadAllowListForCommands } from './terminalSandboxReadAllowList.js';
 
-export { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
+export { isTerminalSandboxEnabled, ITerminalSandboxService, TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 export type { ISandboxDependencyInstallOptions, ISandboxDependencyInstallResult, ISandboxDependencyInstallTerminal, ITerminalSandboxPrerequisiteCheckResult, ITerminalSandboxResolvedNetworkDomains, ITerminalSandboxWrapResult } from '../../../../../platform/sandbox/common/terminalSandboxService.js';
 
 /**
@@ -137,8 +137,8 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		}));
 	}
 
-	public async isEnabled(): Promise<boolean> {
-		return await this._isSandboxConfiguredEnabled();
+	public async isEnabled(): Promise<TerminalSandboxEnablement> {
+		return await this._getSandboxEnablement();
 	}
 
 	public async getOS(): Promise<OperatingSystem> {
@@ -160,6 +160,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 			throw new Error('Sandbox config path or temp dir not initialized');
 		}
 
+		// Check if the command would attempt to access any blocked network domains before wrapping it in the sandbox.
 		const blockedDomainResult = requestUnsandboxedExecution ? { blockedDomains: [], deniedDomains: [] } : this._getBlockedDomains(command);
 		if (!requestUnsandboxedExecution && blockedDomainResult.blockedDomains.length > 0) {
 			return {
@@ -430,6 +431,10 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	}
 
 	private _getBlockedDomains(command: string): { blockedDomains: string[]; deniedDomains: string[] } {
+		if (this._isSandboxAllowNetworkEnabled()) {
+			return { blockedDomains: [], deniedDomains: [] };
+		}
+
 		const domains = this._extractDomains(command);
 		if (domains.length === 0) {
 			return { blockedDomains: [], deniedDomains: [] };
@@ -503,11 +508,15 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	}
 
 	private async _isSandboxConfiguredEnabled(): Promise<boolean> {
+		return isTerminalSandboxEnabled(await this._getSandboxEnablement());
+	}
+
+	private async _getSandboxEnablement(): Promise<TerminalSandboxEnablement> {
 		const os = await this.getOS();
 		if (os === OperatingSystem.Windows) {
-			return false;
+			return TerminalSandboxEnablement.Off;
 		}
-		return this._isSandboxEnabled(this._getSettingValue<AgentSandboxEnabledValue | boolean>(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxSettingId.DeprecatedAgentSandboxEnabled) ?? AgentSandboxEnabledValue.Off);
+		return this._getSandboxEnablementFromValue(this._getSandboxConfiguredEnabledValue());
 	}
 
 	private async _resolveSrtPath(): Promise<void> {
@@ -526,12 +535,11 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 
 	private async _createSandboxConfig(): Promise<string | undefined> {
 
-		if (await this.isEnabled() && !this._tempDir) {
+		if (isTerminalSandboxEnabled(await this.isEnabled()) && !this._tempDir) {
 			await this._initTempDir();
 		}
 		if (this._tempDir) {
-			const allowedDomainsSetting = this._getSettingValue<string[]>(AgentNetworkDomainSettingId.AllowedNetworkDomains, AgentNetworkDomainSettingId.DeprecatedSandboxAllowedNetworkDomains, AgentNetworkDomainSettingId.DeprecatedOldAllowedNetworkDomains) ?? [];
-			const deniedDomainsSetting = this._getSettingValue<string[]>(AgentNetworkDomainSettingId.DeniedNetworkDomains, AgentNetworkDomainSettingId.DeprecatedSandboxDeniedNetworkDomains, AgentNetworkDomainSettingId.DeprecatedOldDeniedNetworkDomains) ?? [];
+			const allowNetwork = this._isSandboxAllowNetworkEnabled();
 			const linuxFileSystemSetting = this._os === OperatingSystem.Linux
 				? this._getSettingValue<ITerminalSandboxFileSystemSetting>(TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem, TerminalChatAgentToolsSettingId.DeprecatedAgentSandboxLinuxFileSystem) ?? {}
 				: {};
@@ -556,10 +564,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 				denyWritePaths = this._resolveLinuxFileSystemPaths(linuxFileSystemSetting.denyWrite);
 			}
 			const sandboxSettings = {
-				network: {
-					allowedDomains: allowedDomainsSetting,
-					deniedDomains: deniedDomainsSetting
-				},
+				network: allowNetwork ? { enabled: false } : this.getResolvedNetworkDomains(),
 				filesystem: {
 					denyRead: denyReadPaths,
 					allowRead: allowReadPaths,
@@ -567,12 +572,18 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 					denyWrite: denyWritePaths,
 				},
 			};
-			this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, runtimeSetting);
+			this._mergeAdditionalSandboxConfigProperties(sandboxSettings as Record<string, unknown>, allowNetwork ? this._withoutNetworkRuntimeSetting(runtimeSetting) : runtimeSetting);
 			this._sandboxConfigPath = configFileUri.path;
 			await this._fileService.createFile(configFileUri, VSBuffer.fromString(JSON.stringify(sandboxSettings, null, '\t')), { overwrite: true });
 			return this._sandboxConfigPath;
 		}
 		return undefined;
+	}
+
+	private _withoutNetworkRuntimeSetting(runtimeSetting: Record<string, unknown>): Record<string, unknown> {
+		const sanitizedRuntimeSetting = { ...runtimeSetting };
+		delete sanitizedRuntimeSetting.network;
+		return sanitizedRuntimeSetting;
 	}
 
 	private _mergeAdditionalSandboxConfigProperties(target: Record<string, unknown>, additional: Record<string, unknown>): void {
@@ -600,7 +611,7 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	};
 
 	private async _initTempDir(): Promise<void> {
-		if (await this.isEnabled()) {
+		if (isTerminalSandboxEnabled(await this.isEnabled())) {
 			this._needsForceUpdateConfigFile = true;
 			const remoteEnv = this._remoteEnvDetails || await this._remoteEnvDetailsPromise;
 			this._tempDir = this._getSandboxTempDirPath(remoteEnv);
@@ -726,8 +737,22 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	}
 
 
-	private _isSandboxEnabled(value: AgentSandboxEnabledValue | boolean): boolean {
-		return value === true || value === AgentSandboxEnabledValue.On;
+	private _getSandboxConfiguredEnabledValue(): AgentSandboxEnabledValue | boolean {
+		return this._getSettingValue<AgentSandboxEnabledValue | boolean>(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxSettingId.DeprecatedAgentSandboxEnabled) ?? AgentSandboxEnabledValue.Off;
+	}
+
+	private _isSandboxAllowNetworkEnabled(): boolean {
+		return this._getSandboxConfiguredEnabledValue() === AgentSandboxEnabledValue.AllowNetwork;
+	}
+
+	private _getSandboxEnablementFromValue(value: AgentSandboxEnabledValue | boolean): TerminalSandboxEnablement {
+		if (value === true || value === AgentSandboxEnabledValue.On) {
+			return TerminalSandboxEnablement.On;
+		}
+		if (value === AgentSandboxEnabledValue.AllowNetwork) {
+			return TerminalSandboxEnablement.NetworkAllowed;
+		}
+		return TerminalSandboxEnablement.Off;
 	}
 
 	private _getSettingValue<T>(settingId: TerminalChatAgentToolsSettingId | AgentNetworkDomainSettingId | AgentSandboxSettingId, ...deprecatedSettingIds: (TerminalChatAgentToolsSettingId | AgentNetworkDomainSettingId | AgentSandboxSettingId)[]): T | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineSandboxAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineSandboxAnalyzer.test.ts
@@ -14,7 +14,7 @@ import type { ICommandLineAnalyzerOptions } from '../../browser/tools/commandLin
 import { CommandLineSandboxAnalyzer } from '../../browser/tools/commandLineAnalyzer/commandLineSandboxAnalyzer.js';
 import { TreeSitterCommandParserLanguage } from '../../browser/treeSitterCommandParser.js';
 import { TerminalChatAgentToolsSettingId } from '../../common/terminalChatAgentToolsConfiguration.js';
-import { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxEnablement } from '../../common/terminalSandboxService.js';
 
 suite('CommandLineSandboxAnalyzer', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -33,7 +33,7 @@ suite('CommandLineSandboxAnalyzer', () => {
 		}, store);
 		instantiationService.stub(ITerminalSandboxService, {
 			_serviceBrand: undefined,
-			isEnabled: async () => sandboxEnabled,
+			isEnabled: async () => sandboxEnabled ? TerminalSandboxEnablement.On : TerminalSandboxEnablement.Off,
 		} as unknown as ITerminalSandboxService);
 
 		analyzer = store.add(instantiationService.createInstance(CommandLineSandboxAnalyzer));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxedCommandLinePresenter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/sandboxedCommandLinePresenter.test.ts
@@ -9,7 +9,7 @@ import { OperatingSystem } from '../../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import type { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
-import { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxEnablement } from '../../common/terminalSandboxService.js';
 
 suite('SandboxedCommandLinePresenter', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -19,7 +19,7 @@ suite('SandboxedCommandLinePresenter', () => {
 		instantiationService = workbenchInstantiationService({}, store);
 		instantiationService.stub(ITerminalSandboxService, {
 			_serviceBrand: undefined,
-			isEnabled: async () => enabled,
+			isEnabled: async () => enabled ? TerminalSandboxEnablement.On : TerminalSandboxEnablement.Off,
 			wrapCommand: async command => ({
 				command,
 				isSandboxWrapped: false,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -907,28 +907,20 @@ suite('TerminalSandboxService - network domains', () => {
 		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.Off, 'Deprecated settings should not be used when only non-user scopes are set');
 	});
 
-	test('should fall back to deprecated chat.agent.sandbox setting in user scope', async () => {
+	test('should not fall back to deprecated chat.agent.sandbox setting due to namespace conflicts', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, undefined);
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.AgentSandboxLinuxFileSystem, {
+			allowWrite: ['/tmp']
+		});
+		const namespaceValue = { fileSystem: { linux: { allowWrite: ['/tmp'] } } };
 		const originalInspect = configurationService.inspect.bind(configurationService);
 		configurationService.inspect = <T>(key: string) => {
-			if (key === AgentSandboxSettingId.AgentSandboxEnabled) {
-				return {
-					value: undefined,
-					defaultValue: AgentSandboxEnabledValue.Off,
-					userValue: undefined,
-					userLocalValue: undefined,
-					userRemoteValue: undefined,
-					workspaceValue: undefined,
-					workspaceFolderValue: undefined,
-					memoryValue: undefined,
-					policyValue: undefined,
-				} as ReturnType<typeof originalInspect<T>>;
-			}
 			if (key === AgentSandboxSettingId.DeprecatedAgentSandboxEnabled) {
 				return {
-					value: true,
+					value: namespaceValue,
 					defaultValue: false,
-					userValue: true,
-					userLocalValue: true,
+					userValue: namespaceValue,
+					userLocalValue: namespaceValue,
 					userRemoteValue: undefined,
 					workspaceValue: undefined,
 					workspaceFolderValue: undefined,
@@ -938,6 +930,15 @@ suite('TerminalSandboxService - network domains', () => {
 			}
 			return originalInspect<T>(key);
 		};
+
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.Off, 'Child settings under chat.agent.sandbox should not be treated as the deprecated boolean setting');
+	});
+
+	test('should fall back to deprecated chat.agent.sandbox setting in user scope', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, undefined);
+		configurationService.setUserConfiguration(AgentSandboxSettingId.DeprecatedAgentSandboxEnabled, true);
 
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -8,7 +8,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestLifecycleService, workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { TestProductService } from '../../../../../test/common/workbenchTestServices.js';
-import { TerminalSandboxPrerequisiteCheck, TerminalSandboxService } from '../../common/terminalSandboxService.js';
+import { TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck, TerminalSandboxService } from '../../common/terminalSandboxService.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
@@ -208,9 +208,17 @@ suite('TerminalSandboxService - network domains', () => {
 	test('dependency checks should not be called for isEnabled', async () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 
-		strictEqual(await sandboxService.isEnabled(), true, 'Sandbox should be enabled when dependencies are present');
-		strictEqual(await sandboxService.isEnabled(), true, 'Sandbox should stay enabled on subsequent checks');
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.On, 'Sandbox should be enabled when dependencies are present');
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.On, 'Sandbox should stay enabled on subsequent checks');
 		strictEqual(sandboxHelperService.callCount, 0, 'Dependency checks should not be called for isEnabled');
+	});
+
+	test('should report enabled when configured to allow network', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.AllowNetwork);
+
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.NetworkAllowed, 'Allow network mode should keep sandboxing enabled with network access allowed');
 	});
 
 	test('should report dependency prereq failures', async () => {
@@ -260,6 +268,31 @@ suite('TerminalSandboxService - network domains', () => {
 			allowedDomains: ['example.com', '*.github.com'],
 			deniedDomains: ['blocked.example.com']
 		});
+	});
+
+	test('should disable runtime network config when configured to allow network', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.AllowNetwork);
+		configurationService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, ['example.com']);
+		configurationService.setUserConfiguration(AgentNetworkDomainSettingId.DeniedNetworkDomains, ['blocked.example.com']);
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.AgentSandboxAdvancedRuntime, {
+			network: {
+				allowedDomains: ['should-not-win.example'],
+				deniedDomains: ['should-not-win-blocked.example'],
+				allowUnixSockets: true,
+			},
+			allowPty: true,
+		});
+
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		const configPath = await sandboxService.getSandboxConfigPath();
+
+		ok(configPath, 'Config path should be defined');
+		const configContent = createdFiles.get(configPath);
+		ok(configContent, 'Config file should be created');
+
+		const config = JSON.parse(configContent);
+		deepStrictEqual(config.network, { enabled: false });
+		strictEqual(config.allowPty, true, 'Non-network runtime settings should still be merged');
 	});
 
 	test('should write configured runtime values to sandbox config root', async () => {
@@ -708,6 +741,21 @@ suite('TerminalSandboxService - network domains', () => {
 		deepStrictEqual(wrapResult.deniedDomains, ['api.github.com']);
 	});
 
+	test('should skip domain checks when configured to allow network', async () => {
+		configurationService.setUserConfiguration(AgentSandboxSettingId.AgentSandboxEnabled, AgentSandboxEnabledValue.AllowNetwork);
+		configurationService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, ['example.com']);
+		configurationService.setUserConfiguration(AgentNetworkDomainSettingId.DeniedNetworkDomains, ['api.github.com']);
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const wrapResult = await sandboxService.wrapCommand('curl https://api.github.com/repos/microsoft/vscode', false, 'bash');
+
+		strictEqual(wrapResult.isSandboxWrapped, true, 'Allow network mode should keep the command sandbox wrapped');
+		strictEqual(wrapResult.requiresUnsandboxConfirmation, undefined, 'Allow network mode should not require unsandbox confirmation for configured domains');
+		strictEqual(wrapResult.blockedDomains, undefined, 'Allow network mode should not report blocked domains');
+		strictEqual(wrapResult.deniedDomains, undefined, 'Allow network mode should not report denied domains');
+	});
+
 	test('should match uppercase hostnames when checking allowlisted domains', async () => {
 		configurationService.setUserConfiguration(AgentNetworkDomainSettingId.AllowedNetworkDomains, ['*.github.com']);
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
@@ -856,7 +904,7 @@ suite('TerminalSandboxService - network domains', () => {
 
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 
-		strictEqual(await sandboxService.isEnabled(), false, 'Deprecated settings should not be used when only non-user scopes are set');
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.Off, 'Deprecated settings should not be used when only non-user scopes are set');
 	});
 
 	test('should fall back to deprecated chat.agent.sandbox setting in user scope', async () => {
@@ -893,7 +941,7 @@ suite('TerminalSandboxService - network domains', () => {
 
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 
-		strictEqual(await sandboxService.isEnabled(), true, 'Deprecated chat.agent.sandbox should still be respected when only the user scope is set');
+		strictEqual(await sandboxService.isEnabled(), TerminalSandboxEnablement.On, 'Deprecated chat.agent.sandbox should still be respected when only the user scope is set');
 	});
 
 	test('should detect ssh style remotes as domains', async () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
@@ -12,7 +12,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import { CommandLineSandboxRewriter } from '../../browser/tools/commandLineRewriter/commandLineSandboxRewriter.js';
 import type { ICommandLineRewriterOptions } from '../../browser/tools/commandLineRewriter/commandLineRewriter.js';
 import type { TreeSitterCommandParser } from '../../browser/treeSitterCommandParser.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck } from '../../common/terminalSandboxService.js';
 
 suite('CommandLineSandboxRewriter', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
@@ -26,7 +26,7 @@ suite('CommandLineSandboxRewriter', () => {
 		instantiationService = workbenchInstantiationService({}, store);
 		instantiationService.stub(ITerminalSandboxService, {
 			_serviceBrand: undefined,
-			isEnabled: async () => false,
+			isEnabled: async () => TerminalSandboxEnablement.Off,
 			wrapCommand: async (command, _requestUnsandboxedExecution) => {
 				return {
 					command,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -40,7 +40,7 @@ import { ChatAgentLocation, ChatPermissionLevel } from '../../../../chat/common/
 import { ChatModel } from '../../../../chat/common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ChatRequestTextPart } from '../../../../chat/common/requestParser/chatParserTypes.js';
-import { ITerminalSandboxService, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
+import { ITerminalSandboxService, TerminalSandboxEnablement, TerminalSandboxPrerequisiteCheck, type ITerminalSandboxPrerequisiteCheckResult } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocationPreparationContext, ToolDataSource, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
@@ -184,7 +184,7 @@ suite('RunInTerminalTool', () => {
 		});
 		terminalSandboxService = {
 			_serviceBrand: undefined,
-			isEnabled: async () => sandboxEnabled,
+			isEnabled: async () => sandboxEnabled ? TerminalSandboxEnablement.On : TerminalSandboxEnablement.Off,
 			wrapCommand: async (command: string, requestUnsandboxedExecution?: boolean) => ({
 				command: requestUnsandboxedExecution ? `unsandboxed:${command}` : `sandbox:${command}`,
 				isSandboxWrapped: !requestUnsandboxedExecution,
@@ -2413,7 +2413,7 @@ suite('ChatAgentToolsContribution - tool registration refresh', () => {
 
 		const terminalSandboxService: ITerminalSandboxService = {
 			_serviceBrand: undefined,
-			isEnabled: async () => sandboxEnabled,
+			isEnabled: async () => sandboxEnabled ? TerminalSandboxEnablement.On : TerminalSandboxEnablement.Off,
 			wrapCommand: async (command: string) => ({
 				command: `sandbox:${command}`,
 				isSandboxWrapped: true,


### PR DESCRIPTION
## Summary
fixes #313409
- Prevent deprecated terminal sandbox settings from being used when `inspect()` returns a namespace object from child settings such as `chat.agent.sandbox.fileSystem.linux`
- Require the exact deprecated user setting key to exist before falling back to deprecated settings
- Add regression coverage for the `chat.agent.sandbox` namespace conflict while preserving exact deprecated user-setting fallback behavior

## Validation

- `npm run transpile-client`
- `npm run test-browser-no-install -- --browser chromium --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts --grep "deprecated chat.agent.sandbox|namespace conflicts|outside user scope"`
- `git --no-pager diff --check -- src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts`
