### PR TITLE
fix(byok): populate Context Window usage for local models (ollama, cu…

### DIFF
--- a/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/test/node/stream.sseProcessor.spec.ts
@@ -533,6 +533,47 @@ data: [DONE]
 		expect(results).toMatchInlineSnapshot(`[]`);
 	});
 
+	test('usage without total_tokens inline with completion chunk should synthesize total_tokens', async function () {
+		// Reproduces the local-model case (Ollama, LM Studio) where total_tokens is omitted
+		const response = [
+			`data: {"choices":[{"text":"foo","index":0,"finish_reason":null}]}\n`,
+			`data: {"choices":[{"text":"bar","index":0,"finish_reason":"stop"}],"usage":{"completion_tokens":2,"prompt_tokens":358}}\n`,
+			`data: [DONE]\n`,
+		];
+		const processor = await SSEProcessor.create(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assert.ok(results[0].usage);
+		assert.strictEqual(results[0]?.usage?.completion_tokens, 2);
+		assert.strictEqual(results[0]?.usage?.prompt_tokens, 358);
+		assert.strictEqual(results[0]?.usage?.total_tokens, 360);
+	});
+
+	test('usage without total_tokens as a separate chunk should synthesize total_tokens', async function () {
+		// Reproduces the local-model case where total_tokens is omitted and usage is a separate chunk
+		const response = [
+			`data: {"choices":[{"text":"foo","index":0,"finish_reason":null}]}\n`,
+			`data: {"choices":[{"text":"bar","index":0,"finish_reason":"stop"}]}\n`,
+			`data: {"choices": [], "usage":{"completion_tokens":2,"prompt_tokens":358}}\n`,
+			`data: [DONE]\n`,
+		];
+		const processor = await SSEProcessor.create(
+			logService,
+			telemetryService,
+			1,
+			createFakeStreamResponse(response),
+		);
+		const results = await getAll(processor.processSSE());
+		assert.ok(results[0].usage);
+		assert.strictEqual(results[0]?.usage?.completion_tokens, 2);
+		assert.strictEqual(results[0]?.usage?.prompt_tokens, 358);
+		assert.strictEqual(results[0]?.usage?.total_tokens, 360);
+	});
+
 	test('usage as a separate chunk should propery be reported for text completions', async function () {
 		const response = [
 			`data: {"choices":[{"text":"foo","index":0,"finish_reason":null}]}\n`,

--- a/extensions/copilot/src/platform/networking/common/openai.ts
+++ b/extensions/copilot/src/platform/networking/common/openai.ts
@@ -68,9 +68,10 @@ export interface APIUsage {
 }
 
 export function isApiUsage(obj: unknown): obj is APIUsage {
+	// total_tokens is intentionally not required — many OpenAI-compatible local
+	// models (Ollama, LM Studio, custom proxies) omit it; it equals prompt_tokens + completion_tokens.
 	return typeof (obj as APIUsage).prompt_tokens === 'number' &&
-		typeof (obj as APIUsage).completion_tokens === 'number' &&
-		typeof (obj as APIUsage).total_tokens === 'number';
+		typeof (obj as APIUsage).completion_tokens === 'number';
 }
 
 

--- a/extensions/copilot/src/platform/networking/common/openai.ts
+++ b/extensions/copilot/src/platform/networking/common/openai.ts
@@ -67,11 +67,17 @@ export interface APIUsage {
 	};
 }
 
-export function isApiUsage(obj: unknown): obj is APIUsage {
-	// total_tokens is intentionally not required — many OpenAI-compatible local
-	// models (Ollama, LM Studio, custom proxies) omit it; it equals prompt_tokens + completion_tokens.
-	return typeof (obj as APIUsage).prompt_tokens === 'number' &&
-		typeof (obj as APIUsage).completion_tokens === 'number';
+/**
+ * Usage as it arrives from an SSE stream. total_tokens is optional because many
+ * OpenAI-compatible local providers (Ollama, LM Studio, custom proxies) omit it;
+ * it can always be derived as prompt_tokens + completion_tokens.
+ * Callers that need a full APIUsage should synthesize total_tokens first.
+ */
+export type StreamingAPIUsage = Omit<APIUsage, 'total_tokens'> & { total_tokens?: number };
+
+export function isApiUsage(obj: unknown): obj is StreamingAPIUsage {
+	return typeof (obj as StreamingAPIUsage).prompt_tokens === 'number' &&
+		typeof (obj as StreamingAPIUsage).completion_tokens === 'number';
 }
 
 

--- a/extensions/copilot/src/platform/networking/node/stream.ts
+++ b/extensions/copilot/src/platform/networking/node/stream.ts
@@ -11,7 +11,7 @@ import { RawThinkingDelta, ThinkingDelta } from '../../thinking/common/thinking'
 import { extractThinkingDeltaFromChoice, } from '../../thinking/common/thinkingUtils';
 import { FinishedCallback, getRequestId, ICodeVulnerabilityAnnotation, ICopilotBeginToolCall, ICopilotConfirmation, ICopilotError, ICopilotFunctionCall, ICopilotReference, ICopilotToolCall, ICopilotToolCallStreamUpdate, IIPCodeCitation, isCodeCitationAnnotation, isCopilotAnnotation, RequestId } from '../common/fetch';
 import { DestroyableStream, Response } from '../common/fetcherService';
-import { APIErrorResponse, APIJsonData, APIUsage, ChoiceLogProbs, FilterReason, FinishedCompletionReason, isApiUsage, IToolCall } from '../common/openai';
+import { APIErrorResponse, APIJsonData, APIUsage, ChoiceLogProbs, FilterReason, FinishedCompletionReason, isApiUsage, IToolCall, StreamingAPIUsage } from '../common/openai';
 
 /** Gathers together many chunks of a single completion choice. */
 class APIJsonDataStreaming {
@@ -279,12 +279,12 @@ export class SSEProcessor {
 				}
 			} else {
 				let completion: FinishedCompletion | undefined;
-				let usage: APIUsage | undefined;
+				let streamingUsage: StreamingAPIUsage | undefined;
 
 				// Process both the usage and the completions, then yield one combined completions
 				for await (const usageOrCompletions of this.processSSEInner(finishedCb)) {
 					if (isApiUsage(usageOrCompletions)) {
-						usage = usageOrCompletions;
+						streamingUsage = usageOrCompletions;
 					} else {
 						completion = usageOrCompletions;
 					}
@@ -295,10 +295,11 @@ export class SSEProcessor {
 				}
 
 				if (completion) {
-					if (usage && typeof usage.total_tokens !== 'number') {
-						// Synthesize total_tokens for models that omit it (e.g. Ollama, LM Studio)
-						usage = { ...usage, total_tokens: usage.prompt_tokens + usage.completion_tokens };
-					}
+					// Upcast to APIUsage, synthesizing total_tokens when the provider omitted it
+					// (many OpenAI-compatible local models such as Ollama and LM Studio do not include it).
+					const usage: APIUsage | undefined = streamingUsage
+						? { ...streamingUsage, total_tokens: streamingUsage.total_tokens ?? streamingUsage.prompt_tokens + streamingUsage.completion_tokens }
+						: undefined;
 					completion.usage = usage;
 					yield completion;
 				}

--- a/extensions/copilot/src/platform/networking/node/stream.ts
+++ b/extensions/copilot/src/platform/networking/node/stream.ts
@@ -295,6 +295,10 @@ export class SSEProcessor {
 				}
 
 				if (completion) {
+					if (usage && typeof usage.total_tokens !== 'number') {
+						// Synthesize total_tokens for models that omit it (e.g. Ollama, LM Studio)
+						usage = { ...usage, total_tokens: usage.prompt_tokens + usage.completion_tokens };
+					}
 					completion.usage = usage;
 					yield completion;
 				}


### PR DESCRIPTION
Fixes: #313458

Problem
The Context Window usage widget stayed at 0 / <max tokens> for all local model providers (Ollama, LM Studio, custom OpenAI-compatible proxies), even when:

The model's token limits (maxInputTokens, maxOutputTokens) were known
The backend was returning usage data in the streaming response
Root Cause
Two issues in the streaming response pipeline:

1. isApiUsage() required total_tokens — [openai.ts:70](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/extensions/copilot/src/platform/networking/common/openai.ts#L70)


// Before — silently rejected usage from models that omit total_tokens
export function isApiUsage(obj: unknown): obj is APIUsage {
    return typeof (obj as APIUsage).prompt_tokens === 'number' &&
           typeof (obj as APIUsage).completion_tokens === 'number' &&
           typeof (obj as APIUsage).total_tokens === 'number';  // ← blocked local models
}
Many OpenAI-compatible local models omit total_tokens since it's derivable. When isApiUsage() returned false, the usage object was silently dropped in stream.ts, leaving completion.usage = undefined.

2. The cascade from there was complete — fetchResult.usage was undefined → toolCallingLoop.ts skipped stream.usage() → response.setUsage() was never called → widget always read response.usage = undefined → ring stayed gray at 0.

Fix
[openai.ts](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/extensions/copilot/src/platform/networking/common/openai.ts) — Remove total_tokens from the isApiUsage() guard. It is always derivable and is not required by the OpenAI streaming spec.

[stream.ts](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/extensions/copilot/src/platform/networking/node/stream.ts) — Synthesize total_tokens before attaching usage to the completion, preserving the APIUsage type contract for downstream consumers (OTel telemetry, etc.).


// After — synthesize total_tokens when absent
if (usage && typeof usage.total_tokens !== 'number') {
    usage = { ...usage, total_tokens: usage.prompt_tokens + usage.completion_tokens };
}
completion.usage = usage;