### PR TITLE
Prevent stale agent edits from silently dirtying the buffer on chat session restore

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -1004,7 +1004,19 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			} else {
 				entry = await this._getOrCreateModifiedFileEntry(snapshotEntry.resource, NotExistBehavior.Abort, snapshotEntry.telemetryInfo);
 				if (entry) {
-					const restoreToDisk = snapshotEntry.state === ModifiedFileEntryState.Modified;
+					let restoreToDisk = snapshotEntry.state === ModifiedFileEntryState.Modified;
+					if (restoreToDisk) {
+						// Guard against overwriting changes made to the file after the
+						// snapshot was persisted (e.g. the user edited and saved the file
+						// in a prior VS Code session or an external tool wrote to it).
+						// If the on-disk content no longer matches the snapshot baseline
+						// we skip restoring the agent edits into the buffer so we never
+						// silently dirty the buffer with stale content.
+						restoreToDisk = await this._isSnapshotCurrentOnDisk(snapshotEntry);
+						if (!restoreToDisk) {
+							this._logService.info(`chatEditingSession: skipping in-buffer restore for ${snapshotEntry.resource.toString()} - on-disk content has changed since snapshot was persisted`);
+						}
+					}
 					await entry.restoreFromSnapshot(snapshotEntry, restoreToDisk);
 				}
 			}
@@ -1227,6 +1239,32 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 			} else {
 				return await doCreate(ChatEditKind.Created);
 			}
+		}
+	}
+
+	/**
+	 * Returns `true` when the on-disk content of the file still matches the
+	 * pre-edit baseline recorded in the snapshot ({@link ISnapshotEntry.original}),
+	 * meaning no external change has occurred since the snapshot was persisted
+	 * and it is therefore safe to restore the agent's in-progress edits into the buffer.
+	 *
+	 * Returns `false` when the file's on-disk content has diverged from the snapshot
+	 * baseline (edited by the user, another tool, or saved from a prior VS Code session).
+	 * The restore is skipped to prevent silently overwriting newer content and marking
+	 * the buffer dirty.
+	 *
+	 * UTF-8 BOM and CRLF line endings are normalised before comparison so encoding
+	 * artefacts that VS Code handles transparently are never treated as external changes.
+	 */
+	private async _isSnapshotCurrentOnDisk(snapshotEntry: ISnapshotEntry): Promise<boolean> {
+		try {
+			const { value } = await this._fileService.readFile(snapshotEntry.resource);
+			const normalise = (s: string): string => s.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+			return normalise(value.toString()) === normalise(snapshotEntry.original);
+		} catch {
+			// File is gone or unreadable; let the entry handle the missing-file
+			// case rather than suppressing the restore unconditionally.
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Closes #313703

## Problem

When a chat session is reopened, \_initEntries\ unconditionally restores the agent's snapshot edits into the editor buffer whenever \snapshotEntry.state === Modified\ - with no check on whether the file has changed since the snapshot was persisted.

This means if the user edited and saved the file between two VS Code sessions, reopening the chat overwrites their newer content with the old agent content and marks the buffer dirty. Any subsequent save (or autosave) then silently discards the user's work.

The same data-loss window exists for files modified by external tools or synced from another machine.

## What changed

**\chatEditingSession.ts\ - \_initEntries\**

Before attempting a disk restore, the code now calls a new helper \_isSnapshotCurrentOnDisk\ that reads the file's current on-disk content and compares it to \snapshotEntry.original\ (the baseline captured before the agent started editing). Only when the two match - meaning the file is unchanged - does the restore proceed.

**\chatEditingSession.ts\ - \_isSnapshotCurrentOnDisk\ (new)**

Reads the file via \IFileService.readFile\, normalises UTF-8 BOM and CRLF line endings on both sides before comparing, then returns:
- \	rue\ - file is unchanged since the snapshot; safe to restore the agent edits
- \alse\ - file has diverged; restore is skipped and the buffer stays on the newer disk content

On read error (file gone, permission denied, etc.) the method returns \	rue\ so the existing missing-file handling in the entry is not bypassed.

A diagnostic log line is emitted at \info\ level when a restore is skipped, making the decision visible in the extension host log.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| File unchanged since snapshot | Restore agent edits | Restore agent edits |
| File saved externally after snapshot | Overwrites with stale content, dirty buffer | Skips restore, buffer shows disk content |
| File edited in VS Code and saved after snapshot | Overwrites newer save, dirty buffer | Skips restore, newer save preserved |
| Only CRLF / BOM difference from snapshot | Spurious dirty buffer | Treated as unchanged, restore proceeds |
| File deleted or unreadable | Entry handles it | Entry handles it (fail-open) |