### PR TITLE
cli plan widget providing feedback improvements

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions.ts
@@ -18,7 +18,6 @@ export const PlanReviewFeedbackMenuId = MenuId.for('planReviewFeedback.editorCon
 
 export const hasPlanReviewFeedback = new RawContextKey<boolean>('planReviewFeedback.hasFeedback', false);
 
-export const submitPlanReviewFeedbackActionId = 'planReviewFeedback.action.submit';
 export const navigatePreviousPlanReviewFeedbackActionId = 'planReviewFeedback.action.navigatePrevious';
 export const navigateNextPlanReviewFeedbackActionId = 'planReviewFeedback.action.navigateNext';
 export const clearAllPlanReviewFeedbackActionId = 'planReviewFeedback.action.clearAll';
@@ -43,36 +42,6 @@ function getActivePlanUri(accessor: ServicesAccessor): URI | undefined {
 	}
 
 	return undefined;
-}
-
-class SubmitPlanReviewFeedbackAction extends Action2 {
-
-	constructor() {
-		super({
-			id: submitPlanReviewFeedbackActionId,
-			title: localize2('planReviewFeedback.submit', 'Submit Feedback'),
-			shortTitle: localize2('planReviewFeedback.submitShort', 'Submit'),
-			icon: Codicon.send,
-			category: CHAT_CATEGORY,
-			precondition: hasPlanReviewFeedback,
-			menu: {
-				id: PlanReviewFeedbackMenuId,
-				group: 'a_submit',
-				order: 0,
-				when: hasPlanReviewFeedback,
-			},
-		});
-	}
-
-	override run(accessor: ServicesAccessor): void {
-		const planUri = getActivePlanUri(accessor);
-		if (!planUri) {
-			return;
-		}
-
-		const planReviewFeedbackService = accessor.get(IPlanReviewFeedbackService);
-		planReviewFeedbackService.submitAllFeedback(planUri);
-	}
 }
 
 class NavigatePlanReviewFeedbackAction extends Action2 {
@@ -132,8 +101,8 @@ class ClearAllPlanReviewFeedbackAction extends Action2 {
 			precondition: hasPlanReviewFeedback,
 			menu: {
 				id: PlanReviewFeedbackMenuId,
-				group: 'a_submit',
-				order: 1,
+				group: 'a_actions',
+				order: 0,
 				when: hasPlanReviewFeedback,
 			},
 		});
@@ -151,7 +120,6 @@ class ClearAllPlanReviewFeedbackAction extends Action2 {
 }
 
 export function registerPlanReviewFeedbackEditorActions(): void {
-	registerAction2(SubmitPlanReviewFeedbackAction);
 	registerAction2(class extends NavigatePlanReviewFeedbackAction { constructor() { super(false); } });
 	registerAction2(class extends NavigatePlanReviewFeedbackAction { constructor() { super(true); } });
 	registerAction2(ClearAllPlanReviewFeedbackAction);
@@ -159,7 +127,7 @@ export function registerPlanReviewFeedbackEditorActions(): void {
 	MenuRegistry.appendMenuItem(PlanReviewFeedbackMenuId, {
 		command: {
 			id: navigationBearingFakeActionId,
-			title: localize('label', 'Navigation Status'),
+			title: localize('planReviewFeedback.navStatus.label', 'Navigation Status'),
 			precondition: ContextKeyExpr.false(),
 		},
 		group: 'navigate',

--- a/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.ts
@@ -314,11 +314,6 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 		this._register(this._planReviewFeedbackService.onDidChangeFeedback(() => this._updateDecorations()));
 		this._register(this._planReviewFeedbackService.onDidChangeNavigation(() => this._updateDecorations()));
 
-		// Editor contributions registered with `Eventually` are instantiated
-		// after the editor's model is already attached, so `onDidChangeModel`
-		// would not fire and `_isActivePlan` would remain false. Sync state
-		// from the current model so the inline overlay activates correctly
-		// when the contribution wakes up against an already-loaded plan file.
 		this._onModelChanged();
 	}
 
@@ -377,10 +372,9 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 	private _show(): void {
 		const widget = this._ensureWidget();
 
-		// Only clear the input when transitioning from hidden to shown.
-		// `_show()` is called on every selection change, so clearing here
-		// unconditionally would wipe a draft if the user momentarily
-		// refocuses the editor while typing a comment.
+		// `_show()` runs on every selection change, so only clear input on
+		// the hidden→shown transition to avoid wiping a draft when the user
+		// briefly refocuses the editor.
 		const wasVisible = this._visible;
 		if (!wasVisible) {
 			this._visible = true;

--- a/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution.ts
@@ -14,7 +14,7 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { OverviewRulerLane } from '../../../../../editor/common/model.js';
 import { themeColorFromId } from '../../../../../platform/theme/common/themeService.js';
 import { overviewRulerInfo } from '../../../../../editor/common/core/editorColorRegistry.js';
-import { addStandardDisposableListener, getWindow, ModifierKeyEmitter } from '../../../../../base/browser/dom.js';
+import { addStandardDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { ActionBar } from '../../../../../base/browser/ui/actionbar/actionbar.js';
@@ -26,7 +26,7 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
 import { IPlanReviewFeedbackService } from './planReviewFeedbackService.js';
-import { hasPlanReviewFeedback, navigationBearingFakeActionId, PlanReviewFeedbackMenuId, submitPlanReviewFeedbackActionId } from './planReviewFeedbackEditorActions.js';
+import { hasPlanReviewFeedback, navigationBearingFakeActionId, PlanReviewFeedbackMenuId } from './planReviewFeedbackEditorActions.js';
 import { ActionViewItem } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { autorun, observableValue } from '../../../../../base/common/observable.js';
 
@@ -43,15 +43,11 @@ class PlanReviewFeedbackInputWidget implements IOverlayWidget {
 	private readonly _measureElement: HTMLElement;
 	private readonly _actionBar: ActionBar;
 	private readonly _addAction: Action;
-	private readonly _addAndSubmitAction: Action;
 	private _position: IOverlayWidgetPosition | null = null;
 	private _lineHeight = 22;
 
 	private readonly _onDidTriggerAdd = new Emitter<void>();
 	readonly onDidTriggerAdd: Event<void> = this._onDidTriggerAdd.event;
-
-	private readonly _onDidTriggerAddAndSubmit = new Emitter<void>();
-	readonly onDidTriggerAddAndSubmit: Event<void> = this._onDidTriggerAddAndSubmit.event;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -70,7 +66,8 @@ class PlanReviewFeedbackInputWidget implements IOverlayWidget {
 		this._measureElement.classList.add('plan-review-feedback-input-measure');
 		this._domNode.appendChild(this._measureElement);
 
-		// Action bar with add/submit actions
+		// Action bar with the add action. Submission of all queued comments
+		// happens from the chat widget so this surface only captures input.
 		const actionsContainer = document.createElement('div');
 		actionsContainer.classList.add('plan-review-feedback-input-actions');
 		this._domNode.appendChild(actionsContainer);
@@ -83,38 +80,10 @@ class PlanReviewFeedbackInputWidget implements IOverlayWidget {
 			() => { this._onDidTriggerAdd.fire(); return Promise.resolve(); }
 		);
 
-		this._addAndSubmitAction = new Action(
-			'planReviewFeedback.addAndSubmit',
-			localize('planReviewFeedback.addAndSubmit', "Add Feedback and Submit (Alt+Enter)"),
-			ThemeIcon.asClassName(Codicon.send),
-			false,
-			() => { this._onDidTriggerAddAndSubmit.fire(); return Promise.resolve(); }
-		);
-
 		this._actionBar = new ActionBar(actionsContainer);
-		this._actionBar.push(this._addAction, { icon: true, label: false, keybinding: localize('enter', "Enter") });
-
-		// Toggle to alt action when Alt key is held
-		const modifierKeyEmitter = ModifierKeyEmitter.getInstance();
-		modifierKeyEmitter.event(status => {
-			this._updateActionForAlt(status.altKey);
-		});
+		this._actionBar.push(this._addAction, { icon: true, label: false, keybinding: localize('planReviewFeedback.enter', "Enter") });
 
 		this._inputElement.style.lineHeight = `${this._lineHeight}px`;
-	}
-
-	private _isShowingAlt = false;
-
-	private _updateActionForAlt(altKey: boolean): void {
-		if (altKey && !this._isShowingAlt) {
-			this._isShowingAlt = true;
-			this._actionBar.clear();
-			this._actionBar.push(this._addAndSubmitAction, { icon: true, label: false, keybinding: localize('altEnter', "Alt+Enter") });
-		} else if (!altKey && this._isShowingAlt) {
-			this._isShowingAlt = false;
-			this._actionBar.clear();
-			this._actionBar.push(this._addAction, { icon: true, label: false, keybinding: localize('enter', "Enter") });
-		}
 	}
 
 	getId(): string {
@@ -163,7 +132,6 @@ class PlanReviewFeedbackInputWidget implements IOverlayWidget {
 	private _updateActionEnabled(): void {
 		const hasText = this._inputElement.value.trim().length > 0;
 		this._addAction.enabled = hasText;
-		this._addAndSubmitAction.enabled = hasText;
 	}
 
 	private _autoSize(): void {
@@ -186,9 +154,7 @@ class PlanReviewFeedbackInputWidget implements IOverlayWidget {
 	dispose(): void {
 		this._actionBar.dispose();
 		this._addAction.dispose();
-		this._addAndSubmitAction.dispose();
 		this._onDidTriggerAdd.dispose();
-		this._onDidTriggerAddAndSubmit.dispose();
 	}
 }
 
@@ -258,28 +224,16 @@ class PlanReviewFeedbackOverlayWidget implements IOverlayWidget {
 								const { activeIdx, totalCount } = that._navigationBearings.read(r);
 								if (totalCount > 0) {
 									const current = activeIdx === -1 ? 1 : activeIdx + 1;
-									this.label.innerText = localize('nOfM', '{0}/{1}', current, totalCount);
+									this.label.innerText = localize('planReviewFeedback.navStatus.nOfM', '{0}/{1}', current, totalCount);
 								} else {
-									this.label.innerText = localize('zero', '0/0');
+									this.label.innerText = localize('planReviewFeedback.navStatus.zero', '0/0');
 								}
 							}));
 						}
 					};
 				}
 
-				const isPrimary = action.id === submitPlanReviewFeedbackActionId;
-				return new class extends ActionViewItem {
-					constructor() {
-						super(undefined, action, { ...options, icon: !isPrimary, label: isPrimary, keybindingNotRenderedWithLabel: true });
-					}
-
-					override render(container: HTMLElement): void {
-						super.render(container);
-						if (isPrimary) {
-							this.element?.classList.add('primary');
-						}
-					}
-				};
+				return new ActionViewItem(undefined, action, { ...options, icon: true, label: false, keybindingNotRenderedWithLabel: true });
 			},
 		}));
 	}
@@ -359,6 +313,13 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 		this._register(this._planReviewFeedbackService.onDidChangeRegistrations(() => this._onModelChanged()));
 		this._register(this._planReviewFeedbackService.onDidChangeFeedback(() => this._updateDecorations()));
 		this._register(this._planReviewFeedbackService.onDidChangeNavigation(() => this._updateDecorations()));
+
+		// Editor contributions registered with `Eventually` are instantiated
+		// after the editor's model is already attached, so `onDidChangeModel`
+		// would not fire and `_isActivePlan` would remain false. Sync state
+		// from the current model so the inline overlay activates correctly
+		// when the contribution wakes up against an already-loaded plan file.
+		this._onModelChanged();
 	}
 
 	private _isWidgetTarget(target: EventTarget | Element | null): boolean {
@@ -369,7 +330,6 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 		if (!this._widget) {
 			this._widget = new PlanReviewFeedbackInputWidget(this._editor);
 			this._register(this._widget.onDidTriggerAdd(() => this._addFeedback()));
-			this._register(this._widget.onDidTriggerAddAndSubmit(() => this._addFeedbackAndSubmit()));
 			this._editor.addOverlayWidget(this._widget);
 		}
 		return this._widget;
@@ -417,12 +377,17 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 	private _show(): void {
 		const widget = this._ensureWidget();
 
-		if (!this._visible) {
+		// Only clear the input when transitioning from hidden to shown.
+		// `_show()` is called on every selection change, so clearing here
+		// unconditionally would wipe a draft if the user momentarily
+		// refocuses the editor while typing a comment.
+		const wasVisible = this._visible;
+		if (!wasVisible) {
 			this._visible = true;
 			this._registerWidgetListeners(widget);
+			widget.clearInput();
 		}
 
-		widget.clearInput();
 		widget.show();
 		this._updatePosition();
 	}
@@ -509,14 +474,7 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 				return;
 			}
 
-			if (e.keyCode === KeyCode.Enter && e.altKey) {
-				e.preventDefault();
-				e.stopPropagation();
-				this._addFeedbackAndSubmit();
-				return;
-			}
-
-			if (e.keyCode === KeyCode.Enter) {
+			if (e.keyCode === KeyCode.Enter && !e.shiftKey) {
 				e.preventDefault();
 				e.stopPropagation();
 				this._addFeedback();
@@ -578,29 +536,6 @@ export class PlanReviewFeedbackEditorContribution extends Disposable implements 
 		this._planReviewFeedbackService.addFeedback(model.uri, line, column, text);
 		this._hideAndRefocusEditor();
 		return true;
-	}
-
-	private _addFeedbackAndSubmit(): void {
-		if (!this._widget) {
-			return;
-		}
-
-		const text = this._widget.inputElement.value.trim();
-		if (!text) {
-			return;
-		}
-
-		const selection = this._editor.getSelection();
-		const model = this._editor.getModel();
-		if (!selection || !model) {
-			return;
-		}
-
-		const line = selection.startLineNumber;
-		const column = selection.startColumn;
-		this._planReviewFeedbackService.addFeedback(model.uri, line, column, text);
-		this._hideAndRefocusEditor();
-		this._planReviewFeedbackService.submitAllFeedback(model.uri);
 	}
 
 	private _updatePosition(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -16,6 +16,7 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../../.
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 import Severity from '../../../../../../base/common/severity.js';
 import { basename } from '../../../../../../base/common/resources.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
@@ -53,6 +54,7 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	private readonly _messageScrollable: DomScrollableElement;
 	private readonly _collapseButton: Button;
 	private readonly _restoreButton: Button;
+	private _reviewButton: Button | undefined;
 
 	private _isCollapsed = false;
 	private _isExpanded = false;
@@ -60,8 +62,12 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	private _selectedAction: IChatPlanApprovalAction;
 	private _feedbackTextarea: HTMLTextAreaElement | undefined;
 	private _feedbackSection: HTMLElement | undefined;
+	private _commentsListEl: HTMLElement | undefined;
+	private _commentsListScrollable: DomScrollableElement | undefined;
+	private _clearAllButtonEl: HTMLElement | undefined;
 	private _isFeedbackMode = false;
 	private readonly _planReviewRegistration = this._register(new MutableDisposable());
+	private readonly _commentRowDisposables = this._register(new DisposableStore());
 
 	constructor(
 		public readonly review: IChatPlanReview,
@@ -88,17 +94,29 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		// Register with the plan review feedback service so the editor
 		// contribution can show inline feedback input for this plan file.
 		// Only register when feedback is allowed and the review hasn't
-		// already been submitted.
+		// already been submitted. Also subscribe to feedback changes so the
+		// in-widget comments list and primary button label stay in sync.
 		if (review.planUri && review.canProvideFeedback && !this._isSubmitted) {
 			const planUri = URI.revive(review.planUri);
-			this._planReviewRegistration.value = this._planReviewFeedbackService.registerPlanReview(planUri, (result) => {
+			const planUriString = planUri.toString();
+			const registrationStore = new DisposableStore();
+			registrationStore.add(this._planReviewFeedbackService.registerPlanReview(planUri, (result) => {
 				if (this._isSubmitted) {
 					return;
 				}
 				this._isSubmitted = true;
 				this._options.onSubmit(result);
 				this.markUsed();
-			});
+			}));
+			// Scope the change listener to the same lifetime as the
+			// registration so it goes away on `markUsed()` instead of
+			// living until widget disposal.
+			registrationStore.add(this._planReviewFeedbackService.onDidChangeFeedback(uri => {
+				if (uri.toString() === planUriString) {
+					this.onInlineFeedbackChanged();
+				}
+			}));
+			this._planReviewRegistration.value = registrationStore;
 		}
 
 		// Build DOM that mirrors chat-confirmation-widget2 so we inherit its
@@ -132,14 +150,18 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		elements.titleLabel.textContent = review.title;
 		this._register(this._hoverService.setupDelayedHover(elements.titleLabel, { content: review.title }));
 
-		// Optional Edit button.
+		// Single Review button — opens the plan file and (when feedback is
+		// allowed) enters review mode in the widget so the user can comment
+		// on the plan from one cohesive surface.
 		if (review.planUri) {
 			const fileName = basename(URI.revive(review.planUri));
-			const editButtonLabel = localize('chat.planReview.editTooltip', 'Edit {0}', fileName);
-			const editButton = this._register(new Button(this._titleActionsEl, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: editButtonLabel, ariaLabel: editButtonLabel }));
-			editButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button');
-			editButton.label = `$(${Codicon.edit.id})`;
-			this._register(editButton.onDidClick(() => this.openPlanFile()));
+			const reviewButtonTooltip = review.canProvideFeedback
+				? localize('chat.planReview.reviewTooltip', 'Review {0}', fileName)
+				: localize('chat.planReview.openTooltip', 'Open {0}', fileName);
+			const reviewButton = this._register(new Button(this._titleActionsEl, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: reviewButtonTooltip, ariaLabel: reviewButtonTooltip }));
+			reviewButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-review-button');
+			this._reviewButton = reviewButton;
+			this._register(reviewButton.onDidClick(() => this.enterReviewMode()));
 		}
 
 		// Restore/expand toggle.
@@ -163,7 +185,10 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this._messageScrollable.getDomNode().classList.add('chat-confirmation-widget-message-scrollable', 'chat-plan-review-body-scrollable');
 		messageParent.insertBefore(this._messageScrollable.getDomNode(), messageNextSibling);
 		const resizeObserver = this._register(new dom.DisposableResizeObserver(() => this._messageScrollable.scanDomNode()));
-		this._register(resizeObserver.observe(this._messageEl));
+		// Observe only the wrapper: the inner `_messageEl` is `height: 100%`
+		// so it only changes size when the wrapper does. Content reflow
+		// inside the inner is handled by the markdown renderer's
+		// `asyncRenderCallback`, which calls `scanDomNode()` directly.
 		this._register(resizeObserver.observe(this._messageScrollable.getDomNode()));
 
 		this.renderMarkdown();
@@ -171,7 +196,16 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		if (review.canProvideFeedback) {
 			this.renderFeedback(elements.feedback);
 			this._feedbackSection = elements.feedback;
-			dom.hide(elements.feedback); // Hidden until user clicks "Provide Feedback"
+			if (review.planUri) {
+				dom.hide(elements.feedback); // Hidden until the user enters review mode or inline feedback exists.
+			} else {
+				// No plan file means no editor surface to coordinate with;
+				// keep the feedback textarea visible from the start so the user
+				// has somewhere to type. Treat as already in review mode so the
+				// primary button reads "Submit Feedback".
+				this._isFeedbackMode = true;
+				this.domNode.classList.add('chat-plan-review-feedback-mode');
+			}
 		} else {
 			dom.hide(elements.feedback);
 		}
@@ -190,6 +224,16 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		if (this._feedbackTextarea && review instanceof ChatPlanReviewData && review.draftFeedback) {
 			this._feedbackTextarea.value = review.draftFeedback;
+			// Mirror the auto-resize behaviour wired up on `input` events so
+			// a multi-line restored draft renders with the right height.
+			this._feedbackTextarea.style.height = 'auto';
+			this._feedbackTextarea.style.height = `${this._feedbackTextarea.scrollHeight}px`;
+		}
+
+		// If inline feedback is already present (e.g. restored from a prior
+		// session), promote into review mode so the user sees it.
+		if (!this._isSubmitted && this.getInlineFeedbackItems().length > 0) {
+			this.enterFeedbackMode({ focus: false });
 		}
 	}
 
@@ -222,17 +266,53 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		dom.clearNode(section);
 		const header = dom.append(section, dom.$('.chat-plan-review-feedback-header'));
 		const label = dom.append(header, dom.$('.chat-plan-review-feedback-label'));
-		label.textContent = localize('chat.planReview.feedbackLabel', 'Additional feedback');
+		label.textContent = localize('chat.planReview.feedbackLabel', 'Feedback');
 
-		const closeButtonAriaLabel = localize('chat.planReview.exitFeedback', "Cancel feedback");
-		const closeButton = this._register(new Button(header, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: closeButtonAriaLabel, ariaLabel: closeButtonAriaLabel }));
-		closeButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-title-icon-button', 'chat-plan-review-feedback-close');
-		closeButton.label = `$(${Codicon.close.id})`;
-		this._register(closeButton.onDidClick(() => this.exitFeedbackMode()));
+		const headerActions = dom.append(header, dom.$('.chat-plan-review-feedback-header-actions'));
+
+		// Clear All button — only relevant when there's anchored feedback
+		// to clear; visibility is updated alongside the comments list.
+		if (this.review.planUri) {
+			const clearAllLabel = localize('chat.planReview.clearAll', "Clear All");
+			const clearAllButton = this._register(new Button(headerActions, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: clearAllLabel, ariaLabel: clearAllLabel }));
+			clearAllButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-feedback-clear-all');
+			clearAllButton.label = clearAllLabel;
+			this._register(clearAllButton.onDidClick(() => this.clearAllInlineFeedback()));
+			this._clearAllButtonEl = clearAllButton.element;
+		}
+
+		// Back button (replaces the previous close X) — only meaningful when
+		// there's a way to re-enter review mode (i.e. the title-bar Review
+		// button, which requires a planUri). Per-comment removal now happens
+		// via each row's × button, so this button is for navigating back to
+		// the normal action set without discarding inline comments.
+		if (this.review.planUri) {
+			const backButtonLabel = localize('chat.planReview.back', "Back");
+			const backButton = this._register(new Button(headerActions, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: backButtonLabel, ariaLabel: backButtonLabel }));
+			backButton.element.classList.add('chat-plan-review-title-button', 'chat-plan-review-feedback-close');
+			backButton.label = backButtonLabel;
+			this._register(backButton.onDidClick(() => this.exitFeedbackMode()));
+		}
+
+		// Inline comments list (shown when there are anchored comments
+		// captured from the editor). Each row is clickable to reveal the
+		// comment in the editor. Wrapped in a Monaco scrollable so the
+		// list gets a styled scrollbar consistent with the rest of the
+		// workbench instead of the native one.
+		this._commentsListEl = dom.$('.chat-plan-review-comments-list');
+		this._commentsListScrollable = this._register(new DomScrollableElement(this._commentsListEl, {
+			vertical: ScrollbarVisibility.Auto,
+			horizontal: ScrollbarVisibility.Hidden,
+			consumeMouseWheelIfScrollbarIsNeeded: true,
+		}));
+		this._commentsListScrollable.getDomNode().classList.add('chat-plan-review-comments-list-scrollable');
+		dom.append(section, this._commentsListScrollable.getDomNode());
+		dom.hide(this._commentsListScrollable.getDomNode());
+		this.renderCommentsList();
 
 		const textarea = dom.append(section, dom.$<HTMLTextAreaElement>('textarea.chat-plan-review-feedback-textarea'));
 		textarea.rows = 1;
-		textarea.placeholder = localize('chat.planReview.feedbackPlaceholder', 'Suggest changes or add instructions...');
+		textarea.placeholder = localize('chat.planReview.feedbackPlaceholder', 'Add an overall comment for the agent...');
 		this._feedbackTextarea = textarea;
 
 		// Matches the behaviour of the question carousel freeform textarea:
@@ -251,6 +331,11 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			if (this.review instanceof ChatPlanReviewData) {
 				this.review.draftFeedback = textarea.value;
 			}
+			// Update primary button label since textarea content affects whether
+			// it should read "Approve" or "Submit Feedback".
+			if (this._isFeedbackMode) {
+				this.renderCurrentActionButtons();
+			}
 		}));
 
 		// Enter submits feedback; Shift+Enter inserts a newline.
@@ -264,15 +349,166 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		}));
 	}
 
+	private renderCommentsList(): void {
+		if (!this._commentsListEl) {
+			return;
+		}
+		this._commentRowDisposables.clear();
+		dom.clearNode(this._commentsListEl);
+
+		const items = this.getInlineFeedbackItems();
+		if (this._clearAllButtonEl) {
+			if (items.length > 0) {
+				dom.show(this._clearAllButtonEl);
+			} else {
+				dom.hide(this._clearAllButtonEl);
+			}
+		}
+		const scrollableNode = this._commentsListScrollable?.getDomNode();
+		if (items.length === 0) {
+			if (scrollableNode) {
+				dom.hide(scrollableNode);
+			}
+			this._commentsListScrollable?.scanDomNode();
+			return;
+		}
+		if (scrollableNode) {
+			dom.show(scrollableNode);
+		}
+
+		for (const item of items) {
+			const row = dom.append(this._commentsListEl, dom.$('.chat-plan-review-comment-row'));
+			const rowLabel = localize('chat.planReview.commentRowAriaLabel', 'Line {0}: {1}', item.line, item.text);
+
+			const revealButton = dom.append(row, dom.$<HTMLButtonElement>('button.chat-plan-review-comment-reveal'));
+			revealButton.type = 'button';
+			revealButton.setAttribute('aria-label', rowLabel);
+
+			const lineEl = dom.append(revealButton, dom.$('span.chat-plan-review-comment-line'));
+			lineEl.textContent = localize('chat.planReview.commentRowLine', 'Line {0}', item.line);
+
+			const textEl = dom.append(revealButton, dom.$('span.chat-plan-review-comment-text'));
+			textEl.textContent = item.text;
+
+			this._commentRowDisposables.add(dom.addDisposableListener(revealButton, dom.EventType.CLICK, () => {
+				this.revealInlineComment(item.id, item.line, item.column);
+			}));
+
+			const removeLabel = localize('chat.planReview.removeComment', "Remove comment on line {0}", item.line);
+			const removeButton = dom.append(row, dom.$<HTMLButtonElement>('button.chat-plan-review-comment-remove'));
+			removeButton.type = 'button';
+			removeButton.setAttribute('aria-label', removeLabel);
+			removeButton.title = removeLabel;
+			removeButton.classList.add(...ThemeIcon.asClassNameArray(Codicon.close));
+
+			this._commentRowDisposables.add(dom.addDisposableListener(removeButton, dom.EventType.CLICK, e => {
+				e.stopPropagation();
+				this.removeInlineComment(item.id);
+			}));
+		}
+		this._commentsListScrollable?.scanDomNode();
+	}
+
+	private getInlineFeedbackItems(): readonly IPlanReviewFeedbackItem[] {
+		if (!this.review.planUri) {
+			return [];
+		}
+		return this._planReviewFeedbackService.getFeedback(URI.revive(this.review.planUri));
+	}
+
+	private async revealInlineComment(itemId: string, line: number, column: number): Promise<void> {
+		if (!this.review.planUri) {
+			return;
+		}
+		const uri = URI.revive(this.review.planUri);
+		this._planReviewFeedbackService.setNavigationAnchor(uri, itemId);
+		await this._editorService.openEditor({
+			resource: uri,
+			options: { selection: { startLineNumber: line, startColumn: column } },
+		});
+	}
+
+	private removeInlineComment(itemId: string): void {
+		if (!this.review.planUri || this._isSubmitted) {
+			return;
+		}
+		this._planReviewFeedbackService.removeFeedback(URI.revive(this.review.planUri), itemId);
+	}
+
+	private async clearAllInlineFeedback(): Promise<void> {
+		if (!this.review.planUri || this._isSubmitted) {
+			return;
+		}
+		const items = this.getInlineFeedbackItems();
+		if (items.length === 0) {
+			return;
+		}
+		const result = await this._dialogService.confirm({
+			type: Severity.Warning,
+			message: localize('chat.planReview.clearAllConfirm', 'Clear {0} inline comment(s)?', items.length),
+			detail: localize('chat.planReview.clearAllDetail', 'These comments will be removed from the plan file and not sent to the agent.'),
+			primaryButton: localize('chat.planReview.clearAllConfirmPrimary', 'Clear All'),
+		});
+		if (!result.confirmed) {
+			return;
+		}
+		this._planReviewFeedbackService.clearFeedback(URI.revive(this.review.planUri));
+	}
+
+	private onInlineFeedbackChanged(): void {
+		if (this._isSubmitted) {
+			return;
+		}
+		const items = this.getInlineFeedbackItems();
+
+		// Auto-promote into review mode the first time a comment shows up
+		// so the chat widget always reflects the live feedback queue.
+		if (items.length > 0 && !this._isFeedbackMode && !this._isCollapsed) {
+			this.enterFeedbackMode({ focus: false });
+			return;
+		}
+
+		this.renderCommentsList();
+		if (this._isFeedbackMode) {
+			this.renderCurrentActionButtons();
+		}
+		this._messageScrollable.scanDomNode();
+		this._onDidChangeHeight.fire();
+	}
+
+	/**
+	 * Render the primary/secondary action buttons into whichever container
+	 * is currently active (footer when expanded, inline title slot when
+	 * collapsed). Always clears the inactive slot so the same buttons can
+	 * never appear in two places at once. Prefer this over calling
+	 * `renderActionButtons` directly when the surface choice is implicit.
+	 */
+	private renderCurrentActionButtons(): void {
+		if (this._isSubmitted) {
+			return;
+		}
+		const target = this._isCollapsed ? this._inlineActionsEl : this._footerButtonsEl;
+		const other = this._isCollapsed ? this._footerButtonsEl : this._inlineActionsEl;
+		dom.clearNode(other);
+		this.renderActionButtons(target, { includeReject: !this._isCollapsed });
+	}
+
 	private renderActionButtons(container: HTMLElement, options?: { includeReject?: boolean }): void {
 		const includeReject = options?.includeReject ?? true;
 		this._buttonStore.clear();
 		dom.clearNode(container);
 
-		// In feedback mode, show Submit + Reject.
+		// In feedback mode, show Submit + Reject. The Submit label includes
+		// the count of pending inline comments so the user can see exactly
+		// what is about to be sent.
 		if (this._isFeedbackMode) {
+			const inlineCount = this.getInlineFeedbackItems().length;
+			const submitLabel = inlineCount > 0
+				? localize('chat.planReview.submitFeedbackWithCount', 'Submit Feedback ({0})', inlineCount)
+				: localize('chat.planReview.submitFeedback', 'Submit Feedback');
 			const submitButton = new Button(container, { ...defaultButtonStyles, supportIcons: true });
-			submitButton.label = localize('chat.planReview.submitFeedback', 'Submit');
+			submitButton.label = submitLabel;
+			submitButton.enabled = this.canSubmitFeedback();
 			this._buttonStore.add(submitButton);
 			this._buttonStore.add(submitButton.onDidClick(() => this.submitFeedback()));
 
@@ -333,17 +569,14 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			this._buttonStore.add(rejectButton);
 			this._buttonStore.add(rejectButton.onDidClick(() => this.submitRejection()));
 		}
+	}
 
-		// Provide Feedback button (grey secondary) — shown only when feedback
-		// is enabled and we are not in collapsed mode. Right-aligned via CSS
-		// so the primary Approve / Reject pair stays grouped on the left.
-		if (this.review.canProvideFeedback && includeReject) {
-			const feedbackButton = new Button(container, { ...defaultButtonStyles, secondary: true });
-			feedbackButton.element.classList.add('chat-plan-review-feedback-button');
-			feedbackButton.label = localize('chat.planReview.provideFeedback', 'Provide Feedback');
-			this._buttonStore.add(feedbackButton);
-			this._buttonStore.add(feedbackButton.onDidClick(() => this.enterFeedbackMode()));
+	private canSubmitFeedback(): boolean {
+		const textareaText = this._feedbackTextarea?.value.trim() ?? '';
+		if (textareaText) {
+			return true;
 		}
+		return this.getInlineFeedbackItems().length > 0;
 	}
 
 	private toggleCollapsed(): void {
@@ -382,21 +615,29 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this._collapseButton.element.setAttribute('aria-expanded', String(!this._isCollapsed));
 		this._collapseButton.setTitle(collapseTooltip);
 
-		// Move the action buttons between the footer and the inline title
-		// slot so the user can approve while collapsed. Reject is omitted in
-		// the collapsed view (matches chatToolConfirmationCarouselPart).
-		if (!this._isSubmitted) {
-			// Collapsing implicitly cancels feedback mode. Route through
-			// `exitFeedbackMode` so the CSS class, draft, and section
-			// visibility teardown stays centralized.
-			if (this._isCollapsed && this._isFeedbackMode) {
-				this.exitFeedbackMode();
+		// When the widget is collapsed the title bar is tight, so the review
+		// affordance is a single pencil icon. When expanded there's room for
+		// a clearer text label, which doubles as a hint that the button also
+		// opens the feedback flow.
+		if (this._reviewButton) {
+			const isIconOnly = this._isCollapsed;
+			this._reviewButton.element.classList.toggle('chat-plan-review-title-icon-button', isIconOnly);
+			if (isIconOnly) {
+				this._reviewButton.label = `$(${Codicon.edit.id})`;
+			} else {
+				this._reviewButton.label = this.review.canProvideFeedback
+					? localize('chat.planReview.reviewButtonLabel', "Edit or Provide Feedback")
+					: localize('chat.planReview.openButtonLabel', "Open Plan");
 			}
-			const target = this._isCollapsed ? this._inlineActionsEl : this._footerButtonsEl;
-			const other = this._isCollapsed ? this._footerButtonsEl : this._inlineActionsEl;
-			dom.clearNode(other);
-			this.renderActionButtons(target, { includeReject: !this._isCollapsed });
 		}
+
+		// Move the action buttons between the footer and the inline title
+		// slot so the user can approve (or submit feedback) while collapsed.
+		// Reject is omitted in the collapsed view (matches
+		// chatToolConfirmationCarouselPart). Feedback mode itself is
+		// preserved across collapse/expand so any draft text or queued
+		// inline comments are retained.
+		this.renderCurrentActionButtons();
 	}
 
 	private updateExpandedPresentation(): void {
@@ -418,6 +659,22 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		}
 		const uri = URI.revive(this.review.planUri);
 		await this._editorService.openEditor({ resource: uri });
+	}
+
+	private async enterReviewMode(): Promise<void> {
+		await this.openPlanFile();
+		if (!this.review.canProvideFeedback || this._isSubmitted) {
+			return;
+		}
+		if (this._isCollapsed) {
+			this._isCollapsed = false;
+			if (this.review instanceof ChatPlanReviewData) {
+				this.review.draftCollapsed = false;
+			}
+			this.updateCollapsedPresentation();
+			this.updateExpandedPresentation();
+		}
+		this.enterFeedbackMode({ focus: true });
 	}
 
 	private async submitApproval(action: IChatPlanApprovalAction): Promise<void> {
@@ -444,34 +701,42 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this.markUsed();
 	}
 
-	private enterFeedbackMode(): void {
+	private enterFeedbackMode(options?: { focus?: boolean }): void {
+		if (this._isFeedbackMode) {
+			if (options?.focus) {
+				this._feedbackTextarea?.focus();
+			}
+			return;
+		}
 		this._isFeedbackMode = true;
 		if (this._feedbackSection) {
 			dom.show(this._feedbackSection);
 		}
 		this.domNode.classList.add('chat-plan-review-feedback-mode');
-		this.renderActionButtons(this._footerButtonsEl, { includeReject: true });
-		this._feedbackTextarea?.focus();
+		this.renderCommentsList();
+		this.renderCurrentActionButtons();
+		if (options?.focus !== false) {
+			this._feedbackTextarea?.focus();
+		}
 		this._messageScrollable.scanDomNode();
 		this._onDidChangeHeight.fire();
 	}
 
-	private exitFeedbackMode(): void {
+	private async exitFeedbackMode(): Promise<void> {
 		if (!this._isFeedbackMode) {
 			return;
 		}
+
+		// "Back" is non-destructive: inline comments and the draft textarea
+		// are preserved so the user can resume by clicking Review again.
+		// Per-row \u00d7 buttons and the Clear All button handle deletion
+		// explicitly.
 		this._isFeedbackMode = false;
-		if (this._feedbackTextarea) {
-			this._feedbackTextarea.value = '';
-			if (this.review instanceof ChatPlanReviewData) {
-				this.review.draftFeedback = '';
-			}
-		}
 		if (this._feedbackSection) {
 			dom.hide(this._feedbackSection);
 		}
 		this.domNode.classList.remove('chat-plan-review-feedback-mode');
-		this.renderActionButtons(this._footerButtonsEl, { includeReject: true });
+		this.renderCurrentActionButtons();
 		this._messageScrollable.scanDomNode();
 		this._onDidChangeHeight.fire();
 	}
@@ -493,26 +758,44 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			return;
 		}
 
-		// Merge textarea feedback with editor-collected inline feedback.
-		const feedbackParts: string[] = [];
-		if (textareaFeedback) {
-			feedbackParts.push(textareaFeedback);
-		}
+		// Build a structured markdown message so the agent (and the chat
+		// transcript) sees a well-formatted block rather than a wall of
+		// concatenated lines. We also keep the overall comment and the
+		// inline-comments block as separate fields on the result so the
+		// transcript can render them differently without parsing the
+		// combined string back apart (which would be locale-dependent).
+		let feedbackInlineMarkdown: string | undefined;
 		if (editorFeedbackItems.length > 0) {
-			const filePath = this.review.planUri?.path ? `(${this.review.planUri.path})` : '';
-			feedbackParts.push(`Here's the feedback for contents of the plan file ${filePath}:`);
-			for (const item of editorFeedbackItems) {
-				if (item.column > 1) {
-					feedbackParts.push(`Line ${item.line}: Column ${item.column}: ${item.text}`);
-				} else {
-					feedbackParts.push(`Line ${item.line}: ${item.text}`);
-				}
-			}
+			const planUri = this.review.planUri ? URI.revive(this.review.planUri) : undefined;
+			const fileName = planUri ? basename(planUri) : '';
+			const heading = fileName
+				? localize('chat.planReview.inlineCommentsHeading', "Inline comments on `{0}`:", fileName)
+				: localize('chat.planReview.inlineCommentsHeadingNoFile', "Inline comments:");
+			const bullets = editorFeedbackItems.map(item => {
+				const location = item.column > 1
+					? localize('chat.planReview.inlineCommentLocation', "Line {0}, Column {1}", item.line, item.column)
+					: localize('chat.planReview.inlineCommentLocationLine', "Line {0}", item.line);
+				return `- **${location}:** ${item.text}`;
+			});
+			feedbackInlineMarkdown = [heading, ...bullets].join('\n');
 		}
 
-		const feedback = feedbackParts.join('\n');
+		const sections: string[] = [];
+		if (textareaFeedback) {
+			sections.push(textareaFeedback);
+		}
+		if (feedbackInlineMarkdown) {
+			sections.push(feedbackInlineMarkdown);
+		}
+
+		const feedback = sections.join('\n\n');
 		this._isSubmitted = true;
-		this._options.onSubmit({ rejected: false, feedback });
+		this._options.onSubmit({
+			rejected: false,
+			feedback,
+			feedbackOverall: textareaFeedback || undefined,
+			feedbackInlineMarkdown,
+		});
 		this.markUsed();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -95,9 +95,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		// Register with the plan review feedback service so the editor
 		// contribution can show inline feedback input for this plan file.
-		// Only register when feedback is allowed and the review hasn't
-		// already been submitted. Also subscribe to feedback changes so the
-		// in-widget comments list and primary button label stay in sync.
+		// Subscribe to feedback changes so the comments list and Submit
+		// button label stay in sync.
 		if (review.planUri && review.canProvideFeedback && !this._isSubmitted) {
 			const planUri = URI.revive(review.planUri);
 			const planUriString = planUri.toString();
@@ -110,9 +109,6 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 				this._options.onSubmit(result);
 				this.markUsed();
 			}));
-			// Scope the change listener to the same lifetime as the
-			// registration so it goes away on `markUsed()` instead of
-			// living until widget disposal.
 			registrationStore.add(this._planReviewFeedbackService.onDidChangeFeedback(uri => {
 				if (uri.toString() === planUriString) {
 					this.onInlineFeedbackChanged();
@@ -152,9 +148,7 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		elements.titleLabel.textContent = review.title;
 		this._register(this._hoverService.setupDelayedHover(elements.titleLabel, { content: review.title }));
 
-		// Single Review button — opens the plan file and (when feedback is
-		// allowed) enters review mode in the widget so the user can comment
-		// on the plan from one cohesive surface.
+		// Review button — opens the plan file and enters feedback mode.
 		if (review.planUri) {
 			const fileName = basename(URI.revive(review.planUri));
 			const reviewButtonTooltip = review.canProvideFeedback
@@ -187,10 +181,9 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this._messageScrollable.getDomNode().classList.add('chat-confirmation-widget-message-scrollable', 'chat-plan-review-body-scrollable');
 		messageParent.insertBefore(this._messageScrollable.getDomNode(), messageNextSibling);
 		const resizeObserver = this._register(new dom.DisposableResizeObserver(() => this._messageScrollable.scanDomNode()));
-		// Observe only the wrapper: the inner `_messageEl` is `height: 100%`
-		// so it only changes size when the wrapper does. Content reflow
-		// inside the inner is handled by the markdown renderer's
-		// `asyncRenderCallback`, which calls `scanDomNode()` directly.
+		// The inner `_messageEl` is `height: 100%`, so observing only the
+		// wrapper is enough; markdown content reflow is handled by the
+		// renderer's `asyncRenderCallback`.
 		this._register(resizeObserver.observe(this._messageScrollable.getDomNode()));
 
 		this.renderMarkdown();
@@ -201,10 +194,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			if (review.planUri) {
 				dom.hide(elements.feedback); // Hidden until the user enters review mode or inline feedback exists.
 			} else {
-				// No plan file means no editor surface to coordinate with;
-				// keep the feedback textarea visible from the start so the user
-				// has somewhere to type. Treat as already in review mode so the
-				// primary button reads "Submit Feedback".
+				// No plan file: keep the textarea visible from the start and
+				// treat as already in feedback mode.
 				this._isFeedbackMode = true;
 				this.domNode.classList.add('chat-plan-review-feedback-mode');
 			}
@@ -226,14 +217,14 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		if (this._feedbackTextarea && review instanceof ChatPlanReviewData && review.draftFeedback) {
 			this._feedbackTextarea.value = review.draftFeedback;
-			// Mirror the auto-resize behaviour wired up on `input` events so
-			// a multi-line restored draft renders with the right height.
+			// Match the auto-resize wired up on `input` so a multi-line
+			// restored draft renders with the right height.
 			this._feedbackTextarea.style.height = 'auto';
 			this._feedbackTextarea.style.height = `${this._feedbackTextarea.scrollHeight}px`;
 		}
 
-		// If inline feedback is already present (e.g. restored from a prior
-		// session), promote into review mode so the user sees it.
+		// Promote into review mode if inline feedback is already present
+		// (e.g. restored from a prior session).
 		if (!this._isSubmitted && this.getInlineFeedbackItems().length > 0) {
 			this.enterFeedbackMode({ focus: false });
 		}
@@ -272,8 +263,7 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		const headerActions = dom.append(header, dom.$('.chat-plan-review-feedback-header-actions'));
 
-		// Clear All button — only relevant when there's anchored feedback
-		// to clear; visibility is updated alongside the comments list.
+		// Clear All — visibility is toggled with the comments list.
 		if (this.review.planUri) {
 			const clearAllLabel = localize('chat.planReview.clearAll', "Clear All");
 			const clearAllButton = this._register(new Button(headerActions, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: clearAllLabel, ariaLabel: clearAllLabel }));
@@ -283,11 +273,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			this._clearAllButtonEl = clearAllButton.element;
 		}
 
-		// Back button (replaces the previous close X) — only meaningful when
-		// there's a way to re-enter review mode (i.e. the title-bar Review
-		// button, which requires a planUri). Per-comment removal now happens
-		// via each row's × button, so this button is for navigating back to
-		// the normal action set without discarding inline comments.
+		// Back — non-destructive exit from feedback mode. Per-row × buttons
+		// and Clear All handle deletion explicitly.
 		if (this.review.planUri) {
 			const backButtonLabel = localize('chat.planReview.back', "Back");
 			const backButton = this._register(new Button(headerActions, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: backButtonLabel, ariaLabel: backButtonLabel }));
@@ -296,11 +283,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			this._register(backButton.onDidClick(() => this.exitFeedbackMode()));
 		}
 
-		// Inline comments list (shown when there are anchored comments
-		// captured from the editor). Each row is clickable to reveal the
-		// comment in the editor. Wrapped in a Monaco scrollable so the
-		// list gets a styled scrollbar consistent with the rest of the
-		// workbench instead of the native one.
+		// Inline comments list — wrapped in a Monaco scrollable for a styled
+		// scrollbar consistent with the rest of the workbench.
 		this._commentsListEl = dom.$('.chat-plan-review-comments-list');
 		this._commentsListScrollable = this._register(new DomScrollableElement(this._commentsListEl, {
 			vertical: ScrollbarVisibility.Auto,
@@ -333,10 +317,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			if (this.review instanceof ChatPlanReviewData) {
 				this.review.draftFeedback = textarea.value;
 			}
-			// Textarea content only affects the Submit button's enabled
-			// state (and label, when inline-count changes). Avoid a full
-			// button-row re-render on every keystroke — just update the
-			// cached Submit button.
+			// Update the cached Submit button rather than re-rendering the
+			// whole button row on every keystroke.
 			this.updateSubmitButtonState();
 		}));
 
@@ -463,8 +445,7 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		}
 		const items = this.getInlineFeedbackItems();
 
-		// Auto-promote into review mode the first time a comment shows up
-		// so the chat widget always reflects the live feedback queue.
+		// Auto-promote into review mode the first time a comment shows up.
 		if (items.length > 0 && !this._isFeedbackMode && !this._isCollapsed) {
 			this.enterFeedbackMode({ focus: false });
 			return;
@@ -472,8 +453,6 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		this.renderCommentsList();
 		if (this._isFeedbackMode) {
-			// Inline-count changed; just update the cached Submit button
-			// rather than re-rendering all action buttons.
 			this.updateSubmitButtonState();
 		}
 		this._messageScrollable.scanDomNode();
@@ -481,11 +460,9 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	}
 
 	/**
-	 * Render the primary/secondary action buttons into whichever container
-	 * is currently active (footer when expanded, inline title slot when
-	 * collapsed). Always clears the inactive slot so the same buttons can
-	 * never appear in two places at once. Prefer this over calling
-	 * `renderActionButtons` directly when the surface choice is implicit.
+	 * Render the action buttons into the active container (footer when
+	 * expanded, inline title slot when collapsed). Clears the inactive slot
+	 * so the same buttons can never appear in two places at once.
 	 */
 	private renderCurrentActionButtons(): void {
 		if (this._isSubmitted) {
@@ -504,9 +481,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this._renderedSubmitInlineCount = -1;
 		dom.clearNode(container);
 
-		// In feedback mode, show Submit + Reject. The Submit label includes
-		// the count of pending inline comments so the user can see exactly
-		// what is about to be sent.
+		// In feedback mode, show Submit + Reject. Submit's label includes
+		// the count of pending inline comments.
 		if (this._isFeedbackMode) {
 			const inlineCount = this.getInlineFeedbackItems().length;
 			const submitButton = new Button(container, { ...defaultButtonStyles, supportIcons: true });
@@ -591,10 +567,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	}
 
 	/**
-	 * Update the cached Submit button's enabled state and (only when the
-	 * inline-comment count changed) its label. Cheap enough to run on every
-	 * keystroke, unlike `renderCurrentActionButtons` which destroys and
-	 * recreates the entire button row.
+	 * Update the cached Submit button's enabled state and label without
+	 * destroying the button row. Cheap enough to run on every keystroke.
 	 */
 	private updateSubmitButtonState(): void {
 		if (!this._submitButton || !this._isFeedbackMode) {
@@ -644,10 +618,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		this._collapseButton.element.setAttribute('aria-expanded', String(!this._isCollapsed));
 		this._collapseButton.setTitle(collapseTooltip);
 
-		// When the widget is collapsed the title bar is tight, so the review
-		// affordance is a single pencil icon. When expanded there's room for
-		// a clearer text label, which doubles as a hint that the button also
-		// opens the feedback flow.
+		// Collapsed title bar uses a pencil icon; expanded uses a text
+		// label that hints at the feedback flow.
 		if (this._reviewButton) {
 			const isIconOnly = this._isCollapsed;
 			this._reviewButton.element.classList.toggle('chat-plan-review-title-icon-button', isIconOnly);
@@ -660,12 +632,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			}
 		}
 
-		// Move the action buttons between the footer and the inline title
-		// slot so the user can approve (or submit feedback) while collapsed.
-		// Reject is omitted in the collapsed view (matches
-		// chatToolConfirmationCarouselPart). Feedback mode itself is
-		// preserved across collapse/expand so any draft text or queued
-		// inline comments are retained.
+		// Move action buttons between footer (expanded) and inline title
+		// slot (collapsed). Reject is omitted when collapsed.
 		this.renderCurrentActionButtons();
 	}
 
@@ -756,10 +724,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			return;
 		}
 
-		// "Back" is non-destructive: inline comments and the draft textarea
-		// are preserved so the user can resume by clicking Review again.
-		// Per-row \u00d7 buttons and the Clear All button handle deletion
-		// explicitly.
+		// Back is non-destructive: inline comments and the textarea draft
+		// persist so the user can resume via the Review button.
 		this._isFeedbackMode = false;
 		if (this._feedbackSection) {
 			dom.hide(this._feedbackSection);
@@ -787,12 +753,10 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			return;
 		}
 
-		// Build a structured markdown message so the agent (and the chat
-		// transcript) sees a well-formatted block rather than a wall of
-		// concatenated lines. We also keep the overall comment and the
-		// inline-comments block as separate fields on the result so the
-		// transcript can render them differently without parsing the
-		// combined string back apart (which would be locale-dependent).
+		// Build a structured markdown message for the agent. Keep the overall
+		// comment and inline-comments block as separate fields on the result
+		// so the transcript can render them differently without re-parsing
+		// the localized combined string.
 		let feedbackInlineMarkdown: string | undefined;
 		if (editorFeedbackItems.length > 0) {
 			const planUri = this.review.planUri ? URI.revive(this.review.planUri) : undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart.ts
@@ -45,6 +45,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	public readonly onDidChangeHeight: Event<void> = this._onDidChangeHeight.event;
 
 	private readonly _buttonStore = this._register(new DisposableStore());
+	private _submitButton: Button | undefined;
+	private _renderedSubmitInlineCount = -1;
 	private readonly _messageContentDisposables = this._register(new MutableDisposable<DisposableStore>());
 
 	private readonly _titleActionsEl: HTMLElement;
@@ -331,11 +333,11 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			if (this.review instanceof ChatPlanReviewData) {
 				this.review.draftFeedback = textarea.value;
 			}
-			// Update primary button label since textarea content affects whether
-			// it should read "Approve" or "Submit Feedback".
-			if (this._isFeedbackMode) {
-				this.renderCurrentActionButtons();
-			}
+			// Textarea content only affects the Submit button's enabled
+			// state (and label, when inline-count changes). Avoid a full
+			// button-row re-render on every keystroke — just update the
+			// cached Submit button.
+			this.updateSubmitButtonState();
 		}));
 
 		// Enter submits feedback; Shift+Enter inserts a newline.
@@ -470,7 +472,9 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 
 		this.renderCommentsList();
 		if (this._isFeedbackMode) {
-			this.renderCurrentActionButtons();
+			// Inline-count changed; just update the cached Submit button
+			// rather than re-rendering all action buttons.
+			this.updateSubmitButtonState();
 		}
 		this._messageScrollable.scanDomNode();
 		this._onDidChangeHeight.fire();
@@ -496,6 +500,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	private renderActionButtons(container: HTMLElement, options?: { includeReject?: boolean }): void {
 		const includeReject = options?.includeReject ?? true;
 		this._buttonStore.clear();
+		this._submitButton = undefined;
+		this._renderedSubmitInlineCount = -1;
 		dom.clearNode(container);
 
 		// In feedback mode, show Submit + Reject. The Submit label includes
@@ -503,12 +509,11 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 		// what is about to be sent.
 		if (this._isFeedbackMode) {
 			const inlineCount = this.getInlineFeedbackItems().length;
-			const submitLabel = inlineCount > 0
-				? localize('chat.planReview.submitFeedbackWithCount', 'Submit Feedback ({0})', inlineCount)
-				: localize('chat.planReview.submitFeedback', 'Submit Feedback');
 			const submitButton = new Button(container, { ...defaultButtonStyles, supportIcons: true });
-			submitButton.label = submitLabel;
+			submitButton.label = this.computeSubmitLabel(inlineCount);
 			submitButton.enabled = this.canSubmitFeedback();
+			this._submitButton = submitButton;
+			this._renderedSubmitInlineCount = inlineCount;
 			this._buttonStore.add(submitButton);
 			this._buttonStore.add(submitButton.onDidClick(() => this.submitFeedback()));
 
@@ -577,6 +582,30 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 			return true;
 		}
 		return this.getInlineFeedbackItems().length > 0;
+	}
+
+	private computeSubmitLabel(inlineCount: number): string {
+		return inlineCount > 0
+			? localize('chat.planReview.submitFeedbackWithCount', 'Submit Feedback ({0})', inlineCount)
+			: localize('chat.planReview.submitFeedback', 'Submit Feedback');
+	}
+
+	/**
+	 * Update the cached Submit button's enabled state and (only when the
+	 * inline-comment count changed) its label. Cheap enough to run on every
+	 * keystroke, unlike `renderCurrentActionButtons` which destroys and
+	 * recreates the entire button row.
+	 */
+	private updateSubmitButtonState(): void {
+		if (!this._submitButton || !this._isFeedbackMode) {
+			return;
+		}
+		this._submitButton.enabled = this.canSubmitFeedback();
+		const inlineCount = this.getInlineFeedbackItems().length;
+		if (inlineCount !== this._renderedSubmitInlineCount) {
+			this._submitButton.label = this.computeSubmitLabel(inlineCount);
+			this._renderedSubmitInlineCount = inlineCount;
+		}
 	}
 
 	private toggleCollapsed(): void {
@@ -826,6 +855,8 @@ export class ChatPlanReviewPart extends Disposable implements IChatContentPart {
 	private markUsed(): void {
 		this.domNode.classList.add('chat-plan-review-used');
 		this._buttonStore.clear();
+		this._submitButton = undefined;
+		this._renderedSubmitInlineCount = -1;
 		// Unregister from the feedback service so the editor contribution
 		// hides/disables immediately, even if the plan file is still open.
 		this._planReviewRegistration.clear();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
@@ -171,11 +171,9 @@
 	min-height: 0;
 }
 
-/* The inner message element is what `DomScrollableElement` actually
- * measures (`clientHeight` / `scrollHeight`). It must fill the wrapper
- * exactly — otherwise its `clientHeight` reports its own (taller) layout
- * height instead of the visible wrapper area, and the scrollbar geometry
- * goes wrong as soon as the feedback section claims part of the widget. */
+/* The inner element must fill the wrapper exactly — `DomScrollableElement`
+ * measures `clientHeight` against it, so a taller layout height would break
+ * scrollbar geometry once the feedback section claims part of the widget. */
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message.chat-plan-review-body {
 	padding: 6px 12px;
 	background: transparent;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatPlanReview.css
@@ -171,32 +171,17 @@
 	min-height: 0;
 }
 
-/* The inner message element must have its own bounded height so that
- * `scrollHeight > clientHeight` and DomScrollableElement renders a scrollbar.
- * Without this the element grows to its natural content size and never
- * scrolls (parity with .chat-confirmation-widget-message in the tool
- * confirmation carousel). */
+/* The inner message element is what `DomScrollableElement` actually
+ * measures (`clientHeight` / `scrollHeight`). It must fill the wrapper
+ * exactly — otherwise its `clientHeight` reports its own (taller) layout
+ * height instead of the visible wrapper area, and the scrollbar geometry
+ * goes wrong as soon as the feedback section claims part of the widget. */
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message.chat-plan-review-body {
 	padding: 6px 12px;
 	background: transparent;
 	border-bottom: none;
-	max-height: min(320px, 40vh);
-}
-
-.interactive-session .chat-plan-review-container.chat-plan-review-expanded .chat-confirmation-widget-message.chat-plan-review-body {
-	max-height: min(620px, 65vh);
-}
-
-/* When the feedback section is open it claims ~80px below the body. Shrink
- * the body's cap so the widget's overall max-height isn't exceeded and the
- * footer buttons + textarea remain visible (otherwise the bottom of the
- * widget gets clipped by the widget's own `overflow: hidden`). */
-.interactive-session .chat-plan-review-container.chat-plan-review-feedback-mode .chat-confirmation-widget-message.chat-plan-review-body {
-	max-height: min(220px, 28vh);
-}
-
-.interactive-session .chat-plan-review-container.chat-plan-review-expanded.chat-plan-review-feedback-mode .chat-confirmation-widget-message.chat-plan-review-body {
-	max-height: min(520px, 55vh);
+	height: 100%;
+	box-sizing: border-box;
 }
 
 .interactive-session .chat-plan-review-container .chat-confirmation-widget-message.chat-plan-review-body .rendered-markdown p:first-child {
@@ -259,6 +244,112 @@
 	color: var(--vscode-input-placeholderForeground);
 }
 
+/* ---------- Inline comments list (anchored feedback captured from editor) ---------- */
+.interactive-session .chat-plan-review-container .chat-plan-review-comments-list-scrollable {
+	margin-bottom: 2px;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comments-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	max-height: 100px;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-row {
+	display: flex;
+	align-items: stretch;
+	min-width: 0;
+	border: 1px solid transparent;
+	border-radius: 4px;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-row:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-row:focus-within {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-reveal {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	padding: 3px 6px;
+	background: transparent;
+	border: none;
+	color: var(--vscode-foreground);
+	font: inherit;
+	font-size: var(--vscode-chat-font-size-body-s);
+	text-align: left;
+	cursor: pointer;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-reveal:focus {
+	outline: none;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-remove {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	color: var(--vscode-icon-foreground);
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-row:hover .chat-plan-review-comment-remove,
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-row:focus-within .chat-plan-review-comment-remove,
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-remove:focus {
+	opacity: 1;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-remove:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+	border-radius: 4px;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-line {
+	flex-shrink: 0;
+	color: var(--vscode-descriptionForeground);
+	font-variant-numeric: tabular-nums;
+}
+
+.interactive-session .chat-plan-review-container .chat-plan-review-comment-text {
+	flex: 1;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* ---------- Feedback header actions (Back, Clear All) ---------- */
+.interactive-session .chat-plan-review-container .chat-plan-review-feedback-header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.interactive-session .chat-plan-review-container .monaco-button.chat-plan-review-feedback-close,
+.interactive-session .chat-plan-review-container .monaco-button.chat-plan-review-feedback-clear-all,
+.interactive-session .chat-plan-review-container .monaco-button.chat-plan-review-review-button:not(.chat-plan-review-title-icon-button) {
+	width: auto;
+	min-width: auto;
+	padding: 0 8px;
+	height: 22px;
+}
+
 /* ---------- Footer buttons ---------- */
 .interactive-session .chat-plan-review-container > .chat-confirmation-widget2.chat-plan-review > .chat-confirmation-widget-buttons.chat-plan-review-footer {
 	justify-content: flex-start;
@@ -271,10 +362,6 @@
 	display: flex;
 	column-gap: 6px;
 	align-items: center;
-}
-
-.interactive-session .chat-plan-review-container > .chat-confirmation-widget2.chat-plan-review > .chat-confirmation-widget-buttons.chat-plan-review-footer .chat-buttons .monaco-button.chat-plan-review-feedback-button {
-	margin-left: auto;
 }
 
 /* ---------- Hidden helper ---------- */

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2933,13 +2933,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 		}
 
-		// Build the inline progress message for the response stream. While
-		// pending, this is "Plan review required" with a spinner. Once the
-		// user has answered, it transitions to the action that was taken
-		// (e.g. "Approved plan", "Started implementation with autopilot",
-		// "Provided feedback"). The actual feedback text is rendered as a
-		// separate user-message bubble; appending it here as a single
-		// collapsed line produced an unreadable wall of text.
+		// Build the inline progress message. While pending: "Plan review
+		// required" with a spinner. Once answered: the action that was
+		// taken (e.g. "Approved plan", "Provided feedback"). The actual
+		// feedback text is rendered as a separate markdown block beneath
+		// rather than collapsed onto the progress line.
 		const renderProgress = (): IChatContentPart => {
 			const message = this.getPlanReviewProgressMessage(review);
 			if (!message) {
@@ -2953,12 +2951,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			const renderedAsUsed = !!review.isUsed;
 			const isPending = !renderedAsUsed;
 			const data = renderedAsUsed && !review.data?.rejected ? review.data : undefined;
-			// Prefer the structured fields populated by `ChatPlanReviewPart`
-			// so we can render the overall comment inline (next to
-			// "Provided feedback:") and the inline-comments markdown block
-			// separately. Fall back to splitting the combined `feedback`
-			// string for backward compatibility with results produced
-			// before the structured fields existed.
+			// Prefer the structured fields from `ChatPlanReviewPart`; fall
+			// back to the combined `feedback` string for older results.
 			let overall = data?.feedbackOverall?.trim();
 			const inlineMd = data?.feedbackInlineMarkdown?.trim();
 			if (!overall && !inlineMd && data?.feedback) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2936,10 +2936,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// Build the inline progress message for the response stream. While
 		// pending, this is "Plan review required" with a spinner. Once the
 		// user has answered, it transitions to the action that was taken
-		// (e.g. "Approved plan", "Started implementation with autopilot"),
-		// and — when the user provided feedback — appends that feedback
-		// inline in the same progress row after a colon, collapsing
-		// whitespace so the transcript reads as a single line.
+		// (e.g. "Approved plan", "Started implementation with autopilot",
+		// "Provided feedback"). The actual feedback text is rendered as a
+		// separate user-message bubble; appending it here as a single
+		// collapsed line produced an unreadable wall of text.
 		const renderProgress = (): IChatContentPart => {
 			const message = this.getPlanReviewProgressMessage(review);
 			if (!message) {
@@ -2952,12 +2952,28 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			// pending → used transition and trigger a re-render.
 			const renderedAsUsed = !!review.isUsed;
 			const isPending = !renderedAsUsed;
-			const feedbackText = renderedAsUsed && !review.data?.rejected ? review.data?.feedback?.trim() : undefined;
-			const fullMessage = feedbackText
-				? localize('chat.planReview.feedbackInline', "{0}: {1}", message, feedbackText.replace(/\s+/g, ' '))
-				: message;
+			const data = renderedAsUsed && !review.data?.rejected ? review.data : undefined;
+			// Prefer the structured fields populated by `ChatPlanReviewPart`
+			// so we can render the overall comment inline (next to
+			// "Provided feedback:") and the inline-comments markdown block
+			// separately. Fall back to splitting the combined `feedback`
+			// string for backward compatibility with results produced
+			// before the structured fields existed.
+			let overall = data?.feedbackOverall?.trim();
+			const inlineMd = data?.feedbackInlineMarkdown?.trim();
+			if (!overall && !inlineMd && data?.feedback) {
+				overall = data.feedback.trim();
+			}
 			const content = new MarkdownString(undefined, { supportThemeIcons: true });
-			content.appendText(fullMessage);
+			if (overall) {
+				content.appendText(localize('chat.planReview.feedbackInline', "{0}: {1}", message, overall.replace(/\s+/g, ' ')));
+			} else {
+				content.appendText(message);
+			}
+			if (inlineMd) {
+				content.appendMarkdown('\n\n');
+				content.appendMarkdown(inlineMd);
+			}
 			const progressPart = this.instantiationService.createInstance(
 				ChatProgressContentPart,
 				{ content },

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1068,7 +1068,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			return;
 		}
 
-
 		this._isSyncingToOrFromInputModel = true;
 		const state = this.getCurrentInputState();
 		if (this._chatSessionIsEmpty) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1042,7 +1042,25 @@ export interface IChatPlanApprovalAction {
 export interface IChatPlanReviewResult {
 	action?: string;
 	rejected: boolean;
+	/**
+	 * The combined feedback string sent to the agent. Includes both the
+	 * overall textarea comment and any inline editor comments, joined with
+	 * blank lines and formatted as markdown.
+	 */
 	feedback?: string;
+	/**
+	 * Display-only: the overall textarea comment, separated from
+	 * `feedbackInlineMarkdown` so the chat transcript can render the two
+	 * parts differently (overall inline next to "Provided feedback:",
+	 * inline comments as a markdown block beneath). When unset, the
+	 * transcript falls back to rendering `feedback` verbatim.
+	 */
+	feedbackOverall?: string;
+	/**
+	 * Display-only: a pre-formatted markdown block listing the inline
+	 * editor comments (heading + bullet list). See `feedbackOverall`.
+	 */
+	feedbackInlineMarkdown?: string;
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1042,24 +1042,15 @@ export interface IChatPlanApprovalAction {
 export interface IChatPlanReviewResult {
 	action?: string;
 	rejected: boolean;
-	/**
-	 * The combined feedback string sent to the agent. Includes both the
-	 * overall textarea comment and any inline editor comments, joined with
-	 * blank lines and formatted as markdown.
-	 */
+	/** Combined feedback string sent to the agent (overall comment + inline
+	 * comments, joined and formatted as markdown). */
 	feedback?: string;
-	/**
-	 * Display-only: the overall textarea comment, separated from
+	/** Display-only: the overall textarea comment, kept separate from
 	 * `feedbackInlineMarkdown` so the chat transcript can render the two
-	 * parts differently (overall inline next to "Provided feedback:",
-	 * inline comments as a markdown block beneath). When unset, the
-	 * transcript falls back to rendering `feedback` verbatim.
-	 */
+	 * parts differently. Falls back to `feedback` when unset. */
 	feedbackOverall?: string;
-	/**
-	 * Display-only: a pre-formatted markdown block listing the inline
-	 * editor comments (heading + bullet list). See `feedbackOverall`.
-	 */
+	/** Display-only: pre-formatted markdown listing the inline comments
+	 * (heading + bullets). See `feedbackOverall`. */
 	feedbackInlineMarkdown?: string;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
@@ -69,11 +69,13 @@ suite('ChatPlanReviewPart', () => {
 
 	let widget: ChatPlanReviewPart;
 	let lastSubmitResult: IChatPlanReviewResult | undefined;
+	let lastFeedbackService: IPlanReviewFeedbackService | undefined;
 
 	function createWidget(review: IChatPlanReview, dialogService?: TestDialogService): ChatPlanReviewPart {
 		const instantiationService = workbenchInstantiationService(undefined, store);
 		const feedbackService = store.add(new PlanReviewFeedbackService());
 		instantiationService.stub(IPlanReviewFeedbackService, feedbackService);
+		lastFeedbackService = feedbackService;
 		if (dialogService) {
 			instantiationService.stub(IDialogService, dialogService);
 		}
@@ -90,6 +92,7 @@ suite('ChatPlanReviewPart', () => {
 			widget.domNode.parentNode.removeChild(widget.domNode);
 		}
 		lastSubmitResult = undefined;
+		lastFeedbackService = undefined;
 	});
 
 	suite('Basic rendering', () => {
@@ -324,7 +327,7 @@ suite('ChatPlanReviewPart', () => {
 			getReviewButton(widget)!.click();
 			await tick();
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 5, 1, 'Fix this step');
 			service.addFeedback(planUri, 12, 1, 'Reword this');
@@ -344,7 +347,7 @@ suite('ChatPlanReviewPart', () => {
 			getReviewButton(widget)!.click();
 			await tick();
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 1, 1, 'Hi');
 
@@ -360,7 +363,7 @@ suite('ChatPlanReviewPart', () => {
 			// Section starts hidden when planUri is present.
 			assert.strictEqual(getFeedbackSection(widget).style.display, 'none');
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 1, 1, 'Surprise comment');
 
@@ -374,7 +377,7 @@ suite('ChatPlanReviewPart', () => {
 			getReviewButton(widget)!.click();
 			await tick();
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 5, 1, 'Fix this');
 			service.addFeedback(planUri, 12, 1, 'Reword');
@@ -410,7 +413,7 @@ suite('ChatPlanReviewPart', () => {
 			getReviewButton(widget)!.click();
 			await tick();
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 1, 1, 'a');
 			service.addFeedback(planUri, 2, 1, 'b');
@@ -432,7 +435,7 @@ suite('ChatPlanReviewPart', () => {
 			getReviewButton(widget)!.click();
 			await tick();
 
-			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const service = lastFeedbackService!;
 			const planUri = URI.revive(review.planUri!);
 			service.addFeedback(planUri, 1, 1, 'a');
 			service.addFeedback(planUri, 2, 1, 'b');

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
@@ -260,7 +260,12 @@ suite('ChatPlanReviewPart', () => {
 			assert.ok(submitButton, 'Submit Feedback button should exist');
 			submitButton!.click();
 
-			assert.deepStrictEqual(lastSubmitResult, { rejected: false, feedback: 'Please also add tests' });
+			assert.deepStrictEqual(lastSubmitResult, {
+				rejected: false,
+				feedback: 'Please also add tests',
+				feedbackOverall: 'Please also add tests',
+				feedbackInlineMarkdown: undefined,
+			});
 		});
 
 		test('clicking Back exits feedback mode but preserves textarea draft', async () => {
@@ -329,7 +334,7 @@ suite('ChatPlanReviewPart', () => {
 
 			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
 			assert.ok(submitButton);
-			assert.match(submitButton!.textContent ?? '', /\(2\)/, 'Submit label should reflect inline count');
+			assert.ok((submitButton!.textContent ?? '').includes('(2)'), 'Submit label should reflect inline count');
 		});
 
 		test('inline comments alone are enough to enable Submit Feedback', async () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatPlanReviewPart.test.ts
@@ -5,10 +5,12 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { URI } from '../../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
 import { TestDialogService } from '../../../../../../../platform/dialogs/test/common/testDialogService.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { IPlanReviewFeedbackService, PlanReviewFeedbackService } from '../../../../browser/planReviewFeedback/planReviewFeedbackService.js';
 import { ChatPlanReviewPart, IChatPlanReviewPartOptions } from '../../../../browser/widget/chatContentParts/chatPlanReviewPart.js';
 import { IChatContentPartRenderContext } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
 import { IChatPlanApprovalAction, IChatPlanReview, IChatPlanReviewResult } from '../../../../common/chatService/chatService.js';
@@ -24,6 +26,14 @@ function createMockReview(overrides?: Partial<IChatPlanReview>): IChatPlanReview
 		canProvideFeedback: false,
 		...overrides,
 	};
+}
+
+function createMockReviewWithPlan(overrides?: Partial<IChatPlanReview>): IChatPlanReview {
+	return createMockReview({
+		canProvideFeedback: true,
+		planUri: URI.parse('file:///plan.md').toJSON(),
+		...overrides,
+	});
 }
 
 function createMockContext(): IChatContentPartRenderContext {
@@ -42,6 +52,18 @@ function getInlineButtons(widget: ChatPlanReviewPart): HTMLElement[] {
 	return container ? Array.from(container.querySelectorAll('.monaco-button')) : [];
 }
 
+function getReviewButton(widget: ChatPlanReviewPart): HTMLElement | null {
+	return widget.domNode.querySelector('.chat-plan-review-review-button') as HTMLElement | null;
+}
+
+function getFeedbackSection(widget: ChatPlanReviewPart): HTMLElement {
+	return widget.domNode.querySelector('.chat-plan-review-feedback') as HTMLElement;
+}
+
+function tick(): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, 0));
+}
+
 suite('ChatPlanReviewPart', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -50,6 +72,8 @@ suite('ChatPlanReviewPart', () => {
 
 	function createWidget(review: IChatPlanReview, dialogService?: TestDialogService): ChatPlanReviewPart {
 		const instantiationService = workbenchInstantiationService(undefined, store);
+		const feedbackService = store.add(new PlanReviewFeedbackService());
+		instantiationService.stub(IPlanReviewFeedbackService, feedbackService);
 		if (dialogService) {
 			instantiationService.stub(IDialogService, dialogService);
 		}
@@ -102,26 +126,40 @@ suite('ChatPlanReviewPart', () => {
 			assert.ok(buttons.some(b => b.textContent?.includes('Reject')), 'should have reject button');
 		});
 
-		test('hides feedback section initially even when canProvideFeedback is true', () => {
-			createWidget(createMockReview({ canProvideFeedback: true }));
+		test('hides feedback section initially when canProvideFeedback and planUri are both set', () => {
+			createWidget(createMockReviewWithPlan());
 
-			const feedbackSection = widget.domNode.querySelector('.chat-plan-review-feedback') as HTMLElement;
+			const feedbackSection = getFeedbackSection(widget);
 			assert.ok(feedbackSection);
 			assert.strictEqual(feedbackSection.style.display, 'none');
 		});
 
-		test('renders Provide Feedback button when canProvideFeedback is true', () => {
+		test('shows feedback section by default when canProvideFeedback is true and there is no planUri', () => {
 			createWidget(createMockReview({ canProvideFeedback: true }));
 
-			const buttons = getFooterButtons(widget);
-			assert.ok(buttons.some(b => b.textContent?.includes('Provide Feedback')), 'should have Provide Feedback button');
+			const feedbackSection = getFeedbackSection(widget);
+			assert.ok(feedbackSection);
+			assert.notStrictEqual(feedbackSection.style.display, 'none');
 		});
 
-		test('does not render Provide Feedback button when canProvideFeedback is false', () => {
-			createWidget(createMockReview({ canProvideFeedback: false }));
+		test('renders Review button when planUri is provided', () => {
+			createWidget(createMockReviewWithPlan());
+
+			const reviewButton = getReviewButton(widget);
+			assert.ok(reviewButton, 'Review button should exist');
+		});
+
+		test('does not render Review button when planUri is absent', () => {
+			createWidget(createMockReview({ canProvideFeedback: true }));
+
+			assert.strictEqual(getReviewButton(widget), null, 'Review button should not exist without planUri');
+		});
+
+		test('does not render Provide Feedback footer button (legacy entry removed)', () => {
+			createWidget(createMockReviewWithPlan());
 
 			const buttons = getFooterButtons(widget);
-			assert.ok(!buttons.some(b => b.textContent?.includes('Provide Feedback')), 'should not have Provide Feedback button');
+			assert.ok(!buttons.some(b => b.textContent?.includes('Provide Feedback')), 'should not have legacy Provide Feedback button');
 		});
 	});
 
@@ -179,42 +217,37 @@ suite('ChatPlanReviewPart', () => {
 	});
 
 	suite('Feedback mode', () => {
-		test('clicking Provide Feedback shows feedback section and Submit button', () => {
-			createWidget(createMockReview({ canProvideFeedback: true }));
+		test('clicking Review button opens feedback section and shows Submit Feedback button', async () => {
+			createWidget(createMockReviewWithPlan());
 
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			assert.ok(feedbackButton);
-			feedbackButton!.click();
+			const reviewButton = getReviewButton(widget)!;
+			reviewButton.click();
+			await tick();
 
-			// Feedback section should now be visible
-			const feedbackSection = widget.domNode.querySelector('.chat-plan-review-feedback') as HTMLElement;
+			// Feedback section should now be visible.
+			const feedbackSection = getFeedbackSection(widget);
 			assert.notStrictEqual(feedbackSection.style.display, 'none', 'feedback section should be visible');
 
-			// Should have Submit button
+			// Footer should have Submit Feedback + Reject (no approve, no Provide Feedback).
 			const buttons = getFooterButtons(widget);
-			assert.ok(buttons.some(b => b.textContent?.includes('Submit')), 'should have Submit button');
-
-			// Autopilot / Provide Feedback buttons should be gone
+			assert.ok(buttons.some(b => b.textContent?.includes('Submit Feedback')), 'should have Submit Feedback button');
+			assert.ok(buttons.some(b => b.textContent?.includes('Reject')), 'should still have Reject button');
 			assert.ok(!buttons.some(b => b.textContent?.includes('Autopilot')), 'approve button should be hidden');
-			assert.ok(!buttons.some(b => b.textContent?.includes('Provide Feedback')), 'feedback button should be hidden');
 		});
 
-		test('reject button remains visible in feedback mode', () => {
-			createWidget(createMockReview({ canProvideFeedback: true }));
+		test('reject button remains visible in feedback mode', async () => {
+			createWidget(createMockReviewWithPlan());
 
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
+			getReviewButton(widget)!.click();
+			await tick();
 
 			const buttons = getFooterButtons(widget);
 			assert.ok(buttons.some(b => b.textContent?.includes('Reject')), 'reject button should still be visible');
 		});
 
 		test('submitting feedback sends feedback value with rejected=false', () => {
+			// canProvideFeedback without planUri auto-shows the feedback section.
 			createWidget(createMockReview({ canProvideFeedback: true }));
-
-			// Enter feedback mode
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
 
 			// Type feedback
 			const textarea = widget.domNode.querySelector('.chat-plan-review-feedback-textarea') as HTMLTextAreaElement;
@@ -223,58 +256,187 @@ suite('ChatPlanReviewPart', () => {
 			textarea.dispatchEvent(new Event('input'));
 
 			// Click submit
-			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit'));
+			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
+			assert.ok(submitButton, 'Submit Feedback button should exist');
 			submitButton!.click();
 
 			assert.deepStrictEqual(lastSubmitResult, { rejected: false, feedback: 'Please also add tests' });
 		});
 
-		test('clicking feedback close button exits feedback mode, hides section, restores buttons, and clears draft', () => {
-			const data = new ChatPlanReviewData('Title', 'Content', [{ label: 'Autopilot', default: true }], true);
+		test('clicking Back exits feedback mode but preserves textarea draft', async () => {
+			const data = new ChatPlanReviewData('Title', 'Content', [{ label: 'Autopilot', default: true }], true, URI.parse('file:///plan.md').toJSON());
 			createWidget(data);
 
-			// Enter feedback mode
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
+			// Enter feedback mode via the Review button.
+			getReviewButton(widget)!.click();
+			await tick();
 
 			// Type some draft feedback
 			const textarea = widget.domNode.querySelector('.chat-plan-review-feedback-textarea') as HTMLTextAreaElement;
 			textarea.value = 'draft feedback';
 			textarea.dispatchEvent(new Event('input'));
 
-			// Click the close button inside the feedback header
-			const closeButton = widget.domNode.querySelector('.chat-plan-review-feedback-close') as HTMLElement;
-			assert.ok(closeButton, 'feedback close button should exist');
-			closeButton.click();
+			// Click Back inside the feedback header
+			const backButton = widget.domNode.querySelector('.chat-plan-review-feedback-close') as HTMLElement;
+			assert.ok(backButton, 'feedback Back button should exist');
+			backButton.click();
+			await tick();
 
 			// Feedback section should be hidden
-			const feedbackSection = widget.domNode.querySelector('.chat-plan-review-feedback') as HTMLElement;
+			const feedbackSection = getFeedbackSection(widget);
 			assert.strictEqual(feedbackSection.style.display, 'none', 'feedback section should be hidden');
 
-			// Footer buttons should be back to the normal set
+			// Footer buttons should be back to the normal set (Approve + Reject only).
 			const buttons = getFooterButtons(widget);
 			assert.ok(buttons.some(b => b.textContent?.includes('Autopilot')), 'approve button should be back');
-			assert.ok(buttons.some(b => b.textContent?.includes('Provide Feedback')), 'provide feedback button should be back');
 			assert.ok(buttons.some(b => b.textContent?.includes('Reject')), 'reject button should be back');
-			assert.ok(!buttons.some(b => b.textContent?.includes('Submit')), 'submit button should be gone');
+			assert.ok(!buttons.some(b => b.textContent?.includes('Submit Feedback')), 'submit button should be gone');
+			assert.ok(!buttons.some(b => b.textContent?.includes('Provide Feedback')), 'provide feedback button should not return');
 
-			// Draft feedback should be cleared
-			assert.strictEqual(textarea.value, '', 'textarea should be cleared');
-			assert.strictEqual(data.draftFeedback, '', 'draft feedback should be cleared');
+			// Back is non-destructive: draft persists.
+			assert.strictEqual(textarea.value, 'draft feedback', 'textarea draft should be preserved');
+			assert.strictEqual(data.draftFeedback, 'draft feedback', 'draft feedback should be preserved');
 		});
 
-		test('submit does nothing when feedback textarea is empty', () => {
-			createWidget(createMockReview({ canProvideFeedback: true }));
+		test('submit is disabled when feedback textarea is empty and no inline comments', async () => {
+			createWidget(createMockReviewWithPlan());
 
-			// Enter feedback mode
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
+			getReviewButton(widget)!.click();
+			await tick();
 
-			// Click submit without typing anything
-			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit'));
-			submitButton!.click();
+			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
+			assert.ok(submitButton);
+			assert.ok(submitButton!.classList.contains('disabled'), 'Submit Feedback should be disabled when nothing to submit');
+		});
+	});
 
-			assert.strictEqual(lastSubmitResult, undefined, 'should not submit with empty feedback');
+	suite('Inline comments list', () => {
+		test('renders comments list and updates Submit Feedback count when service has items', async () => {
+			const review = createMockReviewWithPlan();
+			createWidget(review);
+
+			// Enter feedback mode so the feedback section is visible.
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 5, 1, 'Fix this step');
+			service.addFeedback(planUri, 12, 1, 'Reword this');
+
+			const rows = widget.domNode.querySelectorAll('.chat-plan-review-comment-row');
+			assert.strictEqual(rows.length, 2, 'should render one row per inline comment');
+
+			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
+			assert.ok(submitButton);
+			assert.match(submitButton!.textContent ?? '', /\(2\)/, 'Submit label should reflect inline count');
+		});
+
+		test('inline comments alone are enough to enable Submit Feedback', async () => {
+			const review = createMockReviewWithPlan();
+			createWidget(review);
+
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 1, 1, 'Hi');
+
+			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
+			assert.ok(submitButton);
+			assert.ok(!submitButton!.classList.contains('disabled'), 'Submit Feedback should be enabled with one inline comment');
+		});
+
+		test('inline comments auto-promote into review mode even before Review button is clicked', () => {
+			const review = createMockReviewWithPlan();
+			createWidget(review);
+
+			// Section starts hidden when planUri is present.
+			assert.strictEqual(getFeedbackSection(widget).style.display, 'none');
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 1, 1, 'Surprise comment');
+
+			assert.notStrictEqual(getFeedbackSection(widget).style.display, 'none', 'section should auto-open when comments arrive');
+		});
+
+		test('per-row remove button removes only that comment from the service', async () => {
+			const review = createMockReviewWithPlan();
+			createWidget(review);
+
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 5, 1, 'Fix this');
+			service.addFeedback(planUri, 12, 1, 'Reword');
+			service.addFeedback(planUri, 20, 1, 'Add detail');
+
+			const removeButtons = widget.domNode.querySelectorAll('.chat-plan-review-comment-remove') as NodeListOf<HTMLElement>;
+			assert.strictEqual(removeButtons.length, 3, 'should render one remove button per row');
+
+			// Remove the middle one.
+			removeButtons[1].click();
+
+			const remaining = service.getFeedback(planUri);
+			assert.deepStrictEqual(remaining.map(i => i.text), ['Fix this', 'Add detail'], 'middle comment should be removed');
+		});
+
+		test('Clear All button is hidden when there are no inline comments', async () => {
+			const review = createMockReviewWithPlan();
+			createWidget(review);
+
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const clearAll = widget.domNode.querySelector('.chat-plan-review-feedback-clear-all') as HTMLElement;
+			assert.ok(clearAll, 'Clear All button should be in the DOM');
+			assert.strictEqual(clearAll.style.display, 'none', 'Clear All should be hidden when list is empty');
+		});
+
+		test('Clear All button removes all inline comments after confirmation', async () => {
+			const review = createMockReviewWithPlan();
+			const dialogService = new TestDialogService({ confirmed: true });
+			createWidget(review, dialogService);
+
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 1, 1, 'a');
+			service.addFeedback(planUri, 2, 1, 'b');
+
+			const clearAll = widget.domNode.querySelector('.chat-plan-review-feedback-clear-all') as HTMLElement;
+			assert.ok(clearAll, 'Clear All button should be present');
+			assert.notStrictEqual(clearAll.style.display, 'none', 'Clear All should be visible when list has items');
+			clearAll.click();
+			await tick();
+
+			assert.strictEqual(service.getFeedback(planUri).length, 0, 'all comments should be cleared');
+		});
+
+		test('Clear All cancellation keeps inline comments intact', async () => {
+			const review = createMockReviewWithPlan();
+			const dialogService = new TestDialogService({ confirmed: false });
+			createWidget(review, dialogService);
+
+			getReviewButton(widget)!.click();
+			await tick();
+
+			const service = widget['_planReviewFeedbackService'] as IPlanReviewFeedbackService;
+			const planUri = URI.revive(review.planUri!);
+			service.addFeedback(planUri, 1, 1, 'a');
+			service.addFeedback(planUri, 2, 1, 'b');
+
+			const clearAll = widget.domNode.querySelector('.chat-plan-review-feedback-clear-all') as HTMLElement;
+			clearAll.click();
+			await tick();
+
+			assert.strictEqual(service.getFeedback(planUri).length, 2, 'comments should be untouched when user cancels');
 		});
 	});
 
@@ -332,24 +494,26 @@ suite('ChatPlanReviewPart', () => {
 			assert.ok(!widget.domNode.classList.contains('chat-plan-review-expanded'));
 		});
 
-		test('collapsing resets feedback mode', () => {
-			createWidget(createMockReview({ canProvideFeedback: true }));
+		test('collapsing preserves feedback mode and inline buttons keep Submit Feedback', async () => {
+			createWidget(createMockReviewWithPlan());
 
-			// Enter feedback mode
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
+			// Enter feedback mode via the Review button.
+			getReviewButton(widget)!.click();
+			await tick();
 
-			// Now collapse
+			// Now collapse.
 			const collapseButton = widget.domNode.querySelector('.chat-plan-review-title-icon-button:last-child') as HTMLElement;
 			collapseButton.click();
 
-			// Expand again
-			collapseButton.click();
+			// Inline action should be Submit Feedback (preserves the mode).
+			const inlineButtons = getInlineButtons(widget);
+			assert.ok(inlineButtons.some(b => b.textContent?.includes('Submit Feedback')), 'inline action should be Submit Feedback when feedback mode is active');
 
-			// Should be back to normal mode with approve + feedback + reject
-			const buttons = getFooterButtons(widget);
-			assert.ok(buttons.some(b => b.textContent?.includes('Autopilot')), 'approve button should be back');
-			assert.ok(!buttons.some(b => b.textContent?.includes('Submit')), 'submit button should be gone');
+			// Expand again — still in feedback mode.
+			collapseButton.click();
+			const footerButtons = getFooterButtons(widget);
+			assert.ok(footerButtons.some(b => b.textContent?.includes('Submit Feedback')), 'submit feedback button should remain after expand');
+			assert.ok(!footerButtons.some(b => b.textContent?.includes('Autopilot')), 'approve should still be hidden in feedback mode');
 		});
 
 		test('restores draft collapsed state from ChatPlanReviewData', () => {
@@ -434,15 +598,12 @@ suite('ChatPlanReviewPart', () => {
 		test('disables feedback textarea after submission', () => {
 			createWidget(createMockReview({ canProvideFeedback: true }));
 
-			// Enter feedback mode and submit
-			const feedbackButton = getFooterButtons(widget).find(b => b.textContent?.includes('Provide Feedback'));
-			feedbackButton!.click();
-
+			// Without planUri the feedback section is auto-shown; just type and submit.
 			const textarea = widget.domNode.querySelector('.chat-plan-review-feedback-textarea') as HTMLTextAreaElement;
 			textarea.value = 'some feedback';
 			textarea.dispatchEvent(new Event('input'));
 
-			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit'));
+			const submitButton = getFooterButtons(widget).find(b => b.textContent?.includes('Submit Feedback'));
 			submitButton!.click();
 
 			assert.strictEqual(textarea.disabled, true, 'textarea should be disabled after submission');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

new feedback providing flow for the plan widget:
- clicking on "edit or provide feedback" will open the editor AND put it in the feedback mode.
- in agents, the modal opens and you can provide feedback. closing it, you'll see it in this feedback mode where you can review and also provide additional feedback
- second screenshot is just a visualization of inline + submitted feedback!


<img width="1562" height="878" alt="Screenshot 2026-04-30 at 2 39 49 PM (1)" src="https://github.com/user-attachments/assets/c9d971ea-5761-4c0c-8cfd-d2afc36aed31" />

<img width="754" height="318" alt="Screenshot 2026-04-30 at 2 39 56 PM (1)" src="https://github.com/user-attachments/assets/d1589e59-de6c-4fbb-a026-4d9d8975faff" />
