### PR TITLE
Stop reopening closed repos (#313526)

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3063,7 +3063,7 @@ export class Repository {
 					result.push({
 						name: dirent.name,
 						// Remove '/.git' suffix
-						path: gitdirContent.replace(/\/.git.*$/, ''),
+						path: gitdirContent.replace(/\/\.git$/, ''),
 						// Remove 'ref: ' prefix
 						ref: headContent.replace(/^ref: /, ''),
 						// Detached if HEAD does not start with 'ref: '

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -808,7 +808,7 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			}
 
 			if (repository.kind === 'worktree') {
-				this.logger.trace('[Model][open] Automatic detection of git worktrees is not skipped.');
+				this.logger.trace('[Model][open] Automatic detection of git worktrees is skipped.');
 				return;
 			}
 
@@ -817,7 +817,11 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 				statusListener.dispose();
 			}
 
+			// Skip user-closed worktrees: avoids brief re-appearance during the scan debounce, and dodges path-normalization mismatches with the canonical root stored in the closed set.
+			const closedRepositoryPaths = this._closedRepositoriesManager.repositories;
+
 			repository.worktrees
+				.filter(w => !closedRepositoryPaths.some(closed => pathEquals(closed, w.path)))
 				.slice(0, worktreesLimit)
 				.forEach(w => {
 					this.logger.trace(`[Model][open] Opening worktree: '${w.path}'`);


### PR DESCRIPTION
Fixes #313526

## Summary

- "Close Other Repositories" briefly removed worktree entries but the parent repository's next `git status` immediately re-queued them via `checkForWorktrees()`, so the action looked silently broken.
- Filter the closed set out of `checkForWorktrees()` before queuing scans —  closes the debounce-window flicker and dodges raw-vs-canonical path mismatches that could defeat the existing closed-set guard further down  in `openRepository()`.
- Drive-by: fix the trailing-`.git` regex in `getWorktreesFS()` (unescaped `.` would let a path segment like `/agit/...` false-match and strip too much), and a misleading trace string ("is not skipped" → "is skipped").

## Test plan

- [ ] With `"git.detectWorktrees": true`, open a repo that has 2+ `git worktree`s checked out elsewhere on disk
- [ ] Source Control view shows the main repo + every worktree as siblings
- [ ] Right-click the main repo → **Close Other Repositories** — worktree entries disappear and stay gone
- [ ] Trigger several `git status` refreshes (touch a tracked file, run `git status` in the integrated terminal) — closed worktrees do **not** reappear
- [ ] Reload the window — closed worktrees remain closed (persisted via `workspaceState`)
- [ ] Open one of the closed worktree folders directly via File → Open Folder — it re-opens normally (the `openIfClosed=true` path)