### PR TITLE
Add Cache Explorer view to chat debug panel

### DIFF
--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -915,6 +915,8 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 				const model = asString(span.attributes[GenAiAttr.REQUEST_MODEL])
 					?? asString(span.attributes[GenAiAttr.RESPONSE_MODEL])
 					?? 'unknown';
+				const debugName = asString(span.attributes[CopilotChatAttr.DEBUG_NAME])
+					?? asString(span.attributes[GenAiAttr.AGENT_NAME]);
 				return {
 					ts: span.startTime,
 					dur: duration,
@@ -926,6 +928,7 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 					status: isError ? 'error' : 'ok',
 					attrs: {
 						model,
+						...(debugName ? { debugName } : {}),
 						...(span.attributes[GenAiAttr.USAGE_INPUT_TOKENS] !== undefined
 							? { inputTokens: asNumber(span.attributes[GenAiAttr.USAGE_INPUT_TOKENS]) }
 							: {}),
@@ -937,6 +940,9 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 							: {}),
 						...(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN] !== undefined
 							? { ttft: asNumber(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN]) }
+							: {}),
+						...(span.attributes[GenAiAttr.RESPONSE_ID] !== undefined
+							? { responseId: asString(span.attributes[GenAiAttr.RESPONSE_ID]) }
 							: {}),
 						...(span.attributes[CopilotChatAttr.USER_REQUEST] !== undefined
 							? { userRequest: String(span.attributes[CopilotChatAttr.USER_REQUEST]) }

--- a/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
+++ b/extensions/copilot/src/extension/chat/vscode-node/chatDebugFileLoggerService.ts
@@ -959,6 +959,9 @@ export class ChatDebugFileLoggerService extends Disposable implements IChatDebug
 						...(span.attributes[GenAiAttr.REQUEST_TOP_P] !== undefined
 							? { topP: asNumber(span.attributes[GenAiAttr.REQUEST_TOP_P]) }
 							: {}),
+						...(span.attributes[CopilotChatAttr.REQUEST_OPTIONS] !== undefined
+							? { requestOptions: String(span.attributes[CopilotChatAttr.REQUEST_OPTIONS]) }
+							: {}),
 						...(isError && span.status.message ? { error: span.status.message } : {}),
 					},
 				};

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -2254,21 +2254,14 @@ export function locationToIntent(location: ChatLocation): string {
  * (e.g. switching from `tool_choice: 'auto'` to `'required'`, raising
  * `reasoning_effort`, enabling thinking, changing the response format).
  *
- * Known cache-keying fields are surfaced explicitly. Anything else
- * unrecognized but present at the top level of the body is captured
- * under `extra` so we don't silently miss provider-specific knobs.
+ * Strict allowlist on purpose: we never want a future provider-specific
+ * body field (especially anything resembling auth headers, API keys, or
+ * personal identifiers) to silently leak into the OTel attribute or the
+ * on-disk debug log via a catch-all. New cache-keying knobs must be
+ * added explicitly here.
  */
 function pickCacheRelevantRequestOptions(body: IEndpointBody): Record<string, unknown> | undefined {
-	const known: Record<string, unknown> = {};
-	const seen = new Set<string>();
-	const take = (key: string) => {
-		seen.add(key);
-		const value = (body as Record<string, unknown>)[key];
-		if (value !== undefined) {
-			known[key] = value;
-		}
-	};
-
+	const out: Record<string, unknown> = {};
 	for (const key of [
 		'tool_choice', 'reasoning', 'reasoning_effort', 'thinking', 'thinking_budget',
 		'output_config', 'response_format', 'text', 'truncation', 'context_management',
@@ -2277,33 +2270,10 @@ function pickCacheRelevantRequestOptions(body: IEndpointBody): Record<string, un
 		'service_tier', 'metadata', 'verbosity', 'snippy', 'state', 'intent', 'intent_threshold',
 		'include',
 	] as const) {
-		take(key);
-	}
-
-	// Fields that are already on the OTel span as their own attributes are
-	// excluded here so we don't double-track them (model, temperature, top_p,
-	// max_tokens, max_output_tokens, max_completion_tokens). Messages, tools,
-	// system, prompt_cache_key are excluded because they're either tracked
-	// elsewhere or not stable for caching purposes.
-	const excluded = new Set([
-		'model', 'temperature', 'top_p',
-		'max_tokens', 'max_output_tokens', 'max_completion_tokens',
-		'messages', 'input', 'tools', 'system', 'instructions',
-		'prompt_cache_key', 'previous_response_id', 'n', 'prompt',
-		'dimensions', 'embed', 'qos', 'content', 'path', 'local_hashes',
-		'language_id', 'query', 'scopingQuery', 'scoping_query', 'limit', 'similarity',
-	]);
-
-	const extra: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-		if (seen.has(key) || excluded.has(key) || value === undefined) {
-			continue;
+		const value = (body as Record<string, unknown>)[key];
+		if (value !== undefined) {
+			out[key] = value;
 		}
-		extra[key] = value;
 	}
-	if (Object.keys(extra).length > 0) {
-		known.extra = extra;
-	}
-
-	return Object.keys(known).length > 0 ? known : undefined;
+	return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
+++ b/extensions/copilot/src/extension/prompt/node/chatMLFetcher.ts
@@ -304,6 +304,15 @@ export class ChatMLFetcherImpl extends AbstractChatMLFetcher {
 					if (toolDefs) {
 						otelInferenceSpan.setAttribute(GenAiAttr.TOOL_DEFINITIONS, truncateForOTel(JSON.stringify(toolDefs)));
 					}
+					// Cache-relevant request options. Anything in this blob, when changed
+					// between two requests, will invalidate the prompt cache even when
+					// the messages array is byte-identical. The Cache Explorer uses
+					// this to surface "options changed" drift alongside the message
+					// signature diff.
+					const requestOptions = pickCacheRelevantRequestOptions(requestBody);
+					if (requestOptions) {
+						otelInferenceSpan.setAttribute(CopilotChatAttr.REQUEST_OPTIONS, truncateForOTel(JSON.stringify(requestOptions)));
+					}
 				}
 				tokenCount = await countTokens();
 				const extensionId = source?.extensionId ?? EXTENSION_ID;
@@ -2236,4 +2245,65 @@ export function locationToIntent(location: ChatLocation): string {
 		case ChatLocation.MessagesProxy:
 			return 'messages-proxy';
 	}
+}
+
+/**
+ * Curate the cache-relevant subset of a request body. Anything in the
+ * returned object that differs between two requests will invalidate the
+ * prompt cache even when the message array itself is byte-identical
+ * (e.g. switching from `tool_choice: 'auto'` to `'required'`, raising
+ * `reasoning_effort`, enabling thinking, changing the response format).
+ *
+ * Known cache-keying fields are surfaced explicitly. Anything else
+ * unrecognized but present at the top level of the body is captured
+ * under `extra` so we don't silently miss provider-specific knobs.
+ */
+function pickCacheRelevantRequestOptions(body: IEndpointBody): Record<string, unknown> | undefined {
+	const known: Record<string, unknown> = {};
+	const seen = new Set<string>();
+	const take = (key: string) => {
+		seen.add(key);
+		const value = (body as Record<string, unknown>)[key];
+		if (value !== undefined) {
+			known[key] = value;
+		}
+	};
+
+	for (const key of [
+		'tool_choice', 'reasoning', 'reasoning_effort', 'thinking', 'thinking_budget',
+		'output_config', 'response_format', 'text', 'truncation', 'context_management',
+		'frequency_penalty', 'presence_penalty', 'top_logprobs', 'logit_bias',
+		'store', 'stream', 'stream_options', 'prediction', 'seed', 'parallel_tool_calls',
+		'service_tier', 'metadata', 'verbosity', 'snippy', 'state', 'intent', 'intent_threshold',
+		'include',
+	] as const) {
+		take(key);
+	}
+
+	// Fields that are already on the OTel span as their own attributes are
+	// excluded here so we don't double-track them (model, temperature, top_p,
+	// max_tokens, max_output_tokens, max_completion_tokens). Messages, tools,
+	// system, prompt_cache_key are excluded because they're either tracked
+	// elsewhere or not stable for caching purposes.
+	const excluded = new Set([
+		'model', 'temperature', 'top_p',
+		'max_tokens', 'max_output_tokens', 'max_completion_tokens',
+		'messages', 'input', 'tools', 'system', 'instructions',
+		'prompt_cache_key', 'previous_response_id', 'n', 'prompt',
+		'dimensions', 'embed', 'qos', 'content', 'path', 'local_hashes',
+		'language_id', 'query', 'scopingQuery', 'scoping_query', 'limit', 'similarity',
+	]);
+
+	const extra: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+		if (seen.has(key) || excluded.has(key) || value === undefined) {
+			continue;
+		}
+		extra[key] = value;
+	}
+	if (Object.keys(extra).length > 0) {
+		known.extra = extra;
+	}
+
+	return Object.keys(known).length > 0 ? known : undefined;
 }

--- a/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
+++ b/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
@@ -480,6 +480,7 @@ function resolveModelTurnContent(span: ICompletedSpanData): vscode.ChatDebugEven
 	content.durationInMillis = span.endTime - span.startTime;
 	content.timeToFirstTokenInMillis = asNumber(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN]);
 	content.requestId = asString(span.attributes[GenAiAttr.RESPONSE_ID]);
+	content.requestOptions = asString(span.attributes[CopilotChatAttr.REQUEST_OPTIONS]);
 	content.maxInputTokens = asNumber(span.attributes[CopilotChatAttr.MAX_PROMPT_TOKENS]);
 	content.maxOutputTokens = asNumber(span.attributes[GenAiAttr.REQUEST_MAX_TOKENS]);
 	content.inputTokens = asNumber(span.attributes[GenAiAttr.USAGE_INPUT_TOKENS]);
@@ -809,6 +810,7 @@ async function resolveModelTurnEntry(
 	content.durationInMillis = entry.dur;
 	content.timeToFirstTokenInMillis = entry.attrs.ttft as number | undefined;
 	content.requestId = entry.attrs.responseId as string | undefined;
+	content.requestOptions = entry.attrs.requestOptions as string | undefined;
 	content.maxOutputTokens = entry.attrs.maxTokens as number | undefined;
 	content.inputTokens = entry.attrs.inputTokens as number | undefined;
 	content.outputTokens = entry.attrs.outputTokens as number | undefined;

--- a/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
+++ b/extensions/copilot/src/extension/trajectory/vscode-node/otelSpanToChatDebugEvent.ts
@@ -479,6 +479,7 @@ function resolveModelTurnContent(span: ICompletedSpanData): vscode.ChatDebugEven
 	content.status = spanStatusToString(span.status.code as SpanStatusCode);
 	content.durationInMillis = span.endTime - span.startTime;
 	content.timeToFirstTokenInMillis = asNumber(span.attributes[CopilotChatAttr.TIME_TO_FIRST_TOKEN]);
+	content.requestId = asString(span.attributes[GenAiAttr.RESPONSE_ID]);
 	content.maxInputTokens = asNumber(span.attributes[CopilotChatAttr.MAX_PROMPT_TOKENS]);
 	content.maxOutputTokens = asNumber(span.attributes[GenAiAttr.REQUEST_MAX_TOKENS]);
 	content.inputTokens = asNumber(span.attributes[GenAiAttr.USAGE_INPUT_TOKENS]);
@@ -676,7 +677,7 @@ function entryToModelTurnEvent(entry: IDebugLogEntry): vscode.ChatDebugModelTurn
 	evt.durationInMillis = entry.dur;
 	evt.timeToFirstTokenInMillis = entry.attrs.ttft as number | undefined;
 	evt.maxOutputTokens = entry.attrs.maxTokens as number | undefined;
-	evt.requestName = entry.name;
+	evt.requestName = (entry.attrs.debugName as string | undefined) ?? entry.name;
 	evt.status = entry.status === 'error' ? 'error' : 'success';
 	return evt;
 }
@@ -807,6 +808,7 @@ async function resolveModelTurnEntry(
 	content.status = entry.status === 'error' ? 'error' : 'success';
 	content.durationInMillis = entry.dur;
 	content.timeToFirstTokenInMillis = entry.attrs.ttft as number | undefined;
+	content.requestId = entry.attrs.responseId as string | undefined;
 	content.maxOutputTokens = entry.attrs.maxTokens as number | undefined;
 	content.inputTokens = entry.attrs.inputTokens as number | undefined;
 	content.outputTokens = entry.attrs.outputTokens as number | undefined;

--- a/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
+++ b/extensions/copilot/src/platform/otel/common/genAiAttributes.ts
@@ -118,6 +118,8 @@ export const CopilotChatAttr = {
 	REASONING_CONTENT: 'copilot_chat.reasoning_content',
 	/** User's actual typed message text, extracted from prompt context */
 	USER_REQUEST: 'copilot_chat.user_request',
+	/** Cache-relevant request options as a JSON blob (tool_choice, reasoning_effort, thinking, response_format, etc.). Used by Cache Explorer. */
+	REQUEST_OPTIONS: 'copilot_chat.request.options',
 	/** Resolved context section (code snippets, file contents, etc.) */
 	PROMPT_CONTEXT: 'copilot_chat.prompt_context',
 	/** Custom instructions section */

--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -222,6 +222,8 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 					model: dto.model,
 					status: dto.status,
 					durationInMillis: dto.durationInMillis,
+					timeToFirstTokenInMillis: dto.timeToFirstTokenInMillis,
+					requestId: dto.requestId,
 					inputTokens: dto.inputTokens,
 					outputTokens: dto.outputTokens,
 					cachedTokens: dto.cachedTokens,

--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -228,6 +228,7 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 					outputTokens: dto.outputTokens,
 					cachedTokens: dto.cachedTokens,
 					totalTokens: dto.totalTokens,
+					requestOptions: dto.requestOptions,
 					errorMessage: dto.errorMessage,
 					sections: dto.sections,
 				};

--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -224,6 +224,8 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 					durationInMillis: dto.durationInMillis,
 					timeToFirstTokenInMillis: dto.timeToFirstTokenInMillis,
 					requestId: dto.requestId,
+					maxInputTokens: dto.maxInputTokens,
+					maxOutputTokens: dto.maxOutputTokens,
 					inputTokens: dto.inputTokens,
 					outputTokens: dto.outputTokens,
 					cachedTokens: dto.cachedTokens,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1521,6 +1521,7 @@ export interface IChatDebugEventModelTurnContentDto {
 	readonly outputTokens?: number;
 	readonly cachedTokens?: number;
 	readonly totalTokens?: number;
+	readonly requestOptions?: string;
 	readonly errorMessage?: string;
 	readonly sections?: readonly IChatDebugMessageSectionDto[];
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1514,6 +1514,7 @@ export interface IChatDebugEventModelTurnContentDto {
 	readonly status?: string;
 	readonly durationInMillis?: number;
 	readonly timeToFirstTokenInMillis?: number;
+	readonly requestId?: string;
 	readonly maxInputTokens?: number;
 	readonly maxOutputTokens?: number;
 	readonly inputTokens?: number;

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -291,6 +291,7 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 					outputTokens: mt.outputTokens,
 					cachedTokens: mt.cachedTokens,
 					totalTokens: mt.totalTokens,
+					requestOptions: mt.requestOptions,
 					errorMessage: mt.errorMessage,
 					sections: mt.sections?.map(s => ({ name: s.name, content: s.content })),
 				};

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -342,6 +342,7 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 				evt.sessionResource = sessionResource;
 				evt.parentEventId = dto.parentEventId;
 				evt.model = dto.model;
+				evt.requestName = dto.requestName;
 				evt.inputTokens = dto.inputTokens;
 				evt.outputTokens = dto.outputTokens;
 				evt.cachedTokens = dto.cachedTokens;

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -284,6 +284,7 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 					status: mt.status,
 					durationInMillis: mt.durationInMillis,
 					timeToFirstTokenInMillis: mt.timeToFirstTokenInMillis,
+					requestId: mt.requestId,
 					maxInputTokens: mt.maxInputTokens,
 					maxOutputTokens: mt.maxOutputTokens,
 					inputTokens: mt.inputTokens,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3779,6 +3779,7 @@ export class ChatDebugEventModelTurnContent {
 	outputTokens?: number;
 	cachedTokens?: number;
 	totalTokens?: number;
+	requestOptions?: string;
 	errorMessage?: string;
 	sections?: ChatDebugMessageSection[];
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3634,6 +3634,7 @@ export class ChatDebugModelTurnEvent {
 	created: Date;
 	parentEventId?: string;
 	model?: string;
+	requestName?: string;
 	inputTokens?: number;
 	outputTokens?: number;
 	cachedTokens?: number;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3772,6 +3772,7 @@ export class ChatDebugEventModelTurnContent {
 	status?: string;
 	durationInMillis?: number;
 	timeToFirstTokenInMillis?: number;
+	requestId?: string;
 	maxInputTokens?: number;
 	maxOutputTokens?: number;
 	inputTokens?: number;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Pure helpers used by the Cache Explorer to compare two model-turn requests
+ * (A and B) and identify where the prompt prefix diverges.
+ *
+ * The engine works on the {@link IChatDebugEventModelTurnContent.sections}
+ * "Input Messages" section, which is a JSON-stringified array of
+ *   `[{ role, name?, parts: [{ type: 'text', content, name? }, ...] }]`
+ * matching the OpenTelemetry GenAI semantic convention used by
+ * `chatParticipantTelemetry.ts`.
+ *
+ * All functions are pure — no DOM, no services — so they can be unit tested
+ * in isolation.
+ */
+
+/**
+ * A normalized request message used by the diff engine.
+ */
+export interface INormalizedMessage {
+	readonly role: string;
+	readonly name?: string;
+	/** Concatenation of all `text` parts in the message. */
+	readonly text: string;
+	/** Byte length of `text` (utf-16 code unit count is a close-enough proxy in JS). */
+	readonly byteLength: number;
+}
+
+/** Classification of a single signature token when comparing A and B. */
+export const enum CacheDiffKind {
+	/** Same role+name and same byteLength in both A and B. */
+	Identical = 'identical',
+	/** Same role+name and same byteLength but different content. */
+	ContentDrift = 'contentDrift',
+	/** Same role+name but different byteLength. */
+	LengthChange = 'lengthChange',
+	/** Position exists only in A. */
+	OnlyInA = 'onlyInA',
+	/** Position exists only in B. */
+	OnlyInB = 'onlyInB',
+}
+
+/**
+ * A single token in the side-by-side prompt signature.
+ *
+ * The signature is computed by zipping A's and B's normalized messages
+ * positionally; if they diverge, every position from the divergence onward
+ * is reported as the appropriate non-identical kind.
+ */
+export interface ICacheSignatureToken {
+	readonly index: number;
+	readonly kind: CacheDiffKind;
+	readonly aRole?: string;
+	readonly aName?: string;
+	readonly aByteLength?: number;
+	readonly bRole?: string;
+	readonly bName?: string;
+	readonly bByteLength?: number;
+}
+
+/**
+ * The first place where A and B's prompt prefix diverges. Anything after
+ * this index cannot be served from the prompt cache.
+ */
+export interface ICacheBreak {
+	readonly index: number;
+	readonly kind: Exclude<CacheDiffKind, CacheDiffKind.Identical>;
+}
+
+/**
+ * A single drifting component (e.g. a message at index N).
+ */
+export interface IComponentDrift {
+	readonly name: string;
+	readonly role?: string;
+	readonly status: CacheDiffKind;
+	readonly aSize: number;
+	readonly bSize: number;
+}
+
+/**
+ * Aggregate result of comparing two requests.
+ */
+export interface ICacheDiffResult {
+	readonly signature: readonly ICacheSignatureToken[];
+	readonly break: ICacheBreak | undefined;
+	readonly drift: readonly IComponentDrift[];
+	/**
+	 * Counts of identical / drift / one-sided positions across the whole
+	 * signature. Useful for the summary pills.
+	 */
+	readonly counts: {
+		readonly identical: number;
+		readonly contentDrift: number;
+		readonly lengthChange: number;
+		readonly onlyInA: number;
+		readonly onlyInB: number;
+	};
+}
+
+interface IRawPart {
+	readonly type?: string;
+	readonly content?: string;
+	readonly name?: string;
+}
+
+interface IRawMessage {
+	readonly role?: string;
+	readonly name?: string;
+	readonly parts?: readonly IRawPart[];
+}
+
+/**
+ * Parse a JSON-encoded `inputMessages` payload into normalized messages.
+ *
+ * Returns an empty array on any parse error so callers can render a clear
+ * empty-state without try/catch boilerplate.
+ */
+export function parseInputMessages(inputMessagesJson: string | undefined): readonly INormalizedMessage[] {
+	if (!inputMessagesJson) {
+		return [];
+	}
+	let raw: unknown;
+	try {
+		raw = JSON.parse(inputMessagesJson);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(raw)) {
+		return [];
+	}
+
+	const out: INormalizedMessage[] = [];
+	for (const m of raw as readonly IRawMessage[]) {
+		if (!m || typeof m !== 'object') {
+			continue;
+		}
+		const role = typeof m.role === 'string' ? m.role : 'unknown';
+		const name = typeof m.name === 'string' ? m.name : undefined;
+		let text = '';
+		if (Array.isArray(m.parts)) {
+			for (const p of m.parts) {
+				if (p && typeof p === 'object' && (p.type === undefined || p.type === 'text') && typeof p.content === 'string') {
+					text += p.content;
+				}
+			}
+		}
+		out.push({ role, name, text, byteLength: text.length });
+	}
+	return out;
+}
+
+/**
+ * Returns true iff the two messages have the same role, name, and content.
+ */
+function messagesEqual(a: INormalizedMessage, b: INormalizedMessage): boolean {
+	return a.role === b.role && a.name === b.name && a.byteLength === b.byteLength && a.text === b.text;
+}
+
+/**
+ * Compute the per-position diff between two normalized message arrays.
+ *
+ * The algorithm is intentionally simple (positional zip) rather than a full
+ * Myers diff: prompt caches are prefix-based, so the moment two messages at
+ * the same index diverge in role, length, or content the cache breaks.
+ * Reporting that first divergence is far more useful than computing a
+ * minimum edit script.
+ */
+export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonly INormalizedMessage[]): ICacheDiffResult {
+	const signature: ICacheSignatureToken[] = [];
+	const drift: IComponentDrift[] = [];
+	const counts = { identical: 0, contentDrift: 0, lengthChange: 0, onlyInA: 0, onlyInB: 0 };
+	let breakResult: ICacheBreak | undefined;
+	let broken = false;
+
+	const max = Math.max(a.length, b.length);
+	for (let i = 0; i < max; i++) {
+		const ai = a[i];
+		const bi = b[i];
+
+		if (ai && !bi) {
+			counts.onlyInA++;
+			signature.push({ index: i, kind: CacheDiffKind.OnlyInA, aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength });
+			drift.push({ name: `messages[${i}]`, role: ai.role, status: CacheDiffKind.OnlyInA, aSize: ai.byteLength, bSize: 0 });
+			if (!broken) {
+				broken = true;
+				breakResult = { index: i, kind: CacheDiffKind.OnlyInA };
+			}
+			continue;
+		}
+		if (bi && !ai) {
+			counts.onlyInB++;
+			signature.push({ index: i, kind: CacheDiffKind.OnlyInB, bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength });
+			drift.push({ name: `messages[${i}]`, role: bi.role, status: CacheDiffKind.OnlyInB, aSize: 0, bSize: bi.byteLength });
+			if (!broken) {
+				broken = true;
+				breakResult = { index: i, kind: CacheDiffKind.OnlyInB };
+			}
+			continue;
+		}
+		// Both present
+		if (!ai || !bi) {
+			continue; // unreachable, but appeases strict null checks
+		}
+		if (messagesEqual(ai, bi)) {
+			counts.identical++;
+			signature.push({
+				index: i, kind: CacheDiffKind.Identical,
+				aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength,
+				bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength,
+			});
+			continue;
+		}
+		// Diverged
+		const kind = ai.byteLength === bi.byteLength ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
+		if (kind === CacheDiffKind.ContentDrift) {
+			counts.contentDrift++;
+		} else {
+			counts.lengthChange++;
+		}
+		signature.push({
+			index: i, kind,
+			aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength,
+			bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength,
+		});
+		drift.push({ name: `messages[${i}]`, role: ai.role, status: kind, aSize: ai.byteLength, bSize: bi.byteLength });
+		if (!broken) {
+			broken = true;
+			breakResult = { index: i, kind };
+		}
+	}
+
+	return { signature, break: breakResult, drift, counts };
+}
+
+/**
+ * Add a leading "system" drift entry to the report when the system
+ * instructions differ between the two requests.
+ */
+export function appendSystemDrift(
+	drift: IComponentDrift[],
+	aSystem: string | undefined,
+	bSystem: string | undefined,
+): IComponentDrift[] {
+	if (aSystem === bSystem) {
+		return drift;
+	}
+	const aSize = aSystem?.length ?? 0;
+	const bSize = bSystem?.length ?? 0;
+	let status: CacheDiffKind;
+	if (!aSystem) {
+		status = CacheDiffKind.OnlyInB;
+	} else if (!bSystem) {
+		status = CacheDiffKind.OnlyInA;
+	} else {
+		status = aSize === bSize ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
+	}
+	return [{ name: 'system', status, aSize, bSize }, ...drift];
+}
+
+/**
+ * Format a normalized message into a single-line `role[-name]:bytes` token,
+ * matching the convention used by the existing `promptTypes` telemetry.
+ */
+export function formatSignatureToken(token: ICacheSignatureToken): string {
+	const role = token.bRole ?? token.aRole ?? 'unknown';
+	const name = token.bName ?? token.aName;
+	const a = token.aByteLength;
+	const b = token.bByteLength;
+	const sizeText = a !== undefined && b !== undefined && a !== b
+		? `${a}\u2192${b}`
+		: a !== undefined && b === undefined
+			? `${a}\u21920`
+			: a === undefined && b !== undefined
+				? `0\u2192${b}`
+				: `${b ?? a ?? 0}`;
+	return name ? `${role}-${name}:${sizeText}` : `${role}:${sizeText}`;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -203,6 +203,14 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
  * a way that matches what an HTTP client would actually serialize. We do
  * not normalize key order: if a provider's serializer differs between
  * requests, that *is* a real cache break we want to surface.
+ *
+ * The fallback to {@link String} is reached only for values that
+ * `JSON.stringify` rejects \u2014 circular references or `BigInt` payloads.
+ * Both produce a stable but lossy representation (e.g. `[object Object]`)
+ * which still surfaces as content drift in the diff rather than silently
+ * matching, so the user notices that something unusual went through. We
+ * intentionally do not log here so the diff engine stays free of service
+ * dependencies; the caller is welcome to wrap with logging when needed.
  */
 function stableStringify(value: unknown): string {
 	try {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -26,16 +26,16 @@ export interface INormalizedMessage {
 	/** Concatenation of all `text` parts in the message. */
 	readonly text: string;
 	/** Byte length of `text` (utf-16 code unit count is a close-enough proxy in JS). */
-	readonly byteLength: number;
+	readonly charLength: number;
 }
 
 /** Classification of a single signature token when comparing A and B. */
 export const enum CacheDiffKind {
-	/** Same role+name and same byteLength in both A and B. */
+	/** Same role+name and same charLength in both A and B. */
 	Identical = 'identical',
-	/** Same role+name and same byteLength but different content. */
+	/** Same role+name and same charLength but different content. */
 	ContentDrift = 'contentDrift',
-	/** Same role+name but different byteLength. */
+	/** Same role+name but different charLength. */
 	LengthChange = 'lengthChange',
 	/** Position exists only in A. */
 	OnlyInA = 'onlyInA',
@@ -55,10 +55,10 @@ export interface ICacheSignatureToken {
 	readonly kind: CacheDiffKind;
 	readonly aRole?: string;
 	readonly aName?: string;
-	readonly aByteLength?: number;
+	readonly aCharLength?: number;
 	readonly bRole?: string;
 	readonly bName?: string;
-	readonly bByteLength?: number;
+	readonly bCharLength?: number;
 }
 
 /**
@@ -193,7 +193,7 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 		} else if (hasToolCall && !hasText && role === 'assistant') {
 			role = 'assistant';
 		}
-		out.push({ role, name, text, byteLength: text.length });
+		out.push({ role, name, text, charLength: text.length });
 	}
 	return out;
 }
@@ -216,7 +216,7 @@ function stableStringify(value: unknown): string {
  * Returns true iff the two messages have the same role, name, and content.
  */
 function messagesEqual(a: INormalizedMessage, b: INormalizedMessage): boolean {
-	return a.role === b.role && a.name === b.name && a.byteLength === b.byteLength && a.text === b.text;
+	return a.role === b.role && a.name === b.name && a.charLength === b.charLength && a.text === b.text;
 }
 
 /**
@@ -242,8 +242,8 @@ export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonl
 
 		if (ai && !bi) {
 			counts.onlyInA++;
-			signature.push({ index: i, kind: CacheDiffKind.OnlyInA, aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength });
-			drift.push({ name: `messages[${i}]`, role: ai.role, status: CacheDiffKind.OnlyInA, aSize: ai.byteLength, bSize: 0 });
+			signature.push({ index: i, kind: CacheDiffKind.OnlyInA, aRole: ai.role, aName: ai.name, aCharLength: ai.charLength });
+			drift.push({ name: `messages[${i}]`, role: ai.role, status: CacheDiffKind.OnlyInA, aSize: ai.charLength, bSize: 0 });
 			if (!broken) {
 				broken = true;
 				breakResult = { index: i, kind: CacheDiffKind.OnlyInA };
@@ -252,8 +252,8 @@ export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonl
 		}
 		if (bi && !ai) {
 			counts.onlyInB++;
-			signature.push({ index: i, kind: CacheDiffKind.OnlyInB, bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength });
-			drift.push({ name: `messages[${i}]`, role: bi.role, status: CacheDiffKind.OnlyInB, aSize: 0, bSize: bi.byteLength });
+			signature.push({ index: i, kind: CacheDiffKind.OnlyInB, bRole: bi.role, bName: bi.name, bCharLength: bi.charLength });
+			drift.push({ name: `messages[${i}]`, role: bi.role, status: CacheDiffKind.OnlyInB, aSize: 0, bSize: bi.charLength });
 			if (!broken) {
 				broken = true;
 				breakResult = { index: i, kind: CacheDiffKind.OnlyInB };
@@ -268,13 +268,13 @@ export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonl
 			counts.identical++;
 			signature.push({
 				index: i, kind: CacheDiffKind.Identical,
-				aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength,
-				bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength,
+				aRole: ai.role, aName: ai.name, aCharLength: ai.charLength,
+				bRole: bi.role, bName: bi.name, bCharLength: bi.charLength,
 			});
 			continue;
 		}
 		// Diverged
-		const kind = ai.byteLength === bi.byteLength ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
+		const kind = ai.charLength === bi.charLength ? CacheDiffKind.ContentDrift : CacheDiffKind.LengthChange;
 		if (kind === CacheDiffKind.ContentDrift) {
 			counts.contentDrift++;
 		} else {
@@ -282,10 +282,10 @@ export function diffPromptSignature(a: readonly INormalizedMessage[], b: readonl
 		}
 		signature.push({
 			index: i, kind,
-			aRole: ai.role, aName: ai.name, aByteLength: ai.byteLength,
-			bRole: bi.role, bName: bi.name, bByteLength: bi.byteLength,
+			aRole: ai.role, aName: ai.name, aCharLength: ai.charLength,
+			bRole: bi.role, bName: bi.name, bCharLength: bi.charLength,
 		});
-		drift.push({ name: `messages[${i}]`, role: ai.role, status: kind, aSize: ai.byteLength, bSize: bi.byteLength });
+		drift.push({ name: `messages[${i}]`, role: ai.role, status: kind, aSize: ai.charLength, bSize: bi.charLength });
 		if (!broken) {
 			broken = true;
 			breakResult = { index: i, kind };
@@ -327,8 +327,8 @@ export function appendSystemDrift(
 export function formatSignatureToken(token: ICacheSignatureToken): string {
 	const role = token.bRole ?? token.aRole ?? 'unknown';
 	const name = token.bName ?? token.aName;
-	const a = token.aByteLength;
-	const b = token.bByteLength;
+	const a = token.aCharLength;
+	const b = token.bCharLength;
 	const sizeText = a !== undefined && b !== undefined && a !== b
 		? `${a}\u2192${b}`
 		: a !== undefined && b === undefined

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -103,8 +103,11 @@ export interface ICacheDiffResult {
 
 interface IRawPart {
 	readonly type?: string;
-	readonly content?: string;
+	readonly content?: unknown;
 	readonly name?: string;
+	readonly id?: string;
+	readonly arguments?: unknown;
+	readonly response?: unknown;
 }
 
 interface IRawMessage {
@@ -138,19 +141,75 @@ export function parseInputMessages(inputMessagesJson: string | undefined): reado
 		if (!m || typeof m !== 'object') {
 			continue;
 		}
-		const role = typeof m.role === 'string' ? m.role : 'unknown';
+		let role = typeof m.role === 'string' ? m.role : 'unknown';
 		const name = typeof m.name === 'string' ? m.name : undefined;
 		let text = '';
+		let hasToolResponse = false;
+		let hasToolCall = false;
+		let hasText = false;
 		if (Array.isArray(m.parts)) {
 			for (const p of m.parts) {
-				if (p && typeof p === 'object' && (p.type === undefined || p.type === 'text') && typeof p.content === 'string') {
-					text += p.content;
+				if (!p || typeof p !== 'object') {
+					continue;
+				}
+				switch (p.type) {
+					case undefined:
+					case 'text':
+					case 'reasoning':
+						if (typeof p.content === 'string') {
+							text += p.content;
+							hasText = true;
+						}
+						break;
+					case 'tool_call_response':
+					case 'tool_result':
+						if (typeof p.response === 'string') {
+							text += p.response;
+						} else if (p.response !== undefined) {
+							text += stableStringify(p.response);
+						} else if (typeof p.content === 'string') {
+							text += p.content;
+						} else if (p.content !== undefined) {
+							text += stableStringify(p.content);
+						}
+						hasToolResponse = true;
+						break;
+					case 'tool_call':
+						// Tool calls live on assistant messages; include their
+						// stringified arguments so a tool-call argument change
+						// (e.g. file path) shows up as drift.
+						if (p.name) { text += `call:${p.name}`; }
+						if (p.arguments !== undefined) { text += stableStringify(p.arguments); }
+						hasToolCall = true;
+						break;
 				}
 			}
+		}
+		// If a message is dominated by tool I/O, label its role accordingly
+		// so the visualization labels it as `tool` rather than as a `user`
+		// or `assistant` message with mysterious empty content.
+		if (hasToolResponse && !hasText) {
+			role = 'tool';
+		} else if (hasToolCall && !hasText && role === 'assistant') {
+			role = 'assistant';
 		}
 		out.push({ role, name, text, byteLength: text.length });
 	}
 	return out;
+}
+
+/**
+ * Render an opaque value (tool arguments, response payload) as a string in
+ * a way that matches what an HTTP client would actually serialize. We do
+ * not normalize key order: if a provider's serializer differs between
+ * requests, that *is* a real cache break we want to surface.
+ */
+function stableStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -25,7 +25,7 @@ export interface INormalizedMessage {
 	readonly name?: string;
 	/** Concatenation of all `text` parts in the message. */
 	readonly text: string;
-	/** Byte length of `text` (utf-16 code unit count is a close-enough proxy in JS). */
+	/** Character length of `text` as a UTF-16 code unit count (`text.length`). */
 	readonly charLength: number;
 }
 
@@ -47,8 +47,13 @@ export const enum CacheDiffKind {
  * A single token in the side-by-side prompt signature.
  *
  * The signature is computed by zipping A's and B's normalized messages
- * positionally; if they diverge, every position from the divergence onward
- * is reported as the appropriate non-identical kind.
+ * positionally and classifying each index independently. The first
+ * divergence is what breaks the prompt cache, but later positions can
+ * still be reported as {@link CacheDiffKind.Identical} if their content
+ * happens to match \u2014 we surface per-position truth here and let the
+ * UI decide how to interpret it (the cache-break marker, summary copy,
+ * and "Where the cache broke" line all key off the *first* divergent
+ * index, not the last).
  */
 export interface ICacheSignatureToken {
 	readonly index: number;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheDiff.ts
@@ -214,6 +214,10 @@ function stableStringify(value: unknown): string {
 
 /**
  * Returns true iff the two messages have the same role, name, and content.
+ *
+ * The `charLength` check is redundant with `text` equality but acts as a
+ * cheap fast-fail: comparing two large message bodies that already differ
+ * in length is wasted work.
  */
 function messagesEqual(a: INormalizedMessage, b: INormalizedMessage): boolean {
 	return a.role === b.role && a.name === b.name && a.charLength === b.charLength && a.text === b.text;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -9,6 +9,7 @@ import { BreadcrumbsWidget } from '../../../../../base/browser/ui/breadcrumbs/br
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { safeIntl } from '../../../../../base/common/date.js';
+import { equals } from '../../../../../base/common/objects.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -226,7 +227,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			return;
 		}
 
-		// Default to the most recent turn on first display. Clamp to a valid index.
+		// Default to the most recent turn on first display, and silently
+		// fall back to the most recent turn when switching to a session
+		// that has fewer turns than the previous selection \u2014 the rail
+		// re-renders so the new selection is still visible.
 		if (this.selectedIndex < 0 || this.selectedIndex >= this.modelTurns.length) {
 			this.selectedIndex = this.modelTurns.length - 1;
 		}
@@ -590,6 +594,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		const max = Math.max(totalA, totalB, 1);
 
 		// Compute byte position of cache break inside each side's bar.
+		// Returns undefined if the break index falls outside the side's
+		// segment list (e.g. break is at messages[N] but B has fewer
+		// messages); rendering that as the right edge of the bar would
+		// misleadingly suggest "the cache broke at the end".
 		const breakBytePos = (segs: readonly ISegment[]): number | undefined => {
 			if (!diff.break) {
 				return undefined;
@@ -610,7 +618,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				cumulative += s.bytes;
 				idx++;
 			}
-			return cumulative;
+			return undefined;
 		};
 
 		const buildLane = (label: string, segs: readonly ISegment[], breakPos: number | undefined): HTMLElement => {
@@ -710,7 +718,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			const row = DOM.append(table, $('.chat-debug-cache-options-row'));
 			const av = prev[key];
 			const bv = curr[key];
-			const changed = !deepEqual(av, bv);
+			const changed = !equals(av, bv);
 			if (changed) {
 				row.classList.add('changed');
 			}
@@ -959,7 +967,7 @@ function computeOptionsDiff(a: ISideData, b: ISideData): readonly IOptionDelta[]
 	for (const key of keys) {
 		const av = prev[key];
 		const bv = curr[key];
-		if (!deepEqual(av, bv)) {
+		if (!equals(av, bv)) {
 			out.push({ key, previous: av, current: bv });
 		}
 	}
@@ -993,26 +1001,6 @@ function parseOptions(blob: string | undefined): Record<string, unknown> {
 	return flat;
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
-	if (a === b) {
-		return true;
-	}
-	if (a === undefined || b === undefined || a === null || b === null) {
-		return false;
-	}
-	if (typeof a !== typeof b) {
-		return false;
-	}
-	if (typeof a !== 'object') {
-		return false;
-	}
-	try {
-		return JSON.stringify(a) === JSON.stringify(b);
-	} catch {
-		return false;
-	}
-}
-
 function formatOptionValue(value: unknown): string {
 	if (value === undefined) {
 		return '\u2014';
@@ -1034,11 +1022,14 @@ function formatOptionValue(value: unknown): string {
 }
 
 /**
- * Cache "expiration" heuristic. We can't know for sure why a provider
- * decided to invalidate a cache entry, but if the structural diff says
- * the prompt prefix is byte-identical AND the request options match AND
- * the model still reports 0 cached input tokens, expiration is the most
- * likely cause.
+ * Cache "expiration" heuristic. The provider doesn't tell us *why* it
+ * invalidated a cache entry, so this is a best-effort guess: if the
+ * structural diff says the prompt prefix is byte-identical AND the
+ * request options match AND the model still reports 0 cached input
+ * tokens, expiration is the most likely cause. Other causes we cannot
+ * distinguish from this signal alone include provider-side eviction
+ * under cache pressure, server-side restarts, and per-tenant quota
+ * resets. The headline copy in the UI says "likely" for that reason.
  */
 function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, optionsDiff: readonly IOptionDelta[]): boolean {
 	if (hitPct >= 1) {
@@ -1109,7 +1100,12 @@ function renderInlineDiff(prevHost: HTMLElement, currHost: HTMLElement, prev: st
 		currIdx = modEnd - 1;
 	}
 
-	// Emit any trailing identical context.
+	// Emit any trailing identical context. The line-level diff guarantees
+	// every change range is reported, so anything left over on both sides
+	// after the last change is identical context — the `&&` is intentional:
+	// if one side has more lines than the other at this point the overflow
+	// is already covered by the change ranges above (otherwise we'd have a
+	// bug in the diff computer).
 	while (prevIdx < prevLines.length && currIdx < currLines.length) {
 		appendLine(prevHost, prevLines[prevIdx], 'context');
 		appendLine(currHost, currLines[currIdx], 'context');

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -14,6 +14,8 @@ import { Disposable, DisposableStore } from '../../../../../base/common/lifecycl
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { defaultBreadcrumbsWidgetStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { linesDiffComputers } from '../../../../../editor/common/diff/linesDiffComputers.js';
+import { RangeMapping } from '../../../../../editor/common/diff/rangeMapping.js';
 import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugService, IChatDebugUserMessageEvent } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
@@ -663,13 +665,19 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		const grid = $('.chat-debug-cache-diff');
 		const colA = DOM.append(grid, $('.chat-debug-cache-diff-col'));
 		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "Previous \u00b7 {0} B", numberFormatter.value.format(aSize))));
-		const aBody = DOM.append(colA, DOM.$('div'));
-		aBody.textContent = aText || localize('chatDebug.cache.notPresent', "(not present)");
+		const aBody = DOM.append(colA, $('.chat-debug-cache-diff-body'));
 
 		const colB = DOM.append(grid, $('.chat-debug-cache-diff-col'));
 		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "Current \u00b7 {0} B", numberFormatter.value.format(bSize))));
-		const bBody = DOM.append(colB, DOM.$('div'));
-		bBody.textContent = bText || localize('chatDebug.cache.notPresent', "(not present)");
+		const bBody = DOM.append(colB, $('.chat-debug-cache-diff-body'));
+
+		if (!aText && !bText) {
+			aBody.textContent = localize('chatDebug.cache.notPresent', "(not present)");
+			bBody.textContent = localize('chatDebug.cache.notPresent', "(not present)");
+			return grid;
+		}
+
+		renderInlineDiff(aBody, bBody, aText, bText);
 		return grid;
 	}
 }
@@ -810,7 +818,132 @@ function formatCachePctInt(pct: number): string {
 
 function formatTokens(value: number | undefined): string {
 	if (value === undefined) {
-		return '—';
+		return '\u2014';
 	}
 	return numberFormatter.value.format(value);
+}
+
+const DIFF_OPTIONS = {
+	ignoreTrimWhitespace: false,
+	maxComputationTimeMs: 200,
+	computeMoves: false,
+} as const;
+
+/**
+ * Render a side-by-side line + character diff into the two body elements.
+ *
+ * Uses {@link linesDiffComputers.getDefault()} to compute a line-level diff
+ * with inner character-level mappings, then walks the result to emit one
+ * div per line. Lines belonging to a removed range are styled with the
+ * "remove" class on the previous side; added ranges with the "add" class
+ * on the current side; modified ranges appear on both sides with character
+ * spans highlighted within. Identical lines are placed on both sides as
+ * context.
+ */
+function renderInlineDiff(prevHost: HTMLElement, currHost: HTMLElement, prev: string, curr: string): void {
+	const prevLines = prev.split(/\r?\n/);
+	const currLines = curr.split(/\r?\n/);
+	const result = linesDiffComputers.getDefault().computeDiff(prevLines, currLines, DIFF_OPTIONS);
+
+	let prevIdx = 0;
+	let currIdx = 0;
+	for (const change of result.changes) {
+		const origStart = change.original.startLineNumber;
+		const origEnd = change.original.endLineNumberExclusive;
+		const modStart = change.modified.startLineNumber;
+		const modEnd = change.modified.endLineNumberExclusive;
+
+		// Emit identical context lines up to this change.
+		while (prevIdx + 1 < origStart && currIdx + 1 < modStart) {
+			appendLine(prevHost, prevLines[prevIdx], 'context');
+			appendLine(currHost, currLines[currIdx], 'context');
+			prevIdx++;
+			currIdx++;
+		}
+
+		// Emit changed lines on each side. Inner range mappings give us
+		// character-level spans; we apply them per line.
+		const innerByOrig = groupInnerChangesByLine(change.innerChanges, /* original */ true);
+		const innerByMod = groupInnerChangesByLine(change.innerChanges, /* original */ false);
+
+		for (let line = origStart; line < origEnd; line++) {
+			const lineText = prevLines[line - 1] ?? '';
+			appendChangedLine(prevHost, lineText, innerByOrig.get(line), 'remove');
+		}
+		prevIdx = origEnd - 1;
+
+		for (let line = modStart; line < modEnd; line++) {
+			const lineText = currLines[line - 1] ?? '';
+			appendChangedLine(currHost, lineText, innerByMod.get(line), 'add');
+		}
+		currIdx = modEnd - 1;
+	}
+
+	// Emit any trailing identical context.
+	while (prevIdx < prevLines.length && currIdx < currLines.length) {
+		appendLine(prevHost, prevLines[prevIdx], 'context');
+		appendLine(currHost, currLines[currIdx], 'context');
+		prevIdx++;
+		currIdx++;
+	}
+}
+
+function appendLine(host: HTMLElement, text: string, kind: 'context' | 'add' | 'remove'): void {
+	const line = DOM.append(host, $(`.chat-debug-cache-diff-line.${kind}`));
+	line.textContent = text === '' ? '\u00a0' : text;
+}
+
+interface IInnerChangeRange {
+	readonly startColumn: number;
+	readonly endColumn: number;
+}
+
+function appendChangedLine(host: HTMLElement, text: string, ranges: readonly IInnerChangeRange[] | undefined, kind: 'add' | 'remove'): void {
+	const line = DOM.append(host, $(`.chat-debug-cache-diff-line.${kind}`));
+	if (!ranges || ranges.length === 0) {
+		line.textContent = text === '' ? '\u00a0' : text;
+		return;
+	}
+	let cursor = 1; // 1-based column index
+	const sorted = [...ranges].sort((a, b) => a.startColumn - b.startColumn);
+	for (const r of sorted) {
+		if (r.startColumn > cursor) {
+			DOM.append(line, document.createTextNode(text.substring(cursor - 1, r.startColumn - 1)));
+		}
+		const span = DOM.append(line, $('span.chat-debug-cache-diff-inner'));
+		span.textContent = text.substring(r.startColumn - 1, r.endColumn - 1);
+		cursor = r.endColumn;
+	}
+	if (cursor - 1 < text.length) {
+		DOM.append(line, document.createTextNode(text.substring(cursor - 1)));
+	}
+}
+
+/**
+ * Group {@link DetailedLineRangeMapping.innerChanges} by line so the diff
+ * renderer can look up character ranges per line. Multi-line range
+ * mappings only contribute a partial range to their first/last line; we
+ * approximate by clamping to the line bounds.
+ */
+function groupInnerChangesByLine(
+	innerChanges: readonly RangeMapping[] | undefined,
+	useOriginal: boolean,
+): Map<number, IInnerChangeRange[]> {
+	const out = new Map<number, IInnerChangeRange[]>();
+	if (!innerChanges) {
+		return out;
+	}
+	for (const r of innerChanges) {
+		const range = useOriginal ? r.originalRange : r.modifiedRange;
+		// Only handle single-line inner ranges for v1. Multi-line spans
+		// are flagged at the line level via the surrounding add/remove
+		// styling, so we don't need pixel-perfect column highlights.
+		if (range.startLineNumber !== range.endLineNumber) {
+			continue;
+		}
+		const list = out.get(range.startLineNumber) ?? [];
+		list.push({ startColumn: range.startColumn, endColumn: range.endColumn });
+		out.set(range.startLineNumber, list);
+	}
+	return out;
 }

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../../base/browser/dom.js';
+import { Orientation, Sash, SashState } from '../../../../../base/browser/ui/sash/sash.js';
 import { BreadcrumbsWidget } from '../../../../../base/browser/ui/breadcrumbs/breadcrumbsWidget.js';
-import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { safeIntl } from '../../../../../base/common/date.js';
@@ -13,16 +13,21 @@ import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
-import { defaultBreadcrumbsWidgetStyles, defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
-import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugService } from '../../common/chatDebugService.js';
+import { defaultBreadcrumbsWidgetStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugService, IChatDebugUserMessageEvent } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
-import { appendSystemDrift, CacheDiffKind, diffPromptSignature, formatSignatureToken, ICacheDiffResult, ICacheSignatureToken, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
+import { appendSystemDrift, CacheDiffKind, diffPromptSignature, ICacheDiffResult, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
 import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
 
 const $ = DOM.$;
 const numberFormatter = safeIntl.NumberFormat();
 const timeFormatter = safeIntl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+
+/** Default rail width in pixels. */
+const RAIL_DEFAULT_WIDTH = 280;
+const RAIL_MIN_WIDTH = 180;
+const RAIL_MAX_WIDTH = 600;
 
 /**
  * Navigation events fired by the Cache Explorer breadcrumb.
@@ -38,6 +43,13 @@ interface ISideData {
 	readonly content: IChatDebugEventModelTurnContent | undefined;
 	readonly system: string | undefined;
 	readonly inputMessages: readonly INormalizedMessage[];
+}
+
+/** A grouping of model turns sharing the same parent (one user request). */
+interface ITurnGroup {
+	readonly key: string;
+	readonly userMessage: IChatDebugUserMessageEvent | undefined;
+	readonly turns: readonly { readonly turn: IChatDebugModelTurnEvent; readonly index: number }[];
 }
 
 /**
@@ -57,22 +69,27 @@ export class ChatDebugCacheExplorerView extends Disposable {
 
 	readonly container: HTMLElement;
 	private readonly breadcrumbWidget: BreadcrumbsWidget;
+	private readonly rail: HTMLElement;
 	private readonly railList: HTMLElement;
 	private readonly content: HTMLElement;
+	private readonly sash: Sash;
+	private railWidth = RAIL_DEFAULT_WIDTH;
 	private readonly loadDisposables = this._register(new DisposableStore());
 	private readonly refreshScheduler: RunOnceScheduler;
 
 	private currentSessionResource: URI | undefined;
 	private modelTurns: IChatDebugModelTurnEvent[] = [];
-	private aIndex = 0;
-	private bIndex = 1;
-	private filterFlags = { content: true, onlyA: true, onlyB: true, identical: true };
+	/** Selected turn (B side). A is computed as `selectedIndex - 1`. -1 = no explicit selection yet. */
+	private selectedIndex = -1;
 
 	/** Cache of resolved model-turn content keyed by event id. */
 	private readonly resolvedCache = new Map<string, IChatDebugEventModelTurnContent | undefined>();
 
 	/** Components currently expanded (by component name). */
 	private readonly openComponents = new Set<string>(['system', 'tools']);
+
+	/** Rail groups currently collapsed (by group key — the parent event id). */
+	private readonly collapsedGroups = new Set<string>();
 
 	constructor(
 		parent: HTMLElement,
@@ -100,11 +117,33 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			}
 		}));
 
-		// Body: 2-column split
+		// Body: 2-column split with resizable rail
 		const body = DOM.append(this.container, $('.chat-debug-cache-body'));
-		const rail = DOM.append(body, $('.chat-debug-cache-rail'));
-		this.railList = DOM.append(rail, $('.chat-debug-cache-rail-list'));
+		this.rail = DOM.append(body, $('.chat-debug-cache-rail'));
+		this.rail.style.width = `${this.railWidth}px`;
+		this.railList = DOM.append(this.rail, $('.chat-debug-cache-rail-list'));
 		this.content = DOM.append(body, $('.chat-debug-cache-content'));
+
+		this.sash = this._register(new Sash(body, {
+			getVerticalSashLeft: () => this.railWidth,
+		}, { orientation: Orientation.VERTICAL }));
+		this.sash.state = SashState.Enabled;
+		let sashStartWidth: number | undefined;
+		this._register(this.sash.onDidStart(() => sashStartWidth = this.railWidth));
+		this._register(this.sash.onDidEnd(() => {
+			sashStartWidth = undefined;
+			this.sash.layout();
+		}));
+		this._register(this.sash.onDidChange(e => {
+			if (sashStartWidth === undefined) {
+				return;
+			}
+			const delta = e.currentX - e.startX;
+			const next = Math.max(RAIL_MIN_WIDTH, Math.min(RAIL_MAX_WIDTH, sashStartWidth + delta));
+			this.railWidth = next;
+			this.rail.style.width = `${next}px`;
+			this.sash.layout();
+		}));
 
 		this.refreshScheduler = this._register(new RunOnceScheduler(() => this.render(), 50));
 	}
@@ -112,8 +151,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	setSession(sessionResource: URI): void {
 		if (!this.currentSessionResource || this.currentSessionResource.toString() !== sessionResource.toString()) {
 			this.resolvedCache.clear();
-			this.aIndex = 0;
-			this.bIndex = 1;
+			this.selectedIndex = -1;
 		}
 		this.currentSessionResource = sessionResource;
 	}
@@ -158,6 +196,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 
 		const events = this.chatDebugService.getEvents(this.currentSessionResource);
 		this.modelTurns = events.filter((e): e is IChatDebugModelTurnEvent => e.kind === 'modelTurn');
+		const userMessages = events.filter((e): e is IChatDebugUserMessageEvent => e.kind === 'userMessage');
 
 		if (this.modelTurns.length === 0) {
 			const empty = DOM.append(this.content, $('.chat-debug-cache-empty'));
@@ -165,28 +204,39 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			return;
 		}
 
-		// Clamp indices
-		this.bIndex = Math.min(Math.max(this.bIndex, 0), this.modelTurns.length - 1);
-		this.aIndex = Math.min(Math.max(this.aIndex, 0), this.modelTurns.length - 1);
-		if (this.modelTurns.length > 1 && this.aIndex === this.bIndex) {
-			this.aIndex = Math.max(0, this.bIndex - 1);
+		// Default to the most recent turn on first display. Clamp to a valid index.
+		if (this.selectedIndex < 0 || this.selectedIndex >= this.modelTurns.length) {
+			this.selectedIndex = this.modelTurns.length - 1;
 		}
 
-		this.renderRail();
+		this.renderRail(buildTurnGroups(this.modelTurns, userMessages));
+		this.renderTitleRow();
 
-		const a = await this.resolveSide(this.modelTurns[this.aIndex]);
-		const b = await this.resolveSide(this.modelTurns[this.bIndex]);
+		const bEvent = this.modelTurns[this.selectedIndex];
+		const aEvent = this.selectedIndex > 0 ? this.modelTurns[this.selectedIndex - 1] : undefined;
+
+		if (!aEvent) {
+			// No prior turn to diff against — still surface OTel-reported cache hit
+			// and request metadata for the first turn of a session.
+			const b = await this.resolveSide(bEvent);
+			if (this.selectedIndex < 0 || this.modelTurns[this.selectedIndex] !== bEvent) {
+				return;
+			}
+			this.renderSingleSummary(b);
+			return;
+		}
+
+		const [a, b] = await Promise.all([this.resolveSide(aEvent), this.resolveSide(bEvent)]);
 		// If the user changed selection while resolving, drop this render.
-		if (a.event !== this.modelTurns[this.aIndex] || b.event !== this.modelTurns[this.bIndex]) {
+		if (this.selectedIndex < 0 || this.modelTurns[this.selectedIndex] !== bEvent) {
 			return;
 		}
 
 		const diff = diffPromptSignature(a.inputMessages, b.inputMessages);
 		const drift = appendSystemDrift([...diff.drift], a.system, b.system);
 
-		this.renderTitleRow();
 		this.renderSummary(a, b, diff);
-		this.renderSignature(diff);
+		this.renderSignature(a, b, diff);
 		this.renderComponents(drift, a, b);
 	}
 
@@ -207,182 +257,364 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		return { event, content, system, inputMessages };
 	}
 
-	private renderRail(): void {
-		this.modelTurns.forEach((evt, i) => {
-			const row = DOM.append(this.railList, $('.chat-debug-cache-turn'));
-			if (i === this.aIndex) { row.classList.add('is-a'); }
-			if (i === this.bIndex) { row.classList.add('is-b'); }
-			const idx = DOM.append(row, $('.chat-debug-cache-turn-idx'));
-			idx.textContent = String(i).padStart(2, ' ');
+	private renderRail(groups: readonly ITurnGroup[]): void {
+		for (const group of groups) {
+			const collapsed = this.collapsedGroups.has(group.key);
+			const header = DOM.append(this.railList, $('.chat-debug-cache-group-header'));
+			if (collapsed) {
+				header.classList.add('is-collapsed');
+			}
+			header.tabIndex = 0;
+			header.setAttribute('role', 'button');
+			header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+			header.title = localize('chatDebug.cache.toggleGroup', "Toggle group");
 
-			const main = DOM.append(row, $('.chat-debug-cache-turn-main'));
-			const label = DOM.append(main, $('.chat-debug-cache-turn-label'));
-			label.textContent = evt.model || evt.requestName || localize('chatDebug.cache.modelTurn', "Model Turn");
-			const meta = DOM.append(main, $('.chat-debug-cache-turn-meta'));
-			meta.appendChild(DOM.$('span', undefined, formatTokens(evt.inputTokens)));
-			const hit = computeCacheHit(evt);
-			const bar = DOM.append(meta, $('.chat-debug-cache-bar'));
-			if (hit < 70) { bar.classList.add('bad'); }
-			else if (hit < 95) { bar.classList.add('warn'); }
-			const fill = DOM.append(bar, DOM.$('i'));
-			fill.style.width = `${Math.max(2, hit)}%`;
-			meta.appendChild(DOM.$('span', undefined, localize('chatDebug.cache.hitPct', "cache {0}%", hit.toFixed(0))));
+			const topLine = DOM.append(header, $('.chat-debug-cache-group-top'));
+			DOM.append(topLine, $('span.chat-debug-cache-group-chev'));
+			const headerLine = DOM.append(topLine, $('.chat-debug-cache-group-prompt'));
+			headerLine.textContent = group.userMessage?.message?.trim() || localize('chatDebug.cache.unknownPrompt', "(no prompt captured)");
+			const countBadge = DOM.append(topLine, $('span.chat-debug-cache-group-count'));
+			countBadge.textContent = String(group.turns.length);
 
-			const ts = DOM.append(row, $('.chat-debug-cache-turn-ts'));
-			ts.textContent = timeFormatter.value.format(evt.created);
+			const headerMeta = DOM.append(header, $('.chat-debug-cache-group-meta'));
+			headerMeta.textContent = group.key;
+			headerMeta.title = localize('chatDebug.cache.requestIdTooltip', "Request id: {0}", group.key);
 
-			row.title = localize('chatDebug.cache.turnHelp', "Click to set as B · Shift-click to set as A");
-			this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, (e: MouseEvent) => {
-				if (e.shiftKey) {
-					this.aIndex = i;
+			const toggle = () => {
+				if (this.collapsedGroups.has(group.key)) {
+					this.collapsedGroups.delete(group.key);
 				} else {
-					this.bIndex = i;
-				}
-				if (this.aIndex === this.bIndex) {
-					this.aIndex = Math.max(0, this.bIndex - 1);
+					this.collapsedGroups.add(group.key);
 				}
 				this.refresh();
+			};
+			this.loadDisposables.add(DOM.addDisposableListener(header, DOM.EventType.CLICK, toggle));
+			this.loadDisposables.add(DOM.addDisposableListener(header, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					toggle();
+				}
 			}));
-		});
+
+			if (collapsed) {
+				continue;
+			}
+
+			for (const { turn: evt, index: i } of group.turns) {
+				const row = DOM.append(this.railList, $('.chat-debug-cache-turn'));
+				if (i === this.selectedIndex) { row.classList.add('is-selected'); }
+				const idx = DOM.append(row, $('.chat-debug-cache-turn-idx'));
+				idx.textContent = String(i).padStart(2, ' ');
+
+				const main = DOM.append(row, $('.chat-debug-cache-turn-main'));
+
+				// Top line: agent source with bracketed cache hit, duration, and timestamp
+				const top = DOM.append(main, $('.chat-debug-cache-turn-top'));
+				const source = DOM.append(top, $('span.chat-debug-cache-turn-source'));
+				source.textContent = evt.requestName || localize('chatDebug.cache.modelTurn', "Model Turn");
+				if (evt.cachedTokens !== undefined && evt.inputTokens) {
+					const hit = computeCacheHit(evt);
+					const hitChip = DOM.append(top, $('span.chat-debug-cache-turn-chip.chat-debug-cache-turn-hit', undefined,
+						localize('chatDebug.cache.hitChip', "[cache {0}%]", formatCachePctInt(hit))));
+					if (hit < 90) {
+						hitChip.classList.add('is-bad');
+					}
+				}
+				if (evt.durationInMillis !== undefined) {
+					DOM.append(top, $('span.chat-debug-cache-turn-chip', undefined, localize('chatDebug.cache.msChip', "[{0}ms]", numberFormatter.value.format(Math.round(evt.durationInMillis)))));
+				}
+				DOM.append(top, $('span.chat-debug-cache-turn-chip', undefined, `[${timeFormatter.value.format(evt.created)}]`));
+
+				// Bottom line: model name
+				if (evt.model) {
+					const sub = DOM.append(main, $('.chat-debug-cache-turn-sub'));
+					sub.textContent = evt.model;
+				}
+
+				row.title = localize('chatDebug.cache.turnHelp', "Click to compare this request against the previous one");
+				this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, () => {
+					if (this.selectedIndex !== i) {
+						this.selectedIndex = i;
+						this.refresh();
+					}
+				}));
+			}
+		}
 	}
 
 	private renderTitleRow(): void {
 		const titleRow = DOM.append(this.content, $('.chat-debug-cache-title-row'));
 		const title = DOM.append(titleRow, $('h2.chat-debug-cache-title'));
 		title.textContent = localize('chatDebug.cacheExplorer.title', "Cache Explorer — Prefix Diff");
-
-		const actions = DOM.append(titleRow, $('.chat-debug-cache-title-actions'));
-		const prevBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, secondary: true, title: localize('chatDebug.cache.prevPair', "Previous pair") }));
-		prevBtn.label = localize('chatDebug.cache.prevPair', "Previous pair");
-		this.loadDisposables.add(prevBtn.onDidClick(() => {
-			if (this.bIndex > 1) {
-				this.bIndex--;
-				this.aIndex = this.bIndex - 1;
-				this.refresh();
-			}
-		}));
-		const nextBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, secondary: true, title: localize('chatDebug.cache.nextPair', "Next pair") }));
-		nextBtn.label = localize('chatDebug.cache.nextPair', "Next pair");
-		this.loadDisposables.add(nextBtn.onDidClick(() => {
-			if (this.bIndex < this.modelTurns.length - 1) {
-				this.bIndex++;
-				this.aIndex = this.bIndex - 1;
-				this.refresh();
-			}
-		}));
-		const swapBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, title: localize('chatDebug.cache.swapTitle', "Swap A and B") }));
-		swapBtn.label = localize('chatDebug.cache.swapLabel', "Swap A ↔ B");
-		this.loadDisposables.add(swapBtn.onDidClick(() => {
-			const tmp = this.aIndex;
-			this.aIndex = this.bIndex;
-			this.bIndex = tmp;
-			this.refresh();
-		}));
 	}
 
 	private renderSummary(a: ISideData, b: ISideData, diff: ICacheDiffResult): void {
 		const row = DOM.append(this.content, $('.chat-debug-cache-summary'));
-		row.appendChild(this.renderSideCard('A', a));
-		row.appendChild(this.renderSideCard('B', b));
+		row.appendChild(this.renderSideCard(a, localize('chatDebug.cache.previousRequest', "Previous request")));
+		row.appendChild(this.renderSideCard(b, localize('chatDebug.cache.requestTitle', "Request")));
 
 		const breakCard = DOM.append(row, $('.chat-debug-cache-card.break'));
-		DOM.append(breakCard, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.breakAnalysis', "Cache-break analysis")));
+		DOM.append(breakCard, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.performance', "Cache performance")));
+
+		// Section 1: cache hit headline + absolute counts
+		const hit = computeCacheHit(b.event);
+		const inputTokens = b.event.inputTokens ?? 0;
+		const cachedTokens = b.event.cachedTokens ?? 0;
+		const lostTokens = Math.max(0, inputTokens - cachedTokens);
 		const headline = DOM.append(breakCard, $('.chat-debug-cache-card-headline'));
-		const sharedPct = b.event.inputTokens && b.event.cachedTokens !== undefined
-			? Math.round((b.event.cachedTokens / b.event.inputTokens) * 100)
-			: 0;
-		headline.textContent = localize('chatDebug.cache.sharedPrefix', "~{0}% shared prefix", sharedPct);
-		const sub = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
+		headline.textContent = localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
+		const counts = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
+		counts.textContent = localize('chatDebug.cache.tokensReused',
+			"{0} of {1} input tokens reused",
+			numberFormatter.value.format(cachedTokens),
+			numberFormatter.value.format(inputTokens),
+		);
+
+		// Section 2: where the cache broke
+		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
+		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.whereBroke', "Where the cache broke")));
+		const breakLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
 		if (diff.break) {
 			const componentName = diff.break.index === 0
 				? localize('chatDebug.cache.firstMessage', "the first message")
 				: `messages[${diff.break.index}]`;
-			sub.textContent = localize('chatDebug.cache.breakLocation', "Cache breaks at {0}. Anything after this point cannot reuse cache from A.", componentName);
+			breakLine.textContent = localize('chatDebug.cache.breakAt',
+				"At {0} \u2014 {1}",
+				componentName,
+				describeBreakKind(diff.break.kind, diff, b),
+			);
+			if (lostTokens > 0 && inputTokens > 0) {
+				const lostPct = (lostTokens / inputTokens) * 100;
+				const lossLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
+				lossLine.textContent = localize('chatDebug.cache.lossLine',
+					"Lost: {0} tokens ({1}% of this request)",
+					numberFormatter.value.format(lostTokens),
+					formatCachePct(lostPct),
+				);
+			}
 		} else {
-			sub.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
+			breakLine.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
 		}
-		const pills = DOM.append(breakCard, $('.chat-debug-cache-pills'));
-		this.appendPill(pills, 'drift', localize('chatDebug.cache.contentDriftCount', "{0} content drift", diff.counts.contentDrift + diff.counts.lengthChange));
-		this.appendPill(pills, 'oneSided', localize('chatDebug.cache.oneSidedCount', "{0} one-sided", diff.counts.onlyInA + diff.counts.onlyInB));
-		this.appendPill(pills, 'identical', localize('chatDebug.cache.identicalCount', "{0} identical", diff.counts.identical));
+
+		// Section 3: structural diff summary
+		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
+		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.diffSummary', "Diff summary")));
+		const summaryLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
+		const inPlaceChanged = diff.counts.contentDrift + diff.counts.lengthChange;
+		const addedInB = diff.counts.onlyInB;
+		const droppedFromA = diff.counts.onlyInA;
+		const parts: string[] = [
+			localize('chatDebug.cache.summaryIdentical', "{0} identical", diff.counts.identical),
+			localize('chatDebug.cache.summaryChanged', "{0} in-place changed", inPlaceChanged),
+		];
+		if (addedInB > 0) {
+			parts.push(localize('chatDebug.cache.summaryAdded', "{0} added in this request", addedInB));
+		}
+		if (droppedFromA > 0) {
+			parts.push(localize('chatDebug.cache.summaryDropped', "{0} dropped from previous", droppedFromA));
+		}
+		summaryLine.textContent = parts.join(' \u00b7 ');
 	}
 
-	private renderSideCard(side: 'A' | 'B', data: ISideData): HTMLElement {
-		const card = $(`.chat-debug-cache-card.side-${side.toLowerCase()}`);
-		const header = DOM.append(card, $('.chat-debug-cache-card-h'));
-		const tag = DOM.append(header, $(`span.chat-debug-cache-tag.tag-${side.toLowerCase()}`));
-		tag.textContent = side;
-		const idLabel = DOM.append(header, DOM.$('span'));
-		idLabel.textContent = (data.event.id ?? '').slice(0, 8).toUpperCase() || side;
-		this.appendKv(card, localize('chatDebug.cache.when', "when"), timeFormatter.value.format(data.event.created));
-		this.appendKv(card, localize('chatDebug.cache.model', "model"), data.event.model ?? '—');
+	private renderSideCard(data: ISideData, title?: string): HTMLElement {
+		const card = $('.chat-debug-cache-card');
+		if (title) {
+			DOM.append(card, $('.chat-debug-cache-card-h', undefined, title));
+		}
+		this.appendKv(card, localize('chatDebug.cache.model', "model"), data.event.model ?? '\u2014');
 		this.appendKv(card, localize('chatDebug.cache.inputTok', "input tok"), formatTokens(data.event.inputTokens));
 		this.appendKv(card, localize('chatDebug.cache.cachedTok', "cached tok"), formatTokens(data.event.cachedTokens));
-		this.appendKv(card, localize('chatDebug.cache.cacheHit', "cache hit"), `${computeCacheHit(data.event).toFixed(1)}%`);
+		this.appendKv(card, localize('chatDebug.cache.cacheHit', "cache hit"), `${formatCachePct(computeCacheHit(data.event))}%`);
+
+		const startTime = data.event.created;
+		const endTime = data.event.durationInMillis !== undefined
+			? new Date(startTime.getTime() + data.event.durationInMillis)
+			: undefined;
+		this.appendKv(card, localize('chatDebug.cache.startTime', "startTime"), startTime.toISOString(), true);
+		if (endTime) {
+			this.appendKv(card, localize('chatDebug.cache.endTime', "endTime"), endTime.toISOString(), true);
+		}
+		if (data.event.durationInMillis !== undefined) {
+			this.appendKv(card, localize('chatDebug.cache.duration', "duration"), `${numberFormatter.value.format(Math.round(data.event.durationInMillis))}ms`);
+		}
+		const ttft = data.content?.timeToFirstTokenInMillis;
+		if (ttft !== undefined) {
+			this.appendKv(card, localize('chatDebug.cache.ttft', "timeToFirstToken"), `${numberFormatter.value.format(Math.round(ttft))}ms`);
+		}
+		const requestId = data.content?.requestId ?? data.event.parentEventId ?? data.event.id;
+		if (requestId) {
+			this.appendKv(card, localize('chatDebug.cache.requestId', "requestId"), requestId, true);
+		}
 		return card;
 	}
 
-	private appendKv(parent: HTMLElement, key: string, value: string): void {
+	/**
+	 * Render the summary cards alone when there is no prior turn to diff
+	 * against (e.g. the first request in a brand-new session). The OTel-
+	 * reported cache hit is still useful here — the system prompt and tool
+	 * definitions can already be cached from previous sessions.
+	 */
+	private renderSingleSummary(b: ISideData): void {
+		const row = DOM.append(this.content, $('.chat-debug-cache-summary'));
+		row.appendChild(this.renderSideCard(b, localize('chatDebug.cache.requestTitle', "Request")));
+
+		const note = DOM.append(row, $('.chat-debug-cache-card.break'));
+		DOM.append(note, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.firstRequest', "First request in session")));
+		const headline = DOM.append(note, $('.chat-debug-cache-card-headline'));
+		headline.textContent = `${formatCachePct(computeCacheHit(b.event))}%`;
+		const sub = DOM.append(note, $('.chat-debug-cache-card-sub'));
+		sub.textContent = localize('chatDebug.cache.firstRequestNote', "OTel-reported cache hit. Nothing earlier in this session to diff against \u2014 the system prompt and tools may still match a previous session's cache.");
+	}
+
+	private appendKv(parent: HTMLElement, key: string, value: string, copyable: boolean = false): void {
 		const row = DOM.append(parent, $('.chat-debug-cache-kv'));
 		DOM.append(row, $('span.k', undefined, key));
-		DOM.append(row, $('span.v', undefined, value));
+		const valueEl = DOM.append(row, $('span.v', undefined, value));
+		if (copyable) {
+			valueEl.classList.add('chat-debug-cache-request-id');
+			valueEl.title = value;
+		}
 	}
 
-	private appendPill(parent: HTMLElement, kind: string, text: string): void {
-		const pill = DOM.append(parent, $(`.chat-debug-cache-pill.${kind}`));
-		pill.textContent = text;
-	}
-
-	private renderSignature(diff: ICacheDiffResult): void {
+	private renderSignature(a: ISideData, b: ISideData, diff: ICacheDiffResult): void {
 		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
 		const heading = DOM.append(section, $('h3.chat-debug-cache-section-h'));
 		heading.textContent = localize('chatDebug.cache.signatureHeading', "Prompt Signature");
-		const sig = DOM.append(section, $('.chat-debug-cache-signature'));
 
-		let breakInserted = false;
-		for (const tok of diff.signature) {
-			if (!this.tokenPassesFilter(tok)) {
-				continue;
+		const legend = DOM.append(section, $('.chat-debug-cache-sig-legend'));
+		for (const role of ['system', 'user', 'assistant', 'tool']) {
+			const entry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
+			DOM.append(entry, $(`span.chat-debug-cache-sig-swatch.role-${role}`));
+			DOM.append(entry, DOM.$('span', undefined, role));
+		}
+		const driftEntry = DOM.append(legend, $('span.chat-debug-cache-sig-legend-entry'));
+		DOM.append(driftEntry, $('span.chat-debug-cache-sig-swatch.role-drift'));
+		DOM.append(driftEntry, DOM.$('span', undefined, localize('chatDebug.cache.driftLegend', "drift")));
+
+		// Per-side byte sequences. We prepend a synthetic 'system' segment for
+		// the system prompt so it shows up in the bar even though it's not in
+		// the inputMessages array.
+		interface ISegment {
+			readonly role: string;
+			readonly bytes: number;
+			readonly drift: boolean;
+			readonly label: string;
+		}
+		const toSegments = (side: ISideData, isA: boolean): ISegment[] => {
+			const segs: ISegment[] = [];
+			const sys = side.system;
+			if (sys) {
+				const other = isA ? b.system : a.system;
+				segs.push({ role: 'system', bytes: sys.length, drift: sys !== (other ?? ''), label: 'system' });
 			}
-			const span = DOM.append(sig, $(`span.chat-debug-cache-sig-tok.${tok.kind}`));
-			span.textContent = formatSignatureToken(tok);
-			if (!breakInserted && diff.break && tok.index === diff.break.index) {
-				const marker = DOM.append(sig, $('span.chat-debug-cache-sig-tok.break-marker'));
-				marker.textContent = localize('chatDebug.cache.breakMarker', "cache break");
-				breakInserted = true;
+			side.inputMessages.forEach((m, i) => {
+				const tok = diff.signature[i];
+				const kind = tok?.kind;
+				const drift = kind === CacheDiffKind.ContentDrift
+					|| kind === CacheDiffKind.LengthChange
+					|| (isA && kind === CacheDiffKind.OnlyInA)
+					|| (!isA && kind === CacheDiffKind.OnlyInB);
+				segs.push({ role: m.role, bytes: m.byteLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
+			});
+			return segs;
+		};
+
+		const aSegs = toSegments(a, true);
+		const bSegs = toSegments(b, false);
+		const totalA = aSegs.reduce((s, x) => s + x.bytes, 0);
+		const totalB = bSegs.reduce((s, x) => s + x.bytes, 0);
+		const max = Math.max(totalA, totalB, 1);
+
+		// Compute byte position of cache break inside each side's bar.
+		const breakBytePos = (segs: readonly ISegment[]): number | undefined => {
+			if (!diff.break) {
+				return undefined;
+			}
+			// Skip the synthetic system segment when matching diff.break.index.
+			let cumulative = 0;
+			let skipSystem = segs[0]?.role === 'system';
+			let idx = 0;
+			for (const s of segs) {
+				if (skipSystem) {
+					cumulative += s.bytes;
+					skipSystem = false;
+					continue;
+				}
+				if (idx === diff.break.index) {
+					return cumulative;
+				}
+				cumulative += s.bytes;
+				idx++;
+			}
+			return cumulative;
+		};
+
+		const buildLane = (label: string, segs: readonly ISegment[], breakPos: number | undefined): HTMLElement => {
+			const row = $('.chat-debug-cache-sig-lane-row');
+			DOM.append(row, $('.chat-debug-cache-sig-lane-label', undefined, label));
+			const bar = DOM.append(row, $('.chat-debug-cache-sig-bar'));
+			let sideTotal = 0;
+			for (const s of segs) {
+				if (s.bytes <= 0) {
+					sideTotal += s.bytes;
+					continue;
+				}
+				const widthPct = (s.bytes / max) * 100;
+				const seg = DOM.append(bar, $(`span.chat-debug-cache-sig-seg.role-${roleClass(s.role)}`));
+				if (s.drift) {
+					seg.classList.add('is-drift');
+				}
+				seg.style.width = `${widthPct}%`;
+				seg.title = `${s.label}: ${numberFormatter.value.format(s.bytes)} chars` + (s.drift ? ` \u2014 drift` : '');
+				if (s.bytes > max * 0.05) {
+					seg.textContent = `${s.label}:${numberFormatter.value.format(s.bytes)}`;
+				}
+				sideTotal += s.bytes;
+			}
+			// Pad the lane so both sides share the same x scale.
+			if (sideTotal < max) {
+				const pad = DOM.append(bar, $('span.chat-debug-cache-sig-seg.role-empty'));
+				pad.style.width = `${((max - sideTotal) / max) * 100}%`;
+			}
+			if (breakPos !== undefined && diff.break) {
+				const line = DOM.append(bar, $('.chat-debug-cache-sig-break'));
+				line.style.left = `${(breakPos / max) * 100}%`;
+				line.title = localize('chatDebug.cache.breakLineTooltip', "Cache break at messages[{0}]", diff.break.index);
+			}
+			DOM.append(row, $('.chat-debug-cache-sig-lane-total', undefined, localize('chatDebug.cache.charsTotal', "{0} chars", numberFormatter.value.format(sideTotal))));
+			return row;
+		};
+
+		const lanes = DOM.append(section, $('.chat-debug-cache-sig-lanes'));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakBytePos(aSegs)));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakBytePos(bSegs)));
+
+		// Single-line text summary below the bars.
+		let shared = 0;
+		for (const tok of diff.signature) {
+			if (tok.kind === CacheDiffKind.Identical) {
+				shared += tok.bByteLength ?? 0;
+			} else {
+				break;
 			}
 		}
-
-		// Filter toggles
-		const toggle = DOM.append(section, $('.chat-debug-cache-show-toggle'));
-		DOM.append(toggle, $('span', undefined, localize('chatDebug.cache.showLabel', "SHOW:")));
-		this.appendFilterCheckbox(toggle, 'content', localize('chatDebug.cache.filterContent', "content"));
-		this.appendFilterCheckbox(toggle, 'onlyA', localize('chatDebug.cache.filterOnlyA', "only-A"));
-		this.appendFilterCheckbox(toggle, 'onlyB', localize('chatDebug.cache.filterOnlyB', "only-B"));
-		this.appendFilterCheckbox(toggle, 'identical', localize('chatDebug.cache.filterIdentical', "identical"));
-	}
-
-	private appendFilterCheckbox(parent: HTMLElement, key: keyof typeof this.filterFlags, label: string): void {
-		const wrapper = DOM.append(parent, DOM.$('label'));
-		const input = DOM.append(wrapper, DOM.$('input')) as HTMLInputElement;
-		input.type = 'checkbox';
-		input.checked = this.filterFlags[key];
-		this.loadDisposables.add(DOM.addDisposableListener(input, DOM.EventType.CHANGE, () => {
-			this.filterFlags[key] = input.checked;
-			this.refresh();
-		}));
-		const text = DOM.append(wrapper, DOM.$('span'));
-		text.textContent = label;
-	}
-
-	private tokenPassesFilter(token: ICacheSignatureToken): boolean {
-		switch (token.kind) {
-			case CacheDiffKind.Identical: return this.filterFlags.identical;
-			case CacheDiffKind.OnlyInA: return this.filterFlags.onlyA;
-			case CacheDiffKind.OnlyInB: return this.filterFlags.onlyB;
-			case CacheDiffKind.ContentDrift:
-			case CacheDiffKind.LengthChange:
-				return this.filterFlags.content;
+		if (a.system && a.system === b.system) {
+			shared += a.system.length;
+		}
+		const summary = DOM.append(section, $('.chat-debug-cache-sig-summary'));
+		if (diff.break) {
+			summary.textContent = localize('chatDebug.cache.signatureSummaryBreak',
+				"{0} of {1} chars reused \u00b7 break at messages[{2}]",
+				numberFormatter.value.format(shared),
+				numberFormatter.value.format(totalB),
+				diff.break.index,
+			);
+		} else {
+			summary.textContent = localize('chatDebug.cache.signatureSummaryClean',
+				"{0} of {1} chars reused \u00b7 no divergence detected",
+				numberFormatter.value.format(shared),
+				numberFormatter.value.format(totalB),
+			);
 		}
 	}
 
@@ -430,12 +662,12 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	private renderComponentDiff(aText: string, bText: string, aSize: number, bSize: number): HTMLElement {
 		const grid = $('.chat-debug-cache-diff');
 		const colA = DOM.append(grid, $('.chat-debug-cache-diff-col'));
-		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "A \u00b7 {0} B", numberFormatter.value.format(aSize))));
+		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "Previous \u00b7 {0} B", numberFormatter.value.format(aSize))));
 		const aBody = DOM.append(colA, DOM.$('div'));
 		aBody.textContent = aText || localize('chatDebug.cache.notPresent', "(not present)");
 
 		const colB = DOM.append(grid, $('.chat-debug-cache-diff-col'));
-		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "B \u00b7 {0} B", numberFormatter.value.format(bSize))));
+		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "Current \u00b7 {0} B", numberFormatter.value.format(bSize))));
 		const bBody = DOM.append(colB, DOM.$('div'));
 		bBody.textContent = bText || localize('chatDebug.cache.notPresent', "(not present)");
 		return grid;
@@ -452,6 +684,38 @@ function findSection(sections: readonly IChatDebugMessageSection[] | undefined, 
 		}
 	}
 	return undefined;
+}
+
+/**
+ * Group model turns by request — turns that share the same `parentEventId`
+ * belong to the same agent invocation (one user prompt). The group key is
+ * used as the request id surfaced in the rail header.
+ */
+function buildTurnGroups(turns: readonly IChatDebugModelTurnEvent[], userMessages: readonly IChatDebugUserMessageEvent[]): readonly ITurnGroup[] {
+	// Index user messages by their span id (and the live `user-msg-` prefixed variant).
+	const userById = new Map<string, IChatDebugUserMessageEvent>();
+	for (const um of userMessages) {
+		if (!um.id) {
+			continue;
+		}
+		userById.set(um.id, um);
+		const stripped = um.id.startsWith('user-msg-') ? um.id.slice('user-msg-'.length) : um.id;
+		userById.set(stripped, um);
+	}
+
+	const groups = new Map<string, { userMessage: IChatDebugUserMessageEvent | undefined; turns: { turn: IChatDebugModelTurnEvent; index: number }[] }>();
+	const order: string[] = [];
+	turns.forEach((turn, index) => {
+		const key = turn.parentEventId ?? turn.id ?? `turn-${index}`;
+		let entry = groups.get(key);
+		if (!entry) {
+			entry = { userMessage: userById.get(key) ?? userById.get(`user-msg-${key}`), turns: [] };
+			groups.set(key, entry);
+			order.push(key);
+		}
+		entry.turns.push({ turn, index });
+	});
+	return order.map(key => ({ key, userMessage: groups.get(key)!.userMessage, turns: groups.get(key)!.turns }));
 }
 
 function textForComponent(c: IComponentDrift, side: ISideData): string {
@@ -476,11 +740,72 @@ function badgeLabel(status: CacheDiffKind): string {
 	}
 }
 
+/**
+ * One-line human-readable description of the kind of change at the cache
+ * break, including the role and size of the divergent message when known.
+ */
+function describeBreakKind(kind: Exclude<CacheDiffKind, CacheDiffKind.Identical>, diff: ICacheDiffResult, b: ISideData): string {
+	const tok = diff.signature.find(t => t.index === diff.break?.index);
+	const role = tok?.bRole ?? tok?.aRole ?? 'message';
+	const bMsg = b.inputMessages[diff.break?.index ?? -1];
+	const charsB = bMsg ? numberFormatter.value.format(bMsg.byteLength) : undefined;
+	switch (kind) {
+		case CacheDiffKind.OnlyInB:
+			return charsB
+				? localize('chatDebug.cache.kind.added', "added {0} message ({1} chars)", role, charsB)
+				: localize('chatDebug.cache.kind.addedNoSize', "added {0} message", role);
+		case CacheDiffKind.OnlyInA:
+			return localize('chatDebug.cache.kind.dropped', "previous {0} message dropped", role);
+		case CacheDiffKind.ContentDrift:
+			return charsB
+				? localize('chatDebug.cache.kind.contentDrift', "{0} message body changed ({1} chars)", role, charsB)
+				: localize('chatDebug.cache.kind.contentDriftNoSize', "{0} message body changed", role);
+		case CacheDiffKind.LengthChange:
+			return charsB
+				? localize('chatDebug.cache.kind.lengthChange', "{0} message resized to {1} chars", role, charsB)
+				: localize('chatDebug.cache.kind.lengthChangeNoSize', "{0} message size changed", role);
+	}
+}
+
 function computeCacheHit(event: IChatDebugModelTurnEvent): number {
 	if (!event.inputTokens || event.cachedTokens === undefined) {
 		return 0;
 	}
 	return Math.min(100, (event.cachedTokens / event.inputTokens) * 100);
+}
+
+/**
+ * Maps a normalized message role onto the small set of CSS color classes
+ * the prompt-signature visualization recognizes. Unknown roles fall through
+ * to `tool` so they still get a swatch.
+ */
+function roleClass(role: string): string {
+	switch (role) {
+		case 'system':
+		case 'user':
+		case 'assistant':
+		case 'tool':
+			return role;
+		default:
+			return 'tool';
+	}
+}
+
+/**
+ * Format a cache hit percentage with 2-decimal precision, truncating rather
+ * than rounding so a value like 99.998% does not display as 100%. We only
+ * report a literal `100%` when the ratio is exactly 1.
+ */
+function formatCachePct(pct: number): string {
+	const truncated = Math.floor(pct * 100) / 100;
+	return truncated.toFixed(2);
+}
+
+/**
+ * Integer-precision variant of {@link formatCachePct} for the rail chip.
+ */
+function formatCachePctInt(pct: number): string {
+	return String(Math.floor(pct));
 }
 
 function formatTokens(value: number | undefined): string {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -84,6 +84,15 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	/** Selected turn (B side). A is computed as `selectedIndex - 1`. -1 = no explicit selection yet. */
 	private selectedIndex = -1;
 
+	/**
+	 * Monotonically-increasing render token. Each call to {@link render}
+	 * captures the current value, then re-checks it after each await; if a
+	 * newer render has started in the meantime, the older one bails out
+	 * before mutating the DOM. Avoids races where a slow model-turn
+	 * resolve from one session writes into another's panel.
+	 */
+	private renderToken = 0;
+
 	/** Cache of resolved model-turn content keyed by event id. */
 	private readonly resolvedCache = new Map<string, IChatDebugEventModelTurnContent | undefined>();
 
@@ -153,6 +162,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	setSession(sessionResource: URI): void {
 		if (!this.currentSessionResource || this.currentSessionResource.toString() !== sessionResource.toString()) {
 			this.resolvedCache.clear();
+			this.collapsedGroups.clear();
+			this.openComponents.clear();
+			this.openComponents.add('system');
+			this.openComponents.add('tools');
 			this.selectedIndex = -1;
 		}
 		this.currentSessionResource = sessionResource;
@@ -187,6 +200,13 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	}
 
 	private async render(): Promise<void> {
+		// Monotonically-increasing token. Captured at the start of every
+		// render() and re-checked after each await so an in-flight resolve
+		// that's been superseded by a newer render bails out before
+		// touching the DOM.
+		const token = ++this.renderToken;
+		const isCurrent = () => token === this.renderToken;
+
 		this.updateBreadcrumb();
 		this.loadDisposables.clear();
 		DOM.clearNode(this.railList);
@@ -221,7 +241,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			// No prior turn to diff against — still surface OTel-reported cache hit
 			// and request metadata for the first turn of a session.
 			const b = await this.resolveSide(bEvent);
-			if (this.selectedIndex < 0 || this.modelTurns[this.selectedIndex] !== bEvent) {
+			if (!isCurrent()) {
 				return;
 			}
 			this.renderSingleSummary(b);
@@ -229,8 +249,8 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		}
 
 		const [a, b] = await Promise.all([this.resolveSide(aEvent), this.resolveSide(bEvent)]);
-		// If the user changed selection while resolving, drop this render.
-		if (this.selectedIndex < 0 || this.modelTurns[this.selectedIndex] !== bEvent) {
+		// If a newer render started while we were resolving, drop this one.
+		if (!isCurrent()) {
 			return;
 		}
 
@@ -335,10 +355,21 @@ export class ChatDebugCacheExplorerView extends Disposable {
 				}
 
 				row.title = localize('chatDebug.cache.turnHelp', "Click to compare this request against the previous one");
-				this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, () => {
+				row.tabIndex = 0;
+				row.setAttribute('role', 'button');
+				row.setAttribute('aria-selected', i === this.selectedIndex ? 'true' : 'false');
+				row.setAttribute('aria-label', localize('chatDebug.cache.turnAria', "Turn {0}: {1}", i, evt.requestName ?? evt.model ?? localize('chatDebug.cache.modelTurn', "Model Turn")));
+				const select = () => {
 					if (this.selectedIndex !== i) {
 						this.selectedIndex = i;
 						this.refresh();
+					}
+				};
+				this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, select));
+				this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						select();
 					}
 				}));
 			}
@@ -547,7 +578,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 					|| kind === CacheDiffKind.LengthChange
 					|| (isA && kind === CacheDiffKind.OnlyInA)
 					|| (!isA && kind === CacheDiffKind.OnlyInB);
-				segs.push({ role: m.role, bytes: m.byteLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
+				segs.push({ role: m.role, bytes: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
 			});
 			return segs;
 		};
@@ -626,7 +657,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		let shared = 0;
 		for (const tok of diff.signature) {
 			if (tok.kind === CacheDiffKind.Identical) {
-				shared += tok.bByteLength ?? 0;
+				shared += tok.bCharLength ?? 0;
 			} else {
 				break;
 			}
@@ -733,11 +764,11 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	private renderComponentDiff(aText: string, bText: string, aSize: number, bSize: number): HTMLElement {
 		const grid = $('.chat-debug-cache-diff');
 		const colA = DOM.append(grid, $('.chat-debug-cache-diff-col'));
-		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "Previous \u00b7 {0} B", numberFormatter.value.format(aSize))));
+		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "Previous \u00b7 {0} chars", numberFormatter.value.format(aSize))));
 		const aBody = DOM.append(colA, $('.chat-debug-cache-diff-body'));
 
 		const colB = DOM.append(grid, $('.chat-debug-cache-diff-col'));
-		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "Current \u00b7 {0} B", numberFormatter.value.format(bSize))));
+		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "Current \u00b7 {0} chars", numberFormatter.value.format(bSize))));
 		const bBody = DOM.append(colB, $('.chat-debug-cache-diff-body'));
 
 		if (!aText && !bText) {
@@ -825,7 +856,7 @@ function describeBreakKind(kind: Exclude<CacheDiffKind, CacheDiffKind.Identical>
 	const tok = diff.signature.find(t => t.index === diff.break?.index);
 	const role = tok?.bRole ?? tok?.aRole ?? 'message';
 	const bMsg = b.inputMessages[diff.break?.index ?? -1];
-	const charsB = bMsg ? numberFormatter.value.format(bMsg.byteLength) : undefined;
+	const charsB = bMsg ? numberFormatter.value.format(bMsg.charLength) : undefined;
 	switch (kind) {
 		case CacheDiffKind.OnlyInB:
 			return charsB

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -239,6 +239,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 
 		this.renderSummary(a, b, diff);
 		this.renderSignature(a, b, diff);
+		this.renderRequestOptions(a, b);
 		this.renderComponents(drift, a, b);
 	}
 
@@ -363,8 +364,18 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		const inputTokens = b.event.inputTokens ?? 0;
 		const cachedTokens = b.event.cachedTokens ?? 0;
 		const lostTokens = Math.max(0, inputTokens - cachedTokens);
+		const optionsDiff = computeOptionsDiff(a, b);
+		const expiration = isLikelyCacheExpiration(hit, diff, optionsDiff);
+
 		const headline = DOM.append(breakCard, $('.chat-debug-cache-card-headline'));
-		headline.textContent = localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
+		if (expiration) {
+			headline.textContent = localize('chatDebug.cache.expirationHeadline',
+				"{0}% cache hit \u2014 likely cache expiration",
+				formatCachePct(hit),
+			);
+		} else {
+			headline.textContent = localize('chatDebug.cache.hitHeadline', "{0}% cache hit", formatCachePct(hit));
+		}
 		const counts = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
 		counts.textContent = localize('chatDebug.cache.tokensReused',
 			"{0} of {1} input tokens reused",
@@ -376,7 +387,11 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		DOM.append(breakCard, $('.chat-debug-cache-perf-rule'));
 		DOM.append(breakCard, $('.chat-debug-cache-perf-section-h', undefined, localize('chatDebug.cache.whereBroke', "Where the cache broke")));
 		const breakLine = DOM.append(breakCard, $('.chat-debug-cache-perf-line'));
-		if (diff.break) {
+		if (expiration) {
+			breakLine.textContent = localize('chatDebug.cache.expirationNote',
+				"The prompt prefix matches but the model still treated this as a fresh request. Most likely the cached entry expired between requests.",
+			);
+		} else if (diff.break) {
 			const componentName = diff.break.index === 0
 				? localize('chatDebug.cache.firstMessage', "the first message")
 				: `messages[${diff.break.index}]`;
@@ -394,6 +409,10 @@ export class ChatDebugCacheExplorerView extends Disposable {
 					formatCachePct(lostPct),
 				);
 			}
+		} else if (optionsDiff.length > 0) {
+			breakLine.textContent = localize('chatDebug.cache.optionsBroke',
+				"Request options changed \u2014 the cache was invalidated even though the message prefix matches.",
+			);
 		} else {
 			breakLine.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
 		}
@@ -416,6 +435,18 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			parts.push(localize('chatDebug.cache.summaryDropped', "{0} dropped from previous", droppedFromA));
 		}
 		summaryLine.textContent = parts.join(' \u00b7 ');
+
+		// Inline one-liner: surface request-option drift right under the
+		// summary cards so it is visible regardless of which card the user
+		// scans first. The detailed Request options card lives in the
+		// Components row.
+		if (optionsDiff.length > 0) {
+			const optsLine = DOM.append(this.content, $('.chat-debug-cache-options-banner'));
+			optsLine.textContent = localize('chatDebug.cache.optionsBanner',
+				"Options changed: {0}",
+				optionsDiff.map(d => `${d.key} (${formatOptionValue(d.previous)} \u2192 ${formatOptionValue(d.current)})`).join(', '),
+			);
+		}
 	}
 
 	private renderSideCard(data: ISideData, title?: string): HTMLElement {
@@ -620,6 +651,44 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		}
 	}
 
+	/**
+	 * Render the per-key request-options table. Shows every cache-keying
+	 * option captured from the model provider request body, with a column
+	 * for the previous turn and one for the current turn. Rows whose
+	 * values differ are highlighted.
+	 */
+	private renderRequestOptions(a: ISideData, b: ISideData): void {
+		const prev = sideOptions(a);
+		const curr = sideOptions(b);
+		const keys = new Set<string>([...Object.keys(prev), ...Object.keys(curr)]);
+		if (keys.size === 0) {
+			return;
+		}
+
+		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
+		DOM.append(section, $('h3.chat-debug-cache-section-h', undefined, localize('chatDebug.cache.requestOptionsHeading', "Request Options")));
+
+		const table = DOM.append(section, $('.chat-debug-cache-options-table'));
+		const head = DOM.append(table, $('.chat-debug-cache-options-row.head'));
+		DOM.append(head, $('.chat-debug-cache-options-cell.key', undefined, localize('chatDebug.cache.optionsKey', "Option")));
+		DOM.append(head, $('.chat-debug-cache-options-cell', undefined, localize('chatDebug.cache.optionsPrev', "Previous")));
+		DOM.append(head, $('.chat-debug-cache-options-cell', undefined, localize('chatDebug.cache.optionsCurr', "Current")));
+
+		const sortedKeys = [...keys].sort((x, y) => x.localeCompare(y));
+		for (const key of sortedKeys) {
+			const row = DOM.append(table, $('.chat-debug-cache-options-row'));
+			const av = prev[key];
+			const bv = curr[key];
+			const changed = !deepEqual(av, bv);
+			if (changed) {
+				row.classList.add('changed');
+			}
+			DOM.append(row, $('.chat-debug-cache-options-cell.key', undefined, key));
+			DOM.append(row, $('.chat-debug-cache-options-cell', undefined, formatOptionValue(av)));
+			DOM.append(row, $('.chat-debug-cache-options-cell', undefined, formatOptionValue(bv)));
+		}
+	}
+
 	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData): void {
 		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
 		DOM.append(section, $('h3.chat-debug-cache-section-h', undefined, localize('chatDebug.cache.componentsHeading', "Components")));
@@ -821,6 +890,136 @@ function formatTokens(value: number | undefined): string {
 		return '\u2014';
 	}
 	return numberFormatter.value.format(value);
+}
+
+interface IOptionDelta {
+	readonly key: string;
+	readonly previous: unknown;
+	readonly current: unknown;
+}
+
+/**
+ * Build the cache-relevant options table for one side. Combines the
+ * request body's `request_options` blob with the model id surfaced on
+ * the OTel chat span, since switching models is the most aggressive
+ * cache invalidator and users expect to see it here.
+ */
+function sideOptions(side: ISideData): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	if (side.event.model !== undefined) {
+		out.model = side.event.model;
+	}
+	Object.assign(out, parseOptions(side.content?.requestOptions));
+	return out;
+}
+
+/**
+ * Compute the per-key delta between two requests' option tables.
+ * Keys are flattened one level deep so nested objects (e.g.
+ * `reasoning.effort`) show up with their own row instead of dumping the
+ * full object onto one line. The result is sorted by key for stable
+ * rendering.
+ */
+function computeOptionsDiff(a: ISideData, b: ISideData): readonly IOptionDelta[] {
+	const prev = sideOptions(a);
+	const curr = sideOptions(b);
+	const keys = new Set<string>([...Object.keys(prev), ...Object.keys(curr)]);
+	const out: IOptionDelta[] = [];
+	for (const key of keys) {
+		const av = prev[key];
+		const bv = curr[key];
+		if (!deepEqual(av, bv)) {
+			out.push({ key, previous: av, current: bv });
+		}
+	}
+	out.sort((x, y) => x.key.localeCompare(y.key));
+	return out;
+}
+
+function parseOptions(blob: string | undefined): Record<string, unknown> {
+	if (!blob) {
+		return {};
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(blob);
+	} catch {
+		return {};
+	}
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return {};
+	}
+	const flat: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+		if (v && typeof v === 'object' && !Array.isArray(v)) {
+			for (const [nk, nv] of Object.entries(v as Record<string, unknown>)) {
+				flat[`${k}.${nk}`] = nv;
+			}
+		} else {
+			flat[k] = v;
+		}
+	}
+	return flat;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (a === undefined || b === undefined || a === null || b === null) {
+		return false;
+	}
+	if (typeof a !== typeof b) {
+		return false;
+	}
+	if (typeof a !== 'object') {
+		return false;
+	}
+	try {
+		return JSON.stringify(a) === JSON.stringify(b);
+	} catch {
+		return false;
+	}
+}
+
+function formatOptionValue(value: unknown): string {
+	if (value === undefined) {
+		return '\u2014';
+	}
+	if (value === null) {
+		return 'null';
+	}
+	if (typeof value === 'string') {
+		return value;
+	}
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+/**
+ * Cache "expiration" heuristic. We can't know for sure why a provider
+ * decided to invalidate a cache entry, but if the structural diff says
+ * the prompt prefix is byte-identical AND the request options match AND
+ * the model still reports 0 cached input tokens, expiration is the most
+ * likely cause.
+ */
+function isLikelyCacheExpiration(hitPct: number, diff: ICacheDiffResult, optionsDiff: readonly IOptionDelta[]): boolean {
+	if (hitPct >= 1) {
+		return false;
+	}
+	if (diff.break) {
+		return false;
+	}
+	if (optionsDiff.length > 0) {
+		return false;
+	}
+	return true;
 }
 
 const DIFF_OPTIONS = {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -1,0 +1,491 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { BreadcrumbsWidget } from '../../../../../base/browser/ui/breadcrumbs/breadcrumbsWidget.js';
+import { Button } from '../../../../../base/browser/ui/button/button.js';
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { safeIntl } from '../../../../../base/common/date.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { defaultBreadcrumbsWidgetStyles, defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
+import { IChatDebugEventModelTurnContent, IChatDebugMessageSection, IChatDebugModelTurnEvent, IChatDebugService } from '../../common/chatDebugService.js';
+import { IChatService } from '../../common/chatService/chatService.js';
+import { LocalChatSessionUri } from '../../common/model/chatUri.js';
+import { appendSystemDrift, CacheDiffKind, diffPromptSignature, formatSignatureToken, ICacheDiffResult, ICacheSignatureToken, IComponentDrift, INormalizedMessage, parseInputMessages } from './chatDebugCacheDiff.js';
+import { setupBreadcrumbKeyboardNavigation, TextBreadcrumbItem } from './chatDebugTypes.js';
+
+const $ = DOM.$;
+const numberFormatter = safeIntl.NumberFormat();
+const timeFormatter = safeIntl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+
+/**
+ * Navigation events fired by the Cache Explorer breadcrumb.
+ */
+export const enum CacheExplorerNavigation {
+	Home = 'home',
+	Overview = 'overview',
+}
+
+/** Resolved data for one A or B side. */
+interface ISideData {
+	readonly event: IChatDebugModelTurnEvent;
+	readonly content: IChatDebugEventModelTurnContent | undefined;
+	readonly system: string | undefined;
+	readonly inputMessages: readonly INormalizedMessage[];
+}
+
+/**
+ * Cache Explorer view — the third entry under "Explore Trace Data". Shows a
+ * left rail of model turns with their cache hit %, plus a side-by-side prompt
+ * signature diff that pinpoints where the prefix breaks.
+ *
+ * v1 reads {@link IChatDebugEventModelTurnContent} from the in-memory chat
+ * debug service via {@link IChatDebugService.resolveEvent}. Content may be
+ * truncated by the OTel attribute cap; the file-logger backed full-fidelity
+ * provider is a follow-up.
+ */
+export class ChatDebugCacheExplorerView extends Disposable {
+
+	private readonly _onNavigate = this._register(new Emitter<CacheExplorerNavigation>());
+	readonly onNavigate = this._onNavigate.event;
+
+	readonly container: HTMLElement;
+	private readonly breadcrumbWidget: BreadcrumbsWidget;
+	private readonly railList: HTMLElement;
+	private readonly content: HTMLElement;
+	private readonly loadDisposables = this._register(new DisposableStore());
+	private readonly refreshScheduler: RunOnceScheduler;
+
+	private currentSessionResource: URI | undefined;
+	private modelTurns: IChatDebugModelTurnEvent[] = [];
+	private aIndex = 0;
+	private bIndex = 1;
+	private filterFlags = { content: true, onlyA: true, onlyB: true, identical: true };
+
+	/** Cache of resolved model-turn content keyed by event id. */
+	private readonly resolvedCache = new Map<string, IChatDebugEventModelTurnContent | undefined>();
+
+	/** Components currently expanded (by component name). */
+	private readonly openComponents = new Set<string>(['system', 'tools']);
+
+	constructor(
+		parent: HTMLElement,
+		@IChatService private readonly chatService: IChatService,
+		@IChatDebugService private readonly chatDebugService: IChatDebugService,
+	) {
+		super();
+		this.container = DOM.append(parent, $('.chat-debug-cache'));
+		DOM.hide(this.container);
+
+		// Breadcrumb
+		const breadcrumbContainer = DOM.append(this.container, $('.chat-debug-breadcrumb'));
+		this.breadcrumbWidget = this._register(new BreadcrumbsWidget(breadcrumbContainer, 3, undefined, Codicon.chevronRight, defaultBreadcrumbsWidgetStyles));
+		this._register(setupBreadcrumbKeyboardNavigation(breadcrumbContainer, this.breadcrumbWidget));
+		this._register(this.breadcrumbWidget.onDidSelectItem(e => {
+			if (e.type === 'select' && e.item instanceof TextBreadcrumbItem) {
+				this.breadcrumbWidget.setSelection(undefined);
+				const items = this.breadcrumbWidget.getItems();
+				const idx = items.indexOf(e.item);
+				if (idx === 0) {
+					this._onNavigate.fire(CacheExplorerNavigation.Home);
+				} else if (idx === 1) {
+					this._onNavigate.fire(CacheExplorerNavigation.Overview);
+				}
+			}
+		}));
+
+		// Body: 2-column split
+		const body = DOM.append(this.container, $('.chat-debug-cache-body'));
+		const rail = DOM.append(body, $('.chat-debug-cache-rail'));
+		this.railList = DOM.append(rail, $('.chat-debug-cache-rail-list'));
+		this.content = DOM.append(body, $('.chat-debug-cache-content'));
+
+		this.refreshScheduler = this._register(new RunOnceScheduler(() => this.render(), 50));
+	}
+
+	setSession(sessionResource: URI): void {
+		if (!this.currentSessionResource || this.currentSessionResource.toString() !== sessionResource.toString()) {
+			this.resolvedCache.clear();
+			this.aIndex = 0;
+			this.bIndex = 1;
+		}
+		this.currentSessionResource = sessionResource;
+	}
+
+	show(): void {
+		DOM.show(this.container);
+		this.render();
+	}
+
+	hide(): void {
+		DOM.hide(this.container);
+		this.refreshScheduler.cancel();
+	}
+
+	refresh(): void {
+		if (this.container.style.display !== 'none' && !this.refreshScheduler.isScheduled()) {
+			this.refreshScheduler.schedule();
+		}
+	}
+
+	updateBreadcrumb(): void {
+		if (!this.currentSessionResource) {
+			return;
+		}
+		const sessionTitle = this.chatService.getSessionTitle(this.currentSessionResource) || LocalChatSessionUri.parseLocalSessionId(this.currentSessionResource) || this.currentSessionResource.toString();
+		this.breadcrumbWidget.setItems([
+			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Logs"), true),
+			new TextBreadcrumbItem(sessionTitle, true),
+			new TextBreadcrumbItem(localize('chatDebug.cacheExplorer', "Cache Explorer")),
+		]);
+	}
+
+	private async render(): Promise<void> {
+		this.updateBreadcrumb();
+		this.loadDisposables.clear();
+		DOM.clearNode(this.railList);
+		DOM.clearNode(this.content);
+
+		if (!this.currentSessionResource) {
+			return;
+		}
+
+		const events = this.chatDebugService.getEvents(this.currentSessionResource);
+		this.modelTurns = events.filter((e): e is IChatDebugModelTurnEvent => e.kind === 'modelTurn');
+
+		if (this.modelTurns.length === 0) {
+			const empty = DOM.append(this.content, $('.chat-debug-cache-empty'));
+			empty.textContent = localize('chatDebug.cache.noTurns', "No model turns recorded for this session yet.");
+			return;
+		}
+
+		// Clamp indices
+		this.bIndex = Math.min(Math.max(this.bIndex, 0), this.modelTurns.length - 1);
+		this.aIndex = Math.min(Math.max(this.aIndex, 0), this.modelTurns.length - 1);
+		if (this.modelTurns.length > 1 && this.aIndex === this.bIndex) {
+			this.aIndex = Math.max(0, this.bIndex - 1);
+		}
+
+		this.renderRail();
+
+		const a = await this.resolveSide(this.modelTurns[this.aIndex]);
+		const b = await this.resolveSide(this.modelTurns[this.bIndex]);
+		// If the user changed selection while resolving, drop this render.
+		if (a.event !== this.modelTurns[this.aIndex] || b.event !== this.modelTurns[this.bIndex]) {
+			return;
+		}
+
+		const diff = diffPromptSignature(a.inputMessages, b.inputMessages);
+		const drift = appendSystemDrift([...diff.drift], a.system, b.system);
+
+		this.renderTitleRow();
+		this.renderSummary(a, b, diff);
+		this.renderSignature(diff);
+		this.renderComponents(drift, a, b);
+	}
+
+	private async resolveSide(event: IChatDebugModelTurnEvent): Promise<ISideData> {
+		let content: IChatDebugEventModelTurnContent | undefined;
+		if (event.id) {
+			if (this.resolvedCache.has(event.id)) {
+				content = this.resolvedCache.get(event.id);
+			} else {
+				const r = await this.chatDebugService.resolveEvent(event.id);
+				content = r && r.kind === 'modelTurn' ? r : undefined;
+				this.resolvedCache.set(event.id, content);
+			}
+		}
+		const system = findSection(content?.sections, 'System');
+		const inputMessagesJson = findSection(content?.sections, 'Input Messages');
+		const inputMessages = parseInputMessages(inputMessagesJson);
+		return { event, content, system, inputMessages };
+	}
+
+	private renderRail(): void {
+		this.modelTurns.forEach((evt, i) => {
+			const row = DOM.append(this.railList, $('.chat-debug-cache-turn'));
+			if (i === this.aIndex) { row.classList.add('is-a'); }
+			if (i === this.bIndex) { row.classList.add('is-b'); }
+			const idx = DOM.append(row, $('.chat-debug-cache-turn-idx'));
+			idx.textContent = String(i).padStart(2, ' ');
+
+			const main = DOM.append(row, $('.chat-debug-cache-turn-main'));
+			const label = DOM.append(main, $('.chat-debug-cache-turn-label'));
+			label.textContent = evt.model || evt.requestName || localize('chatDebug.cache.modelTurn', "Model Turn");
+			const meta = DOM.append(main, $('.chat-debug-cache-turn-meta'));
+			meta.appendChild(DOM.$('span', undefined, formatTokens(evt.inputTokens)));
+			const hit = computeCacheHit(evt);
+			const bar = DOM.append(meta, $('.chat-debug-cache-bar'));
+			if (hit < 70) { bar.classList.add('bad'); }
+			else if (hit < 95) { bar.classList.add('warn'); }
+			const fill = DOM.append(bar, DOM.$('i'));
+			fill.style.width = `${Math.max(2, hit)}%`;
+			meta.appendChild(DOM.$('span', undefined, localize('chatDebug.cache.hitPct', "cache {0}%", hit.toFixed(0))));
+
+			const ts = DOM.append(row, $('.chat-debug-cache-turn-ts'));
+			ts.textContent = timeFormatter.value.format(evt.created);
+
+			row.title = localize('chatDebug.cache.turnHelp', "Click to set as B · Shift-click to set as A");
+			this.loadDisposables.add(DOM.addDisposableListener(row, DOM.EventType.CLICK, (e: MouseEvent) => {
+				if (e.shiftKey) {
+					this.aIndex = i;
+				} else {
+					this.bIndex = i;
+				}
+				if (this.aIndex === this.bIndex) {
+					this.aIndex = Math.max(0, this.bIndex - 1);
+				}
+				this.refresh();
+			}));
+		});
+	}
+
+	private renderTitleRow(): void {
+		const titleRow = DOM.append(this.content, $('.chat-debug-cache-title-row'));
+		const title = DOM.append(titleRow, $('h2.chat-debug-cache-title'));
+		title.textContent = localize('chatDebug.cacheExplorer.title', "Cache Explorer — Prefix Diff");
+
+		const actions = DOM.append(titleRow, $('.chat-debug-cache-title-actions'));
+		const prevBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, secondary: true, title: localize('chatDebug.cache.prevPair', "Previous pair") }));
+		prevBtn.label = localize('chatDebug.cache.prevPair', "Previous pair");
+		this.loadDisposables.add(prevBtn.onDidClick(() => {
+			if (this.bIndex > 1) {
+				this.bIndex--;
+				this.aIndex = this.bIndex - 1;
+				this.refresh();
+			}
+		}));
+		const nextBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, secondary: true, title: localize('chatDebug.cache.nextPair', "Next pair") }));
+		nextBtn.label = localize('chatDebug.cache.nextPair', "Next pair");
+		this.loadDisposables.add(nextBtn.onDidClick(() => {
+			if (this.bIndex < this.modelTurns.length - 1) {
+				this.bIndex++;
+				this.aIndex = this.bIndex - 1;
+				this.refresh();
+			}
+		}));
+		const swapBtn = this.loadDisposables.add(new Button(actions, { ...defaultButtonStyles, title: localize('chatDebug.cache.swapTitle', "Swap A and B") }));
+		swapBtn.label = localize('chatDebug.cache.swapLabel', "Swap A ↔ B");
+		this.loadDisposables.add(swapBtn.onDidClick(() => {
+			const tmp = this.aIndex;
+			this.aIndex = this.bIndex;
+			this.bIndex = tmp;
+			this.refresh();
+		}));
+	}
+
+	private renderSummary(a: ISideData, b: ISideData, diff: ICacheDiffResult): void {
+		const row = DOM.append(this.content, $('.chat-debug-cache-summary'));
+		row.appendChild(this.renderSideCard('A', a));
+		row.appendChild(this.renderSideCard('B', b));
+
+		const breakCard = DOM.append(row, $('.chat-debug-cache-card.break'));
+		DOM.append(breakCard, $('.chat-debug-cache-card-h', undefined, localize('chatDebug.cache.breakAnalysis', "Cache-break analysis")));
+		const headline = DOM.append(breakCard, $('.chat-debug-cache-card-headline'));
+		const sharedPct = b.event.inputTokens && b.event.cachedTokens !== undefined
+			? Math.round((b.event.cachedTokens / b.event.inputTokens) * 100)
+			: 0;
+		headline.textContent = localize('chatDebug.cache.sharedPrefix', "~{0}% shared prefix", sharedPct);
+		const sub = DOM.append(breakCard, $('.chat-debug-cache-card-sub'));
+		if (diff.break) {
+			const componentName = diff.break.index === 0
+				? localize('chatDebug.cache.firstMessage', "the first message")
+				: `messages[${diff.break.index}]`;
+			sub.textContent = localize('chatDebug.cache.breakLocation', "Cache breaks at {0}. Anything after this point cannot reuse cache from A.", componentName);
+		} else {
+			sub.textContent = localize('chatDebug.cache.noBreak', "No prefix divergence detected.");
+		}
+		const pills = DOM.append(breakCard, $('.chat-debug-cache-pills'));
+		this.appendPill(pills, 'drift', localize('chatDebug.cache.contentDriftCount', "{0} content drift", diff.counts.contentDrift + diff.counts.lengthChange));
+		this.appendPill(pills, 'oneSided', localize('chatDebug.cache.oneSidedCount', "{0} one-sided", diff.counts.onlyInA + diff.counts.onlyInB));
+		this.appendPill(pills, 'identical', localize('chatDebug.cache.identicalCount', "{0} identical", diff.counts.identical));
+	}
+
+	private renderSideCard(side: 'A' | 'B', data: ISideData): HTMLElement {
+		const card = $(`.chat-debug-cache-card.side-${side.toLowerCase()}`);
+		const header = DOM.append(card, $('.chat-debug-cache-card-h'));
+		const tag = DOM.append(header, $(`span.chat-debug-cache-tag.tag-${side.toLowerCase()}`));
+		tag.textContent = side;
+		const idLabel = DOM.append(header, DOM.$('span'));
+		idLabel.textContent = (data.event.id ?? '').slice(0, 8).toUpperCase() || side;
+		this.appendKv(card, localize('chatDebug.cache.when', "when"), timeFormatter.value.format(data.event.created));
+		this.appendKv(card, localize('chatDebug.cache.model', "model"), data.event.model ?? '—');
+		this.appendKv(card, localize('chatDebug.cache.inputTok', "input tok"), formatTokens(data.event.inputTokens));
+		this.appendKv(card, localize('chatDebug.cache.cachedTok', "cached tok"), formatTokens(data.event.cachedTokens));
+		this.appendKv(card, localize('chatDebug.cache.cacheHit', "cache hit"), `${computeCacheHit(data.event).toFixed(1)}%`);
+		return card;
+	}
+
+	private appendKv(parent: HTMLElement, key: string, value: string): void {
+		const row = DOM.append(parent, $('.chat-debug-cache-kv'));
+		DOM.append(row, $('span.k', undefined, key));
+		DOM.append(row, $('span.v', undefined, value));
+	}
+
+	private appendPill(parent: HTMLElement, kind: string, text: string): void {
+		const pill = DOM.append(parent, $(`.chat-debug-cache-pill.${kind}`));
+		pill.textContent = text;
+	}
+
+	private renderSignature(diff: ICacheDiffResult): void {
+		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
+		const heading = DOM.append(section, $('h3.chat-debug-cache-section-h'));
+		heading.textContent = localize('chatDebug.cache.signatureHeading', "Prompt Signature");
+		const sig = DOM.append(section, $('.chat-debug-cache-signature'));
+
+		let breakInserted = false;
+		for (const tok of diff.signature) {
+			if (!this.tokenPassesFilter(tok)) {
+				continue;
+			}
+			const span = DOM.append(sig, $(`span.chat-debug-cache-sig-tok.${tok.kind}`));
+			span.textContent = formatSignatureToken(tok);
+			if (!breakInserted && diff.break && tok.index === diff.break.index) {
+				const marker = DOM.append(sig, $('span.chat-debug-cache-sig-tok.break-marker'));
+				marker.textContent = localize('chatDebug.cache.breakMarker', "cache break");
+				breakInserted = true;
+			}
+		}
+
+		// Filter toggles
+		const toggle = DOM.append(section, $('.chat-debug-cache-show-toggle'));
+		DOM.append(toggle, $('span', undefined, localize('chatDebug.cache.showLabel', "SHOW:")));
+		this.appendFilterCheckbox(toggle, 'content', localize('chatDebug.cache.filterContent', "content"));
+		this.appendFilterCheckbox(toggle, 'onlyA', localize('chatDebug.cache.filterOnlyA', "only-A"));
+		this.appendFilterCheckbox(toggle, 'onlyB', localize('chatDebug.cache.filterOnlyB', "only-B"));
+		this.appendFilterCheckbox(toggle, 'identical', localize('chatDebug.cache.filterIdentical', "identical"));
+	}
+
+	private appendFilterCheckbox(parent: HTMLElement, key: keyof typeof this.filterFlags, label: string): void {
+		const wrapper = DOM.append(parent, DOM.$('label'));
+		const input = DOM.append(wrapper, DOM.$('input')) as HTMLInputElement;
+		input.type = 'checkbox';
+		input.checked = this.filterFlags[key];
+		this.loadDisposables.add(DOM.addDisposableListener(input, DOM.EventType.CHANGE, () => {
+			this.filterFlags[key] = input.checked;
+			this.refresh();
+		}));
+		const text = DOM.append(wrapper, DOM.$('span'));
+		text.textContent = label;
+	}
+
+	private tokenPassesFilter(token: ICacheSignatureToken): boolean {
+		switch (token.kind) {
+			case CacheDiffKind.Identical: return this.filterFlags.identical;
+			case CacheDiffKind.OnlyInA: return this.filterFlags.onlyA;
+			case CacheDiffKind.OnlyInB: return this.filterFlags.onlyB;
+			case CacheDiffKind.ContentDrift:
+			case CacheDiffKind.LengthChange:
+				return this.filterFlags.content;
+		}
+	}
+
+	private renderComponents(drift: readonly IComponentDrift[], a: ISideData, b: ISideData): void {
+		const section = DOM.append(this.content, $('.chat-debug-cache-section'));
+		DOM.append(section, $('h3.chat-debug-cache-section-h', undefined, localize('chatDebug.cache.componentsHeading', "Components")));
+		const acc = DOM.append(section, $('.chat-debug-cache-acc'));
+
+		if (drift.length === 0) {
+			const empty = DOM.append(acc, $('.chat-debug-cache-acc-empty'));
+			empty.textContent = localize('chatDebug.cache.allComponentsIdentical', "All components are identical between A and B.");
+			return;
+		}
+
+		for (const c of drift) {
+			const item = DOM.append(acc, $('.chat-debug-cache-acc-item'));
+			if (this.openComponents.has(c.name)) { item.classList.add('open'); }
+			const head = DOM.append(item, $('.chat-debug-cache-acc-head'));
+			DOM.append(head, $('span.chat-debug-cache-chev'));
+			const name = DOM.append(head, $('.chat-debug-cache-acc-name'));
+			if (c.role) { DOM.append(name, $('span.role', undefined, c.role)); }
+			DOM.append(name, DOM.$('span', undefined, c.name));
+			const badge = DOM.append(head, $(`span.chat-debug-cache-acc-badge.${c.status}`));
+			badge.textContent = badgeLabel(c.status);
+			const sizes = DOM.append(head, $('span.chat-debug-cache-acc-sizes'));
+			sizes.textContent = `${formatTokens(c.aSize)} → ${formatTokens(c.bSize)} B`;
+
+			const body = DOM.append(item, $('.chat-debug-cache-acc-body'));
+			const aText = textForComponent(c, a);
+			const bText = textForComponent(c, b);
+			body.appendChild(this.renderComponentDiff(aText, bText, c.aSize, c.bSize));
+
+			this.loadDisposables.add(DOM.addDisposableListener(head, DOM.EventType.CLICK, () => {
+				if (this.openComponents.has(c.name)) {
+					this.openComponents.delete(c.name);
+					item.classList.remove('open');
+				} else {
+					this.openComponents.add(c.name);
+					item.classList.add('open');
+				}
+			}));
+		}
+	}
+
+	private renderComponentDiff(aText: string, bText: string, aSize: number, bSize: number): HTMLElement {
+		const grid = $('.chat-debug-cache-diff');
+		const colA = DOM.append(grid, $('.chat-debug-cache-diff-col'));
+		DOM.append(colA, $('h4', undefined, localize('chatDebug.cache.diffSideA', "A \u00b7 {0} B", numberFormatter.value.format(aSize))));
+		const aBody = DOM.append(colA, DOM.$('div'));
+		aBody.textContent = aText || localize('chatDebug.cache.notPresent', "(not present)");
+
+		const colB = DOM.append(grid, $('.chat-debug-cache-diff-col'));
+		DOM.append(colB, $('h4', undefined, localize('chatDebug.cache.diffSideB', "B \u00b7 {0} B", numberFormatter.value.format(bSize))));
+		const bBody = DOM.append(colB, DOM.$('div'));
+		bBody.textContent = bText || localize('chatDebug.cache.notPresent', "(not present)");
+		return grid;
+	}
+}
+
+function findSection(sections: readonly IChatDebugMessageSection[] | undefined, name: string): string | undefined {
+	if (!sections) {
+		return undefined;
+	}
+	for (const s of sections) {
+		if (s.name === name) {
+			return s.content;
+		}
+	}
+	return undefined;
+}
+
+function textForComponent(c: IComponentDrift, side: ISideData): string {
+	if (c.name === 'system') {
+		return side.system ?? '';
+	}
+	const m = /^messages\[(\d+)\]$/.exec(c.name);
+	if (m) {
+		const idx = parseInt(m[1], 10);
+		return side.inputMessages[idx]?.text ?? '';
+	}
+	return '';
+}
+
+function badgeLabel(status: CacheDiffKind): string {
+	switch (status) {
+		case CacheDiffKind.Identical: return localize('chatDebug.cache.badge.identical', "identical");
+		case CacheDiffKind.ContentDrift: return localize('chatDebug.cache.badge.contentDrift', "content drift");
+		case CacheDiffKind.LengthChange: return localize('chatDebug.cache.badge.lengthChange', "length change");
+		case CacheDiffKind.OnlyInA: return localize('chatDebug.cache.badge.onlyA', "only in A");
+		case CacheDiffKind.OnlyInB: return localize('chatDebug.cache.badge.onlyB', "only in B");
+	}
+}
+
+function computeCacheHit(event: IChatDebugModelTurnEvent): number {
+	if (!event.inputTokens || event.cachedTokens === undefined) {
+		return 0;
+	}
+	return Math.min(100, (event.cachedTokens / event.inputTokens) * 100);
+}
+
+function formatTokens(value: number | undefined): string {
+	if (value === undefined) {
+		return '—';
+	}
+	return numberFormatter.value.format(value);
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView.ts
@@ -98,7 +98,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 	private readonly resolvedCache = new Map<string, IChatDebugEventModelTurnContent | undefined>();
 
 	/** Components currently expanded (by component name). */
-	private readonly openComponents = new Set<string>(['system', 'tools']);
+	private readonly openComponents = new Set<string>(['system']);
 
 	/** Rail groups currently collapsed (by group key — the parent event id). */
 	private readonly collapsedGroups = new Set<string>();
@@ -166,7 +166,6 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			this.collapsedGroups.clear();
 			this.openComponents.clear();
 			this.openComponents.add('system');
-			this.openComponents.add('tools');
 			this.selectedIndex = -1;
 		}
 		this.currentSessionResource = sessionResource;
@@ -559,12 +558,12 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		DOM.append(driftEntry, $('span.chat-debug-cache-sig-swatch.role-drift'));
 		DOM.append(driftEntry, DOM.$('span', undefined, localize('chatDebug.cache.driftLegend', "drift")));
 
-		// Per-side byte sequences. We prepend a synthetic 'system' segment for
+		// Per-side char-length sequences. We prepend a synthetic 'system' segment for
 		// the system prompt so it shows up in the bar even though it's not in
 		// the inputMessages array.
 		interface ISegment {
 			readonly role: string;
-			readonly bytes: number;
+			readonly chars: number;
 			readonly drift: boolean;
 			readonly label: string;
 		}
@@ -573,7 +572,7 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			const sys = side.system;
 			if (sys) {
 				const other = isA ? b.system : a.system;
-				segs.push({ role: 'system', bytes: sys.length, drift: sys !== (other ?? ''), label: 'system' });
+				segs.push({ role: 'system', chars: sys.length, drift: sys !== (other ?? ''), label: 'system' });
 			}
 			side.inputMessages.forEach((m, i) => {
 				const tok = diff.signature[i];
@@ -582,23 +581,23 @@ export class ChatDebugCacheExplorerView extends Disposable {
 					|| kind === CacheDiffKind.LengthChange
 					|| (isA && kind === CacheDiffKind.OnlyInA)
 					|| (!isA && kind === CacheDiffKind.OnlyInB);
-				segs.push({ role: m.role, bytes: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
+				segs.push({ role: m.role, chars: m.charLength, drift, label: m.name ? `${m.role}-${m.name}` : m.role });
 			});
 			return segs;
 		};
 
 		const aSegs = toSegments(a, true);
 		const bSegs = toSegments(b, false);
-		const totalA = aSegs.reduce((s, x) => s + x.bytes, 0);
-		const totalB = bSegs.reduce((s, x) => s + x.bytes, 0);
+		const totalA = aSegs.reduce((s, x) => s + x.chars, 0);
+		const totalB = bSegs.reduce((s, x) => s + x.chars, 0);
 		const max = Math.max(totalA, totalB, 1);
 
-		// Compute byte position of cache break inside each side's bar.
+		// Compute char position of cache break inside each side's bar.
 		// Returns undefined if the break index falls outside the side's
 		// segment list (e.g. break is at messages[N] but B has fewer
 		// messages); rendering that as the right edge of the bar would
 		// misleadingly suggest "the cache broke at the end".
-		const breakBytePos = (segs: readonly ISegment[]): number | undefined => {
+		const breakCharPos = (segs: readonly ISegment[]): number | undefined => {
 			if (!diff.break) {
 				return undefined;
 			}
@@ -608,14 +607,14 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			let idx = 0;
 			for (const s of segs) {
 				if (skipSystem) {
-					cumulative += s.bytes;
+					cumulative += s.chars;
 					skipSystem = false;
 					continue;
 				}
 				if (idx === diff.break.index) {
 					return cumulative;
 				}
-				cumulative += s.bytes;
+				cumulative += s.chars;
 				idx++;
 			}
 			return undefined;
@@ -627,21 +626,21 @@ export class ChatDebugCacheExplorerView extends Disposable {
 			const bar = DOM.append(row, $('.chat-debug-cache-sig-bar'));
 			let sideTotal = 0;
 			for (const s of segs) {
-				if (s.bytes <= 0) {
-					sideTotal += s.bytes;
+				if (s.chars <= 0) {
+					sideTotal += s.chars;
 					continue;
 				}
-				const widthPct = (s.bytes / max) * 100;
+				const widthPct = (s.chars / max) * 100;
 				const seg = DOM.append(bar, $(`span.chat-debug-cache-sig-seg.role-${roleClass(s.role)}`));
 				if (s.drift) {
 					seg.classList.add('is-drift');
 				}
 				seg.style.width = `${widthPct}%`;
-				seg.title = `${s.label}: ${numberFormatter.value.format(s.bytes)} chars` + (s.drift ? ` \u2014 drift` : '');
-				if (s.bytes > max * 0.05) {
-					seg.textContent = `${s.label}:${numberFormatter.value.format(s.bytes)}`;
+				seg.title = `${s.label}: ${numberFormatter.value.format(s.chars)} chars` + (s.drift ? ` \u2014 drift` : '');
+				if (s.chars > max * 0.05) {
+					seg.textContent = `${s.label}:${numberFormatter.value.format(s.chars)}`;
 				}
-				sideTotal += s.bytes;
+				sideTotal += s.chars;
 			}
 			// Pad the lane so both sides share the same x scale.
 			if (sideTotal < max) {
@@ -658,8 +657,8 @@ export class ChatDebugCacheExplorerView extends Disposable {
 		};
 
 		const lanes = DOM.append(section, $('.chat-debug-cache-sig-lanes'));
-		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakBytePos(aSegs)));
-		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakBytePos(bSegs)));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.lanePrevious', "Previous"), aSegs, breakCharPos(aSegs)));
+		lanes.appendChild(buildLane(localize('chatDebug.cache.laneCurrent', "Current"), bSegs, breakCharPos(bSegs)));
 
 		// Single-line text summary below the bars.
 		let shared = 0;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
@@ -31,6 +31,7 @@ import { ChatDebugHomeView } from './chatDebugHomeView.js';
 import { ChatDebugOverviewView, OverviewNavigation } from './chatDebugOverviewView.js';
 import { ChatDebugLogsView, LogsNavigation } from './chatDebugLogsView.js';
 import { ChatDebugFlowChartView, FlowChartNavigation } from './chatDebugFlowChartView.js';
+import { ChatDebugCacheExplorerView, CacheExplorerNavigation } from './chatDebugCacheExplorerView.js';
 
 const $ = DOM.$;
 
@@ -44,7 +45,7 @@ type ChatDebugViewSwitchedEvent = {
 };
 
 type ChatDebugViewSwitchedClassification = {
-	viewState: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The view the user navigated to (home, overview, logs, flowchart).' };
+	viewState: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The view the user navigated to (home, overview, logs, flowchart, cache).' };
 	owner: 'vijayu';
 	comment: 'Tracks which views users navigate to in the Agent Debug Logs.';
 };
@@ -62,6 +63,7 @@ export class ChatDebugEditor extends EditorPane {
 	private overviewView: ChatDebugOverviewView | undefined;
 	private logsView: ChatDebugLogsView | undefined;
 	private flowChartView: ChatDebugFlowChartView | undefined;
+	private cacheExplorerView: ChatDebugCacheExplorerView | undefined;
 	private filterState: ChatDebugFilterState | undefined;
 
 	private readonly sessionModelListener = this._register(new MutableDisposable());
@@ -122,6 +124,9 @@ export class ChatDebugEditor extends EditorPane {
 				case OverviewNavigation.FlowChart:
 					this.showView(ViewState.FlowChart);
 					break;
+				case OverviewNavigation.CacheExplorer:
+					this.showView(ViewState.CacheExplorer);
+					break;
 			}
 		}));
 
@@ -151,6 +156,19 @@ export class ChatDebugEditor extends EditorPane {
 			}
 		}));
 
+		this.cacheExplorerView = this._register(this.instantiationService.createInstance(ChatDebugCacheExplorerView, this.container));
+		this._register(this.cacheExplorerView.onNavigate(nav => {
+			switch (nav) {
+				case CacheExplorerNavigation.Home:
+					this.endActiveSession();
+					this.showView(ViewState.Home);
+					break;
+				case CacheExplorerNavigation.Overview:
+					this.showView(ViewState.Overview);
+					break;
+			}
+		}));
+
 		// When new debug events arrive, refresh the active session view
 		this._register(this.chatDebugService.onDidAddEvent(event => {
 			if (this.viewState === ViewState.Home) {
@@ -160,6 +178,8 @@ export class ChatDebugEditor extends EditorPane {
 					this.overviewView?.refresh();
 				} else if (this.viewState === ViewState.FlowChart) {
 					this.flowChartView?.refresh();
+				} else if (this.viewState === ViewState.CacheExplorer) {
+					this.cacheExplorerView?.refresh();
 				}
 				// Note: Logs view is intentionally omitted here — it handles
 				// onDidAddEvent internally via loadEvents() → addEvent() →
@@ -182,10 +202,11 @@ export class ChatDebugEditor extends EditorPane {
 				if (e.kind === 'setCustomTitle') {
 					if (this.viewState === ViewState.Home) {
 						this.homeView?.render();
-					} else if (this.viewState === ViewState.Overview || this.viewState === ViewState.Logs || this.viewState === ViewState.FlowChart) {
+					} else if (this.viewState === ViewState.Overview || this.viewState === ViewState.Logs || this.viewState === ViewState.FlowChart || this.viewState === ViewState.CacheExplorer) {
 						this.overviewView?.updateBreadcrumb();
 						this.logsView?.updateBreadcrumb();
 						this.flowChartView?.updateBreadcrumb();
+						this.cacheExplorerView?.updateBreadcrumb();
 					}
 				}
 			}));
@@ -237,9 +258,15 @@ export class ChatDebugEditor extends EditorPane {
 			this.flowChartView?.hide();
 		}
 
+		if (state === ViewState.CacheExplorer) {
+			this.cacheExplorerView?.show();
+		} else {
+			this.cacheExplorerView?.hide();
+		}
+
 	}
 
-	navigateToSession(sessionResource: URI, view?: 'logs' | 'overview' | 'flowchart'): void {
+	navigateToSession(sessionResource: URI, view?: 'logs' | 'overview' | 'flowchart' | 'cache'): void {
 		// End the previous session's streaming pipeline before switching
 		const previousSessionResource = this.chatDebugService.activeSessionResource;
 		if (previousSessionResource && previousSessionResource.toString() !== sessionResource.toString()) {
@@ -255,8 +282,13 @@ export class ChatDebugEditor extends EditorPane {
 		this.overviewView?.setSession(sessionResource);
 		this.logsView?.setSession(sessionResource);
 		this.flowChartView?.setSession(sessionResource);
+		this.cacheExplorerView?.setSession(sessionResource);
 
-		this.showView(view === 'logs' ? ViewState.Logs : view === 'flowchart' ? ViewState.FlowChart : ViewState.Overview);
+		const targetState = view === 'logs' ? ViewState.Logs
+			: view === 'flowchart' ? ViewState.FlowChart
+				: view === 'cache' ? ViewState.CacheExplorer
+					: ViewState.Overview;
+		this.showView(targetState);
 	}
 
 	private trackSessionModelChanges(sessionResource: URI): void {
@@ -331,6 +363,8 @@ export class ChatDebugEditor extends EditorPane {
 			this.navigateToSession(sessionResource, 'logs');
 		} else if (viewHint === 'flowchart' && sessionResource) {
 			this.navigateToSession(sessionResource, 'flowchart');
+		} else if (viewHint === 'cache' && sessionResource) {
+			this.navigateToSession(sessionResource, 'cache');
 		} else if (viewHint === 'overview' && sessionResource) {
 			this.navigateToSession(sessionResource, 'overview');
 		} else if (viewHint === 'home') {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowGraph.ts
@@ -784,19 +784,19 @@ function getEventTooltip(event: IChatDebugEvent): string | undefined {
 			if (event.model) {
 				parts.push(event.model);
 			}
-			if (event.totalTokens) {
+			if (event.totalTokens !== undefined) {
 				parts.push(localize('tooltipTokens', "Tokens: {0}", event.totalTokens));
 			}
-			if (event.inputTokens) {
+			if (event.inputTokens !== undefined) {
 				parts.push(localize('tooltipInputTokens', "Input tokens: {0}", event.inputTokens));
 			}
-			if (event.outputTokens) {
+			if (event.outputTokens !== undefined) {
 				parts.push(localize('tooltipOutputTokens', "Output tokens: {0}", event.outputTokens));
 			}
 			if (event.cachedTokens !== undefined) {
 				parts.push(localize('tooltipCachedTokens', "Cached tokens: {0}", event.cachedTokens));
 			}
-			if (event.durationInMillis) {
+			if (event.durationInMillis !== undefined) {
 				parts.push(localize('tooltipDuration', "Duration: {0}", formatDuration(event.durationInMillis)));
 			}
 			return parts.length > 0 ? parts.join('\n') : undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
@@ -191,7 +191,7 @@ export class ChatDebugLogsView extends Disposable {
 					case 'toolCall': return localize('chatDebug.aria.toolCall', "Tool call: {0}{1}", e.toolName, e.result ? ` (${e.result})` : '');
 					case 'modelTurn': return localize('chatDebug.aria.modelTurn', "Model turn: {0}{1}{2}",
 						e.model ?? localize('chatDebug.aria.model', "model"),
-						e.totalTokens ? localize('chatDebug.aria.tokenCount', " {0} tokens", e.totalTokens) : '',
+						e.totalTokens !== undefined ? localize('chatDebug.aria.tokenCount', " {0} tokens", e.totalTokens) : '',
 						e.cachedTokens !== undefined ? localize('chatDebug.aria.cachedTokens', " {0} cached", e.cachedTokens) : '');
 					case 'generic': return `${e.category ? e.category + ': ' : ''}${e.name}: ${e.details ?? ''}`;
 					case 'subagentInvocation': return localize('chatDebug.aria.subagent', "Subagent: {0}{1}", e.agentName, e.description ? ` - ${e.description}` : '');

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
@@ -30,6 +30,7 @@ export const enum OverviewNavigation {
 	Home = 'home',
 	Logs = 'logs',
 	FlowChart = 'flowchart',
+	CacheExplorer = 'cache',
 }
 
 export class ChatDebugOverviewView extends Disposable {
@@ -250,6 +251,13 @@ export class ChatDebugOverviewView extends Disposable {
 		flowChartBtn.label = `$(type-hierarchy) ${localize('chatDebug.agentFlowChart', "Agent Flow Chart")}`;
 		this.loadDisposables.add(flowChartBtn.onDidClick(() => {
 			this._onNavigate.fire(OverviewNavigation.FlowChart);
+		}));
+
+		const cacheBtn = this.loadDisposables.add(new Button(row, { ...defaultButtonStyles, secondary: true, supportIcons: true, title: localize('chatDebug.cacheExplorer', "Cache Explorer") }));
+		cacheBtn.element.classList.add('chat-debug-overview-action-button');
+		cacheBtn.label = `$(database) ${localize('chatDebug.cacheExplorer', "Cache Explorer")}`;
+		this.loadDisposables.add(cacheBtn.onDidClick(() => {
+			this._onNavigate.fire(OverviewNavigation.CacheExplorer);
 		}));
 
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
@@ -18,7 +18,7 @@ const $ = DOM.$;
  */
 export interface IChatDebugEditorOptions extends IEditorOptions {
 	readonly sessionResource?: URI;
-	readonly viewHint?: 'home' | 'overview' | 'logs' | 'flowchart';
+	readonly viewHint?: 'home' | 'overview' | 'logs' | 'flowchart' | 'cache';
 	/** When set, automatically applies this text as the log filter. */
 	readonly filter?: string;
 }
@@ -28,6 +28,7 @@ export const enum ViewState {
 	Overview = 'overview',
 	Logs = 'logs',
 	FlowChart = 'flowchart',
+	CacheExplorer = 'cache',
 }
 
 export const enum LogsViewMode {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1308,3 +1308,31 @@
 	font-weight: 600;
 	text-transform: uppercase;
 }
+.chat-debug-cache-diff-body {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	line-height: 1.4;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+.chat-debug-cache-diff-line {
+	padding: 0 4px;
+	border-radius: 2px;
+}
+.chat-debug-cache-diff-line.add {
+	background: var(--vscode-diffEditor-insertedLineBackground, rgba(95, 184, 107, 0.12));
+}
+.chat-debug-cache-diff-line.remove {
+	background: var(--vscode-diffEditor-removedLineBackground, rgba(244, 135, 113, 0.12));
+}
+.chat-debug-cache-diff-line.context {
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-cache-diff-line.add .chat-debug-cache-diff-inner {
+	background: var(--vscode-diffEditor-insertedTextBackground, rgba(95, 184, 107, 0.4));
+	border-radius: 2px;
+}
+.chat-debug-cache-diff-line.remove .chat-debug-cache-diff-inner {
+	background: var(--vscode-diffEditor-removedTextBackground, rgba(244, 135, 113, 0.4));
+	border-radius: 2px;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -788,3 +788,402 @@
 	justify-content: center;
 	margin: 12px 0 0;
 }
+
+/* ---- Cache Explorer view ---- */
+.chat-debug-cache {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	flex: 1;
+	min-height: 0;
+}
+.chat-debug-cache-body {
+	display: grid;
+	grid-template-columns: 280px 1fr;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+.chat-debug-cache-rail {
+	border-right: 1px solid var(--vscode-widget-border, transparent);
+	background: var(--vscode-sideBar-background);
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.chat-debug-cache-rail-list {
+	flex: 1 1 auto;
+	overflow-y: auto;
+	padding: 4px 0;
+}
+.chat-debug-cache-turn {
+	padding: 6px 10px;
+	display: grid;
+	grid-template-columns: 28px 1fr 70px;
+	gap: 4px 8px;
+	align-items: center;
+	cursor: pointer;
+	border-left: 3px solid transparent;
+}
+.chat-debug-cache-turn:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+.chat-debug-cache-turn.is-a {
+	border-left-color: var(--vscode-charts-blue);
+	background: var(--vscode-list-inactiveSelectionBackground);
+}
+.chat-debug-cache-turn.is-b {
+	border-left-color: var(--vscode-charts-green);
+	background: var(--vscode-list-inactiveSelectionBackground);
+}
+.chat-debug-cache-turn-idx {
+	font-family: var(--monaco-monospace-font);
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
+	text-align: right;
+	grid-row: span 1;
+}
+.chat-debug-cache-turn-main {
+	overflow: hidden;
+}
+.chat-debug-cache-turn-label {
+	font-size: 11.5px;
+	color: var(--vscode-foreground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.chat-debug-cache-turn-meta {
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	margin-top: 2px;
+}
+.chat-debug-cache-turn-ts {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	text-align: right;
+}
+.chat-debug-cache-bar {
+	display: inline-block;
+	width: 50px;
+	height: 4px;
+	background: var(--vscode-progressBar-background);
+	border-radius: 2px;
+	overflow: hidden;
+}
+.chat-debug-cache-bar > i {
+	display: block;
+	height: 100%;
+	background: var(--vscode-charts-green);
+}
+.chat-debug-cache-bar.warn > i {
+	background: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-bar.bad > i {
+	background: var(--vscode-charts-red);
+}
+.chat-debug-cache-content {
+	overflow-y: auto;
+	padding: 16px 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	min-width: 0;
+}
+.chat-debug-cache-empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-cache-title-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+.chat-debug-cache-title {
+	margin: 0;
+	font-size: 14px;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-title-actions {
+	display: flex;
+	gap: 6px;
+}
+.chat-debug-cache-summary {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1.5fr;
+	gap: 12px;
+}
+.chat-debug-cache-card {
+	background: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-radius: 6px;
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.chat-debug-cache-card.break {
+	border-color: var(--vscode-charts-red);
+}
+.chat-debug-cache-card-h {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+.chat-debug-cache-card-headline {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-card-sub {
+	font-size: 11.5px;
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-tag {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10px;
+	padding: 1px 6px;
+	border-radius: 8px;
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-tag.tag-a {
+	color: var(--vscode-charts-blue);
+	border-color: var(--vscode-charts-blue);
+}
+.chat-debug-cache-tag.tag-b {
+	color: var(--vscode-charts-green);
+	border-color: var(--vscode-charts-green);
+}
+.chat-debug-cache-kv {
+	display: flex;
+	justify-content: space-between;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+}
+.chat-debug-cache-kv .k {
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-cache-kv .v {
+	color: var(--vscode-foreground);
+}
+.chat-debug-cache-pills {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 4px;
+}
+.chat-debug-cache-pill {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	padding: 2px 7px;
+	border-radius: 10px;
+	background: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	border: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-cache-pill.drift {
+	color: var(--vscode-charts-red);
+	border-color: var(--vscode-charts-red);
+	background: transparent;
+}
+.chat-debug-cache-pill.oneSided {
+	color: var(--vscode-charts-blue);
+	border-color: var(--vscode-charts-blue);
+	background: transparent;
+}
+.chat-debug-cache-pill.identical {
+	color: var(--vscode-descriptionForeground);
+	background: transparent;
+}
+.chat-debug-cache-section-h {
+	margin: 0 0 8px;
+	font-size: 12px;
+	color: var(--vscode-foreground);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+.chat-debug-cache-signature {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	background: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-radius: 6px;
+	padding: 10px 12px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 6px;
+	line-height: 1.7;
+	overflow-x: auto;
+}
+.chat-debug-cache-sig-tok {
+	padding: 2px 7px;
+	border-radius: 10px;
+	border: 1px solid transparent;
+	white-space: nowrap;
+}
+.chat-debug-cache-sig-tok.identical {
+	color: var(--vscode-descriptionForeground);
+	border-color: var(--vscode-widget-border, transparent);
+}
+.chat-debug-cache-sig-tok.contentDrift,
+.chat-debug-cache-sig-tok.lengthChange {
+	color: var(--vscode-charts-red);
+	border-color: var(--vscode-charts-red);
+	font-weight: 600;
+}
+.chat-debug-cache-sig-tok.onlyInB {
+	color: var(--vscode-charts-blue);
+	border-color: var(--vscode-charts-blue);
+}
+.chat-debug-cache-sig-tok.onlyInA {
+	color: var(--vscode-charts-yellow);
+	border-color: var(--vscode-charts-yellow);
+	text-decoration: line-through;
+}
+.chat-debug-cache-sig-tok.break-marker {
+	background: var(--vscode-charts-red);
+	color: var(--vscode-button-foreground);
+	border-color: var(--vscode-charts-red);
+	font-weight: 700;
+}
+.chat-debug-cache-show-toggle {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-top: 8px;
+}
+.chat-debug-cache-show-toggle label {
+	display: flex;
+	gap: 4px;
+	align-items: center;
+	cursor: pointer;
+}
+.chat-debug-cache-acc {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.chat-debug-cache-acc-empty {
+	font-size: 11.5px;
+	color: var(--vscode-descriptionForeground);
+}
+.chat-debug-cache-acc-item {
+	background: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-radius: 6px;
+	overflow: hidden;
+}
+.chat-debug-cache-acc-head {
+	display: grid;
+	grid-template-columns: 16px 1fr auto auto;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 12px;
+	cursor: pointer;
+}
+.chat-debug-cache-acc-head:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+.chat-debug-cache-chev::before {
+	content: '\25B6';
+	display: inline-block;
+	color: var(--vscode-descriptionForeground);
+	font-size: 10px;
+	transition: transform 0.15s;
+}
+.chat-debug-cache-acc-item.open .chat-debug-cache-chev::before {
+	transform: rotate(90deg);
+}
+.chat-debug-cache-acc-name {
+	font-family: var(--monaco-monospace-font);
+	font-size: 12px;
+	color: var(--vscode-foreground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.chat-debug-cache-acc-name .role {
+	color: var(--vscode-descriptionForeground);
+	margin-right: 6px;
+}
+.chat-debug-cache-acc-badge {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	padding: 2px 8px;
+	border-radius: 10px;
+	background: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+}
+.chat-debug-cache-acc-badge.identical {
+	color: var(--vscode-descriptionForeground);
+	background: transparent;
+	border: 1px solid var(--vscode-widget-border, transparent);
+}
+.chat-debug-cache-acc-badge.contentDrift,
+.chat-debug-cache-acc-badge.lengthChange {
+	color: var(--vscode-charts-red);
+	background: transparent;
+	border: 1px solid var(--vscode-charts-red);
+}
+.chat-debug-cache-acc-badge.onlyInA {
+	color: var(--vscode-charts-yellow);
+	background: transparent;
+	border: 1px solid var(--vscode-charts-yellow);
+}
+.chat-debug-cache-acc-badge.onlyInB {
+	color: var(--vscode-charts-blue);
+	background: transparent;
+	border: 1px solid var(--vscode-charts-blue);
+}
+.chat-debug-cache-acc-sizes {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	min-width: 130px;
+	text-align: right;
+}
+.chat-debug-cache-acc-body {
+	display: none;
+	border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-acc-item.open .chat-debug-cache-acc-body {
+	display: block;
+}
+.chat-debug-cache-diff {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+}
+.chat-debug-cache-diff-col {
+	padding: 8px 12px;
+	overflow-x: auto;
+	white-space: pre-wrap;
+	max-height: 320px;
+	overflow-y: auto;
+	word-break: break-word;
+}
+.chat-debug-cache-diff-col + .chat-debug-cache-diff-col {
+	border-left: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-diff-col h4 {
+	margin: 0 0 6px;
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	font-weight: 600;
+	text-transform: uppercase;
+}

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -108,8 +108,12 @@
 }
 
 @keyframes chat-debug-shimmer {
-	0% { background-position: 120% 0; }
-	100% { background-position: -120% 0; }
+	0% {
+		background-position: 120% 0;
+	}
+	100% {
+		background-position: -120% 0;
+	}
 }
 
 /* ---- Breadcrumb ---- */
@@ -409,17 +413,21 @@
 }
 .chat-debug-log-row.chat-debug-log-error,
 .chat-debug-log-row.chat-debug-log-error:hover {
-	background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1)) !important;
+	background-color: var(--vscode-inputValidation-errorBackground,
+				rgba(255, 0, 0, 0.1)) !important;
 	color: var(--vscode-errorForeground) !important;
 }
 .monaco-tl-row:has(.chat-debug-log-row.chat-debug-log-error) {
-	background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1)) !important;
+	background-color: var(--vscode-inputValidation-errorBackground,
+				rgba(255, 0, 0, 0.1)) !important;
 }
 .chat-debug-log-row.chat-debug-log-warning {
-	background-color: var(--vscode-inputValidation-warningBackground, rgba(255, 204, 0, 0.1)) !important;
+	background-color: var(--vscode-inputValidation-warningBackground,
+				rgba(255, 204, 0, 0.1)) !important;
 }
 .monaco-tl-row:has(.chat-debug-log-row.chat-debug-log-warning) {
-	background-color: var(--vscode-inputValidation-warningBackground, rgba(255, 204, 0, 0.1)) !important;
+	background-color: var(--vscode-inputValidation-warningBackground,
+				rgba(255, 204, 0, 0.1)) !important;
 }
 .chat-debug-log-row.chat-debug-log-trace {
 	opacity: 0.7;
@@ -798,10 +806,10 @@
 	min-height: 0;
 }
 .chat-debug-cache-body {
-	display: grid;
-	grid-template-columns: 280px 1fr;
+	display: flex;
 	flex: 1 1 auto;
 	min-height: 0;
+	position: relative;
 }
 .chat-debug-cache-rail {
 	border-right: 1px solid var(--vscode-widget-border, transparent);
@@ -809,81 +817,148 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+	flex-shrink: 0;
+	overflow: hidden;
 }
 .chat-debug-cache-rail-list {
 	flex: 1 1 auto;
 	overflow-y: auto;
 	padding: 4px 0;
 }
+.chat-debug-cache-group-header {
+	padding: 10px 10px 4px 10px;
+	border-top: 1px solid var(--vscode-widget-border, transparent);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	cursor: pointer;
+	user-select: none;
+}
+.chat-debug-cache-group-header:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+.chat-debug-cache-group-header:focus,
+.chat-debug-cache-group-header:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+.chat-debug-cache-rail-list > .chat-debug-cache-group-header:first-child {
+	border-top: none;
+}
+.chat-debug-cache-group-top {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+.chat-debug-cache-group-chev::before {
+	content: "\25BE";
+	display: inline-block;
+	width: 10px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 10px;
+	transition: transform 0.15s;
+}
+.chat-debug-cache-group-header.is-collapsed .chat-debug-cache-group-chev::before {
+	transform: rotate(-90deg);
+}
+.chat-debug-cache-group-prompt {
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+.chat-debug-cache-group-count {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	color: var(--vscode-badge-foreground);
+	background: var(--vscode-badge-background);
+	padding: 1px 7px;
+	border-radius: 10px;
+	flex-shrink: 0;
+}
+.chat-debug-cache-group-meta {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	margin-left: 16px;
+}
+.chat-debug-cache-request-id {
+	font-family: var(--monaco-monospace-font);
+	user-select: text;
+	cursor: text;
+	overflow-wrap: anywhere;
+	text-align: right;
+}
 .chat-debug-cache-turn {
 	padding: 6px 10px;
 	display: grid;
-	grid-template-columns: 28px 1fr 70px;
-	gap: 4px 8px;
-	align-items: center;
+	grid-template-columns: 24px 1fr;
+	gap: 2px 8px;
+	align-items: start;
 	cursor: pointer;
 	border-left: 3px solid transparent;
 }
 .chat-debug-cache-turn:hover {
 	background: var(--vscode-list-hoverBackground);
 }
-.chat-debug-cache-turn.is-a {
-	border-left-color: var(--vscode-charts-blue);
-	background: var(--vscode-list-inactiveSelectionBackground);
-}
-.chat-debug-cache-turn.is-b {
-	border-left-color: var(--vscode-charts-green);
-	background: var(--vscode-list-inactiveSelectionBackground);
+.chat-debug-cache-turn.is-selected {
+	border-left-color: var(--vscode-focusBorder);
+	background: var(--vscode-list-activeSelectionBackground);
+	color: var(--vscode-list-activeSelectionForeground);
 }
 .chat-debug-cache-turn-idx {
 	font-family: var(--monaco-monospace-font);
 	color: var(--vscode-descriptionForeground);
 	font-size: 11px;
 	text-align: right;
-	grid-row: span 1;
+	padding-top: 1px;
 }
 .chat-debug-cache-turn-main {
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
 }
-.chat-debug-cache-turn-label {
+.chat-debug-cache-turn-top {
 	font-size: 11.5px;
 	color: var(--vscode-foreground);
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 4px;
+	min-width: 0;
+}
+.chat-debug-cache-turn-source {
+	font-weight: 600;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	max-width: 100%;
 }
-.chat-debug-cache-turn-meta {
-	font-size: 10.5px;
-	color: var(--vscode-descriptionForeground);
-	display: flex;
-	gap: 8px;
-	align-items: center;
-	margin-top: 2px;
-}
-.chat-debug-cache-turn-ts {
+.chat-debug-cache-turn-chip {
 	font-family: var(--monaco-monospace-font);
 	font-size: 10.5px;
 	color: var(--vscode-descriptionForeground);
-	text-align: right;
 }
-.chat-debug-cache-bar {
-	display: inline-block;
-	width: 50px;
-	height: 4px;
-	background: var(--vscode-progressBar-background);
-	border-radius: 2px;
+.chat-debug-cache-turn-hit.is-bad {
+	color: var(--vscode-charts-red);
+	font-weight: 600;
+}
+.chat-debug-cache-turn-sub {
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
 	overflow: hidden;
-}
-.chat-debug-cache-bar > i {
-	display: block;
-	height: 100%;
-	background: var(--vscode-charts-green);
-}
-.chat-debug-cache-bar.warn > i {
-	background: var(--vscode-charts-yellow);
-}
-.chat-debug-cache-bar.bad > i {
-	background: var(--vscode-charts-red);
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .chat-debug-cache-content {
 	overflow-y: auto;
@@ -892,6 +967,7 @@
 	flex-direction: column;
 	gap: 16px;
 	min-width: 0;
+	flex: 1 1 auto;
 }
 .chat-debug-cache-empty {
 	display: flex;
@@ -950,61 +1026,39 @@
 	font-size: 11.5px;
 	color: var(--vscode-foreground);
 }
-.chat-debug-cache-tag {
+.chat-debug-cache-perf-rule {
+	height: 1px;
+	background: var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	margin: 12px 0 4px;
+}
+.chat-debug-cache-perf-section-h {
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	margin-bottom: 4px;
+}
+.chat-debug-cache-perf-line {
 	font-family: var(--monaco-monospace-font);
-	font-size: 10px;
-	padding: 1px 6px;
-	border-radius: 8px;
-	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
-}
-.chat-debug-cache-tag.tag-a {
-	color: var(--vscode-charts-blue);
-	border-color: var(--vscode-charts-blue);
-}
-.chat-debug-cache-tag.tag-b {
-	color: var(--vscode-charts-green);
-	border-color: var(--vscode-charts-green);
+	font-size: 11.5px;
+	color: var(--vscode-foreground);
+	line-height: 1.5;
 }
 .chat-debug-cache-kv {
 	display: flex;
 	justify-content: space-between;
+	gap: 12px;
 	font-family: var(--monaco-monospace-font);
 	font-size: 11.5px;
+	flex-wrap: wrap;
 }
 .chat-debug-cache-kv .k {
 	color: var(--vscode-descriptionForeground);
+	flex-shrink: 0;
 }
 .chat-debug-cache-kv .v {
 	color: var(--vscode-foreground);
-}
-.chat-debug-cache-pills {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-	margin-top: 4px;
-}
-.chat-debug-cache-pill {
-	font-family: var(--monaco-monospace-font);
-	font-size: 10.5px;
-	padding: 2px 7px;
-	border-radius: 10px;
-	background: var(--vscode-badge-background);
-	color: var(--vscode-badge-foreground);
-	border: 1px solid var(--vscode-widget-border, transparent);
-}
-.chat-debug-cache-pill.drift {
-	color: var(--vscode-charts-red);
-	border-color: var(--vscode-charts-red);
-	background: transparent;
-}
-.chat-debug-cache-pill.oneSided {
-	color: var(--vscode-charts-blue);
-	border-color: var(--vscode-charts-blue);
-	background: transparent;
-}
-.chat-debug-cache-pill.identical {
-	color: var(--vscode-descriptionForeground);
-	background: transparent;
+	min-width: 0;
 }
 .chat-debug-cache-section-h {
 	margin: 0 0 8px;
@@ -1013,64 +1067,131 @@
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
-.chat-debug-cache-signature {
+.chat-debug-cache-sig-legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 16px;
 	font-family: var(--monaco-monospace-font);
-	font-size: 11.5px;
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	margin-bottom: 8px;
+}
+.chat-debug-cache-sig-legend-entry {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+.chat-debug-cache-sig-swatch {
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	border-radius: 2px;
+}
+.chat-debug-cache-sig-swatch.role-system {
+	background: var(--vscode-charts-purple, #b292ff);
+}
+.chat-debug-cache-sig-swatch.role-user {
+	background: var(--vscode-charts-blue);
+}
+.chat-debug-cache-sig-swatch.role-assistant {
+	background: var(--vscode-charts-green);
+}
+.chat-debug-cache-sig-swatch.role-tool {
+	background: var(--vscode-charts-yellow);
+}
+.chat-debug-cache-sig-swatch.role-drift {
+	background: transparent;
+	outline: 2px solid var(--vscode-charts-red);
+	outline-offset: -2px;
+}
+.chat-debug-cache-sig-lanes {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 	background: var(--vscode-editorWidget-background);
 	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
 	border-radius: 6px;
-	padding: 10px 12px;
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px 6px;
-	line-height: 1.7;
-	overflow-x: auto;
+	padding: 12px 14px;
 }
-.chat-debug-cache-sig-tok {
-	padding: 2px 7px;
-	border-radius: 10px;
-	border: 1px solid transparent;
+.chat-debug-cache-sig-lane-row {
+	display: grid;
+	grid-template-columns: 70px 1fr 110px;
+	gap: 10px;
+	align-items: center;
+}
+.chat-debug-cache-sig-lane-label {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+.chat-debug-cache-sig-lane-total {
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	color: var(--vscode-descriptionForeground);
+	text-align: right;
+}
+.chat-debug-cache-sig-bar {
+	height: 22px;
+	background: var(--vscode-input-background, #2a2a2a);
+	border-radius: 4px;
+	overflow: hidden;
+	display: flex;
+	position: relative;
+}
+.chat-debug-cache-sig-seg {
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: var(--monaco-monospace-font);
+	font-size: 10.5px;
+	overflow: hidden;
 	white-space: nowrap;
+	border-right: 1px solid rgba(0, 0, 0, 0.3);
+	transition: filter 0.1s;
 }
-.chat-debug-cache-sig-tok.identical {
-	color: var(--vscode-descriptionForeground);
-	border-color: var(--vscode-widget-border, transparent);
+.chat-debug-cache-sig-seg:hover {
+	filter: brightness(1.2);
 }
-.chat-debug-cache-sig-tok.contentDrift,
-.chat-debug-cache-sig-tok.lengthChange {
-	color: var(--vscode-charts-red);
-	border-color: var(--vscode-charts-red);
-	font-weight: 600;
+.chat-debug-cache-sig-seg.role-system {
+	background: var(--vscode-charts-purple, #b292ff);
+	color: #1a0e30;
 }
-.chat-debug-cache-sig-tok.onlyInB {
-	color: var(--vscode-charts-blue);
-	border-color: var(--vscode-charts-blue);
+.chat-debug-cache-sig-seg.role-user {
+	background: var(--vscode-charts-blue);
+	color: #06243d;
 }
-.chat-debug-cache-sig-tok.onlyInA {
-	color: var(--vscode-charts-yellow);
-	border-color: var(--vscode-charts-yellow);
-	text-decoration: line-through;
+.chat-debug-cache-sig-seg.role-assistant {
+	background: var(--vscode-charts-green);
+	color: #082b0c;
 }
-.chat-debug-cache-sig-tok.break-marker {
-	background: var(--vscode-charts-red);
-	color: var(--vscode-button-foreground);
-	border-color: var(--vscode-charts-red);
-	font-weight: 700;
+.chat-debug-cache-sig-seg.role-tool {
+	background: var(--vscode-charts-yellow);
+	color: #2a1d00;
 }
-.chat-debug-cache-show-toggle {
-	font-size: 11px;
-	color: var(--vscode-descriptionForeground);
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	flex-wrap: wrap;
+.chat-debug-cache-sig-seg.role-empty {
+	background: transparent;
+	border-right: none;
+}
+.chat-debug-cache-sig-seg.is-drift {
+	outline: 2px solid var(--vscode-charts-red);
+	outline-offset: -2px;
+	filter: brightness(0.85);
+}
+.chat-debug-cache-sig-break {
+	position: absolute;
+	top: -2px;
+	bottom: -2px;
+	border-left: 2px dashed var(--vscode-charts-red);
+	pointer-events: none;
+}
+.chat-debug-cache-sig-summary {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	color: var(--vscode-foreground);
 	margin-top: 8px;
-}
-.chat-debug-cache-show-toggle label {
-	display: flex;
-	gap: 4px;
-	align-items: center;
-	cursor: pointer;
 }
 .chat-debug-cache-acc {
 	display: flex;
@@ -1099,7 +1220,7 @@
 	background: var(--vscode-list-hoverBackground);
 }
 .chat-debug-cache-chev::before {
-	content: '\25B6';
+	content: "\25B6";
 	display: inline-block;
 	color: var(--vscode-descriptionForeground);
 	font-size: 10px;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -1044,6 +1044,52 @@
 	color: var(--vscode-foreground);
 	line-height: 1.5;
 }
+.chat-debug-cache-options-banner {
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	color: var(--vscode-charts-yellow);
+	background: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-charts-yellow);
+	border-radius: 4px;
+	padding: 6px 10px;
+}
+.chat-debug-cache-options-table {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+	border-radius: 6px;
+	overflow: hidden;
+}
+.chat-debug-cache-options-row {
+	display: grid;
+	grid-template-columns: 200px 1fr 1fr;
+	gap: 12px;
+	padding: 6px 12px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+}
+.chat-debug-cache-options-row:first-child {
+	border-top: none;
+}
+.chat-debug-cache-options-row.head {
+	background: var(--vscode-editorWidget-background);
+	color: var(--vscode-descriptionForeground);
+	text-transform: uppercase;
+	font-size: 10.5px;
+	letter-spacing: 0.05em;
+}
+.chat-debug-cache-options-row.changed {
+	background: var(--vscode-diffEditor-removedLineBackground, rgba(244, 135, 113, 0.08));
+}
+.chat-debug-cache-options-cell {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.chat-debug-cache-options-cell.key {
+	color: var(--vscode-descriptionForeground);
+}
 .chat-debug-cache-kv {
 	display: flex;
 	justify-content: space-between;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/media/chatDebug.css
@@ -909,6 +909,10 @@
 .chat-debug-cache-turn:hover {
 	background: var(--vscode-list-hoverBackground);
 }
+.chat-debug-cache-turn:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
 .chat-debug-cache-turn.is-selected {
 	border-left-color: var(--vscode-focusBorder);
 	background: var(--vscode-list-activeSelectionBackground);

--- a/src/vs/workbench/contrib/chat/common/chatDebugService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugService.ts
@@ -350,6 +350,7 @@ export interface IChatDebugEventModelTurnContent {
 	readonly status?: string;
 	readonly durationInMillis?: number;
 	readonly timeToFirstTokenInMillis?: number;
+	readonly requestId?: string;
 	readonly maxInputTokens?: number;
 	readonly maxOutputTokens?: number;
 	readonly inputTokens?: number;

--- a/src/vs/workbench/contrib/chat/common/chatDebugService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugService.ts
@@ -357,6 +357,7 @@ export interface IChatDebugEventModelTurnContent {
 	readonly outputTokens?: number;
 	readonly cachedTokens?: number;
 	readonly totalTokens?: number;
+	readonly requestOptions?: string;
 	readonly errorMessage?: string;
 	readonly sections?: readonly IChatDebugMessageSection[];
 }

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
@@ -23,9 +23,9 @@ suite('chatDebugCacheDiff', () => {
 			const json = JSON.stringify([msg('system', 'hi'), msg('user', 'hello'), msg('tool', 'result', 'tool_a')]);
 			const parsed = parseInputMessages(json);
 			assert.deepStrictEqual(parsed, [
-				{ role: 'system', name: undefined, text: 'hi', byteLength: 2 },
-				{ role: 'user', name: undefined, text: 'hello', byteLength: 5 },
-				{ role: 'tool', name: 'tool_a', text: 'result', byteLength: 6 },
+				{ role: 'system', name: undefined, text: 'hi', charLength: 2 },
+				{ role: 'user', name: undefined, text: 'hello', charLength: 5 },
+				{ role: 'tool', name: 'tool_a', text: 'result', charLength: 6 },
 			]);
 		});
 
@@ -41,7 +41,7 @@ suite('chatDebugCacheDiff', () => {
 				{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_1', response: 'Found 12 references.' }] },
 			]);
 			assert.deepStrictEqual(parseInputMessages(json), [
-				{ role: 'tool', name: undefined, text: 'Found 12 references.', byteLength: 'Found 12 references.'.length },
+				{ role: 'tool', name: undefined, text: 'Found 12 references.', charLength: 'Found 12 references.'.length },
 			]);
 		});
 
@@ -51,7 +51,7 @@ suite('chatDebugCacheDiff', () => {
 			]);
 			const expected = `call:fs_read${JSON.stringify({ path: '/etc/hosts' })}`;
 			assert.deepStrictEqual(parseInputMessages(json), [
-				{ role: 'assistant', name: undefined, text: expected, byteLength: expected.length },
+				{ role: 'assistant', name: undefined, text: expected, charLength: expected.length },
 			]);
 		});
 	});
@@ -162,15 +162,15 @@ suite('chatDebugCacheDiff', () => {
 	suite('formatSignatureToken', () => {
 		test('formats identical, drift, and one-sided tokens', () => {
 			assert.strictEqual(
-				formatSignatureToken({ index: 0, kind: CacheDiffKind.Identical, aRole: 'user', aByteLength: 12, bRole: 'user', bByteLength: 12 }),
+				formatSignatureToken({ index: 0, kind: CacheDiffKind.Identical, aRole: 'user', aCharLength: 12, bRole: 'user', bCharLength: 12 }),
 				'user:12',
 			);
 			assert.strictEqual(
-				formatSignatureToken({ index: 1, kind: CacheDiffKind.LengthChange, aRole: 'user', aByteLength: 5, bRole: 'user', bByteLength: 8 }),
+				formatSignatureToken({ index: 1, kind: CacheDiffKind.LengthChange, aRole: 'user', aCharLength: 5, bRole: 'user', bCharLength: 8 }),
 				'user:5\u21928',
 			);
 			assert.strictEqual(
-				formatSignatureToken({ index: 2, kind: CacheDiffKind.OnlyInB, bRole: 'tool', bName: 'fs_read', bByteLength: 320 }),
+				formatSignatureToken({ index: 2, kind: CacheDiffKind.OnlyInB, bRole: 'tool', bName: 'fs_read', bCharLength: 320 }),
 				'tool-fs_read:0\u2192320',
 			);
 		});

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
@@ -35,6 +35,25 @@ suite('chatDebugCacheDiff', () => {
 			assert.deepStrictEqual(parseInputMessages('not json'), []);
 			assert.deepStrictEqual(parseInputMessages('"a string"'), []);
 		});
+
+		test('extracts tool_call_response content and reclassifies role to tool', () => {
+			const json = JSON.stringify([
+				{ role: 'user', parts: [{ type: 'tool_call_response', id: 'call_1', response: 'Found 12 references.' }] },
+			]);
+			assert.deepStrictEqual(parseInputMessages(json), [
+				{ role: 'tool', name: undefined, text: 'Found 12 references.', byteLength: 'Found 12 references.'.length },
+			]);
+		});
+
+		test('extracts tool_call arguments on assistant messages', () => {
+			const json = JSON.stringify([
+				{ role: 'assistant', parts: [{ type: 'tool_call', id: 'call_1', name: 'fs_read', arguments: { path: '/etc/hosts' } }] },
+			]);
+			const expected = `call:fs_read${JSON.stringify({ path: '/etc/hosts' })}`;
+			assert.deepStrictEqual(parseInputMessages(json), [
+				{ role: 'assistant', name: undefined, text: expected, byteLength: expected.length },
+			]);
+		});
 	});
 
 	suite('diffPromptSignature', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugCacheDiff.test.ts
@@ -1,0 +1,159 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { appendSystemDrift, CacheDiffKind, diffPromptSignature, formatSignatureToken, parseInputMessages } from '../../browser/chatDebug/chatDebugCacheDiff.js';
+
+function msg(role: string, content: string, name?: string) {
+	const part: { type: string; content: string; name?: string } = { type: 'text', content };
+	if (name) {
+		part.name = name;
+	}
+	return { role, ...(name ? { name } : {}), parts: [part] };
+}
+
+suite('chatDebugCacheDiff', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('parseInputMessages', () => {
+		test('parses well-formed input messages and computes byte length', () => {
+			const json = JSON.stringify([msg('system', 'hi'), msg('user', 'hello'), msg('tool', 'result', 'tool_a')]);
+			const parsed = parseInputMessages(json);
+			assert.deepStrictEqual(parsed, [
+				{ role: 'system', name: undefined, text: 'hi', byteLength: 2 },
+				{ role: 'user', name: undefined, text: 'hello', byteLength: 5 },
+				{ role: 'tool', name: 'tool_a', text: 'result', byteLength: 6 },
+			]);
+		});
+
+		test('returns empty array for malformed inputs', () => {
+			assert.deepStrictEqual(parseInputMessages(undefined), []);
+			assert.deepStrictEqual(parseInputMessages(''), []);
+			assert.deepStrictEqual(parseInputMessages('not json'), []);
+			assert.deepStrictEqual(parseInputMessages('"a string"'), []);
+		});
+	});
+
+	suite('diffPromptSignature', () => {
+		test('all identical messages produce no break and only identical tokens', () => {
+			const a = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1')]));
+			const b = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1')]));
+			const result = diffPromptSignature(a, b);
+			assert.deepStrictEqual(
+				{
+					break: result.break,
+					counts: result.counts,
+					kinds: result.signature.map(s => s.kind),
+					drift: result.drift.map(d => d.name + ':' + d.status),
+				},
+				{
+					break: undefined,
+					counts: { identical: 2, contentDrift: 0, lengthChange: 0, onlyInA: 0, onlyInB: 0 },
+					kinds: [CacheDiffKind.Identical, CacheDiffKind.Identical],
+					drift: [],
+				},
+			);
+		});
+
+		test('content drift at index 1 reports a contentDrift break', () => {
+			const a = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'aaaa')]));
+			const b = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'bbbb')]));
+			const result = diffPromptSignature(a, b);
+			assert.deepStrictEqual(
+				{
+					break: result.break,
+					counts: result.counts,
+					kinds: result.signature.map(s => s.kind),
+					drift: result.drift.map(d => `${d.name}:${d.status}:${d.aSize}->${d.bSize}`),
+				},
+				{
+					break: { index: 1, kind: CacheDiffKind.ContentDrift },
+					counts: { identical: 1, contentDrift: 1, lengthChange: 0, onlyInA: 0, onlyInB: 0 },
+					kinds: [CacheDiffKind.Identical, CacheDiffKind.ContentDrift],
+					drift: ['messages[1]:contentDrift:4->4'],
+				},
+			);
+		});
+
+		test('length change at index 1 reports a lengthChange break', () => {
+			const a = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'short')]));
+			const b = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'much longer text')]));
+			const result = diffPromptSignature(a, b);
+			assert.deepStrictEqual(
+				{
+					break: result.break,
+					counts: result.counts,
+					kinds: result.signature.map(s => s.kind),
+					drift: result.drift.map(d => `${d.name}:${d.status}:${d.aSize}->${d.bSize}`),
+				},
+				{
+					break: { index: 1, kind: CacheDiffKind.LengthChange },
+					counts: { identical: 1, contentDrift: 0, lengthChange: 1, onlyInA: 0, onlyInB: 0 },
+					kinds: [CacheDiffKind.Identical, CacheDiffKind.LengthChange],
+					drift: ['messages[1]:lengthChange:5->16'],
+				},
+			);
+		});
+
+		test('B has trailing messages A does not — break at first onlyInB', () => {
+			const a = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1')]));
+			const b = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1'), msg('assistant', 'a1'), msg('user', 'q2')]));
+			const result = diffPromptSignature(a, b);
+			assert.deepStrictEqual(
+				{
+					break: result.break,
+					counts: result.counts,
+					kinds: result.signature.map(s => s.kind),
+				},
+				{
+					break: { index: 2, kind: CacheDiffKind.OnlyInB },
+					counts: { identical: 2, contentDrift: 0, lengthChange: 0, onlyInA: 0, onlyInB: 2 },
+					kinds: [CacheDiffKind.Identical, CacheDiffKind.Identical, CacheDiffKind.OnlyInB, CacheDiffKind.OnlyInB],
+				},
+			);
+		});
+
+		test('A has trailing messages B does not — break at first onlyInA', () => {
+			const a = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1'), msg('assistant', 'a1')]));
+			const b = parseInputMessages(JSON.stringify([msg('system', 'sys'), msg('user', 'q1')]));
+			const result = diffPromptSignature(a, b);
+			assert.deepStrictEqual(
+				{ break: result.break, counts: result.counts },
+				{
+					break: { index: 2, kind: CacheDiffKind.OnlyInA },
+					counts: { identical: 2, contentDrift: 0, lengthChange: 0, onlyInA: 1, onlyInB: 0 },
+				},
+			);
+		});
+
+		test('appendSystemDrift inserts a system row when system instructions differ', () => {
+			const drift = appendSystemDrift([], 'old system', 'new system!!');
+			assert.deepStrictEqual(drift, [{ name: 'system', status: CacheDiffKind.LengthChange, aSize: 10, bSize: 12 }]);
+		});
+
+		test('appendSystemDrift returns input unchanged when system matches', () => {
+			const existing = [{ name: 'messages[0]', role: 'user', status: CacheDiffKind.ContentDrift, aSize: 4, bSize: 4 }];
+			assert.deepStrictEqual(appendSystemDrift(existing, 'sys', 'sys'), existing);
+		});
+	});
+
+	suite('formatSignatureToken', () => {
+		test('formats identical, drift, and one-sided tokens', () => {
+			assert.strictEqual(
+				formatSignatureToken({ index: 0, kind: CacheDiffKind.Identical, aRole: 'user', aByteLength: 12, bRole: 'user', bByteLength: 12 }),
+				'user:12',
+			);
+			assert.strictEqual(
+				formatSignatureToken({ index: 1, kind: CacheDiffKind.LengthChange, aRole: 'user', aByteLength: 5, bRole: 'user', bByteLength: 8 }),
+				'user:5\u21928',
+			);
+			assert.strictEqual(
+				formatSignatureToken({ index: 2, kind: CacheDiffKind.OnlyInB, bRole: 'tool', bName: 'fs_read', bByteLength: 320 }),
+				'tool-fs_read:0\u2192320',
+			);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/chatDebugEventDetailRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatDebugEventDetailRenderer.test.ts
@@ -62,6 +62,7 @@ suite('formatEventDetail', () => {
 			model: 'gpt-4o',
 			inputTokens: 100,
 			outputTokens: 50,
+			cachedTokens: 80,
 			totalTokens: 150,
 			durationInMillis: 320,
 		};
@@ -69,6 +70,7 @@ suite('formatEventDetail', () => {
 		assert.ok(result.includes('gpt-4o'));
 		assert.ok(result.includes('100'));
 		assert.ok(result.includes('50'));
+		assert.ok(result.includes('80'));
 		assert.ok(result.includes('150'));
 		assert.ok(result.includes('320'));
 	});

--- a/src/vscode-dts/vscode.proposed.chatDebug.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatDebug.d.ts
@@ -174,6 +174,14 @@ declare module 'vscode' {
 		requestName?: string;
 
 		/**
+		 * Cache-relevant request options as a JSON-stringified blob (e.g.
+		 * `tool_choice`, `reasoning_effort`, `thinking`, `response_format`).
+		 * When this differs between two requests, the prompt cache is
+		 * invalidated even if the message array is byte-identical.
+		 */
+		requestOptions?: string;
+
+		/**
 		 * The outcome status of the model turn (e.g., "success", "failure", "canceled").
 		 */
 		status?: string;
@@ -585,6 +593,14 @@ declare module 'vscode' {
 		 * The total number of tokens consumed (input + output).
 		 */
 		totalTokens?: number;
+
+		/**
+		 * Cache-relevant request options as a JSON-stringified blob (e.g.
+		 * `tool_choice`, `reasoning_effort`, `thinking`, `response_format`).
+		 * When this differs between two requests, the prompt cache is
+		 * invalidated even if the message array is byte-identical.
+		 */
+		requestOptions?: string;
 
 		/**
 		 * An error message, if the model turn failed.

--- a/src/vscode-dts/vscode.proposed.chatDebug.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatDebug.d.ts
@@ -154,6 +154,11 @@ declare module 'vscode' {
 		timeToFirstTokenInMillis?: number;
 
 		/**
+		 * The unique request id assigned by the model provider for this turn.
+		 */
+		requestId?: string;
+
+		/**
 		 * The maximum number of prompt/input tokens allowed for this request.
 		 */
 		maxInputTokens?: number;
@@ -545,6 +550,11 @@ declare module 'vscode' {
 		 * first response token.
 		 */
 		timeToFirstTokenInMillis?: number;
+
+		/**
+		 * The unique request id assigned by the model provider for this turn.
+		 */
+		requestId?: string;
 
 		/**
 		 * The maximum number of prompt/input tokens allowed for this request.


### PR DESCRIPTION
Add a **Cache Explorer** entry under "Explore Trace Data" in the agent debug panel. It helps diagnose prompt-cache misses by diffing the current request against the previous one in a session.

Also contributed to by @kevin-m-kent

<img width="1246" height="1078" alt="image" src="https://github.com/user-attachments/assets/1af4b6e1-9f54-4f41-b5d4-0775a7218c3d" />

