### PR TITLE
Agentic browser tools + Agent Host

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -66,7 +66,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 		'terminal.integrated.initialHint': false,
 
 		'workbench.browser.openLocalhostLinks': true,
-		'workbench.browser.enableChatTools': false,
+		'workbench.browser.enableChatTools': true,
 
 		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',
 		'workbench.editor.restoreEditors': false,

--- a/src/vs/workbench/contrib/browserView/common/browserChatToolReferenceNames.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserChatToolReferenceNames.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tool reference names for the integrated browser tools.
+ */
+export const BrowserChatToolReferenceName = {
+	OpenBrowserPage: 'openBrowserPage',
+	ReadPage: 'readPage',
+	ScreenshotPage: 'screenshotPage',
+	NavigatePage: 'navigatePage',
+	ClickElement: 'clickElement',
+	TypeInPage: 'typeInPage',
+	HoverElement: 'hoverElement',
+	DragElement: 'dragElement',
+	HandleDialog: 'handleDialog',
+	RunPlaywrightCode: 'runPlaywrightCode',
+} as const;
+
+/**
+ * All browser-tool reference names as a flat list.
+ */
+export const browserChatToolReferenceNames = Object.values(BrowserChatToolReferenceName);

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize2 } from '../../../../nls.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, registerAction2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -16,6 +16,8 @@ import { BrowserViewCommandId } from '../../../../platform/browserView/common/br
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { BrowserEditorInput } from '../common/browserEditorInput.js';
+import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
+import { AgentHostBrowserToolsEnabledSettingId } from './browserViewWorkbenchService.js';
 
 // Context key expression to check if browser editor is active
 export const BROWSER_EDITOR_ACTIVE = ContextKeyExpr.equals('activeEditor', BrowserEditorInput.EDITOR_ID);
@@ -238,7 +240,12 @@ class OpenBrowserSettingsAction extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const preferencesService = accessor.get(IPreferencesService);
-		await preferencesService.openSettings({ query: '@id:workbench.browser.*,chat.sendElementsToChat.*' });
+		const contextKeyService = accessor.get(IContextKeyService);
+		const ids = ['workbench.browser.*', 'chat.sendElementsToChat.*'];
+		if (IsSessionsWindowContext.getValue(contextKeyService)) {
+			ids.push(AgentHostBrowserToolsEnabledSettingId);
+		}
+		await preferencesService.openSettings({ query: `@id:${ids.join(',')}` });
 	}
 }
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -17,7 +17,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 import { BrowserEditorInput } from '../common/browserEditorInput.js';
 import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
-import { AgentHostBrowserToolsEnabledSettingId } from './browserViewWorkbenchService.js';
+import { AgentHostChatToolsEnabledSettingId } from './browserViewWorkbenchService.js';
 
 // Context key expression to check if browser editor is active
 export const BROWSER_EDITOR_ACTIVE = ContextKeyExpr.equals('activeEditor', BrowserEditorInput.EDITOR_ID);
@@ -243,7 +243,7 @@ class OpenBrowserSettingsAction extends Action2 {
 		const contextKeyService = accessor.get(IContextKeyService);
 		const ids = ['workbench.browser.*', 'chat.sendElementsToChat.*'];
 		if (IsSessionsWindowContext.getValue(contextKeyService)) {
-			ids.push(AgentHostBrowserToolsEnabledSettingId);
+			ids.push(AgentHostChatToolsEnabledSettingId);
 		}
 		await preferencesService.openSettings({ query: `@id:${ids.join(',')}` });
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -21,7 +21,16 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
+import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 import { ChatConfiguration } from '../../chat/common/constants.js';
+import { AgentHostEnabledSettingId } from '../../../../platform/agentHost/common/agentService.js';
+
+/**
+ * When enabled, integrated browser tools are exposed as client-provided tools
+ * to agent host sessions in the Sessions window. Has no effect outside the
+ * Sessions window or when the agent host is disabled.
+ */
+export const AgentHostBrowserToolsEnabledSettingId = 'chat.agentHost.browserToolsEnabled';
 
 /** Command IDs whose accelerators are shown in browser view context menus. */
 const browserViewContextMenuCommands = [
@@ -40,11 +49,33 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 	private readonly _onDidChangeBrowserViews = this._register(new Emitter<void>());
 	readonly onDidChangeBrowserViews: Event<void> = this._onDidChangeBrowserViews.event;
 
-	/** Context expression for whether browser tools / sharing is available. */
+	/**
+	 * Context expression for whether browser tools / sharing is available.
+	 *
+	 * Always requires chat to be enabled, agent mode to be enabled, and
+	 * `workbench.browser.enableChatTools` to be set. In addition:
+	 *
+	 * - **Regular workbench window**: the above is sufficient (historical
+	 *   behavior).
+	 * - **Sessions/Agents window**: browser tools are off by default and
+	 *   only become available when the agent host is running
+	 *   (`chat.agentHost.enabled`) and the dedicated feature flag
+	 *   (`chat.agentHost.browserToolsEnabled`) is set. They are surfaced to
+	 *   agent-host sessions through the client-tool bridge configured by
+	 *   `chat.agentHost.clientTools`.
+	 */
 	private static readonly _sharingAvailableContext = ContextKeyExpr.and(
 		ChatContextKeys.enabled,
 		ContextKeyExpr.has(`config.${ChatConfiguration.AgentEnabled}`),
 		ContextKeyExpr.has(`config.workbench.browser.enableChatTools`),
+		ContextKeyExpr.or(
+			IsSessionsWindowContext.negate(),
+			ContextKeyExpr.and(
+				IsSessionsWindowContext,
+				ContextKeyExpr.has(`config.${AgentHostEnabledSettingId}`),
+				ContextKeyExpr.has(`config.${AgentHostBrowserToolsEnabledSettingId}`),
+			),
+		),
 	)!;
 
 	private _isSharingAvailable: boolean = false;

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -49,25 +49,11 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 	private readonly _onDidChangeBrowserViews = this._register(new Emitter<void>());
 	readonly onDidChangeBrowserViews: Event<void> = this._onDidChangeBrowserViews.event;
 
-	/**
-	 * Context expression for whether browser tools / sharing is available.
-	 *
-	 * Always requires chat to be enabled, agent mode to be enabled, and
-	 * `workbench.browser.enableChatTools` to be set. In addition:
-	 *
-	 * - **Regular workbench window**: the above is sufficient (historical
-	 *   behavior).
-	 * - **Sessions/Agents window**: browser tools are off by default and
-	 *   only become available when the agent host is running
-	 *   (`chat.agentHost.enabled`) and the dedicated feature flag
-	 *   (`workbench.browser.agentHostChatToolsEnabled`) is set. They are
-	 *   surfaced to agent-host sessions through the client-tool bridge
-	 *   configured by `chat.agentHost.clientTools`.
-	 */
 	private static readonly _sharingAvailableContext = ContextKeyExpr.and(
 		ChatContextKeys.enabled,
 		ContextKeyExpr.has(`config.${ChatConfiguration.AgentEnabled}`),
 		ContextKeyExpr.has(`config.workbench.browser.enableChatTools`),
+		// If we're in Sessions Window, we require some additional conditions.
 		ContextKeyExpr.or(
 			IsSessionsWindowContext.negate(),
 			ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -21,7 +21,6 @@ import { IEditorGroupsService } from '../../../services/editor/common/editorGrou
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
-import { IsSessionsWindowContext } from '../../../common/contextkeys.js';
 import { ChatConfiguration } from '../../chat/common/constants.js';
 
 /** Command IDs whose accelerators are shown in browser view context menus. */
@@ -44,7 +43,6 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 	/** Context expression for whether browser tools / sharing is available. */
 	private static readonly _sharingAvailableContext = ContextKeyExpr.and(
 		ChatContextKeys.enabled,
-		IsSessionsWindowContext.negate(),
 		ContextKeyExpr.has(`config.${ChatConfiguration.AgentEnabled}`),
 		ContextKeyExpr.has(`config.workbench.browser.enableChatTools`),
 	)!;

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewWorkbenchService.ts
@@ -30,7 +30,7 @@ import { AgentHostEnabledSettingId } from '../../../../platform/agentHost/common
  * to agent host sessions in the Sessions window. Has no effect outside the
  * Sessions window or when the agent host is disabled.
  */
-export const AgentHostBrowserToolsEnabledSettingId = 'chat.agentHost.browserToolsEnabled';
+export const AgentHostChatToolsEnabledSettingId = 'workbench.browser.agentHostChatToolsEnabled';
 
 /** Command IDs whose accelerators are shown in browser view context menus. */
 const browserViewContextMenuCommands = [
@@ -60,9 +60,9 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 	 * - **Sessions/Agents window**: browser tools are off by default and
 	 *   only become available when the agent host is running
 	 *   (`chat.agentHost.enabled`) and the dedicated feature flag
-	 *   (`chat.agentHost.browserToolsEnabled`) is set. They are surfaced to
-	 *   agent-host sessions through the client-tool bridge configured by
-	 *   `chat.agentHost.clientTools`.
+	 *   (`workbench.browser.agentHostChatToolsEnabled`) is set. They are
+	 *   surfaced to agent-host sessions through the client-tool bridge
+	 *   configured by `chat.agentHost.clientTools`.
 	 */
 	private static readonly _sharingAvailableContext = ContextKeyExpr.and(
 		ChatContextKeys.enabled,
@@ -73,7 +73,7 @@ export class BrowserViewWorkbenchService extends Disposable implements IBrowserV
 			ContextKeyExpr.and(
 				IsSessionsWindowContext,
 				ContextKeyExpr.has(`config.${AgentHostEnabledSettingId}`),
-				ContextKeyExpr.has(`config.${AgentHostBrowserToolsEnabledSettingId}`),
+				ContextKeyExpr.has(`config.${AgentHostChatToolsEnabledSettingId}`),
 			),
 		),
 	)!;

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -35,9 +35,12 @@ import { BrowserEditor, BrowserEditorContribution, IBrowserEditorWidgetContribut
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { PolicyCategory } from '../../../../../base/common/policy.js';
+import product from '../../../../../platform/product/common/product.js';
+import { AgentHostEnabledSettingId } from '../../../../../platform/agentHost/common/agentService.js';
 import { workbenchConfigurationNodeBase } from '../../../../common/configuration.js';
 import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
 import { BrowserActionCategory } from '../browserViewActions.js';
+import { AgentHostBrowserToolsEnabledSettingId } from '../browserViewWorkbenchService.js';
 
 // Register tools
 import '../tools/browserTools.contribution.js';
@@ -627,6 +630,14 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 					}
 				},
 			}
+		},
+		[AgentHostBrowserToolsEnabledSettingId]: {
+			type: 'boolean',
+			markdownDescription: localize('chat.agentHost.browserToolsEnabled', "When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}.", `\`#${AgentHostEnabledSettingId}#\``, '`#workbench.browser.enableChatTools#`'),
+			default: false,
+			experiment: { mode: 'startup' },
+			tags: ['experimental', 'advanced'],
+			included: product.quality !== 'stable',
 		}
 	}
 });

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures.ts
@@ -40,7 +40,7 @@ import { AgentHostEnabledSettingId } from '../../../../../platform/agentHost/com
 import { workbenchConfigurationNodeBase } from '../../../../common/configuration.js';
 import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
 import { BrowserActionCategory } from '../browserViewActions.js';
-import { AgentHostBrowserToolsEnabledSettingId } from '../browserViewWorkbenchService.js';
+import { AgentHostChatToolsEnabledSettingId } from '../browserViewWorkbenchService.js';
 
 // Register tools
 import '../tools/browserTools.contribution.js';
@@ -631,9 +631,9 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				},
 			}
 		},
-		[AgentHostBrowserToolsEnabledSettingId]: {
+		[AgentHostChatToolsEnabledSettingId]: {
 			type: 'boolean',
-			markdownDescription: localize('chat.agentHost.browserToolsEnabled', "When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}.", `\`#${AgentHostEnabledSettingId}#\``, '`#workbench.browser.enableChatTools#`'),
+			markdownDescription: localize('workbench.browser.agentHostChatToolsEnabled', "When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}.", `\`#${AgentHostEnabledSettingId}#\``, '`#workbench.browser.enableChatTools#`'),
 			default: false,
 			experiment: { mode: 'startup' },
 			tags: ['experimental', 'advanced'],

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, playwrightInvoke } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const ClickBrowserToolData: IToolData = {
 	id: 'click_element',
-	toolReferenceName: 'clickElement',
+	toolReferenceName: BrowserChatToolReferenceName.ClickElement,
 	displayName: localize('clickBrowserTool.displayName', 'Click Element'),
 	userDescription: localize('clickBrowserTool.userDescription', 'Click an element in a browser page'),
 	modelDescription: 'Click on an element in a browser page.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, playwrightInvoke } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const DragElementToolData: IToolData = {
 	id: 'drag_element',
-	toolReferenceName: 'dragElement',
+	toolReferenceName: BrowserChatToolReferenceName.DragElement,
 	displayName: localize('dragElementTool.displayName', 'Drag Element'),
 	userDescription: localize('dragElementTool.userDescription', 'Drag an element over another element'),
 	modelDescription: 'Drag an element over another element in a browser page.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const HandleDialogBrowserToolData: IToolData = {
 	id: 'handle_dialog',
-	toolReferenceName: 'handleDialog',
+	toolReferenceName: BrowserChatToolReferenceName.HandleDialog,
 	displayName: localize('handleDialogBrowserTool.displayName', 'Handle Dialog'),
 	userDescription: localize('handleDialogBrowserTool.userDescription', 'Respond to a dialog in a browser page'),
 	modelDescription: 'Respond to a pending modal (alert, confirm, prompt) or file chooser dialog on a browser page.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, DEFAULT_ELEMENT_LABEL, errorResult, playwrightInvoke } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const HoverElementToolData: IToolData = {
 	id: 'hover_element',
-	toolReferenceName: 'hoverElement',
+	toolReferenceName: BrowserChatToolReferenceName.HoverElement,
 	displayName: localize('hoverElementTool.displayName', 'Hover Element'),
 	userDescription: localize('hoverElementTool.userDescription', 'Hover over an element in a browser page'),
 	modelDescription: 'Hover over an element in a browser page. Provide either a Playwright selector or an element reference.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
@@ -12,11 +12,12 @@ import { IPlaywrightService } from '../../../../../platform/browserView/common/p
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { IAgentNetworkFilterService } from '../../../../../platform/networkFilter/common/networkFilterService.js';
 import { createBrowserPageLink, errorResult, playwrightInvoke } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const NavigateBrowserToolData: IToolData = {
 	id: 'navigate_page',
-	toolReferenceName: 'navigatePage',
+	toolReferenceName: BrowserChatToolReferenceName.NavigatePage,
 	displayName: localize('navigateBrowserTool.displayName', 'Navigate Page'),
 	userDescription: localize('navigateBrowserTool.userDescription', 'Navigate or reload a browser page'),
 	modelDescription: 'Navigate a browser page by URL, history, or reload.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/openBrowserTool.ts
@@ -23,13 +23,14 @@ import { IChatRequestModel } from '../../../chat/common/model/chatModel.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { BrowserViewSharingState, IBrowserViewWorkbenchService } from '../../common/browserView.js';
 import { BrowserEditorInput } from '../../common/browserEditorInput.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { createBrowserPageLink, findExistingPagesByHost, getExistingPagesResult } from './browserToolHelpers.js';
 
 export const OpenPageToolId = 'open_browser_page';
 
 export const OpenBrowserToolData: IToolData = {
 	id: OpenPageToolId,
-	toolReferenceName: 'openBrowserPage',
+	toolReferenceName: BrowserChatToolReferenceName.OpenBrowserPage,
 	displayName: localize('openBrowserTool.displayName', 'Open Browser Page'),
 	userDescription: localize('openBrowserTool.userDescription', 'Open a URL in the integrated browser'),
 	modelDescription: `Open a new browser page in the integrated browser at the given URL.

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const ReadBrowserToolData: IToolData = {
 	id: 'read_page',
-	toolReferenceName: 'readPage',
+	toolReferenceName: BrowserChatToolReferenceName.ReadPage,
 	displayName: localize('readBrowserTool.displayName', 'Read Page'),
 	userDescription: localize('readBrowserTool.userDescription', 'Read the content of a browser page'),
 	modelDescription: 'Get a snapshot of the current browser page state. This is better than screenshot.',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
@@ -10,11 +10,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { errorResult, invokeFunctionResultToToolResult } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const RunPlaywrightCodeToolData: IToolData = {
 	id: 'run_playwright_code',
-	toolReferenceName: 'runPlaywrightCode',
+	toolReferenceName: BrowserChatToolReferenceName.RunPlaywrightCode,
 	displayName: localize('runPlaywrightCodeTool.displayName', 'Run Playwright Code'),
 	userDescription: localize('runPlaywrightCodeTool.userDescription', 'Run a Playwright code snippet against a browser page'),
 	modelDescription: `Run a Playwright code snippet to control a browser page. Only use this if other browser tools are insufficient.`,

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
@@ -14,12 +14,13 @@ import { IPlaywrightService } from '../../../../../platform/browserView/common/p
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { IBrowserViewWorkbenchService } from '../../common/browserView.js';
 import { errorResult, playwrightInvokeRaw } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 import { ReadBrowserToolData } from './readBrowserTool.js';
 
 export const ScreenshotBrowserToolData: IToolData = {
 	id: 'screenshot_page',
-	toolReferenceName: 'screenshotPage',
+	toolReferenceName: BrowserChatToolReferenceName.ScreenshotPage,
 	displayName: localize('screenshotBrowserTool.displayName', 'Screenshot Page'),
 	userDescription: localize('screenshotBrowserTool.userDescription', 'Capture a screenshot of a browser page'),
 	modelDescription: `Capture a screenshot of the current browser page. You can't perform actions based on the screenshot; use ${ReadBrowserToolData.id} for actions.`,

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
@@ -13,11 +13,12 @@ import { localize } from '../../../../../nls.js';
 import { IPlaywrightService } from '../../../../../platform/browserView/common/playwrightService.js';
 import { ToolDataSource, type CountTokensCallback, type IPreparedToolInvocation, type IToolData, type IToolImpl, type IToolInvocation, type IToolInvocationPreparationContext, type IToolResult, type ToolProgress } from '../../../chat/common/tools/languageModelToolsService.js';
 import { createBrowserPageLink, errorResult, playwrightInvoke } from './browserToolHelpers.js';
+import { BrowserChatToolReferenceName } from '../../common/browserChatToolReferenceNames.js';
 import { OpenPageToolId } from './openBrowserTool.js';
 
 export const TypeBrowserToolData: IToolData = {
 	id: 'type_in_page',
-	toolReferenceName: 'typeInPage',
+	toolReferenceName: BrowserChatToolReferenceName.TypeInPage,
 	displayName: localize('typeBrowserTool.displayName', 'Type in Page'),
 	userDescription: localize('typeBrowserTool.userDescription', 'Type text or press keys in a browser page'),
 	modelDescription: 'Type text or press keys in a browser page.',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -195,12 +195,7 @@ CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor
 const toolReferenceNameEnumValues: string[] = [];
 const toolReferenceNameEnumDescriptions: string[] = [];
 
-/**
- * Tool reference names for the integrated browser tools registered in
- * `src/vs/workbench/contrib/browserView/electron-browser/tools/`. Exposing
- * these as agent-host client tools lets background agents drive the
- * integrated browser pane (open/read pages, click, type, screenshot, etc.).
- */
+// Tool reference names for the integrated browser tools.
 const browserClientTools = [
 	'openBrowserPage',
 	'readPage',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -195,7 +195,12 @@ CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor
 const toolReferenceNameEnumValues: string[] = [];
 const toolReferenceNameEnumDescriptions: string[] = [];
 
-// Tool reference names for the integrated browser tools.
+/**
+ * Tool reference names for the integrated browser tools.
+ * Always present in the {@link ChatConfiguration.AgentHostClientTools} default but
+ * only effective when the tools themselves are actually registered, which is currently
+ * feature-flag-gated.
+ */
 const browserClientTools = [
 	'openBrowserPage',
 	'readPage',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -195,6 +195,25 @@ CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor
 const toolReferenceNameEnumValues: string[] = [];
 const toolReferenceNameEnumDescriptions: string[] = [];
 
+/**
+ * Tool reference names for the integrated browser tools registered in
+ * `src/vs/workbench/contrib/browserView/electron-browser/tools/`. Exposing
+ * these as agent-host client tools lets background agents drive the
+ * integrated browser pane (open/read pages, click, type, screenshot, etc.).
+ */
+const browserClientTools = [
+	'openBrowserPage',
+	'readPage',
+	'screenshotPage',
+	'navigatePage',
+	'clickElement',
+	'typeInPage',
+	'hoverElement',
+	'dragElement',
+	'handleDialog',
+	'runPlaywrightCode',
+];
+
 // Register JSON schema for hook files
 const jsonContributionRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 jsonContributionRegistry.registerSchema(HOOK_SCHEMA_URI, hookFileSchema);
@@ -969,7 +988,10 @@ configurationRegistry.registerConfiguration({
 			type: 'array',
 			items: { type: 'string' },
 			description: nls.localize('chat.agentHost.clientTools', "Tool reference names to expose as client-provided tools in agent host sessions."),
-			default: ['runTask', 'getTaskOutput', 'problems', 'runTests'],
+			default: [
+				'runTask', 'getTaskOutput', 'problems', 'runTests',
+				...browserClientTools,
+			],
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',
 		},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -197,9 +197,8 @@ const toolReferenceNameEnumDescriptions: string[] = [];
 
 /**
  * Tool reference names for the integrated browser tools.
- * Always present in the {@link ChatConfiguration.AgentHostClientTools} default but
- * only effective when the tools themselves are actually registered, which is currently
- * feature-flag-gated.
+ * These are always present in the {@link ChatConfiguration.AgentHostClientTools} default but
+ * out of these, only the tools that are actually registered/enabled are seen by the agent.
  */
 const browserClientTools = [
 	'openBrowserPage',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -187,6 +187,7 @@ import { ChatQueuePickerRendering } from './widget/input/chatQueuePickerActionIt
 import { ExploreAgentDefaultModel } from './exploreAgentDefaultModel.js';
 import { PlanAgentDefaultModel } from './planAgentDefaultModel.js';
 import { ChatImageCarouselService, IChatImageCarouselService } from './chatImageCarouselService.js';
+import { browserChatToolReferenceNames } from '../../browserView/common/browserChatToolReferenceNames.js';
 
 CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor: ServicesAccessor, resolveId: string, answers?: import('../common/chatService/chatService.js').IChatQuestionAnswers) => {
 	accessor.get(IChatService).notifyQuestionCarouselAnswer('', resolveId, answers);
@@ -194,24 +195,6 @@ CommandsRegistry.registerCommand('_chat.notifyQuestionCarouselAnswer', (accessor
 
 const toolReferenceNameEnumValues: string[] = [];
 const toolReferenceNameEnumDescriptions: string[] = [];
-
-/**
- * Tool reference names for the integrated browser tools.
- * These are always present in the {@link ChatConfiguration.AgentHostClientTools} default but
- * out of these, only the tools that are actually registered/enabled are seen by the agent.
- */
-const browserClientTools = [
-	'openBrowserPage',
-	'readPage',
-	'screenshotPage',
-	'navigatePage',
-	'clickElement',
-	'typeInPage',
-	'hoverElement',
-	'dragElement',
-	'handleDialog',
-	'runPlaywrightCode',
-];
 
 // Register JSON schema for hook files
 const jsonContributionRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
@@ -989,7 +972,9 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.agentHost.clientTools', "Tool reference names to expose as client-provided tools in agent host sessions."),
 			default: [
 				'runTask', 'getTaskOutput', 'problems', 'runTests',
-				...browserClientTools,
+				// These are always present in the {@link ChatConfiguration.AgentHostClientTools} default but
+				// out of these, only the tools that are actually registered/enabled are seen by the agent.
+				...browserChatToolReferenceNames,
 			],
 			tags: ['experimental', 'advanced'],
 			included: product.quality !== 'stable',


### PR DESCRIPTION
* Closes https://github.com/microsoft/vscode/issues/313798

To try it out in OSS:

- Open Agents app
  - <img width="380" height="41" alt="image" src="https://github.com/user-attachments/assets/fbafb4e7-92fb-46ca-b13b-b44dd5f9c7c7" />
- Set `"chat.agentHost.enabled": true,`
- Set `"workbench.browser.agentHostChatToolsEnabled": true,`
- In Agents app, click on the option to select a workspace or folder, then click on Select Folders... > Local Agent Host
  - <img width="1954" height="278" alt="image" src="https://github.com/user-attachments/assets/0b627e57-d620-4a6a-9390-2bbd97174c4f" />
- Select a folder
- Send a prompt that uses browser. It doesn't matter if you use a Folder or Worktree type of session
  - <img width="360" height="135" alt="image" src="https://github.com/user-attachments/assets/a1429f55-73da-4114-aa47-da06cc00c724" />