### PR TITLE
docs: fix typo in README contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are many ways in which you can participate in this project, for example:
 
 * [Submit bugs and feature requests](https://github.com/microsoft/vscode/issues), and help us verify as they are checked in
 * Review [source code changes](https://github.com/microsoft/vscode/pulls)
-* Review the [documentation](https://github.com/microsoft/vscode-docs) and make pull requests for anything from typos to and new content.
+* Review the [documentation](https://github.com/microsoft/vscode-docs) and make pull requests for anything from typos to new content
 
 If you are interested in fixing issues and contributing directly to the code base,
 please see the document [How to Contribute](https://github.com/microsoft/vscode/wiki/How-to-Contribute), which covers the following:


### PR DESCRIPTION
Remove redundant 'and' from documentation review bullet.
Fixes microsoft/vscode#312439