### PR TITLE
Preserve newlines in notification messages

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -146,7 +146,18 @@ class NotificationMessageRenderer {
 
 		for (const node of message.linkedText.nodes) {
 			if (typeof node === 'string') {
-				messageContainer.appendChild(document.createTextNode(node));
+				// Preserve newlines in the message by rendering each '\n' as a
+				// line break. Note: '\r' and '\r\n' are normalized to '\n' when
+				// the notification message is parsed (see `notifications.ts`).
+				const segments = node.split('\n');
+				for (let i = 0; i < segments.length; i++) {
+					if (i > 0) {
+						messageContainer.appendChild($('br'));
+					}
+					if (segments[i].length > 0) {
+						messageContainer.appendChild(document.createTextNode(segments[i]));
+					}
+				}
 			} else {
 				let title = node.title;
 

--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -522,8 +522,11 @@ export class NotificationViewItem extends Disposable implements INotificationVie
 			message = `${message.substr(0, NotificationViewItem.MAX_MESSAGE_LENGTH)}...`;
 		}
 
-		// Remove newlines from messages as we do not support that and it makes link parsing hard
-		message = message.replace(/(\r\n|\n|\r)/gm, ' ').trim();
+		// Normalize line breaks to '\n' so the renderer can split on a single
+		// character. Newlines are preserved in the message and rendered as
+		// line breaks; link parsing still works because the link pattern does
+		// not span lines.
+		message = message.replace(/\r\n|\r/g, '\n').trim();
 
 		// Parse Links
 		const linkedText = parseLinkedText(message);

--- a/src/vs/workbench/test/common/notifications.test.ts
+++ b/src/vs/workbench/test/common/notifications.test.ts
@@ -161,6 +161,40 @@ suite('Notifications', () => {
 		}
 	});
 
+	test('Items - preserves newlines in messages (#178796)', () => {
+
+		// '\n' is preserved verbatim in the parsed message so the renderer can
+		// translate it to a line break.
+		const item1 = NotificationViewItem.create({ severity: Severity.Info, message: 'Line one\nLine two' }, noFilter)!;
+		assert.strictEqual(item1.message.linkedText.toString(), 'Line one\nLine two');
+		assert.strictEqual(item1.message.raw, 'Line one\nLine two');
+
+		// '\r\n' (Windows) and '\r' (legacy Mac) are normalized to '\n'.
+		const item2 = NotificationViewItem.create({ severity: Severity.Info, message: 'Line one\r\nLine two' }, noFilter)!;
+		assert.strictEqual(item2.message.linkedText.toString(), 'Line one\nLine two');
+
+		const item3 = NotificationViewItem.create({ severity: Severity.Info, message: 'Line one\rLine two' }, noFilter)!;
+		assert.strictEqual(item3.message.linkedText.toString(), 'Line one\nLine two');
+
+		// Leading and trailing whitespace (including newlines) is trimmed so
+		// no empty leading/trailing line is rendered.
+		const item4 = NotificationViewItem.create({ severity: Severity.Info, message: '\n\nLine one\nLine two\n\n' }, noFilter)!;
+		assert.strictEqual(item4.message.linkedText.toString(), 'Line one\nLine two');
+
+		// Newlines do not break link parsing: a link before a newline is still
+		// recognized, and text on the next line remains a plain string node.
+		const item5 = NotificationViewItem.create({ severity: Severity.Info, message: 'Click [here](https://example.com)\nfor details.' }, noFilter)!;
+		const nodes = item5.message.linkedText.nodes;
+		assert.strictEqual(nodes.length, 3);
+		assert.strictEqual(nodes[0], 'Click ');
+		assert.deepStrictEqual(nodes[1], { label: 'here', href: 'https://example.com' });
+		assert.strictEqual(nodes[2], '\nfor details.');
+
+		for (const item of [item1, item2, item3, item4, item5]) {
+			item.close();
+		}
+	});
+
 	test('Items - does not fire changed when message did not change (content, severity)', async () => {
 		const item1 = NotificationViewItem.create({ severity: Severity.Error, message: 'Error Message' }, noFilter)!;
 


### PR DESCRIPTION
## Summary

`NotificationViewItem.parseMessage` previously flattened all line breaks to spaces:

```ts
// Before
message = message.replace(/(\r\n|\n|\r)/gm, ' ').trim();
```

This PR keeps `\n` intact and normalizes `\r\n` / `\r` to `\n`. The renderer (`NotificationMessageRenderer.render`) splits plain string nodes on `\n` and emits a `<br>` between segments, so multi-line notification messages render with the line breaks the producer intended.

Fixes #178796

## Implementation

- `src/vs/workbench/common/notifications.ts` — change the parse-time strip to a normalize-to-`\n`. Link parsing still works because the link pattern in `parseLinkedText` does not span lines, so any `\n` always ends up in a plain string node before/after a parsed link.
- `src/vs/workbench/browser/parts/notifications/notificationsViewer.ts` — when iterating `message.linkedText.nodes`, split each plain string on `\n` and emit a `<br>` element between segments. Empty segments are skipped so a trimmed-trailing-newline message doesn't append a stray `<br>`.

### No CSS changes needed

- Expanded notification messages already declare `white-space: normal; word-wrap: break-word;` and the offset helper used for auto-expansion height calculation already wraps.
- Collapsed rows have a fixed `LINE_HEIGHT (22)` with `overflow: hidden`, so the single-line preview look is preserved while the offset helper correctly computes a taller preferred height — driving auto-expansion already works.

### Accessibility

`notificationsAlerts.ts` reads `notification.message.linkedText.toString()` for ARIA alerts. Screen readers naturally pause at `\n`, so multi-line announcements read more naturally than today's space-flattened output.

`message.raw` is unchanged — it's set before the parse-time normalization, so existing aria-label/clipboard-copy callers (`notificationsToasts.ts`, `notificationsList.ts`, `notificationsActions.ts`) see no behavior difference.

## Conflict note for reviewers

This PR conflicts with my open PR #313707 (Render inline code spans in notification messages, fixes #191713) on the same two files. Both touch the `notifications.ts` parse path and the `notificationsViewer.ts` rendering. The conflict is mechanical — one introduces a `nodes: NotificationMessageNode[]` shape; this one preserves `\n` in plain text nodes. Whichever lands first, I'm happy to rebase the other.

## Test plan

- [x] New regression test in `notifications.test.ts` covering: a plain `\n` is preserved through parsing; `\r\n` and `\r` are normalized to `\n`; leading/trailing newlines are trimmed; newlines coexist with markdown links.
- [ ] Manual: post a notification with `\n` in the message via `vscode.window.showInformationMessage("Line one\nLine two")` from an extension or `notification.show({ severity: Severity.Info, message: "Line one\nLine two" })` — verify both lines render.
- [ ] Manual: ensure existing single-line notifications render identically (no extra `<br>`).
- [ ] Manual: a multi-line message with a link mid-message keeps both the line breaks and the parsed link.