### PR TITLE
Render inline code spans in notification messages

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -62,6 +62,13 @@
 	color: var(--vscode-notificationLink-foreground);
 }
 
+.monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-message code {
+	font-family: var(--monaco-monospace-font);
+	background-color: var(--vscode-textCodeBlock-background);
+	border-radius: 3px;
+	padding: 0 0.4em;
+}
+
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-message a:focus {
 	outline-width: 1px;
 	outline-style: solid;

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -15,6 +15,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { dispose, DisposableStore, Disposable } from '../../../../base/common/lifecycle.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { INotificationViewItem, NotificationViewItem, NotificationViewItemContentChangeKind, INotificationMessage, ChoiceAction, NotificationsSettings, getNotificationsPosition } from '../../../common/notifications.js';
+import { isCodeSpan } from '../../../common/notificationMessageParser.js';
 import { ClearNotificationAction, ExpandNotificationAction, CollapseNotificationAction, ConfigureNotificationAction, getNotificationExpandIcon, getNotificationCollapseIcon } from './notificationsActions.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ProgressBar } from '../../../../base/browser/ui/progressbar/progressbar.js';
@@ -144,9 +145,13 @@ class NotificationMessageRenderer {
 	static render(message: INotificationMessage, actionHandler?: IMessageActionHandler): HTMLElement {
 		const messageContainer = $('span');
 
-		for (const node of message.linkedText.nodes) {
+		for (const node of message.nodes) {
 			if (typeof node === 'string') {
 				messageContainer.appendChild(document.createTextNode(node));
+			} else if (isCodeSpan(node)) {
+				const code = $('code');
+				code.appendChild(document.createTextNode(node.code));
+				messageContainer.appendChild(code);
 			} else {
 				let title = node.title;
 

--- a/src/vs/workbench/common/notificationMessageParser.ts
+++ b/src/vs/workbench/common/notificationMessageParser.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILink, parseLinkedText } from '../../base/common/linkedText.js';
+
+export interface ICodeSpan {
+	readonly code: string;
+}
+
+export type NotificationMessageNode = string | ILink | ICodeSpan;
+
+export function isCodeSpan(node: NotificationMessageNode): node is ICodeSpan {
+	return typeof node !== 'string' && 'code' in node;
+}
+
+/**
+ * Parses a notification message into nodes consisting of plain strings,
+ * markdown-style links and inline code spans (single-backtick delimited).
+ *
+ * Code spans are tokenized before link parsing so that bracket/parenthesis
+ * sequences inside backticks are not interpreted as links.
+ *
+ * Rules:
+ * - `code` renders as a code span containing the inner text.
+ * - Empty backticks (``) are kept literal.
+ * - An unmatched single backtick stays literal.
+ * - A backslash-escaped backtick (\`) stays literal (the backslash is dropped).
+ */
+export function parseNotificationMessage(text: string): NotificationMessageNode[] {
+	const result: NotificationMessageNode[] = [];
+
+	let buffer = '';
+	let i = 0;
+
+	const flushBuffer = () => {
+		if (buffer.length === 0) {
+			return;
+		}
+		// Run link parsing on the accumulated plain text so that links are
+		// recognized only outside of code spans.
+		for (const node of parseLinkedText(buffer).nodes) {
+			result.push(node);
+		}
+		buffer = '';
+	};
+
+	while (i < text.length) {
+		const ch = text[i];
+
+		// Backslash-escaped backtick: drop the backslash, keep the backtick literal.
+		if (ch === '\\' && text[i + 1] === '`') {
+			buffer += '`';
+			i += 2;
+			continue;
+		}
+
+		if (ch === '`') {
+			// Look for the next unescaped backtick to close the span.
+			let j = i + 1;
+			let inner = '';
+			let closed = false;
+			while (j < text.length) {
+				if (text[j] === '\\' && text[j + 1] === '`') {
+					inner += '`';
+					j += 2;
+					continue;
+				}
+				if (text[j] === '`') {
+					closed = true;
+					break;
+				}
+				inner += text[j];
+				j++;
+			}
+
+			if (!closed) {
+				// Unmatched: keep the opening backtick literal.
+				buffer += '`';
+				i++;
+				continue;
+			}
+
+			if (inner.length === 0) {
+				// Empty backticks: keep them literal.
+				buffer += '``';
+				i = j + 1;
+				continue;
+			}
+
+			// Valid code span.
+			flushBuffer();
+			result.push({ code: inner });
+			i = j + 1;
+			continue;
+		}
+
+		buffer += ch;
+		i++;
+	}
+
+	flushBuffer();
+
+	return result;
+}

--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -11,6 +11,7 @@ import { isCancellationError } from '../../base/common/errors.js';
 import { Action } from '../../base/common/actions.js';
 import { equals } from '../../base/common/arrays.js';
 import { parseLinkedText, LinkedText } from '../../base/common/linkedText.js';
+import { NotificationMessageNode, parseNotificationMessage } from './notificationMessageParser.js';
 import { mapsStrictEqualIgnoreOrder } from '../../base/common/map.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 
@@ -443,6 +444,7 @@ export interface INotificationMessage {
 	raw: string;
 	original: NotificationMessage;
 	linkedText: LinkedText;
+	nodes: NotificationMessageNode[];
 }
 
 export class NotificationViewItem extends Disposable implements INotificationViewItem {
@@ -528,7 +530,10 @@ export class NotificationViewItem extends Disposable implements INotificationVie
 		// Parse Links
 		const linkedText = parseLinkedText(message);
 
-		return { raw, linkedText, original: input };
+		// Parse code spans + Links (used by the renderer)
+		const nodes = parseNotificationMessage(message);
+
+		return { raw, linkedText, nodes, original: input };
 	}
 
 	private constructor(

--- a/src/vs/workbench/test/common/notificationMessageParser.test.ts
+++ b/src/vs/workbench/test/common/notificationMessageParser.test.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { isCodeSpan, parseNotificationMessage } from '../../common/notificationMessageParser.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+
+suite('NotificationMessageParser', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('plain text passes through unchanged', () => {
+		assert.deepStrictEqual(parseNotificationMessage(''), []);
+		assert.deepStrictEqual(parseNotificationMessage('hello world'), ['hello world']);
+	});
+
+	test('plain link still parses as a link', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('See [docs](https://example.com) for more.'),
+			[
+				'See ',
+				{ label: 'docs', href: 'https://example.com' },
+				' for more.'
+			]
+		);
+	});
+
+	test('single backtick span renders as code', () => {
+		const nodes = parseNotificationMessage('Use `npm install` to begin.');
+		assert.deepStrictEqual(nodes, [
+			'Use ',
+			{ code: 'npm install' },
+			' to begin.'
+		]);
+		assert.ok(isCodeSpan(nodes[1] as any));
+	});
+
+	test('code span and link can co-exist in the same message', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('Run `npm install` then visit [docs](https://example.com).'),
+			[
+				'Run ',
+				{ code: 'npm install' },
+				' then visit ',
+				{ label: 'docs', href: 'https://example.com' },
+				'.'
+			]
+		);
+	});
+
+	test('empty backticks stay literal', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('before `` after'),
+			['before `` after']
+		);
+	});
+
+	test('unmatched trailing backtick stays literal', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('hello `world'),
+			['hello `world']
+		);
+	});
+
+	test('escaped backtick stays literal and drops the backslash', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('use \\`literal\\` text'),
+			['use `literal` text']
+		);
+	});
+
+	test('escaped backtick inside a code span is preserved as a literal backtick', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('value `a\\`b` end'),
+			[
+				'value ',
+				{ code: 'a`b' },
+				' end'
+			]
+		);
+	});
+
+	test('link inside code span is NOT parsed as a link', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('see `[click](https://example.com)` for syntax'),
+			[
+				'see ',
+				{ code: '[click](https://example.com)' },
+				' for syntax'
+			]
+		);
+	});
+
+	test('multiple code spans in a single message', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('Run `npm i` and then `npm test`.'),
+			[
+				'Run ',
+				{ code: 'npm i' },
+				' and then ',
+				{ code: 'npm test' },
+				'.'
+			]
+		);
+	});
+
+	test('command-link still works with surrounding code spans', () => {
+		assert.deepStrictEqual(
+			parseNotificationMessage('Selected: `(.venv)` — see [details](command:foo).'),
+			[
+				'Selected: ',
+				{ code: '(.venv)' },
+				' — see ',
+				{ label: 'details', href: 'command:foo' },
+				'.'
+			]
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds support for inline code spans (single backticks) in workbench notification messages, as discussed in #191713. Code spans render inside a `<code>` element styled with the existing `--vscode-textCodeBlock-background` token, mirroring the styling used by hover and parameter-hints widgets.

Fixes #191713

## Implementation

A new `parseNotificationMessage` helper lives in `src/vs/workbench/common/notificationMessageParser.ts`. It tokenizes single-backtick code spans first, then delegates to `parseLinkedText` for each non-code segment — this naturally satisfies the rule that markdown links inside a code span should not be parsed as links. The shared `parseLinkedText` API is left untouched, so the ~15 other callers (welcome page / getting-started, language status, search messages, quick input, workspace trust, view panes, etc.) are unchanged.

`INotificationMessage` gains an additive `nodes: NotificationMessageNode[]` field alongside the existing `linkedText: LinkedText`. Existing consumers that read `linkedText.toString()` (notification accessibility alerts, etc.) keep working without any changes.

### Edge cases handled
- Empty backticks (` `` `) stay literal.
- An unmatched trailing backtick stays literal.
- A backslash-escaped backtick (`\` `) stays literal (the backslash is dropped).
- Links inside a code span are not parsed as links.
- Fenced code blocks and other markdown features are intentionally not supported — only inline code, per the scope of #191713.

### Files
- `src/vs/workbench/common/notificationMessageParser.ts` (new) — parser + `NotificationMessageNode` types.
- `src/vs/workbench/common/notifications.ts` — adds `nodes` to `INotificationMessage`.
- `src/vs/workbench/browser/parts/notifications/notificationsViewer.ts` — iterates `message.nodes` and emits a `<code>` element for code-span nodes.
- `src/vs/workbench/browser/parts/notifications/media/notificationsList.css` — minimal style rule scoped to `.notification-list-item-message code`.
- `src/vs/workbench/test/common/notificationMessageParser.test.ts` (new) — 7 unit tests.

## Test plan

- [x] 7 unit tests covering: plain text, single code span, code span + link in same message, multiple code spans, empty backticks, unmatched backtick, escaped backtick, link inside backticks.
- [ ] Manual: from the command palette, run "Notifications: Toggle Notifications" with a message containing a backtick span — verify the inner text renders inside a `<code>` element with the expected styling.
- [ ] Manual: a message with both a backtick span and a `[link](https://example.com)` renders both correctly.
- [ ] Manual: existing notifications (no backticks) render identically to before.