### PR TITLE
Add cached tokens to chat debug overview

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -932,6 +932,9 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 						...(span.attributes[GenAiAttr.USAGE_OUTPUT_TOKENS] !== undefined
 							? { outputTokens: asNumber(span.attributes[GenAiAttr.USAGE_OUTPUT_TOKENS]) }
 							: {}),
+						...(span.attributes[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS] !== undefined
+							? { cachedTokens: asNumber(span.attributes[GenAiAttr.USAGE_CACHE_READ_INPUT_TOKENS]) }
+							: {}),
 						...(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN] !== undefined
 							? { ttft: asNumber(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN]) }
 							: {}),

--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -114,7 +114,7 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 			case 'toolCall':
 				return { ...base, kind: 'toolCall', toolName: event.toolName, toolCallId: event.toolCallId, input: event.input, output: event.output, result: event.result, durationInMillis: event.durationInMillis };
 			case 'modelTurn':
-				return { ...base, kind: 'modelTurn', model: event.model, requestName: event.requestName, inputTokens: event.inputTokens, outputTokens: event.outputTokens, totalTokens: event.totalTokens, durationInMillis: event.durationInMillis };
+				return { ...base, kind: 'modelTurn', model: event.model, requestName: event.requestName, inputTokens: event.inputTokens, outputTokens: event.outputTokens, cachedTokens: event.cachedTokens, totalTokens: event.totalTokens, durationInMillis: event.durationInMillis };
 			case 'generic':
 				return { ...base, kind: 'generic', name: event.name, details: event.details, level: event.level, category: event.category };
 			case 'subagentInvocation':
@@ -154,6 +154,7 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 					requestName: dto.requestName,
 					inputTokens: dto.inputTokens,
 					outputTokens: dto.outputTokens,
+					cachedTokens: dto.cachedTokens,
 					totalTokens: dto.totalTokens,
 					durationInMillis: dto.durationInMillis,
 				};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1444,6 +1444,7 @@ export interface IChatDebugModelTurnEventDto extends IChatDebugEventCommonDto {
 	readonly requestName?: string;
 	readonly inputTokens?: number;
 	readonly outputTokens?: number;
+	readonly cachedTokens?: number;
 	readonly totalTokens?: number;
 	readonly durationInMillis?: number;
 }

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -155,6 +155,7 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 					requestName: e.requestName,
 					inputTokens: e.inputTokens,
 					outputTokens: e.outputTokens,
+					cachedTokens: e.cachedTokens,
 					totalTokens: e.totalTokens,
 					durationInMillis: e.durationInMillis,
 				};
@@ -341,6 +342,7 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 				evt.model = dto.model;
 				evt.inputTokens = dto.inputTokens;
 				evt.outputTokens = dto.outputTokens;
+				evt.cachedTokens = dto.cachedTokens;
 				evt.totalTokens = dto.totalTokens;
 				evt.durationInMillis = dto.durationInMillis;
 				return evt;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3636,6 +3636,7 @@ export class ChatDebugModelTurnEvent {
 	model?: string;
 	inputTokens?: number;
 	outputTokens?: number;
+	cachedTokens?: number;
 	totalTokens?: number;
 	cost?: number;
 	durationInMillis?: number;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
@@ -259,9 +259,11 @@ export class ChatDebugOverviewView extends Disposable {
 		const placeholderLabels = [
 			localize('chatDebug.metric.modelTurns', "Model Turns"),
 			localize('chatDebug.metric.toolCalls', "Tool Calls"),
+			localize('chatDebug.metric.totalInputTokens', "Total Input Tokens"),
+			localize('chatDebug.metric.totalOutputTokens', "Total Output Tokens"),
+			localize('chatDebug.metric.totalCachedInputTokens', "Total Cached Input Tokens"),
 			localize('chatDebug.metric.totalTokens', "Total Tokens"),
 			localize('chatDebug.metric.errors', "Errors"),
-			localize('chatDebug.metric.totalEvents', "Total Events"),
 		];
 		for (const label of placeholderLabels) {
 			const card = DOM.append(container, $('.chat-debug-overview-metric-card'));
@@ -280,15 +282,21 @@ export class ChatDebugOverviewView extends Disposable {
 			(e.kind === 'toolCall' && e.result === 'error')
 		);
 
+		const fmt = numberFormatter.value;
+		const totalInputTokens = modelTurns.reduce((sum, e) => sum + (e.inputTokens ?? 0), 0);
+		const totalOutputTokens = modelTurns.reduce((sum, e) => sum + (e.outputTokens ?? 0), 0);
+		const totalCachedTokens = modelTurns.reduce((sum, e) => sum + (e.cachedTokens ?? 0), 0);
 		const totalTokens = modelTurns.reduce((sum, e) => sum + (e.totalTokens ?? 0), 0);
 
 		interface OverviewMetric { label: string; value: string }
 		const metrics: OverviewMetric[] = [
-			{ label: localize('chatDebug.metric.modelTurns', "Model Turns"), value: String(modelTurns.length) },
-			{ label: localize('chatDebug.metric.toolCalls', "Tool Calls"), value: String(toolCalls.length) },
-			{ label: localize('chatDebug.metric.totalTokens', "Total Tokens"), value: numberFormatter.value.format(totalTokens) },
-			{ label: localize('chatDebug.metric.errors', "Errors"), value: String(errors.length) },
-			{ label: localize('chatDebug.metric.totalEvents', "Total Events"), value: String(events.length) },
+			{ label: localize('chatDebug.metric.modelTurns', "Model Turns"), value: fmt.format(modelTurns.length) },
+			{ label: localize('chatDebug.metric.toolCalls', "Tool Calls"), value: fmt.format(toolCalls.length) },
+			{ label: localize('chatDebug.metric.totalInputTokens', "Total Input Tokens"), value: fmt.format(totalInputTokens) },
+			{ label: localize('chatDebug.metric.totalOutputTokens', "Total Output Tokens"), value: fmt.format(totalOutputTokens) },
+			{ label: localize('chatDebug.metric.totalCachedInputTokens', "Total Cached Input Tokens"), value: fmt.format(totalCachedTokens) },
+			{ label: localize('chatDebug.metric.totalTokens', "Total Tokens"), value: fmt.format(totalTokens) },
+			{ label: localize('chatDebug.metric.errors', "Errors"), value: fmt.format(errors.length) },
 		];
 
 		for (const metric of metrics) {

--- a/src/vs/workbench/contrib/chat/common/chatDebugService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugService.ts
@@ -63,6 +63,7 @@ export interface IChatDebugModelTurnEvent extends IChatDebugEventCommon {
 	readonly requestName?: string;
 	readonly inputTokens?: number;
 	readonly outputTokens?: number;
+	readonly cachedTokens?: number;
 	readonly totalTokens?: number;
 	readonly durationInMillis?: number;
 }


### PR DESCRIPTION
Add `cachedTokens` field to the model turn event pipeline (ext host types, protocol DTOs, main thread, and file logger) so cached input token counts flow from OTel spans to the debug UI.

Update the chat debug overview to show **Total Input Tokens**, **Total Output Tokens**, and **Total Cached Input Tokens** metrics, replacing the less useful "Total Events" card. All metric values now use the number formatter for consistency.