### PR TITLE
Show cached tokens in chat debug tree view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer.ts
@@ -27,6 +27,7 @@ export function formatEventDetail(event: IChatDebugEvent): string {
 			const parts = [event.model ?? localize('chatDebug.detail.modelTurn', "Model Turn")];
 			if (event.inputTokens !== undefined) { parts.push(localize('chatDebug.detail.inputTokens', "Input tokens: {0}", numberFormatter.value.format(event.inputTokens))); }
 			if (event.outputTokens !== undefined) { parts.push(localize('chatDebug.detail.outputTokens', "Output tokens: {0}", numberFormatter.value.format(event.outputTokens))); }
+			if (event.cachedTokens !== undefined) { parts.push(localize('chatDebug.detail.cachedTokens', "Cached tokens: {0}", numberFormatter.value.format(event.cachedTokens))); }
 			if (event.totalTokens !== undefined) { parts.push(localize('chatDebug.detail.totalTokens', "Total tokens: {0}", numberFormatter.value.format(event.totalTokens))); }
 			if (event.durationInMillis !== undefined) { parts.push(localize('chatDebug.detail.durationMs', "Duration: {0}ms", numberFormatter.value.format(event.durationInMillis))); }
 			return parts.join('\n');

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
@@ -793,6 +793,9 @@ function getEventTooltip(event: IChatDebugEvent): string | undefined {
 			if (event.outputTokens) {
 				parts.push(localize('tooltipOutputTokens', "Output tokens: {0}", event.outputTokens));
 			}
+			if (event.cachedTokens !== undefined) {
+				parts.push(localize('tooltipCachedTokens', "Cached tokens: {0}", event.cachedTokens));
+			}
 			if (event.durationInMillis) {
 				parts.push(localize('tooltipDuration', "Duration: {0}", formatDuration(event.durationInMillis)));
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
@@ -189,7 +189,10 @@ export class ChatDebugLogsView extends Disposable {
 			getAriaLabel: (e: IChatDebugEvent) => {
 				switch (e.kind) {
 					case 'toolCall': return localize('chatDebug.aria.toolCall', "Tool call: {0}{1}", e.toolName, e.result ? ` (${e.result})` : '');
-					case 'modelTurn': return localize('chatDebug.aria.modelTurn', "Model turn: {0}{1}", e.model ?? localize('chatDebug.aria.model', "model"), e.totalTokens ? localize('chatDebug.aria.tokenCount', " {0} tokens", e.totalTokens) : '');
+					case 'modelTurn': return localize('chatDebug.aria.modelTurn', "Model turn: {0}{1}{2}",
+						e.model ?? localize('chatDebug.aria.model', "model"),
+						e.totalTokens ? localize('chatDebug.aria.tokenCount', " {0} tokens", e.totalTokens) : '',
+						e.cachedTokens !== undefined ? localize('chatDebug.aria.cachedTokens', " {0} cached", e.cachedTokens) : '');
 					case 'generic': return `${e.category ? e.category + ': ' : ''}${e.name}: ${e.details ?? ''}`;
 					case 'subagentInvocation': return localize('chatDebug.aria.subagent', "Subagent: {0}{1}", e.agentName, e.description ? ` - ${e.description}` : '');
 					case 'userMessage': return localize('chatDebug.aria.userMessage', "User message: {0}", e.message);


### PR DESCRIPTION
Surface cached read input tokens in three additional places that consume model turn events:

- Tree row aria label, so screen readers announce cached tokens.
- Flow chart node tooltip.
- Fallback detail formatter (used when no resolved content is available).

The detail panel renderer and overview metrics already display `cachedTokens` (added in #313602); this fills out the remaining tree view surfaces.

All three call sites gate on `cachedTokens !== undefined` (matching the pattern of neighboring fields like input/output tokens), so a cached-tokens line appears whenever the value is present, including zero.