### PR TITLE
Remove agentHistorySummarizationInline experiment

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -4493,16 +4493,6 @@
 							"experimental"
 						]
 					},
-					"github.copilot.chat.agentHistorySummarizationInline": {
-						"type": "boolean",
-						"default": true,
-						"markdownDescription": "%github.copilot.config.agentHistorySummarizationInline%",
-						"tags": [
-							"advanced",
-							"experimental",
-							"onExp"
-						]
-					},
 					"github.copilot.chat.useResponsesApiTruncation": {
 						"type": "boolean",
 						"default": false,

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -397,7 +397,6 @@
 	"github.copilot.config.instantApply.shortContextLimit": "Token limit for short context instant apply.",
 	"github.copilot.config.summarizeAgentConversationHistoryThreshold": "Threshold for compacting agent conversation history.",
 	"github.copilot.config.agentHistorySummarizationMode": "Mode for agent history summarization.",
-	"github.copilot.config.agentHistorySummarizationInline": "Summarize conversation inline within the agent loop instead of a separate LLM call, maximizing prompt cache hits.",
 	"github.copilot.config.useResponsesApiTruncation": "Use Responses API for truncation.",
 	"github.copilot.config.enableReadFileV2": "Enable version 2 of the read file tool.",
 	"github.copilot.config.enableAskAgent": "Enable the Ask agent for answering questions.",

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -49,7 +49,7 @@ import { IBuildPromptResult, IIntent, IIntentInvocation } from '../../prompt/nod
 import { AgentPrompt, AgentPromptProps } from '../../prompts/node/agent/agentPrompt';
 import { BackgroundSummarizationState, BackgroundSummarizer, IBackgroundSummarizationResult, shouldKickOffBackgroundSummarization } from '../../prompts/node/agent/backgroundSummarizer';
 import { AgentPromptCustomizations, PromptRegistry } from '../../prompts/node/agent/promptRegistry';
-import { extractInlineSummary, InlineSummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts } from '../../prompts/node/agent/summarizedConversationHistory';
+import { extractSummary, SummarizationUserMessage, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder, appendTranscriptHintToSummary, computeSummarizationRoundCounts } from '../../prompts/node/agent/summarizedConversationHistory';
 import { PromptRenderer, renderPromptElement } from '../../prompts/node/base/promptRenderer';
 import { ICodeMapperService } from '../../prompts/node/codeMapper/codeMapperService';
 import { EditCodePrompt2 } from '../../prompts/node/panel/editCodePrompt2';
@@ -368,7 +368,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 	private _lastModelCapabilities: { enableThinking: boolean; reasoningEffort: string | undefined; enableToolSearch: boolean; enableContextEditing: boolean } | undefined;
 
 	/**
-	 * RNG used to jitter the inline-summarization trigger threshold around 0.80.
+	 * RNG used to jitter the background-summarization trigger threshold around 0.80.
 	 * Tests may overwrite this directly (e.g. `(invocation as any)._thresholdRng = () => 0.5`).
 	 */
 	private _thresholdRng: () => number = Math.random;
@@ -436,7 +436,6 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		const useTruncation = this.endpoint.apiType === 'responses' && this.configurationService.getConfig(ConfigKey.Advanced.UseResponsesApiTruncation);
 		const responsesCompactionContextManagementEnabled = isResponsesCompactionContextManagementEnabled(this.endpoint, this.configurationService, this.expService);
 		const summarizationEnabled = this.configurationService.getConfig(ConfigKey.SummarizeAgentConversationHistory) && this.prompt === AgentPrompt && !responsesCompactionContextManagementEnabled;
-		const useInlineSummarization = summarizationEnabled && this.configurationService.getExperimentBasedConfig(ConfigKey.Advanced.AgentHistorySummarizationInline, this.expService);
 
 		// When tools are present, apply a 10% safety margin on the message portion
 		// to account for tokenizer discrepancies between our tool-token counter and
@@ -477,8 +476,10 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		//   BudgetExceeded: if bg is InProgress/Completed, wait/apply.
 		//                   Otherwise fall back to foreground summarization.
 		//
-		//   Post-render (≥ 80% + Idle): kick off background compaction
-		//                                so it is ready for a future turn.
+		//   Post-render: kick off background compaction if Idle and the
+		//                jittered/emergency threshold is met (see
+		//                shouldKickOffBackgroundSummarization) so it is
+		//                ready for a future turn.
 		//
 		const backgroundSummarizer = summarizationEnabled ? this._getOrCreateBackgroundSummarizer(promptContext.conversation?.sessionId) : undefined;
 		const contextRatio = backgroundSummarizer && baseBudget > 0
@@ -689,12 +690,10 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		}
 
 		// Post-render: kick off background compaction if idle and over the
-		// threshold. For the inline-summarization path we care about prompt
-		// cache parity with the main agent fetch — so we gate kick-off on a
-		// completed tool call (cache has been warmed) and jitter the threshold
-		// around 0.80 to avoid firing at the same exact boundary every time.
-		// The non-inline path forks its own prompt and sees no cache benefit,
-		// so it keeps the simple >= 0.80 behavior.
+		// threshold. Prompt cache parity with the main agent fetch matters
+		// here — so we gate kick-off on a completed tool call (cache has been
+		// warmed) and jitter the threshold around 0.80 to avoid firing at the
+		// same exact boundary every time.
 		if (summarizationEnabled && backgroundSummarizer && !didSummarizeThisIteration) {
 			const postRenderRatio = baseBudget > 0
 				? (result.tokenCount + toolTokens) / baseBudget
@@ -705,28 +704,26 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 
 			const cacheWarm = (promptContext.toolCallRounds?.length ?? 0) > 0;
 
-			const kickOff = shouldKickOffBackgroundSummarization(postRenderRatio, useInlineSummarization, cacheWarm, this._thresholdRng);
+			const kickOff = shouldKickOffBackgroundSummarization(postRenderRatio, cacheWarm, this._thresholdRng);
 
 			if (kickOff && idleOrFailed) {
-				if (useInlineSummarization) {
-					// Compute and cache model capabilities from the current render's
-					// messages. These must match the main agent fetch for cache parity.
-					const strippedMessages = ToolCallingLoop.stripInternalToolCallIds(result.messages);
-					const rawEffort = this.request.modelConfiguration?.reasoningEffort;
-					const isSubagent = !!this.request.subAgentInvocationId;
-					// Must match the main agent's enableThinking logic in
-					// toolCallingLoop.ts runOne() — thinking is only disabled
-					// on continuation turns for Anthropic when no thinking
-					// blocks exist yet in the messages.
-					const shouldDisableThinking = !!promptContext.isContinuation && isAnthropicFamily(this.endpoint) && !ToolCallingLoop.messagesContainThinking(strippedMessages);
-					this._lastModelCapabilities = {
-						enableThinking: !shouldDisableThinking,
-						reasoningEffort: typeof rawEffort === 'string' ? rawEffort : undefined,
-						enableToolSearch: !isSubagent && !!this.endpoint.supportsToolSearch,
-						enableContextEditing: !isSubagent && isAnthropicContextEditingEnabled(this.endpoint, this.configurationService, this.expService),
-					};
-				}
-				this._startBackgroundSummarization(backgroundSummarizer, result.messages, promptContext, props, token, postRenderRatio, useInlineSummarization);
+				// Compute and cache model capabilities from the current render's
+				// messages. These must match the main agent fetch for cache parity.
+				const strippedMessages = ToolCallingLoop.stripInternalToolCallIds(result.messages);
+				const rawEffort = this.request.modelConfiguration?.reasoningEffort;
+				const isSubagent = !!this.request.subAgentInvocationId;
+				// Must match the main agent's enableThinking logic in
+				// toolCallingLoop.ts runOne() — thinking is only disabled
+				// on continuation turns for Anthropic when no thinking
+				// blocks exist yet in the messages.
+				const shouldDisableThinking = !!promptContext.isContinuation && isAnthropicFamily(this.endpoint) && !ToolCallingLoop.messagesContainThinking(strippedMessages);
+				this._lastModelCapabilities = {
+					enableThinking: !shouldDisableThinking,
+					reasoningEffort: typeof rawEffort === 'string' ? rawEffort : undefined,
+					enableToolSearch: !isSubagent && !!this.endpoint.supportsToolSearch,
+					enableContextEditing: !isSubagent && isAnthropicContextEditingEnabled(this.endpoint, this.configurationService, this.expService),
+				};
+				this._startBackgroundSummarization(backgroundSummarizer, result.messages, promptContext, props, token, postRenderRatio);
 			}
 		}
 
@@ -800,9 +797,8 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		props: AgentPromptProps,
 		token: vscode.CancellationToken,
 		contextRatio: number,
-		useInlineSummarization: boolean,
 	): void {
-		this.logService.debug(`[ConversationHistorySummarizer] context at ${(contextRatio * 100).toFixed(0)}% — starting background compaction (inline=${useInlineSummarization})`);
+		this.logService.debug(`[ConversationHistorySummarizer] context at ${(contextRatio * 100).toFixed(0)}% — starting background compaction`);
 
 		const bgStartTime = Date.now();
 
@@ -853,187 +849,146 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 
 		backgroundSummarizer.start(async bgToken => {
 			try {
-				if (useInlineSummarization) {
-					// Inline mode: fork the exact messages from the main render
-					// and append a summary user message. The prompt prefix is
-					// byte-identical to the main agent loop for cache hits.
-					const strippedMainMessages = ToolCallingLoop.stripInternalToolCallIds(mainRenderMessages);
-					const summaryMsgResult = await renderPromptElement(
-						this.instantiationService,
-						this.endpoint,
-						InlineSummarizationUserMessage,
-						{ endpoint: this.endpoint },
-						undefined,
-						bgToken,
-					);
-					const messages = [
-						...strippedMainMessages,
-						...summaryMsgResult.messages,
-					];
+				// Fork the exact messages from the main render and append a
+				// summary user message. The prompt prefix is byte-identical
+				// to the main agent loop for cache hits.
+				const strippedMainMessages = ToolCallingLoop.stripInternalToolCallIds(mainRenderMessages);
+				const summaryMsgResult = await renderPromptElement(
+					this.instantiationService,
+					this.endpoint,
+					SummarizationUserMessage,
+					{ endpoint: this.endpoint },
+					undefined,
+					bgToken,
+				);
+				const messages = [
+					...strippedMainMessages,
+					...summaryMsgResult.messages,
+				];
 
-					const response = await this.endpoint.makeChatRequest2({
-						debugName: 'summarizeConversationHistory-inline',
-						messages,
-						finishedCb: undefined,
-						location: ChatLocation.Agent,
-						conversationId,
-						requestOptions: {
-							temperature: 0,
-							stream: false,
-							...toolOpts,
-						},
-						modelCapabilities,
-						telemetryProperties: associatedRequestId ? { associatedRequestId } : undefined,
-						enableRetryOnFilter: true,
-					}, bgToken);
-					if (response.type !== ChatFetchResponseType.Success) {
-						throw new Error(`Background inline summarization request failed: ${response.type}`);
-					}
-					const rawSummaryText = extractInlineSummary(response.value);
-					if (!rawSummaryText) {
-						throw new Error('Background inline summarization: no <summary> tags found in response');
-					}
-					if (!toolCallRoundId) {
-						throw new Error('Background inline summarization: no round ID to apply summary to');
-					}
-					// Flush the transcript before snapshotting the line count so
-					// the baked "N lines" hint matches the on-disk file at this
-					// moment (mirrors the full/simple path in SummarizedConversationHistory.render).
-					if (conversationId && this.sessionTranscriptService.getTranscriptPath(conversationId)) {
-						await this.sessionTranscriptService.flush(conversationId);
-					}
-					const summaryText = conversationId
-						? appendTranscriptHintToSummary(rawSummaryText, conversationId, this.sessionTranscriptService)
-						: rawSummaryText;
-					this.logService.debug(`[ConversationHistorySummarizer] background inline compaction completed (${summaryText.length} chars, roundId=${toolCallRoundId})`);
-
-					// Send summarizedConversationHistory telemetry for parity
-					// with the standard ConversationHistorySummarizer path.
-					const { numRounds, numRoundsSinceLastSummarization } = computeSummarizationRoundCounts(history, rounds);
-					const numRoundsInCurrentTurn = rounds.length;
-					const lastUsedTool = rounds.at(-1)?.toolCalls?.at(-1)?.name
-						?? history.at(-1)?.rounds.at(-1)?.toolCalls?.at(-1)?.name ?? 'none';
-					const promptTypes = messages.map(msg => `${msg.role}${'name' in msg && msg.name ? `-${msg.name}` : ''}:${getTextPart(msg.content).length}`).join(',');
-					/* __GDPR__
-						"summarizedConversationHistory" : {
-							"owner": "bhavyau",
-							"comment": "Tracks background inline summarization outcome",
-							"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." },
-							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
-							"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
-							"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
-							"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
-							"lastUsedTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The last tool used before summarization." },
-							"requestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The request ID from the summarization call." },
-							"promptTypes": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Role and character count of each prompt message in order, as a proxy for cache hit rate (e.g. system:1234,user:567)." },
-							"numRounds": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Total tool call rounds." },
-							"turnIndex": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The index of the current turn." },
-							"curTurnRoundIndex": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The index of the current round within the current turn." },
-							"isDuringToolCalling": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether this was triggered during tool calling." },
-							"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Duration in ms." },
-							"promptTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Prompt tokens." },
-							"promptCacheTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Cached prompt tokens." },
-							"responseTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Output tokens." }
-						}
-					*/
-					this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
-						outcome: 'success',
-						model: this.endpoint.model,
-						summarizationMode: 'inline',
-						conversationId,
-						chatRequestId: associatedRequestId,
-						lastUsedTool,
-						requestId: response.requestId,
-						promptTypes,
-					}, {
-						numRounds,
-						turnIndex: history.length,
-						curTurnRoundIndex: numRoundsInCurrentTurn,
-						isDuringToolCalling: numRoundsInCurrentTurn > 0 ? 1 : 0,
-						duration: Date.now() - bgStartTime,
-						promptTokenCount: response.usage?.prompt_tokens,
-						promptCacheTokenCount: response.usage?.prompt_tokens_details?.cached_tokens,
-						responseTokenCount: response.usage?.completion_tokens,
-					});
-
-					return {
-						summary: summaryText,
-						toolCallRoundId,
-						promptTokens: response.usage?.prompt_tokens,
-						promptCacheTokens: response.usage?.prompt_tokens_details?.cached_tokens,
-						outputTokens: response.usage?.completion_tokens,
-						durationMs: Date.now() - bgStartTime,
-						model: this.endpoint.model,
-						summarizationMode: 'inline',
-						numRounds,
-						numRoundsSinceLastSummarization,
-					};
-				} else {
-					// Standard mode: use triggerSummarize which makes a separate
-					// LLM call with a summarization-specific prompt during render.
-					const snapshotProps: AgentPromptProps = {
-						...props,
-						promptContext: {
-							...promptContext,
-							toolCallRounds: promptContext.toolCallRounds ? [...promptContext.toolCallRounds] : undefined,
-							toolCallResults: promptContext.toolCallResults ? { ...promptContext.toolCallResults } : undefined,
-						}
-					};
-					const bgRenderer = PromptRenderer.create(this.instantiationService, this.endpoint, this.prompt, {
-						...snapshotProps,
-						endpoint: this.endpoint,
-						promptContext: snapshotProps.promptContext,
-						triggerSummarize: true,
-					});
-					const bgProgress: vscode.Progress<vscode.ChatResponseReferencePart | vscode.ChatResponseProgressPart> = { report: () => { } };
-					const bgRenderResult = await bgRenderer.render(bgProgress, bgToken);
-					const summaryMetadata = bgRenderResult.metadata.get(SummarizedConversationHistoryMetadata);
-					if (!summaryMetadata) {
-						throw new Error('Background compaction produced no summary metadata');
-					}
-					this.logService.debug(`[ConversationHistorySummarizer] background compaction completed successfully (roundId=${summaryMetadata.toolCallRoundId})`);
-					return {
-						summary: summaryMetadata.text,
-						toolCallRoundId: summaryMetadata.toolCallRoundId,
-						promptTokens: summaryMetadata.usage?.prompt_tokens,
-						promptCacheTokens: summaryMetadata.usage?.prompt_tokens_details?.cached_tokens,
-						outputTokens: summaryMetadata.usage?.completion_tokens,
-						durationMs: Date.now() - bgStartTime,
-						model: summaryMetadata.model,
-						summarizationMode: summaryMetadata.summarizationMode,
-						numRounds: summaryMetadata.numRounds,
-						numRoundsSinceLastSummarization: summaryMetadata.numRoundsSinceLastSummarization,
-					};
+				const response = await this.endpoint.makeChatRequest2({
+					debugName: 'summarizeConversationHistory',
+					messages,
+					finishedCb: undefined,
+					location: ChatLocation.Agent,
+					conversationId,
+					requestOptions: {
+						temperature: 0,
+						stream: false,
+						...toolOpts,
+					},
+					modelCapabilities,
+					telemetryProperties: associatedRequestId ? { associatedRequestId } : undefined,
+					enableRetryOnFilter: true,
+				}, bgToken);
+				if (response.type !== ChatFetchResponseType.Success) {
+					throw new Error(`Background summarization request failed: ${response.type}`);
 				}
+				const rawSummaryText = extractSummary(response.value);
+				if (!rawSummaryText) {
+					throw new Error('Background summarization: no <summary> tags found in response');
+				}
+				if (!toolCallRoundId) {
+					throw new Error('Background summarization: no round ID to apply summary to');
+				}
+				// Flush the transcript before snapshotting the line count so
+				// the baked "N lines" hint matches the on-disk file at this
+				// moment (mirrors the full/simple path in SummarizedConversationHistory.render).
+				if (conversationId && this.sessionTranscriptService.getTranscriptPath(conversationId)) {
+					await this.sessionTranscriptService.flush(conversationId);
+				}
+				const summaryText = conversationId
+					? appendTranscriptHintToSummary(rawSummaryText, conversationId, this.sessionTranscriptService)
+					: rawSummaryText;
+				this.logService.debug(`[ConversationHistorySummarizer] background compaction completed (${summaryText.length} chars, roundId=${toolCallRoundId})`);
+
+				// Send summarizedConversationHistory telemetry for parity
+				// with the standard ConversationHistorySummarizer path.
+				const { numRounds, numRoundsSinceLastSummarization } = computeSummarizationRoundCounts(history, rounds);
+				const numRoundsInCurrentTurn = rounds.length;
+				const lastUsedTool = rounds.at(-1)?.toolCalls?.at(-1)?.name
+					?? history.at(-1)?.rounds.at(-1)?.toolCalls?.at(-1)?.name ?? 'none';
+				const promptTypes = messages.map(msg => `${msg.role}${'name' in msg && msg.name ? `-${msg.name}` : ''}:${getTextPart(msg.content).length}`).join(',');
+				/* __GDPR__
+					"summarizedConversationHistory" : {
+						"owner": "bhavyau",
+						"comment": "Tracks background summarization outcome",
+						"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." },
+						"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
+						"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
+						"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
+						"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
+						"lastUsedTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The last tool used before summarization." },
+						"requestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The request ID from the summarization call." },
+						"promptTypes": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Role and character count of each prompt message in order, as a proxy for cache hit rate (e.g. system:1234,user:567)." },
+						"numRounds": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Total tool call rounds." },
+						"turnIndex": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The index of the current turn." },
+						"curTurnRoundIndex": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "The index of the current round within the current turn." },
+						"isDuringToolCalling": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Whether this was triggered during tool calling." },
+						"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Duration in ms." },
+						"promptTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Prompt tokens." },
+						"promptCacheTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Cached prompt tokens." },
+						"responseTokenCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "comment": "Output tokens." }
+					}
+				*/
+				this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
+					outcome: 'success',
+					model: this.endpoint.model,
+					summarizationMode: 'full',
+					conversationId,
+					chatRequestId: associatedRequestId,
+					lastUsedTool,
+					requestId: response.requestId,
+					promptTypes,
+				}, {
+					numRounds,
+					turnIndex: history.length,
+					curTurnRoundIndex: numRoundsInCurrentTurn,
+					isDuringToolCalling: numRoundsInCurrentTurn > 0 ? 1 : 0,
+					duration: Date.now() - bgStartTime,
+					promptTokenCount: response.usage?.prompt_tokens,
+					promptCacheTokenCount: response.usage?.prompt_tokens_details?.cached_tokens,
+					responseTokenCount: response.usage?.completion_tokens,
+				});
+
+				return {
+					summary: summaryText,
+					toolCallRoundId,
+					promptTokens: response.usage?.prompt_tokens,
+					promptCacheTokens: response.usage?.prompt_tokens_details?.cached_tokens,
+					outputTokens: response.usage?.completion_tokens,
+					durationMs: Date.now() - bgStartTime,
+					model: this.endpoint.model,
+					summarizationMode: 'full',
+					numRounds,
+					numRoundsSinceLastSummarization,
+				};
 			} catch (err) {
 				this.logService.error(err, `[ConversationHistorySummarizer] background compaction failed`);
 
-				// Send failure telemetry for inline background summarization
-				if (useInlineSummarization) {
-					/* __GDPR__
-						"summarizedConversationHistory" : {
-							"owner": "bhavyau",
-							"comment": "Tracks background inline summarization failure",
-							"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." },
-							"detailedOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Detailed failure reason." },
-							"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
-							"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
-							"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
-							"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
-							"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Duration in ms." }
-						}
-					*/
-					this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
-						outcome: 'failed',
-						detailedOutcome: err instanceof Error ? err.message : String(err),
-						model: this.endpoint.model,
-						summarizationMode: 'inline',
-						conversationId,
-						chatRequestId: associatedRequestId,
-					}, {
-						duration: Date.now() - bgStartTime,
-					});
-				}
+				/* __GDPR__
+					"summarizedConversationHistory" : {
+						"owner": "bhavyau",
+						"comment": "Tracks background summarization failure",
+						"outcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." },
+						"detailedOutcome": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Detailed failure reason." },
+						"model": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The model ID." },
+						"summarizationMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The summarization mode." },
+						"conversationId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "Session id." },
+						"chatRequestId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The chat request ID." },
+						"duration": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "comment": "Duration in ms." }
+					}
+				*/
+				this.telemetryService.sendMSFTTelemetryEvent('summarizedConversationHistory', {
+					outcome: 'failed',
+					detailedOutcome: err instanceof Error ? err.message : String(err),
+					model: this.endpoint.model,
+					summarizationMode: 'full',
+					conversationId,
+					chatRequestId: associatedRequestId,
+				}, {
+					duration: Date.now() - bgStartTime,
+				});
 
 				throw err;
 			}

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -885,7 +885,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 					throw new Error(`Background summarization request failed: ${response.type}`);
 				}
 				const rawSummaryText = extractSummary(response.value);
-				if (!rawSummaryText) {
+				if (rawSummaryText === undefined) {
 					throw new Error('Background summarization: no <summary> tags found in response');
 				}
 				if (!toolCallRoundId) {

--- a/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/backgroundSummarizer.ts
@@ -44,17 +44,15 @@ export interface IBackgroundSummarizationResult {
  * tests can reference the same numbers without repeating them.
  */
 export const BackgroundSummarizationThresholds = {
-	/** Trigger ratio for the non-inline path (no prompt-cache benefit). */
-	base: 0.80,
-	/** Minimum of the jittered warm-cache range for the inline path. */
+	/** Minimum of the jittered warm-cache range. */
 	warmJitterMin: 0.78,
 	/** Width of the jittered warm-cache range; together with `warmJitterMin` yields [0.78, 0.82). */
 	warmJitterSpan: 0.04,
 	/**
-	 * Cold-cache emergency ratio for the inline path. Above this we kick off
-	 * even without a warmed cache to avoid forcing a foreground sync compaction
-	 * on the next render. Tuned low enough that long-running sessions stay
-	 * ahead of the budget without relying on foreground compaction.
+	 * Cold-cache emergency ratio. Above this we kick off even without a warmed
+	 * cache to avoid forcing a foreground sync compaction on the next render.
+	 * Tuned low enough that long-running sessions stay ahead of the budget
+	 * without relying on foreground compaction.
 	 */
 	emergency: 0.90,
 } as const;
@@ -62,7 +60,7 @@ export const BackgroundSummarizationThresholds = {
 /**
  * Decide whether to kick off post-render background compaction.
  *
- * For the inline-summarization path prompt-cache parity matters, so we:
+ * Prompt-cache parity matters, so we:
  *   - require a completed tool call in this turn ("warm" cache) before
  *     firing at the normal, jittered ~0.80 threshold;
  *   - allow an emergency kick-off at >= 0.90 even with a cold cache to
@@ -72,20 +70,15 @@ export const BackgroundSummarizationThresholds = {
  * bar") — the goal is to avoid always firing at the exact same boundary,
  * not to kick off systematically earlier.
  *
- * The non-inline path forks its own prompt (no cache benefit) and keeps the
- * simple >= 0.80 behavior. `rng` is only consumed on the warm-cache inline
- * branch, which keeps deterministic tests straightforward.
+ * `rng` is only consumed on the warm-cache branch, which keeps deterministic
+ * tests straightforward.
  */
 export function shouldKickOffBackgroundSummarization(
 	postRenderRatio: number,
-	useInlineSummarization: boolean,
 	cacheWarm: boolean,
 	rng: () => number,
 ): boolean {
 	const t = BackgroundSummarizationThresholds;
-	if (!useInlineSummarization) {
-		return postRenderRatio >= t.base;
-	}
 	if (!cacheWarm) {
 		return postRenderRatio >= t.emergency;
 	}

--- a/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/summarizedConversationHistory.tsx
@@ -904,11 +904,10 @@ function replaceImageContentWithPlaceholders(messages: ChatMessage[]): void {
  * Bake a stable transcript pointer into a freshly-produced summary text.
  *
  * Shared by both the full/simple summarization path
- * ({@link ConversationHistorySummarizer}) and the inline background
- * summarization path in `agentIntent.ts`. The hint is appended exactly once,
- * at summary creation time, so the resulting string is frozen from then on
- * and replayed verbatim — preserving Anthropic prompt cache hits across
- * subsequent renders.
+ * ({@link ConversationHistorySummarizer}) and the background summarization
+ * path in `agentIntent.ts`. The hint is appended exactly once, at summary
+ * creation time, so the resulting string is frozen from then on and replayed
+ * verbatim — preserving Anthropic prompt cache hits across subsequent renders.
  *
  * Returns the input unchanged when there is no transcript on disk for the
  * session.
@@ -1101,17 +1100,17 @@ class SummaryMessageElement extends PromptElement<SummaryMessageProps> {
 	}
 }
 
-export interface InlineSummarizationUserMessageProps extends BasePromptElementProps {
+export interface SummarizationUserMessageProps extends BasePromptElementProps {
 	readonly endpoint: IChatEndpoint;
 }
 
 /**
- * User message appended to the agent prompt when inline summarization is triggered.
- * Instructs the model to output ONLY a summary wrapped in `<summary>` tags, with
- * no tool calls. The summary is extracted from the response and stored on the round
- * for the next iteration.
+ * User message appended to the agent prompt when background summarization is
+ * triggered. Instructs the model to output ONLY a summary wrapped in
+ * `<summary>` tags, with no tool calls. The summary is extracted from the
+ * response and stored on the round for the next iteration.
  */
-export class InlineSummarizationUserMessage extends PromptElement<InlineSummarizationUserMessageProps> {
+export class SummarizationUserMessage extends PromptElement<SummarizationUserMessageProps> {
 	override async render(state: void, sizing: PromptSizing) {
 		const isOpus = this.props.endpoint.model.startsWith('claude-opus');
 		return <UserMessage priority={1000}>
@@ -1130,7 +1129,7 @@ export class InlineSummarizationUserMessage extends PromptElement<InlineSummariz
 }
 
 /**
- * Extracts an inline summary from the model's response text.
+ * Extracts a summary from the model's response text.
  *
  * Parsing strategy (multi-level fallback):
  * 1. Clean `<summary>...</summary>` tags → extracts content between them
@@ -1139,7 +1138,7 @@ export class InlineSummarizationUserMessage extends PromptElement<InlineSummariz
  *
  * @returns The extracted summary text, or `undefined` if no summary could be found.
  */
-export function extractInlineSummary(responseText: string): string | undefined {
+export function extractSummary(responseText: string): string | undefined {
 	// 1. Try clean <summary>...</summary> extraction
 	const openTag = '<summary>';
 	const closeTag = '</summary>';

--- a/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/backgroundSummarizer.spec.ts
@@ -254,65 +254,56 @@ describe('BackgroundSummarizer', () => {
 	});
 });
 
-const { base, warmJitterMin, warmJitterSpan, emergency } = BackgroundSummarizationThresholds;
+const { warmJitterMin, warmJitterSpan, emergency } = BackgroundSummarizationThresholds;
 
 // rng that always returns 0.5 -> threshold sits exactly at the center of the
 // jitter range. With [0.78, 0.82) that's 0.80.
 const midRng = () => 0.5;
 // rng that forces the maximum of the jitter range.
 const maxRng = () => 1 - Number.EPSILON;
-// rng that should never be called on cold/non-inline branches.
+// rng that should never be called on cold-cache branches.
 const unusedRng = () => {
 	throw new Error('rng should not be consumed');
 };
 
 describe('shouldKickOffBackgroundSummarization', () => {
-	describe('inline + cold cache', () => {
+	describe('cold cache', () => {
 		test('defers kick-off below the emergency threshold', () => {
 			// Cold turn sitting in the old 0.80 trigger band — must not fire.
-			expect(shouldKickOffBackgroundSummarization(0.85, true, false, unusedRng)).toBe(false);
+			expect(shouldKickOffBackgroundSummarization(0.85, false, unusedRng)).toBe(false);
 		});
 
 		test('kicks off at the emergency threshold', () => {
-			expect(shouldKickOffBackgroundSummarization(emergency, true, false, unusedRng)).toBe(true);
-			expect(shouldKickOffBackgroundSummarization(0.91, true, false, unusedRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(emergency, false, unusedRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(0.91, false, unusedRng)).toBe(true);
 		});
 
 		test('does not consume the rng on the cold branch', () => {
 			// The unusedRng would throw if consumed — asserting no throw is the check.
-			expect(() => shouldKickOffBackgroundSummarization(0.85, true, false, unusedRng)).not.toThrow();
-			expect(() => shouldKickOffBackgroundSummarization(0.91, true, false, unusedRng)).not.toThrow();
+			expect(() => shouldKickOffBackgroundSummarization(0.85, false, unusedRng)).not.toThrow();
+			expect(() => shouldKickOffBackgroundSummarization(0.91, false, unusedRng)).not.toThrow();
 		});
 	});
 
-	describe('inline + warm cache', () => {
+	describe('warm cache', () => {
 		test('kicks off at the jittered midpoint (0.80) when ratio meets it', () => {
-			expect(shouldKickOffBackgroundSummarization(0.80, true, true, midRng)).toBe(true);
-			expect(shouldKickOffBackgroundSummarization(0.81, true, true, midRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(0.80, true, midRng)).toBe(true);
+			expect(shouldKickOffBackgroundSummarization(0.81, true, midRng)).toBe(true);
 		});
 
 		test('defers when ratio is under the jittered threshold', () => {
 			// midRng -> 0.80; 0.77 is below the entire jitter window.
-			expect(shouldKickOffBackgroundSummarization(0.77, true, true, midRng)).toBe(false);
+			expect(shouldKickOffBackgroundSummarization(0.77, true, midRng)).toBe(false);
 			// Also below the minimum of the window regardless of rng.
-			expect(shouldKickOffBackgroundSummarization(warmJitterMin - 0.0001, true, true, () => 0)).toBe(false);
+			expect(shouldKickOffBackgroundSummarization(warmJitterMin - 0.0001, true, () => 0)).toBe(false);
 		});
 
 		test('respects the top of the jitter range', () => {
 			// With maxRng, threshold approaches warmJitterMin + warmJitterSpan = 0.82.
 			// 0.81 lands below it, so we defer.
-			expect(shouldKickOffBackgroundSummarization(0.81, true, true, maxRng)).toBe(false);
+			expect(shouldKickOffBackgroundSummarization(0.81, true, maxRng)).toBe(false);
 			// 0.82 meets it.
-			expect(shouldKickOffBackgroundSummarization(warmJitterMin + warmJitterSpan, true, true, maxRng)).toBe(true);
-		});
-	});
-
-	describe('non-inline path', () => {
-		test('uses the fixed base threshold and ignores cache warmth', () => {
-			// Warm, cold — both behave the same on non-inline.
-			expect(shouldKickOffBackgroundSummarization(base, false, false, unusedRng)).toBe(true);
-			expect(shouldKickOffBackgroundSummarization(base, false, true, unusedRng)).toBe(true);
-			expect(shouldKickOffBackgroundSummarization(base - 0.0001, false, true, unusedRng)).toBe(false);
+			expect(shouldKickOffBackgroundSummarization(warmJitterMin + warmJitterSpan, true, maxRng)).toBe(true);
 		});
 	});
 });

--- a/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
+++ b/extensions/copilot/src/extension/prompts/node/agent/test/summarization.spec.tsx
@@ -31,7 +31,7 @@ import { PromptRenderer } from '../../base/promptRenderer';
 import { AgentPrompt, AgentPromptProps } from '../agentPrompt';
 import { PromptRegistry } from '../promptRegistry';
 import { ISessionTranscriptService, NullSessionTranscriptService } from '../../../../../platform/chat/common/sessionTranscriptService';
-import { appendTranscriptHintToSummary, ConversationHistorySummarizationPrompt, extractInlineSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
+import { appendTranscriptHintToSummary, ConversationHistorySummarizationPrompt, extractSummary, stripToolSearchMessages, SummarizedConversationHistory, SummarizedConversationHistoryMetadata, SummarizedConversationHistoryPropsBuilder } from '../summarizedConversationHistory';
 
 suite('Agent Summarization', () => {
 	let accessor: ITestingServicesAccessor;
@@ -538,47 +538,47 @@ suite('Agent Summarization', () => {
 	});
 });
 
-suite('extractInlineSummary', () => {
+suite('extractSummary', () => {
 	test('extracts clean summary tags', () => {
 		const text = 'Some preamble\n<summary>\nThis is the summary content.\n</summary>\nSome trailing text';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBe('This is the summary content.');
 	});
 
 	test('extracts summary with no closing tag', () => {
 		const text = 'Preamble text\n<summary>\nThis is a partial summary that was cut off';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBe('This is a partial summary that was cut off');
 	});
 
 	test('returns undefined when no tags found', () => {
 		const text = 'This is just a normal response with no summary tags at all.';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBeUndefined();
 	});
 
 	test('uses first complete summary when multiple blocks exist', () => {
 		const text = '<summary>First summary</summary>\n<summary>Second summary</summary>';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBe('First summary');
 	});
 
 	test('handles empty summary tags', () => {
 		const text = '<summary></summary>';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBe('');
 	});
 
 	test('handles summary with analysis tags inside', () => {
 		const text = '<summary>\n<analysis>Some analysis</analysis>\n\n1. Overview: test\n2. Details: test\n</summary>';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toContain('1. Overview: test');
 		expect(result).toContain('<analysis>Some analysis</analysis>');
 	});
 
 	test('trims whitespace from extracted summary', () => {
 		const text = '<summary>\n\n  Padded summary text  \n\n</summary>';
-		const result = extractInlineSummary(text);
+		const result = extractSummary(text);
 		expect(result).toBe('Padded summary text');
 	});
 });

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -647,7 +647,6 @@ export namespace ConfigKey {
 
 		export const InstantApplyShortModelName = defineAndMigrateExpSetting<string>('chat.advanced.instantApply.shortContextModelName', 'chat.instantApply.shortContextModelName', CHAT_MODEL.SHORT_INSTANT_APPLY);
 		export const InstantApplyShortContextLimit = defineAndMigrateExpSetting<number>('chat.advanced.instantApply.shortContextLimit', 'chat.instantApply.shortContextLimit', 8000);
-		export const AgentHistorySummarizationInline = defineAndMigrateExpSetting<boolean>('chat.advanced.agentHistorySummarizationInline', 'chat.agentHistorySummarizationInline', true);
 		export const PromptFileContext = defineAndMigrateExpSetting<boolean>('chat.advanced.promptFileContextProvider.enabled', 'chat.promptFileContextProvider.enabled', true);
 		export const DefaultToolsGrouped = defineAndMigrateExpSetting<boolean>('chat.advanced.tools.defaultToolsGrouped', 'chat.tools.defaultToolsGrouped', false);
 		export const Gpt5AlternativePatch = defineAndMigrateExpSetting<boolean>('chat.advanced.gpt5AlternativePatch', 'chat.gpt5AlternativePatch', false);


### PR DESCRIPTION
Make background inline summarization the default and only path; remove the experiment-gated setting and the dead non-inline branch.

## Changes

- Delete `chat.advanced.agentHistorySummarizationInline` (setting, package.json contribution, NLS string).
- `agentIntent.ts`: drop `useInlineSummarization`, remove the `else` branch in `_startBackgroundSummarization` (it forked a fresh prompt via `triggerSummarize` with no cache reuse), make failure telemetry unconditional.
- `backgroundSummarizer.ts`: simplify `shouldKickOffBackgroundSummarization` — drop the `useInlineSummarization` parameter and the obsolete `base` threshold.
- Rename `InlineSummarizationUserMessage` → `SummarizationUserMessage` and `extractInlineSummary` → `extractSummary`.
- Telemetry: `summarizationMode` value `'inline'` → `'full'`. Verified no dashboards use the old value.

The foreground budget-exceeded fallback (`renderWithSummarization`) is untouched.