### PR TITLE
agentHost/claude: add CAPI-backed local Anthropic proxy service

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostMain.ts
+++ b/src/vs/platform/agentHost/node/agentHostMain.ts
@@ -21,6 +21,7 @@ import { IAgentConfigurationService } from './agentConfigurationService.js';
 import { IAgentHostTerminalManager } from './agentHostTerminalManager.js';
 import { CopilotAgent } from './copilot/copilotAgent.js';
 import { CopilotApiService, ICopilotApiService } from './shared/copilotApiService.js';
+import { ClaudeProxyService, IClaudeProxyService } from './claude/claudeProxyService.js';
 import { ProtocolServerHandler } from './protocolServerHandler.js';
 import { WebSocketProtocolServer } from './webSocketTransport.js';
 import { INativeEnvironmentService } from '../../environment/common/environment.js';
@@ -107,6 +108,8 @@ function startAgentHost(): void {
 		diServices.set(IAgentHostGitService, gitService);
 		const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
 		diServices.set(ICopilotApiService, copilotApiService);
+		const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
+		diServices.set(IClaudeProxyService, claudeProxyService);
 		agentService = new AgentService(logService, fileService, sessionDataService, productService, gitService, rootConfigResource);
 		const pluginManager = new AgentPluginManager(URI.file(environmentService.userDataPath), fileService, logService);
 		diServices.set(IAgentPluginManager, pluginManager);

--- a/src/vs/platform/agentHost/node/claude/CONTEXT.md
+++ b/src/vs/platform/agentHost/node/claude/CONTEXT.md
@@ -1,0 +1,472 @@
+# Claude Agent (Agent Host)
+
+The Claude-side of the agent host: a `ClaudeAgent` implementation of `IAgent`
+that drives Anthropic-format tool-using sessions via the Claude Agent SDK,
+with all `messages` traffic proxied through a local server that translates
+Anthropic requests into GitHub Copilot CAPI calls.
+
+## Language
+
+**Agent Host**:
+The utility process that owns all `IAgent` providers (Copilot, Claude). Hosts
+this code.
+
+**Claude Agent**:
+The `IAgent` provider for the Claude SDK. Owns the lifecycle of the Claude
+proxy and one `Query` per session.
+_Avoid_: "Claude provider" (overloaded with `AgentProvider` ID).
+
+**Claude Proxy** / `ClaudeProxyService`:
+A local HTTP server that speaks the **Anthropic Messages API** wire format on
+the inbound side and `ICopilotApiService` on the outbound side. Registered
+as a singleton in the agent host DI container; **one proxy per agent host
+process**, shared across any Claude-family agents.
+_Avoid_: "Anthropic proxy", "language model server".
+
+**CAPI**:
+GitHub Copilot's chat completions API, accessed through `ICopilotApiService`.
+The terminal hop after the proxy.
+
+## Relationships
+
+- The **Agent Host** owns one **Claude Proxy** for the lifetime of the process.
+- The **Claude Agent** uses the **Claude Proxy** to talk to **CAPI**; the
+  proxy is injected via DI, not constructed by the agent.
+- The **Claude Proxy** translates inbound **Anthropic Messages API** requests
+  into outbound `ICopilotApiService` calls, then to **CAPI**.
+- The **Claude Agent SDK** subprocess sees the **Claude Proxy** as its
+  Anthropic API endpoint via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`.
+
+## Flagged ambiguities
+
+_None yet._
+
+## Phase 2 — `IClaudeProxyService` design log
+
+Decisions that have been grilled and locked in. Each entry is the closed
+form of a design question.
+
+### Q1 — Naming
+`IClaudeProxyService` / `ClaudeProxyService`. Files under `node/claude/`.
+
+### Q2 — Lifecycle / DI
+Registered as a DI singleton in `agentHostMain.ts` alongside
+`ICopilotApiService`. One instance per agent host process.
+
+### Q3 — API shape
+
+```ts
+interface IClaudeProxyHandle extends IDisposable {
+    readonly baseUrl: string;
+    readonly nonce: string;
+}
+
+interface IClaudeProxyService {
+    readonly _serviceBrand: undefined;
+    start(githubToken: string): Promise<IClaudeProxyHandle>;
+    dispose(): void;
+}
+```
+
+- **Refcounted**: each `start()` increments, each `handle.dispose()`
+  decrements. At refcount 0 the listener closes, the token slot clears,
+  and the nonce is destroyed. The next `start()` rebinds with a new
+  port and a fresh nonce.
+- **Shared token slot, last-writer-wins**. Single-tenant per roadmap;
+  multi-tenant is a Phase 4+ concern.
+- **Subprocess ownership**: callers that hand the handle's `baseUrl` /
+  `nonce` to a Claude SDK subprocess MUST kill that subprocess before
+  disposing the handle. The subprocess cannot outlive the handle.
+
+### Q4 — Auth
+Enforce `Authorization: Bearer <nonce>.<sessionId>` on authenticated
+routes. Parse and log `sessionId` at trace level only; treat it as
+opaque in Phase 2. `x-api-key` is ignored.
+
+Bearer enforcement runs FIRST on authenticated routes, so a bad token
+yields 401 — never 501 or 404.
+
+### Q5 — Routes
+
+| Route | Status | Notes |
+| --- | --- | --- |
+| `POST /v1/messages` | full impl | streaming + non-streaming |
+| `GET /v1/models` | net new | passthrough filtered to `vendor: 'Anthropic'` and `supported_endpoints` containing `/v1/messages`; reshaped to `Anthropic.ModelInfo`: `{ id, type: 'model', display_name, created_at: '1970-01-01T00:00:00Z', capabilities: null, max_input_tokens: null, max_tokens: null }`. (RFC3339 string instead of `0` because the SDK type forces it — settled by council C1.) |
+| `POST /v1/messages/count_tokens` | net new | returns 501 with Anthropic error envelope: `{ type: 'error', error: { type: 'api_error', message: 'count_tokens not supported by CAPI' } }` |
+| `GET /` | health | plain-text `'ok'` |
+| anything else | 404 | Anthropic error envelope |
+
+No `OPTIONS` handler — same-process consumer, CORS does not apply.
+
+### Q6 — Model ID translation
+The SDK does literal prefix matching (e.g. `id.startsWith('claude-opus-4-6')`).
+CAPI uses dotted versions (`claude-opus-4.6`), the SDK uses hyphenated
+Anthropic-canonical IDs (`claude-opus-4-6-20250929`). Translation is
+**bidirectional**.
+
+- Port `extensions/copilot/src/extension/chatSessions/claude/{common,node}/claudeModelId.ts`
+  into `node/claude/claudeModelId.ts` with a comment marking it as a
+  mirror that must be kept in sync. Lift the same test fixtures.
+- Two pure helpers exposed: `tryParseClaudeModelId(id)` returning a
+  `ParsedClaudeModelId` with `toSdkModelId()` / `toEndpointModelId()`.
+  No service, no class — the parser caches internally.
+- Three rewrite points in the proxy:
+  1. inbound `requestBody.model` (SDK → CAPI)
+  2. outbound `model` fields on streaming events and non-streaming
+     responses (CAPI → SDK), e.g. `message_start.message.model`
+  3. `GET /v1/models` response IDs (CAPI → SDK)
+- **Inbound parse failure**: 404 with Anthropic `not_found_error` —
+  before any CAPI call.
+- **Outbound parse failure**: log a warning, pass the raw value through.
+  Worse than translating, strictly better than dropping the response.
+- Model **availability fallback** ("user picked an unavailable model,
+  pick the newest Sonnet") is a Phase 4 `ClaudeAgent` concern. The
+  proxy stays dumb.
+
+### Q7 — Anthropic-beta + header passthrough
+
+- Lift `filterSupportedBetas()` and the three-entry `SUPPORTED_ANTHROPIC_BETAS`
+  allowlist (`interleaved-thinking`, `context-management`, `advanced-tool-use`)
+  into `node/claude/anthropicBetas.ts` with a "keep in sync" comment.
+  Allowlist match is prefix + `-` (date-suffix discipline). Lift the
+  same 7 test fixtures.
+- Applied at `POST /v1/messages` after auth, before model translation.
+  If the filtered result is a non-empty string, set it on the outbound
+  `ICopilotApiServiceRequestOptions.headers['anthropic-beta']`. If
+  `undefined`, omit the header entirely — never forward `''`.
+- Inbound header passthrough is restricted to `anthropic-version`
+  (verbatim) and `anthropic-beta` (filtered). All other client headers
+  are dropped, including `x-request-id` / `request-id` — CAPI generates
+  its own.
+- The proxy ignores `request.metadata` and any SDK-side `betas` field;
+  only the `anthropic-beta` header drives behavior.
+
+### Q8 — Streaming: framing, backpressure, mid-stream errors
+
+The reference (`extensions/copilot/.../claudeLanguageModelServer.ts`) is a
+**byte-passthrough** — it pipes raw upstream SSE chunks straight to the
+client. Our proxy can't do that: `ICopilotApiService.messages()` returns
+`AsyncGenerator<Anthropic.MessageStreamEvent>` (already-parsed event
+objects), so we MUST construct SSE frames ourselves.
+
+**Framing.** Hand-rolled, per event:
+
+```
+event: <event.type>\ndata: <JSON.stringify(event)>\n\n
+```
+
+Response headers, set once before the first event:
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+
+After `writeHead(200, …)` call `res.flushHeaders()` so the SDK gets
+status + content-type before the first event, and
+`req.socket.setNoDelay(true)` so small frames aren't held by Nagle.
+
+**Event mutation.** 1:1 passthrough with one surgical rewrite — the
+`model` field on `message_start.message.model` (Q6 outbound CAPI→SDK).
+No `[DONE]` line (Anthropic ends with `message_stop`, not OpenAI's
+sentinel). No synthesized `ping` events. No event reordering.
+
+**Backpressure.** The reference does NOT handle this and we treat that
+as a bug, not a guideline. When `res.write()` returns `false`,
+`await once(res, 'drain')` before pulling the next event from the
+generator. This naturally backpressures the upstream.
+
+**Mid-stream errors.** The reference's `catch` tries to `writeHead(500)`
+after streaming has started, which throws — its mid-stream error
+handling is silently broken. We emit an Anthropic-shaped SSE error
+frame and end:
+
+```
+event: error
+data: { "type": "error", "error": { "type": "api_error", "message": "..." } }
+```
+
+Then `res.end()`. Do not emit `message_stop` after `error` — `error` is
+terminal in the Anthropic SDK.
+
+**Non-streaming branch.** When `request.stream !== true`:
+- `Content-Type: application/json`
+- Single body: `JSON.stringify(message)` where `message` is the
+  `Anthropic.Message` returned by the non-streaming
+  `ICopilotApiService.messages()` overload, with the `model` field
+  rewritten to SDK format.
+- The reference forces `stream: true` upstream and SSE-frames everything
+  — we explicitly do NOT do this. Honor `request.stream`.
+
+### Q9 — Abort / disconnect propagation
+
+One `AbortController` per inbound request, plumbed through to
+`ICopilotApiServiceRequestOptions.signal`.
+
+```ts
+const ac = new AbortController();
+res.on('close', () => ac.abort());
+
+try {
+    const stream = copilotApi.messages(body, { signal: ac.signal, headers });
+    for await (const event of stream) { /* emit */ }
+} catch (err) {
+    if (ac.signal.aborted) { return; } // client gone — silent
+    // else: emit Anthropic SSE error frame (Q8)
+}
+```
+
+- **Single trigger**: `res.on('close')`. The reference also uses this;
+  `req.on('close')` and `req.on('aborted')` are redundant.
+- **No polling**. Pass `signal` to `ICopilotApiService.messages()`; the
+  generator rejects with `AbortError` on the next iteration. The for-await
+  unwinds naturally.
+- **No error frame on client-disconnect**. Writing to a closed socket
+  either silently drops or throws `ERR_STREAM_WRITE_AFTER_END`. On
+  caught error, check `signal.aborted` and `return` without writing.
+- **Non-streaming branch**: same pattern. The awaited
+  `ICopilotApiService.messages()` rejects with `AbortError`; we `return`
+  without writing a body.
+- **`dispose()` aborts in-flight**. The service holds a
+  `Set<AbortController>` (added on request entry, removed in `finally`).
+  On refcount→0 dispose: abort all controllers, then `server.close()`,
+  then clear the token slot and destroy the nonce.
+
+### Q10 — Error envelopes
+
+Two distinct flows. Don't conflate.
+
+**Proxy-authored errors.** No upstream response exists, so we construct
+the Anthropic envelope ourselves via one helper:
+
+```ts
+function writeJsonError(res, status, type, message) {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type, message } }));
+}
+```
+
+Status + `error.type` per case:
+
+| Case | Status | `error.type` |
+| --- | --- | --- |
+| Missing/malformed `Authorization` | 401 | `authentication_error` |
+| Bearer nonce mismatch | 401 | `authentication_error` |
+| Bearer with no `.sessionId` | 401 | `authentication_error` |
+| Unknown route | 404 | `not_found_error` |
+| Bad JSON body | 400 | `invalid_request_error` |
+| Missing required field (`model`, `messages`) | 400 | `invalid_request_error` |
+| Model parse failure (Q6 inbound) | 404 | `not_found_error` |
+| `POST /v1/messages/count_tokens` | 501 | `api_error` |
+
+**CAPI errors — passthrough, not mapping.** CAPI already speaks
+Anthropic wire format. The `@anthropic-ai/sdk` parses non-2xx into
+`Anthropic.APIError` with `err.status` + `err.error` (the parsed
+envelope, verbatim). We just re-serialize:
+
+```ts
+catch (err) {
+    if (err instanceof Anthropic.APIError && err.error) {
+        res.writeHead(err.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(err.error));
+        return;
+    }
+    // network / non-APIError — synthesize
+    writeJsonError(res, 502, 'api_error', err.message ?? 'Upstream error');
+}
+```
+
+No `instanceof` ladder per `APIError` subclass. No mapping table. No
+`err.message` sanitization — passthrough.
+
+**Mid-stream variant.** Same idea, SSE frame instead of JSON body:
+
+```ts
+res.write(`event: error\ndata: ${JSON.stringify(err.error ?? fallback)}\n\n`);
+res.end();
+```
+
+Status is ignored once headers are sent (Q8). On `signal.aborted`,
+write nothing — client is gone (Q9).
+
+### Q11 — File layout (as shipped)
+
+```
+node/claude/
+├── claudeProxyService.ts   # interface + impl + lifecycle + server + dispatch + route handlers
+├── claudeModelId.ts        # parser (Q6) — mirror of extension copy
+├── anthropicBetas.ts       # filterSupportedBetas + allowlist (Q7)
+├── anthropicErrors.ts      # buildErrorEnvelope, writeJsonError, writeUpstreamJsonError, formatSseErrorFrame (Q10)
+└── claudeProxyAuth.ts      # parseProxyBearer (Q4)
+
+test/node/
+├── claudeModelId.test.ts
+├── anthropicBetas.test.ts
+├── claudeProxyAuth.test.ts
+└── claudeProxyService.test.ts
+```
+
+- **Pure helpers** (`claudeModelId`, `anthropicBetas`, `anthropicErrors`,
+  `claudeProxyAuth`) are platform-free pure functions, testable in
+  isolation.
+- **Route handlers live inside `ClaudeProxyService`.** The original plan
+  split them into separate `claudeProxyMessages.ts` /
+  `claudeProxyModels.ts` classes; we collapsed them into private methods
+  (`_handleModels`, `_handleMessages`, `_sendNonStreamingMessage`,
+  `_streamMessages`) on `ClaudeProxyService` because they share the
+  per-request bookkeeping (`IInFlight`, the `runtime` token slot, the
+  abort plumbing). Splitting them would require passing the same five
+  arguments around; keeping them inline kept the file under 800 lines
+  and avoided redundant injection.
+- **`claudeProxyService.ts`** owns the `IClaudeProxyService` interface,
+  the impl, `IClaudeProxyHandle`, refcounted lifecycle, the
+  `http.createServer()`, the top-level dispatch switch on
+  `url.pathname`, the `Set<IInFlight>` of in-flight requests, and all
+  route handlers.
+- **Interface lives next to impl.** No `common/` split for Phase 2 —
+  both consumers (`agentHostMain.ts`, future `ClaudeAgent`) are in
+  `node`. Promote later if a second platform consumer appears.
+
+### Q12 — Acceptance criteria
+
+Phase 2 is "done" when all of the following pass:
+
+**Hygiene (must run frequently during development, not as a final step):**
+- [ ] `compile-check-ts-native` clean
+- [ ] `eslint` clean
+- [ ] `valid-layers-check` clean
+- [ ] Hygiene check (gulp `hygiene`) clean — copyright headers, tabs,
+      string quoting, formatting
+
+**Lifecycle (Q2/Q3):**
+- [ ] `start(token)` returns a handle with `baseUrl` (e.g.
+  `http://127.0.0.1:54321`) and a 256-bit hex `nonce`
+- [ ] Two concurrent `start()` calls share one server, share the latest
+  token, return handles with the same `baseUrl` and `nonce`
+- [ ] Disposing one handle while the other is alive: server stays up,
+  in-flight requests on the other handle continue
+- [ ] Disposing the last handle: `server.close()` runs, in-flight
+  controllers abort, port is freed
+- [ ] `start()` after refcount-0 dispose binds a new port and a fresh
+  nonce
+
+**Bind safety:** server binds only to `127.0.0.1`, not `0.0.0.0`.
+
+**Auth (Q4):** missing / wrong nonce / no `.sessionId` / `x-api-key`
+alone all → 401; `Bearer <nonce>.<sessionId>` proceeds.
+
+**Routes (Q5):**
+- [ ] `GET /` → 200 `'ok'`, no auth required
+- [ ] `GET /v1/models` (authed) → 200 with Anthropic-shaped model
+  objects, IDs in SDK format (Q6 outbound)
+- [ ] `POST /v1/messages/count_tokens` (authed) → 501 `api_error`
+- [ ] `GET /something-else` (authed) → 404 `not_found_error`
+
+**Model translation (Q6):** SDK ID inbound translates to CAPI; CAPI ID
+inbound also works; unparseable → 404 with no CAPI call;
+`message_start.message.model` and non-streaming `message.model`
+rewritten to SDK format on the way out; `/v1/models` IDs in SDK format.
+
+**Beta filtering (Q7):** date-suffixed allowlist members forwarded;
+non-allowlist dropped; empty result → header omitted.
+
+**Header passthrough (Q7):** `anthropic-version` forwarded verbatim;
+all others (including `x-request-id`) dropped.
+
+**Streaming (Q8):** `stream:true` → SSE with hand-rolled
+`event:/data:` framing in CAPI's emitted order; `stream:false` → JSON
+body; tool-use and thinking deltas reach the client; no `[DONE]`;
+`socket.setNoDelay(true)`.
+
+**Abort (Q9):** mid-stream client disconnect aborts upstream;
+mid-stream `dispose()` aborts all; non-streaming disconnect writes no
+body.
+
+**Errors (Q10):** proxy-authored errors emit the Q10 envelope;
+`Anthropic.APIError` re-emitted verbatim; non-`APIError` → 502
+`api_error`; mid-stream errors become SSE `event: error` frames.
+
+### Q13 — Testing strategy
+
+Three surfaces.
+
+**Surface 1 — pure-helper unit tests** (zero deps, fast,
+deterministic):
+
+```
+src/vs/platform/agentHost/test/node/
+├── claudeModelId.test.ts        # port extension fixtures, bidirectional
+├── anthropicBetas.test.ts       # port the 7 reference fixtures
+├── claudeProxyAuth.test.ts      # auth matrix
+└── claudeProxyService.test.ts   # see Surface 2
+```
+
+**Surface 2 — service-level tests** with a single mock
+(`FakeCopilotApiService`); everything else (real `http.Server`, real
+`AbortController`, real parser, real filter) is real. Per the codebase
+guideline: minimal mocking, mock only true I/O boundaries.
+
+```ts
+class FakeCopilotApiService implements ICopilotApiService {
+    nextMessagesResult: Anthropic.Message
+        | AsyncGenerator<Anthropic.MessageStreamEvent>
+        | Anthropic.APIError;
+    lastCall: { body: Anthropic.MessageCreateParams; options: ICopilotApiServiceRequestOptions };
+    messages(body, options): ...
+    models(): ...
+    countTokens(): ...
+}
+```
+
+Cases: lifecycle / refcount / port / dispose; auth fixtures end-to-end
+through real HTTP; route status matrix; model translation roundtrip;
+beta filter forwarded correctly to mock; streaming order + framing;
+non-streaming JSON body shape; mid-stream abort propagates
+`signal.aborted` to mock; mid-stream `APIError` becomes SSE error
+frame; pre-stream `APIError` becomes JSON error; disconnect aborts
+upstream.
+
+**Surface 3 — real-CAPI smoke (Phase 2, not deferred).**
+
+Procedure (manual, run at the end of Phase 2 implementation):
+
+1. Temporarily modify the existing `CopilotAgent` (or wherever the
+   agent host first authenticates) to call
+   `claudeProxyService.start(token)` once a real GitHub token is
+   minted, and log the resulting `baseUrl` and `nonce` at info level.
+2. Launch the dev build (`./scripts/code.sh --agents` or
+   `Run Dev Agents`) and authenticate.
+3. Use the **code-oss-logs** skill to read `agenthost.log` from the
+   most recent run; grep for the proxy line; extract `baseUrl` +
+   `nonce`.
+4. From a separate terminal:
+   ```bash
+   curl -H "Authorization: Bearer ${NONCE}.smoke-test" \
+        "${BASE_URL}/v1/models"
+   curl -H "Authorization: Bearer ${NONCE}.smoke-test" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-version: 2023-06-01" \
+        --data '{"model":"claude-opus-4-6-20250929","messages":[{"role":"user","content":"say hi"}],"max_tokens":64}' \
+        "${BASE_URL}/v1/messages"
+   ```
+5. Verify: 200; SDK-format model IDs in `/v1/models`; non-streaming
+   `Anthropic.Message` shape with `model` rewritten to SDK format.
+6. Repeat with `"stream": true` and `--no-buffer`; verify SSE frames.
+7. Revert the temporary `CopilotAgent` change.
+
+This validates real CAPI without waiting for Phase 4's `ClaudeAgent`.
+
+**What we explicitly do NOT test in Phase 2:** real Claude Agent SDK
+subprocess (Phase 4), multi-tenant token isolation (Phase 4+), proxy
+/ PAC support (deferred — see "Deferred for later phases").
+
+## Deferred for later phases
+
+Captured here so they aren't lost. None of these block Phase 2.
+
+- **HTTP proxy support** (`HTTP_PROXY` / `HTTPS_PROXY` env vars, VS Code's
+  `http.proxy` setting, PAC files, proxy auth). The Phase 2 proxy talks
+  to CAPI through `ICopilotApiService`, so any outbound proxying is
+  inherited from whatever HTTP client that service uses. If the agent
+  host needs to honor user proxy configuration we'll need an explicit
+  agent / dispatcher injection point on `ICopilotApiService` and a way
+  to source the config from the renderer. Track separately when we
+  pick this up.

--- a/src/vs/platform/agentHost/node/claude/anthropicBetas.ts
+++ b/src/vs/platform/agentHost/node/claude/anthropicBetas.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Mirror of {@link
+ * file://./../../../../../extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts
+ * `extensions/copilot/.../claudeLanguageModelServer.ts`}'s `filterSupportedBetas`
+ * + `SUPPORTED_ANTHROPIC_BETAS` allowlist.
+ *
+ * **Keep in sync with the extension copy.** When CAPI gains support for
+ * a new Anthropic beta, add it here. The filter is applied at the
+ * inbound `POST /v1/messages` boundary on the `anthropic-beta` header
+ * before forwarding to {@link ICopilotApiService.messages}.
+ */
+
+/**
+ * Beta identifiers (without date suffix) that CAPI is known to honor.
+ * The match is prefix + `-`, so an entry like `'context-management'`
+ * accepts `'context-management-2025-06-27'` but rejects
+ * `'context-management'` (no date) — date-suffix discipline.
+ */
+const SUPPORTED_ANTHROPIC_BETAS: readonly string[] = [
+	'interleaved-thinking',
+	'context-management',
+	'advanced-tool-use',
+];
+
+/**
+ * Filters a comma-separated `anthropic-beta` header value to only include
+ * betas that match {@link SUPPORTED_ANTHROPIC_BETAS}. Entries are matched by
+ * prefix so that e.g. `'context-management'` allows `'context-management-2025-06-27'`.
+ *
+ * Returns the filtered comma-separated string, or `undefined` if no betas matched.
+ * Callers must omit the outbound header entirely when this returns `undefined`
+ * — never forward an empty string.
+ */
+export function filterSupportedBetas(headerValue: string): string | undefined {
+	const filtered = headerValue
+		.split(',')
+		.map(b => b.trim())
+		.filter(b => b && SUPPORTED_ANTHROPIC_BETAS.some(supported => b.startsWith(supported + '-')));
+
+	return filtered.length > 0 ? filtered.join(',') : undefined;
+}

--- a/src/vs/platform/agentHost/node/claude/anthropicErrors.ts
+++ b/src/vs/platform/agentHost/node/claude/anthropicErrors.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type * as http from 'http';
+
+/**
+ * Anthropic-error helpers shared by the proxy. Two shapes:
+ *
+ * - **Proxy-authored errors**: synthesized by the proxy when no upstream
+ *   response exists (auth failure, bad route, malformed body, model
+ *   parse failure, `count_tokens`). Sent as a JSON body or an SSE error
+ *   frame.
+ * - **CAPI errors** (passthrough): a `CopilotApiError` already carries
+ *   the upstream `Anthropic.ErrorResponse`. The proxy re-emits it
+ *   verbatim — see `claudeProxyService.ts` for that branch.
+ */
+
+/**
+ * Build a synthetic Anthropic error envelope. `request_id` is `null`
+ * because the proxy authored this error itself (no upstream request was
+ * made, or the upstream request didn't supply one).
+ */
+export function buildErrorEnvelope(type: Anthropic.ErrorType, message: string): Anthropic.ErrorResponse {
+	return {
+		type: 'error',
+		error: { type, message },
+		request_id: null,
+	};
+}
+
+/**
+ * Send a proxy-authored JSON error response. Caller must NOT have
+ * written headers or body yet.
+ */
+export function writeJsonError(
+	res: http.ServerResponse,
+	status: number,
+	type: Anthropic.ErrorType,
+	message: string,
+): void {
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(buildErrorEnvelope(type, message)));
+}
+
+/**
+ * Send an upstream {@link Anthropic.ErrorResponse} verbatim with the
+ * supplied HTTP status. Used by the CAPI passthrough branch in
+ * `claudeProxyService` so any extra fields on the upstream envelope
+ * (e.g. `request_id`) propagate to the SDK unchanged.
+ */
+export function writeUpstreamJsonError(
+	res: http.ServerResponse,
+	status: number,
+	envelope: Anthropic.ErrorResponse,
+): void {
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(envelope));
+}
+
+/**
+ * Encode a single SSE frame for an Anthropic streaming error. Used after
+ * `writeHead(200)` has already been called (so we can no longer change
+ * the HTTP status). Caller should `res.end()` after writing this frame
+ * — the Anthropic SDK treats `event: error` as terminal.
+ */
+export function formatSseErrorFrame(envelope: Anthropic.ErrorResponse): string {
+	return `event: error\ndata: ${JSON.stringify(envelope)}\n\n`;
+}

--- a/src/vs/platform/agentHost/node/claude/claudeModelId.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeModelId.ts
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Mirror of `extensions/copilot/src/extension/chatSessions/claude/{common,node}/claudeModelId.ts`.
+ *
+ * The Claude Agent SDK speaks Anthropic-canonical hyphenated model IDs
+ * (e.g. `claude-opus-4-6-20251101`). CAPI speaks dotted endpoint IDs
+ * (`claude-opus-4.6`). The Phase 2 proxy needs bidirectional translation
+ * at three points: inbound `requestBody.model` (SDK→CAPI), outbound
+ * `model` fields on streaming events / non-streaming responses (CAPI→SDK),
+ * and `GET /v1/models` response IDs (CAPI→SDK).
+ *
+ * **Keep in sync with the extension copy.** When the model-ID grammar
+ * changes (new family name, new modifier suffix), update both files.
+ */
+
+export interface ParsedClaudeModelId {
+	readonly name: string;
+	readonly version: string;
+	readonly modifiers: string;
+	toSdkModelId(): string;
+	toEndpointModelId(): string;
+}
+
+/**
+ * Known model suffixes that are meaningful variants and should be preserved
+ * in SDK/endpoint model IDs. Mapped per model family. Date-based suffixes
+ * (e.g. 20251101) are intentionally excluded — they are build identifiers
+ * that should not appear in the normalized output.
+ */
+const VALID_SUFFIXES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+	['opus', new Set(['1m'])],
+]);
+
+const cache = new Map<string, ParsedClaudeModelId | undefined>();
+
+/**
+ * Parses a Claude model ID string (SDK or endpoint format) into its components.
+ * Throws if the model ID is unparseable or not a Claude ID.
+ *
+ * Use {@link tryParseClaudeModelId} when the input may not be a valid Claude model ID
+ * (e.g. model IDs from disk or external sources).
+ */
+export function parseClaudeModelId(modelId: string): ParsedClaudeModelId {
+	const result = tryParseClaudeModelId(modelId);
+	if (!result) {
+		throw new Error(`Unable to parse Claude model ID: '${modelId}'`);
+	}
+	return result;
+}
+
+/**
+ * Attempts to parse a Claude model ID string (SDK or endpoint format) into its components.
+ *
+ * Accepts either format:
+ * - SDK: `claude-opus-4-5-20251101`, `claude-3-5-sonnet-20241022`, `claude-sonnet-4-20250514`
+ * - Endpoint: `claude-opus-4.5`, `claude-sonnet-4`, `claude-haiku-3.5`
+ *
+ * Returns `undefined` for unparseable or non-Claude IDs.
+ */
+export function tryParseClaudeModelId(modelId: string): ParsedClaudeModelId | undefined {
+	const cacheKey = modelId.toLowerCase();
+	if (cache.has(cacheKey)) {
+		return cache.get(cacheKey);
+	}
+
+	const result = doParse(cacheKey);
+	cache.set(cacheKey, result);
+	return result;
+}
+
+const DATE_SUFFIX_RE = /^(?<base>.*)-(?<date>\d{8})$/;
+
+function doParse(lower: string): ParsedClaudeModelId | undefined {
+	let dateSuffix = '';
+	let base = lower;
+
+	const dateMatch = DATE_SUFFIX_RE.exec(lower);
+	if (dateMatch?.groups) {
+		base = dateMatch.groups.base;
+		dateSuffix = dateMatch.groups.date;
+	}
+
+	// Pattern 1: claude-{name}-{major}-{minor}[-{mod}] (e.g. claude-opus-4-5, claude-opus-4-6-1m)
+	const p1 = base.match(/^claude-(?<name>\w+)-(?<major>\d+)-(?<minor>\d+)(?:-(?<mod>.+))?$/);
+	if (p1?.groups) {
+		return makeResult(p1.groups.name, p1.groups.major, p1.groups.minor, joinModifiers(p1.groups.mod, dateSuffix));
+	}
+
+	// Pattern 2: claude-{major}-{minor}-{name}[-{mod}] (e.g. claude-3-5-sonnet)
+	const p2 = base.match(/^claude-(?<major>\d+)-(?<minor>\d+)-(?<name>\w+)(?:-(?<mod>.+))?$/);
+	if (p2?.groups) {
+		return makeResult(p2.groups.name, p2.groups.major, p2.groups.minor, joinModifiers(p2.groups.mod, dateSuffix));
+	}
+
+	// Pattern 3: claude-{name}-{major}.{minor}[-{mod}] (e.g. claude-opus-4.5, claude-opus-4.6-1m)
+	const p3 = base.match(/^claude-(?<name>\w+)-(?<major>\d+)\.(?<minor>\d+)(?:-(?<mod>.+))?$/);
+	if (p3?.groups) {
+		return makeResult(p3.groups.name, p3.groups.major, p3.groups.minor, joinModifiers(p3.groups.mod, dateSuffix));
+	}
+
+	// Pattern 4: claude-{name}-{major}[-{mod}] (e.g. claude-sonnet-4, claude-sonnet-4-1m)
+	const p4 = base.match(/^claude-(?<name>\w+)-(?<major>\d+)(?:-(?<mod>.+))?$/);
+	if (p4?.groups) {
+		return makeResult(p4.groups.name, p4.groups.major, undefined, joinModifiers(p4.groups.mod, dateSuffix));
+	}
+
+	// Pattern 5: claude-{major}-{name}[-{mod}] (e.g. claude-3-opus)
+	const p5 = base.match(/^claude-(?<major>\d+)-(?<name>\w+)(?:-(?<mod>.+))?$/);
+	if (p5?.groups) {
+		return makeResult(p5.groups.name, p5.groups.major, undefined, joinModifiers(p5.groups.mod, dateSuffix));
+	}
+
+	// Pattern 6: bare model name with no version (e.g. nectarine)
+	const p6 = base.match(/^(?<name>\w+)$/);
+	if (p6?.groups) {
+		return makeBareResult(p6.groups.name);
+	}
+
+	return undefined;
+}
+
+function joinModifiers(mod: string | undefined, dateSuffix: string): string {
+	if (mod && dateSuffix) {
+		return `${mod}-${dateSuffix}`;
+	}
+	return mod || dateSuffix;
+}
+
+function formatModelId(name: string, major: string, minor: string | undefined, versionSep: string, validSuffix: string): string {
+	const base = minor !== undefined
+		? `claude-${name}-${major}${versionSep}${minor}`
+		: `claude-${name}-${major}`;
+	return validSuffix ? `${base}-${validSuffix}` : base;
+}
+
+function makeBareResult(name: string): ParsedClaudeModelId {
+	return {
+		name,
+		version: '',
+		modifiers: '',
+		toSdkModelId: () => name,
+		toEndpointModelId: () => name,
+	};
+}
+
+function makeResult(name: string, major: string, minor: string | undefined, modifiers: string): ParsedClaudeModelId {
+	const version = minor !== undefined ? `${major}.${minor}` : major;
+	const validSuffix = extractValidSuffix(name, modifiers);
+	return {
+		name,
+		version,
+		modifiers,
+		toSdkModelId: () => formatModelId(name, major, minor, '-', validSuffix),
+		toEndpointModelId: () => formatModelId(name, major, minor, '.', validSuffix),
+	};
+}
+
+/**
+ * Extracts the valid suffix portion from modifiers for a given model family.
+ * For example, given modifiers '1m-20251101' and family 'opus', returns '1m'.
+ * Returns an empty string if no valid suffix is found.
+ */
+function extractValidSuffix(name: string, modifiers: string): string {
+	if (!modifiers) {
+		return '';
+	}
+	const allowedSuffixes = VALID_SUFFIXES.get(name);
+	if (!allowedSuffixes) {
+		return '';
+	}
+	// Check the full modifier string first (e.g. '1m')
+	if (allowedSuffixes.has(modifiers)) {
+		return modifiers;
+	}
+	// Check the first segment of compound modifiers (e.g. '1m' from '1m-20251101')
+	const firstSegment = modifiers.split('-')[0];
+	if (allowedSuffixes.has(firstSegment)) {
+		return firstSegment;
+	}
+	return '';
+}

--- a/src/vs/platform/agentHost/node/claude/claudeProxyAuth.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyAuth.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as http from 'http';
+
+/**
+ * Result of {@link parseProxyBearer}. `valid` is `true` only when the
+ * `Authorization` header contains `Bearer <expectedNonce>.<sessionId>`
+ * with a non-empty `sessionId`.
+ *
+ * Phase 2 deliberately does NOT accept the legacy `Bearer <nonce>` (no
+ * dot) format that the Copilot extension's `extractSessionId` accepts —
+ * the agent host always issues full `nonce.sessionId` tokens.
+ */
+export interface ProxyBearerAuth {
+	readonly valid: boolean;
+	readonly sessionId: string | undefined;
+}
+
+const INVALID: ProxyBearerAuth = Object.freeze({ valid: false, sessionId: undefined });
+
+/**
+ * Parses + validates the inbound Bearer token on Claude proxy requests.
+ *
+ * Accepts only `Authorization: Bearer <nonce>.<sessionId>` where the
+ * leading nonce equals `expectedNonce` and `sessionId` is non-empty.
+ * The `x-api-key` header is ignored to prevent a user's
+ * `ANTHROPIC_API_KEY` env var from interfering with proxy auth.
+ *
+ * Rejects (returns `{ valid: false, sessionId: undefined }`):
+ * - missing or non-`Bearer` `Authorization`
+ * - `Bearer <nonce>` (no dot)
+ * - `Bearer <nonce>.` (empty sessionId)
+ * - `Bearer <wrong-nonce>.<sessionId>`
+ */
+export function parseProxyBearer(headers: http.IncomingHttpHeaders, expectedNonce: string): ProxyBearerAuth {
+	const authHeader = headers['authorization'];
+	if (typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
+		return INVALID;
+	}
+
+	const token = authHeader.slice('Bearer '.length);
+	const dotIndex = token.indexOf('.');
+	if (dotIndex === -1) {
+		// Phase 2 explicitly rejects the legacy nonce-only format.
+		return INVALID;
+	}
+
+	const nonce = token.slice(0, dotIndex);
+	const sessionId = token.slice(dotIndex + 1);
+	if (nonce !== expectedNonce || sessionId.length === 0) {
+		return INVALID;
+	}
+
+	return { valid: true, sessionId };
+}

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -260,24 +260,7 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		const nonce = generateNonce();
 		const inFlight = new Set<IInFlight>();
 		const httpModule = await import('http');
-		const server = httpModule.createServer((req, res) => {
-			this._handleRequest(req, res, runtime).catch(err => {
-				// Last-resort safety net. All known throw paths are
-				// already handled inside `_handleRequest`.
-				this._logService.error(`[${PROXY_USER_FACING_NAME}] unhandled request error: ${stringifyError(err)}`);
-				if (!res.headersSent) {
-					try {
-						writeJsonError(res, 500, 'api_error', 'Internal proxy error');
-					} catch {
-						// nothing else we can do
-					}
-				} else if (!res.writableEnded) {
-					try {
-						res.end();
-					} catch { /* ignore */ }
-				}
-			});
-		});
+		const server = httpModule.createServer();
 
 		await new Promise<void>((resolve, reject) => {
 			const onError = (err: Error) => { reject(err); };
@@ -296,8 +279,6 @@ export class ClaudeProxyService implements IClaudeProxyService {
 		const baseUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
 		this._logService.info(`[${PROXY_USER_FACING_NAME}] listening on ${baseUrl}`);
 
-		// Bound below so the `createServer` callback can reference the
-		// runtime via closure even though it's constructed afterwards.
 		const runtime: IProxyRuntime = {
 			server,
 			baseUrl,
@@ -306,6 +287,31 @@ export class ClaudeProxyService implements IClaudeProxyService {
 			githubToken,
 			refcount: 0,
 		};
+
+		// Attach the request handler only after `runtime` is fully
+		// built. Node's single-threaded event loop guarantees no
+		// `request` event can be parsed and dispatched between
+		// `listen` resolving and this synchronous registration, so
+		// the handler can safely close over `runtime` as a `const`.
+		server.on('request', (req, res) => {
+			this._handleRequest(req, res, runtime).catch(err => {
+				// Last-resort safety net. All known throw paths are
+				// already handled inside `_handleRequest`.
+				this._logService.error(`[${PROXY_USER_FACING_NAME}] unhandled request error: ${stringifyError(err)}`);
+				if (!res.headersSent) {
+					try {
+						writeJsonError(res, 500, 'api_error', 'Internal proxy error');
+					} catch {
+						// nothing else we can do
+					}
+				} else if (!res.writableEnded) {
+					try {
+						res.end();
+					} catch { /* ignore */ }
+				}
+			});
+		});
+
 		return runtime;
 	}
 

--- a/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeProxyService.ts
@@ -1,0 +1,755 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CCAModel } from '@vscode/copilot-api';
+import type * as http from 'http';
+import { once } from 'events';
+import { AddressInfo } from 'net';
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { createDecorator } from '../../../instantiation/common/instantiation.js';
+import { ILogService } from '../../../log/common/log.js';
+import {
+	COPILOT_API_ERROR_STATUS_STREAMING,
+	CopilotApiError,
+	ICopilotApiService,
+	type ICopilotApiServiceRequestOptions,
+} from '../shared/copilotApiService.js';
+import { filterSupportedBetas } from './anthropicBetas.js';
+import {
+	buildErrorEnvelope,
+	formatSseErrorFrame,
+	writeJsonError,
+	writeUpstreamJsonError,
+} from './anthropicErrors.js';
+import { tryParseClaudeModelId } from './claudeModelId.js';
+import { parseProxyBearer } from './claudeProxyAuth.js';
+
+// #region Public types
+
+/**
+ * Handle returned by {@link IClaudeProxyService.start}. Refcounts the
+ * underlying server: when every handle is disposed, the listener closes,
+ * the token slot clears, and the nonce is destroyed. The next `start()`
+ * call rebinds with a new port and a fresh nonce.
+ *
+ * **Subprocess ownership invariant.** Callers that hand `baseUrl` /
+ * `nonce` to a Claude SDK subprocess MUST kill that subprocess before
+ * calling `dispose()`. The subprocess cannot outlive the handle —
+ * after `dispose()` the proxy may rebind on a different port and the
+ * subprocess would silently lose its endpoint.
+ */
+export interface IClaudeProxyHandle extends IDisposable {
+	/** e.g. `http://127.0.0.1:54321` — no trailing slash. */
+	readonly baseUrl: string;
+	/** 256-bit hex string. Combine with a session id as `Bearer <nonce>.<sessionId>`. */
+	readonly nonce: string;
+}
+
+export interface IClaudeProxyService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Start the proxy (if not already running) and return a refcounted
+	 * handle. The supplied `githubToken` becomes the active token for
+	 * outbound CAPI requests; if multiple callers hold handles
+	 * concurrently, the most recent token wins (single-tenant assumption,
+	 * see roadmap section 6).
+	 */
+	start(githubToken: string): Promise<IClaudeProxyHandle>;
+
+	/**
+	 * Force-close the proxy regardless of refcount and abort any
+	 * in-flight requests. Idempotent. Subsequent `start()` calls rebind.
+	 */
+	dispose(): void;
+}
+
+export const IClaudeProxyService = createDecorator<IClaudeProxyService>('claudeProxyService');
+
+// #endregion
+
+// #region Internal state
+
+/**
+ * Per-request bookkeeping. `clientGone` distinguishes a client-driven
+ * disconnect (socket already closed — write nothing) from a service-
+ * driven `dispose()` (socket still open — `res.destroy()` to unblock
+ * the client) when the abort signal fires.
+ */
+interface IInFlight {
+	readonly ac: AbortController;
+	readonly res: http.ServerResponse;
+	clientGone: boolean;
+}
+
+/**
+ * Process-wide proxy state. Created lazily on first `start()` and torn
+ * down when refcount → 0 (or `dispose()` is called explicitly).
+ */
+interface IProxyRuntime {
+	readonly server: http.Server;
+	readonly baseUrl: string;
+	readonly nonce: string;
+	readonly inFlight: Set<IInFlight>;
+	githubToken: string;
+	refcount: number;
+}
+
+// #endregion
+
+// #region Implementation
+
+const KNOWN_CLAUDE_VENDORS = new Set(['anthropic']);
+const ANTHROPIC_MESSAGES_ENDPOINT = '/v1/messages';
+const PROXY_USER_FACING_NAME = 'ClaudeProxyService';
+
+/**
+ * Build the 256-bit hex nonce embedded in the `Bearer <nonce>.<sessionId>`
+ * token. Web Crypto is available in Node 18+ (used elsewhere in this
+ * folder via `generateUuid`).
+ */
+function generateNonce(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	let out = '';
+	for (let i = 0; i < bytes.length; i++) {
+		out += bytes[i].toString(16).padStart(2, '0');
+	}
+	return out;
+}
+
+/**
+ * Local HTTP proxy that speaks the Anthropic Messages API on the inbound
+ * side and {@link ICopilotApiService} on the outbound side. The Claude
+ * Agent SDK connects via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`
+ * and sees this as a real Anthropic endpoint.
+ *
+ * Lifecycle is refcounted via {@link IClaudeProxyHandle}; see
+ * {@link IClaudeProxyService.start} and the subprocess-ownership
+ * invariant on `IClaudeProxyHandle`.
+ */
+export class ClaudeProxyService implements IClaudeProxyService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private _runtime: IProxyRuntime | undefined;
+	private _starting: Promise<IProxyRuntime> | undefined;
+	private _disposed = false;
+
+	constructor(
+		@ILogService private readonly _logService: ILogService,
+		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
+	) { }
+
+	async start(githubToken: string): Promise<IClaudeProxyHandle> {
+		if (this._disposed) {
+			throw new Error('ClaudeProxyService has been disposed');
+		}
+
+		const runtime = await this._ensureRuntime(githubToken);
+		// Re-check after the await: dispose() may have run while
+		// _ensureRuntime was awaiting the bind, in which case the
+		// runtime we received is already torn down (see
+		// _ensureRuntime) — but a fresh start() in between is also
+		// possible, so verify the active runtime hasn't moved.
+		if (this._disposed || this._runtime !== runtime) {
+			throw new Error('ClaudeProxyService has been disposed');
+		}
+		// Late-binding token update covers the case where multiple
+		// concurrent callers awaited the same _ensureRuntime — last
+		// caller's token wins, matching the single-tenant contract.
+		runtime.githubToken = githubToken;
+		runtime.refcount++;
+
+		let disposed = false;
+		const handle: IClaudeProxyHandle = {
+			baseUrl: runtime.baseUrl,
+			nonce: runtime.nonce,
+			dispose: () => {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				this._releaseHandle(runtime);
+			},
+		};
+		return handle;
+	}
+
+	dispose(): void {
+		if (this._disposed) {
+			return;
+		}
+		this._disposed = true;
+		this._teardownRuntime();
+	}
+
+	/**
+	 * Returns the shared runtime, binding a new server if there isn't
+	 * one yet. Concurrent callers share the same in-flight bind via
+	 * {@link _starting}; this prevents two listeners from being
+	 * created when {@link start} is invoked twice before the first
+	 * bind resolves.
+	 *
+	 * If {@link dispose} runs while the bind is in flight, the
+	 * just-bound server is torn down here and the awaiting caller
+	 * sees a rejected promise.
+	 */
+	private _ensureRuntime(githubToken: string): Promise<IProxyRuntime> {
+		if (this._runtime) {
+			return Promise.resolve(this._runtime);
+		}
+		if (!this._starting) {
+			this._starting = (async () => {
+				try {
+					const rt = await this._startServer(githubToken);
+					if (this._disposed) {
+						// dispose() ran while we were binding — the
+						// teardown noop'd because _runtime was still
+						// undefined, so close what we just created.
+						rt.server.closeAllConnections();
+						rt.server.close();
+						throw new Error('ClaudeProxyService has been disposed');
+					}
+					this._runtime = rt;
+					return rt;
+				} finally {
+					this._starting = undefined;
+				}
+			})();
+		}
+		return this._starting;
+	}
+
+	private _releaseHandle(runtime: IProxyRuntime): void {
+		// If `dispose()` (or a later `start()`) already replaced the
+		// runtime, the handle's refcount no longer applies.
+		if (this._runtime !== runtime) {
+			return;
+		}
+		runtime.refcount--;
+		if (runtime.refcount === 0) {
+			this._teardownRuntime();
+		}
+	}
+
+	private _teardownRuntime(): void {
+		const runtime = this._runtime;
+		if (!runtime) {
+			return;
+		}
+		this._runtime = undefined;
+		// Abort in-flight requests so the catch handlers run and
+		// destroy still-open responses; closeAllConnections() then
+		// frees the listening socket immediately.
+		for (const entry of runtime.inFlight) {
+			entry.ac.abort();
+		}
+		runtime.server.closeAllConnections();
+		runtime.server.close(err => {
+			if (err) {
+				this._logService.warn(`[${PROXY_USER_FACING_NAME}] server.close error: ${err.message}`);
+			}
+		});
+	}
+
+	private async _startServer(githubToken: string): Promise<IProxyRuntime> {
+		const nonce = generateNonce();
+		const inFlight = new Set<IInFlight>();
+		const httpModule = await import('http');
+		const server = httpModule.createServer((req, res) => {
+			this._handleRequest(req, res, runtime).catch(err => {
+				// Last-resort safety net. All known throw paths are
+				// already handled inside `_handleRequest`.
+				this._logService.error(`[${PROXY_USER_FACING_NAME}] unhandled request error: ${stringifyError(err)}`);
+				if (!res.headersSent) {
+					try {
+						writeJsonError(res, 500, 'api_error', 'Internal proxy error');
+					} catch {
+						// nothing else we can do
+					}
+				} else if (!res.writableEnded) {
+					try {
+						res.end();
+					} catch { /* ignore */ }
+				}
+			});
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			const onError = (err: Error) => { reject(err); };
+			server.once('error', onError);
+			server.listen(0, '127.0.0.1', () => {
+				server.removeListener('error', onError);
+				resolve();
+			});
+		});
+
+		const address = server.address();
+		if (!address || typeof address === 'string') {
+			server.close();
+			throw new Error(`${PROXY_USER_FACING_NAME} failed to bind: unexpected address ${String(address)}`);
+		}
+		const baseUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+		this._logService.info(`[${PROXY_USER_FACING_NAME}] listening on ${baseUrl}`);
+
+		// Bound below so the `createServer` callback can reference the
+		// runtime via closure even though it's constructed afterwards.
+		const runtime: IProxyRuntime = {
+			server,
+			baseUrl,
+			nonce,
+			inFlight,
+			githubToken,
+			refcount: 0,
+		};
+		return runtime;
+	}
+
+	// #region Dispatch
+
+	private async _handleRequest(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		runtime: IProxyRuntime,
+	): Promise<void> {
+		const method = req.method ?? 'GET';
+		const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname;
+		this._logService.trace(`[${PROXY_USER_FACING_NAME}] ${method} ${pathname}`);
+
+		// Health check is the only unauthenticated route.
+		if (method === 'GET' && pathname === '/') {
+			res.writeHead(200, { 'Content-Type': 'text/plain' });
+			res.end('ok');
+			return;
+		}
+
+		const auth = parseProxyBearer(req.headers, runtime.nonce);
+		if (!auth.valid) {
+			writeJsonError(res, 401, 'authentication_error', 'Invalid authentication');
+			return;
+		}
+
+		if (method === 'GET' && pathname === '/v1/models') {
+			await this._handleModels(res, runtime);
+			return;
+		}
+
+		if (method === 'POST' && pathname === '/v1/messages') {
+			await this._handleMessages(req, res, runtime);
+			return;
+		}
+
+		if (method === 'POST' && pathname === '/v1/messages/count_tokens') {
+			writeJsonError(res, 501, 'api_error', 'count_tokens not supported by CAPI');
+			return;
+		}
+
+		writeJsonError(res, 404, 'not_found_error', `No route for ${method} ${pathname}`);
+	}
+
+	// #endregion
+
+	// #region GET /v1/models
+
+	private async _handleModels(res: http.ServerResponse, runtime: IProxyRuntime): Promise<void> {
+		let models: CCAModel[];
+		try {
+			models = await this._copilotApiService.models(runtime.githubToken);
+		} catch (err) {
+			this._writeUpstreamErrorResponse(res, err);
+			return;
+		}
+
+		const data: Anthropic.ModelInfo[] = [];
+		for (const m of models) {
+			if (!isAnthropicMessagesModel(m)) {
+				continue;
+			}
+			const parsed = tryParseClaudeModelId(m.id);
+			const sdkId = parsed ? parsed.toSdkModelId() : m.id;
+			data.push({
+				id: sdkId,
+				type: 'model',
+				display_name: m.name || sdkId,
+				created_at: '1970-01-01T00:00:00Z',
+				capabilities: null,
+				max_input_tokens: null,
+				max_tokens: null,
+			});
+		}
+
+		const body = {
+			data,
+			has_more: false,
+			first_id: data.length > 0 ? data[0].id : null,
+			last_id: data.length > 0 ? data[data.length - 1].id : null,
+		};
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify(body));
+	}
+
+	// #endregion
+
+	// #region POST /v1/messages
+
+	private async _handleMessages(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		runtime: IProxyRuntime,
+	): Promise<void> {
+		let bodyString: string;
+		try {
+			bodyString = await readRequestBody(req);
+		} catch (err) {
+			writeJsonError(res, 400, 'invalid_request_error', `Failed to read request body: ${stringifyError(err)}`);
+			return;
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(bodyString);
+		} catch {
+			writeJsonError(res, 400, 'invalid_request_error', 'Request body is not valid JSON');
+			return;
+		}
+		if (!parsed || typeof parsed !== 'object') {
+			writeJsonError(res, 400, 'invalid_request_error', 'Request body must be a JSON object');
+			return;
+		}
+
+		const body = parsed as Record<string, unknown>;
+		const sdkModelId = body.model;
+		if (typeof sdkModelId !== 'string' || sdkModelId.length === 0) {
+			writeJsonError(res, 400, 'invalid_request_error', 'Missing required field: model');
+			return;
+		}
+		if (!Array.isArray(body.messages)) {
+			writeJsonError(res, 400, 'invalid_request_error', 'Missing required field: messages');
+			return;
+		}
+
+		const parsedModel = tryParseClaudeModelId(sdkModelId);
+		if (!parsedModel) {
+			writeJsonError(res, 404, 'not_found_error', `Unknown model: ${sdkModelId}`);
+			return;
+		}
+		const endpointModelId = parsedModel.toEndpointModelId();
+		body.model = endpointModelId;
+
+		const stream = body.stream === true;
+		const headers = buildOutboundHeaders(req.headers);
+
+		const entry: IInFlight = {
+			ac: new AbortController(),
+			res,
+			clientGone: false,
+		};
+		runtime.inFlight.add(entry);
+		const onClose = () => {
+			entry.clientGone = true;
+			entry.ac.abort();
+		};
+		res.on('close', onClose);
+
+		try {
+			if (stream) {
+				await this._streamMessages(
+					body as unknown as Anthropic.MessageCreateParamsStreaming,
+					headers,
+					res,
+					entry,
+					runtime,
+					sdkModelId,
+				);
+			} else {
+				await this._sendNonStreamingMessage(
+					body as unknown as Anthropic.MessageCreateParamsNonStreaming,
+					headers,
+					res,
+					entry,
+					runtime,
+					sdkModelId,
+				);
+			}
+		} finally {
+			res.removeListener('close', onClose);
+			runtime.inFlight.delete(entry);
+		}
+	}
+
+	private async _sendNonStreamingMessage(
+		body: Anthropic.MessageCreateParamsNonStreaming,
+		headers: Record<string, string>,
+		res: http.ServerResponse,
+		entry: IInFlight,
+		runtime: IProxyRuntime,
+		originalSdkModelId: string,
+	): Promise<void> {
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
+		let message: Anthropic.Message;
+		try {
+			message = await this._copilotApiService.messages(runtime.githubToken, body, options);
+		} catch (err) {
+			if (entry.ac.signal.aborted) {
+				if (!entry.clientGone && !res.writableEnded) {
+					res.destroy();
+				}
+				return;
+			}
+			this._writeUpstreamErrorResponse(res, err);
+			return;
+		}
+
+		// Rewrite outbound `model` to SDK format. Failure to re-parse
+		// shouldn't normally happen because we just translated it on
+		// the way in, but log + passthrough rather than dropping.
+		const outboundModel = rewriteModelToSdk(message.model, this._logService) ?? originalSdkModelId;
+		const responseBody: Anthropic.Message = { ...message, model: outboundModel };
+
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify(responseBody));
+	}
+
+	private async _streamMessages(
+		body: Anthropic.MessageCreateParamsStreaming,
+		headers: Record<string, string>,
+		res: http.ServerResponse,
+		entry: IInFlight,
+		runtime: IProxyRuntime,
+		_originalSdkModelId: string,
+	): Promise<void> {
+		const options: ICopilotApiServiceRequestOptions = { headers, signal: entry.ac.signal };
+		let stream: AsyncGenerator<Anthropic.MessageStreamEvent>;
+		try {
+			stream = this._copilotApiService.messages(runtime.githubToken, body, options);
+		} catch (err) {
+			// Synchronous throws from the generator factory (rare —
+			// CAPI errors come from the first iteration).
+			if (entry.ac.signal.aborted) {
+				if (!entry.clientGone && !res.writableEnded) {
+					res.destroy();
+				}
+				return;
+			}
+			this._writeUpstreamErrorResponse(res, err);
+			return;
+		}
+
+		// Pull the first event before committing to a 200 response so
+		// we can surface a pre-stream error as a regular JSON error.
+		let first: IteratorResult<Anthropic.MessageStreamEvent>;
+		try {
+			first = await stream.next();
+		} catch (err) {
+			if (entry.ac.signal.aborted) {
+				if (!entry.clientGone && !res.writableEnded) {
+					res.destroy();
+				}
+				return;
+			}
+			this._writeUpstreamErrorResponse(res, err);
+			return;
+		}
+
+		// Commit to streaming response now.
+		res.writeHead(200, {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			'Connection': 'keep-alive',
+		});
+		res.flushHeaders();
+		req_setNoDelay(res);
+
+		const writeFrame = async (event: Anthropic.MessageStreamEvent): Promise<boolean> => {
+			const transformed = rewriteEventModel(event, this._logService);
+			const frame = `event: ${transformed.type}\ndata: ${JSON.stringify(transformed)}\n\n`;
+			const ok = res.write(frame);
+			if (!ok) {
+				try {
+					await once(res, 'drain', { signal: entry.ac.signal });
+				} catch {
+					// signal aborted while waiting on drain — bail out
+					return false;
+				}
+			}
+			return true;
+		};
+
+		try {
+			if (!first.done) {
+				const ok = await writeFrame(first.value);
+				if (!ok) {
+					return;
+				}
+			}
+			while (true) {
+				let next: IteratorResult<Anthropic.MessageStreamEvent>;
+				try {
+					next = await stream.next();
+				} catch (err) {
+					if (entry.ac.signal.aborted) {
+						if (!entry.clientGone && !res.writableEnded) {
+							res.destroy();
+						}
+						return;
+					}
+					// Mid-stream error: emit Anthropic SSE error frame, then end.
+					const envelope = err instanceof CopilotApiError
+						? err.envelope
+						: buildErrorEnvelope('api_error', stringifyError(err));
+					if (!res.writableEnded) {
+						try {
+							res.write(formatSseErrorFrame(envelope));
+						} catch { /* socket may have died */ }
+						try {
+							res.end();
+						} catch { /* ignore */ }
+					}
+					return;
+				}
+				if (next.done) {
+					break;
+				}
+				const ok = await writeFrame(next.value);
+				if (!ok) {
+					return;
+				}
+			}
+			if (!res.writableEnded) {
+				res.end();
+			}
+		} catch (err) {
+			// Defense in depth — should not be reached.
+			this._logService.warn(`[${PROXY_USER_FACING_NAME}] stream loop unexpected error: ${stringifyError(err)}`);
+			if (!res.writableEnded) {
+				try { res.end(); } catch { /* ignore */ }
+			}
+		}
+	}
+
+	// #endregion
+
+	// #region Error helpers
+
+	private _writeUpstreamErrorResponse(res: http.ServerResponse, err: unknown): void {
+		if (res.headersSent) {
+			// Headers are already sent — caller should have routed to
+			// the SSE error path. This is a defensive log.
+			this._logService.warn(`[${PROXY_USER_FACING_NAME}] cannot write upstream error after headers sent: ${stringifyError(err)}`);
+			if (!res.writableEnded) {
+				try { res.end(); } catch { /* ignore */ }
+			}
+			return;
+		}
+		if (err instanceof CopilotApiError) {
+			// Mid-stream sentinel doesn't map to a meaningful HTTP
+			// status before headers are sent. Coerce to 502 so we
+			// don't ship a 520 with a JSON body that violates HTTP
+			// semantics for the consumer.
+			const status = err.status === COPILOT_API_ERROR_STATUS_STREAMING ? 502 : err.status;
+			writeUpstreamJsonError(res, status, err.envelope);
+			return;
+		}
+		writeJsonError(res, 502, 'api_error', err instanceof Error ? err.message : String(err));
+	}
+
+	// #endregion
+}
+
+// #endregion
+
+// #region Helpers
+
+function isAnthropicMessagesModel(m: CCAModel): boolean {
+	if (!KNOWN_CLAUDE_VENDORS.has(m.vendor.toLowerCase())) {
+		return false;
+	}
+	return Array.isArray(m.supported_endpoints) && m.supported_endpoints.includes(ANTHROPIC_MESSAGES_ENDPOINT);
+}
+
+function rewriteModelToSdk(modelId: string, logService: ILogService): string | undefined {
+	const parsed = tryParseClaudeModelId(modelId);
+	if (!parsed) {
+		logService.warn(`[${PROXY_USER_FACING_NAME}] outbound model ID could not be parsed for SDK rewrite: ${modelId}`);
+		return undefined;
+	}
+	return parsed.toSdkModelId();
+}
+
+/**
+ * Pure-function rewrite of `model` fields on `Anthropic.MessageStreamEvent`
+ * objects from CAPI (endpoint format) to SDK (hyphenated) format. Only
+ * `message_start.message.model` carries a model ID in the streaming
+ * taxonomy; other event types pass through unchanged.
+ */
+function rewriteEventModel(
+	event: Anthropic.MessageStreamEvent,
+	logService: ILogService,
+): Anthropic.MessageStreamEvent {
+	if (event.type !== 'message_start') {
+		return event;
+	}
+	const sdkModel = rewriteModelToSdk(event.message.model, logService);
+	if (sdkModel === undefined || sdkModel === event.message.model) {
+		return event;
+	}
+	return {
+		...event,
+		message: { ...event.message, model: sdkModel },
+	};
+}
+
+/**
+ * Build the headers we forward to {@link ICopilotApiService.messages}
+ * from the inbound request. Drops everything except `anthropic-version`
+ * (verbatim) and `anthropic-beta` (filtered through
+ * {@link filterSupportedBetas}).
+ */
+function buildOutboundHeaders(inbound: http.IncomingHttpHeaders): Record<string, string> {
+	const out: Record<string, string> = {};
+	const version = inbound['anthropic-version'];
+	if (typeof version === 'string' && version.length > 0) {
+		out['anthropic-version'] = version;
+	}
+	const beta = inbound['anthropic-beta'];
+	if (typeof beta === 'string' && beta.length > 0) {
+		const filtered = filterSupportedBetas(beta);
+		if (filtered !== undefined) {
+			out['anthropic-beta'] = filtered;
+		}
+	}
+	return out;
+}
+
+function readRequestBody(req: http.IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+		req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+		req.on('error', reject);
+	});
+}
+
+function req_setNoDelay(res: http.ServerResponse): void {
+	const socket = res.socket;
+	if (socket && typeof socket.setNoDelay === 'function') {
+		try {
+			socket.setNoDelay(true);
+		} catch {
+			// not all socket implementations support it (mocks etc.)
+		}
+	}
+}
+
+function stringifyError(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	return String(err);
+}
+
+// #endregion

--- a/src/vs/platform/agentHost/node/claude/phase-plan.2.md
+++ b/src/vs/platform/agentHost/node/claude/phase-plan.2.md
@@ -1,0 +1,808 @@
+# Phase 2 Plan — `IClaudeProxyService`
+
+**Status:** ✅ done. Shipped `ClaudeProxyService` + helpers + tests +
+DI registration in `agentHostMain.ts`. Council-reviewed and hardened
+(F1/F2 race fixes applied; F3 test coverage added). Smoke-validated
+end-to-end against real CAPI for all three surfaces (`GET /v1/models`,
+streaming `POST /v1/messages`, non-streaming `POST /v1/messages`). No
+callers wire it up yet — Phase 4 (`ClaudeAgent`) does that. Two
+documented deviations from the original plan are inlined below as
+"Shipped:" notes.
+
+A self-contained design + implementation plan for Phase 2 of the Claude
+agent roadmap.
+
+> Sibling docs: [`roadmap.md`](./roadmap.md) (the multi-phase plan
+> Phase 2 lives in), [`CONTEXT.md`](./CONTEXT.md) (the glossary that
+> defines `Agent Host`, `Claude Agent`, `Claude Proxy`, `CAPI`).
+
+---
+
+## 1. Context
+
+### What ships before this phase
+
+**Phase 1 (done):** `ICopilotApiService` at
+`src/vs/platform/agentHost/node/shared/copilotApiService.ts`. A
+gateway to GitHub Copilot's chat completions API ("**CAPI**") that
+exposes:
+
+```ts
+interface ICopilotApiService {
+    readonly _serviceBrand: undefined;
+    messages(githubToken: string, body: Anthropic.MessageCreateParamsNonStreaming, options?: ICopilotApiServiceRequestOptions): Promise<Anthropic.Message>;
+    messages(githubToken: string, body: Anthropic.MessageCreateParamsStreaming, options?: ICopilotApiServiceRequestOptions): AsyncGenerator<Anthropic.MessageStreamEvent>;
+    countTokens(githubToken: string): Promise<never>; // throws — CAPI does not support this
+    models(githubToken: string): Promise<CCAModel[]>;
+}
+
+interface ICopilotApiServiceRequestOptions {
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+}
+```
+
+`messages()` is a TypeScript overload — streaming returns an
+`AsyncGenerator` of pre-parsed `Anthropic.MessageStreamEvent` objects;
+non-streaming returns a `Promise<Anthropic.Message>`. CAPI is wire-
+compatible with the Anthropic Messages API.
+
+`ICopilotApiService` is hand-rolled HTTP (not the `@anthropic-ai/sdk`
+client) and currently throws plain `Error` on both non-2xx and SSE
+error events. **Q10's passthrough design depends on widening this
+contract — see §1.5.**
+
+**Phase 1.5 (done):** widened `ICopilotApiService` to use raw
+`Anthropic.MessageStreamEvent` types and accept
+`ICopilotApiServiceRequestOptions { headers?, signal? }`.
+
+### What this phase delivers
+
+A `ClaudeProxyService` — a local HTTP server that **speaks the
+Anthropic Messages API on the inbound side and `ICopilotApiService`
+on the outbound side**. The Claude Agent SDK
+(`@anthropic-ai/claude-agent-sdk@0.2.112`) runs as a subprocess and
+sees this proxy as its Anthropic API endpoint via
+`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`.
+
+Phase 2 does NOT include the `ClaudeAgent` itself (Phase 4) — only
+the proxy and its DI registration in the agent host.
+
+### Why a proxy at all
+
+- The SDK is hard-wired to call `https://api.anthropic.com`-shaped
+  endpoints. We can't redirect at the SDK level.
+- We don't ship Anthropic API keys; we ship GitHub Copilot tokens.
+  The proxy authenticates via Bearer-token-with-nonce, mints CAPI
+  tokens internally, and forwards.
+- All routing/translation logic stays out of the SDK subprocess.
+
+### Reference implementation
+
+A working version exists in the Copilot **extension** at
+`extensions/copilot/src/extension/chatSessions/claude/`. Our proxy
+**borrows** from it (model-ID parser, beta filter, disconnect
+detection) but is structurally different in two ways:
+
+1. The reference is a **byte-passthrough** — it pipes upstream SSE
+   chunks verbatim. Our `ICopilotApiService.messages()` returns
+   pre-parsed event objects, so we MUST construct SSE frames ourselves.
+2. The reference forces `stream: true` upstream and has known bugs
+   (no backpressure; mid-stream error handler tries to `writeHead`
+   after streaming has started). We support both branches and fix
+   these.
+
+---
+
+## 1.5. Pre-Phase 2 dependency: widen Phase 1 error contract
+
+**Status:** ✅ done (verified live against CAPI).
+
+Phase 1 originally threw plain `Error` instances on both failure
+paths, which discarded the upstream `status` + Anthropic error
+envelope. Q10's passthrough design needs both to re-emit verbatim,
+so Phase 1.5 widened the error contract.
+
+**Shipped change.** A typed error class carrying SDK-typed envelopes:
+
+```ts
+import type Anthropic from '@anthropic-ai/sdk';
+
+export class CopilotApiError extends Error {
+    constructor(
+        readonly status: number,
+        readonly envelope: Anthropic.ErrorResponse,
+        message?: string,
+    ) {
+        super(message ?? envelope.error.message);
+        this.name = 'CopilotApiError';
+    }
+}
+```
+
+Both throw sites construct this with the parsed Anthropic envelope:
+
+- **Non-2xx HTTP responses** — conforming bodies are passed through
+  verbatim (preserving any `request_id` and SDK-known extras);
+  non-conforming bodies (plain text, malformed JSON, missing
+  fields) are synthesized into a minimal `{ type: 'error', error:
+  { type: 'api_error', message }, request_id: null }` envelope.
+- **Streaming `event: error` SSE frames** — `status` is set to the
+  sentinel `COPILOT_API_ERROR_STATUS_STREAMING = 520` (the upstream
+  HTTP response was 200; the real status is no longer meaningful
+  once the stream has started). Consumers should branch on
+  `envelope.error.type` rather than `status` for these.
+
+Network/transport failures (connection reset, DNS failure, etc.)
+and token-mint failures stay as plain `Error` so consumers can
+distinguish API errors from transport/auth-tier errors.
+
+Phase 2's Q10 does an `instanceof CopilotApiError` check and
+re-serializes `err.envelope` with `err.status`; non-`CopilotApiError`
+falls through to the synthetic 502 path.
+
+**Verified live (smoke probe against real CAPI):** `models()`
+success, streaming `messages()` success with full
+`message_start → content_block_* → message_delta → message_stop`
+sequence and SDK-typed `delta.stop_reason` access, and the
+documented token-mint-vs-CAPI-error tier separation.
+
+---
+
+## 2. Design decisions
+
+Each decision was grilled, with alternatives considered, before being
+locked in. The numbering matches the design log in `CONTEXT.md`.
+
+### Q1 — Naming
+
+`IClaudeProxyService` / `ClaudeProxyService`. Files under
+`src/vs/platform/agentHost/node/claude/`.
+
+### Q2 — Lifecycle / DI
+
+Registered as a DI singleton in `agentHostMain.ts` alongside
+`ICopilotApiService`. One instance per agent host process.
+
+### Q3 — API shape
+
+```ts
+interface IClaudeProxyHandle extends IDisposable {
+    readonly baseUrl: string;
+    readonly nonce: string;
+}
+
+interface IClaudeProxyService {
+    readonly _serviceBrand: undefined;
+    start(githubToken: string): Promise<IClaudeProxyHandle>;
+    dispose(): void;
+}
+```
+
+- **Refcounted.** Each `start()` increments, each `handle.dispose()`
+  decrements. At refcount 0 the listener closes, the token slot
+  clears, and the nonce is destroyed. The next `start()` rebinds with
+  a new port and a fresh nonce.
+- **Shared token slot, last-writer-wins.** Single-tenant per roadmap.
+  Multi-tenant is Phase 4+.
+- **Subprocess ownership invariant.** Callers that hand the handle's
+  `baseUrl` / `nonce` to a Claude SDK subprocess MUST kill that
+  subprocess before disposing the handle. The subprocess cannot
+  outlive the handle.
+
+### Q4 — Auth
+
+Enforce `Authorization: Bearer <nonce>.<sessionId>` on authenticated
+routes. Parse and log `sessionId` at trace level only; treat it as
+opaque in Phase 2. `x-api-key` is ignored.
+
+Bearer enforcement runs FIRST on authenticated routes — bad token
+yields 401, never 501 or 404.
+
+**Do NOT port `extractSessionId` from the reference verbatim.** The
+reference
+([claudeLanguageModelServer.ts L348-361](../../../../extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts#L348-L361))
+accepts nonce-only bearer tokens (no `.sessionId`) as a legacy path.
+Phase 2 deliberately rejects that — `Bearer <nonce>` (no dot) → 401.
+Write a fresh parser in `claudeProxyAuth.ts`; the reference's test
+fixtures cannot be lifted unchanged.
+
+### Q5 — Routes
+
+| Route | Status | Notes |
+| --- | --- | --- |
+| `POST /v1/messages` | full impl | streaming + non-streaming |
+| `GET /v1/models` | net new | passthrough filtered to `vendor: 'Anthropic'` and `supported_endpoints` containing `/v1/messages`; reshaped to Anthropic's `Page<ModelInfo>` envelope (see below) |
+| `POST /v1/messages/count_tokens` | net new | 501 with Anthropic error envelope: `{ type: 'error', error: { type: 'api_error', message: 'count_tokens not supported by CAPI' } }`. Settled as always-501 because `ICopilotApiService.countTokens()` itself throws (CAPI has no endpoint). The roadmap's earlier "pass-through (or 501)" wording is superseded. |
+| `GET /` | health | plain-text `'ok'` |
+| anything else | 404 | Anthropic error envelope |
+
+No `OPTIONS` handler — same-process consumer, CORS does not apply.
+
+**`/v1/models` response shape.** The Anthropic SDK's
+`client.models.list()` calls `getAPIList('/v1/models', Page<ModelInfo>, ...)`
+which expects a `PageResponse<Item>` envelope per
+[`pagination.d.ts` L39-44](../../../../node_modules/@anthropic-ai/sdk/core/pagination.d.ts#L39-L44):
+
+```json
+{
+  "data": [
+    { "id": "claude-opus-4-6-20250929", "type": "model", "display_name": "Claude Opus 4.6", "created_at": 0 },
+    ...
+  ],
+  "has_more": false,
+  "first_id": null,
+  "last_id": null
+}
+```
+
+Returning a bare array breaks SDK pagination.
+
+### Q6 — Model ID translation
+
+The SDK does literal prefix matching (e.g.
+`id.startsWith('claude-opus-4-6')`). CAPI uses dotted versions
+(`claude-opus-4.6`); the SDK uses hyphenated Anthropic-canonical IDs
+(`claude-opus-4-6-20250929`). Translation is **bidirectional**.
+
+- Port `extensions/copilot/src/extension/chatSessions/claude/{common,node}/claudeModelId.ts`
+  into `node/claude/claudeModelId.ts` with a comment marking it as a
+  mirror that must be kept in sync. Lift the same test fixtures.
+- Two pure helpers: `tryParseClaudeModelId(id)` returning a
+  `ParsedClaudeModelId` with `toSdkModelId()` /
+  `toEndpointModelId()`. No service, no class — the parser caches
+  internally.
+- **Three rewrite points** in the proxy:
+  1. inbound `requestBody.model` (SDK → CAPI)
+  2. outbound `model` fields on streaming events and non-streaming
+     responses (CAPI → SDK), e.g. `message_start.message.model`
+  3. `GET /v1/models` response IDs (CAPI → SDK)
+- **Inbound parse failure**: 404 `not_found_error` — before any CAPI
+  call.
+- **Outbound parse failure**: log a warning, pass the raw value
+  through. Strictly worse than translating, but strictly better than
+  dropping the response.
+- Model **availability fallback** ("user picked an unavailable model,
+  pick the newest Sonnet") is a Phase 4 `ClaudeAgent` concern. The
+  proxy stays dumb.
+
+### Q7 — Anthropic-beta + header passthrough
+
+- Lift `filterSupportedBetas()` and the three-entry
+  `SUPPORTED_ANTHROPIC_BETAS` allowlist (`interleaved-thinking`,
+  `context-management`, `advanced-tool-use`) into
+  `node/claude/anthropicBetas.ts` with a "keep in sync" comment.
+  Allowlist match is prefix + `-` (date-suffix discipline).
+- Applied at `POST /v1/messages` after auth, before model translation.
+  If the filtered result is a non-empty string, set it on the outbound
+  `ICopilotApiServiceRequestOptions.headers['anthropic-beta']`. If
+  `undefined`, omit the header entirely — never forward `''`.
+- **Inbound header passthrough** is restricted to `anthropic-version`
+  (verbatim) and `anthropic-beta` (filtered). All other client headers
+  are dropped, including `x-request-id` / `request-id` — CAPI
+  generates its own.
+- The proxy ignores `request.metadata` and any SDK-side `betas`
+  field; only the `anthropic-beta` header drives behavior.
+
+### Q8 — Streaming: framing, backpressure, mid-stream errors
+
+The reference is a byte-passthrough. We can't do that:
+`ICopilotApiService.messages()` returns
+`AsyncGenerator<Anthropic.MessageStreamEvent>` (already-parsed event
+objects), so we MUST construct SSE frames ourselves.
+
+**Framing.** Hand-rolled, per event:
+
+```
+event: <event.type>\ndata: <JSON.stringify(event)>\n\n
+```
+
+Response headers, set once before the first event:
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+
+After `writeHead(200, …)` call `res.flushHeaders()` so the SDK gets
+status + content-type before the first event, and
+`req.socket.setNoDelay(true)` so small frames aren't held by Nagle.
+
+**Event mutation.** 1:1 passthrough with one surgical rewrite — the
+`model` field on `message_start.message.model` (Q6 outbound CAPI→SDK).
+No `[DONE]` line (Anthropic ends with `message_stop`, not OpenAI's
+sentinel). No synthesized `ping` events. No event reordering.
+
+**Backpressure.** The reference does NOT handle this and we treat
+that as a bug, not a guideline. When `res.write()` returns `false`,
+`await once(res, 'drain', { signal: ac.signal })` before pulling the
+next event from the generator. The signal is required — if the
+client closes mid-buffer, `drain` never fires; passing `ac.signal`
+lets abort reject the wait and unwind the loop. This also naturally
+backpressures the upstream.
+
+**Mid-stream errors.** The reference's `catch` tries to
+`writeHead(500)` after streaming has started, which throws — its
+mid-stream error handling is silently broken. We emit an Anthropic-
+shaped SSE error frame and end:
+
+```
+event: error
+data: { "type": "error", "error": { "type": "api_error", "message": "..." } }
+```
+
+Then `res.end()`. Do not emit `message_stop` after `error` — `error`
+is terminal in the Anthropic SDK.
+
+**Non-streaming branch.** When `request.stream !== true`:
+
+- `Content-Type: application/json`
+- Single body: `JSON.stringify(message)` where `message` is the
+  `Anthropic.Message` returned by the non-streaming
+  `ICopilotApiService.messages()` overload, with the `model` field
+  rewritten to SDK format.
+- The reference forces `stream: true` upstream and SSE-frames
+  everything — we explicitly do NOT do this. Honor `request.stream`.
+
+### Q9 — Abort / disconnect propagation
+
+One `AbortController` per inbound request, plumbed through to
+`ICopilotApiServiceRequestOptions.signal`. Two distinct abort
+sources — must be distinguished, because `server.close()` does NOT
+destroy existing sockets and a `return` without writing leaves the
+client hanging until TCP timeout.
+
+```ts
+type InFlight = { ac: AbortController; res: ServerResponse; clientGone: boolean };
+const inFlight = new Set<InFlight>();
+
+const entry: InFlight = { ac: new AbortController(), res, clientGone: false };
+inFlight.add(entry);
+res.on('close', () => { entry.clientGone = true; entry.ac.abort(); });
+
+try {
+    const stream = copilotApi.messages(githubToken, body, { signal: entry.ac.signal, headers });
+    for await (const event of stream) { /* emit */ }
+} catch (err) {
+    if (entry.ac.signal.aborted) {
+        if (!entry.clientGone) { res.destroy(); } // dispose-driven; client still listening
+        return;
+    }
+    // else: emit Anthropic SSE error frame (Q8)
+} finally {
+    inFlight.delete(entry);
+}
+```
+
+- **Single client-disconnect trigger**: `res.on('close')` sets
+  `clientGone = true` and aborts. The reference also uses this;
+  `req.on('close')` and `req.on('aborted')` are redundant.
+- **No polling**. Pass `signal` to `ICopilotApiService.messages()`;
+  the generator rejects with `AbortError` on the next iteration. The
+  for-await unwinds naturally.
+- **Client-disconnect path**: socket already closed — `return`
+  without writing.
+- **Dispose-driven path**: socket still open — `res.destroy()`
+  before returning so the client doesn't hang.
+- **Non-streaming branch**: same pattern. The awaited
+  `ICopilotApiService.messages()` rejects with `AbortError`; we
+  `res.destroy()` (if dispose-driven) or `return` (if
+  client-disconnect) without writing a body.
+- **`dispose()` aborts in-flight**. On refcount→0 dispose: for each
+  `entry` in `inFlight`, call `entry.ac.abort()`. The catch handler
+  then `res.destroy()`s any still-open responses. After all
+  in-flight resolves, `server.close()`, clear the token slot, destroy
+  the nonce.
+
+### Q10 — Error envelopes
+
+Two distinct flows.
+
+**Proxy-authored errors.** No upstream response exists, so we
+construct the Anthropic envelope ourselves via one helper:
+
+```ts
+function writeJsonError(res, status, type, message) {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type, message } }));
+}
+```
+
+Status + `error.type` per case:
+
+| Case | Status | `error.type` |
+| --- | --- | --- |
+| Missing/malformed `Authorization` | 401 | `authentication_error` |
+| Bearer nonce mismatch | 401 | `authentication_error` |
+| Bearer with no `.sessionId` | 401 | `authentication_error` |
+| Unknown route | 404 | `not_found_error` |
+| Bad JSON body | 400 | `invalid_request_error` |
+| Missing required field (`model`, `messages`) | 400 | `invalid_request_error` |
+| Model parse failure (Q6 inbound) | 404 | `not_found_error` |
+| `POST /v1/messages/count_tokens` | 501 | `api_error` |
+
+**CAPI errors — passthrough, not mapping.** CAPI already speaks
+Anthropic wire format. After §1.5's Phase 1 widening,
+`ICopilotApiService` throws `CopilotApiError` carrying `err.status`
++ `err.envelope` (the parsed envelope, verbatim). We just
+re-serialize:
+
+```ts
+catch (err) {
+    if (err instanceof CopilotApiError) {
+        res.writeHead(err.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(err.envelope));
+        return;
+    }
+    // network / non-API error — synthesize
+    writeJsonError(res, 502, 'api_error', err.message ?? 'Upstream error');
+}
+```
+
+No subclass ladder. No mapping table. No `err.message` sanitization
+— passthrough.
+
+**Mid-stream variant.** Same idea, SSE frame instead of JSON body:
+
+```ts
+const envelope = err instanceof CopilotApiError
+    ? err.envelope
+    : { type: 'error', error: { type: 'api_error', message: err.message ?? 'Upstream error' } };
+res.write(`event: error\ndata: ${JSON.stringify(envelope)}\n\n`);
+res.end();
+```
+
+Status is ignored once headers are sent (Q8). On `signal.aborted`,
+write nothing — client is gone (Q9).
+
+### Q11 — File layout
+
+**Shipped:** route handlers were collapsed into private methods on
+`ClaudeProxyService` rather than separate `claudeProxyMessages.ts` /
+`claudeProxyModels.ts` classes. They share per-request bookkeeping
+(`IInFlight`, the `runtime` token slot, the abort plumbing); splitting
+them would have required threading the same five arguments through
+every call. Final layout:
+
+```
+src/vs/platform/agentHost/node/claude/
+├── claudeProxyService.ts   # interface + impl + lifecycle + server + dispatch + route handlers
+├── claudeModelId.ts        # parser (Q6) — mirror of extension copy
+├── anthropicBetas.ts       # filterSupportedBetas + allowlist (Q7)
+├── anthropicErrors.ts      # buildErrorEnvelope, writeJsonError, writeUpstreamJsonError, formatSseErrorFrame (Q10)
+└── claudeProxyAuth.ts      # parseProxyBearer (Q4)
+
+src/vs/platform/agentHost/test/node/   (flat, matches existing convention)
+├── claudeModelId.test.ts
+├── anthropicBetas.test.ts
+├── claudeProxyAuth.test.ts
+└── claudeProxyService.test.ts
+```
+
+- **Pure helpers** (`claudeModelId`, `anthropicBetas`,
+  `anthropicErrors`, `claudeProxyAuth`) are platform-free pure
+  functions, testable in isolation.
+- **Route handlers live inside `ClaudeProxyService`** as private
+  methods (`_handleModels`, `_handleMessages`,
+  `_sendNonStreamingMessage`, `_streamMessages`).
+- **`claudeProxyService.ts`** owns the `IClaudeProxyService` interface,
+  the impl, `IClaudeProxyHandle`, refcounted lifecycle, the
+  `http.createServer()`, the top-level dispatch switch on
+  `url.pathname`, the `Set<IInFlight>` of in-flight requests, and all
+  route handlers.
+- **Interface lives next to impl.** No `common/` split for Phase 2
+  — both consumers (`agentHostMain.ts`, future `ClaudeAgent`) are
+  in `node`.
+
+---
+
+## 3. Acceptance criteria
+
+Phase 2 is "done" when all of the following pass.
+
+### Hygiene (run frequently during development)
+
+- [ ] `compile-check-ts-native` clean
+- [ ] `eslint` clean
+- [ ] `valid-layers-check` clean
+- [ ] Hygiene check (gulp `hygiene`) clean — copyright headers,
+      tabs, string quoting, formatting
+
+### Lifecycle (Q2/Q3)
+
+- [ ] `start(token)` returns a handle with `baseUrl` (e.g.
+  `http://127.0.0.1:54321`) and a 256-bit hex `nonce`
+- [ ] Two concurrent `start()` calls share one server, share the
+  latest token, return handles with the same `baseUrl` and `nonce`
+- [ ] Disposing one handle while the other is alive: server stays
+  up, in-flight requests on the other handle continue
+- [ ] Disposing the last handle: `server.close()` runs, in-flight
+  controllers abort, port is freed
+- [ ] `start()` after refcount-0 dispose binds a new port and a
+  fresh nonce
+
+### Bind safety
+
+- [ ] Server binds only to `127.0.0.1`, not `0.0.0.0`
+
+### Auth (Q4)
+
+- [ ] Missing `Authorization` → 401 `authentication_error`
+- [ ] `Bearer wrong-nonce.x` → 401
+- [ ] `Bearer <nonce>` (no dot) → 401
+- [ ] `Bearer <nonce>.` (empty sessionId) → 401
+- [ ] `Bearer <nonce>.abc-123` → request proceeds; sessionId logged
+- [ ] `x-api-key: <nonce>` alone → 401
+- [ ] **Auth-first precedence on authenticated routes:**
+  - [ ] `GET /v1/models` with `Bearer wrong-nonce.x` → 401 (not 200)
+  - [ ] `POST /v1/messages/count_tokens` with `Bearer wrong-nonce.x`
+    → 401 (not 501)
+  - [ ] `POST /v1/messages` with `Bearer wrong-nonce.x` → 401 (not
+    200, not a CAPI call made)
+
+### Routes (Q5)
+
+- [ ] `GET /` → 200, body `'ok'`, no auth required
+- [ ] `GET /v1/models` (authed) → 200, response shape is
+  `{ data: [...], has_more: false, first_id: null, last_id: null }`
+  with each item `{ id, type: 'model', display_name, created_at: '1970-01-01T00:00:00Z', capabilities: null, max_input_tokens: null, max_tokens: null }`
+  and `id` in SDK format. (RFC3339 string instead of `0` because the
+  SDK `Anthropic.ModelInfo` type forces it — settled by council C1.)
+- [ ] `POST /v1/messages/count_tokens` (authed) → 501 `api_error`
+- [ ] `GET /something-else` (authed) → 404 `not_found_error`
+
+### Model translation (Q6)
+
+- [ ] SDK ID inbound translates to CAPI; CAPI ID inbound also works
+- [ ] Unparseable model ID → 404 with no CAPI call
+- [ ] `message_start.message.model` rewritten to SDK format on the
+  way out (streaming)
+- [ ] Non-streaming `message.model` rewritten to SDK format on the
+  way out
+- [ ] `/v1/models` IDs in SDK format
+
+### Beta filtering (Q7)
+
+- [ ] `anthropic-beta: interleaved-thinking-2025-05-14` → forwarded
+- [ ] `anthropic-beta: foo,bar,baz` → header omitted upstream
+- [ ] `anthropic-beta: interleaved-thinking-2025-05-14,foo` →
+  forwarded as `interleaved-thinking-2025-05-14`
+- [ ] `anthropic-beta: interleaved-thinking` (no date) → omitted
+
+### Header passthrough (Q7)
+
+- [ ] `anthropic-version: 2023-06-01` → forwarded verbatim
+- [ ] `x-request-id: foo` → dropped
+- [ ] Random `x-custom-header` → dropped
+
+### Streaming (Q8)
+
+- [ ] `request.stream === true` → SSE with hand-rolled
+  `event:/data:` framing in CAPI's emitted order
+- [ ] `request.stream !== true` → JSON body
+- [ ] Tool-use streams reach client (`input_json_delta` events
+  present)
+- [ ] Thinking streams reach client (`thinking_delta` events
+  present)
+- [ ] No `[DONE]` line emitted
+- [ ] `socket.setNoDelay(true)` is called
+
+### Abort (Q9)
+
+- [ ] Mid-stream client disconnect → upstream
+  `ICopilotApiService.messages()` receives `signal.aborted`;
+  generator unwinds; no further writes
+- [ ] `await once(res, 'drain', { signal: ac.signal })` rejects
+  promptly when client disconnects mid-buffer (no hang)
+- [ ] Mid-stream `dispose()` → all in-flight `res.destroy()`'d;
+  client doesn't hang waiting on a half-open socket; server closes
+- [ ] Non-streaming client disconnect → no JSON body written
+- [ ] Non-streaming `dispose()` → `res.destroy()` called; client
+  doesn't hang
+
+### Errors (Q10)
+
+- [ ] Proxy-authored errors emit the Q10 envelope with correct
+  status from the table
+- [ ] CAPI `CopilotApiError` (per §1.5) → re-emitted with original
+  `err.status` + `err.envelope` verbatim
+- [ ] Mid-stream CAPI error → SSE `event: error` frame with
+  `err.envelope`, then `res.end()`, no `message_stop`
+- [ ] Network error (non-`CopilotApiError`) → 502 `api_error`
+
+---
+
+## 4. Testing strategy
+
+Three surfaces.
+
+### Surface 1 — pure-helper unit tests
+
+Zero deps, fast, deterministic. Located in
+`src/vs/platform/agentHost/test/node/`:
+
+- `claudeModelId.test.ts` — port the extension's fixture matrix;
+  bidirectional round-trip
+- `anthropicBetas.test.ts` — port the 7 reference fixtures from
+  `extensions/copilot/.../test/extractSessionId.spec.ts`
+- `claudeProxyAuth.test.ts` — auth matrix from Q4
+
+### Surface 2 — service-level tests
+
+`claudeProxyService.test.ts` boots the real service against a fake
+`ICopilotApiService`; uses real `http.Server` to hit
+`127.0.0.1:<port>`.
+
+`FakeCopilotApiService` is the **only** mock — everything else (real
+HTTP, real `AbortController`, real parser, real filter) is real. Per
+the codebase guideline: minimal mocking, mock only true I/O
+boundaries.
+
+```ts
+class FakeCopilotApiService implements ICopilotApiService {
+    nextMessagesResult: Anthropic.Message
+        | AsyncGenerator<Anthropic.MessageStreamEvent>
+        | CopilotApiError; // §1.5
+    lastCall: {
+        githubToken: string;
+        body: Anthropic.MessageCreateParams;
+        options: ICopilotApiServiceRequestOptions;
+    };
+    messages(githubToken, body, options): ...
+    models(githubToken): ...
+    countTokens(githubToken): ...
+}
+```
+
+Cases: lifecycle / refcount / port / dispose; auth fixtures
+end-to-end through real HTTP; auth-first precedence on each
+authenticated route; route status matrix; `/v1/models` Page envelope
+shape; model translation roundtrip; beta filter forwarded correctly
+to mock; streaming order + framing; non-streaming JSON body shape;
+mid-stream abort propagates `signal.aborted` to mock; mid-stream
+`CopilotApiError` becomes SSE error frame with `err.envelope`;
+pre-stream `CopilotApiError` becomes JSON error with `err.status`;
+client-disconnect aborts upstream and writes nothing;
+dispose-driven abort calls `res.destroy()` on every in-flight
+response.
+
+### Surface 3 — real-CAPI smoke (Phase 2, manual)
+
+Validates real CAPI without waiting for Phase 4's `ClaudeAgent`.
+
+Procedure:
+
+1. Temporarily modify the existing `CopilotAgent` (or wherever the
+   agent host first authenticates) to call
+   `claudeProxyService.start(token)` once a real GitHub token is
+   minted, and log the resulting `baseUrl` and `nonce` at info
+   level.
+2. Launch the dev build (`./scripts/code.sh --agents` or
+   `Run Dev Agents`) and authenticate.
+3. Use the **code-oss-logs** skill to read `agenthost.log` from the
+   most recent run; grep for the proxy line; extract `baseUrl` +
+   `nonce`.
+4. From a separate terminal:
+
+   ```bash
+   curl -H "Authorization: Bearer ${NONCE}.smoke-test" \
+        "${BASE_URL}/v1/models"
+   curl -H "Authorization: Bearer ${NONCE}.smoke-test" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-version: 2023-06-01" \
+        --data '{"model":"claude-opus-4-6-20250929","messages":[{"role":"user","content":"say hi"}],"max_tokens":64}' \
+        "${BASE_URL}/v1/messages"
+   ```
+
+5. Verify: 200; SDK-format model IDs in `/v1/models`; non-streaming
+   `Anthropic.Message` shape with `model` rewritten to SDK format.
+6. Repeat with `"stream": true` and `--no-buffer`; verify SSE frames.
+7. Revert the temporary `CopilotAgent` change.
+
+### What we explicitly do NOT test in Phase 2
+
+- Real Claude Agent SDK subprocess (Phase 4)
+- Multi-tenant token isolation (Phase 4+)
+- Proxy / PAC support (deferred — see §6)
+
+---
+
+## 5. Implementation order
+
+Build in this order so each step has a green compile, lint, and
+tests before the next begins.
+
+0. **Pre-Phase 2 dependency (§1.5)**
+   - Widen `ICopilotApiService` to throw `CopilotApiError` (or
+     equivalent typed error carrying `status` + Anthropic envelope)
+     on both non-2xx and SSE error paths.
+   - Update Phase 1 tests to cover the new error contract.
+   - Phase 2 cannot start cleanly without this — Q10 depends on it.
+1. **Pure helpers + their tests** (no service yet)
+   - `claudeModelId.ts` + test
+   - `anthropicBetas.ts` + test
+   - `anthropicErrors.ts` (types + helpers, no `res.write` yet)
+   - `claudeProxyAuth.ts` + test (fresh implementation per Q4 — do
+     NOT port `extractSessionId`)
+   - Run hygiene + eslint after each
+2. **Service shell**
+   - `IClaudeProxyService`, `IClaudeProxyHandle` interface
+   - lifecycle (start / refcount / dispose) with empty server
+   - test the lifecycle without any routes
+3. **Routes**
+   - `GET /` (health) — easy, builds confidence in dispatch
+   - `GET /v1/models` — first real CAPI integration; verify Page
+     envelope
+   - `POST /v1/messages/count_tokens` — easy 501
+   - `POST /v1/messages` — both branches; biggest piece
+   - tests at each step
+4. **Real CAPI smoke** with the temporary `CopilotAgent` hook
+5. **Revert hook, ensure all hygiene/lint/test green**
+
+---
+
+## 6. Deferred for later phases
+
+Captured here so they aren't lost. None of these block Phase 2.
+
+- **HTTP proxy support** (`HTTP_PROXY` / `HTTPS_PROXY` env vars,
+  VS Code's `http.proxy` setting, PAC files, proxy auth). The Phase 2
+  proxy talks to CAPI through `ICopilotApiService`, so any outbound
+  proxying is inherited from whatever HTTP client that service uses.
+  If the agent host needs to honor user proxy configuration we'll
+  need an explicit agent / dispatcher injection point on
+  `ICopilotApiService` and a way to source the config from the
+  renderer. Track separately when we pick this up.
+- **Model availability fallback.** "User picked a model that's not
+  available on CAPI today, pick the newest Sonnet instead." Lives in
+  the `ClaudeAgent`, not the proxy. Phase 4.
+- **Multi-tenant token isolation.** Multiple GitHub identities
+  concurrently using the same agent host process. Phase 4+.
+
+---
+
+## 7. Open questions for reviewers
+
+Areas where additional eyes would be most useful:
+
+1. **Refcounted lifecycle vs. one-shot per agent.** We chose
+   refcount because the Claude Agent SDK can be invoked
+   concurrently for multiple sessions and we don't want each session
+   to bind a new port. Is there a scenario this misses?
+2. **Shared token slot, last-writer-wins.** Single-tenant assumption
+   — good for Phase 2, but the second writer silently shadows the
+   first. Should we instead reject concurrent `start(token)` calls
+   if the new token differs from the current one?
+3. **Outbound parse failure (Q6) — log + passthrough.** We chose
+   passthrough so we don't drop responses, but the SDK's prefix
+   matcher may then fail downstream. Is "warn + passthrough" or
+   "warn + 502" the better failure mode for a model the parser can't
+   recognize?
+4. **Real-CAPI smoke as a manual procedure.** It validates the
+   full path against real CAPI without Phase 4 infrastructure, but
+   it requires a code-modify-then-revert. Worth a dedicated `--smoke`
+   CLI flag that triggers the same hook automatically?
+
+## 8. Resolved concerns (council review log)
+
+A prior cross-reviewed council pass surfaced and resolved the
+following items, captured here so reviewers don't re-litigate:
+
+- **Phase 1 throws plain `Error`, not `Anthropic.APIError`.**
+  Resolved by §1.5 (widen Phase 1 to `CopilotApiError`).
+- **`ICopilotApiService` methods take `githubToken` as first
+  parameter.** Resolved — interface sketch (§1), Q9 pseudocode, and
+  `FakeCopilotApiService` (§4) all updated.
+- **Auth-first precedence not in acceptance criteria.** Resolved
+  — §3 now has explicit `Bearer wrong-nonce` cases for each
+  authenticated route.
+- **`/v1/models` needed `Page` envelope, not bare array.** Resolved
+  — Q5 specifies the full `{ data, has_more, first_id, last_id }`
+  shape.
+- **`dispose()` would orphan client sockets.** Resolved — Q9
+  distinguishes client-disconnect (socket already closed) from
+  dispose-driven abort (`res.destroy()` required).
+- **`once(res, 'drain')` could hang on client disconnect.**
+  Resolved — Q8 now passes `{ signal: ac.signal }`.
+- **`extractSessionId` from reference can't be ported verbatim.**
+  Resolved — Q4 explicitly notes a fresh implementation is required;
+  reference accepts nonce-only, Phase 2 rejects it.

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -151,7 +151,7 @@ interface ICopilotApiService {
 - Where does **model ID translation** live? Tentatively the proxy (Phase 2),
   so `model` in `MessageCreateParams` stays an opaque string here.
 
-### Phase 2 — `IClaudeProxyService` (local proxy)
+### Phase 2 — `IClaudeProxyService` (local proxy) ✅ **DONE**
 
 A local HTTP server that speaks Anthropic's `/v1/messages`, `/v1/models`, and
 `/v1/messages/count_tokens` wire format on the inbound side, and

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -57,12 +57,108 @@ interface ICapiInit {
 // #region Constants
 
 /**
+ * Sentinel {@link CopilotApiError.status} used when the error came from a
+ * mid-stream SSE `event: error` frame rather than an HTTP non-2xx response.
+ * The upstream HTTP status was 200 (the stream had already started); the
+ * real HTTP status is no longer meaningful, so consumers that need an HTTP
+ * status code (e.g. when re-emitting before headers are sent) should not
+ * trust this value. Use `envelope.error.type` instead.
+ */
+export const COPILOT_API_ERROR_STATUS_STREAMING = 520;
+
+/**
  * Refresh the cached Copilot token this many seconds before its real expiry,
  * so an in-flight request never hits a token that expires mid-request.
  */
 const TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60;
 
 const TOKEN_API_VERSION = '2025-04-01';
+
+// #endregion
+
+// #region Errors
+
+/**
+ * Thrown by {@link ICopilotApiService} when CAPI returns an Anthropic-format
+ * API error — either as a non-2xx HTTP response or as a mid-stream
+ * `event: error` SSE frame. Carries enough information for the Phase 2
+ * Claude proxy to re-emit the error passthrough without re-mapping.
+ *
+ * Network/transport failures (connection reset, DNS failure, etc.) are
+ * **not** wrapped as `CopilotApiError` — they propagate as raw `fetch`
+ * rejections so consumers can distinguish API errors from transport errors.
+ */
+export class CopilotApiError extends Error {
+
+	/**
+	 * @param status HTTP status from the originating CAPI response, or
+	 *   {@link COPILOT_API_ERROR_STATUS_STREAMING} for mid-stream SSE errors.
+	 * @param envelope Anthropic-format error envelope. For HTTP errors with a
+	 *   non-conforming body (plain text, malformed JSON, missing fields) this
+	 *   is synthesized; for conforming bodies and SSE frames it is the
+	 *   server's envelope verbatim.
+	 * @param message Optional override for `Error.message`. Defaults to
+	 *   `envelope.error.message`. **Never includes auth tokens.**
+	 */
+	constructor(
+		readonly status: number,
+		readonly envelope: Anthropic.ErrorResponse,
+		message?: string,
+	) {
+		super(message ?? envelope.error.message);
+		this.name = 'CopilotApiError';
+	}
+}
+
+/**
+ * Build a {@link CopilotApiError} from a CAPI HTTP response body. If the
+ * body parses as a conforming Anthropic envelope, it is used verbatim;
+ * otherwise a synthetic envelope is constructed with `error.type:
+ * 'api_error'` and the response body as `error.message` (or status text
+ * when the body is empty). The returned error's `message` deliberately
+ * mirrors the original `"<prefix>: <status> <statusText>"` format so
+ * existing log-line consumers continue to read identifiably. `prefix`
+ * defaults to `"CAPI request failed"` (the historical wording for
+ * `messages`); pass `"CAPI models request failed"` for the `models()` path.
+ */
+function buildCopilotApiHttpError(status: number, statusText: string, bodyText: string, prefix = 'CAPI request failed'): CopilotApiError {
+	let envelope: Anthropic.ErrorResponse | undefined;
+	if (bodyText) {
+		try {
+			const parsed = JSON.parse(bodyText) as unknown;
+			if (
+				parsed && typeof parsed === 'object'
+				&& (parsed as { type?: unknown }).type === 'error'
+			) {
+				const err = (parsed as { error?: unknown }).error;
+				if (
+					err && typeof err === 'object'
+					&& typeof (err as { type?: unknown }).type === 'string'
+					&& typeof (err as { message?: unknown }).message === 'string'
+				) {
+					envelope = parsed as Anthropic.ErrorResponse;
+				}
+			}
+		} catch {
+			// non-JSON body — fall through to synthesis
+		}
+	}
+	if (!envelope) {
+		envelope = {
+			type: 'error',
+			error: {
+				type: 'api_error',
+				message: bodyText || `${status} ${statusText}`,
+			},
+			request_id: null,
+		};
+	}
+	return new CopilotApiError(
+		status,
+		envelope,
+		`${prefix}: ${status} ${statusText} \u2014 ${envelope.error.message}`,
+	);
+}
 
 // #endregion
 
@@ -112,11 +208,21 @@ export const ICopilotApiService = createDecorator<ICopilotApiService>('copilotAp
  *
  * ## Error semantics
  *
- * - Network/transport errors propagate as raw `fetch` rejections.
- * - Non-2xx responses throw an `Error` whose message includes the HTTP status,
- *   status text, and response body. **Tokens are never embedded in error
- *   messages.**
- * - Streaming `error` SSE events throw with the server-supplied message.
+ * - Network/transport errors propagate as raw `fetch` rejections (e.g.
+ *   connection reset, DNS failure). Consumers can distinguish them from
+ *   API errors by `instanceof CopilotApiError`.
+ * - Non-2xx responses from CAPI's `messages` and `models` endpoints throw
+ *   {@link CopilotApiError} carrying the HTTP `status` and the parsed
+ *   Anthropic error `envelope` (synthesized if the response body isn't a
+ *   conforming envelope). **Tokens are never embedded in error messages.**
+ * - Streaming `event: error` SSE frames throw {@link CopilotApiError} with
+ *   `status` set to {@link COPILOT_API_ERROR_STATUS_STREAMING} (the upstream
+ *   HTTP status was 200 and is no longer meaningful) and the server-supplied
+ *   error envelope preserved verbatim.
+ * - Failures of the internal Copilot token-mint endpoint throw plain
+ *   `Error` (not `CopilotApiError`) with a `"Copilot token minting failed:
+ *   ..."` prefix — token mint is an implementation detail of this service
+ *   and is not part of the Anthropic-shaped CAPI surface.
  * - Malformed JSON in an SSE `data:` line is logged and skipped, not thrown.
  */
 export interface ICopilotApiService {
@@ -246,7 +352,7 @@ export class CopilotApiService implements ICopilotApiService {
 				this._invalidateCachedToken(githubToken);
 			}
 			const text = await response.text().catch(() => '');
-			throw new Error(`CAPI models request failed: ${response.status} ${response.statusText} — ${text}`);
+			throw buildCopilotApiHttpError(response.status, response.statusText, text, 'CAPI models request failed');
 		}
 
 		const json = await response.json();
@@ -382,7 +488,7 @@ export class CopilotApiService implements ICopilotApiService {
 				this._invalidateCachedToken(githubToken);
 			}
 			const text = await response.text().catch(() => '');
-			throw new Error(`CAPI request failed: ${response.status} ${response.statusText} — ${text}`);
+			throw buildCopilotApiHttpError(response.status, response.statusText, text);
 		}
 
 		return response;
@@ -545,8 +651,34 @@ export class CopilotApiService implements ICopilotApiService {
 		}
 
 		if (type === 'error') {
-			const error = (parsed as { error?: { message?: string } }).error;
-			throw new Error(error?.message ?? 'Unknown streaming error');
+			// Preserve the upstream envelope verbatim when it conforms to the
+			// Anthropic shape (so any extra fields propagate to Phase 2's
+			// passthrough proxy). Fall back to a clean api_error synthesis
+			// when fields are missing or `error` is unstructured.
+			const rawError = (parsed as { error?: unknown }).error;
+			let envelope: Anthropic.ErrorResponse;
+			if (
+				rawError && typeof rawError === 'object'
+				&& typeof (rawError as { type?: unknown }).type === 'string'
+				&& typeof (rawError as { message?: unknown }).message === 'string'
+			) {
+				envelope = parsed as Anthropic.ErrorResponse;
+			} else {
+				let errorMessage: string;
+				if (typeof rawError === 'string') {
+					errorMessage = rawError;
+				} else if (typeof (rawError as { message?: unknown } | undefined)?.message === 'string') {
+					errorMessage = (rawError as { message: string }).message;
+				} else {
+					errorMessage = 'Unknown streaming error';
+				}
+				envelope = {
+					type: 'error',
+					error: { type: 'api_error', message: errorMessage },
+					request_id: null,
+				};
+			}
+			throw new CopilotApiError(COPILOT_API_ERROR_STATUS_STREAMING, envelope);
 		}
 
 		if (!KNOWN_SSE_EVENT_TYPES.has(type)) {

--- a/src/vs/platform/agentHost/test/node/anthropicBetas.test.ts
+++ b/src/vs/platform/agentHost/test/node/anthropicBetas.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { filterSupportedBetas } from '../../node/claude/anthropicBetas.js';
+
+suite('filterSupportedBetas', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('allows exact match from supported list', () => {
+		assert.strictEqual(filterSupportedBetas('interleaved-thinking-2025-05-14'), 'interleaved-thinking-2025-05-14');
+	});
+
+	test('allows prefix match for context-management', () => {
+		assert.strictEqual(filterSupportedBetas('context-management-2025-06-27'), 'context-management-2025-06-27');
+	});
+
+	test('allows prefix match for advanced-tool-use', () => {
+		assert.strictEqual(filterSupportedBetas('advanced-tool-use-2025-11-20'), 'advanced-tool-use-2025-11-20');
+	});
+
+	test('filters out unsupported betas', () => {
+		assert.strictEqual(filterSupportedBetas('unsupported-beta-123'), undefined);
+	});
+
+	test('filters a comma-separated list to only supported betas', () => {
+		assert.strictEqual(
+			filterSupportedBetas('interleaved-thinking-2025-05-14,unsupported-beta,context-management-2025-06-27'),
+			'interleaved-thinking-2025-05-14,context-management-2025-06-27',
+		);
+	});
+
+	test('handles whitespace around commas', () => {
+		assert.strictEqual(
+			filterSupportedBetas('interleaved-thinking-2025-05-14 , context-management-2025-06-27'),
+			'interleaved-thinking-2025-05-14,context-management-2025-06-27',
+		);
+	});
+
+	test('returns undefined when all betas are unsupported', () => {
+		assert.strictEqual(filterSupportedBetas('foo,bar,baz'), undefined);
+	});
+
+	test('returns undefined for empty string', () => {
+		assert.strictEqual(filterSupportedBetas(''), undefined);
+	});
+
+	test('rejects supported family without date suffix (date-suffix discipline)', () => {
+		assert.strictEqual(filterSupportedBetas('interleaved-thinking'), undefined);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/claudeModelId.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeModelId.test.ts
@@ -1,0 +1,261 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { parseClaudeModelId, tryParseClaudeModelId } from '../../node/claude/claudeModelId.js';
+
+suite('parseClaudeModelId', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('parsing SDK model IDs', () => {
+		test('parses claude-{name}-{major}-{minor}-{date}', () => {
+			const result = parseClaudeModelId('claude-opus-4-5-20251101');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.5', modifiers: '20251101' },
+			);
+		});
+
+		test('parses claude-{major}-{minor}-{name}-{date} (old format)', () => {
+			const result = parseClaudeModelId('claude-3-5-sonnet-20241022');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'sonnet', version: '3.5', modifiers: '20241022' },
+			);
+		});
+
+		test('parses claude-{name}-{major}-{date}', () => {
+			const result = parseClaudeModelId('claude-sonnet-4-20250514');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'sonnet', version: '4', modifiers: '20250514' },
+			);
+		});
+
+		test('parses claude-{major}-{name}-{date} (old format)', () => {
+			const result = parseClaudeModelId('claude-3-opus-20240229');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '3', modifiers: '20240229' },
+			);
+		});
+
+		test('parses SDK ID without date suffix', () => {
+			const result = parseClaudeModelId('claude-opus-4-5');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.5', modifiers: '' },
+			);
+		});
+	});
+
+	suite('parsing endpoint model IDs', () => {
+		test('parses claude-{name}-{major}.{minor}', () => {
+			const result = parseClaudeModelId('claude-opus-4.5');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.5', modifiers: '' },
+			);
+		});
+
+		test('parses claude-{name}-{major}', () => {
+			const result = parseClaudeModelId('claude-sonnet-4');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'sonnet', version: '4', modifiers: '' },
+			);
+		});
+
+		test('parses claude-haiku-3.5', () => {
+			const result = parseClaudeModelId('claude-haiku-3.5');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'haiku', version: '3.5', modifiers: '' },
+			);
+		});
+	});
+
+	suite('modifiers (non-date suffixes)', () => {
+		test('parses endpoint ID with 1m context variant (dot version)', () => {
+			const result = parseClaudeModelId('claude-opus-4.6-1m');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.6', modifiers: '1m' },
+			);
+		});
+
+		test('parses SDK ID with 1m context variant (dash version)', () => {
+			const result = parseClaudeModelId('claude-opus-4-6-1m');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.6', modifiers: '1m' },
+			);
+		});
+
+		test('parses SDK ID with both 1m modifier and date suffix', () => {
+			const result = parseClaudeModelId('claude-opus-4-6-1m-20251101');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'opus', version: '4.6', modifiers: '1m-20251101' },
+			);
+		});
+
+		test('parses single-version ID with modifier', () => {
+			const result = parseClaudeModelId('claude-sonnet-4-1m');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'sonnet', version: '4', modifiers: '1m' },
+			);
+		});
+
+		test('1m on opus converts to correct SDK model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4.6-1m').toSdkModelId(), 'claude-opus-4-6-1m');
+		});
+
+		test('1m on opus converts to correct endpoint model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4-6-1m').toEndpointModelId(), 'claude-opus-4.6-1m');
+		});
+
+		test('1m on non-opus model is not included in SDK model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-sonnet-4-1m').toSdkModelId(), 'claude-sonnet-4');
+		});
+
+		test('1m on non-opus model is not included in endpoint model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-sonnet-4-1m').toEndpointModelId(), 'claude-sonnet-4');
+		});
+
+		test('1m with date suffix on opus keeps only 1m in SDK model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4-6-1m-20251101').toSdkModelId(), 'claude-opus-4-6-1m');
+		});
+
+		test('1m with date suffix on opus keeps only 1m in endpoint model ID', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4-6-1m-20251101').toEndpointModelId(), 'claude-opus-4.6-1m');
+		});
+	});
+
+	suite('bare model names', () => {
+		test('parses a bare name with no version', () => {
+			const result = parseClaudeModelId('foo');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'foo', version: '', modifiers: '' },
+			);
+		});
+
+		test('toSdkModelId returns the bare name', () => {
+			assert.strictEqual(parseClaudeModelId('foo').toSdkModelId(), 'foo');
+		});
+
+		test('toEndpointModelId returns the bare name', () => {
+			assert.strictEqual(parseClaudeModelId('foo').toEndpointModelId(), 'foo');
+		});
+
+		test('parses bare "claude" as a bare name', () => {
+			const result = parseClaudeModelId('claude');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'claude', version: '', modifiers: '' },
+			);
+		});
+	});
+
+	suite('unparseable inputs', () => {
+		test('throws for hyphenated non-Claude IDs', () => {
+			assert.throws(() => parseClaudeModelId('gpt-4o'), /Unable to parse Claude model ID: 'gpt-4o'/);
+		});
+
+		test('throws for garbage with hyphens', () => {
+			assert.throws(() => parseClaudeModelId('invalid-model-id'));
+		});
+	});
+
+	suite('tryParseClaudeModelId', () => {
+		test('returns undefined for hyphenated non-Claude IDs', () => {
+			assert.strictEqual(tryParseClaudeModelId('gpt-4o'), undefined);
+		});
+
+		test('returns a result for bare names', () => {
+			const result = tryParseClaudeModelId('foo');
+			assert.ok(result);
+			assert.deepStrictEqual({ name: result.name, version: result.version }, { name: 'foo', version: '' });
+		});
+
+		test('returns a result for valid Claude IDs', () => {
+			const result = tryParseClaudeModelId('claude-sonnet-4');
+			assert.ok(result);
+			assert.deepStrictEqual({ name: result.name, version: result.version }, { name: 'sonnet', version: '4' });
+		});
+	});
+
+	suite('case insensitivity', () => {
+		test('parses uppercase input', () => {
+			const result = parseClaudeModelId('CLAUDE-OPUS-4-5');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version },
+				{ name: 'opus', version: '4.5' },
+			);
+		});
+
+		test('parses mixed case input', () => {
+			const result = parseClaudeModelId('Claude-Sonnet-4-20250514');
+			assert.deepStrictEqual(
+				{ name: result.name, version: result.version, modifiers: result.modifiers },
+				{ name: 'sonnet', version: '4', modifiers: '20250514' },
+			);
+		});
+	});
+
+	suite('caching', () => {
+		test('returns the same object for repeated calls', () => {
+			const first = parseClaudeModelId('claude-opus-4-5-20251101');
+			const second = parseClaudeModelId('claude-opus-4-5-20251101');
+			assert.strictEqual(first, second);
+		});
+
+		test('returns the same object for different casing of the same ID', () => {
+			const lower = parseClaudeModelId('claude-haiku-3-5');
+			const upper = parseClaudeModelId('CLAUDE-HAIKU-3-5');
+			assert.strictEqual(lower, upper);
+		});
+	});
+
+	suite('toSdkModelId', () => {
+		test('produces dash-separated version for major.minor', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4.5').toSdkModelId(), 'claude-opus-4-5');
+		});
+
+		test('produces single-digit version when no minor', () => {
+			assert.strictEqual(parseClaudeModelId('claude-sonnet-4').toSdkModelId(), 'claude-sonnet-4');
+		});
+
+		test('normalizes old-format SDK IDs to new format', () => {
+			assert.strictEqual(parseClaudeModelId('claude-3-5-sonnet-20241022').toSdkModelId(), 'claude-sonnet-3-5');
+		});
+
+		test('strips date suffix from SDK IDs', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4-5-20251101').toSdkModelId(), 'claude-opus-4-5');
+		});
+	});
+
+	suite('toEndpointModelId', () => {
+		test('produces dot-separated version for major.minor', () => {
+			assert.strictEqual(parseClaudeModelId('claude-opus-4-5-20251101').toEndpointModelId(), 'claude-opus-4.5');
+		});
+
+		test('produces single-digit version when no minor', () => {
+			assert.strictEqual(parseClaudeModelId('claude-sonnet-4-20250514').toEndpointModelId(), 'claude-sonnet-4');
+		});
+
+		test('normalizes old-format SDK IDs', () => {
+			assert.strictEqual(parseClaudeModelId('claude-3-5-sonnet-20241022').toEndpointModelId(), 'claude-sonnet-3.5');
+		});
+
+		test('is identity for endpoint-format IDs', () => {
+			assert.strictEqual(parseClaudeModelId('claude-haiku-4.5').toEndpointModelId(), 'claude-haiku-4.5');
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/claudeProxyAuth.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeProxyAuth.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { parseProxyBearer } from '../../node/claude/claudeProxyAuth.js';
+
+const NONCE = 'test-nonce-deadbeef';
+
+suite('parseProxyBearer', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('accepts Bearer <nonce>.<sessionId> with non-empty sessionId', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': `Bearer ${NONCE}.session-abc` }, NONCE),
+			{ valid: true, sessionId: 'session-abc' },
+		);
+	});
+
+	test('preserves dots inside the sessionId portion', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': `Bearer ${NONCE}.session.with.dots` }, NONCE),
+			{ valid: true, sessionId: 'session.with.dots' },
+		);
+	});
+
+	test('rejects missing Authorization header', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({}, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('rejects non-Bearer Authorization scheme', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': `Basic ${NONCE}.s` }, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('rejects Bearer with wrong nonce', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': 'Bearer wrong-nonce.session-abc' }, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('rejects Bearer <nonce> with no dot (legacy format not supported)', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': `Bearer ${NONCE}` }, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('rejects Bearer <nonce>. with empty sessionId', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'authorization': `Bearer ${NONCE}.` }, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('ignores x-api-key when only x-api-key is present', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({ 'x-api-key': NONCE }, NONCE),
+			{ valid: false, sessionId: undefined },
+		);
+	});
+
+	test('uses Authorization header when both x-api-key and Authorization are present', () => {
+		assert.deepStrictEqual(
+			parseProxyBearer({
+				'x-api-key': 'sk-ant-real-api-key',
+				'authorization': `Bearer ${NONCE}.s`,
+			}, NONCE),
+			{ valid: true, sessionId: 's' },
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeProxyService.test.ts
@@ -1,0 +1,1343 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CCAModel } from '@vscode/copilot-api';
+import type * as http from 'http';
+import * as net from 'net';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import {
+	COPILOT_API_ERROR_STATUS_STREAMING,
+	CopilotApiError,
+	type ICopilotApiService,
+	type ICopilotApiServiceRequestOptions,
+} from '../../node/shared/copilotApiService.js';
+import { ClaudeProxyService } from '../../node/claude/claudeProxyService.js';
+
+// #region Test fakes
+
+interface IFakeCall {
+	githubToken: string;
+	body: Anthropic.MessageCreateParams;
+	options: ICopilotApiServiceRequestOptions | undefined;
+}
+
+interface IModelsCall {
+	githubToken: string;
+	options: ICopilotApiServiceRequestOptions | undefined;
+}
+
+type MessagesResult =
+	| { kind: 'message'; message: Anthropic.Message }
+	| { kind: 'stream'; events: Anthropic.MessageStreamEvent[]; midStreamError?: CopilotApiError | Error }
+	| { kind: 'error'; error: Error };
+
+class FakeCopilotApiService implements ICopilotApiService {
+	declare readonly _serviceBrand: undefined;
+
+	messagesResult: MessagesResult = { kind: 'error', error: new Error('not configured') };
+	modelsResult: { kind: 'value'; value: CCAModel[] } | { kind: 'error'; error: Error } = { kind: 'value', value: [] };
+
+	readonly messagesCalls: IFakeCall[] = [];
+	readonly modelsCalls: IModelsCall[] = [];
+
+	/**
+	 * Resolved when the next streaming consumer reads its first event,
+	 * useful for tests that need to assert on mid-stream behavior.
+	 */
+	onStreamFirstRead?: () => void;
+
+	messages(
+		githubToken: string,
+		request: Anthropic.MessageCreateParamsStreaming,
+		options?: ICopilotApiServiceRequestOptions,
+	): AsyncGenerator<Anthropic.MessageStreamEvent>;
+	messages(
+		githubToken: string,
+		request: Anthropic.MessageCreateParamsNonStreaming,
+		options?: ICopilotApiServiceRequestOptions,
+	): Promise<Anthropic.Message>;
+	messages(
+		githubToken: string,
+		request: Anthropic.MessageCreateParams,
+		options?: ICopilotApiServiceRequestOptions,
+	): AsyncGenerator<Anthropic.MessageStreamEvent> | Promise<Anthropic.Message> {
+		this.messagesCalls.push({ githubToken, body: request, options });
+		const result = this.messagesResult;
+		if (request.stream) {
+			return this._streamGen(result, options);
+		}
+		if (result.kind === 'message') {
+			return Promise.resolve(result.message);
+		}
+		if (result.kind === 'error') {
+			return Promise.reject(result.error);
+		}
+		return Promise.reject(new Error(`stream result configured but non-streaming request received`));
+	}
+
+	private async *_streamGen(
+		result: MessagesResult,
+		options: ICopilotApiServiceRequestOptions | undefined,
+	): AsyncGenerator<Anthropic.MessageStreamEvent> {
+		if (result.kind === 'error') {
+			throw result.error;
+		}
+		if (result.kind !== 'stream') {
+			throw new Error(`non-stream result configured but streaming request received`);
+		}
+		let firstReadFired = false;
+		for (const ev of result.events) {
+			if (options?.signal?.aborted) {
+				const e = new Error('Aborted');
+				(e as { name: string }).name = 'AbortError';
+				throw e;
+			}
+			if (!firstReadFired) {
+				firstReadFired = true;
+				this.onStreamFirstRead?.();
+			}
+			yield ev;
+		}
+		if (result.midStreamError) {
+			throw result.midStreamError;
+		}
+	}
+
+	async countTokens(): Promise<Anthropic.MessageTokensCount> {
+		throw new Error('countTokens not supported');
+	}
+
+	async models(githubToken: string, options?: ICopilotApiServiceRequestOptions): Promise<CCAModel[]> {
+		this.modelsCalls.push({ githubToken, options });
+		if (this.modelsResult.kind === 'error') {
+			throw this.modelsResult.error;
+		}
+		return this.modelsResult.value;
+	}
+}
+
+// #endregion
+
+// #region HTTP helpers
+
+let _httpModule: typeof http | undefined;
+async function getHttp(): Promise<typeof http> {
+	if (!_httpModule) {
+		_httpModule = await import('http');
+	}
+	return _httpModule;
+}
+
+interface IFetchedJson {
+	status: number;
+	headers: http.IncomingHttpHeaders;
+	body: string;
+	parsed: unknown;
+}
+
+function fetchJson(url: string, init?: { method?: string; headers?: Record<string, string>; body?: string }): Promise<IFetchedJson> {
+	return getHttp().then(httpMod => new Promise<IFetchedJson>((resolve, reject) => {
+		const u = new URL(url);
+		const req = httpMod.request({
+			hostname: u.hostname,
+			port: u.port,
+			path: u.pathname + u.search,
+			method: init?.method ?? 'GET',
+			headers: init?.headers,
+		}, res => {
+			const chunks: Buffer[] = [];
+			res.on('data', c => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+			res.on('end', () => {
+				const body = Buffer.concat(chunks).toString('utf8');
+				let parsed: unknown;
+				try { parsed = body ? JSON.parse(body) : undefined; } catch { parsed = undefined; }
+				resolve({ status: res.statusCode ?? 0, headers: res.headers, body, parsed });
+			});
+			res.on('error', reject);
+		});
+		req.on('error', reject);
+		if (init?.body !== undefined) {
+			req.write(init.body);
+		}
+		req.end();
+	}));
+}
+
+interface ISseResult {
+	status: number;
+	headers: http.IncomingHttpHeaders;
+	rawBody: string;
+	events: { type: string; data: unknown }[];
+}
+
+function fetchSse(
+	url: string,
+	init: { method: string; headers?: Record<string, string>; body?: string },
+	onResponse?: (res: http.IncomingMessage, abort: () => void) => void,
+): Promise<ISseResult> {
+	return getHttp().then(httpMod => new Promise<ISseResult>((resolve, reject) => {
+		const u = new URL(url);
+		const req = httpMod.request({
+			hostname: u.hostname,
+			port: u.port,
+			path: u.pathname + u.search,
+			method: init.method,
+			headers: init.headers,
+		}, res => {
+			const chunks: Buffer[] = [];
+			res.on('data', c => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+			res.on('end', () => {
+				const rawBody = Buffer.concat(chunks).toString('utf8');
+				resolve({
+					status: res.statusCode ?? 0,
+					headers: res.headers,
+					rawBody,
+					events: parseSseFrames(rawBody),
+				});
+			});
+			res.on('error', reject);
+			onResponse?.(res, () => req.destroy());
+		});
+		req.on('error', err => {
+			// Aborted requests reject naturally — surface as resolution
+			// with whatever we got rather than failing the test.
+			reject(err);
+		});
+		if (init.body !== undefined) {
+			req.write(init.body);
+		}
+		req.end();
+	}));
+}
+
+function parseSseFrames(raw: string): { type: string; data: unknown }[] {
+	const out: { type: string; data: unknown }[] = [];
+	const blocks = raw.split('\n\n');
+	for (const block of blocks) {
+		if (!block.trim()) {
+			continue;
+		}
+		let event = '';
+		let data = '';
+		for (const line of block.split('\n')) {
+			if (line.startsWith('event: ')) {
+				event = line.slice('event: '.length).trim();
+			} else if (line.startsWith('data: ')) {
+				data = line.slice('data: '.length);
+			}
+		}
+		if (event && data) {
+			let parsed: unknown;
+			try { parsed = JSON.parse(data); } catch { parsed = data; }
+			out.push({ type: event, data: parsed });
+		}
+	}
+	return out;
+}
+
+// #endregion
+
+// #region Fixtures
+
+const ANTHROPIC_MODEL: CCAModel = {
+	id: 'claude-opus-4.6',
+	name: 'Claude Opus 4.6',
+	vendor: 'Anthropic',
+	supported_endpoints: ['/v1/messages'],
+	object: 'model',
+	version: '4.6',
+	is_chat_default: false,
+	is_chat_fallback: false,
+	model_picker_category: '',
+	model_picker_enabled: true,
+	preview: false,
+	billing: { is_premium: false } as unknown as CCAModel['billing'],
+	capabilities: {} as CCAModel['capabilities'],
+	policy: {} as CCAModel['policy'],
+};
+
+const NON_ANTHROPIC_MODEL: CCAModel = {
+	...ANTHROPIC_MODEL,
+	id: 'gpt-5',
+	name: 'GPT-5',
+	vendor: 'OpenAI',
+	supported_endpoints: ['/v1/chat/completions'],
+};
+
+const NON_MESSAGES_ANTHROPIC: CCAModel = {
+	...ANTHROPIC_MODEL,
+	id: 'claude-instant-tokenizer',
+	name: 'Anthropic Tokenizer',
+	supported_endpoints: ['/v1/tokenize'],
+};
+
+function makeMessage(model: string, text: string): Anthropic.Message {
+	return {
+		id: 'msg_test',
+		type: 'message',
+		role: 'assistant',
+		model,
+		content: [{ type: 'text', text, citations: null }],
+		stop_reason: 'end_turn',
+		stop_sequence: null,
+		usage: {
+			input_tokens: 1,
+			output_tokens: 1,
+			cache_creation_input_tokens: null,
+			cache_read_input_tokens: null,
+			server_tool_use: null,
+			service_tier: null,
+		},
+	} as Anthropic.Message;
+}
+
+function makeStreamEvents(model: string): Anthropic.MessageStreamEvent[] {
+	const message = makeMessage(model, '');
+	return [
+		{ type: 'message_start', message },
+		{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '', citations: [] } } as Anthropic.MessageStreamEvent,
+		{ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hello' } } as Anthropic.MessageStreamEvent,
+		{ type: 'content_block_stop', index: 0 },
+		{ type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: null, cache_read_input_tokens: null, server_tool_use: null } as Anthropic.MessageDeltaUsage } as Anthropic.MessageStreamEvent,
+		{ type: 'message_stop' },
+	];
+}
+
+// #endregion
+
+// #region Service builder
+
+function createProxyService(fakeApi: FakeCopilotApiService): ClaudeProxyService {
+	return new ClaudeProxyService(new NullLogService(), fakeApi);
+}
+
+const TOKEN = 'gh-test-token';
+
+// #endregion
+
+suite('ClaudeProxyService', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	// #region Lifecycle
+
+	suite('Lifecycle', () => {
+
+		test('start() returns handle with baseUrl and 256-bit hex nonce', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				assert.match(handle.baseUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+				assert.match(handle.nonce, /^[0-9a-f]{64}$/);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('two concurrent handles share baseUrl and nonce', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			// Issue both starts before the first bind resolves; they
+			// must share the runtime — without this the second caller
+			// will bind a second server and orphan the first.
+			const [h1, h2] = await Promise.all([
+				service.start(TOKEN),
+				service.start('gh-other'),
+			]);
+			try {
+				assert.strictEqual(h1.baseUrl, h2.baseUrl);
+				assert.strictEqual(h1.nonce, h2.nonce);
+			} finally {
+				h1.dispose();
+				h2.dispose();
+				service.dispose();
+			}
+		});
+
+		test('dispose() while start() is awaiting bind rejects the start', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const startPromise = service.start(TOKEN);
+			service.dispose();
+			await assert.rejects(() => startPromise, /disposed/);
+			// A subsequent start() must also reject — the service is
+			// disposed and no orphaned runtime should be reachable.
+			await assert.rejects(() => service.start(TOKEN), /disposed/);
+		});
+
+		test('disposing one handle while another is alive keeps server up', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.modelsResult = { kind: 'value', value: [ANTHROPIC_MODEL] };
+			const service = createProxyService(fake);
+			const h1 = await service.start(TOKEN);
+			const h2 = await service.start(TOKEN);
+			h1.dispose();
+
+			const res = await fetchJson(`${h2.baseUrl}/v1/models`, {
+				headers: { 'Authorization': `Bearer ${h2.nonce}.s1` },
+			});
+			assert.strictEqual(res.status, 200);
+
+			h2.dispose();
+			service.dispose();
+		});
+
+		test('start() after refcount-0 dispose binds a new port and fresh nonce', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const h1 = await service.start(TOKEN);
+			const baseUrl1 = h1.baseUrl;
+			const nonce1 = h1.nonce;
+			h1.dispose();
+
+			const h2 = await service.start(TOKEN);
+			try {
+				assert.notStrictEqual(h2.nonce, nonce1);
+				// port may or may not be different depending on OS reuse,
+				// but baseUrl reflects whatever the new bind chose
+				assert.match(h2.baseUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+				// also: previous baseUrl is no longer reachable in tests
+				// — verified indirectly via fresh nonce above
+				void baseUrl1;
+			} finally {
+				h2.dispose();
+				service.dispose();
+			}
+		});
+
+		test('dispose() throws on subsequent start()', async () => {
+			const service = createProxyService(new FakeCopilotApiService());
+			service.dispose();
+			await assert.rejects(() => service.start(TOKEN), /disposed/);
+		});
+
+		test('start() updates token slot last-writer-wins', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.modelsResult = { kind: 'value', value: [] };
+			const service = createProxyService(fake);
+			const h1 = await service.start('token-A');
+			const h2 = await service.start('token-B');
+			try {
+				await fetchJson(`${h2.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${h2.nonce}.s1` },
+				});
+				assert.strictEqual(fake.modelsCalls.at(-1)?.githubToken, 'token-B');
+			} finally {
+				h1.dispose();
+				h2.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Bind safety
+
+	suite('Bind safety', () => {
+		test('binds only on 127.0.0.1', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				assert.ok(handle.baseUrl.startsWith('http://127.0.0.1:'));
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Auth
+
+	suite('Auth', () => {
+
+		async function withProxy<T>(fn: (handle: { baseUrl: string; nonce: string }, fake: FakeCopilotApiService) => Promise<T>): Promise<T> {
+			const fake = new FakeCopilotApiService();
+			fake.modelsResult = { kind: 'value', value: [ANTHROPIC_MODEL] };
+			fake.messagesResult = { kind: 'message', message: makeMessage('claude-opus-4.6', 'hi') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				return await fn(handle, fake);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		}
+
+		test('missing Authorization header → 401', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`);
+				assert.strictEqual(res.status, 401);
+				assert.deepStrictEqual(res.parsed, {
+					type: 'error',
+					error: { type: 'authentication_error', message: 'Invalid authentication' },
+					request_id: null,
+				});
+			});
+		});
+
+		test('Bearer wrong-nonce.x → 401', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': 'Bearer wrong-nonce.session' },
+				});
+				assert.strictEqual(res.status, 401);
+			});
+		});
+
+		test('Bearer <nonce> (no dot) → 401', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}` },
+				});
+				assert.strictEqual(res.status, 401);
+			});
+		});
+
+		test('Bearer <nonce>. (empty sessionId) → 401', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.` },
+				});
+				assert.strictEqual(res.status, 401);
+			});
+		});
+
+		test('x-api-key alone → 401', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'x-api-key': handle.nonce },
+				});
+				assert.strictEqual(res.status, 401);
+			});
+		});
+
+		test('Bearer <nonce>.<sessionId> → request proceeds', async () => {
+			await withProxy(async (handle, fake) => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.session-abc` },
+				});
+				assert.strictEqual(res.status, 200);
+				assert.strictEqual(fake.modelsCalls.length, 1);
+			});
+		});
+
+		test('auth-first precedence: GET /v1/models with bad auth does not reach upstream', async () => {
+			await withProxy(async (handle, fake) => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': 'Bearer wrong.s' },
+				});
+				assert.strictEqual(res.status, 401);
+				assert.strictEqual(fake.modelsCalls.length, 0);
+			});
+		});
+
+		test('auth-first precedence: POST /v1/messages with bad auth does not reach upstream', async () => {
+			await withProxy(async (handle, fake) => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': 'Bearer wrong.s',
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(res.status, 401);
+				assert.strictEqual(fake.messagesCalls.length, 0);
+			});
+		});
+
+		test('auth-first precedence: POST /v1/messages/count_tokens with bad auth → 401 (not 501)', async () => {
+			await withProxy(async handle => {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages/count_tokens`, {
+					method: 'POST',
+					headers: { 'Authorization': 'Bearer wrong.s' },
+					body: '{}',
+				});
+				assert.strictEqual(res.status, 401);
+			});
+		});
+	});
+
+	// #endregion
+
+	// #region Routes
+
+	suite('Routes', () => {
+
+		test('GET / → 200 ok, no auth required', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/`);
+				assert.strictEqual(res.status, 200);
+				assert.strictEqual(res.body, 'ok');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('POST /v1/messages/count_tokens → 501 api_error', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages/count_tokens`, {
+					method: 'POST',
+					headers: { 'Authorization': `Bearer ${handle.nonce}.s` },
+					body: '{}',
+				});
+				assert.strictEqual(res.status, 501);
+				assert.deepStrictEqual(res.parsed, {
+					type: 'error',
+					error: { type: 'api_error', message: 'count_tokens not supported by CAPI' },
+					request_id: null,
+				});
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('GET /something-else → 404 not_found_error', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v2/whatever`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.s` },
+				});
+				assert.strictEqual(res.status, 404);
+				const env = res.parsed as Anthropic.ErrorResponse;
+				assert.strictEqual(env.type, 'error');
+				assert.strictEqual(env.error.type, 'not_found_error');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Models route
+
+	suite('GET /v1/models', () => {
+
+		test('returns Page envelope with SDK-format IDs and filters by vendor + endpoint', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.modelsResult = { kind: 'value', value: [ANTHROPIC_MODEL, NON_ANTHROPIC_MODEL, NON_MESSAGES_ANTHROPIC] };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.s` },
+				});
+				assert.strictEqual(res.status, 200);
+				const body = res.parsed as { data: Anthropic.ModelInfo[]; has_more: boolean; first_id: string | null; last_id: string | null };
+				assert.deepStrictEqual(body, {
+					data: [{
+						id: 'claude-opus-4-6',
+						type: 'model',
+						display_name: 'Claude Opus 4.6',
+						created_at: '1970-01-01T00:00:00Z',
+						capabilities: null,
+						max_input_tokens: null,
+						max_tokens: null,
+					}],
+					has_more: false,
+					first_id: 'claude-opus-4-6',
+					last_id: 'claude-opus-4-6',
+				});
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('upstream CopilotApiError is re-emitted verbatim with original status', async () => {
+			const fake = new FakeCopilotApiService();
+			const envelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'rate_limit_error', message: 'slow down' },
+				request_id: 'req_123',
+			};
+			fake.modelsResult = { kind: 'error', error: new CopilotApiError(429, envelope) };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.s` },
+				});
+				assert.strictEqual(res.status, 429);
+				assert.deepStrictEqual(res.parsed, envelope);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('non-CopilotApiError → 502 api_error', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.modelsResult = { kind: 'error', error: new Error('ECONNRESET') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/models`, {
+					headers: { 'Authorization': `Bearer ${handle.nonce}.s` },
+				});
+				assert.strictEqual(res.status, 502);
+				const env = res.parsed as Anthropic.ErrorResponse;
+				assert.strictEqual(env.error.type, 'api_error');
+				assert.strictEqual(env.error.message, 'ECONNRESET');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Messages — model translation
+
+	suite('POST /v1/messages model translation', () => {
+
+		test('SDK ID inbound is translated to endpoint ID upstream', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'message', message: makeMessage('claude-opus-4.6', 'hi') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6-20251101', messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(fake.messagesCalls.length, 1);
+				assert.strictEqual(fake.messagesCalls[0].body.model, 'claude-opus-4.6');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('endpoint ID inbound is also accepted', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'message', message: makeMessage('claude-opus-4.6', 'hi') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4.6', messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(fake.messagesCalls[0].body.model, 'claude-opus-4.6');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('unparseable model → 404 with no upstream call', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'gpt-4o', messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(res.status, 404);
+				const env = res.parsed as Anthropic.ErrorResponse;
+				assert.strictEqual(env.error.type, 'not_found_error');
+				assert.strictEqual(fake.messagesCalls.length, 0);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('non-streaming response model is rewritten to SDK format', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'message', message: makeMessage('claude-opus-4.6', 'hi') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(res.status, 200);
+				const msg = res.parsed as Anthropic.Message;
+				assert.strictEqual(msg.model, 'claude-opus-4-6');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Body validation
+
+	suite('Body validation', () => {
+
+		test('non-JSON body → 400', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: 'not-json',
+				});
+				assert.strictEqual(res.status, 400);
+				const env = res.parsed as Anthropic.ErrorResponse;
+				assert.strictEqual(env.error.type, 'invalid_request_error');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('missing model field → 400', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ messages: [], max_tokens: 8 }),
+				});
+				assert.strictEqual(res.status, 400);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('missing messages field → 400', async () => {
+			const fake = new FakeCopilotApiService();
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', max_tokens: 8 }),
+				});
+				assert.strictEqual(res.status, 400);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Header passthrough
+
+	suite('Header passthrough', () => {
+
+		async function postAndCaptureHeaders(beta: string | undefined, version: string | undefined): Promise<Record<string, string> | undefined> {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'message', message: makeMessage('claude-opus-4.6', 'hi') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			const headers: Record<string, string> = {
+				'Authorization': `Bearer ${handle.nonce}.s`,
+				'Content-Type': 'application/json',
+				'x-request-id': 'caller-rid-123',
+				'x-custom-thing': 'should-drop',
+			};
+			if (beta !== undefined) {
+				headers['anthropic-beta'] = beta;
+			}
+			if (version !== undefined) {
+				headers['anthropic-version'] = version;
+			}
+			try {
+				await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers,
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8 }),
+				});
+				return fake.messagesCalls[0].options?.headers as Record<string, string> | undefined;
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		}
+
+		test('forwards anthropic-version verbatim', async () => {
+			const headers = await postAndCaptureHeaders(undefined, '2023-06-01');
+			assert.strictEqual(headers?.['anthropic-version'], '2023-06-01');
+		});
+
+		test('forwards supported anthropic-beta', async () => {
+			const headers = await postAndCaptureHeaders('interleaved-thinking-2025-05-14', undefined);
+			assert.strictEqual(headers?.['anthropic-beta'], 'interleaved-thinking-2025-05-14');
+		});
+
+		test('filters out unsupported betas', async () => {
+			const headers = await postAndCaptureHeaders('foo,bar,baz', undefined);
+			assert.strictEqual(headers?.['anthropic-beta'], undefined);
+		});
+
+		test('drops supported family without date suffix', async () => {
+			const headers = await postAndCaptureHeaders('interleaved-thinking', undefined);
+			assert.strictEqual(headers?.['anthropic-beta'], undefined);
+		});
+
+		test('mixed beta list keeps supported entries only', async () => {
+			const headers = await postAndCaptureHeaders('interleaved-thinking-2025-05-14,foo', undefined);
+			assert.strictEqual(headers?.['anthropic-beta'], 'interleaved-thinking-2025-05-14');
+		});
+
+		test('drops x-request-id and arbitrary headers', async () => {
+			const headers = await postAndCaptureHeaders('interleaved-thinking-2025-05-14', '2023-06-01') ?? {};
+			assert.deepStrictEqual(Object.keys(headers).sort(), ['anthropic-beta', 'anthropic-version']);
+		});
+	});
+
+	// #endregion
+
+	// #region Streaming
+
+	suite('Streaming', () => {
+
+		test('emits SSE frames in order with hand-rolled framing and rewrites message_start.message.model', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'stream', events: makeStreamEvents('claude-opus-4.6') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				assert.strictEqual(res.status, 200);
+				assert.strictEqual(res.headers['content-type'], 'text/event-stream');
+				const types = res.events.map(e => e.type);
+				assert.deepStrictEqual(types, [
+					'message_start',
+					'content_block_start',
+					'content_block_delta',
+					'content_block_stop',
+					'message_delta',
+					'message_stop',
+				]);
+				const start = res.events[0].data as { type: 'message_start'; message: { model: string } };
+				assert.strictEqual(start.message.model, 'claude-opus-4-6');
+				assert.ok(!res.rawBody.includes('[DONE]'));
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('mid-stream CopilotApiError → SSE error frame, then end, no message_stop after', async () => {
+			const fake = new FakeCopilotApiService();
+			const events: Anthropic.MessageStreamEvent[] = [
+				{ type: 'message_start', message: makeMessage('claude-opus-4.6', '') },
+				{ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '', citations: [] } } as Anthropic.MessageStreamEvent,
+			];
+			const upstreamEnvelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'rate_limit_error', message: 'slow down' },
+				request_id: 'req_xyz',
+			};
+			fake.messagesResult = {
+				kind: 'stream',
+				events,
+				midStreamError: new CopilotApiError(COPILOT_API_ERROR_STATUS_STREAMING, upstreamEnvelope),
+			};
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				assert.strictEqual(res.status, 200);
+				const lastEvent = res.events.at(-1);
+				assert.ok(lastEvent);
+				assert.strictEqual(lastEvent.type, 'error');
+				assert.deepStrictEqual(lastEvent.data, upstreamEnvelope);
+				const types = res.events.map(e => e.type);
+				assert.ok(!types.includes('message_stop'), 'no message_stop after error frame');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('pre-stream CopilotApiError → JSON error response with original status', async () => {
+			const fake = new FakeCopilotApiService();
+			const envelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'authentication_error', message: 'token expired' },
+				request_id: 'req_pre',
+			};
+			fake.messagesResult = { kind: 'error', error: new CopilotApiError(401, envelope) };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				assert.strictEqual(res.status, 401);
+				assert.deepStrictEqual(res.parsed, envelope);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('pre-stream CopilotApiError with streaming sentinel coerces to 502 but preserves envelope', async () => {
+			// The 520 sentinel is meaningless as an HTTP status pre-
+			// header; the proxy must coerce to 502 while keeping the
+			// upstream envelope verbatim. See plan §1.5.
+			const fake = new FakeCopilotApiService();
+			const envelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'overloaded_error', message: 'capacity full' },
+				request_id: 'req_sentinel',
+			};
+			fake.messagesResult = { kind: 'error', error: new CopilotApiError(COPILOT_API_ERROR_STATUS_STREAMING, envelope) };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchJson(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				assert.strictEqual(res.status, 502);
+				assert.deepStrictEqual(res.parsed, envelope);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('mid-stream non-CopilotApiError → synthesized SSE error frame', async () => {
+			const fake = new FakeCopilotApiService();
+			const events: Anthropic.MessageStreamEvent[] = [
+				{ type: 'message_start', message: makeMessage('claude-opus-4.6', '') },
+			];
+			fake.messagesResult = { kind: 'stream', events, midStreamError: new Error('socket hang up') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				const lastEvent = res.events.at(-1);
+				assert.strictEqual(lastEvent?.type, 'error');
+				const env = lastEvent.data as Anthropic.ErrorResponse;
+				assert.strictEqual(env.error.type, 'api_error');
+				assert.strictEqual(env.error.message, 'socket hang up');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('tool-use input_json_delta events pass through', async () => {
+			const fake = new FakeCopilotApiService();
+			const events: Anthropic.MessageStreamEvent[] = [
+				{ type: 'message_start', message: makeMessage('claude-opus-4.6', '') },
+				{ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_1', name: 'do_thing', input: {} } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"a":' } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '1}' } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_stop', index: 0 },
+				{ type: 'message_stop' },
+			];
+			fake.messagesResult = { kind: 'stream', events };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				const deltas = res.events.filter(e => e.type === 'content_block_delta').map(e => e.data as { delta: { type: string; partial_json?: string } });
+				assert.deepStrictEqual(deltas.map(d => d.delta.type), ['input_json_delta', 'input_json_delta']);
+				assert.deepStrictEqual(deltas.map(d => d.delta.partial_json), ['{"a":', '1}']);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('thinking_delta events pass through', async () => {
+			const fake = new FakeCopilotApiService();
+			const events: Anthropic.MessageStreamEvent[] = [
+				{ type: 'message_start', message: makeMessage('claude-opus-4.6', '') },
+				{ type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'hmm' } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: ' ok' } } as Anthropic.MessageStreamEvent,
+				{ type: 'content_block_stop', index: 0 },
+				{ type: 'message_stop' },
+			];
+			fake.messagesResult = { kind: 'stream', events };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+			try {
+				const res = await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				const deltas = res.events.filter(e => e.type === 'content_block_delta').map(e => e.data as { delta: { type: string; thinking?: string } });
+				assert.deepStrictEqual(deltas.map(d => d.delta.type), ['thinking_delta', 'thinking_delta']);
+				assert.deepStrictEqual(deltas.map(d => d.delta.thinking), ['hmm', ' ok']);
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('socket.setNoDelay(true) is called on streaming responses', async () => {
+			const fake = new FakeCopilotApiService();
+			fake.messagesResult = { kind: 'stream', events: makeStreamEvents('claude-opus-4.6') };
+			const service = createProxyService(fake);
+			const handle = await service.start(TOKEN);
+
+			// Patch net.Socket.prototype.setNoDelay to track calls during
+			// this test only.
+			const original = net.Socket.prototype.setNoDelay;
+			const calls: boolean[] = [];
+			net.Socket.prototype.setNoDelay = function (this: net.Socket, enable?: boolean): net.Socket {
+				calls.push(enable !== false);
+				return original.call(this, enable as boolean);
+			};
+			try {
+				await fetchSse(`${handle.baseUrl}/v1/messages`, {
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${handle.nonce}.s`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }),
+				});
+				assert.ok(calls.some(c => c === true), 'expected setNoDelay(true) to have been called at least once');
+			} finally {
+				net.Socket.prototype.setNoDelay = original;
+				handle.dispose();
+				service.dispose();
+			}
+		});
+	});
+
+	// #endregion
+
+	// #region Abort
+
+	suite('Abort', () => {
+
+		test('client disconnect mid-stream propagates AbortSignal upstream and writes nothing else', async () => {
+			let signalSeen: AbortSignal | undefined;
+			let resolveAborted!: () => void;
+			const abortObserved = new Promise<void>(resolve => { resolveAborted = resolve; });
+			const wrapped: ICopilotApiService = {
+				_serviceBrand: undefined,
+				// Custom stream: yield message_start, then wait until the
+				// caller's AbortSignal fires (mimics a real long-running
+				// upstream stream waiting for tokens to arrive). The test
+				// client disconnects after receiving the first frame, and
+				// we assert that the abort propagated.
+				messages: ((_token: string, _body: Anthropic.MessageCreateParams, options?: ICopilotApiServiceRequestOptions) => {
+					signalSeen = options?.signal;
+					async function* gen(): AsyncGenerator<Anthropic.MessageStreamEvent> {
+						yield { type: 'message_start', message: makeMessage('claude-opus-4.6', '') };
+						await new Promise<void>((_resolve, reject) => {
+							const onAbort = () => {
+								resolveAborted();
+								const e = new Error('Aborted');
+								(e as { name: string }).name = 'AbortError';
+								reject(e);
+							};
+							if (options?.signal?.aborted) {
+								onAbort();
+								return;
+							}
+							options?.signal?.addEventListener('abort', onAbort);
+						});
+					}
+					return gen();
+				}) as ICopilotApiService['messages'],
+				countTokens: () => Promise.reject(new Error('not used')),
+				models: () => Promise.resolve([]),
+			};
+			const service = new ClaudeProxyService(new NullLogService(), wrapped);
+			const handle = await service.start(TOKEN);
+
+			try {
+				const u = new URL(`${handle.baseUrl}/v1/messages`);
+				const httpMod = await getHttp();
+				const clientFinished = new Promise<void>(resolve => {
+					const req = httpMod.request({
+						hostname: u.hostname,
+						port: u.port,
+						path: u.pathname,
+						method: 'POST',
+						headers: {
+							'Authorization': `Bearer ${handle.nonce}.s`,
+							'Content-Type': 'application/json',
+						},
+					}, res => {
+						let frames = 0;
+						res.on('data', () => {
+							frames++;
+							if (frames >= 1) {
+								req.destroy();
+								resolve();
+							}
+						});
+						res.on('error', () => resolve());
+						res.on('close', () => resolve());
+					});
+					req.on('error', () => resolve());
+					req.write(JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8, stream: true }));
+					req.end();
+				});
+				await clientFinished;
+				// Wait for the upstream generator to observe the abort.
+				await Promise.race([
+					abortObserved,
+					new Promise<void>((_resolve, reject) => setTimeout(() => reject(new Error('upstream did not observe abort within 2s')), 2000)),
+				]);
+
+				assert.ok(signalSeen, 'expected upstream signal');
+				assert.ok(signalSeen.aborted, 'expected abort to fire on client disconnect');
+			} finally {
+				handle.dispose();
+				service.dispose();
+			}
+		});
+
+		test('dispose() with in-flight non-streaming aborts the upstream call', async () => {
+			const fake = new FakeCopilotApiService();
+			let signalSeen: AbortSignal | undefined;
+			let releaseUpstream: () => void = () => { };
+			const upstream = new Promise<Anthropic.Message>((_resolve, reject) => {
+				releaseUpstream = () => reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+			});
+			const wrapped: ICopilotApiService = {
+				_serviceBrand: undefined,
+				messages: ((token, body, options) => {
+					signalSeen = options?.signal;
+					if (body.stream) {
+						return fake.messages(token, body as Anthropic.MessageCreateParamsStreaming, options);
+					}
+					options?.signal?.addEventListener('abort', () => releaseUpstream());
+					return upstream;
+				}) as ICopilotApiService['messages'],
+				countTokens: fake.countTokens.bind(fake),
+				models: fake.models.bind(fake),
+			};
+			const service = new ClaudeProxyService(new NullLogService(), wrapped);
+			const handle = await service.start(TOKEN);
+
+			const inflight = fetchJson(`${handle.baseUrl}/v1/messages`, {
+				method: 'POST',
+				headers: {
+					'Authorization': `Bearer ${handle.nonce}.s`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ model: 'claude-opus-4-6', messages: [], max_tokens: 8 }),
+			}).catch(err => ({ aborted: true, err: err as Error }));
+
+			// Wait until upstream has been called.
+			await new Promise<void>(resolve => {
+				const i = setInterval(() => {
+					if (signalSeen) { clearInterval(i); resolve(); }
+				}, 10);
+			});
+
+			handle.dispose();
+			service.dispose();
+
+			const result = await inflight;
+			assert.ok(signalSeen?.aborted, 'expected abort to fire on dispose');
+			// connection should have been destroyed; result is either an
+			// http error or a partial response — just verify we didn't get
+			// a 200 with a body.
+			void result;
+		});
+	});
+
+	// #endregion
+});

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import type Anthropic from '@anthropic-ai/sdk';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CopilotApiService, type FetchFunction } from '../../../node/shared/copilotApiService.js';
+import { COPILOT_API_ERROR_STATUS_STREAMING, CopilotApiError, CopilotApiService, type FetchFunction } from '../../../node/shared/copilotApiService.js';
 import { NullLogService } from '../../../../log/common/log.js';
 import { IProductService } from '../../../../product/common/productService.js';
 import product from '../../../../product/common/product.js';
@@ -658,7 +658,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => service.messages('gh-tok', baseRequest),
-				(err: Error) => err.message.includes('CAPI request failed: 429'),
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === 429
+					&& err.message.includes('CAPI request failed: 429'),
 			);
 		});
 
@@ -670,7 +672,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => service.messages('gh-tok', baseRequest),
-				(err: Error) => err.message.includes('CAPI request failed: 500'),
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === 500
+					&& err.message.includes('CAPI request failed: 500'),
 			);
 		});
 	});
@@ -776,7 +780,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
-				(err: Error) => err.message === 'overloaded',
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === COPILOT_API_ERROR_STATUS_STREAMING
+					&& err.message === 'overloaded',
 			);
 		});
 
@@ -790,7 +796,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
-				(err: Error) => err.message === 'Unknown streaming error',
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === COPILOT_API_ERROR_STATUS_STREAMING
+					&& err.message === 'Unknown streaming error',
 			);
 		});
 
@@ -802,7 +810,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
-				(err: Error) => err.message.includes('CAPI request failed: 529'),
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === 529
+					&& err.message.includes('CAPI request failed: 529'),
 			);
 		});
 
@@ -1037,6 +1047,274 @@ suite('CopilotApiService', () => {
 
 	// #endregion
 
+	// #region CopilotApiError contract
+
+	suite('CopilotApiError contract', () => {
+
+		async function captureCopilotApiError(promise: Promise<unknown>): Promise<CopilotApiError> {
+			try {
+				await promise;
+			} catch (err) {
+				assert.ok(err instanceof CopilotApiError, `expected CopilotApiError, got: ${err instanceof Error ? err.message : String(err)}`);
+				return err;
+			}
+			assert.fail('expected to throw CopilotApiError');
+		}
+
+		test('non-2xx with conforming Anthropic envelope: passthrough verbatim', async () => {
+			const upstreamEnvelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'rate_limit_error', message: 'You are sending requests too fast.' },
+				request_id: 'req_abc',
+			};
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response(JSON.stringify(upstreamEnvelope), { status: 429, statusText: 'Too Many Requests' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.messages('gh-tok', baseRequest));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{ status: 429, envelope: upstreamEnvelope },
+			);
+		});
+
+		test('non-2xx with non-Anthropic JSON body: synthesizes api_error envelope', async () => {
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response('{"error":"rate_limited"}', { status: 429, statusText: 'Too Many Requests' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.messages('gh-tok', baseRequest));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{
+					status: 429,
+					envelope: {
+						type: 'error',
+						error: { type: 'api_error', message: '{"error":"rate_limited"}' },
+						request_id: null,
+					},
+				},
+			);
+		});
+
+		test('non-2xx with plain-text body: synthesizes api_error envelope using body', async () => {
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response('internal server error', { status: 500, statusText: 'Internal Server Error' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.messages('gh-tok', baseRequest));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{
+					status: 500,
+					envelope: {
+						type: 'error',
+						error: { type: 'api_error', message: 'internal server error' },
+						request_id: null,
+					},
+				},
+			);
+		});
+
+		test('non-2xx with empty body: synthesizes api_error envelope using status text', async () => {
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response('', { status: 502, statusText: 'Bad Gateway' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.messages('gh-tok', baseRequest));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{
+					status: 502,
+					envelope: {
+						type: 'error',
+						error: { type: 'api_error', message: '502 Bad Gateway' },
+						request_id: null,
+					},
+				},
+			);
+		});
+
+		test('SSE error frame with full envelope: passthrough type and message', async () => {
+			const service = streamService([
+				sseLines(
+					'event: error',
+					'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_42"}',
+				),
+			]);
+
+			const err = await captureCopilotApiError(
+				collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
+			);
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{
+					status: COPILOT_API_ERROR_STATUS_STREAMING,
+					envelope: {
+						type: 'error',
+						error: { type: 'overloaded_error', message: 'Overloaded' },
+						request_id: 'req_42',
+					},
+				},
+			);
+		});
+
+		test('SSE error frame missing type: defaults to api_error', async () => {
+			const service = streamService([
+				sseLines(
+					'event: error',
+					'data: {"type":"error","error":{"message":"oh no"}}',
+				),
+			]);
+
+			const err = await captureCopilotApiError(
+				collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
+			);
+			assert.deepStrictEqual(err.envelope, {
+				type: 'error',
+				error: { type: 'api_error', message: 'oh no' },
+				request_id: null,
+			});
+		});
+
+		test('SSE error frame missing message: defaults to "Unknown streaming error"', async () => {
+			const service = streamService([
+				sseLines(
+					'event: error',
+					'data: {"type":"error","error":{"type":"api_error"}}',
+				),
+			]);
+
+			const err = await captureCopilotApiError(
+				collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
+			);
+			assert.deepStrictEqual(err.envelope, {
+				type: 'error',
+				error: { type: 'api_error', message: 'Unknown streaming error' },
+				request_id: null,
+			});
+		});
+
+		test('SSE error frame with conforming envelope is preserved verbatim (extra fields propagate)', async () => {
+			// The Phase 2 proxy must be able to re-emit the original error frame
+			// with full fidelity — any extra fields the upstream emits should
+			// survive the round-trip through CopilotApiError.envelope.
+			const service = streamService([
+				sseLines(
+					'event: error',
+					'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded","request_id":"req_xyz"}}',
+				),
+			]);
+
+			const err = await captureCopilotApiError(
+				collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
+			);
+			assert.deepStrictEqual(err.envelope, {
+				type: 'error',
+				error: { type: 'overloaded_error', message: 'Overloaded', request_id: 'req_xyz' },
+			});
+		});
+
+		test('SSE error frame with unstructured-string error: uses the string as message', async () => {
+			const service = streamService([
+				sseLines(
+					'event: error',
+					'data: {"type":"error","error":"rate_limited"}',
+				),
+			]);
+
+			const err = await captureCopilotApiError(
+				collect(service.messages('gh-tok', { ...baseRequest, stream: true as const })),
+			);
+			assert.deepStrictEqual(err.envelope, {
+				type: 'error',
+				error: { type: 'api_error', message: 'rate_limited' },
+				request_id: null,
+			});
+		});
+
+		test('models() non-2xx throws typed error with synthesized envelope', async () => {
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response('upstream down', { status: 503, statusText: 'Service Unavailable' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.models('gh-tok'));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{
+					status: 503,
+					envelope: {
+						type: 'error',
+						error: { type: 'api_error', message: 'upstream down' },
+						request_id: null,
+					},
+				},
+			);
+			assert.ok(err.message.includes('CAPI models request failed: 503'));
+		});
+
+		test('models() non-2xx with conforming Anthropic envelope: passthrough verbatim', async () => {
+			const upstreamEnvelope: Anthropic.ErrorResponse = {
+				type: 'error',
+				error: { type: 'authentication_error', message: 'Invalid token.' },
+				request_id: 'req_def',
+			};
+			const { fetch: fetchFn } = routingFetch(
+				() => new Response(JSON.stringify(upstreamEnvelope), { status: 401, statusText: 'Unauthorized' }),
+			);
+			const service = createService(fetchFn);
+
+			const err = await captureCopilotApiError(service.models('gh-tok'));
+			assert.deepStrictEqual(
+				{ status: err.status, envelope: err.envelope },
+				{ status: 401, envelope: upstreamEnvelope },
+			);
+		});
+
+		test('error message never embeds auth tokens', async () => {
+			const service = createService(async (input) => {
+				const url = getUrl(input);
+				if (url.includes('/copilot_internal')) {
+					return tokenResponse({ token: 'super-secret-copilot-token-xyz' });
+				}
+				return new Response('rate limited', { status: 429, statusText: 'Too Many Requests' });
+			});
+
+			const err = await captureCopilotApiError(service.messages('super-secret-gh-token-xyz', baseRequest));
+			const serialized = JSON.stringify({ message: err.message, envelope: err.envelope });
+			assert.ok(!serialized.includes('super-secret-copilot-token-xyz'));
+			assert.ok(!serialized.includes('super-secret-gh-token-xyz'));
+		});
+
+		test('401 still invalidates the cached token (regression)', async () => {
+			let mintCount = 0;
+			let next401 = true;
+			const service = createService(async (input) => {
+				const url = getUrl(input);
+				if (url.includes('/copilot_internal')) {
+					mintCount++;
+					return tokenResponse();
+				}
+				if (next401) {
+					next401 = false;
+					return new Response('unauthorized', { status: 401, statusText: 'Unauthorized' });
+				}
+				return anthropicResponse([{ type: 'text', text: 'ok' }]);
+			});
+
+			await captureCopilotApiError(service.messages('gh-tok', baseRequest));
+			await service.messages('gh-tok', baseRequest);
+			assert.strictEqual(mintCount, 2);
+		});
+	});
+
+	// #endregion
+
 	// #region Cancellation
 
 	suite('Cancellation', () => {
@@ -1230,7 +1508,9 @@ suite('CopilotApiService', () => {
 
 			await assert.rejects(
 				() => service.models('gh-tok'),
-				(err: Error) => err.message.includes('CAPI models request failed: 403'),
+				(err: unknown) => err instanceof CopilotApiError
+					&& err.status === 403
+					&& err.message.includes('CAPI models request failed: 403'),
 			);
 		});
 


### PR DESCRIPTION
## Summary

Lands `ClaudeProxyService` and supporting helpers under `src/vs/platform/agentHost/node/claude/` — a refcounted local HTTP proxy that speaks the Anthropic Messages API on the inbound side and `ICopilotApiService` on the outbound side. A future `ClaudeAgent` (Phase 4) will run a Claude Agent SDK subprocess pointing at this proxy via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, getting Claude models routed through CAPI without ever talking to api.anthropic.com.

> [!NOTE]
> Nothing wires this up yet — this is preparation for the Claude Agent integration. No callers; no behavior changes for existing agents. The service is registered in DI so Phase 4 can pick it up directly.

## What's in this PR

**Phase 2 surfaces:**

| Route | Behavior |
| --- | --- |
| `GET /` | unauthenticated health check (`'ok'`) |
| `GET /v1/models` | filtered to vendor `Anthropic` + `supported_endpoints: '/v1/messages'`, IDs translated CAPI→SDK, reshaped into `Anthropic.ModelInfo` page envelope |
| `POST /v1/messages` | non-streaming + SSE streaming pass-through; `model` field translated SDK→CAPI on the way in and CAPI→SDK on the way out |
| `POST /v1/messages/count_tokens` | `501 api_error` (CAPI has no equivalent) |
| anything else (authed) | `404 not_found_error` |

**Modules:**

- `claudeProxyService.ts` — interface, impl, `IClaudeProxyHandle`, refcounted lifecycle, `http.createServer()`, dispatch, route handlers
- `claudeModelId.ts` — bidirectional model ID parser (`claude-opus-4-6` ↔ `claude-opus-4-6-20250929`)
- `anthropicBetas.ts` — `anthropic-beta` allowlist filter (`interleaved-thinking`, `context-management`, `advanced-tool-use`, date-suffix discipline)
- `anthropicErrors.ts` — proxy-authored Anthropic error envelopes; uses `Anthropic.ErrorType` from the SDK
- `claudeProxyAuth.ts` — `Bearer <nonce>.<sessionId>` parser

**Phase 1.5 contract changes in `CopilotApiService`:**

- New `CopilotApiError` class carrying `Anthropic.ErrorResponse` + status — replaces plain `Error` so the proxy can passthrough the upstream envelope verbatim
- `COPILOT_API_ERROR_STATUS_STREAMING = 520` sentinel for mid-stream errors that have no upstream HTTP status. The proxy coerces this to `502` if it surfaces before SSE headers are sent.

**DI registration** added in `agentHostMain.ts` (no callers yet).

## Lifecycle

`ClaudeProxyService` is a `Disposable` registered on the agent host main store. `start()` returns refcounted handles; the listener binds lazily on first `start()` and tears down when refcount hits 0 (or `dispose()` is called explicitly).

Concurrent `start()` calls share an in-flight bind via a `_starting` promise to avoid orphaned servers. If `dispose()` runs while binding, the just-bound server is torn down and the awaiting caller's promise rejects.

**Subprocess ownership invariant** (documented on `IClaudeProxyHandle`): callers that hand `baseUrl` + `nonce` to a Claude SDK subprocess MUST kill the subprocess before disposing the handle. After `dispose()` the proxy may rebind on a different port and the subprocess would silently lose its endpoint.

## Tests

187 / 187 passing across the four test files:

- `claudeModelId.test.ts` — round-trip parser fixtures
- `anthropicBetas.test.ts` — allowlist filter
- `claudeProxyAuth.test.ts` — bearer parsing matrix
- `claudeProxyService.test.ts` — full proxy request lifecycle (non-streaming, streaming, error mapping, refcounting, concurrent start/dispose, dispose-while-binding race, late-binding token update, pre-stream sentinel coercion)

Plus new `copilotApiService.test.ts` cases for the Phase 1.5 contract additions.

## Validation

- ✅ `compile-check-ts-native` clean
- ✅ `eslint` clean
- ✅ `valid-layers-check` clean
- ✅ All 187 tests green
- ✅ Real-CAPI smoke verified against all three surfaces (`GET /v1/models`, streaming + non-streaming `POST /v1/messages`) with full SSE event sequence and SDK-format model rewrite
- ✅ Council-reviewed; consensus blockers F1 (concurrent-bind orphan) + F2 (dispose-during-bind) fixed; F3 test coverage added

## Drafted because

Plan + roadmap docs (`CONTEXT.md`, `phase-plan.2.md`, `roadmap.md`) are committed alongside the code for in-tree design history. If reviewers prefer those land separately, happy to split.