### PR TITLE
fix: Chronicle agent_name backfill, summary JSON filtering, schema description

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -245,6 +245,57 @@ export function isGitHubMcpTool(toolName: string): boolean {
 const OTEL_TRUNCATION_MARKER = '...[truncated';
 
 /**
+ * Extracts the agent name from an invoke_agent span.
+ * Tries the explicit attribute first, then parses it from the span name,
+ * finally falls back to 'unknown'.
+ */
+export function extractAgentName(span: { name: string; attributes: Record<string, unknown> }): string {
+	// 1. Prefer explicit attribute
+	const attr = span.attributes[GenAiAttr.AGENT_NAME] as string | undefined;
+	if (attr?.trim()) {
+		return attr.trim();
+	}
+	// 2. Parse span name: "invoke_agent copilot" → "copilot"
+	const match = span.name.match(/^invoke_agent\s+(.+)/);
+	if (match?.[1]?.trim()) {
+		return match[1].trim();
+	}
+	// 3. Fallback
+	return 'unknown';
+}
+
+/**
+ * Extracts human-readable plain text from potentially JSON-encoded content.
+ * Returns undefined for unrecognized JSON (tool results, etc.) to skip the summary write.
+ * Returns the original string unchanged if it is not JSON.
+ */
+export function extractPlainTextFromContent(content: string): string | undefined {
+	const trimmed = content.trim();
+	if (!trimmed.startsWith('[') && !trimmed.startsWith('{')) {
+		return trimmed || undefined;
+	}
+	try {
+		const parsed = JSON.parse(trimmed);
+		// Handle [{type:"text", text:"..."}] multi-modal parts array
+		if (Array.isArray(parsed)) {
+			const textPart = parsed.find((p: unknown) => typeof p === 'object' && p !== null && (p as Record<string, unknown>).type === 'text' && typeof (p as Record<string, unknown>).text === 'string');
+			if (textPart) {
+				return ((textPart as Record<string, unknown>).text as string).trim() || undefined;
+			}
+			return undefined; // Array with no text parts (tool results, images, etc.)
+		}
+		// Handle {role:"...", content:"..."} chat messages with string content
+		// Note: content may be an array (multi-modal) — only handle string case
+		if (typeof (parsed as Record<string, unknown>).content === 'string') {
+			return ((parsed as Record<string, unknown>).content as string).trim() || undefined;
+		}
+		return undefined; // Unrecognized JSON structure
+	} catch {
+		return trimmed || undefined; // JSON parse failed — keep as plain text
+	}
+}
+
+/**
  * Extract assistant response text from the gen_ai.output.messages span attribute.
  * Handles both valid JSON and truncated JSON (where truncateForOTel cut the
  * JSON structure mid-string and appended a suffix).

--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -291,7 +291,7 @@ export function extractPlainTextFromContent(content: string): string | undefined
 		}
 		return undefined; // Unrecognized JSON structure
 	} catch {
-		return trimmed || undefined; // JSON parse failed — keep as plain text
+		return undefined; // JSON-looking input that failed to parse — skip to avoid storing raw/truncated JSON
 	}
 }
 

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
@@ -253,7 +253,7 @@ describe('extractPlainTextFromContent', () => {
 		expect(extractPlainTextFromContent('{"role":"user","content":[{"type":"text"}]}')).toBeUndefined();
 	});
 
-	it('returns original string for invalid/truncated JSON', () => {
-		expect(extractPlainTextFromContent('[{"type":"text","text":"Fix')).toBe('[{"type":"text","text":"Fix');
+	it('returns undefined for invalid/truncated JSON', () => {
+		expect(extractPlainTextFromContent('[{"type":"text","text":"Fix')).toBeUndefined();
 	});
 });

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, it } from 'vitest';
-import { extractFilePath, extractRefsFromMcpTool, extractRefsFromTerminal, extractRepoFromMcpTool, isGitHubMcpTool } from '../sessionStoreTracking';
+import { extractAgentName, extractFilePath, extractPlainTextFromContent, extractRefsFromMcpTool, extractRefsFromTerminal, extractRepoFromMcpTool, isGitHubMcpTool } from '../sessionStoreTracking';
 
 describe('extractFilePath', () => {
 	it('extracts filePath from replace_string_in_file', () => {
@@ -181,5 +181,79 @@ describe('extractRefsFromTerminal', () => {
 
 	it('returns empty for unrelated commands', () => {
 		expect(extractRefsFromTerminal({ command: 'ls -la' }, 'output')).toEqual([]);
+	});
+});
+
+describe('extractAgentName', () => {
+	it('returns trimmed attribute value when present', () => {
+		expect(extractAgentName({ name: 'invoke_agent', attributes: { 'gen_ai.agent.name': '  copilot  ' } }))
+			.toBe('copilot');
+	});
+
+	it('parses agent name from span name when attribute is absent', () => {
+		expect(extractAgentName({ name: 'invoke_agent copilot', attributes: {} }))
+			.toBe('copilot');
+	});
+
+	it('parses multi-word agent name from span name', () => {
+		expect(extractAgentName({ name: 'invoke_agent GitHub Copilot Chat', attributes: {} }))
+			.toBe('GitHub Copilot Chat');
+	});
+
+	it('returns unknown when span name is invoke_agent with no suffix', () => {
+		expect(extractAgentName({ name: 'invoke_agent ', attributes: {} }))
+			.toBe('unknown');
+	});
+
+	it('falls back to span name when attribute is empty string', () => {
+		expect(extractAgentName({ name: 'invoke_agent copilot', attributes: { 'gen_ai.agent.name': '' } }))
+			.toBe('copilot');
+	});
+
+	it('returns unknown when span name does not start with invoke_agent', () => {
+		expect(extractAgentName({ name: 'execute_tool read_file', attributes: {} }))
+			.toBe('unknown');
+	});
+});
+
+describe('extractPlainTextFromContent', () => {
+	it('returns plain text string unchanged', () => {
+		expect(extractPlainTextFromContent('Fix the bug')).toBe('Fix the bug');
+	});
+
+	it('returns undefined for empty string', () => {
+		expect(extractPlainTextFromContent('')).toBeUndefined();
+	});
+
+	it('returns undefined for whitespace-only string', () => {
+		expect(extractPlainTextFromContent('   ')).toBeUndefined();
+	});
+
+	it('extracts text from [{type:"text", text:"..."}] array', () => {
+		expect(extractPlainTextFromContent('[{"type":"text","text":"Fix the bug"}]')).toBe('Fix the bug');
+	});
+
+	it('trims whitespace from text part', () => {
+		expect(extractPlainTextFromContent('[{"type":"text","text":"  padded  "}]')).toBe('padded');
+	});
+
+	it('returns undefined for text part with empty text', () => {
+		expect(extractPlainTextFromContent('[{"type":"text","text":""}]')).toBeUndefined();
+	});
+
+	it('returns undefined for array with no text parts (tool results)', () => {
+		expect(extractPlainTextFromContent('[{"type":"tool_result","content":"some result"}]')).toBeUndefined();
+	});
+
+	it('extracts content from {role, content} object with string content', () => {
+		expect(extractPlainTextFromContent('{"role":"user","content":"Fix the login bug"}')).toBe('Fix the login bug');
+	});
+
+	it('returns undefined for object with array content (multi-modal)', () => {
+		expect(extractPlainTextFromContent('{"role":"user","content":[{"type":"text"}]}')).toBeUndefined();
+	});
+
+	it('returns original string for invalid/truncated JSON', () => {
+		expect(extractPlainTextFromContent('[{"type":"text","text":"Fix')).toBe('[{"type":"text","text":"Fix');
 	});
 });

--- a/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
+++ b/extensions/copilot/src/extension/chronicle/node/sessionReindexer.ts
@@ -13,6 +13,7 @@ import {
 	MAX_USER_MESSAGE_LENGTH,
 	extractAssistantResponse,
 	extractFilePath,
+	extractPlainTextFromContent,
 	extractRefsFromMcpTool,
 	extractRefsFromTerminal,
 	extractRepoFromMcpTool,
@@ -261,7 +262,7 @@ function processAssistantResponse(
 
 	// Use first user message as summary if not yet set
 	if (!buffer.session?.summary && state.pendingUserMessage) {
-		const summary = truncateForStore(state.pendingUserMessage, MAX_SUMMARY_LENGTH);
+		const summary = truncateForStore(extractPlainTextFromContent(state.pendingUserMessage), MAX_SUMMARY_LENGTH);
 		if (!buffer.session) {
 			buffer.session = { id: sessionId, host_type: 'vscode' };
 		}

--- a/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
+++ b/extensions/copilot/src/extension/chronicle/vscode-node/sessionStoreTracker.ts
@@ -17,8 +17,10 @@ import { IExtensionContribution } from '../../common/contributions';
 import {
 	MAX_ASSISTANT_RESPONSE_LENGTH,
 	MAX_SUMMARY_LENGTH,
+	extractAgentName,
 	extractAssistantResponse,
 	extractFilePath,
+	extractPlainTextFromContent,
 	extractRefsFromMcpTool,
 	extractRefsFromTerminal,
 	extractRepoFromMcpTool,
@@ -211,7 +213,7 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 	private _initSession(sessionId: string, span: ICompletedSpanData): void {
 		this._initializedSessions.add(sessionId);
 
-		const sessionSource = (span.attributes[GenAiAttr.AGENT_NAME] as string | undefined) ?? 'unknown';
+		const sessionSource = extractAgentName(span);
 		const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 		this._bufferSessionUpsert({ id: sessionId, host_type: 'vscode', agent_name: sessionSource, ...(cwd ? { cwd } : {}) });
 
@@ -244,7 +246,7 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 		const userRequest = span.attributes[CopilotChatAttr.USER_REQUEST] as string | undefined;
 
 		if (branch || remoteUrl || userRequest) {
-			const summary = truncateForStore(userRequest, MAX_SUMMARY_LENGTH);
+			const summary = userRequest ? truncateForStore(extractPlainTextFromContent(userRequest), MAX_SUMMARY_LENGTH) : undefined;
 
 			this._bufferSessionUpsert({
 				id: sessionId,
@@ -252,6 +254,11 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 				...(remoteUrl ? { repository: remoteUrl } : {}),
 				...(summary ? { summary } : {}),
 			});
+		}
+
+		const agentName = extractAgentName(span);
+		if (agentName !== 'unknown') {
+			this._bufferSessionUpsert({ id: sessionId, agent_name: agentName });
 		}
 	}
 
@@ -322,8 +329,8 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 		// Use the first user message as the session summary if one hasn't been set yet
 		const existingSession = this._buffer.sessions.get(sessionId);
 		if (!existingSession?.summary) {
-			const firstMessage = userMessages[0]?.content ?? userRequest;
-			const summary = truncateForStore(firstMessage, MAX_SUMMARY_LENGTH);
+			const rawFirst = userMessages[0]?.content ?? userRequest;
+			const summary = rawFirst ? truncateForStore(extractPlainTextFromContent(rawFirst), MAX_SUMMARY_LENGTH) : undefined;
 			if (summary) {
 				this._bufferSessionUpsert({ id: sessionId, summary });
 			}
@@ -371,6 +378,7 @@ export class SessionStoreTracker extends Disposable implements IExtensionContrib
 				...(session.host_type ? { host_type: session.host_type } : {}),
 				...(session.branch ? { branch: session.branch } : {}),
 				...(session.summary ? { summary: session.summary } : {}),
+				...(session.agent_name && session.agent_name !== 'unknown' ? { agent_name: session.agent_name } : {}),
 			});
 		} else {
 			this._buffer.sessions.set(session.id, { ...session });

--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -476,7 +476,7 @@ Always JOIN sessions with turns to get session content — do not rely on sessio
 - **turns**: session_id, turn_index, user_message, assistant_response (first ~1000 characters of the assistant reply, with an ellipsis if truncated — not the full response; may be empty for older sessions), timestamp. The richest source of what actually happened — always JOIN sessions with turns for meaningful results.
 - **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were read/edited and which tools were used. May be empty for older sessions.
 - **session_refs**: session_id, ref_type (commit/pr/issue), ref_value, turn_index. Tracks PRs created, issues referenced, commits made. May be empty for older sessions.
-- **search_index**: FTS5 virtual table indexing turns.user_message and turns.assistant_response. Use \`WHERE search_index MATCH 'query'\` for full-text search across conversation content.
+- **search_index**: FTS5 virtual table indexing conversation turns (user_message + assistant_response), checkpoint sections (overview, history, work_done, etc.), and workspace artifacts. Records have a source_type column (unindexed) distinguishing content origin. Use \`WHERE search_index MATCH 'query'\` for full-text search across all indexed session content.
 
 Use \`datetime('now', '-1 day')\` for date math.
 Join sessions with turns/files/refs using session_id for complete analysis.`;

--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -472,11 +472,11 @@ Use the session_store_sql tool to run queries. Start with a broad query, then dr
 Use \`now() - INTERVAL '1 day'\` for date math, \`ILIKE\` for text search.
 Always JOIN sessions with turns to get session content — do not rely on sessions.summary alone.`
 			: `Available tables (SQLite syntax — local):
-- **sessions**: id, cwd (workspace folder path), repository, branch, summary, host_type, agent_name, agent_description, created_at, updated_at. NOTE: agent_name and agent_description may be empty for older sessions. summary may contain raw JSON — prefer JOINing with turns.user_message for text search.
+- **sessions**: id, cwd (workspace folder path), repository, branch, summary, host_type (always 'vscode' locally), agent_name (who created the session, e.g. 'GitHub Copilot Chat', 'copilotcli', 'claude'), agent_description, created_at, updated_at. NOTE: agent_name and agent_description may be empty for older sessions. summary is human-readable plain text (up to 100 chars) — may be empty for older sessions.
 - **turns**: session_id, turn_index, user_message, assistant_response (first ~1000 characters of the assistant reply, with an ellipsis if truncated — not the full response; may be empty for older sessions), timestamp. The richest source of what actually happened — always JOIN sessions with turns for meaningful results.
 - **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were read/edited and which tools were used. May be empty for older sessions.
 - **session_refs**: session_id, ref_type (commit/pr/issue), ref_value, turn_index. Tracks PRs created, issues referenced, commits made. May be empty for older sessions.
-- **search_index**: FTS5 table. Use \`WHERE search_index MATCH 'query'\`
+- **search_index**: FTS5 virtual table indexing turns.user_message and turns.assistant_response. Use \`WHERE search_index MATCH 'query'\` for full-text search across conversation content.
 
 Use \`datetime('now', '-1 day')\` for date math.
 Join sessions with turns/files/refs using session_id for complete analysis.`;


### PR DESCRIPTION
Fixes the remaining open sub-issues of #312292 (Chronicle local schema drift).

## Changes

### `extractAgentName` — fixes #312296

`sessions.agent_name` was always `'unknown'` in the local store because:
1. `_initSession` fell through to `'unknown'` when the span lacked `gen_ai.agent.name`
2. `_bufferSessionUpsert` didn't include `agent_name` in its merge list, so later spans couldn't correct it

**Fix**: Add `extractAgentName(span)` with a fallback chain: attribute → span-name parsing (`"invoke_agent copilot"` → `"copilot"`) → `'unknown'`. Use it in `_initSession`, add `agent_name` to the `_bufferSessionUpsert` merge list (prerequisite for backfill to work), and backfill from `_backfillFromSpanAttributes`.

### `extractPlainTextFromContent` — fixes #312295

`sessions.summary` was stored verbatim from `USER_REQUEST` span attributes or first user message events, which can be structured JSON (e.g. `[{"type":"tool_result","content":"..."}]`). This broke `LIKE`-based queries and the FTS index.

**Fix**: Add `extractPlainTextFromContent(content)` that detects JSON content and extracts human-readable text from known structures (multi-modal text parts, chat message objects), returning `undefined` for unrecognized JSON (tool results, images, etc.) to skip the summary write entirely. Route all three summary write sites through it:
- `_backfillFromSpanAttributes` (sessionStoreTracker.ts)
- `_handleAgentSpan` (sessionStoreTracker.ts, both event and fallback paths)
- `processAssistantResponse` summary path in sessionReindexer.ts (was missing from prior fix attempts)

### Schema description — addresses #312292

Updated the local schema description in `_getSchemaDescription()`:
- `agent_name`: added example values (`'GitHub Copilot Chat'`, `'copilotcli'`, `'claude'`)
- `host_type`: noted it's always `'vscode'` locally (not a distinguishing field)
- `summary`: removed the raw JSON warning now that the write path filters it
- `search_index`: clarified it indexes `turns.user_message` and `turns.assistant_response` content

## Testing

16 new unit tests in `sessionStoreTracking.spec.ts`:
- `extractAgentName`: attribute present, span-name fallback, multi-word names, empty suffix, empty attribute, non-invoke span
- `extractPlainTextFromContent`: plain text, empty string, text parts, tool results, chat messages, array content, truncated JSON
