### PR TITLE
Fix terminal instantly quitting by clamping initial POSIX terminal pty dimensions

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -157,13 +157,15 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._properties[ProcessPropertyType.Cwd] = this._initialCwd;
 		const useConpty = process.platform === 'win32' && getWindowsBuildNumberSync() >= 18309;
 		const useConptyDll = useConpty && this._options.windowsUseConptyDll;
+		const ptyCols = isWindows ? cols : Math.max(cols, 1);
+		const ptyRows = isWindows ? rows : Math.max(rows, 1);
 		this._ptyOptions = {
 			name,
 			cwd,
 			// TODO: When node-pty is updated this cast can be removed
 			env: env as { [key: string]: string },
-			cols,
-			rows,
+			cols: ptyCols,
+			rows: ptyRows,
 			useConpty,
 			useConptyDll,
 			// This option will force conpty to not redraw the whole viewport on launch


### PR DESCRIPTION
Fixes #313694
Relates to #313693

This clamps the initial pty dimensions passed to node pty on non Windows platforms.

`TerminalProcess.resize()` already clamps `cols` and `rows` to at least `1`, but the initial spawn options still receive the constructor values directly. In the macOS arm64 Insiders regression, the terminal process can become ready, immediately hit a resize path with `ioctl(2) failed, EBADF`, and exit before the shell starts.

This keeps Windows startup behavior unchanged, including the existing Git Bash delayed resize path, and only normalizes the POSIX spawn options.

Validation I ran locally on the affected Insiders install:

- Integrated terminal starts and stays open
- `stty size` and `tty` return valid output
- nested `zsh` launches
- nonzero command exit does not kill the terminal
- interactive Python REPL accepts input through the pty
- output polling and terminal cleanup paths work
- large Unicode output plus stderr worked

I also made a separate user side workaround script for people stuck on the broken Insiders build, but that is intentionally not part of this PR.