### PR TITLE
Default `git.addAICoAuthor` to `off`

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3740,7 +3740,7 @@
             "%config.addAICoAuthor.all%"
           ],
           "scope": "resource",
-          "default": "chatAndAgent",
+          "default": "off",
           "description": "%config.addAICoAuthor%"
         },
         "git.ignoreSubmodules": {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1498,7 +1498,7 @@ export class Repository implements Disposable {
 		}
 
 		const config = workspace.getConfiguration('git', Uri.file(this.root));
-		const addAICoAuthor = config.get<'off' | 'chatAndAgent' | 'all'>('addAICoAuthor', 'chatAndAgent');
+		const addAICoAuthor = config.get<'off' | 'chatAndAgent' | 'all'>('addAICoAuthor', 'off');
 
 		if (addAICoAuthor === 'off') {
 			return message;


### PR DESCRIPTION
The unauthorized addition of product advertisements without notifying users has drawn widespread criticism:

- https://github.com/orgs/community/discussions/194075
- https://byteiota.com/vs-code-copilot-co-author-default-copyright-chaos-ensues/
- https://news.ycombinator.com/item?id=47966278

I personally don't care much about this, but you can't assume that everyone accepts it.