### PR TITLE
Make deleteLeft and deleteRight work in dialogs and inputs

### DIFF
--- a/src/vs/editor/browser/coreCommands.ts
+++ b/src/vs/editor/browser/coreCommands.ts
@@ -9,7 +9,7 @@ import { KeyCode, KeyMod } from '../../base/common/keyCodes.js';
 import * as types from '../../base/common/types.js';
 import { status } from '../../base/browser/ui/aria/aria.js';
 import { ICodeEditor } from './editorBrowser.js';
-import { Command, EditorCommand, ICommandOptions, registerEditorCommand, MultiCommand, UndoCommand, RedoCommand, SelectAllCommand } from './editorExtensions.js';
+import { Command, EditorCommand, ICommandOptions, registerEditorCommand, MultiCommand, UndoCommand, RedoCommand, SelectAllCommand, DeleteLeftCommand, DeleteRightCommand } from './editorExtensions.js';
 import { ICodeEditorService } from './services/codeEditorService.js';
 import { ColumnSelection, IColumnSelectResult } from '../common/cursor/cursorColumnSelection.js';
 import { CursorState, EditOperationType, IColumnSelectData, PartialCursorState } from '../common/cursorCommon.js';
@@ -2044,22 +2044,20 @@ export namespace CoreEditingCommands {
 		}
 	});
 
-	export const DeleteLeft: EditorCommand = registerEditorCommand(new class extends CoreEditingCommand {
+	export const DeleteLeft = new class extends EditorOrNativeTextInputCommand {
+		public readonly id = 'deleteLeft';
 		constructor() {
-			super({
-				id: 'deleteLeft',
-				precondition: undefined,
-				kbOpts: {
-					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
-					primary: KeyCode.Backspace,
-					secondary: [KeyMod.Shift | KeyCode.Backspace],
-					mac: { primary: KeyCode.Backspace, secondary: [KeyMod.Shift | KeyCode.Backspace, KeyMod.WinCtrl | KeyCode.KeyH, KeyMod.WinCtrl | KeyCode.Backspace] }
-				}
-			});
+			super(DeleteLeftCommand);
 		}
-
-		public runCoreEditingCommand(editor: ICodeEditor, viewModel: IViewModel, args: unknown): void {
+		public runDOMCommand(activeElement: Element): void {
+			activeElement.ownerDocument.execCommand('delete');
+		}
+		public runEditorCommand(accessor: ServicesAccessor | null, editor: ICodeEditor, args: unknown): void {
+			const viewModel = editor._getViewModel();
+			if (!viewModel) {
+				// the editor has no view => has no cursors
+				return;
+			}
 			const [shouldPushStackElementBefore, commands] = DeleteOperations.deleteLeft(viewModel.getPrevEditOperationType(), viewModel.cursorConfig, viewModel.model, viewModel.getCursorStates().map(s => s.modelState.selection), viewModel.getCursorAutoClosedCharacters());
 			if (shouldPushStackElementBefore) {
 				editor.pushUndoStop();
@@ -2067,23 +2065,22 @@ export namespace CoreEditingCommands {
 			editor.executeCommands(this.id, commands);
 			viewModel.setPrevEditOperationType(EditOperationType.DeletingLeft);
 		}
-	});
+	}();
 
-	export const DeleteRight: EditorCommand = registerEditorCommand(new class extends CoreEditingCommand {
+	export const DeleteRight = new class extends EditorOrNativeTextInputCommand {
+		public readonly id = 'deleteRight';
 		constructor() {
-			super({
-				id: 'deleteRight',
-				precondition: undefined,
-				kbOpts: {
-					weight: CORE_WEIGHT,
-					kbExpr: EditorContextKeys.textInputFocus,
-					primary: KeyCode.Delete,
-					mac: { primary: KeyCode.Delete, secondary: [KeyMod.WinCtrl | KeyCode.KeyD, KeyMod.WinCtrl | KeyCode.Delete] }
-				}
-			});
+			super(DeleteRightCommand);
 		}
-
-		public runCoreEditingCommand(editor: ICodeEditor, viewModel: IViewModel, args: unknown): void {
+		public runDOMCommand(activeElement: Element): void {
+			activeElement.ownerDocument.execCommand('forwardDelete');
+		}
+		public runEditorCommand(accessor: ServicesAccessor | null, editor: ICodeEditor, args: unknown): void {
+			const viewModel = editor._getViewModel();
+			if (!viewModel) {
+				// the editor has no view => has no cursors
+				return;
+			}
 			const [shouldPushStackElementBefore, commands] = DeleteOperations.deleteRight(viewModel.getPrevEditOperationType(), viewModel.cursorConfig, viewModel.model, viewModel.getCursorStates().map(s => s.modelState.selection));
 			if (shouldPushStackElementBefore) {
 				editor.pushUndoStop();
@@ -2091,7 +2088,7 @@ export namespace CoreEditingCommands {
 			editor.executeCommands(this.id, commands);
 			viewModel.setPrevEditOperationType(EditOperationType.DeletingRight);
 		}
-	});
+	}();
 
 	export const Undo = new class extends EditorOrNativeTextInputCommand {
 		constructor() {

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -724,3 +724,26 @@ export const SelectAllCommand = registerCommand(new MultiCommand({
 		order: 1
 	}]
 }));
+
+export const DeleteLeftCommand = registerCommand(new MultiCommand({
+	id: 'deleteLeft',
+	precondition: undefined,
+	kbOpts: {
+		weight: KeybindingWeight.EditorCore,
+		kbExpr: null,
+		primary: KeyCode.Backspace,
+		secondary: [KeyMod.Shift | KeyCode.Backspace],
+		mac: { primary: KeyCode.Backspace, secondary: [KeyMod.Shift | KeyCode.Backspace, KeyMod.WinCtrl | KeyCode.KeyH, KeyMod.WinCtrl | KeyCode.Backspace] }
+	}
+}));
+
+export const DeleteRightCommand = registerCommand(new MultiCommand({
+	id: 'deleteRight',
+	precondition: undefined,
+	kbOpts: {
+		weight: KeybindingWeight.EditorCore,
+		kbExpr: null,
+		primary: KeyCode.Delete,
+		mac: { primary: KeyCode.Delete, secondary: [KeyMod.WinCtrl | KeyCode.KeyD, KeyMod.WinCtrl | KeyCode.Delete] }
+	}
+}));


### PR DESCRIPTION
## Summary

`deleteLeft` and `deleteRight` were registered as editor-only `CoreEditingCommand`s with `kbExpr: EditorContextKeys.textInputFocus`. As a result, when a user binds a keybinding such as `Ctrl+H` → `deleteLeft` and runs it from a dialog, QuickInput, or any non-Monaco `<input>` / `<textarea>`, the command either silently no-ops or routes to the last focused code editor — bypassing the focused input entirely.

This PR converts both commands to the same `EditorOrNativeTextInputCommand` pattern that `Undo`, `Redo`, and `SelectAll` already use immediately above in the same file. The dispatch order becomes:

1. Focused code editor → existing edit logic (`DeleteOperations.deleteLeft/Right`, push undo stop, set `EditOperationType.DeletingLeft/Right`).
2. Focused `<input>` / `<textarea>` → `activeElement.ownerDocument.execCommand('delete'|'forwardDelete')`.
3. Active editor as fallback.

`InputBox` and `QuickInputBox` need no changes — they already participate in the `generic-dom-input-textarea` branch via the existing `isEditableElement` check.

Fixes #147218

## Implementation

- `src/vs/editor/browser/editorExtensions.ts` — added `DeleteLeftCommand` and `DeleteRightCommand` `MultiCommand`s with id `'deleteLeft'` / `'deleteRight'`, `kbExpr: null` (the line that fixes the routing bug), and the original keybindings preserved verbatim (Backspace / Delete plus mac `Ctrl+H` / `Ctrl+D` / `Shift+Backspace` / `Ctrl+Backspace` / `Ctrl+Delete` secondaries).
- `src/vs/editor/browser/coreCommands.ts` — replaced the `registerEditorCommand(new class extends CoreEditingCommand)` blocks for the same two ids with `new class extends EditorOrNativeTextInputCommand` instances bound to the new `MultiCommand`s. The editor-side `runEditorCommand` retains the existing `DeleteOperations` logic; `runDOMCommand` calls `execCommand('delete')` / `'forwardDelete'`. A `public readonly id` field is exposed for the existing reader in `inlineCompletionsController.ts`.

### Out of scope

`deleteWordLeft` / `deleteWordRight` live in `src/vs/editor/contrib/wordOperations/` rather than core. They share the same root cause and could be follow-up work, but applying the fix there would broaden this PR substantially. Issue #147218 only mentions `deleteLeft` / `deleteRight`.

## Test plan

- [x] Existing tests using `editor.runCommand(CoreEditingCommands.DeleteLeft|Right, args)` (cursor.test.ts, suggestModel.test.ts, linkedEditing.test.ts, cursorUndo.test.ts, inlineCompletions/utils.ts) compile unchanged because the new objects implement the same `runEditorCommand(accessor, editor, args)` signature.
- [ ] Manual: bind `Ctrl+H` to `deleteLeft` via Keyboard Shortcuts. Press `Ctrl+H` in a Monaco editor — deletes left. Press `Ctrl+H` in the Find widget input, the Quick Open input, and a Settings search input — also deletes left.
- [ ] Manual: bind `Ctrl+D` to `deleteRight`. Same scenarios — deletes right.
- [ ] Manual: native Backspace and Delete behavior in editors and inputs is unchanged.