### PR TITLE
docs: add ascii cat to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Docker / the Codespace should have at least **4 cores and 6 GB of RAM (8 GB reco
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+```
+ /\_/\
+( o.o )
+ > ^ <
+```
+
 ## License
 
 Copyright (c) Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
## Summary
- Add a small ASCII cat to `README.md` between the Code of Conduct and License sections.

## Testing
- Not run (not requested)
