### PR TITLE
Sessions: always show Remote tab in workspace picker, fix manage actions

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -482,8 +482,6 @@ export interface IActionListOptions {
 	 */
 	readonly showGroupTitleOnFirstItem?: boolean;
 
-
-
 	/**
 	 * When true and filtering is enabled, focuses the filter input when the list opens.
 	 */

--- a/src/vs/platform/actionWidget/browser/tabbedActionListWidget.ts
+++ b/src/vs/platform/actionWidget/browser/tabbedActionListWidget.ts
@@ -7,6 +7,7 @@ import * as dom from '../../../base/browser/dom.js';
 import { IListAccessibilityProvider } from '../../../base/browser/ui/list/listWidget.js';
 import { Radio } from '../../../base/browser/ui/radio/radio.js';
 import { KeyCode } from '../../../base/common/keyCodes.js';
+import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../base/common/lifecycle.js';
 import { IContextViewService } from '../../contextview/browser/contextView.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
@@ -14,7 +15,7 @@ import { ActionList, IActionListDelegate, IActionListItem, IActionListOptions } 
 import './tabbedActionListWidget.css';
 
 /**
- * Result of {@link ITabbedActionListShowOptions.buildItems}. The list
+ * Result of {@link ITabbedActionListShowOptions.createActionList}. The list
  * options are recomputed on every tab switch so callers can vary filter
  * visibility, width, etc. by tab.
  */
@@ -39,7 +40,7 @@ export interface ITabbedActionListShowOptions<T> {
 	/** Initially active tab. Must be present in {@link tabs}. */
 	readonly initialTab: string;
 	/** Computes the list items and per-tab options shown when the given tab is active. */
-	buildItems(activeTab: string): ITabbedActionListBuildResult<T>;
+	createActionList(activeTab: string): ITabbedActionListBuildResult<T>;
 	/** Item delegate (selection, hide, focus). */
 	readonly delegate: IActionListDelegate<T>;
 	/** Optional accessibility provider passed to the underlying list. */
@@ -48,21 +49,18 @@ export interface ITabbedActionListShowOptions<T> {
 	readonly width?: number;
 	/** Optional class name to add to the tab bar element (in addition to `.tabbed-action-list-tabbar`). Must be a single class. */
 	readonly tabBarClassName?: string;
-	/** Fired with the new tab when the user switches tabs. */
-	onDidChangeTab?(tab: string): void;
-	/** Fired when the popup hides for any reason. */
-	onHide?(): void;
 }
 
 /**
- * Composite popup widget that renders a horizontal tab bar above an
- * {@link ActionList}. Owns its own context-view lifecycle and swap state;
- * consumers describe the data and react to tab changes via callbacks.
- *
- * Bypasses `IActionWidgetService` so this widget can compose with any
- * caller-driven state without extending the platform action widget API.
+ * A widget that shows a tabbed action list in a context view popup
  */
 export class TabbedActionListWidget extends Disposable {
+
+	private readonly _onDidChangeTab = this._register(new Emitter<string>());
+	readonly onDidChangeTab = this._onDidChangeTab.event;
+
+	private readonly _onDidHide = this._register(new Emitter<void>());
+	readonly onDidHide = this._onDidHide.event;
 
 	private readonly _activePopup = this._register(new MutableDisposable());
 	private _swappingTab = false;
@@ -129,7 +127,7 @@ export class TabbedActionListWidget extends Disposable {
 						return;
 					}
 					activeTab = next;
-					options.onDidChangeTab?.(next);
+					this._onDidChangeTab.fire(next);
 					this.show({ ...options, initialTab: next });
 				};
 
@@ -140,7 +138,7 @@ export class TabbedActionListWidget extends Disposable {
 					}
 				}));
 
-				const { items, listOptions } = options.buildItems(activeTab);
+				const { items, listOptions } = options.createActionList(activeTab);
 				const list = renderDisposables.add(this._instantiationService.createInstance(
 					ActionList<T>,
 					options.user,
@@ -238,7 +236,7 @@ export class TabbedActionListWidget extends Disposable {
 					this._activePopup.value = undefined;
 				}
 				options.delegate.onHide?.();
-				options.onHide?.();
+				this._onDidHide.fire();
 			},
 			get anchorPosition() { return listRef?.anchorPosition; },
 		}, undefined, false);

--- a/src/vs/platform/actionWidget/test/browser/tabbedActionListWidget.test.ts
+++ b/src/vs/platform/actionWidget/test/browser/tabbedActionListWidget.test.ts
@@ -111,7 +111,7 @@ suite('TabbedActionListWidget', () => {
 			anchor,
 			tabs: ['Local', 'Remote'],
 			initialTab: 'Local',
-			buildItems: () => ({ items: [action('a')] }),
+			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },
 		});
 		assert.strictEqual(widget.isVisible, true);
@@ -132,7 +132,7 @@ suite('TabbedActionListWidget', () => {
 			anchor,
 			tabs: ['Local', 'Remote'],
 			initialTab: 'Remote',
-			buildItems: (tab) => {
+			createActionList: (tab) => {
 				calls.push(tab);
 				return { items: [action(tab)] };
 			},
@@ -153,7 +153,7 @@ suite('TabbedActionListWidget', () => {
 			anchor,
 			tabs: ['Local'],
 			initialTab: 'Local',
-			buildItems: () => ({ items: [action('a')] }),
+			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },
 		});
 
@@ -165,26 +165,26 @@ suite('TabbedActionListWidget', () => {
 		widget.hide();
 	});
 
-	test('onHide fires when the popup dismisses', () => {
+	test('onDidHide fires when the popup dismisses', () => {
 		const { widget, contextView } = createWidget(disposables);
 		const anchor = document.createElement('div');
 		document.body.appendChild(anchor);
 		disposables.add({ dispose: () => anchor.remove() });
 
 		let hidden = 0;
+		disposables.add(widget.onDidHide(() => { hidden++; }));
 		widget.show<ITestItem>({
 			user: 'test',
 			anchor,
 			tabs: ['Local'],
 			initialTab: 'Local',
-			buildItems: () => ({ items: [action('a')] }),
+			createActionList: () => ({ items: [action('a')] }),
 			delegate: { onSelect: () => { }, onHide: () => { } },
-			onHide: () => { hidden++; },
 		});
 
 		// Simulate an external dismissal (e.g. user clicked outside).
 		contextView.hideContextView();
-		assert.strictEqual(hidden, 1, `expected onHide to fire once, got ${hidden}; widget visible: ${widget.isVisible}`);
+		assert.strictEqual(hidden, 1, `expected onDidHide to fire once, got ${hidden}; widget visible: ${widget.isVisible}`);
 		assert.strictEqual(widget.isVisible, false);
 	});
 });

--- a/src/vs/sessions/common/contextkeys.ts
+++ b/src/vs/sessions/common/contextkeys.ts
@@ -33,6 +33,12 @@ export const SessionsWelcomeVisibleContext = new RawContextKey<boolean>('session
 
 //#endregion
 
+//#region < --- Workspace Picker --- >
+
+export const SessionWorkspacePickerGroupContext = new RawContextKey<string>('sessionWorkspacePickerGroup', '', localize('sessionWorkspacePickerGroup', "The currently active group tab in the session workspace picker"));
+
+//#endregion
+
 //#region < --- Aquarium --- >
 
 export const SessionsAquariumActiveContext = new RawContextKey<boolean>('sessionsAquariumActive', false, localize('sessionsAquariumActive', "Whether the sessions aquarium overlay is active"));

--- a/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/localAgentHostSessionsProvider.ts
@@ -14,7 +14,6 @@ import { localize } from '../../../../nls.js';
 import { IAgentConnection, IAgentHostService, type IAgentSessionMetadata } from '../../../../platform/agentHost/common/agentService.js';
 import type { ISessionGitState } from '../../../../platform/agentHost/common/state/sessionState.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
@@ -42,13 +41,13 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 	readonly label: string;
 	readonly icon: ThemeIcon = Codicon.vm;
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
+	readonly supportsLocalWorkspaces = true;
 
 	private readonly _localLabel = localize('localAgentHostSessionTypeLocation', "Local");
 	private readonly _localDescription = new MarkdownString(this._localLabel);
 
 	constructor(
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
-		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@IChatSessionsService chatSessionsService: IChatSessionsService,
 		@IChatService chatService: IChatService,
 		@IChatWidgetService chatWidgetService: IChatWidgetService,
@@ -60,14 +59,7 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 
 		this.label = localize('localAgentHostLabel', "Local Agent Host");
 
-		this.browseActions = [{
-			label: localize('folders', "Folders"),
-			description: this.label,
-			group: SESSION_WORKSPACE_GROUP_LOCAL,
-			icon: Codicon.folderOpened,
-			providerId: this.id,
-			run: () => this._browseForFolder(),
-		}];
+		this.browseActions = [];
 
 		this._attachConnectionListeners(this._agentHostService, this._store);
 
@@ -160,24 +152,5 @@ export class LocalAgentHostSessionsProvider extends BaseAgentHostSessionsProvide
 			repositories: [{ uri: repositoryUri, workingDirectory: undefined, detail: undefined, baseBranchName: undefined }],
 			requiresWorkspaceTrust: true,
 		};
-	}
-
-	// -- Browse --------------------------------------------------------------
-
-	private async _browseForFolder(): Promise<ISessionWorkspace | undefined> {
-		try {
-			const selected = await this._fileDialogService.showOpenDialog({
-				canSelectFiles: false,
-				canSelectFolders: true,
-				canSelectMany: false,
-				title: localize('selectLocalFolder', "Select Folder"),
-			});
-			if (selected?.[0]) {
-				return this.resolveWorkspace(selected[0]);
-			}
-		} catch {
-			// dialog was cancelled or failed
-		}
-		return undefined;
 	}
 }

--- a/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/agentHost/test/browser/localAgentHostSessionsProvider.test.ts
@@ -354,11 +354,10 @@ suite('LocalAgentHostSessionsProvider', () => {
 
 	// ---- Browse actions -------
 
-	test('has one browse action for local folders', () => {
+	test('has no browse actions', () => {
 		const provider = createProvider(disposables, agentHost);
 
-		assert.strictEqual(provider.browseActions.length, 1);
-		assert.strictEqual(provider.browseActions[0].providerId, provider.id);
+		assert.strictEqual(provider.browseActions.length, 0);
 	});
 
 	// ---- Session listing via notifications -------

--- a/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/scopedWorkspacePicker.ts
@@ -12,7 +12,9 @@ import { IRemoteAgentHostService } from '../../../../platform/agentHost/common/r
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
@@ -44,6 +46,8 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 		@IMenuService menuService: IMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
+		@IFileDialogService fileDialogService: IFileDialogService,
+		@IQuickInputService quickInputService: IQuickInputService,
 		@IAgentHostFilterService private readonly _agentHostFilterService: IAgentHostFilterService,
 	) {
 		super(
@@ -58,6 +62,8 @@ export class ScopedWorkspacePicker extends WorkspacePicker {
 			menuService,
 			contextKeyService,
 			instantiationService,
+			fileDialogService,
+			quickInputService,
 		);
 
 		// When the scoped host changes, if the current selection no longer

--- a/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionWorkspacePicker.ts
@@ -5,7 +5,7 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import * as touch from '../../../../base/browser/touch.js';
-import { IAction, SubmenuAction, toAction } from '../../../../base/common/actions.js';
+import { IAction, toAction } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { disposableTimeout } from '../../../../base/common/async.js';
@@ -22,14 +22,17 @@ import { IRemoteAgentHostService, RemoteAgentHostConnectionStatus } from '../../
 import { TUNNEL_ADDRESS_PREFIX } from '../../../../platform/agentHost/common/tunnelAgentHost.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKeyService, IContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_CLOUD, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../services/sessions/common/session.js';
+import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../services/sessions/common/session.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { SessionWorkspacePickerGroupContext } from '../../../common/contextkeys.js';
 import { getStatusHover, getStatusLabel, showRemoteHostOptions } from '../../remoteAgentHost/browser/remoteHostOptions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { COPILOT_PROVIDER_ID } from '../../copilotChatSessions/browser/copilotChatSessionsProvider.js';
@@ -47,18 +50,6 @@ const MAX_RECENT_WORKSPACES = 10;
  * tabs.
  */
 const TABBED_PICKER_WIDTH = 360;
-
-/**
- * Canonical order in which well-known tab labels are rendered. Tabs whose
- * labels don't match any of these constants are appended in registration
- * order after the recognized ones.
- */
-const KNOWN_TAB_ORDER: readonly string[] = [
-	SESSION_WORKSPACE_GROUP_LOCAL,
-	SESSION_WORKSPACE_GROUP_CLOUD,
-	SESSION_WORKSPACE_GROUP_REMOTE,
-];
-const KNOWN_TAB_SET = new Set<string>(KNOWN_TAB_ORDER);
 
 /**
  * Grace period for a restored remote workspace's provider to reach Connected
@@ -95,6 +86,8 @@ export interface IWorkspacePickerItem {
 	readonly checked?: boolean;
 	/** Command to execute when this item is selected. */
 	readonly commandId?: string;
+	/** Inline action to run when this item is selected. */
+	readonly run?: () => void;
 }
 
 /**
@@ -128,9 +121,13 @@ export class WorkspacePicker extends Disposable {
 	 */
 	private readonly _connectionStatusWatch = this._register(new MutableDisposable());
 
+	/** Provider ID chosen during the last local folder browse. */
+	private _selectedLocalProviderId: string | undefined;
+
 	private _triggerElement: HTMLElement | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	private readonly _tabbedWidget: TabbedActionListWidget;
+	private readonly _pickerGroupContext: IContextKey<string>;
 
 	/**
 	 * Currently active workspace tab (a group label contributed by a
@@ -164,10 +161,21 @@ export class WorkspacePicker extends Disposable {
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IFileDialogService private readonly fileDialogService: IFileDialogService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
 	) {
 		super();
 
 		this._tabbedWidget = this._register(this.instantiationService.createInstance(TabbedActionListWidget));
+		this._pickerGroupContext = SessionWorkspacePickerGroupContext.bindTo(this.contextKeyService);
+		this._register(this._tabbedWidget.onDidChangeTab(tab => {
+			this._activeTab = tab;
+			this._userPickedTab = true;
+			this._pickerGroupContext.set(tab);
+		}));
+		this._register(this._tabbedWidget.onDidHide(() => {
+			this._pickerGroupContext.reset();
+		}));
 
 		// Migrate legacy storage to new key
 		this._migrateLegacyStorage();
@@ -275,7 +283,7 @@ export class WorkspacePicker extends Disposable {
 			return;
 		}
 
-		const tabs = this._showTabs() ? this._getAvailableTabs() : [];
+		const tabs = this._showTabs() ? this._getAvailableGroups() : [];
 
 		// Default the active tab to the group of the currently selected
 		// workspace. The user-pick latch is reset on every selection change,
@@ -308,31 +316,23 @@ export class WorkspacePicker extends Disposable {
 		return true;
 	}
 
-	/**
-	 * Discovers the union of `group` labels contributed by all providers'
-	 * browse actions and recent workspaces. Well-known labels (Local /
-	 * Cloud / Remote) come first in canonical order; any custom labels
-	 * provider plug-ins might contribute follow in registration order.
-	 *
-	 * Visible to tests; not part of the public API.
-	 */
-	protected _getAvailableTabs(): string[] {
-		const seen = new Set<string>();
+	protected _getAvailableGroups(): string[] {
+		const groups = new Set<string>();
+		groups.add(SESSION_WORKSPACE_GROUP_REMOTE);
 		for (const provider of this.sessionsProvidersService.getProviders()) {
+			if (provider.supportsLocalWorkspaces) {
+				groups.add(SESSION_WORKSPACE_GROUP_LOCAL);
+			}
 			for (const action of provider.browseActions) {
 				if (action.group) {
-					seen.add(action.group);
+					groups.add(action.group);
 				}
 			}
 		}
-		for (const { workspace } of this._getRecentWorkspaces()) {
-			if (workspace.group) {
-				seen.add(workspace.group);
-			}
-		}
-		const known = KNOWN_TAB_ORDER.filter(g => seen.has(g));
-		const extra = [...seen].filter(g => !KNOWN_TAB_SET.has(g));
-		return [...known, ...extra];
+		return Array.from(groups).sort((a, b) =>
+			a === SESSION_WORKSPACE_GROUP_LOCAL ? -1
+				: b === SESSION_WORKSPACE_GROUP_LOCAL ? 1
+					: a.localeCompare(b));
 	}
 
 	/**
@@ -343,7 +343,9 @@ export class WorkspacePicker extends Disposable {
 		return {
 			onSelect: (item) => {
 				hide();
-				if (item.commandId) {
+				if (item.run) {
+					item.run();
+				} else if (item.commandId) {
 					this.commandService.executeCommand(item.commandId);
 				} else if (item.selection && this._isProviderUnavailable(item.selection.providerId)) {
 					// Workspace belongs to an unavailable remote — ignore selection
@@ -419,24 +421,21 @@ export class WorkspacePicker extends Disposable {
 		};
 
 		triggerElement.setAttribute('aria-expanded', 'true');
+		this._pickerGroupContext.set(this._activeTab ?? tabs[0]);
 		this._tabbedWidget.show<IWorkspacePickerItem>({
 			user: 'workspacePicker',
 			anchor: triggerElement,
 			tabs,
 			initialTab: this._activeTab ?? tabs[0],
-			buildItems: (tab) => {
+			createActionList: (tab) => {
 				this._activeTab = tab;
 				const items = this._buildItems();
-				return { items, listOptions: this._buildListOptions(items, TABBED_PICKER_WIDTH) };
+				return { items, listOptions: { inlineDescription: true, showGroupTitleOnFirstItem: true } };
 			},
 			delegate,
 			accessibilityProvider,
 			width: TABBED_PICKER_WIDTH,
 			tabBarClassName: 'sessions-workspace-picker-tabbar',
-			onDidChangeTab: (tab) => {
-				this._activeTab = tab;
-				this._userPickedTab = true;
-			},
 		});
 	}
 
@@ -510,7 +509,15 @@ export class WorkspacePicker extends Disposable {
 		try {
 			const workspace = await action.run();
 			if (workspace) {
-				this._selectProject({ providerId: action.providerId, workspace });
+				let providerId = action.providerId;
+				if (!providerId) {
+					// Picker-owned local action — use the provider chosen during browse
+					providerId = this._selectedLocalProviderId ?? '';
+					this._selectedLocalProviderId = undefined;
+				}
+				if (providerId) {
+					this._selectProject({ providerId, workspace });
+				}
 			}
 		} catch {
 			// browse action was cancelled or failed
@@ -523,27 +530,62 @@ export class WorkspacePicker extends Disposable {
 	 */
 	protected _getAllBrowseActions(): ISessionWorkspaceBrowseAction[] {
 		const all = this.sessionsProvidersService.getProviders().flatMap(p => p.browseActions);
+		const hasLocalSupport = this.sessionsProvidersService.getProviders().some(p => p.supportsLocalWorkspaces);
+		if (hasLocalSupport) {
+			const localAction: ISessionWorkspaceBrowseAction = {
+				label: localize('workspacePicker.browseSelectLocal', "Select..."),
+				group: SESSION_WORKSPACE_GROUP_LOCAL,
+				icon: Codicon.folderOpened,
+				providerId: '',
+				run: () => this._browseForLocalFolder(),
+			};
+			all.unshift(localAction);
+		}
 		if (!this._isTabFiltered()) {
 			return all;
 		}
 		return all.filter(a => a.group === this._activeTab);
 	}
 
-	/** True when the picker is currently scoped to a single tab. */
-	protected _isTabFiltered(): boolean {
-		return this._showTabs() && !!this._activeTab && this._getAvailableTabs().length > 1;
+	/**
+	 * Opens a folder picker dialog and resolves the selected folder through
+	 * a provider that supports local workspaces. When multiple providers
+	 * support local workspaces, shows a quick pick to choose the provider first.
+	 */
+	private async _browseForLocalFolder(): Promise<ISessionWorkspace | undefined> {
+		const localProviders = this.sessionsProvidersService.getProviders().filter(p => p.supportsLocalWorkspaces);
+		if (localProviders.length === 0) {
+			return undefined;
+		}
+
+		let provider = localProviders[0];
+		if (localProviders.length > 1) {
+			const picked = await this.quickInputService.pick(
+				localProviders.map(p => ({ label: p.label, provider: p })),
+				{ placeHolder: localize('pickLocalProvider', "Select a provider") },
+			);
+			if (!picked) {
+				return undefined;
+			}
+			provider = picked.provider;
+		}
+
+		const result = await this.fileDialogService.showOpenDialog({
+			canSelectFolders: true,
+			canSelectFiles: false,
+			canSelectMany: false,
+		});
+		if (!result?.length) {
+			return undefined;
+		}
+
+		this._selectedLocalProviderId = provider.id;
+		return provider.resolveWorkspace(result[0]);
 	}
 
-	/**
-	 * Whether the bottom "Manage…" submenu should be included. Hidden
-	 * outside the Remote tab because the contributed actions (Tunnels…,
-	 * SSH…, remote provider list) are remote-specific.
-	 */
-	protected _includeManageSubmenu(): boolean {
-		if (!this._isTabFiltered()) {
-			return true;
-		}
-		return this._activeTab === SESSION_WORKSPACE_GROUP_REMOTE;
+	/** True when the picker is currently scoped to a single tab. */
+	protected _isTabFiltered(): boolean {
+		return this._showTabs() && !!this._activeTab && this._getAvailableGroups().length > 1;
 	}
 
 	/**
@@ -595,12 +637,12 @@ export class WorkspacePicker extends Disposable {
 
 		// Browse actions from all providers (filtered to the active tab)
 		const allBrowseActions = this._getAllBrowseActions();
-		// Remote providers with connection status — only relevant for the
-		// Manage submenu, which is itself only included on the Remote tab.
+		// Remote providers with connection status — shown as dynamic rows
+		// in the Manage submenu on the Remote tab.
 		const remoteProviders = allProviders.filter(isAgentHostProvider).filter(p => p.connectionStatus !== undefined);
-		const includeManage = this._includeManageSubmenu();
+		const includeRemoteProviders = this._activeTab === SESSION_WORKSPACE_GROUP_REMOTE;
 
-		if (items.length > 0 && (allBrowseActions.length > 0 || (includeManage && remoteProviders.length > 0))) {
+		if (items.length > 0 && (allBrowseActions.length > 0)) {
 			items.push({ kind: ActionListItemKind.Separator, label: '' });
 		}
 
@@ -613,7 +655,7 @@ export class WorkspacePicker extends Disposable {
 			const isUnavailable = connectionStatus === RemoteAgentHostConnectionStatus.Disconnected || connectionStatus === RemoteAgentHostConnectionStatus.Connecting;
 			items.push({
 				kind: ActionListItemKind.Action,
-				label: localize('workspacePicker.browseSelectAction', "Select {0}...", action.label),
+				label: localize('workspacePicker.browseSelectAction', "Select..."),
 				description: action.description,
 				group: { title: '', icon: action.icon },
 				disabled: isUnavailable,
@@ -621,12 +663,11 @@ export class WorkspacePicker extends Disposable {
 			});
 		});
 
-		// Inline "Manage" entries: dynamic remote provider rows + menu-contributed
-		// actions (Tunnels…, SSH…), separated from the workspace list above.
-		// The actions are tracked in a per-render array so the picker delegate
-		// can dispatch by index when an item is selected.
+		// Inline "Manage" entries: dynamic remote provider rows (scoped to
+		// the Remote tab) + menu-contributed actions (filtered by the
+		// `sessionWorkspacePickerGroup` context key).
 		const manageActions: IAction[] = [];
-		if (includeManage) {
+		if (includeRemoteProviders) {
 			for (const provider of remoteProviders) {
 				const status = provider.connectionStatus!.get();
 				const isTunnel = provider.remoteAddress?.startsWith(TUNNEL_ADDRESS_PREFIX);
@@ -651,14 +692,14 @@ export class WorkspacePicker extends Disposable {
 				}
 				manageActions.push(action);
 			}
+		}
 
-			const menuActions = this.menuService.getMenuActions(Menus.SessionWorkspaceManage, this.contextKeyService, { renderShortTitle: true });
-			for (const [, actions] of menuActions) {
-				for (const menuAction of actions) {
-					if (menuAction instanceof MenuItemAction) {
-						const icon = ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
-						manageActions.push(Object.assign(menuAction, { icon }));
-					}
+		const menuActions = this.menuService.getMenuActions(Menus.SessionWorkspaceManage, this.contextKeyService, { renderShortTitle: true });
+		for (const [, actions] of menuActions) {
+			for (const menuAction of actions) {
+				if (menuAction instanceof MenuItemAction) {
+					const icon = ThemeIcon.isThemeIcon(menuAction.item.icon) ? menuAction.item.icon : undefined;
+					manageActions.push(Object.assign(menuAction, { icon }));
 				}
 			}
 		}
@@ -667,13 +708,15 @@ export class WorkspacePicker extends Disposable {
 			if (items.length > 0 && items[items.length - 1].kind !== ActionListItemKind.Separator) {
 				items.push({ kind: ActionListItemKind.Separator, label: '' });
 			}
-			items.push({
-				kind: ActionListItemKind.Action,
-				label: localize('workspacePicker.manage', "Manage..."),
-				group: { title: '', icon: Codicon.settingsGear },
-				item: {},
-				submenuActions: [new SubmenuAction('workspacePicker.manage.submenu', '', manageActions)],
-			});
+			for (const action of manageActions) {
+				const icon = (action as IAction & { icon?: ThemeIcon }).icon;
+				items.push({
+					kind: ActionListItemKind.Action,
+					label: action.label,
+					group: { title: '', icon: icon ?? Codicon.settingsGear },
+					item: { run: () => action.run(), commandId: action.id },
+				});
+			}
 		}
 
 		return items;

--- a/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionWorkspacePicker.test.ts
@@ -26,12 +26,16 @@ import { extUri } from '../../../../../base/common/resources.js';
 import { ISessionsProvidersChangeEvent, ISessionsProvidersService } from '../../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsProvider } from '../../../../services/sessions/common/sessionsProvider.js';
 import { IAgentHostSessionsProvider } from '../../../../common/agentHostSessionsProvider.js';
-import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_CLOUD, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
+import { ISessionWorkspace, ISessionWorkspaceBrowseAction, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE } from '../../../../services/sessions/common/session.js';
 import { WorkspacePicker, IWorkspaceSelection } from '../../browser/sessionWorkspacePicker.js';
 import { IWorkspacesService } from '../../../../../platform/workspaces/common/workspaces.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IMenuService } from '../../../../../platform/actions/common/actions.js';
 
 // ---- Storage key (must match the one in sessionWorkspacePicker.ts) ----------
 const STORAGE_KEY_RECENT_WORKSPACES = 'sessions.recentlyPickedWorkspaces';
@@ -148,6 +152,9 @@ function createTestPicker(
 	instantiationService.stub(IOutputService, {});
 	instantiationService.stub(IConfigurationService, { getValue: () => undefined });
 	instantiationService.stub(ICommandService, { executeCommand: async () => { } });
+	instantiationService.stub(IFileDialogService, {});
+	instantiationService.stub(IContextKeyService, new MockContextKeyService());
+	instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
 	instantiationService.stub(IWorkspacesService, {
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
@@ -512,7 +519,7 @@ suite('WorkspacePicker - Connection Status', () => {
 /** Minimal subclass that exposes the protected `_getAvailableTabs` for testing. */
 class TestablePicker extends WorkspacePicker {
 	getAvailableTabs(): string[] {
-		return this._getAvailableTabs();
+		return this._getAvailableGroups();
 	}
 }
 
@@ -540,6 +547,9 @@ function createTestablePicker(disposables: DisposableStore, providersService: Mo
 	instantiationService.stub(IOutputService, {});
 	instantiationService.stub(IConfigurationService, { getValue: () => undefined });
 	instantiationService.stub(ICommandService, { executeCommand: async () => { } });
+	instantiationService.stub(IFileDialogService, {});
+	instantiationService.stub(IContextKeyService, new MockContextKeyService());
+	instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
 	instantiationService.stub(IWorkspacesService, {
 		getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 		onDidChangeRecentlyOpened: Event.None,
@@ -561,20 +571,20 @@ suite('WorkspacePicker - Tab discovery', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('returns empty list when no providers contribute groups', () => {
+	test('returns Remote group even when no providers contribute groups', () => {
 		providersService.setProviders([createMockProvider('p1')]);
 		const picker = createTestablePicker(disposables, providersService);
-		assert.deepStrictEqual(picker.getAvailableTabs(), []);
+		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 
-	test('orders well-known groups Local → Cloud → Remote regardless of contribution order', () => {
+	test('orders well-known groups Local first, then alphabetical', () => {
 		providersService.setProviders([
 			createMockProvider('remote', { browseActions: [makeBrowseAction('remote', SESSION_WORKSPACE_GROUP_REMOTE)] }),
-			createMockProvider('cloud', { browseActions: [makeBrowseAction('cloud', SESSION_WORKSPACE_GROUP_CLOUD)] }),
+			createMockProvider('cloud', { browseActions: [makeBrowseAction('cloud', 'Cloud')] }),
 			createMockProvider('local', { browseActions: [makeBrowseAction('local', SESSION_WORKSPACE_GROUP_LOCAL)] }),
 		]);
 		const picker = createTestablePicker(disposables, providersService);
-		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_CLOUD, SESSION_WORKSPACE_GROUP_REMOTE]);
+		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL, 'Cloud', SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 
 	test('deduplicates groups contributed by multiple providers / actions', () => {
@@ -583,18 +593,18 @@ suite('WorkspacePicker - Tab discovery', () => {
 			createMockProvider('p2', { browseActions: [makeBrowseAction('p2', SESSION_WORKSPACE_GROUP_LOCAL), makeBrowseAction('p2', SESSION_WORKSPACE_GROUP_LOCAL)] }),
 		]);
 		const picker = createTestablePicker(disposables, providersService);
-		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL]);
+		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 
-	test('appends custom group labels after well-known ones', () => {
+	test('appends custom group labels after Local', () => {
 		providersService.setProviders([
 			createMockProvider('p1', { browseActions: [makeBrowseAction('p1', 'Custom A'), makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_LOCAL)] }),
 			createMockProvider('p2', { browseActions: [makeBrowseAction('p2', 'Custom B'), makeBrowseAction('p2', SESSION_WORKSPACE_GROUP_REMOTE)] }),
 		]);
 		const picker = createTestablePicker(disposables, providersService);
 		const tabs = picker.getAvailableTabs();
-		assert.deepStrictEqual(tabs.slice(0, 2), [SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE]);
-		assert.deepStrictEqual(tabs.slice(2).sort(), ['Custom A', 'Custom B']);
+		assert.strictEqual(tabs[0], SESSION_WORKSPACE_GROUP_LOCAL);
+		assert.deepStrictEqual(tabs.slice(1).sort(), ['Custom A', 'Custom B', SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 
 	test('ignores browse actions without a group', () => {
@@ -602,16 +612,16 @@ suite('WorkspacePicker - Tab discovery', () => {
 			createMockProvider('p1', { browseActions: [makeBrowseAction('p1', undefined), makeBrowseAction('p1', SESSION_WORKSPACE_GROUP_LOCAL)] }),
 		]);
 		const picker = createTestablePicker(disposables, providersService);
-		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL]);
+		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 
-	test('discovers groups from recent workspaces too', () => {
+	test('discovers groups from recent workspaces does not add extra tabs', () => {
 		const provider: ISessionsProvider = {
 			...createMockProvider('p1'),
 			resolveWorkspace: (uri: URI): ISessionWorkspace => ({
 				label: uri.path,
 				icon: Codicon.folder,
-				group: SESSION_WORKSPACE_GROUP_CLOUD,
+				group: 'Cloud',
 				repositories: [{ uri, workingDirectory: undefined, detail: undefined, baseBranchName: undefined }],
 				requiresWorkspaceTrust: false,
 			}),
@@ -633,11 +643,16 @@ suite('WorkspacePicker - Tab discovery', () => {
 		instantiationService.stub(IOutputService, {});
 		instantiationService.stub(IConfigurationService, { getValue: () => undefined });
 		instantiationService.stub(ICommandService, { executeCommand: async () => { } });
+		instantiationService.stub(IFileDialogService, {});
+		instantiationService.stub(IContextKeyService, new MockContextKeyService());
+		instantiationService.stub(IMenuService, { createMenu: () => ({ onDidChange: Event.None, getActions: () => [], dispose: () => { } }) });
 		instantiationService.stub(IWorkspacesService, {
 			getRecentlyOpened: async () => ({ workspaces: [], files: [] }),
 			onDidChangeRecentlyOpened: Event.None,
 		});
 		const picker = disposables.add(instantiationService.createInstance(TestablePicker));
-		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_CLOUD]);
+		// Recent workspace group ('Cloud') is not added as a tab — only
+		// browse actions and the always-present Remote group contribute tabs.
+		assert.deepStrictEqual(picker.getAvailableTabs(), [SESSION_WORKSPACE_GROUP_REMOTE]);
 	});
 });

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -14,7 +14,7 @@ import { autorun, constObservable, derived, IObservable, IReader, observableFrom
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IAgentSession } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { getRepositoryName } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.js';
@@ -23,7 +23,7 @@ import { AgentSessionProviders, AgentSessionTarget } from '../../../../workbench
 import { IChatService, IChatSendRequestOptions } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { IChatResponseModel } from '../../../../workbench/contrib/chat/common/model/chatModel.js';
 import { ChatSessionStatus, IChatSessionsService, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, SessionType } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, CopilotCLISessionType, CopilotCloudSessionType, ClaudeCodeSessionType, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL, SESSION_WORKSPACE_GROUP_CLOUD } from '../../../services/sessions/common/session.js';
+import { ISession, IChat, ISessionRepository, ISessionWorkspace, SessionStatus, GITHUB_REMOTE_FILE_SCHEME, IGitHubInfo, CopilotCLISessionType, CopilotCloudSessionType, ClaudeCodeSessionType, ISessionType, ISessionWorkspaceBrowseAction, ISessionFileChange, toSessionId, SESSION_WORKSPACE_GROUP_LOCAL } from '../../../services/sessions/common/session.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
 import { basename, dirname, isEqual } from '../../../../base/common/resources.js';
 import { ISendRequestOptions, ISessionChangeEvent, ISessionsProvider } from '../../../services/sessions/common/sessionsProvider.js';
@@ -44,6 +44,8 @@ import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
 import { computePullRequestIcon, GitHubPullRequestState } from '../../github/common/types.js';
+
+const SESSION_WORKSPACE_GROUP_GITHUB = localize('sessionWorkspaceGroup.github', "GitHub");
 
 export interface ICopilotChatSession {
 	/** Globally unique session ID (`providerId:localId`). */
@@ -1124,7 +1126,7 @@ class AgentSessionAdapter implements ICopilotChatSession {
 		return {
 			label: getRepositoryName(session) ?? basename(repository.uri),
 			icon: repoUri?.scheme === GITHUB_REMOTE_FILE_SCHEME ? Codicon.repo : Codicon.folder,
-			group: repoUri?.scheme === GITHUB_REMOTE_FILE_SCHEME ? SESSION_WORKSPACE_GROUP_CLOUD : SESSION_WORKSPACE_GROUP_LOCAL,
+			group: repoUri?.scheme === GITHUB_REMOTE_FILE_SCHEME ? SESSION_WORKSPACE_GROUP_GITHUB : SESSION_WORKSPACE_GROUP_LOCAL,
 			repositories: [repository],
 			requiresWorkspaceTrust: session.providerType !== AgentSessionProviders.Cloud,
 		};
@@ -1226,13 +1228,13 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	private _claudeEnabled: boolean;
 
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
+	readonly supportsLocalWorkspaces = true;
 
 	constructor(
 		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
 		@IChatService private readonly chatService: IChatService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
-		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -1261,15 +1263,8 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 		this.browseActions = [
 			{
-				label: localize('folders', "Folders"),
-				group: SESSION_WORKSPACE_GROUP_LOCAL,
-				icon: Codicon.folderOpened,
-				providerId: this.id,
-				run: () => this._browseForFolder(),
-			},
-			{
 				label: localize('repositories', "Repositories"),
-				group: SESSION_WORKSPACE_GROUP_CLOUD,
+				group: SESSION_WORKSPACE_GROUP_GITHUB,
 				icon: Codicon.library,
 				providerId: this.id,
 				run: () => this._browseForRepo(),
@@ -2150,25 +2145,6 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 
 	// -- Private --
 
-	private async _browseForFolder(): Promise<ISessionWorkspace | undefined> {
-		const result = await this.fileDialogService.showOpenDialog({
-			canSelectFolders: true,
-			canSelectFiles: false,
-			canSelectMany: false,
-		});
-		if (result?.length) {
-			const uri = result[0];
-			return {
-				label: this._labelFromUri(uri),
-				icon: this._iconFromUri(uri),
-				group: SESSION_WORKSPACE_GROUP_LOCAL,
-				repositories: [{ uri, workingDirectory: undefined, detail: undefined, baseBranchName: undefined }],
-				requiresWorkspaceTrust: true
-			};
-		}
-		return undefined;
-	}
-
 	private async _browseForRepo(): Promise<ISessionWorkspace | undefined> {
 		const repoId = await this.commandService.executeCommand<string>(OPEN_REPO_COMMAND);
 		if (repoId) {
@@ -2176,7 +2152,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 			return {
 				label: this._labelFromUri(uri),
 				icon: this._iconFromUri(uri),
-				group: SESSION_WORKSPACE_GROUP_CLOUD,
+				group: SESSION_WORKSPACE_GROUP_GITHUB,
 				repositories: [{ uri, workingDirectory: undefined, detail: undefined, baseBranchName: undefined }],
 				requiresWorkspaceTrust: false,
 			};
@@ -2191,7 +2167,7 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 		return {
 			label: this._labelFromUri(repositoryUri),
 			description: this._descriptionFromUri(repositoryUri),
-			group: repositoryUri.scheme === GITHUB_REMOTE_FILE_SCHEME ? SESSION_WORKSPACE_GROUP_CLOUD : SESSION_WORKSPACE_GROUP_LOCAL,
+			group: repositoryUri.scheme === GITHUB_REMOTE_FILE_SCHEME ? SESSION_WORKSPACE_GROUP_GITHUB : SESSION_WORKSPACE_GROUP_LOCAL,
 			icon: this._iconFromUri(repositoryUri),
 			repositories: [{ uri: repositoryUri, workingDirectory: undefined, detail: undefined, baseBranchName: undefined }],
 			requiresWorkspaceTrust: repositoryUri.scheme !== GITHUB_REMOTE_FILE_SCHEME

--- a/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/test/browser/copilotChatSessionsProvider.test.ts
@@ -887,13 +887,6 @@ suite('CopilotChatSessionsProvider', () => {
 		assert.doesNotThrow(() => URI.joinPath(workspace.repositories[0].uri, '.vscode/extensions.json'));
 	});
 
-	test('has folder and repo browse actions', () => {
-		const provider = createProvider(disposables, model);
-		assert.strictEqual(provider.browseActions.length, 2);
-		assert.strictEqual(provider.browseActions[0].providerId, COPILOT_PROVIDER_ID);
-		assert.strictEqual(provider.browseActions[1].providerId, COPILOT_PROVIDER_ID);
-	});
-
 	// ---- Claude session creation -------
 
 	function makeClaudeInFlightProvider(): { provider: CopilotChatSessionsProvider; cancelRequest: () => void; realResource: URI; commitSession: () => void } {

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions.ts
@@ -27,11 +27,13 @@ import { IViewsService } from '../../../../workbench/services/views/common/views
 import { IAuthenticationService } from '../../../../workbench/services/authentication/common/authentication.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { SessionsCategories } from '../../../common/categories.js';
+import { SessionWorkspacePickerGroupContext } from '../../../common/contextkeys.js';
 import { Menus } from '../../../browser/menus.js';
 import { NewChatViewPane, SessionsViewId } from '../../chat/browser/newChatViewPane.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { IAgentHostSessionsProvider, isAgentHostProvider } from '../../../common/agentHostSessionsProvider.js';
+import { SESSION_WORKSPACE_GROUP_REMOTE } from '../../../services/sessions/common/session.js';
 
 /** Action / command IDs registered by this file. */
 export const RemoteAgentHostCommandIds = {
@@ -606,6 +608,7 @@ registerAction2(class extends Action2 {
 			menu: {
 				id: Menus.SessionWorkspaceManage,
 				order: 20,
+				when: SessionWorkspacePickerGroupContext.isEqualTo(SESSION_WORKSPACE_GROUP_REMOTE),
 			},
 		});
 	}
@@ -979,6 +982,7 @@ registerAction2(class extends Action2 {
 			menu: {
 				id: Menus.SessionWorkspaceManage,
 				order: 10,
+				when: SessionWorkspacePickerGroupContext.isEqualTo(SESSION_WORKSPACE_GROUP_REMOTE),
 			},
 		});
 	}

--- a/src/vs/sessions/services/sessions/common/session.ts
+++ b/src/vs/sessions/services/sessions/common/session.ts
@@ -276,7 +276,6 @@ export interface ISessionCapabilities {
  * of contributed values.
  */
 export const SESSION_WORKSPACE_GROUP_LOCAL = localize('sessionWorkspaceGroup.local', "Local");
-export const SESSION_WORKSPACE_GROUP_CLOUD = localize('sessionWorkspaceGroup.github', "GitHub");
 export const SESSION_WORKSPACE_GROUP_REMOTE = localize('sessionWorkspaceGroup.remote', "Remote");
 
 export interface ISessionWorkspaceBrowseAction {

--- a/src/vs/sessions/services/sessions/common/sessionsProvider.ts
+++ b/src/vs/sessions/services/sessions/common/sessionsProvider.ts
@@ -83,6 +83,13 @@ export interface ISessionsProvider {
 	readonly browseActions: readonly ISessionWorkspaceBrowseAction[];
 
 	/**
+	 * Whether this provider can resolve and run sessions against local file-system workspaces.
+	 * When `true`, the workspace picker includes a "Local" tab with a built-in
+	 * folder browse action that resolves through this provider.
+	 */
+	readonly supportsLocalWorkspaces?: boolean;
+
+	/**
 	 * Resolve a workspace for the given repository URI.
 	 * Returns `undefined` when the provider cannot handle the given URI
 	 * (e.g. wrong scheme or authority).


### PR DESCRIPTION
- Always include Remote group in workspace picker tabs even without remote providers
- Remove browse action from local agent host provider (moved to picker)
- Fix remote status manage actions not triggering by adding inline run callback
- Use SESSION_WORKSPACE_GROUP_REMOTE constant instead of hardcoded string
- Update tests for new tab discovery behavior