### PR TITLE
fix: enable text selection in elicitation dialog markdown content

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -462,6 +462,13 @@
 	}
 }
 
+/* user-select: text for elicitation dialog text areas */
+.interactive-session .chat-question-carousel-container .chat-question-detailed-message,
+.interactive-session .chat-question-carousel-container .chat-question-description {
+	user-select: text;
+	-webkit-user-select: text;
+}
+
 /* carousel-level message (e.g. from MCP elicitation) */
 .interactive-session .chat-question-carousel-container .chat-question-carousel-message {
 	padding: 8px 16px 0;
@@ -470,6 +477,8 @@
 	max-height: min(220px, 25vh);
 	overflow-y: auto;
 	overscroll-behavior: contain;
+	user-select: text;
+	-webkit-user-select: text;
 
 	.rendered-markdown p {
 		margin: 0;


### PR DESCRIPTION
## Summary

Fix for [#307977](https://github.com/microsoft/vscode/issues/307977): Cannot select or copy text from Elicitation dialog output.

### Problem
In VS Code extensions using the Elicitation dialog (MCP tools), users cannot select or copy text from scrollable markdown content areas. This affects:
- Detailed message text in scrollable input area
- Carousel-level message text (MCP elicitation)
- Field description text

### Root Cause
These markdown content areas were inheriting `user-select: none` from parent elements, with no explicit override to enable text selection.

### Fix
Added `user-select: text` and `-webkit-user-select: text` to three CSS selectors:
- `.chat-question-detailed-message` — rendered detailedMessage in scrollable area
- `.chat-question-carousel-message` — carousel-level message (MCP elicitation)
- `.chat-question-description` — field description text

### Testing
- Verified that the fix targets the correct CSS classes in the elicitation dialog component tree
- No other UI elements affected

Fixes #307977