### PR TITLE
fix(chronicle): scope /chronicle:tips to current workspace

### DIFF
--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -368,6 +368,10 @@ export class ChronicleIntent implements IIntent {
 		return {};
 	}
 
+	private _getWorkspacePath(request: vscode.ChatRequest): string | undefined {
+		return request.workspaceFolder?.uri?.fsPath;
+	}
+
 	private async _handleTips(
 		extra: string | undefined,
 		stream: vscode.ChatResponseStream,
@@ -380,6 +384,7 @@ export class ChronicleIntent implements IIntent {
 	): Promise<vscode.ChatResult> {
 		const hasCloud = this._indexingPreference.hasCloudConsent();
 		const schema = this._getSchemaDescription(hasCloud);
+		const workspacePath = this._getWorkspacePath(request);
 
 		let prompt = `You have access to the session_store_sql tool that can execute read-only SQL queries against the user's Copilot session database.
 
@@ -387,10 +392,19 @@ Your task: Analyze the user's Copilot usage patterns and provide personalized, a
 
 Database schema:
 
-${schema}
+${schema}`;
+
+		if (workspacePath) {
+			prompt += `
+
+**IMPORTANT - Workspace Scoping**: Always filter queries to the current workspace: ${workspacePath}
+Use the \`cwd\` column in the sessions table. For example: \`WHERE cwd = '${workspacePath.replace(/'/g, "''")}'\`. Do not include sessions from other workspaces.`;
+		}
+
+		prompt += `
 
 Instructions:
-1. IMMEDIATELY call the session_store_sql tool to query sessions from the last 7 days. Do not explain what you will do first.
+1. IMMEDIATELY call the session_store_sql tool to query sessions from the last 7 days${workspacePath ? ' in the current workspace' : ''}. Do not explain what you will do first.
 2. Query the turns table to understand what kinds of prompts the user writes and how conversations flow.
 3. Query session_files to see which files and tools are used most frequently.
 4. Query session_refs to see PR/issue/commit activity patterns.
@@ -406,7 +420,7 @@ Analysis dimensions to explore:
 Query guidelines:
 - Only one query per call — do not combine multiple statements with semicolons.
 - Always use LIMIT (max 100) in your queries and prefer aggregations (COUNT, GROUP BY) over raw row dumps.
-- Use the turns table to understand conversation quality, not just session metadata.`;
+- Use the turns table to understand conversation quality, not just session metadata.${workspacePath ? '\n- Always filter on \`cwd\` to scope results to the current workspace.' : ''}`;
 
 		if (extra) {
 			prompt += `\n\nThe user is especially interested in: ${extra}`;

--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -397,7 +397,7 @@ ${schema}`;
 		if (workspacePath) {
 			prompt += `
 
-**IMPORTANT - Workspace Scoping**: Always filter queries to the current workspace: ${workspacePath}
+**IMPORTANT - Workspace Scoping**: Always filter queries to the current workspace: \`${workspacePath}\`
 Use the \`cwd\` column in the sessions table. For example: \`WHERE cwd = '${workspacePath.replace(/'/g, "''")}'\`. Do not include sessions from other workspaces.`;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -462,6 +462,13 @@
 	}
 }
 
+/* user-select: text for elicitation dialog text areas */
+.interactive-session .chat-question-carousel-container .chat-question-detailed-message,
+.interactive-session .chat-question-carousel-container .chat-question-description {
+	user-select: text;
+	-webkit-user-select: text;
+}
+
 /* carousel-level message (e.g. from MCP elicitation) */
 .interactive-session .chat-question-carousel-container .chat-question-carousel-message {
 	padding: 8px 16px 0;
@@ -470,6 +477,8 @@
 	max-height: min(220px, 25vh);
 	overflow-y: auto;
 	overscroll-behavior: contain;
+	user-select: text;
+	-webkit-user-select: text;
 
 	.rendered-markdown p {
 		margin: 0;


### PR DESCRIPTION
## Summary

Fixes #313752 — `/chronicle:tips` returns identical results across different workspaces because the prompt never includes the current workspace folder path.

## Root Cause

The `_handleTips` prompt instructs the model to query sessions from the last 7 days, but **never provides the current workspace folder path** and never instructs the model to filter by `cwd`. The sessions table has a `cwd` column (workspace folder path) that is already documented in the schema description, but the tips prompt doesn't use it.

## Fix

1. Added `_getWorkspacePath()` helper that extracts `request.workspaceFolder?.uri?.fsPath`
2. When a workspace path is available, the prompt now includes:
   - An **IMPORTANT - Workspace Scoping** section explaining to filter by `cwd`
   - An example SQL filter: `WHERE cwd = '${workspacePath}'`
   - Updated instruction #1 to mention "in the current workspace"
   - Added workspace-specific query guideline for `cwd` filtering

## Testing

1. Open workspace A → run `/chronicle:tips` → note results
2. Switch to workspace B → run `/chronicle:tips` → should now show different, workspace-scoped results