### PR TITLE
Align Chronicle session store schema with actual stored data

### DIFF
--- a/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
+++ b/extensions/copilot/src/extension/chronicle/common/sessionStoreTracking.ts
@@ -23,7 +23,7 @@ export const MAX_ASSISTANT_RESPONSE_LENGTH = 1000;
 export const MAX_SUMMARY_LENGTH = 100;
 
 /**
- * Truncate a string to at most `maxLength` stored characters, appending '...' if truncated.
+ * Truncate a string to at most `maxLength` stored characters, appending '…' if truncated.
  * The returned value, including the truncation suffix, never exceeds `maxLength`.
  * Returns `undefined` for falsy input.
  */
@@ -34,7 +34,7 @@ export function truncateForStore(value: string | undefined, maxLength: number): 
 	if (value.length <= maxLength) {
 		return value;
 	}
-	const ellipsis = '...';
+	const ellipsis = '…';
 	if (maxLength <= ellipsis.length) {
 		return ellipsis.slice(0, maxLength);
 	}
@@ -63,7 +63,7 @@ export function extractToolArgs(span: ICompletedSpanData): Record<string, unknow
 	return {};
 }
 
-/** Tools whose arguments contain a file path being modified or read. */
+/** Tools whose arguments contain a file path being written (created or modified). */
 const FILE_TRACKING_TOOLS = new Set([
 	// VS Code model-facing tool names (from ToolName enum)
 	'replace_string_in_file',
@@ -73,9 +73,6 @@ const FILE_TRACKING_TOOLS = new Set([
 	'create_directory',
 	'edit_notebook_file',
 	'apply_patch',
-	'read_file',
-	'view_image',
-	'list_dir',
 	// CLI-agent tool names (backward compat)
 	'str_replace_editor',
 	'create',

--- a/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
+++ b/extensions/copilot/src/extension/chronicle/common/test/sessionStoreTracking.spec.ts
@@ -37,14 +37,14 @@ describe('extractFilePath', () => {
 			.toBe('/nb.ipynb');
 	});
 
-	it('extracts filePath from read_file', () => {
+	it('returns undefined for read_file (read-only, not tracked in session_files)', () => {
 		expect(extractFilePath('read_file', { filePath: '/src/read.ts', startLine: 1, endLine: 10 }))
-			.toBe('/src/read.ts');
+			.toBeUndefined();
 	});
 
-	it('extracts path from list_dir', () => {
+	it('returns undefined for list_dir (read-only, not tracked in session_files)', () => {
 		expect(extractFilePath('list_dir', { path: '/src' }))
-			.toBe('/src');
+			.toBeUndefined();
 	});
 
 	it('extracts dirPath from create_directory', () => {
@@ -85,10 +85,12 @@ describe('extractFilePath', () => {
 			.toBe('/cli/new.py');
 	});
 
-	it('returns undefined for unknown tools', () => {
+	it('returns undefined for read-only and unknown tools', () => {
 		expect(extractFilePath('run_in_terminal', { command: 'ls' }))
 			.toBeUndefined();
 		expect(extractFilePath('file_search', { query: '**/*.ts' }))
+			.toBeUndefined();
+		expect(extractFilePath('view_image', { filePath: '/img.png' }))
 			.toBeUndefined();
 	});
 

--- a/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/chronicleIntent.ts
@@ -550,15 +550,15 @@ Use the session_store_sql tool to run queries. Start with a broad query, then dr
 			? `Available tables (cloud SQL syntax):
 - **sessions**: id, repository, branch, summary, agent_name (who created the session, e.g. 'VS Code', 'cli', 'Copilot Coding Agent', 'Copilot Code Review'), agent_description, created_at, updated_at (TIMESTAMP). NOTE: cwd is always NULL in the cloud. IMPORTANT: Always filter on **updated_at** (not created_at) for time ranges — some session types have created_at set to epoch zero. NOTE: summary and repository/branch may be NULL — always JOIN with turns to get actual content.
 - **turns**: session_id, turn_index, user_message, assistant_response, timestamp (TIMESTAMP). The richest and most reliable source of what actually happened — the first turn (turn_index=0) user_message is effectively the session summary. Always JOIN sessions with turns for meaningful results.
-- **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were read/edited and which tools were used.
+- **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were edited or created and which tool was used.
 - **session_refs**: session_id, ref_type (commit/pr/issue), ref_value, turn_index. Tracks PRs created, issues referenced, commits made.
 
 Use \`now() - INTERVAL '1 day'\` for date math, \`ILIKE\` for text search.
 Always JOIN sessions with turns to get session content — do not rely on sessions.summary alone.`
 			: `Available tables (SQLite syntax — local):
 - **sessions**: id, cwd (workspace folder path), repository, branch, summary, host_type (always 'vscode' locally), agent_name (who created the session, e.g. 'GitHub Copilot Chat', 'copilotcli', 'claude'), agent_description, created_at, updated_at. NOTE: agent_name and agent_description may be empty for older sessions. summary is human-readable plain text (up to 100 chars) — may be empty for older sessions.
-- **turns**: session_id, turn_index, user_message, assistant_response (first ~1000 characters of the assistant reply, with an ellipsis if truncated — not the full response; may be empty for older sessions), timestamp. The richest source of what actually happened — always JOIN sessions with turns for meaningful results.
-- **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were read/edited and which tools were used. May be empty for older sessions.
+- **turns**: session_id, turn_index, user_message, assistant_response (first ~1000 characters of the assistant reply, with … if truncated — not the full response; may be empty for older sessions), timestamp. The richest source of what actually happened — always JOIN sessions with turns for meaningful results.
+- **session_files**: session_id, file_path, tool_name, turn_index. Tracks which files were edited or created and which tool was used. May be empty for older sessions.
 - **session_refs**: session_id, ref_type (commit/pr/issue), ref_value, turn_index. Tracks PRs created, issues referenced, commits made. May be empty for older sessions.
 - **search_index**: FTS5 virtual table indexing conversation turns (user_message + assistant_response), checkpoint sections (overview, history, work_done, etc.), and workspace artifacts. Records have a source_type column (unindexed) distinguishing content origin. Use \`WHERE search_index MATCH 'query'\` for full-text search across all indexed session content.
 


### PR DESCRIPTION
Fixes #313640.

Two divergences between the documented schema and stored data:

**1. Truncation marker**

The schema description stated truncated content ends with the unicode ellipsis (U+2026 `...`), but `truncateForStore` appended three ASCII periods (`...`). This caused queries like `assistant_response LIKE '%...'` to return 0 rows while `LIKE '%...'` returned 36 - the opposite of what the documentation implied.

Change the `ellipsis` constant from `'...'` to the single unicode character so the stored marker matches the documented value. A secondary benefit: the suffix shrinks from 3 code units to 1, freeing 2 more characters of content per truncated value without exceeding `maxLength`.

**2. `session_files` tool_name scope**

`read_file`, `list_dir`, and `view_image` were included in `FILE_TRACKING_TOOLS`, so every file the agent read was inserted into `session_files`. In practice `read_file` alone accounted for 90% of rows (165 out of ~183). The intent of `session_files` is to record files the agent wrote, not every file it inspected.

Remove those three read-only tools from `FILE_TRACKING_TOOLS`. Only write operations (`replace_string_in_file`, `insert_edit_into_file`, `create_file`, `edit_notebook_file`, `apply_patch`, `str_replace_editor`, `create`, `create_directory`, `multi_replace_string_in_file`) now populate `session_files`.

Update the schema description in `chronicleIntent.ts` and the JSDoc on `FILE_TRACKING_TOOLS` to match.

**Tests**

- `read_file` and `list_dir` cases updated to assert `undefined` (not tracked).
- `view_image` added to the read-only/unknown assertion group.
- Length-based truncation tests in `sessionReindexer.spec.ts` are unaffected because they only check `.length <= max`, not the specific suffix character.