### PR TITLE
Queue skill button requests so they appear in the chat UI

### DIFF
--- a/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
@@ -15,7 +15,7 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
-import { ChatRequestQueueKind, ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
 import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { resolvePromptSlashCommandToVariableEntry } from '../../../../workbench/contrib/chat/common/promptSyntax/resolvePromptSlashCommand.js';
@@ -208,15 +208,7 @@ function registerAgentHostSkillButton(spec: IAgentHostSkillButtonSpec): void {
 			await sessionsManagementService.openSession(activeSession.resource, { preserveFocus: true });
 			const ref = await chatService.acquireOrLoadSession(activeSession.resource, ChatAgentLocation.Chat, CancellationToken.None, 'AgentHostSkillButton');
 			try {
-				// Try direct send first (agent idle — preserves full attachedContext).
-				// Fall back to queued if the agent is currently busy.
-				let result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext });
-				if (result.kind === 'rejected') {
-					result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext, queue: ChatRequestQueueKind.Queued });
-				}
-				if (ChatSendResult.isQueued(result)) {
-					result = await result.deferred;
-				}
+				const result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext });
 				if (ChatSendResult.isSent(result)) {
 					await result.data.responseCompletePromise;
 				}

--- a/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
@@ -208,7 +208,12 @@ function registerAgentHostSkillButton(spec: IAgentHostSkillButtonSpec): void {
 			await sessionsManagementService.openSession(activeSession.resource, { preserveFocus: true });
 			const ref = await chatService.acquireOrLoadSession(activeSession.resource, ChatAgentLocation.Chat, CancellationToken.None, 'AgentHostSkillButton');
 			try {
-				let result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext, queue: ChatRequestQueueKind.Queued });
+				// Try direct send first (agent idle — preserves full attachedContext).
+				// Fall back to queued if the agent is currently busy.
+				let result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext });
+				if (result.kind === 'rejected') {
+					result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext, queue: ChatRequestQueueKind.Queued });
+				}
 				if (ChatSendResult.isQueued(result)) {
 					result = await result.deferred;
 				}

--- a/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
+++ b/src/vs/sessions/contrib/agentHost/browser/agentHostSkillButtons.ts
@@ -15,8 +15,11 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { bindContextKey } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IsSessionsWindowContext } from '../../../../workbench/common/contextkeys.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
-import { ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { ChatRequestQueueKind, ChatSendResult, IChatService } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../../workbench/contrib/chat/common/constants.js';
+import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
+import { resolvePromptSlashCommandToVariableEntry } from '../../../../workbench/contrib/chat/common/promptSyntax/resolvePromptSlashCommand.js';
+import { ILanguageModelToolsService } from '../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
 import { ISessionsProvidersService } from '../../../services/sessions/browser/sessionsProvidersService.js';
 import { ISessionsManagementService } from '../../../services/sessions/common/sessionsManagement.js';
 import { ActiveSessionContextKeys, IsolationMode } from '../../changes/common/changes.js';
@@ -182,6 +185,8 @@ function registerAgentHostSkillButton(spec: IAgentHostSkillButtonSpec): void {
 		async run(accessor: ServicesAccessor): Promise<void> {
 			const sessionsManagementService = accessor.get(ISessionsManagementService);
 			const chatService = accessor.get(IChatService);
+			const customizationHarnessService = accessor.get(ICustomizationHarnessService);
+			const toolsService = accessor.get(ILanguageModelToolsService);
 
 			const activeSession = sessionsManagementService.activeSession.get();
 			if (!activeSession) {
@@ -197,9 +202,13 @@ function registerAgentHostSkillButton(spec: IAgentHostSkillButtonSpec): void {
 			// agent-host providers, so it is NOT a valid agent id here.
 			const agentId = activeSession.resource.scheme;
 			const prompt = `/${spec.skill}`;
+			const promptFile = await resolvePromptSlashCommandToVariableEntry(prompt, agentId, customizationHarnessService, toolsService, CancellationToken.None);
+			const attachedContext = promptFile ? [promptFile] : undefined;
+
+			await sessionsManagementService.openSession(activeSession.resource, { preserveFocus: true });
 			const ref = await chatService.acquireOrLoadSession(activeSession.resource, ChatAgentLocation.Chat, CancellationToken.None, 'AgentHostSkillButton');
 			try {
-				let result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId });
+				let result = await chatService.sendRequest(activeSession.resource, prompt, { agentIdSilent: agentId, attachedContext, queue: ChatRequestQueueKind.Queued });
 				if (ChatSendResult.isQueued(result)) {
 					result = await result.deferred;
 				}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -592,18 +592,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}));
 			}
 
-			// Set up pending message sync once the chat model is created.
-			// This must be deferred because the model is created after this
-			// function returns. Without this, queued skill-button requests
-			// would never dispatch SessionPendingMessageSet to the server
-			// and remain stuck as "QUEUED" in the UI.
-			const capturedBackend = resolvedSession;
-			session.registerDisposable(Event.once(this._chatService.onDidCreateModel)(model => {
-				if (isEqual(model.sessionResource, sessionResource)) {
-					this._ensurePendingMessageSubscription(sessionResource, capturedBackend);
-				}
-			}));
-
 			// If reconnecting to an active turn, wire up an ongoing state listener
 			// to stream new progress into the session's progressObs.
 			if (activeTurnId && initialProgress !== undefined) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -592,6 +592,18 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				}));
 			}
 
+			// Set up pending message sync once the chat model is created.
+			// This must be deferred because the model is created after this
+			// function returns. Without this, queued skill-button requests
+			// would never dispatch SessionPendingMessageSet to the server
+			// and remain stuck as "QUEUED" in the UI.
+			const capturedBackend = resolvedSession;
+			session.registerDisposable(Event.once(this._chatService.onDidCreateModel)(model => {
+				if (isEqual(model.sessionResource, sessionResource)) {
+					this._ensurePendingMessageSubscription(sessionResource, capturedBackend);
+				}
+			}));
+
 			// If reconnecting to an active turn, wire up an ongoing state listener
 			// to stream new progress into the session's progressObs.
 			if (activeTurnId && initialProgress !== undefined) {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -35,9 +35,9 @@ import { ChatSessionOptionsMap, ChatSessionStatus, IChatNewSessionRequest, IChat
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
-import { IChatService, ResponseModelState } from '../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, IChatService, ResponseModelState } from '../../common/chatService/chatService.js';
 import { autorun, observableFromEvent } from '../../../../../base/common/observable.js';
-import { IChatRequestVariableEntry, PromptFileVariableKind, toPromptFileVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+import { IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ChatViewId } from '../chat.js';
 import { ChatViewPane } from '../widgetHosts/viewPane/chatViewPane.js';
@@ -48,11 +48,10 @@ import { isUntitledChatSession, LocalChatSessionUri } from '../../common/model/c
 import { assertNever } from '../../../../../base/common/assert.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { Target } from '../../common/promptSyntax/promptTypes.js';
-import { slashReg } from '../../common/requestParser/chatRequestParser.js';
-import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
 import { IChatModel } from '../../common/model/chatModel.js';
 import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { resolvePromptSlashCommandToVariableEntry } from '../../common/promptSyntax/resolvePromptSlashCommand.js';
 
 const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsExtensionPoint[]>({
 	extensionPoint: 'chatSessions',
@@ -567,12 +566,12 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 						const resource = URI.revive(chatOptions.resource);
 						const ref = await chatService.acquireOrLoadSession(resource, ChatAgentLocation.Chat, CancellationToken.None, 'ChatSessionsContribution#sendPrompt');
 						try {
-							const promptFile = await resolvePromptSlashCommand(chatOptions.prompt, contribution.type, customizationHarnessService, toolsService);
+							const promptFile = await resolvePromptSlashCommandToVariableEntry(chatOptions.prompt, contribution.type, customizationHarnessService, toolsService, CancellationToken.None);
 							if (promptFile) {
 								attachedContext = [promptFile, ...(attachedContext ?? [])];
 							}
 
-							const result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext });
+							const result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext, queue: ChatRequestQueueKind.Queued });
 							if (result.kind === 'queued') {
 								await result.deferred;
 							} else if (result.kind === 'sent') {
@@ -1383,7 +1382,7 @@ async function openChatSession(accessor: ServicesAccessor, openOptions: NewChatS
 			}
 
 			let attachedContext = chatSendOptions.attachedContext;
-			const promptFile = await resolvePromptSlashCommand(chatSendOptions.prompt, openOptions.type, customizationHarnessService, toolsService);
+			const promptFile = await resolvePromptSlashCommandToVariableEntry(chatSendOptions.prompt, openOptions.type, customizationHarnessService, toolsService, CancellationToken.None);
 			if (promptFile) {
 				attachedContext = [promptFile, ...(attachedContext ?? [])];
 			}
@@ -1414,26 +1413,6 @@ function normalizeSessionOptions(options: ReadonlyChatSessionOptionsMap | Readon
 	}
 	// Plain object fallback (e.g. from JSON deserialization)
 	return ChatSessionOptionsMap.fromRecord(options as unknown as Record<string, string | IChatSessionProviderOptionItem>);
-}
-
-/**
- * Returns the variable entry for a slash command if the prompt starts with a slash command that can be resolved to a prompt file, otherwise returns undefined.
- */
-async function resolvePromptSlashCommand(prompt: string, sessionType: string, customizationHarnessService: ICustomizationHarnessService, toolsService: ILanguageModelToolsService): Promise<IChatRequestVariableEntry | undefined> {
-	const slashMatch = prompt.match(slashReg);
-	// starts with a slash command, add the corresponding prompt file to the context if it exists
-	if (slashMatch) {
-		// need to resolve the slash command to get the prompt file
-		const slashCommand = await customizationHarnessService.resolvePromptSlashCommand(slashMatch[1], sessionType, CancellationToken.None);
-		if (slashCommand) {
-			const parseResult = slashCommand.parsedPromptFile;
-			// add the prompt file to the context
-			const refs = parseResult.body?.variableReferences.map(({ name, offset, fullLength }) => ({ name, range: new OffsetRange(offset, offset + fullLength) })) ?? [];
-			const toolReferences = toolsService.toToolReferences(refs);
-			return toPromptFileVariableEntry(parseResult.uri, PromptFileVariableKind.PromptFile, undefined, true, toolReferences);
-		}
-	}
-	return undefined;
 }
 
 export function getResourceForNewChatSession(options: NewChatSessionOpenOptions): URI {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -571,7 +571,12 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 								attachedContext = [promptFile, ...(attachedContext ?? [])];
 							}
 
-							const result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext, queue: ChatRequestQueueKind.Queued });
+							// Try direct send first (agent idle — preserves full attachedContext).
+							// Fall back to queued if the agent is currently busy.
+							let result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext });
+							if (result.kind === 'rejected') {
+								result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext, queue: ChatRequestQueueKind.Queued });
+							}
 							if (result.kind === 'queued') {
 								await result.deferred;
 							} else if (result.kind === 'sent') {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -35,7 +35,7 @@ import { ChatSessionOptionsMap, ChatSessionStatus, IChatNewSessionRequest, IChat
 import { ChatAgentLocation, ChatModeKind } from '../../common/constants.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
-import { ChatRequestQueueKind, IChatService, ResponseModelState } from '../../common/chatService/chatService.js';
+import { IChatService, ResponseModelState } from '../../common/chatService/chatService.js';
 import { autorun, observableFromEvent } from '../../../../../base/common/observable.js';
 import { IChatRequestVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
@@ -571,15 +571,8 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 								attachedContext = [promptFile, ...(attachedContext ?? [])];
 							}
 
-							// Try direct send first (agent idle — preserves full attachedContext).
-							// Fall back to queued if the agent is currently busy.
-							let result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext });
-							if (result.kind === 'rejected') {
-								result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext, queue: ChatRequestQueueKind.Queued });
-							}
-							if (result.kind === 'queued') {
-								await result.deferred;
-							} else if (result.kind === 'sent') {
+							const result = await chatService.sendRequest(resource, chatOptions.prompt, { agentIdSilent: type, attachedContext });
+							if (result.kind === 'sent') {
 								await result.data.responseCompletePromise;
 							}
 						} finally {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/resolvePromptSlashCommand.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/resolvePromptSlashCommand.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { IChatRequestVariableEntry, PromptFileVariableKind, toPromptFileVariableEntry } from '../attachments/chatVariableEntries.js';
+import { ICustomizationHarnessService } from '../customizationHarnessService.js';
+import { slashReg } from '../requestParser/chatRequestParser.js';
+import { ILanguageModelToolsService } from '../tools/languageModelToolsService.js';
+
+/**
+ * Returns the variable entry for a slash command if the prompt starts with a
+ * slash command that can be resolved to a prompt file.
+ */
+export async function resolvePromptSlashCommandToVariableEntry(prompt: string, sessionType: string, customizationHarnessService: ICustomizationHarnessService, toolsService: ILanguageModelToolsService, token: CancellationToken): Promise<IChatRequestVariableEntry | undefined> {
+	const slashMatch = prompt.match(slashReg);
+	if (!slashMatch) {
+		return undefined;
+	}
+
+	const slashCommand = await customizationHarnessService.resolvePromptSlashCommand(slashMatch[1], sessionType, token);
+	if (!slashCommand) {
+		return undefined;
+	}
+
+	const parseResult = slashCommand.parsedPromptFile;
+	const refs = parseResult.body?.variableReferences.map(({ name, offset, fullLength }) => ({ name, range: new OffsetRange(offset, offset + fullLength) })) ?? [];
+	const toolReferences = toolsService.toToolReferences(refs);
+	return toPromptFileVariableEntry(parseResult.uri, PromptFileVariableKind.PromptFile, undefined, true, toolReferences);
+}


### PR DESCRIPTION
When a skill button is clicked (e.g. "Create Pull Request"), the request was sent but never appeared in the chat UI.

## Root cause

The previous fix added `queue: ChatRequestQueueKind.Queued` to the `sendRequest` call, which was the wrong approach. Queued requests require a client→server sync (`SessionPendingMessageSet`) and a server→client reply (`SessionTurnStarted`) before anything renders. For restored sessions, `_ensurePendingMessageSubscription` was never set up, so that sync never happened and requests stayed stuck as "QUEUED" forever.

## Fix

A plain `sendRequest` (no queue) is sufficient. When a skill button is clicked, the agent has just finished a turn and is idle. The direct send:
1. Adds the request to the chat model immediately on the client → renders in the UI
2. Invokes the agent host to process the turn

No queue, no server round-trip needed for rendering.

(Written by Copilot)