### PR TITLE
agentHost/claude: ground Phase 3 in the production reference

### DIFF
--- a/src/vs/platform/agentHost/node/claude/phase4-plan.md
+++ b/src/vs/platform/agentHost/node/claude/phase4-plan.md
@@ -1,0 +1,456 @@
+# Phase 4 Implementation Plan — `ClaudeAgent` Skeleton
+
+> **Handoff plan** — written to be executed by an agent with no prior conversation context. All file paths and line citations are verified against the workspace at synthesis time. Cross-reference [roadmap.md](./roadmap.md) before committing exact phase numbers.
+
+## 1. Goal
+
+Add a `ClaudeAgent` provider to the agent host that registers with `IAgentService`, advertises Anthropic models from `ICopilotApiService.models()`, and authenticates against the same GitHub resource as `CopilotAgent`. **No SDK / subprocess / sendMessage** in this phase — those are Phase 6+. Most `IAgent` methods throw `Error('TODO: Phase N')`.
+
+**Exit criteria:** A workbench client connecting to the agent host sees a `claude` provider in root state, can pick a Claude model, and `sendMessage()` throws `TODO: Phase 6`.
+
+## 2. Files to create / modify
+
+| Action | File | Purpose |
+|---|---|---|
+| **Create** | `src/vs/platform/agentHost/node/claude/claudeAgent.ts` | The `ClaudeAgent` class. ~200–300 lines. |
+| **Create** | `src/vs/platform/agentHost/test/node/claudeAgent.test.ts` | Unit tests. |
+| **Modify** | `src/vs/platform/agentHost/node/agentHostMain.ts` | Register `ClaudeAgent` next to `CopilotAgent` at line 121. |
+| **Modify** | `src/vs/platform/agentHost/node/agentHostServerMain.ts` | Register `ICopilotApiService`, `IClaudeProxyService`, and `ClaudeAgent`. Currently has none of these. |
+
+## 3. `ClaudeAgent` class spec
+
+**Reference implementation map:**
+
+| Phase 4 concern | Reference |
+|---|---|
+| Class shell, `Disposable`, emitter, observable | `src/vs/platform/agentHost/node/copilot/copilotAgent.ts` (in-tree `IAgent` reference) |
+| `getDescriptor` / `getProtectedResources` / `authenticate` | `CopilotAgent` ONLY — extension has no `IAgent` analog |
+| Model filter | `extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeModels.ts:165–179` |
+
+**Do NOT** copy `ClaudeCodeSession` (claudeCodeAgent.ts:122+) verbatim — that class has accreted ~20 layered concerns (MCP gateway, plugins, edit tracker, settings tracker, OTel, hooks, debug logger, ripgrep PATH, runtime data, folder MRU). Each concern enters the in-tree implementation in the phase that actually needs it.
+
+### 3.1 Class shell
+
+```ts
+export class ClaudeAgent extends Disposable implements IAgent {
+    readonly id = 'claude' as const;
+
+    private readonly _onDidSessionProgress = this._register(new Emitter<AgentSignal>());
+    readonly onDidSessionProgress = this._onDidSessionProgress.event;
+
+    private readonly _models = observableValue<readonly IAgentModelInfo[]>(this, []);
+    readonly models: IObservable<readonly IAgentModelInfo[]> = this._models;
+
+    private _githubToken: string | undefined;
+    private _proxyHandle: IClaudeProxyHandle | undefined;
+
+    constructor(
+        @ILogService private readonly _logService: ILogService,
+        @ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
+        @IClaudeProxyService private readonly _claudeProxyService: IClaudeProxyService,
+    ) {
+        super();
+    }
+    // ...
+}
+```
+
+**Provider id is `'claude'`** (not `'claude-code'`). The id becomes the URI scheme via `AgentSession.uri()` at `src/vs/platform/agentHost/common/agentService.ts:314`. Branding goes in `displayName`.
+
+### 3.2 `getDescriptor()` and `getProtectedResources()`
+
+Mirror `CopilotAgent` lines 249–266. Use `localize()` for user-visible strings:
+
+```ts
+getDescriptor(): IAgentDescriptor {
+    return {
+        provider: 'claude',
+        displayName: localize('claudeAgent.displayName', "Claude"),
+        description: localize('claudeAgent.description', "Claude agent backed by the Anthropic Claude Agent SDK"),
+    };
+}
+
+getProtectedResources(): ProtectedResourceMetadata[] {
+    return [{
+        resource: 'https://api.github.com',
+        resource_name: 'GitHub Copilot',
+        authorization_servers: ['https://github.com/login/oauth'],
+        scopes_supported: ['read:user', 'user:email'],
+        required: true,
+    }];
+}
+```
+
+### 3.3 `authenticate()` — the only real logic in this phase
+
+Defer proxy startup until a token arrives. `IClaudeProxyService.start()` requires a non-empty github token (`src/vs/platform/agentHost/node/claude/claudeProxyService.ts:61`), so eager construction is impossible.
+
+Mirror `CopilotAgent.authenticate()` (lines 277–309):
+
+```ts
+async authenticate(resource: string, token: string): Promise<boolean> {
+    if (resource !== 'https://api.github.com') {
+        return false;
+    }
+    const tokenChanged = this._githubToken !== token;
+    this._githubToken = token;
+    this._logService.info(`[Claude] Auth token ${tokenChanged ? 'updated' : 'unchanged'}`);
+    if (tokenChanged) {
+        // Restart proxy with new token. Old handle's dispose() decrements
+        // refcount; ClaudeProxyService applies most-recent-token-wins.
+        const oldHandle = this._proxyHandle;
+        this._proxyHandle = await this._claudeProxyService.start(token);
+        oldHandle?.dispose();
+        void this._refreshModels();
+    }
+    return true;
+}
+```
+
+**Order matters:** acquire new handle before disposing old one so the proxy server doesn't tear down between the two calls (refcount stays ≥ 1 throughout).
+
+### 3.4 `_refreshModels()` — token-change-driven, with stale guard
+
+Copy CopilotAgent's pattern (lines 299–313):
+
+```ts
+private async _refreshModels(): Promise<void> {
+    const tokenAtStart = this._githubToken;
+    if (!tokenAtStart) {
+        this._models.set([], undefined);
+        return;
+    }
+    try {
+        const all = await this._copilotApiService.models(tokenAtStart);
+        const filtered = all.filter(m => isClaudeModel(m)).map(m => toAgentModelInfo(m, this.id));
+        if (this._githubToken === tokenAtStart) {
+            this._models.set(filtered, undefined);
+        }
+    } catch (err) {
+        this._logService.error(err, '[Claude] Failed to refresh models');
+        if (this._githubToken === tokenAtStart) {
+            this._models.set([], undefined);
+        }
+    }
+}
+```
+
+### 3.5 Model filter (module-level helpers)
+
+Two checks combined: CCAModel surface filter + Claude id parser. The id parser elegantly excludes synthetic ids like `auto`:
+
+```ts
+function isClaudeModel(m: CCAModel): boolean {
+    return (
+        m.vendor === 'Anthropic' &&
+        !!m.supported_endpoints?.includes('/v1/messages') &&
+        !!m.model_picker_enabled &&
+        !!m.capabilities?.supports?.tool_calls &&
+        tryParseClaudeModelId(m.id) !== undefined  // from claudeModelId.ts
+    );
+}
+
+function toAgentModelInfo(m: CCAModel, provider: AgentProvider): IAgentModelInfo {
+    return {
+        provider,
+        id: m.id,
+        name: m.name,
+        maxContextWindow: m.capabilities?.limits?.max_context_window_tokens,
+        supportsVision: !!m.capabilities?.supports?.vision,
+    };
+}
+```
+
+Field references (`src/typings/copilot-api.d.ts`):
+- `vendor` → line 113
+- `supported_endpoints` → line 115 (optional, use `?.`)
+- `model_picker_enabled` → line 140
+- `capabilities.supports.tool_calls` → line 150
+- `capabilities.limits.max_context_window_tokens` → line ~133
+
+Verify the exact `IAgentModelInfo` shape against `src/vs/platform/agentHost/common/agentService.ts:204` before writing. Drop fields that don't exist in the interface.
+
+### 3.6 Stub map
+
+Every required `IAgent` method that isn't implemented yet throws `new Error('TODO: Phase N')`. Phase numbers from [roadmap.md](./roadmap.md):
+
+| Method | Phase N | Notes |
+|---|---|---|
+| `createSession` | 5 | |
+| `disposeSession` | 5 | |
+| `getSessionMessages` | 5 | Comment: full transcript reconstruction is Phase 13 |
+| `listSessions` | 5 | |
+| `resolveSessionConfig` | 5 | |
+| `sessionConfigCompletions` | 5 | |
+| `shutdown` | 5 | |
+| `sendMessage` | 6 | |
+| `respondToPermissionRequest` | 7 | |
+| `respondToUserInputRequest` | 7 | |
+| `abortSession` | 9 | |
+| `changeModel` | 9 | |
+| `setClientTools` | 10 | |
+| `onClientToolCallComplete` | 10 | |
+| `setClientCustomizations` | 11 | |
+| `setCustomizationEnabled` | 11 | |
+
+**Cross-reference roadmap before committing each Phase N** — exact numbers may have shifted since this plan was written.
+
+**Optional methods to OMIT** (interface allows): `truncateSession?`, `setPendingMessages?`, `getCustomizations?`, `getSessionCustomizations?`, `onArchivedChanged?`, `onDidCustomizationsChange?`.
+
+### 3.7 `dispose()` — REAL, not a TODO
+
+`AgentService.dispose()` calls `provider.dispose()` unconditionally. The `_proxyHandle` is refcounted; failing to dispose leaks the proxy server lifetime.
+
+```ts
+override dispose(): void {
+    // Phase 6+ INVARIANT: SDK subprocess(es) MUST be killed before disposing
+    // the proxy handle. In Phase 4 there are no subprocesses, so this is safe.
+    this._proxyHandle?.dispose();
+    this._proxyHandle = undefined;
+    this._githubToken = undefined;
+    this._models.set([], undefined);
+    super.dispose();
+}
+```
+
+The comment is mandatory — Phase 6 will add SDK spawn and the order matters per `IClaudeProxyHandle` doc at `src/vs/platform/agentHost/node/claude/claudeProxyService.ts:33`.
+
+## 4. Registration changes
+
+### 4.1 `agentHostMain.ts` (already has DI for the prerequisites)
+
+`ICopilotApiService` and `IClaudeProxyService` are already registered at lines 110–112. Just add one more `registerProvider` call after line 121:
+
+```ts
+agentService.registerProvider(instantiationService.createInstance(CopilotAgent));
+agentService.registerProvider(instantiationService.createInstance(ClaudeAgent));  // NEW
+```
+
+Add the import: `import { ClaudeAgent } from './claude/claudeAgent.js';`
+
+### 4.2 `agentHostServerMain.ts` (DI bare — add three things)
+
+Currently this file does NOT register `ICopilotApiService` or `IClaudeProxyService`. Inside the `if (!options.quiet)` block (around line 188), before `instantiationService.createInstance(CopilotAgent)`:
+
+```ts
+const copilotApiService = instantiationService.createInstance(CopilotApiService, undefined);
+diServices.set(ICopilotApiService, copilotApiService);
+const claudeProxyService = disposables.add(instantiationService.createInstance(ClaudeProxyService));
+diServices.set(IClaudeProxyService, claudeProxyService);
+```
+
+Then register Claude:
+
+```ts
+const claudeAgent = disposables.add(instantiationService.createInstance(ClaudeAgent));
+agentService.registerProvider(claudeAgent);
+log('ClaudeAgent registered');
+```
+
+Imports needed (mirror `agentHostMain.ts` lines ~20–25):
+- `CopilotApiService`, `ICopilotApiService` from `./shared/copilotApiService.js`
+- `ClaudeProxyService`, `IClaudeProxyService` from `./claude/claudeProxyService.js`
+- `ClaudeAgent` from `./claude/claudeAgent.js`
+
+**`undefined` second arg to `CopilotApiService` is intentional** — that's the `fetchFn` slot, and `agentHostMain.ts:110` does the same.
+
+## 5. Test file spec
+
+New file: `src/vs/platform/agentHost/test/node/claudeAgent.test.ts`. Mirror the harness style of `src/vs/platform/agentHost/test/node/copilotAgent.test.ts` (read lines 233–262 for the `createTestAgentContext` pattern).
+
+**Mock services (no extensive mocking — minimal stand-ins):**
+- `IClaudeProxyService` mock: `start(token)` returns `{ baseUrl: 'http://127.0.0.1:0', nonce: 'test-nonce', dispose: () => disposeCount++ }`. Track call count and last token.
+- `ICopilotApiService` mock: `models(token)` returns a canned `CCAModel[]` mixing Anthropic + non-Anthropic + non-tool-calls + non-picker.
+
+**Test cases (use `assert.deepStrictEqual` snapshots per repo guidelines):**
+
+1. `getDescriptor()` returns `{ provider: 'claude', displayName: 'Claude', description: ... }`.
+2. `getProtectedResources()` matches the GitHub resource shape.
+3. Models observable is empty before `authenticate`.
+4. `authenticate('https://api.github.com', token)` returns `true`, calls `start(token)`, populates models with only the Claude-family entries, in correct `IAgentModelInfo` shape.
+5. `authenticate('https://other.example.com', token)` returns `false`; a follow-up `authenticate('https://api.github.com', token)` still works (proxy `start` called exactly once total). Catches implementations that early-return `false` after corrupting state.
+6. Calling `authenticate` twice with the **same** token does NOT call `start()` again (token unchanged path).
+7. Calling `authenticate` with a **different** token: new `start(tokenB)` was called AND old handle was disposed.
+8. Filter excludes: non-Anthropic vendor (e.g. `vendor: 'copilot'` for the synthetic `auto` model — verified at `extensions/copilot/src/extension/conversation/vscode-node/chatParticipants.ts:312`), missing `/v1/messages` endpoint, `model_picker_enabled: false`, `tool_calls: false`, unparseable Claude id (e.g. id `'auto'` would also fail `tryParseClaudeModelId`).
+9. `AgentSession.uri('claude', 'abc')` round-trips: scheme `'claude'`, `AgentSession.id()` returns `'abc'`, `AgentSession.provider()` returns `'claude'`.
+10. `dispose()` disposes the proxy handle; second `dispose()` is idempotent.
+11. Each stubbed method (sample 3–4) throws an `Error` whose message contains `'TODO: Phase'` and the right number.
+12. **Registration smoke:** instantiate `AgentService` + register `ClaudeAgent` + assert it appears in root state via the public service surface.
+13. **Stale-write guard:** if a slow `models(tokA)` call resolves *after* `authenticate(tokB)` has already published `[B]`, the late `[A]` result must be discarded.
+    Use `DeferredPromise` from [src/vs/base/common/async.ts](src/vs/base/common/async.ts#L1739) to control the resolution order:
+    ```ts
+    const tokAModels = new DeferredPromise<CCAModel[]>();
+    mockApi.models = (token: string) => token === 'tokA' ? tokAModels.p : Promise.resolve([CLAUDE_MODEL_B]);
+
+    void agent.authenticate('https://api.github.com', 'tokA');  // refresh-A starts, hangs on tokAModels.p
+    await agent.authenticate('https://api.github.com', 'tokB'); // refresh-B runs to completion, models == [B]
+
+    tokAModels.complete([CLAUDE_MODEL_A]);                       // refresh-A unblocks; guard must drop the write
+    await new Promise(r => setImmediate(r));
+
+    assert.deepStrictEqual(agent.models.get().map(m => m.id), [CLAUDE_MODEL_B.id]);
+    ```
+    Codifies the invariant that the in-tree `CopilotAgent` already relies on but doesn't currently test.
+
+Use `ensureNoDisposablesAreLeakedInTestSuite()` at the top.
+
+## 6. Risks / gotchas
+
+| Risk | Mitigation |
+|---|---|
+| Older roadmap revisions said "start proxy in constructor" — that's wrong. `start()` requires a token. | This plan and the current `roadmap.md` agree: defer to `authenticate()`. If you find a contradicting note elsewhere, this plan + Phase 2's `claudeProxyService.ts:61` win. |
+| `agentHostServerMain.ts` lacks DI for `ICopilotApiService`/`IClaudeProxyService` — server mode would crash. | Add both registrations as in §4.2. |
+| `CCAModel.supported_endpoints` is `string[] \| undefined` — direct `.includes()` will throw. | Use `?.includes()` everywhere. |
+| `_refreshModels` writes after `await` — token may have rotated. | Snapshot `_githubToken` at start, gate the write on equality. (Mirrors CopilotAgent.) |
+| `_proxyHandle.dispose()` is the ONLY way to release the proxy refcount — leaving `dispose()` as a TODO leaks. | Implement real `dispose()` in this phase; comment Phase 6 ordering invariant. |
+| `IClaudeProxyService` constructor requires `ICopilotApiService` (verified Phase 2). | Register `ICopilotApiService` first in `agentHostServerMain.ts`. |
+| Test assertions after `authenticate` are async-sensitive (model fetch is a promise). | For tests that just need the refresh to settle: `await new Promise(r => setImmediate(r))` to drain microtasks. For tests that need to *control* refresh ordering (e.g. stale-write guard): use `DeferredPromise` from [async.ts](src/vs/base/common/async.ts#L1739) on the mock `models()` call. Avoid timer-based waits. |
+| Disposable leak detection: mock `IClaudeProxyHandle` should not register with the test store unless tracked. | Use a lightweight object literal — its `dispose` is a closure, not a disposable. |
+
+## 7. Acceptance criteria
+
+The PR is **done** when every box below is checked. Run them in order — earlier failures invalidate later checks.
+
+### 7.1 Code structure
+
+- [ ] `src/vs/platform/agentHost/node/claude/claudeAgent.ts` exists with `export class ClaudeAgent extends Disposable implements IAgent`.
+- [ ] `id = 'claude'` (not `'claude-code'`, not `'copilotcli'`).
+- [ ] Constructor takes exactly `@ILogService`, `@ICopilotApiService`, `@IClaudeProxyService` (no other deps).
+- [ ] All 16 stubbed methods (§3.6) throw `Error('TODO: Phase N')` with the correct N.
+- [ ] No optional methods are present (`truncateSession?`, `getCustomizations?`, etc.).
+- [ ] `dispose()` is real (not a TODO) and disposes `_proxyHandle`.
+- [ ] Phase-6 subprocess-ownership invariant is in a code comment near `dispose()`.
+- [ ] Microsoft copyright header is on every new file.
+
+### 7.2 Registration
+
+- [ ] `agentHostMain.ts` registers `ClaudeAgent` next to `CopilotAgent` (one new line + import).
+- [ ] `agentHostServerMain.ts` registers `ICopilotApiService`, `IClaudeProxyService`, AND `ClaudeAgent` (was missing all three).
+
+### 7.3 Compile + lint + layers
+
+- [ ] `VS Code - Build` task shows zero TypeScript errors. If task is unavailable, `npm run compile-check-ts-native` exits 0.
+- [ ] `npm run eslint -- src/vs/platform/agentHost/node/claude/claudeAgent.ts src/vs/platform/agentHost/test/node/claudeAgent.test.ts` exits 0.
+- [ ] `npm run valid-layers-check` exits 0.
+- [ ] `npm run hygiene` exits 0.
+
+### 7.4 Tests
+
+- [ ] `src/vs/platform/agentHost/test/node/claudeAgent.test.ts` exists with all 13 cases from §5.
+- [ ] `ensureNoDisposablesAreLeakedInTestSuite()` is at the top of the suite.
+- [ ] `scripts/test.sh --grep ClaudeAgent` exits 0 — every case passes.
+- [ ] No test uses `as any` or `as unknown as Foo` casts.
+- [ ] No test depends on real network or real subprocesses.
+
+### 7.5 Behavioral exit criteria (matches §1)
+
+These are the *outcomes* the unit tests verify. §7.8 is the live-system smoke that proves they hold end-to-end.
+
+- [ ] A workbench client connecting to the agent host sees `'claude'` listed in root state alongside `'copilotcli'`.
+- [ ] After authenticate, the client sees Anthropic models in the picker (filtered by §3.5 predicate).
+- [ ] Calling `sendMessage` on a Claude session throws `Error('TODO: Phase 6')` (or whatever §3.6 maps to in the current roadmap).
+
+### 7.6 PR readiness
+
+- [ ] PR title: `agentHost/claude: Phase 4 — ClaudeAgent skeleton`.
+- [ ] PR description links to [roadmap.md](./roadmap.md) Phase 4 section and notes the exit criteria are met.
+- [ ] PR description lists the stubbed methods + their target phase as a table.
+- [ ] PR is opened as draft until the build passes; promote when green.
+
+### 7.7 What to do if a step fails
+
+| Failure | Likely cause | First debugging step |
+|---|---|---|
+| Compile error on `IAgentModelInfo` | Added a non-existent field (e.g. `family`) | Re-read `src/vs/platform/agentHost/common/agentService.ts:204`; drop unsupported fields. |
+| Compile error on `supportsVision` | Returned `boolean \| undefined` | Coerce: `!!m.capabilities?.supports?.vision`. |
+| `valid-layers-check` fails | Imported from a higher layer (`vs/workbench/`, `vs/sessions/`) by accident | Check imports — only `vs/base`, `vs/platform`, `vs/typings` allowed. |
+| Test 13 (stale-write) flakes | Microtask draining timing | Replace timer waits with `DeferredPromise` resolution + `await new Promise(r => setImmediate(r))`. |
+| `dispose()` test leaks | Mock proxy handle counted as a tracked disposable | Plain object literal, not `Disposable` subclass. |
+| `agentHostServerMain.ts` server crashes at startup | DI registration order | Register `ICopilotApiService` BEFORE `IClaudeProxyService`. |
+| `Cannot find module './claude/claudeAgent.js'` | Forgot the `.js` extension on the import | All in-tree imports use `.js` even for `.ts` source files. |
+
+### 7.8 Live-system smoke (mandatory before merging)
+
+This is the proof Phase 4 actually ships. The unit tests prove the class is wired correctly in isolation; this proves it boots, registers, and surfaces in the UI when an authenticated user opens the Agents app.
+
+Run this with the **`launch`** and **`code-oss-logs`** skills (in `.agents/skills/`).
+
+**0. Pre-flight.** Ensure the build is fresh: confirm `VS Code - Build` task has completed without errors, OR run `npm run compile-check-ts-native` and `npm run gulp compile-extensions` once.
+
+**1. Launch the Agents app with CDP attached:**
+
+```bash
+unset ELECTRON_RUN_AS_NODE
+./scripts/code.sh --agents \
+    --user-data-dir=$HOME/.vscode-oss-sessions-dev \
+    --extensions-dir=$HOME/.vscode-oss-sessions-dev/extensions \
+    --remote-debugging-port=9224
+```
+
+Wait for the window, then attach: `for i in 1 2 3 4 5; do npx @playwright/cli attach --cdp=http://127.0.0.1:9224 2>/dev/null && break || sleep 3; done`. Sign in to GitHub when prompted (real login is required — the agent only registers Anthropic models after auth).
+
+**2. Verify in the agent host log** (`~/.vscode-oss-sessions-dev/logs/<latest>/agenthost.log`):
+
+```bash
+LOG=$(ls -td ~/.vscode-oss-sessions-dev/logs/*/ | head -1)
+grep -E "Registering agent provider" "$LOG/agenthost.log"
+```
+
+- [ ] Output contains BOTH `Registering agent provider: copilotcli` AND `Registering agent provider: claude`. If only `copilotcli` appears, registration in `agentHostMain.ts` is broken (see §4.1).
+
+**3. Verify root state surfaces both agents** (`window1/output_<ts>/agenthost.<id>.log`):
+
+```bash
+WIN=$(ls -td "$LOG"/window1/output_*/ | head -1)
+grep -A3 '"provider": "claude"' "$WIN"/agenthost.*.log | head -40
+```
+
+- [ ] At least one `rootState.onDidChange` event includes a top-level agent block with `"provider": "claude"`, `"displayName": "Claude"`.
+- [ ] After auth, the same agent's `models` array is non-empty and every model entry has `"provider": "claude"` (matches `this.id` in `_listModels`; the upstream `vendor: 'Anthropic'` field is consumed by the model filter in §3.5 and not re-serialized).
+- [ ] At least one model id parses through `tryParseClaudeModelId` (e.g. `claude-sonnet-4.6`, `claude-opus-4.7`). If `models` is empty, either auth never reached the agent or the filter is rejecting everything — check for `authenticate called: resource=https://api.github.com` in `agenthost.log` followed by a successful refresh.
+
+**4. Verify the picker shows Claude:**
+
+```bash
+npx @playwright/cli snapshot
+grep -E "Pick Session Type|Claude" .playwright-cli/page-*.yml | tail
+```
+
+Then click the session-target dropdown at the bottom of the chat input (the pill currently labeled "Copilot CLI"):
+
+```bash
+# Look up the latest button ref from the snapshot above
+npx @playwright/cli click <ref>
+SCREENSHOT_DIR="/tmp/claude-phase4-smoke/$(date +%Y-%m-%dT%H-%M-%S)"
+mkdir -p "$SCREENSHOT_DIR"
+npx @playwright/cli screenshot --filename="$SCREENSHOT_DIR/picker-open.png"
+```
+
+- [ ] The picker shows two entries: `Copilot CLI` and `Claude` (label sourced from `agent.displayName` in `_registerAgent`; in the Sessions window the suffix `- Agent Host` is omitted).
+- [ ] Save the screenshot in the PR description as visual proof.
+
+**5. Verify selecting Claude creates a `agent-host-claude:` session:** click "Claude" in the picker. The chat input refreshes and a new empty session is created. Inspect the session URI:
+
+```bash
+npx @playwright/cli evaluate "() => document.querySelector('.interactive-session')?.getAttribute('data-session-uri')"
+```
+
+- [ ] URI starts with `agent-host-claude:`. (If it starts with `agent-host-copilotcli:` the wrong provider was selected; if it errors with `No content provider`, the session handler registration in `AgentHostContribution._registerAgent` did not pick up the new provider — usually means the agent didn't appear in `rootState.agents`.)
+
+**6. Verify `sendMessage` fails loudly with the Phase 6 stub:** type any prompt and submit. Expected: an error toast or inline error containing the text `TODO: Phase 6` (the exact wording from §3.6). Capture the screenshot.
+
+- [ ] An error surfaces. The exact message contains `TODO: Phase 6`. If the prompt actually sends and gets a response, the stub was overridden — not a Phase 4 deliverable.
+
+**7. Capture and attach to PR:**
+   - `agenthost.log` excerpt showing both `Registering agent provider: ...` lines.
+   - `picker-open.png` showing both targets.
+   - Screenshot of the `TODO: Phase 6` error.
+
+**Tear-down:** `lsof -t -i :9224 | xargs -r kill` — leaves the user data dir intact for re-runs.
+
+If any step in §7.8 fails, the PR is **not** ready regardless of whether §7.1–7.7 are green.
+
+## 8. Resolved decisions
+
+**Should `dispose()` await an in-flight `_refreshModels`?**
+No. `dispose()` clears `this._githubToken` *before* `super.dispose()`, so any hung `_refreshModels` will, on resume, see `this._githubToken !== tokenAtStart` and drop its write — making the in-flight refresh a no-op. Test 13 (stale-write guard) codifies this invariant. Fire-and-forget; matches `CopilotAgent`.

--- a/src/vs/platform/agentHost/node/claude/roadmap.md
+++ b/src/vs/platform/agentHost/node/claude/roadmap.md
@@ -65,7 +65,8 @@ roadmap.
   settings/tools change, MCP gateway with idle timer, restart-on-toggle for
   customizations. **Caveats:**
     - Uses `_abortController.abort()` (line 719), not `Query.interrupt()` —
-      verify in Phase 3 spike which mechanism actually cancels the SDK turn.
+      Phase 9 should mirror this. `Query.interrupt()` exists in 0.2.112 but
+      is not used by the production reference.
     - Uses `mcpServers` config for HTTP-based MCP (lines 391–416) — does
       **not** use `createSdkMcpServer` + `tool()`. The in-process tool path
       lives in `extensions/copilot/src/extension/chatSessions/claude/common/mcpServers/ideMcpServer.ts`.
@@ -223,42 +224,127 @@ Exit criteria: `curl` against the proxy with `Bearer <nonce>.test` returns the
 same payload shape Anthropic would, and `ICopilotApiService` sees the right
 calls.
 
-### Phase 3 — Claude Agent SDK integration spike
+### Phase 3 — Ground the SDK contract in the production reference ✅ **DONE**
 
-A throw-away spike that proves the SDK can be pointed at `IClaudeProxyService`
-and complete a tool-using turn end-to-end. **Not** an `IAgent` implementation
-yet.
+The Copilot extension already ships a working integration of
+`@anthropic-ai/claude-agent-sdk` 0.2.112 with a local proxy. That implementation
+is our highest-fidelity evidence for what the SDK does and does not need; an
+ad-hoc spike cannot beat a production user.
+
+**Reference files** (read these before touching Phase 4):
+
+- [`extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts`](../../../../../../extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeAgent.ts)
+  — `ClaudeCodeSession` builds the SDK `Options` and runs the message loop.
+- [`extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts`](../../../../../../extensions/copilot/src/extension/chatSessions/claude/node/claudeLanguageModelServer.ts)
+  — `ClaudeLanguageModelServer`, the extension's analogue of our
+  `ClaudeProxyService`. Implements `/v1/messages` (only), filters
+  `anthropic-beta` to a whitelist (`interleaved-thinking`,
+  `context-management`, `advanced-tool-use`), and intentionally ignores
+  `x-api-key` to prevent personal-key leakage.
+- [`extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeSdkService.ts`](../../../../../../extensions/copilot/src/extension/chatSessions/claude/node/claudeCodeSdkService.ts)
+  — DI wrapper around the SDK with lazy `import()`.
+
+**Use the extension as a reference, not a blueprint.** It has accreted ~20
+concerns (MCP gateway, plugins, edit tracker, settings change tracker, OTel
+forwarding, hook events, debug file logger, ripgrep PATH munging, runtime data
+caching, folder MRU, …) that are *layered on top of* the core SDK ↔ proxy
+contract. Phase 4 should start with the smallest `Options` that produces a
+working turn, and pull in each additional concern only when a phase actually
+needs it. Adopting the full extension shape on day one would obscure which
+pieces are essential and make incremental review impossible.
 
 **SDK version:** pin `@anthropic-ai/claude-agent-sdk` at **`0.2.112`** — the
-same version currently in `extensions/copilot/package.json`. Do **not**
-upgrade yet; versions > 0.2.112 introduce native binary dependencies that
-require additional build infrastructure (see Phase 15).
+same version `extensions/copilot/package.json` ships. Versions > 0.2.112 add
+native binary dependencies that require build-infra changes (see Phase 15).
 
-Goals:
+#### Required for Phase 4 to function at all
 
-- Confirm the SDK actually routes every messages call through
-  `ANTHROPIC_BASE_URL` (no leaks to api.anthropic.com).
-- Confirm the SSE event sequence the proxy emits is byte-compatible with what
-  the SDK expects.
-- Confirm model-ID resolution works end-to-end.
-- **Validate which abort mechanism actually works:** `Query.interrupt()` vs.
-  AbortController on the underlying fetch. The reference uses the
-  AbortController approach; verify whether `Query.interrupt()` even exists
-  on the SDK version we pin.
-- **Validate `enableFileCheckpointing` and `Query.rewindFiles()` exist** in
-  the SDK version we pin (they're not in the reference; may be newer-only).
-  If absent, Phase 8 needs a different mechanism.
-- Smoke `Query.setModel()`, `Query.setPermissionMode()`, `Query.streamInput()`.
-- Identify any SDK behaviors not anticipated.
+These are non-negotiable: omit any of them and either the SDK errors out, the
+proxy can't authenticate, the agent host has no cancellation contract, or
+egress leaks. Each row cites the production reference so future readers can
+see why it's required.
 
-Deliverable: a `node/claude/scripts/spike.ts` plus a short findings note
-appended to this roadmap. **Code thrown away**, learnings captured. Spike
-findings update Phase 6/8/9 plans.
+| `Options` field | Value (Phase 4 start) | Why required | Reference |
+|---|---|---|---|
+| `cwd` | session workspace folder | SDK validates and forwards to tools (Read/Write/Bash). | `claudeCodeAgent.ts` `_doStartSession` |
+| `executable` | `process.execPath as 'node'` | Force the SDK to fork the agent host's node process; otherwise it tries to find its own runtime. | `claudeCodeAgent.ts` line 437 |
+| `abortController` | per-session `AbortController` | The mechanism the extension actually uses to cancel a turn. `Query.interrupt()` exists but is not used in production. Phase 6 should mirror this. | `claudeCodeAgent.ts` line 138, 274, 435 |
+| `allowDangerouslySkipPermissions` | `true` | Disables the SDK's built-in approval UI so we can drive permissions ourselves via `canUseTool`. The two are a *pair* — one without the other is broken. | `claudeCodeAgent.ts` line 433 |
+| `canUseTool` | callback into `IClaudeToolPermissionService`-equivalent | Real per-tool permission UX. Phase 4 may stub to `{ behavior: 'allow' }` and defer the real UX to Phase 9. | `claudeCodeAgent.ts` line 463 |
+| `model` | `<sdkModelId>` from session state | Required for any meaningful turn. Resolve the canonical Anthropic ID via the model registry. | `claudeCodeAgent.ts` line 442 |
+| `permissionMode` | session permission mode | Required (default `'acceptEdits'` in the extension). | `claudeCodeAgent.ts` line 444 |
+| `systemPrompt` | `{ type: 'preset', preset: 'claude_code' }` | Without this the SDK has no system prompt at all and behavior degrades. | `claudeCodeAgent.ts` line 482 |
+| `settings.env.ANTHROPIC_BASE_URL` | `http://localhost:${proxy.port}` | Routes all CAPI traffic through our proxy. **Note:** under `settings.env`, NOT top-level `Options.env`. | `claudeCodeAgent.ts` line 454 |
+| `settings.env.ANTHROPIC_AUTH_TOKEN` | `${proxy.nonce}.${sessionId}` | Per-session bearer; proxy splits at `.` to recover session id. | `claudeCodeAgent.ts` line 455 |
+| `settings.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `'1'` | Disables Anthropic-direct telemetry/feature flags. Required for our leak-tightness guarantees. | `claudeCodeAgent.ts` line 456 |
+| `disallowedTools` | `['WebSearch']` | CAPI doesn't support WebSearch; the SDK will error if invoked. | `claudeCodeAgent.ts` line 440 |
+| `stderr` | wire to `ILogService.error` | Without it, SDK errors are invisible. | `claudeCodeAgent.ts` line 487 |
 
-Exit criteria: an SDK-driven session completes one turn through the proxy,
-including at least one tool call round-trip, with no traffic to anthropic.com.
+#### Deferred to later phases
+
+Each of these has a clear home; pulling them in earlier than necessary just
+expands the Phase 4 surface area for no review benefit.
+
+| Concern | Phase | Production reference |
+|---|---|---|
+| `settingSources` (load CLAUDE.md / hooks / agents from disk) | Phase 9 (settings/permissions UX). Phase 4 starts with `[]` for SDK isolation. | `claudeCodeAgent.ts` line 486 |
+| `mcpServers` (per-session MCP gateway) | Phase 7 (tool integration) | `claudeCodeAgent.ts` line 472 |
+| `plugins` (skill plugin locations) | Defer until skills are in scope | `claudeCodeAgent.ts` line 473 |
+| `additionalDirectories` (multi-root) | When multi-root support is needed | `claudeCodeAgent.ts` line 432 |
+| `effort` (reasoning controls) | When reasoning effort UX exists | `claudeCodeAgent.ts` line 436 |
+| `resume` / `sessionId` | Phase 5 (persistence) | `claudeCodeAgent.ts` lines 446–448 |
+| `includeHookEvents: true` | When hooks are exposed | `claudeCodeAgent.ts` line 471 |
+| OTel env (`deriveClaudeOTelEnv`) | When OTel is wired in agent host | `claudeCodeAgent.ts` line 460 |
+| Bundled ripgrep on `PATH` + `USE_BUILTIN_RIPGREP=0` | When bundled ripgrep is needed | `claudeCodeAgent.ts` lines 457–458 |
+| `enableFileCheckpointing` + `Query.rewindFiles()` | Phase 8 (checkpoints). Type definitions confirm both exist in 0.2.112; the extension does not use them, so Phase 8 must validate them itself. | `sdk.d.ts` lines 1105, 1280 |
+| Edit tracker, settings change tracker, runtime data cache, folder MRU, debug file logger | Workbench-side concerns; out of scope for the agent host core | `claudeCodeAgent.ts` (assorted) |
+
+#### One genuine open question
+
+**Byte-equivalence between our `ClaudeProxyService` and the extension's
+`ClaudeLanguageModelServer`.** The extension can't answer this for us; both
+proxies must produce streams the SDK accepts, but they're different
+implementations and could diverge on edge cases (`input_json_delta` shape,
+`message_delta.usage`, error-frame format). Closing path:
+
+- Phase 4 lands a unit test that points the SDK (with a stubbed CAPI) at
+  `ClaudeProxyService` and asserts the same `system/init → assistant →
+  user(tool_result) → assistant → result` sequence the extension's tests
+  assert. Lives in the repo and runs in CI.
+- No throw-away spike required.
+
+#### Notes on items the extension does differently from our Phase 2 design
+
+These are not bugs — just places the extension and our proxy currently
+diverge. Phase 4 should decide whether to converge.
+
+- **`/v1/models`:** the extension's proxy 404s it; ours forwards to
+  `ICopilotApiService.models()`. Either is fine in practice; the SDK does
+  not require `/v1/models` to function. Keeping ours is harmless.
+- **`/v1/messages/count_tokens`:** the extension's proxy 404s it; ours
+  returns 501. The SDK does not call `count_tokens` during a normal turn,
+  so neither matters in practice. If a future SDK version starts calling
+  it, both proxies will need real support.
+- **`anthropic-beta` whitelist:** the extension whitelists
+  `interleaved-thinking`, `context-management`, `advanced-tool-use`. Our
+  Phase 2 design only mentioned `interleaved-thinking`. Phase 4 should
+  widen the whitelist to match.
+- **`x-api-key` header:** the extension intentionally ignores it to prevent
+  the user's personal Anthropic key from leaking through our proxy. Our
+  Phase 2 design already enforces nonce-only auth; matching the
+  "explicitly ignore" behavior is a defense-in-depth improvement.
+
+Exit criteria: this section captures (a) the required `Options` shape for
+Phase 4, (b) the deferred-concerns map for later phases, and (c) the one
+remaining open question (byte-equivalence) with a concrete plan to close it
+in Phase 4. No throw-away code committed.
 
 ### Phase 4 — `ClaudeAgent` skeleton implementing `IAgent`
+
+> **Implementation contract: [phase4-plan.md](./phase4-plan.md).** That file
+> is the source of truth for the Phase 4 PR — code skeleton, registration
+> sites, full test list, acceptance checklist, and live-system smoke. The
+> summary below stays high-level for roadmap continuity.
 
 A registered `IAgent` whose lifecycle methods are wired but minimal. Mirror
 the pattern in `node/copilot/copilotAgent.ts`.
@@ -283,8 +369,12 @@ Scope (just enough surface for the agent to be discoverable):
   declares.
 - `authenticate(resource, token)` — store the GitHub token, push it into the
   proxy's GitHub-token slot.
-- **Spin up the `IClaudeProxyService` once at agent construction time** (one
-  proxy per agent, shared across sessions).
+- **Lazily acquire `IClaudeProxyService` handle inside `authenticate()`** (not
+  in the constructor). `IClaudeProxyService.start()` requires a non-empty
+  github token (`claudeProxyService.ts:61`), so eager construction is
+  impossible. The handle is refcounted; one outstanding handle per agent is
+  the right shared-proxy pattern. See [phase4-plan.md](./phase4-plan.md) §3.3
+  for the acquire-then-dispose-old ordering.
 - **Strip `ANTHROPIC_API_KEY`** from any spawned SDK subprocess env.
 - `models` observable — derived from `ICopilotApiService.models()`, filtered
   to Claude-family models.
@@ -404,8 +494,11 @@ SDK options pinned in this phase (matching the reference):
   Phase 11 customization-hooks wiring depends on receiving these events.
 - `spawnClaudeCodeProcess`: **not overridden** (Agent Host is the isolation
   boundary).
-- `enableFileCheckpointing: true` if the spike confirms it exists; otherwise
-  defer to Phase 8 to find an alternative.
+- `enableFileCheckpointing: true` — type definitions confirm it exists in
+  0.2.112 (`sdk.d.ts:1105`). The production reference does not use it, so
+  Phase 8 must validate the actual checkpointing/rewind behavior before
+  committing to it. If it doesn't behave as advertised, fall back to the
+  in-agent edit-history mechanism described in Phase 8.
 - **`systemPrompt: { type: 'preset', preset: 'claude_code' }`** — match
   `claudeCodeAgent.ts:478`. **Not** `tools: { type: 'preset' }` (that was a
   v1 roadmap error).
@@ -467,12 +560,14 @@ Build the Claude analog of `fileEditTracker.ts` from `node/copilot/`.
   client can render diffs, accept/reject per-file, and undo.
 - Per-file undo: client-driven, **not** part of `truncateSession`.
 - **Undo mechanism:**
-  - **If Phase 3 spike confirms `enableFileCheckpointing` + `Query.rewindFiles`
-    exist:** use them, but the surface stays per-file (the SDK rewinds all
-    files; we apply that selectively).
-  - **If they don't exist:** record file-edit history in the agent itself
-    and restore via direct file writes. Document this as a fallback in the
-    Phase 3 findings.
+  - **Preferred:** `enableFileCheckpointing` + `Query.rewindFiles()` (both
+    exist in 0.2.112 per `sdk.d.ts:1105, 1280`). Surface stays per-file —
+    the SDK rewinds all tracked files; we apply that selectively to honor
+    per-file accept/reject.
+  - **Fallback if rewind misbehaves:** record file-edit history in the
+    agent itself and restore via direct file writes. The production
+    reference does not exercise SDK rewind, so Phase 8 owns the
+    validation step.
 - **Known gap:** Bash-tool edits (`sed -i`, `cat > file`) aren't tracked by
   the SDK. Document; consider a file-watcher diff fallback in a follow-up.
 
@@ -484,9 +579,11 @@ works.
 
 ### Phase 9 — Abort + steering + model change + shutdown polish
 
-- **`abortSession`** — cancel the underlying SDK turn. The reference uses
-  `_abortController.abort()`; if Phase 3 spike confirms `Query.interrupt()`
-  also works, prefer it (cleaner). Propagates through SDK → proxy →
+- **`abortSession`** — cancel the underlying SDK turn via
+  `_abortController.abort()`, matching the production reference. Phase 9
+  may experiment with `Query.interrupt()` if the abort path turns out to
+  orphan the subprocess, but the default plan is the AbortController route
+  the extension already proves works. Propagates through SDK → proxy →
   `ICopilotApiService`.
 - **Steering / `setPendingMessages`** — use `Query.streamInput()` to push
   additional `SDKUserMessage`s mid-turn.
@@ -659,9 +756,9 @@ in place.
 - Audit the native dependency: determine the addon's platform matrix, verify
   the agent-host build pipeline can package and code-sign it for all
   supported targets (win32-x64, darwin-x64, darwin-arm64, linux-x64).
-- Validate the upgraded SDK against the full Phase 3 spike test matrix
-  (`Query.*` API surface, `enableFileCheckpointing`, `Query.rewindFiles`,
-  `Query.interrupt`).
+- Validate the upgraded SDK against the full Phase 6–13 integration test
+  matrix (`Query.*` API surface, `enableFileCheckpointing`,
+  `Query.rewindFiles`, `Query.interrupt`).
 - Update `agentHost/package.json` (or the shared platform `package.json`)
   to the new version and update any API callsites that changed between
   0.2.112 and the target version.
@@ -680,10 +777,14 @@ native dependency is packaged in all production builds.
   signature.
 - **Model ID translation location** — tentatively the proxy. Confirm in
   Phase 1.5.
-- **`Query.interrupt()` vs `_abortController.abort()`** — which actually
-  cancels a turn? Phase 3 spike answers.
-- **`enableFileCheckpointing` / `Query.rewindFiles()` SDK availability** —
-  Phase 3 spike answers; Phase 8 plan branches.
+- **`Query.interrupt()` vs `_abortController.abort()`** — the production
+  reference uses `_abortController.abort()`; Phase 9 starts there. If the
+  abort path orphans the subprocess in practice, Phase 9 evaluates
+  `Query.interrupt()` as a follow-up.
+- **`enableFileCheckpointing` / `Query.rewindFiles()` runtime behavior** —
+  type definitions confirm both exist in 0.2.112; the production
+  reference does not exercise them. Phase 8 owns the validation step
+  before committing to the rewind-based undo path.
 - **ZodSchema generation strategy for client tools** — Phase 10.
 - **MCP gateway idle timeout default** — Phase 10.
 - **Transcript cache invalidation key** —


### PR DESCRIPTION
The Copilot extension at `extensions/copilot/src/extension/chatSessions/claude/` already ships a working integration of `@anthropic-ai/claude-agent-sdk` 0.2.112 with a local proxy. That implementation is higher-fidelity evidence than any ad-hoc spike could produce.

This replaces the original "Phase 3 spike + findings" framing with a reference-grounded scoping for Phase 4. The Copilot extension is the **reference and the guiding path** — not a verbatim blueprint. It has accreted ~20 concerns (MCP gateway, plugins, edit tracker, settings change tracker, OTel forwarding, hook events, debug file logger, ripgrep PATH munging, runtime data caching, folder MRU, …) layered on top of the core SDK ↔ proxy contract. Copying the whole shape on day one would obscure which pieces are essential and break incremental review.

### What the new Phase 3 section captures

1. **Required-for-Phase-4 Options table.** The minimum set of `Options` fields to produce a working turn (cwd, executable, abortController, allowDangerouslySkipPermissions + canUseTool pair, model, permissionMode, systemPrompt preset, settings.env with proxy URL/auth/disable-nonessential-traffic, disallowedTools: ['WebSearch'], stderr). Each row cites the line in `claudeCodeAgent.ts` where the production code uses it.
2. **Deferred-concerns table.** Every additional knob the extension uses (`mcpServers`, `plugins`, `settingSources`, OTel env, ripgrep PATH, hook events, edit/settings trackers, etc.) mapped to the phase that should pull it in. Phase 4 starts small.
3. **One genuine open question** the extension cannot answer for us: byte-equivalence between our `ClaudeProxyService` and the extension's `ClaudeLanguageModelServer`. Closed by a Phase 4 unit test that points the SDK (with a stubbed CAPI) at our proxy and asserts the same message sequence the extension's tests assert. No throw-away spike committed.
4. **Phase 2 design divergences** with the extension noted (e.g. our proxy's `/v1/models` and `count_tokens` handling, the `anthropic-beta` whitelist size). Phase 4 decides whether to converge.

### Downstream phases aligned

- **Phase 6:** `enableFileCheckpointing` note now points at Phase 8 owning the validation step.
- **Phase 8:** undo mechanism keeps the SDK rewind path as preferred and the in-agent edit-history mechanism as the fallback if rewind misbehaves.
- **Phase 9:** `abortSession` defaults to `_abortController.abort()` (matching the reference), with `Query.interrupt()` evaluated as a follow-up only if the default path orphans the subprocess.
- **Phase 15 + Open questions:** dropped "Phase 3 spike answers" framing in favor of phase-owned validation steps.

### What's NOT in this PR

- No spike code. The earlier draft committed a small throwaway script; that was over-confident given how much the production extension already proves. The script is deleted.
- No code changes to `ClaudeProxyService` or anything else under `src/vs/platform/agentHost/`.

Just a roadmap update.