### PR TITLE
Run agent host shell tools on independent terminals

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotShellTools.ts
@@ -8,7 +8,7 @@ import { generateUuid } from '../../../../base/common/uuid.js';
 import { URI } from '../../../../base/common/uri.js';
 import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import * as platform from '../../../../base/common/platform.js';
-import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, type IReference, toDisposable } from '../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILogService } from '../../../log/common/log.js';
 import { TerminalClaimKind, type TerminalSessionClaim } from '../../common/state/protocol/state.js';
@@ -64,6 +64,8 @@ export class ShellManager {
 
 	private readonly _shells = new Map<string, IManagedShell>();
 	private readonly _toolCallShells = new Map<string, string>();
+	/** Set of shell ids currently executing a command and unsafe to share. */
+	private readonly _busyShellIds = new Set<string>();
 
 	private readonly _onDidAssociateTerminal = new Emitter<{ toolCallId: string; terminalUri: string; displayName: string }>();
 	readonly onDidAssociateTerminal: Event<{ toolCallId: string; terminalUri: string; displayName: string }> = this._onDidAssociateTerminal.event;
@@ -75,21 +77,36 @@ export class ShellManager {
 		@ILogService private readonly _logService: ILogService,
 	) { }
 
+	/**
+	 * Acquire a shell of the given type for executing a single command. The
+	 * returned reference holds the shell exclusively — its terminal will not
+	 * be handed out to another concurrent caller until the reference is
+	 * disposed. If no idle shell of the requested type exists, a new one is
+	 * created.
+	 */
 	async getOrCreateShell(
 		shellType: ShellType,
 		turnId: string,
 		toolCallId: string,
 		cwd?: string,
-	): Promise<IManagedShell> {
+	): Promise<IReference<IManagedShell>> {
 		for (const shell of this._shells.values()) {
-			if (shell.shellType === shellType && this._terminalManager.hasTerminal(shell.terminalUri)) {
-				const exitCode = this._terminalManager.getExitCode(shell.terminalUri);
-				if (exitCode === undefined) {
-					this._trackToolCall(toolCallId, shell.id);
-					return shell;
-				}
-				this._shells.delete(shell.id);
+			if (shell.shellType !== shellType || !this._terminalManager.hasTerminal(shell.terminalUri)) {
+				continue;
 			}
+			const exitCode = this._terminalManager.getExitCode(shell.terminalUri);
+			if (exitCode !== undefined) {
+				this._shells.delete(shell.id);
+				continue;
+			}
+			if (this._busyShellIds.has(shell.id)) {
+				// Skip — a command is already running on this terminal. Sharing
+				// it would interleave input/output and garble both commands.
+				continue;
+			}
+			this._busyShellIds.add(shell.id);
+			this._trackToolCall(toolCallId, shell.id);
+			return this._makeReference(shell);
 		}
 
 		const id = generateUuid();
@@ -113,9 +130,24 @@ export class ShellManager {
 
 		const shell: IManagedShell = { id, terminalUri, shellType };
 		this._shells.set(id, shell);
+		this._busyShellIds.add(id);
 		this._trackToolCall(toolCallId, id);
 		this._logService.info(`[ShellManager] Created ${shellType} shell ${id} (terminal=${terminalUri})`);
-		return shell;
+		return this._makeReference(shell);
+	}
+
+	private _makeReference(shell: IManagedShell): IReference<IManagedShell> {
+		let disposed = false;
+		return {
+			object: shell,
+			dispose: () => {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				this._busyShellIds.delete(shell.id);
+			},
+		};
 	}
 
 	private _trackToolCall(toolCallId: string, shellId: string): void {
@@ -156,6 +188,7 @@ export class ShellManager {
 		}
 		this._terminalManager.disposeTerminal(shell.terminalUri);
 		this._shells.delete(id);
+		this._busyShellIds.delete(id);
 		this._logService.info(`[ShellManager] Shut down shell ${id}`);
 		return true;
 	}
@@ -168,6 +201,7 @@ export class ShellManager {
 		}
 		this._shells.clear();
 		this._toolCallShells.clear();
+		this._busyShellIds.clear();
 	}
 }
 
@@ -456,13 +490,17 @@ export function createShellTools(
 		},
 		overridesBuiltInTool: true,
 		handler: async (args, invocation) => {
-			const shell = await shellManager.getOrCreateShell(
+			const timeoutMs = args.timeout ?? DEFAULT_TIMEOUT_MS;
+			const ref = await shellManager.getOrCreateShell(
 				shellType,
 				invocation.toolCallId,
 				invocation.toolCallId,
 			);
-			const timeoutMs = args.timeout ?? DEFAULT_TIMEOUT_MS;
-			return executeCommandInShell(shell, args.command, timeoutMs, terminalManager, logService);
+			try {
+				return await executeCommandInShell(ref.object, args.command, timeoutMs, terminalManager, logService);
+			} finally {
+				ref.dispose();
+			}
 		},
 	};
 

--- a/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotShellTools.test.ts
@@ -57,8 +57,8 @@ suite('CopilotShellTools', () => {
 		const explicitCwd = URI.file('/explicit/cwd').fsPath;
 		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), URI.file(worktreePath)));
 
-		await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
-		await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', explicitCwd);
+		(await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1')).dispose();
+		(await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2', explicitCwd)).dispose();
 
 		assert.deepStrictEqual(terminalManager.created.map(c => c.params.cwd), [
 			worktreePath,
@@ -85,5 +85,44 @@ suite('CopilotShellTools', () => {
 	test('prefixForHistorySuppression prepends a space for POSIX shells, no-op for PowerShell', () => {
 		assert.strictEqual(prefixForHistorySuppression('bash'), ' ');
 		assert.strictEqual(prefixForHistorySuppression('powershell'), '');
+	});
+
+	test('getOrCreateShell reuses an idle shell after the reference is disposed', async () => {
+		const terminalManager = new TestAgentHostTerminalManager();
+		// Pretend created terminals exist and are still running.
+		(terminalManager as unknown as { hasTerminal: () => boolean }).hasTerminal = () => true;
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IAgentHostTerminalManager, terminalManager);
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		services.set(IInstantiationService, instantiationService);
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+
+		const first = await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
+		first.dispose();
+		const second = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.strictEqual(second.object.id, first.object.id, 'should reuse idle shell');
+		assert.strictEqual(terminalManager.created.length, 1);
+		second.dispose();
+	});
+
+	test('getOrCreateShell creates a new shell when the existing reference is still held', async () => {
+		const terminalManager = new TestAgentHostTerminalManager();
+		(terminalManager as unknown as { hasTerminal: () => boolean }).hasTerminal = () => true;
+		const services = new ServiceCollection();
+		services.set(ILogService, new NullLogService());
+		services.set(IAgentHostTerminalManager, terminalManager);
+		const instantiationService: IInstantiationService = disposables.add(new InstantiationService(services));
+		services.set(IInstantiationService, instantiationService);
+		const shellManager = disposables.add(instantiationService.createInstance(ShellManager, URI.parse('copilot:/session-1'), undefined));
+
+		const first = await shellManager.getOrCreateShell('bash', 'turn-1', 'tool-1');
+		const second = await shellManager.getOrCreateShell('bash', 'turn-2', 'tool-2');
+
+		assert.notStrictEqual(second.object.id, first.object.id, 'should create a new shell when existing is busy');
+		assert.strictEqual(terminalManager.created.length, 2);
+		first.dispose();
+		second.dispose();
 	});
 });


### PR DESCRIPTION
Concurrent invocations of the bash/powershell shell tools used to share a single PTY, which caused input streams and output to interleave and garble each other.

Acquire shells via a disposable `IReference<IManagedShell>`: idle shells are reused, busy ones are skipped, and a new terminal is created when none are idle. The reference's `dispose()` returns the shell to the idle pool.

The lookup-and-claim is synchronous, so two concurrent acquires can never pick the same idle shell; concurrent acquires that find no idle shell each fall through to creating their own new PTY.